### PR TITLE
Add convenience API for providers to send custom events to clients

### DIFF
--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -8,6 +8,7 @@ import logging
 from typing import TYPE_CHECKING, Any, TypeVar, final, overload
 
 from music_assistant_models.config_entries import ConfigValueType
+from music_assistant_models.enums import EventType
 from music_assistant_models.errors import UnsupportedFeaturedException
 
 from music_assistant.constants import CONF_LOG_LEVEL, MASS_LOGGER_NAME
@@ -210,6 +211,21 @@ class Provider:
             raise UnsupportedFeaturedException(
                 f"Provider {self.name} does not support feature {feature.name}"
             )
+
+    @final
+    def signal_provider_event(self, data: Any, sub_scope: str | None = None) -> None:
+        """
+        Signal a custom provider event to all subscribers (e.g. connected clients).
+
+        Emits a PROVIDER_EVENT with this provider's instance_id as object_id,
+        optionally suffixed with /sub_scope to allow clients to distinguish
+        multiple event streams from the same provider.
+
+        :param data: The (JSON serializable) event payload, defined by the provider.
+        :param sub_scope: Optional sub scope to append to the object_id.
+        """
+        object_id = f"{self.instance_id}/{sub_scope}" if sub_scope else self.instance_id
+        self.mass.signal_event(EventType.PROVIDER_EVENT, object_id=object_id, data=data)
 
     @overload
     def get_config_value(

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -213,7 +213,7 @@ class Provider:
             )
 
     @final
-    def signal_provider_event(self, data: Any, sub_scope: str | None = None) -> None:
+    def signal_provider_event(self, data: SerializableType, sub_scope: str | None = None) -> None:
         """
         Signal a custom provider event to all subscribers (e.g. connected clients).
 
@@ -221,7 +221,7 @@ class Provider:
         optionally suffixed with /sub_scope to allow clients to distinguish
         multiple event streams from the same provider.
 
-        :param data: The (JSON serializable) event payload, defined by the provider.
+        :param data: The JSON serializable event payload, defined by the provider.
         :param sub_scope: Optional sub scope to append to the object_id.
         """
         object_id = f"{self.instance_id}/{sub_scope}" if sub_scope else self.instance_id

--- a/tests/controllers/webserver/test_event_dispatch.py
+++ b/tests/controllers/webserver/test_event_dispatch.py
@@ -40,11 +40,13 @@ def webserver(mass_minimal: MusicAssistant) -> WebserverController:
     return webserver
 
 
-def create_ws_client(webserver: WebserverController, username: str) -> WebsocketClientHandler:
+def create_ws_client(
+    webserver: WebserverController, username: str, role: UserRole = UserRole.ADMIN
+) -> WebsocketClientHandler:
     """Create an authenticated + event-subscribed websocket client handler (no real socket)."""
     request = make_mocked_request("GET", "/ws", app=web.Application())
     client = WebsocketClientHandler(webserver, request)
-    client._authenticated_user = User(user_id=username, username=username, role=UserRole.ADMIN)
+    client._authenticated_user = User(user_id=username, username=username, role=role)
     client._subscribe_to_events()
     return client
 
@@ -93,3 +95,20 @@ async def test_tasks_updated_payload_per_user(
     assert "task-for-user2" not in msg1
     assert "task-for-user2" in msg2
     assert "task-for-user1" not in msg2
+
+
+async def test_provider_event_delivered_to_guest_clients(
+    mass_minimal: MusicAssistant,
+    webserver: WebserverController,
+) -> None:
+    """PROVIDER_EVENT reaches all clients, including guest-scoped ones."""
+    guest = create_ws_client(webserver, "guest1", role=UserRole.GUEST)
+    admin = create_ws_client(webserver, "admin1")
+
+    mass_minimal.signal_event(EventType.PROVIDER_EVENT, "music_quiz--abcd/game_state", {"round": 1})
+    await drain_event_callbacks()
+
+    msg_guest = get_written_message(guest)
+    msg_admin = get_written_message(admin)
+    assert msg_guest == msg_admin
+    assert "music_quiz--abcd/game_state" in msg_guest

--- a/tests/models/test_provider.py
+++ b/tests/models/test_provider.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import fields
+from typing import cast
 from unittest.mock import MagicMock
 
-from music_assistant_models.enums import ProviderType
+from music_assistant_models.enums import EventType, ProviderType
 from music_assistant_models.provider import ProviderInstance
 
 from music_assistant.models.provider import Provider
@@ -30,3 +31,21 @@ def test_to_dict_matches_provider_instance_schema() -> None:
     assert set(result) == {f.name for f in fields(ProviderInstance)}
     # the served payload must also deserialize back into the model
     ProviderInstance.from_dict(result)
+
+
+def test_signal_provider_event() -> None:
+    """signal_provider_event() emits a PROVIDER_EVENT with the instance_id as object_id."""
+    provider = _make_base_provider()
+    provider.signal_provider_event({"foo": "bar"})
+    cast("MagicMock", provider.mass).signal_event.assert_called_once_with(
+        EventType.PROVIDER_EVENT, object_id="test_instance", data={"foo": "bar"}
+    )
+
+
+def test_signal_provider_event_with_sub_scope() -> None:
+    """signal_provider_event() appends the sub_scope to the object_id."""
+    provider = _make_base_provider()
+    provider.signal_provider_event({"round": 1}, sub_scope="game_state")
+    cast("MagicMock", provider.mass).signal_event.assert_called_once_with(
+        EventType.PROVIDER_EVENT, object_id="test_instance/game_state", data={"round": 1}
+    )


### PR DESCRIPTION
# What does this implement/fix?

Plugins (and other providers) currently have no way to push live state updates to connected clients, forcing frontends to poll. For example, the upcoming Music Quiz plugin has guest phones polling the game state every 1-2 seconds.

This adds a small convenience API so any provider can emit a custom `PROVIDER_EVENT` over the existing event bus, which all connected websocket clients (including guest-scoped ones) receive.

- Add `Provider.signal_provider_event(data, sub_scope=None)` which emits `EventType.PROVIDER_EVENT` with `object_id` set to the provider's instance_id (optionally suffixed with `/sub_scope`)
- Bump music-assistant-models to 1.1.156 (brings the new event type from music-assistant/models#292)
- Tests for the event emission (with/without sub scope) and for delivery to guest websocket clients

Guest websocket clients already receive all events (filtering only applies to player/queue events with a player filter), so no changes to event dispatch were needed.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.