### PR TITLE
Faster and more robust global search with per-provider timeouts and caching

### DIFF
--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -26,8 +26,11 @@ SEARCH_PROVIDER_SOFT_TIMEOUT: Final[int] = 8
 # absolute max time a (background) provider search may run,
 # rate limited providers can be very slow to respond
 SEARCH_PROVIDER_HARD_TIMEOUT: Final[int] = 120
-# how long to cache raw per-provider search results
-SEARCH_CACHE_EXPIRATION_PROVIDER: Final[int] = 900
+# how long to cache raw per-provider search results; streaming catalogs barely
+# change so they can be cached a lot longer than local providers where the
+# user may add or change content at any time
+SEARCH_CACHE_EXPIRATION_STREAMING_PROVIDER: Final[int] = 24 * 3600
+SEARCH_CACHE_EXPIRATION_LOCAL_PROVIDER: Final[int] = 900
 # how long to cache combined search results (fast path for repeated searches)
 SEARCH_CACHE_EXPIRATION_COMBINED: Final[int] = 600
 

--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -18,6 +18,19 @@ DYNAMIC_RADIO_DYNAMIC_TARGET: Final[int] = 50
 
 CACHE_CATEGORY_SEARCH_RESULTS: Final[int] = 10
 
+# max time to wait for a single provider's search results before
+# contributing empty results for it, so one slow provider can never block
+# the whole search; the provider search itself continues in the background
+# so its result is cached and available for a next search request
+SEARCH_PROVIDER_SOFT_TIMEOUT: Final[int] = 8
+# absolute max time a (background) provider search may run,
+# rate limited providers can be very slow to respond
+SEARCH_PROVIDER_HARD_TIMEOUT: Final[int] = 120
+# how long to cache raw per-provider search results
+SEARCH_CACHE_EXPIRATION_PROVIDER: Final[int] = 900
+# how long to cache combined search results (fast path for repeated searches)
+SEARCH_CACHE_EXPIRATION_COMBINED: Final[int] = 600
+
 # max time to wait for a single provider's recommendations before skipping it,
 # so one slow provider can never block the whole discover page
 RECOMMENDATIONS_PROVIDER_TIMEOUT: Final[int] = 30

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -63,7 +63,8 @@ from music_assistant.controllers.music.constants import (
     PROVIDER_MAPPING_CORRECTION_TASK_ID,
     RECOMMENDATIONS_PROVIDER_TIMEOUT,
     SEARCH_CACHE_EXPIRATION_COMBINED,
-    SEARCH_CACHE_EXPIRATION_PROVIDER,
+    SEARCH_CACHE_EXPIRATION_LOCAL_PROVIDER,
+    SEARCH_CACHE_EXPIRATION_STREAMING_PROVIDER,
     SEARCH_PROVIDER_HARD_TIMEOUT,
     SEARCH_PROVIDER_SOFT_TIMEOUT,
 )
@@ -2263,7 +2264,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         await self.mass.cache.set(
             key=cache_key,
             data=result.to_dict(),
-            expiration=SEARCH_CACHE_EXPIRATION_PROVIDER,
+            expiration=SEARCH_CACHE_EXPIRATION_STREAMING_PROVIDER
+            if prov.is_streaming_provider
+            else SEARCH_CACHE_EXPIRATION_LOCAL_PROVIDER,
             provider=prov.instance_id,
             category=CACHE_CATEGORY_SEARCH_RESULTS,
         )

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -489,12 +489,8 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         # only cache the combined result if all providers contributed,
         # so a failed or timed out provider is retried on a next search
         if all_results_complete:
-            await self.mass.cache.set(
-                key=cache_key,
-                data=result.to_dict(),
-                expiration=SEARCH_CACHE_EXPIRATION_COMBINED,
-                provider=self.domain,
-                category=CACHE_CATEGORY_SEARCH_RESULTS,
+            await self._cache_search_results(
+                cache_key, result, SEARCH_CACHE_EXPIRATION_COMBINED, self.domain
             )
         return result
 
@@ -2261,16 +2257,32 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             return None
         # only successful results are cached, so failed or timed out
         # provider searches are simply retried on a next search
-        await self.mass.cache.set(
-            key=cache_key,
-            data=result.to_dict(),
-            expiration=SEARCH_CACHE_EXPIRATION_STREAMING_PROVIDER
-            if prov.is_streaming_provider
+        await self._cache_search_results(
+            cache_key,
+            result,
+            # plugin providers do not declare is_streaming_provider,
+            # treat them as local so their results only get the short expiration
+            SEARCH_CACHE_EXPIRATION_STREAMING_PROVIDER
+            if getattr(prov, "is_streaming_provider", False)
             else SEARCH_CACHE_EXPIRATION_LOCAL_PROVIDER,
-            provider=prov.instance_id,
-            category=CACHE_CATEGORY_SEARCH_RESULTS,
+            prov.instance_id,
         )
         return result
+
+    async def _cache_search_results(
+        self, cache_key: str, result: SearchResults, expiration: int, provider: str
+    ) -> None:
+        """Store search results in the cache, logging (instead of raising) any cache errors."""
+        try:
+            await self.mass.cache.set(
+                key=cache_key,
+                data=result.to_dict(),
+                expiration=expiration,
+                provider=provider,
+                category=CACHE_CATEGORY_SEARCH_RESULTS,
+            )
+        except Exception as err:
+            self.logger.warning("Failed to cache search results for %s: %s", provider, str(err))
 
     def _get_covered_media_types(
         self, library_results: SearchResults, search_query: str

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -426,6 +426,12 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 for item in sublist
                 if item is not None
             ][:limit],
+            genres=[
+                item
+                for sublist in zip_longest(*[x.genres for x in results_per_provider])
+                for item in sublist
+                if item is not None
+            ][:limit],
             tracks=[
                 item
                 for sublist in zip_longest(*[x.tracks for x in results_per_provider])
@@ -456,18 +462,29 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 for item in sublist
                 if item is not None
             ][:limit],
+            sound_effects=[
+                item
+                for sublist in zip_longest(*[x.sound_effects for x in results_per_provider])
+                for item in sublist
+                if item is not None
+            ][:limit],
         )
 
         # the search results should already be sorted by relevance
         # but we apply one extra round of sorting and that is to put exact name
         # matches and library items first
-        result.artists = sort_search_result(search_query, result.artists)
-        result.albums = sort_search_result(search_query, result.albums)
-        result.tracks = sort_search_result(search_query, result.tracks)
-        result.playlists = sort_search_result(search_query, result.playlists)
-        result.radio = sort_search_result(search_query, result.radio)
-        result.audiobooks = sort_search_result(search_query, result.audiobooks)
-        result.podcasts = sort_search_result(search_query, result.podcasts)
+        for field in (
+            "artists",
+            "albums",
+            "genres",
+            "tracks",
+            "playlists",
+            "radio",
+            "audiobooks",
+            "podcasts",
+            "sound_effects",
+        ):
+            setattr(result, field, sort_search_result(search_query, getattr(result, field)))
         # only cache the combined result if all providers contributed,
         # so a failed or timed out provider is retried on a next search
         if all_results_complete:
@@ -2210,11 +2227,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 prov.name,
             )
             return None
-        except MusicAssistantError as err:
-            self.logger.warning("Search on provider %s failed: %s", prov.name, str(err))
-            return None
-        except Exception as err:
-            self.logger.error("Search on provider %s failed: %s", prov.name, str(err), exc_info=err)
+        if prov_search_results is None:
             return None
         return filter_search_results(prov_search_results, prov.domain, skip_item_ids)
 
@@ -2225,10 +2238,26 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         media_types: list[MediaType],
         limit: int,
         cache_key: str,
-    ) -> SearchResults:
-        """Execute the actual search on a provider and cache the result."""
-        async with asyncio.timeout(SEARCH_PROVIDER_HARD_TIMEOUT):
-            result = await prov.search(search_query, media_types, limit)
+    ) -> SearchResults | None:
+        """
+        Execute the actual search on a provider and cache the result.
+
+        Returns None if the provider search failed or timed out. All errors are
+        handled here (and not raised) as this coroutine runs as a background task
+        that may outlive the request that started it.
+        """
+        try:
+            async with asyncio.timeout(SEARCH_PROVIDER_HARD_TIMEOUT):
+                result = await prov.search(search_query, media_types, limit)
+        except TimeoutError:
+            self.logger.warning("Search on provider %s timed out", prov.name)
+            return None
+        except MusicAssistantError as err:
+            self.logger.warning("Search on provider %s failed: %s", prov.name, str(err))
+            return None
+        except Exception as err:
+            self.logger.error("Search on provider %s failed: %s", prov.name, str(err), exc_info=err)
+            return None
         # only successful results are cached, so failed or timed out
         # provider searches are simply retried on a next search
         await self.mass.cache.set(

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable, Iterable, Sequence
+from collections.abc import Awaitable, Callable, Coroutine, Iterable, Sequence
 from contextlib import suppress
 from copy import deepcopy
 from datetime import datetime
@@ -42,7 +42,6 @@ from music_assistant_models.media_items import (
     Playlist,
     Podcast,
     ProviderMapping,
-    Radio,
     RecommendationFolder,
     SearchResults,
     SoundEffect,
@@ -63,9 +62,13 @@ from music_assistant.controllers.music.constants import (
     MUSIC_SYNC_COMPLETION_CHECK_TASK_ID,
     PROVIDER_MAPPING_CORRECTION_TASK_ID,
     RECOMMENDATIONS_PROVIDER_TIMEOUT,
+    SEARCH_CACHE_EXPIRATION_COMBINED,
+    SEARCH_CACHE_EXPIRATION_PROVIDER,
+    SEARCH_PROVIDER_HARD_TIMEOUT,
+    SEARCH_PROVIDER_SOFT_TIMEOUT,
 )
 from music_assistant.controllers.music.database import MusicDatabaseSetupMixin
-from music_assistant.controllers.music.helpers import sort_search_result
+from music_assistant.controllers.music.helpers import filter_search_results, sort_search_result
 from music_assistant.controllers.music.media.albums import AlbumsController
 from music_assistant.controllers.music.media.artists import ArtistsController
 from music_assistant.controllers.music.media.audiobooks import AudiobooksController
@@ -285,6 +288,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         media_types: list[MediaType] = MediaType.ALL,
         limit: int = 25,
         library_only: bool = False,
+        providers: list[str] | None = None,
     ) -> SearchResults:
         """
         Perform global search for media items on all providers.
@@ -292,8 +296,18 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param search_query: Search query.
         :param media_types: A list of media_types to include.
         :param limit: number of items to return in the search (per type).
+        :param library_only: Deprecated - use providers=["library"] instead.
+        :param providers: Optionally restrict the search to the given providers
+            (by instance id or domain), where the special value "library" selects
+            the library. Omit to search the library and all available providers.
         """
-        # use cache to avoid repeated searches
+        if not media_types:
+            media_types = MediaType.ALL
+        if library_only and providers is None:
+            # handle deprecated library_only flag
+            providers = ["library"]
+        # resolve the search targets: all (unique) music providers plus plugin
+        # providers with search support, optionally filtered by the providers argument
         plugin_search_providers = [
             p.instance_id
             for p in self.mass.get_providers_supporting_feature(
@@ -301,9 +315,24 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 priority=(ProviderType.PLUGIN,),
             )
         ]
-        search_providers = sorted(self.get_unique_providers() + plugin_search_providers)
-        cache_provider_key = "library" if library_only else ",".join(search_providers)
-        cache_key = f"{search_query}{'-'.join(sorted([mt.value for mt in media_types]))}-{limit}-{library_only}-{cache_provider_key}"
+        all_search_providers = sorted(self.get_unique_providers() + plugin_search_providers)
+        if providers is None:
+            include_library = True
+            search_providers = all_search_providers
+        else:
+            include_library = "library" in providers
+            requested_providers = set(providers)
+            search_providers = [
+                instance_id
+                for instance_id in all_search_providers
+                if (prov := self.mass.get_provider(instance_id))
+                and (prov.instance_id in requested_providers or prov.domain in requested_providers)
+            ]
+        # use cache to avoid repeated searches
+        cache_key = (
+            f"{search_query}-{'-'.join(sorted([mt.value for mt in media_types]))}-{limit}-"
+            f"{int(include_library)}-{','.join(search_providers)}"
+        )
         if cache := await self.mass.cache.get(
             key=cache_key,
             provider=self.domain,
@@ -311,50 +340,19 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             base_class=SearchResults,
         ):
             return cast("SearchResults", cache)
-        if not media_types:
-            media_types = MediaType.ALL
         # Check if the search query is a streaming provider public shareable URL
-        try:
-            media_type, provider_instance_id_or_domain, item_id = await parse_uri(
-                search_query, validate_id=True
-            )
-        except InvalidProviderURI:
-            pass
-        except InvalidProviderID as err:
-            self.logger.warning("%s", str(err))
-            return SearchResults()
-        else:
-            # handle special case of direct shareable url search
-            if provider_instance_id_or_domain in PROVIDERS_WITH_SHAREABLE_URLS:
-                try:
-                    item = await self.get_item(
-                        media_type=media_type,
-                        item_id=item_id,
-                        provider_instance_id_or_domain=provider_instance_id_or_domain,
-                    )
-                except MusicAssistantError as err:
-                    self.logger.warning("%s", str(err))
-                    return SearchResults()
-                else:
-                    if media_type == MediaType.ARTIST:
-                        return SearchResults(artists=[cast("Artist", item)])
-                    if media_type == MediaType.ALBUM:
-                        return SearchResults(albums=[cast("Album", item)])
-                    if media_type == MediaType.TRACK:
-                        return SearchResults(tracks=[cast("Track", item)])
-                    if media_type == MediaType.PLAYLIST:
-                        return SearchResults(playlists=[cast("Playlist", item)])
-                    if media_type == MediaType.AUDIOBOOK:
-                        return SearchResults(audiobooks=[cast("Audiobook", item)])
-                    if media_type == MediaType.PODCAST:
-                        return SearchResults(podcasts=[cast("Podcast", item)])
-                    return SearchResults()
-        # handle normal global search by querying all providers
-        results_per_provider: list[SearchResults] = []
-        # always first search the library
+        if (url_result := await self._search_shareable_url(search_query)) is not None:
+            return url_result
+        # handle normal global search by querying the library and all providers
+        # the library is always searched first: it is fast and its results are used
+        # to deduplicate provider results and to skip provider searches for media
+        # types that already have a (near) exact match in the library
         library_results = await self.search_library(search_query, media_types, limit=limit)
-        results_per_provider.append(library_results)
-        if not library_only:
+        results_per_provider: list[SearchResults] = []
+        if include_library:
+            results_per_provider.append(library_results)
+        all_results_complete = True
+        if search_providers:
             # create a set of all provider item ids already in library
             # this way we can avoid returning duplicates in the search results
             all_prov_item_ids = {
@@ -370,26 +368,48 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 for item in items
                 for prov_mapping in cast("MediaItemType", item).provider_mappings
             }
-            # include results from library + all (unique) music providers
-            # one failing provider must not break the entire search,
-            # so exceptions are logged and excluded from the results
-            gather_results = await asyncio.gather(
-                *[
+            # only apply the exact match shortcut on a regular global search;
+            # an explicit providers selection must always search those providers
+            covered_media_types = (
+                self._get_covered_media_types(library_results, search_query)
+                if providers is None
+                else set()
+            )
+            provider_searches: list[Coroutine[Any, Any, SearchResults | None]] = []
+            for provider_instance in search_providers:
+                if not (prov := self.mass.get_provider(provider_instance)):
+                    continue
+                # skip media types for which the library already holds a (near)
+                # exact match that is mapped to this provider: searching the
+                # provider again for that media type will not add anything new
+                prov_media_types = [
+                    mt
+                    for mt in media_types
+                    if (mt, prov.domain) not in covered_media_types
+                    and (mt, prov.instance_id) not in covered_media_types
+                ]
+                if not prov_media_types:
+                    continue
+                provider_searches.append(
                     self._search_provider(
                         search_query,
                         provider_instance,
-                        media_types,
+                        prov_media_types,
                         limit=limit,
                         skip_item_ids=all_prov_item_ids,
                     )
-                    for provider_instance in search_providers
-                ],
-                return_exceptions=True,
-            )
+                )
+            # include results from all (unique) music providers
+            # one failing provider must not break the entire search,
+            # so exceptions are logged and excluded from the results
+            gather_results = await asyncio.gather(*provider_searches, return_exceptions=True)
             for res in gather_results:
                 if isinstance(res, SearchResults):
                     results_per_provider.append(res)
-                else:
+                    continue
+                # a provider that failed or timed out contributes no results
+                all_results_complete = False
+                if isinstance(res, BaseException):
                     self.logger.error("Search on provider failed", exc_info=res)
         # return result from all providers while keeping index
         # so the result is sorted as each provider delivered
@@ -448,13 +468,16 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         result.radio = sort_search_result(search_query, result.radio)
         result.audiobooks = sort_search_result(search_query, result.audiobooks)
         result.podcasts = sort_search_result(search_query, result.podcasts)
-        await self.mass.cache.set(
-            key=cache_key,
-            data=result.to_dict(),
-            expiration=600,
-            provider=self.domain,
-            category=CACHE_CATEGORY_SEARCH_RESULTS,
-        )
+        # only cache the combined result if all providers contributed,
+        # so a failed or timed out provider is retried on a next search
+        if all_results_complete:
+            await self.mass.cache.set(
+                key=cache_key,
+                data=result.to_dict(),
+                expiration=SEARCH_CACHE_EXPIRATION_COMBINED,
+                provider=self.domain,
+                category=CACHE_CATEGORY_SEARCH_RESULTS,
+            )
         return result
 
     async def search_library(
@@ -470,25 +493,28 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param media_types: A list of media_types to include.
         :param limit: number of items to return in the search (per type).
         """
+        result_fields: dict[MediaType, str] = {
+            MediaType.ARTIST: "artists",
+            MediaType.ALBUM: "albums",
+            MediaType.GENRE: "genres",
+            MediaType.TRACK: "tracks",
+            MediaType.PLAYLIST: "playlists",
+            MediaType.RADIO: "radio",
+            MediaType.AUDIOBOOK: "audiobooks",
+            MediaType.PODCAST: "podcasts",
+        }
         result = SearchResults()
-        for media_type in media_types:
-            ctrl = self.get_controller(media_type)
-            search_results = await ctrl.search(search_query, "library", limit=limit)
-            if search_results:
-                if media_type == MediaType.ARTIST:
-                    result.artists = cast("list[Artist]", search_results)
-                elif media_type == MediaType.ALBUM:
-                    result.albums = cast("list[Album]", search_results)
-                elif media_type == MediaType.TRACK:
-                    result.tracks = cast("list[Track]", search_results)
-                elif media_type == MediaType.PLAYLIST:
-                    result.playlists = cast("list[Playlist]", search_results)
-                elif media_type == MediaType.RADIO:
-                    result.radio = cast("list[Radio]", search_results)
-                elif media_type == MediaType.AUDIOBOOK:
-                    result.audiobooks = cast("list[Audiobook]", search_results)
-                elif media_type == MediaType.PODCAST:
-                    result.podcasts = cast("list[Podcast]", search_results)
+        # search all media types in parallel, each is an independent db query
+        searchable_media_types = [x for x in media_types if x in result_fields]
+        search_results = await asyncio.gather(
+            *[
+                self.get_controller(media_type).search(search_query, "library", limit=limit)
+                for media_type in searchable_media_types
+            ]
+        )
+        for media_type, items in zip(searchable_media_types, search_results, strict=True):
+            if items:
+                setattr(result, result_fields[media_type], items)
         return result
 
     @api_command("music/browse", required_scope=Scope.LIBRARY_READ)
@@ -2086,6 +2112,46 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             if p.type != ProviderType.MUSIC or p.instance_id in user_provider_filter
         ]
 
+    async def _search_shareable_url(self, search_query: str) -> SearchResults | None:
+        """
+        Handle a search query that is a streaming provider public shareable URL.
+
+        Returns None if the query is not such a URL and a regular search must be done.
+        """
+        try:
+            media_type, provider_instance_id_or_domain, item_id = await parse_uri(
+                search_query, validate_id=True
+            )
+        except InvalidProviderURI:
+            return None
+        except InvalidProviderID as err:
+            self.logger.warning("%s", str(err))
+            return SearchResults()
+        if provider_instance_id_or_domain not in PROVIDERS_WITH_SHAREABLE_URLS:
+            return None
+        try:
+            item = await self.get_item(
+                media_type=media_type,
+                item_id=item_id,
+                provider_instance_id_or_domain=provider_instance_id_or_domain,
+            )
+        except MusicAssistantError as err:
+            self.logger.warning("%s", str(err))
+            return SearchResults()
+        if media_type == MediaType.ARTIST:
+            return SearchResults(artists=[cast("Artist", item)])
+        if media_type == MediaType.ALBUM:
+            return SearchResults(albums=[cast("Album", item)])
+        if media_type == MediaType.TRACK:
+            return SearchResults(tracks=[cast("Track", item)])
+        if media_type == MediaType.PLAYLIST:
+            return SearchResults(playlists=[cast("Playlist", item)])
+        if media_type == MediaType.AUDIOBOOK:
+            return SearchResults(audiobooks=[cast("Audiobook", item)])
+        if media_type == MediaType.PODCAST:
+            return SearchResults(podcasts=[cast("Podcast", item)])
+        return SearchResults()
+
     async def _search_provider(
         self,
         search_query: str,
@@ -2093,15 +2159,17 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         media_types: list[MediaType],
         limit: int = 10,
         skip_item_ids: set[tuple[MediaType, str, str]] | None = None,
-    ) -> SearchResults:
+    ) -> SearchResults | None:
         """
-        Perform search on given provider.
+        Perform search on given provider, returns None if the search failed or timed out.
 
         :param search_query: Search query
         :param provider_instance_id_or_domain: instance_id or domain of the provider
                                                to perform the search on.
         :param media_types: A list of media_types to include.
         :param limit: number of items to return in the search (per type).
+        :param skip_item_ids: Optional set of (media_type, provider_domain, item_id)
+                              tuples to filter out of the results.
         """
         prov = self.mass.get_provider(provider_instance_id_or_domain, provider_type=MusicProvider)
         if not prov:
@@ -2111,53 +2179,112 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
 
         # create safe search string
         search_query = search_query.replace("/", " ").replace("'", "")
-        # guard against a failing provider: return empty results instead of
-        # raising, so a global search can still succeed with the other providers
-        try:
-            prov_search_results = await prov.search(
-                search_query,
-                media_types,
-                limit,
+        # use the per-provider cache so repeated and overlapping searches
+        # do not hit the provider again
+        cache_key = f"{search_query}-{'-'.join(sorted([mt.value for mt in media_types]))}-{limit}"
+        if (
+            cache := await self.mass.cache.get(
+                key=cache_key,
+                provider=prov.instance_id,
+                category=CACHE_CATEGORY_SEARCH_RESULTS,
+                base_class=SearchResults,
             )
+        ) is not None:
+            return filter_search_results(cast("SearchResults", cache), prov.domain, skip_item_ids)
+        # run the provider search as a separate task (deduplicated by task_id so
+        # identical concurrent searches share a single provider call) and wait for
+        # it a limited amount of time only: a slow provider then contributes no
+        # results now, while its search continues in the background so the result
+        # is cached and available for a next search request
+        task = self.mass.create_task(
+            self._execute_provider_search(prov, search_query, media_types, limit, cache_key),
+            task_id=f"provider_search_{prov.instance_id}_{cache_key}",
+        )
+        try:
+            async with asyncio.timeout(SEARCH_PROVIDER_SOFT_TIMEOUT):
+                prov_search_results = await asyncio.shield(task)
+        except TimeoutError:
+            self.logger.warning(
+                "Search on provider %s did not return in time, "
+                "the search continues in the background",
+                prov.name,
+            )
+            return None
         except MusicAssistantError as err:
             self.logger.warning("Search on provider %s failed: %s", prov.name, str(err))
-            return SearchResults()
+            return None
         except Exception as err:
             self.logger.error("Search on provider %s failed: %s", prov.name, str(err), exc_info=err)
-            return SearchResults()
-        if skip_item_ids:
-            # filter out items already in skip_item_ids
-            prov_search_results.artists = [
-                item
-                for item in prov_search_results.artists
-                if (item.media_type, prov.domain, item.item_id) not in skip_item_ids
-            ]
-            prov_search_results.albums = [
-                item
-                for item in prov_search_results.albums
-                if (item.media_type, prov.domain, item.item_id) not in skip_item_ids
-            ]
-            prov_search_results.tracks = [
-                item
-                for item in prov_search_results.tracks
-                if (item.media_type, prov.domain, item.item_id) not in skip_item_ids
-            ]
-            prov_search_results.playlists = [
-                item
-                for item in prov_search_results.playlists
-                if (item.media_type, prov.domain, item.item_id) not in skip_item_ids
-            ]
-            prov_search_results.audiobooks = [
-                item
-                for item in prov_search_results.audiobooks
-                if (item.media_type, prov.domain, item.item_id) not in skip_item_ids
-            ]
-            prov_search_results.podcasts = [
-                item
-                for item in prov_search_results.podcasts
-                if (item.media_type, prov.domain, item.item_id) not in skip_item_ids
-            ]
-        return prov_search_results
+            return None
+        return filter_search_results(prov_search_results, prov.domain, skip_item_ids)
+
+    async def _execute_provider_search(
+        self,
+        prov: MusicProvider,
+        search_query: str,
+        media_types: list[MediaType],
+        limit: int,
+        cache_key: str,
+    ) -> SearchResults:
+        """Execute the actual search on a provider and cache the result."""
+        async with asyncio.timeout(SEARCH_PROVIDER_HARD_TIMEOUT):
+            result = await prov.search(search_query, media_types, limit)
+        # only successful results are cached, so failed or timed out
+        # provider searches are simply retried on a next search
+        await self.mass.cache.set(
+            key=cache_key,
+            data=result.to_dict(),
+            expiration=SEARCH_CACHE_EXPIRATION_PROVIDER,
+            provider=prov.instance_id,
+            category=CACHE_CATEGORY_SEARCH_RESULTS,
+        )
+        return result
+
+    def _get_covered_media_types(
+        self, library_results: SearchResults, search_query: str
+    ) -> set[tuple[MediaType, str]]:
+        """
+        Return the (media_type, provider domain/instance) pairs covered by the library.
+
+        A pair is considered covered when the library holds a (near) exact name match
+        for the search query that is mapped to that provider.
+        """
+        covered: set[tuple[MediaType, str]] = set()
+        # extract the artist and title part in case the
+        # query is formatted as "artist - title"
+        if " - " in search_query:
+            artist_part, title_part = search_query.split(" - ", 1)
+        else:
+            artist_part, title_part = None, search_query
+        items: Sequence[MediaItemType | ItemMapping]
+        for items in (
+            library_results.artists,
+            library_results.albums,
+            library_results.tracks,
+            library_results.playlists,
+            library_results.radio,
+            library_results.audiobooks,
+            library_results.podcasts,
+        ):
+            for item in items:
+                if compare_strings(item.name, search_query, strict=False):
+                    pass
+                elif artist_part and compare_strings(item.name, title_part, strict=False):
+                    # the item name matches the title part only,
+                    # so the artist part must match one of the item artists
+                    if not any(
+                        compare_strings(artist.name, artist_part, strict=False)
+                        for artist in getattr(item, "artists", [])
+                    ):
+                        continue
+                else:
+                    continue
+                for prov_mapping in cast("MediaItemType", item).provider_mappings:
+                    if not prov_mapping.available:
+                        continue
+                    covered.add((item.media_type, prov_mapping.provider_domain))
+                    covered.add((item.media_type, prov_mapping.provider_instance))
+        return covered
 
     def _import_album_tracks_if_enabled(self, album: Album) -> None:
         """Import all album tracks into the library for providers that have this enabled."""

--- a/music_assistant/controllers/music/helpers.py
+++ b/music_assistant/controllers/music/helpers.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
-from music_assistant_models.media_items import Artist, ItemMapping, MediaItemType
+from music_assistant_models.media_items import Artist, ItemMapping, MediaItemType, SearchResults
 from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.helpers.compare import create_safe_string
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from music_assistant_models.enums import MediaType
 
 
 def sort_search_result[SortItemT: MediaItemType | ItemMapping](
@@ -48,3 +53,35 @@ def sort_search_result[SortItemT: MediaItemType | ItemMapping](
     # so we add all remaining items in their original order. We just prioritize
     # exact name matches and library items.
     return UniqueList([*[x[1] for x in scored_items], *items])
+
+
+def filter_search_results(
+    results: SearchResults,
+    provider_domain: str,
+    skip_item_ids: set[tuple[MediaType, str, str]] | None,
+) -> SearchResults:
+    """
+    Return a copy of the given search results without the items in skip_item_ids.
+
+    :param results: The search results to filter.
+    :param provider_domain: Domain of the provider the results originate from.
+    :param skip_item_ids: Set of (media_type, provider_domain, item_id) tuples to filter out.
+    """
+    if not skip_item_ids:
+        return results
+
+    def _keep(item: MediaItemType | ItemMapping) -> bool:
+        return (item.media_type, provider_domain, item.item_id) not in skip_item_ids
+
+    # build a new SearchResults object as the original may be a (shared) cached object
+    return SearchResults(
+        artists=[x for x in results.artists if _keep(x)],
+        albums=[x for x in results.albums if _keep(x)],
+        genres=results.genres,
+        tracks=[x for x in results.tracks if _keep(x)],
+        playlists=[x for x in results.playlists if _keep(x)],
+        radio=[x for x in results.radio if _keep(x)],
+        audiobooks=[x for x in results.audiobooks if _keep(x)],
+        podcasts=[x for x in results.podcasts if _keep(x)],
+        sound_effects=results.sound_effects,
+    )

--- a/music_assistant/controllers/music/helpers.py
+++ b/music_assistant/controllers/music/helpers.py
@@ -77,11 +77,11 @@ def filter_search_results(
     return SearchResults(
         artists=[x for x in results.artists if _keep(x)],
         albums=[x for x in results.albums if _keep(x)],
-        genres=results.genres,
+        genres=[x for x in results.genres if _keep(x)],
         tracks=[x for x in results.tracks if _keep(x)],
         playlists=[x for x in results.playlists if _keep(x)],
         radio=[x for x in results.radio if _keep(x)],
         audiobooks=[x for x in results.audiobooks if _keep(x)],
         podcasts=[x for x in results.podcasts if _keep(x)],
-        sound_effects=results.sound_effects,
+        sound_effects=[x for x in results.sound_effects if _keep(x)],
     )

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -341,7 +341,13 @@ class TracksController(MediaControllerBase[Track]):
         search_query = f"{full_track.artist_str} - {full_track.name}"
         # TODO: we could use musicbrainz info here to get a list of all releases known
         unique_ids: set[str] = set()
-        for prov_item in (await self.mass.music.search(search_query, [MediaType.TRACK])).tracks:
+        # explicitly search all providers as we want all album versions
+        # of this track, including those already mapped in the library
+        search_providers = ["library", *self.mass.music.get_unique_providers()]
+        search_results = await self.mass.music.search(
+            search_query, [MediaType.TRACK], providers=search_providers
+        )
+        for prov_item in search_results.tracks:
             if not isinstance(prov_item, Track):  # for type checking
                 continue
             if not loose_compare_strings(full_track.name, prov_item.name):

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, Mock
 
 from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import MusicAssistantError
-from music_assistant_models.media_items import ProviderMapping, SearchResults, Track
+from music_assistant_models.media_items import Artist, ProviderMapping, SearchResults, Track
 
 from music_assistant.controllers.music import MusicController
 from music_assistant.models.music_provider import MusicProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import pytest
 
 
 def _make_track(item_id: str, provider: str, name: str) -> Track:
@@ -29,11 +37,27 @@ def _make_track(item_id: str, provider: str, name: str) -> Track:
     )
 
 
-def _make_search_provider(instance_id: str) -> Mock:
+def _make_library_artist(name: str, mapped_provider: str) -> Artist:
+    """Return a library Artist with a provider mapping to the given provider."""
+    return Artist(
+        item_id="lib1",
+        provider="library",
+        name=name,
+        provider_mappings={
+            ProviderMapping(
+                item_id="artist1",
+                provider_domain=mapped_provider,
+                provider_instance=mapped_provider,
+            )
+        },
+    )
+
+
+def _make_search_provider(instance_id: str, domain: str | None = None) -> Mock:
     """Return a mocked music provider that supports search."""
     prov = Mock(spec=MusicProvider)
     prov.instance_id = instance_id
-    prov.domain = instance_id
+    prov.domain = domain or instance_id
     prov.name = instance_id
     prov.supported_features = {ProviderFeature.SEARCH}
     prov.search = AsyncMock(return_value=SearchResults())
@@ -51,6 +75,29 @@ def _make_controller(providers: list[Mock]) -> MusicController:
             (p for p in providers if p.instance_id == instance_id), None
         )
     )
+    # mimic the task_id deduplication behavior of the real create_task implementation
+    tracked_tasks: dict[str, asyncio.Task[Any]] = {}
+
+    def _create_task(
+        target: Any, *_args: Any, task_id: str | None = None, **_kwargs: Any
+    ) -> asyncio.Task[Any]:
+        if task_id and (existing := tracked_tasks.get(task_id)) and not existing.done():
+            target.close()
+            return existing
+        task = asyncio.get_running_loop().create_task(target)
+
+        def _task_done(_task: asyncio.Task[Any]) -> None:
+            if task_id:
+                tracked_tasks.pop(task_id, None)
+            if not _task.cancelled():
+                _task.exception()
+
+        task.add_done_callback(_task_done)
+        if task_id:
+            tracked_tasks[task_id] = task
+        return task
+
+    mass.create_task = Mock(side_effect=_create_task)
     controller = MusicController.__new__(MusicController)
     controller.mass = mass
     controller.domain = "music"
@@ -62,14 +109,27 @@ def _make_controller(providers: list[Mock]) -> MusicController:
     return controller
 
 
-async def test_search_provider_returns_empty_on_provider_error() -> None:
-    """A provider error during search yields empty results instead of raising."""
+def _cache_writes(controller: MusicController, provider: str) -> list[Any]:
+    """Return the cache.set calls made for the given provider."""
+    cache_set = cast("AsyncMock", controller.mass.cache.set)
+    return [call for call in cache_set.await_args_list if call.kwargs.get("provider") == provider]
+
+
+async def _wait_for(condition: Callable[[], bool], timeout: float = 1.0) -> None:
+    """Wait until the given condition is true."""
+    async with asyncio.timeout(timeout):
+        while not condition():
+            await asyncio.sleep(0.01)
+
+
+async def test_search_provider_returns_none_on_provider_error() -> None:
+    """A provider error during search yields None instead of raising."""
     prov = _make_search_provider("prov_a")
     controller = _make_controller([prov])
     for error in (MusicAssistantError("rate limited"), ValueError("unexpected")):
         prov.search.side_effect = error
         result = await controller._search_provider("query", "prov_a", [MediaType.TRACK])
-        assert result == SearchResults()
+        assert result is None
 
 
 async def test_global_search_returns_partial_results_when_provider_fails() -> None:
@@ -86,3 +146,222 @@ async def test_global_search_returns_partial_results_when_provider_fails() -> No
 
     assert [track.item_id for track in result.tracks] == ["track1"]
     prov_bad.search.assert_awaited_once()
+    # an incomplete result may not be cached so the failed provider is retried
+    assert not _cache_writes(controller, "music")
+
+
+async def test_global_search_soft_timeout_returns_partial_and_caches_late(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slow provider is not awaited beyond the soft timeout but still caches its result."""
+    monkeypatch.setattr(
+        "music_assistant.controllers.music.controller.SEARCH_PROVIDER_SOFT_TIMEOUT", 0.1
+    )
+    prov_fast = _make_search_provider("prov_fast")
+    prov_fast.search.return_value = SearchResults(
+        tracks=[_make_track("track1", "prov_fast", "My Song")]
+    )
+    prov_slow = _make_search_provider("prov_slow")
+    slow_results = SearchResults(tracks=[_make_track("track2", "prov_slow", "My Song")])
+
+    async def _slow_search(*_args: Any, **_kwargs: Any) -> SearchResults:
+        await asyncio.sleep(0.5)
+        return slow_results
+
+    prov_slow.search.side_effect = _slow_search
+    controller = _make_controller([prov_fast, prov_slow])
+
+    start = time.monotonic()
+    result = await controller.search("My Song", media_types=[MediaType.TRACK], limit=5)
+    duration = time.monotonic() - start
+
+    # the search returned within the soft timeout with the results of the fast provider
+    assert duration < 0.4
+    assert [track.item_id for track in result.tracks] == ["track1"]
+    assert not _cache_writes(controller, "music")
+    # the slow provider search completes in the background and caches its result
+    await _wait_for(lambda: bool(_cache_writes(controller, "prov_slow")))
+    late_writes = _cache_writes(controller, "prov_slow")
+    assert len(late_writes) == 1
+    assert late_writes[0].kwargs["data"] == slow_results.to_dict()
+
+
+async def test_global_search_hard_timeout_aborts_provider_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider search that exceeds the hard timeout is aborted and never cached."""
+    monkeypatch.setattr(
+        "music_assistant.controllers.music.controller.SEARCH_PROVIDER_SOFT_TIMEOUT", 0.05
+    )
+    monkeypatch.setattr(
+        "music_assistant.controllers.music.controller.SEARCH_PROVIDER_HARD_TIMEOUT", 0.1
+    )
+    prov_hung = _make_search_provider("prov_hung")
+    search_aborted = asyncio.Event()
+
+    async def _hung_search(*_args: Any, **_kwargs: Any) -> SearchResults:
+        try:
+            await asyncio.sleep(5)
+        finally:
+            search_aborted.set()
+        return SearchResults()
+
+    prov_hung.search.side_effect = _hung_search
+    controller = _make_controller([prov_hung])
+
+    result = await controller.search("My Song", media_types=[MediaType.TRACK], limit=5)
+
+    assert result.tracks == []
+    # the hard timeout cancels the provider search and nothing is cached
+    await _wait_for(search_aborted.is_set)
+    cache_set = cast("AsyncMock", controller.mass.cache.set)
+    assert not cache_set.await_args_list
+
+
+async def test_search_provider_cache_hit_avoids_provider_call() -> None:
+    """A cached provider result is served without hitting the provider again."""
+    prov = _make_search_provider("prov_a")
+    controller = _make_controller([prov])
+    cached_results = SearchResults(tracks=[_make_track("track1", "prov_a", "My Song")])
+
+    async def _fake_cache_get(*, provider: str = "default", **_kwargs: Any) -> Any:
+        return cached_results if provider == "prov_a" else None
+
+    controller.mass.cache.get = AsyncMock(side_effect=_fake_cache_get)  # type: ignore[method-assign]
+
+    result = await controller.search("My Song", media_types=[MediaType.TRACK], limit=5)
+
+    assert [track.item_id for track in result.tracks] == ["track1"]
+    prov.search.assert_not_awaited()
+
+
+async def test_concurrent_identical_searches_share_one_provider_call() -> None:
+    """Identical concurrent searches are coalesced into a single provider call."""
+    prov = _make_search_provider("prov_a")
+
+    async def _slowish_search(*_args: Any, **_kwargs: Any) -> SearchResults:
+        await asyncio.sleep(0.05)
+        return SearchResults(tracks=[_make_track("track1", "prov_a", "My Song")])
+
+    prov.search.side_effect = _slowish_search
+    controller = _make_controller([prov])
+
+    result1, result2 = await asyncio.gather(
+        controller.search("My Song", media_types=[MediaType.TRACK], limit=5),
+        controller.search("My Song", media_types=[MediaType.TRACK], limit=5),
+    )
+
+    assert [track.item_id for track in result1.tracks] == ["track1"]
+    assert [track.item_id for track in result2.tracks] == ["track1"]
+    prov.search.assert_awaited_once()
+
+
+async def test_search_dedup_filters_provider_items_already_in_library() -> None:
+    """Provider items that map to a library item are filtered from the results."""
+    library_track = Track(
+        item_id="lib1",
+        provider="library",
+        name="Library Song",
+        provider_mappings={
+            ProviderMapping(
+                item_id="track1",
+                provider_domain="prov_a",
+                provider_instance="prov_a",
+            )
+        },
+    )
+    prov = _make_search_provider("prov_a")
+    prov.search.return_value = SearchResults(
+        tracks=[
+            _make_track("track1", "prov_a", "My Song"),
+            _make_track("track2", "prov_a", "My Song 2"),
+        ]
+    )
+    controller = _make_controller([prov])
+    controller.search_library = AsyncMock(  # type: ignore[method-assign]
+        return_value=SearchResults(tracks=[library_track])
+    )
+
+    result = await controller.search("My Song", media_types=[MediaType.TRACK], limit=5)
+
+    assert [track.item_id for track in result.tracks] == ["lib1", "track2"]
+
+
+async def test_search_providers_param_restricts_search() -> None:
+    """The providers param restricts the search to the given providers."""
+    prov_a = _make_search_provider("prov_a")
+    prov_b = _make_search_provider("spotify--abc", domain="spotify")
+    prov_b.search.return_value = SearchResults(
+        tracks=[_make_track("track1", "spotify--abc", "My Song")]
+    )
+    controller = _make_controller([prov_a, prov_b])
+    controller.search_library = AsyncMock(  # type: ignore[method-assign]
+        return_value=SearchResults(tracks=[_make_track("lib1", "library", "My Song")])
+    )
+
+    # domain match: only the matching provider is searched, library results excluded
+    result = await controller.search(
+        "My Song", media_types=[MediaType.TRACK], limit=5, providers=["spotify"]
+    )
+    assert [track.item_id for track in result.tracks] == ["track1"]
+    prov_a.search.assert_not_awaited()
+    prov_b.search.assert_awaited_once()
+
+    # the special value "library" selects the library only
+    prov_b.search.reset_mock()
+    result = await controller.search(
+        "My Song", media_types=[MediaType.TRACK], limit=5, providers=["library"]
+    )
+    assert [track.item_id for track in result.tracks] == ["lib1"]
+    prov_a.search.assert_not_awaited()
+    prov_b.search.assert_not_awaited()
+
+
+async def test_search_library_only_maps_to_library_provider() -> None:
+    """The deprecated library_only flag behaves as providers=["library"]."""
+    prov = _make_search_provider("prov_a")
+    controller = _make_controller([prov])
+    controller.search_library = AsyncMock(  # type: ignore[method-assign]
+        return_value=SearchResults(tracks=[_make_track("lib1", "library", "My Song")])
+    )
+
+    result = await controller.search(
+        "My Song", media_types=[MediaType.TRACK], limit=5, library_only=True
+    )
+
+    assert [track.item_id for track in result.tracks] == ["lib1"]
+    prov.search.assert_not_awaited()
+
+
+async def test_search_exact_library_match_skips_provider_media_types() -> None:
+    """A (near) exact library match skips searching mapped providers for that media type."""
+    prov = _make_search_provider("prov_a")
+    controller = _make_controller([prov])
+    controller.search_library = AsyncMock(  # type: ignore[method-assign]
+        return_value=SearchResults(artists=[_make_library_artist("Nirvana", "prov_a")])
+    )
+
+    # the only requested media type is covered by the library: skip the provider
+    result = await controller.search("Nirvana", media_types=[MediaType.ARTIST], limit=5)
+    assert [artist.item_id for artist in result.artists] == ["lib1"]
+    prov.search.assert_not_awaited()
+
+    # other media types are still searched on the provider
+    await controller.search("Nirvana", media_types=[MediaType.ARTIST, MediaType.TRACK], limit=5)
+    prov.search.assert_awaited_once()
+    assert prov.search.await_args.args[1] == [MediaType.TRACK]
+
+
+async def test_search_exact_match_shortcut_skipped_for_explicit_providers() -> None:
+    """An explicit providers selection always searches those providers."""
+    prov = _make_search_provider("prov_a")
+    controller = _make_controller([prov])
+    controller.search_library = AsyncMock(  # type: ignore[method-assign]
+        return_value=SearchResults(artists=[_make_library_artist("Nirvana", "prov_a")])
+    )
+
+    await controller.search(
+        "Nirvana", media_types=[MediaType.ARTIST], limit=5, providers=["prov_a"]
+    )
+
+    prov.search.assert_awaited_once()

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -261,6 +261,34 @@ async def test_search_provider_cache_expiration_by_provider_type() -> None:
     assert local_writes[0].kwargs["expiration"] == SEARCH_CACHE_EXPIRATION_LOCAL_PROVIDER
 
 
+async def test_search_provider_without_streaming_attribute_gets_local_expiration() -> None:
+    """Providers lacking is_streaming_provider (e.g. plugins) get the short cache expiration."""
+    prov = _make_search_provider("prov_plugin")
+    del prov.is_streaming_provider
+    prov.search.return_value = SearchResults(
+        tracks=[_make_track("track1", "prov_plugin", "My Song")]
+    )
+    controller = _make_controller([prov])
+
+    result = await controller.search("My Song", media_types=[MediaType.TRACK], limit=5)
+
+    assert [track.item_id for track in result.tracks] == ["track1"]
+    writes = _cache_writes(controller, "prov_plugin")
+    assert writes[0].kwargs["expiration"] == SEARCH_CACHE_EXPIRATION_LOCAL_PROVIDER
+
+
+async def test_search_cache_write_failure_does_not_break_search() -> None:
+    """A failing cache write still returns the provider results."""
+    prov = _make_search_provider("prov_a")
+    prov.search.return_value = SearchResults(tracks=[_make_track("track1", "prov_a", "My Song")])
+    controller = _make_controller([prov])
+    controller.mass.cache.set = AsyncMock(side_effect=RuntimeError("cache boom"))  # type: ignore[method-assign]
+
+    result = await controller.search("My Song", media_types=[MediaType.TRACK], limit=5)
+
+    assert [track.item_id for track in result.tracks] == ["track1"]
+
+
 async def test_concurrent_identical_searches_share_one_provider_call() -> None:
     """Identical concurrent searches are coalesced into a single provider call."""
     prov = _make_search_provider("prov_a")

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -10,7 +10,13 @@ from unittest.mock import AsyncMock, Mock
 
 from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import MusicAssistantError
-from music_assistant_models.media_items import Artist, ProviderMapping, SearchResults, Track
+from music_assistant_models.media_items import (
+    Artist,
+    Genre,
+    ProviderMapping,
+    SearchResults,
+    Track,
+)
 
 from music_assistant.controllers.music import MusicController
 from music_assistant.models.music_provider import MusicProvider
@@ -285,6 +291,22 @@ async def test_search_dedup_filters_provider_items_already_in_library() -> None:
     result = await controller.search("My Song", media_types=[MediaType.TRACK], limit=5)
 
     assert [track.item_id for track in result.tracks] == ["lib1", "track2"]
+
+
+async def test_search_includes_genre_results_from_library() -> None:
+    """Genre results from the library search end up in the combined search result."""
+    library_genre = Genre(
+        item_id="genre1", provider="library", name="Rock", provider_mappings=set()
+    )
+    prov = _make_search_provider("prov_a")
+    controller = _make_controller([prov])
+    controller.search_library = AsyncMock(  # type: ignore[method-assign]
+        return_value=SearchResults(genres=[library_genre])
+    )
+
+    result = await controller.search("Rock", media_types=[MediaType.GENRE], limit=5)
+
+    assert [genre.item_id for genre in result.genres] == ["genre1"]
 
 
 async def test_search_providers_param_restricts_search() -> None:

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -19,6 +19,10 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.controllers.music import MusicController
+from music_assistant.controllers.music.constants import (
+    SEARCH_CACHE_EXPIRATION_LOCAL_PROVIDER,
+    SEARCH_CACHE_EXPIRATION_STREAMING_PROVIDER,
+)
 from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
@@ -66,6 +70,7 @@ def _make_search_provider(instance_id: str, domain: str | None = None) -> Mock:
     prov.domain = domain or instance_id
     prov.name = instance_id
     prov.supported_features = {ProviderFeature.SEARCH}
+    prov.is_streaming_provider = True
     prov.search = AsyncMock(return_value=SearchResults())
     return prov
 
@@ -239,6 +244,21 @@ async def test_search_provider_cache_hit_avoids_provider_call() -> None:
 
     assert [track.item_id for track in result.tracks] == ["track1"]
     prov.search.assert_not_awaited()
+
+
+async def test_search_provider_cache_expiration_by_provider_type() -> None:
+    """Streaming provider results are cached longer than local provider results."""
+    prov_stream = _make_search_provider("prov_stream")
+    prov_local = _make_search_provider("prov_local")
+    prov_local.is_streaming_provider = False
+    controller = _make_controller([prov_stream, prov_local])
+
+    await controller.search("My Song", media_types=[MediaType.TRACK], limit=5)
+
+    stream_writes = _cache_writes(controller, "prov_stream")
+    local_writes = _cache_writes(controller, "prov_local")
+    assert stream_writes[0].kwargs["expiration"] == SEARCH_CACHE_EXPIRATION_STREAMING_PROVIDER
+    assert local_writes[0].kwargs["expiration"] == SEARCH_CACHE_EXPIRATION_LOCAL_PROVIDER
 
 
 async def test_concurrent_identical_searches_share_one_provider_call() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Global search is currently as slow as the slowest provider: one rate-limited or hung provider (Spotify being the usual suspect) stalls the entire search, and the library scan runs serially before the provider fan-out even starts. This PR makes the whole search pipeline parallel, time-bounded and smarter about avoiding needless provider calls.

Changes:

- Per-provider soft timeout (8s): a slow provider no longer blocks the search, its search continues in the background and the result is cached so it is available on the next search (hard cap 120s).
- Identical concurrent searches share a single provider call (in-flight coalescing).
- Per-provider result cache (24h for streaming providers, 15 min for local providers), so repeated/overlapping searches don't re-hit every provider.
- Library search now runs its media type queries in parallel (also fixes genre results never being populated).
- Exact match shortcut: when the library already holds a (near) exact name match mapped to a provider, that provider is skipped for that media type - saves API calls and latency.
- New `providers` parameter on `music/search` to search a subset of providers (or just the library), enabling the frontend to load search results per provider progressively. `library_only` is now deprecated in favor of `providers=["library"]`.
- Combined search results are only cached when all providers actually contributed, so failed/timed out providers are retried.

Measured (3 fast providers ~0.4s, one slow 25s, 300ms library scan):

| | before | after |
|---|---|---|
| search wall time | 25.3s | 8.3s (soft timeout cap) |
| repeat search after slow provider finished | n/a | 0.3s, all results incl. slow provider |
| one provider raising | whole search fails | partial results |

Follow-up ideas (out of scope here): FTS5 index for library substring search, streaming search results per provider over the websocket, fuzzy matching in library search.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.