### PR TITLE
Add audio overlay support to queue playback

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -44,6 +44,7 @@ from music_assistant_models.media_items import (
     PlayableMediaItemType,
     Playlist,
     PodcastEpisode,
+    SoundEffect,
     Track,
 )
 from music_assistant_models.player_queue import PlayerQueue
@@ -343,6 +344,58 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             # upcoming transition (only when the player has already loaded the current track)
             if next_item := self.get_next_item(queue_id, queue.index_in_buffer):
                 self._enqueue_next_item(queue_id, next_item)
+
+    @api_command("player_queues/overlay", required_scope=Scope.QUEUES_CONTROL)
+    async def set_overlay(
+        self,
+        queue_id: str,
+        enabled: bool | None = None,
+        source: str | None = None,
+        volume: int | None = None,
+    ) -> None:
+        """
+        Configure the audio overlay for the given queue.
+
+        The audio overlay mixes a looping sound effect (e.g. rain or white noise)
+        into the queue's audio stream. Changes take effect immediately: if the
+        queue is playing, playback is restarted from the current position.
+
+        :param queue_id: queue_id of the queue to configure.
+        :param enabled: Enable or disable the audio overlay. Omit to leave unchanged.
+        :param source: URI of the sound effect item to mix in. Omit to leave unchanged.
+        :param volume: Overlay loudness relative to the music in percent
+            (0-200, 100 = equally loud). Omit to leave unchanged.
+        """
+        queue = self._queue_data[queue_id].queue
+        changed = audible_change = False
+        if source is not None:
+            item = await self.mass.music.get_item_by_uri(source)
+            if item.media_type != MediaType.SOUND_EFFECT:
+                raise InvalidDataError("Audio overlay source must be a sound effect item")
+            mapping = ItemMapping.from_item(cast("SoundEffect", item))
+            if queue.overlay_source != mapping:
+                queue.overlay_source = mapping
+                changed = True
+                audible_change = queue.overlay_enabled
+        if volume is not None:
+            if not (0 <= volume <= 200):
+                raise InvalidDataError(f"Overlay volume must be between 0 and 200, got {volume}")
+            if queue.overlay_volume != volume:
+                queue.overlay_volume = volume
+                changed = True
+                audible_change |= queue.overlay_enabled
+        if enabled is not None and queue.overlay_enabled != enabled:
+            if enabled and queue.overlay_source is None:
+                raise InvalidCommand("Can not enable audio overlay: no overlay source selected")
+            queue.overlay_enabled = enabled
+            changed = audible_change = True
+        if not changed:
+            return
+        self.signal_update(queue_id)
+        if audible_change and queue.state == PlaybackState.PLAYING:
+            # restart playback from the current position so the change is heard
+            # immediately instead of after the player's audio buffer drains
+            await self.resume(queue_id)
 
     # Two timebases are used in this controller when variable playback speed is in
     # effect (atempo applied server-side):

--- a/music_assistant/controllers/streams/README.md
+++ b/music_assistant/controllers/streams/README.md
@@ -12,6 +12,7 @@ This document provides an overview of the Music Assistant Streams Controller arc
 - [Streaming Pipeline](#streaming-pipeline)
 - [Analyze Callbacks](#analyze-callbacks)
 - [Smart Fades](#smart-fades)
+- [Audio Overlay](#audio-overlay)
 - [Stream Types](#stream-types)
 - [Configuration](#configuration)
 
@@ -23,6 +24,7 @@ The Streams Controller is a core controller that manages all audio streaming to 
 - Volume normalization (dynamic, measurement-based, and fixed gain)
 - Smart crossfading between tracks
 - Flow mode for continuous queue playback
+- Audio overlay: a looping sound effect (e.g. rain) mixed into queue playback
 - Announcement and plugin source streaming
 - Ahead-of-time audio analysis (loudness, beat detection) via buffer callbacks
 
@@ -148,6 +150,25 @@ The smart fades system provides intelligent crossfading between tracks:
 - **Smart Crossfade**: Analyzes audio beats to detect natural fade points
 - **Standard Crossfade**: Fixed-duration overlap crossfade with silence stripping
 - Operates in both flow mode (continuous stream) and per-item mode (gapless playback)
+
+## Audio Overlay
+
+The audio overlay is a per-queue feature (configured via `player_queues/overlay`) that mixes a
+looping sound effect — any `sound_effect` media item offered by a provider — into the queue's
+audio stream:
+
+- Mixing happens once per queue stream (ffmpeg `amix`, overlay looped via `-stream_loop -1`),
+  so all (synced) players consuming the stream hear the identical mix.
+- An active overlay forces flow mode: the overlay must play continuously across track
+  boundaries, which is impossible with per-item stream requests. Radio is the exception —
+  it always plays as a single long-lived stream and is wrapped per-request instead.
+- The internal PCM format is upgraded to F32 (like crossfade/DSP) for clipping-free headroom.
+- Failures degrade gracefully: when the overlay source can not be resolved, playback simply
+  continues without overlay; when the overlay input dies mid-stream, ffmpeg keeps passing
+  the main audio. Music playback is never interrupted by the overlay.
+- Note: audio already sitting in a player's (pre)buffer is unaffected by overlay changes,
+  which is why the queue controller restarts playback on an audible change. For the same
+  reason a seek can momentarily shift the overlay position — acceptable for ambient content.
 
 ## Stream Types
 

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -105,7 +105,7 @@ from music_assistant.helpers.audio import (
     resample_pcm_audio,
 )
 from music_assistant.helpers.dsp import filter_to_ffmpeg_params
-from music_assistant.helpers.ffmpeg import FFMpeg, get_ffmpeg_stream
+from music_assistant.helpers.ffmpeg import FFMpeg, get_ffmpeg_overlay_stream, get_ffmpeg_stream
 from music_assistant.helpers.named_pipe import read_named_pipe
 from music_assistant.helpers.playlists import IsHLSPlaylist, PlaylistItem, fetch_playlist, parse_m3u
 from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER
@@ -189,6 +189,11 @@ def _pcm_formats_match(a: AudioFormat, b: AudioFormat) -> bool:
         and a.bit_depth == b.bit_depth
         and a.channels == b.channels
     )
+
+
+def overlay_active(queue: PlayerQueue) -> bool:
+    """Return True if the given queue has an audio overlay enabled and a source selected."""
+    return queue.overlay_enabled and queue.overlay_source is not None
 
 
 class StreamsAudio:
@@ -1334,6 +1339,7 @@ class StreamsAudio:
         player: Player,
         start_streamdetails: StreamDetails | None = None,
         crossfade_enabled: bool = False,
+        overlay_active: bool = False,
     ) -> AudioFormat:
         """
         Select the internal PCM format for a Queue Flow Mode stream.
@@ -1355,6 +1361,7 @@ class StreamsAudio:
             bit-depth optimization. May be omitted for the fixed-rate modes — when
             omitted the bit depth defaults to F32.
         :param crossfade_enabled: Whether the queue will use crossfade transitions.
+        :param overlay_active: Whether an audio overlay will be mixed into the stream.
         """
         if start_streamdetails is not None and (
             start_streamdetails.media_type == MediaType.AUDIO_SOURCE
@@ -1386,7 +1393,7 @@ class StreamsAudio:
             output_sample_rate = _snap_supported_rate_up(target_rate, supported_sample_rates)
 
         content_type, bit_depth = self._pick_pcm_bit_depth(
-            player, start_streamdetails, crossfade_enabled
+            player, start_streamdetails, crossfade_enabled, overlay_active
         )
         return AudioFormat(
             content_type=content_type,
@@ -2426,6 +2433,38 @@ class StreamsAudio:
             # so it can handle the case where new items were added after the flow stream ended
             self.mass.player_queues.queue_buffer_completed(queue.queue_id)
 
+    async def get_overlay_mixed_stream(
+        self,
+        queue: PlayerQueue,
+        audio_input: AsyncGenerator[bytes],
+        pcm_format: AudioFormat,
+    ) -> AsyncGenerator[bytes]:
+        """
+        Mix the queue's audio overlay (looping sound effect) into the given PCM stream.
+
+        The mixed output has the exact same PCM format, duration and chunking as the
+        input stream. If the overlay source can not be resolved, the original stream
+        is passed through unchanged so playback is never interrupted.
+
+        :param queue: The PlayerQueue holding the overlay source and volume.
+        :param audio_input: The audio stream (raw PCM in ``pcm_format``) to mix into.
+        :param pcm_format: PCM format of both the input and the mixed output.
+        """
+        overlay_input = await self._resolve_overlay_input(queue)
+        if overlay_input is None:
+            # overlay source unavailable: degrade gracefully to music-only
+            async for chunk in audio_input:
+                yield chunk
+            return
+        async for chunk in get_ffmpeg_overlay_stream(
+            audio_input=audio_input,
+            overlay_input=overlay_input,
+            pcm_format=pcm_format,
+            overlay_volume=queue.overlay_volume,
+            chunk_size=pcm_format.pcm_sample_size,
+        ):
+            yield chunk
+
     def crossfade_allowed(
         self,
         queue_item: QueueItem,
@@ -2932,21 +2971,23 @@ class StreamsAudio:
         player: Player,
         streamdetails: StreamDetails | None,
         crossfade_enabled: bool,
+        overlay_active: bool = False,
     ) -> tuple[ContentType, int]:
         """
         Return ``(content_type, bit_depth)`` for an internal PCM stream.
 
-        F32 is chosen when audio processing (crossfade, volume normalization, DSP)
-        will run on the stream — those need the extra headroom to avoid clipping
-        and precision loss. Otherwise the source's native bit depth is reused so
-        we don't waste memory upcasting a 16-bit stream to 32-bit just to pass it
-        through. When the source is unknown (no streamdetails) we fall back to
-        F32 conservatively.
+        F32 is chosen when audio processing (crossfade, audio overlay, volume
+        normalization, DSP) will run on the stream — those need the extra
+        headroom to avoid clipping and precision loss. Otherwise the source's
+        native bit depth is reused so we don't waste memory upcasting a 16-bit
+        stream to 32-bit just to pass it through. When the source is unknown
+        (no streamdetails) we fall back to F32 conservatively.
         """
         if streamdetails is None:
             return INTERNAL_PCM_FORMAT.content_type, INTERNAL_PCM_FORMAT.bit_depth
         needs_headroom = (
             crossfade_enabled
+            or overlay_active
             or streamdetails.volume_normalization_mode != VolumeNormalizationMode.DISABLED
             or self._resolve_player_dsp_config(player).enabled
         )
@@ -3194,3 +3235,39 @@ class StreamsAudio:
             msg = "Radio stream requires at least one URL"
             raise InvalidDataError(msg)
         return [part.path for part in url]
+
+    async def _resolve_overlay_input(self, queue: PlayerQueue) -> str | None:
+        """
+        Resolve the queue's overlay source to a file path or URL for ffmpeg.
+
+        Returns None (with a warning logged) when the source can not be resolved,
+        so the caller can degrade to music-only playback.
+        """
+        if not (mapping := queue.overlay_source):
+            return None
+        try:
+            provider = self.mass.get_provider(mapping.provider)
+            if provider is None:
+                raise MediaNotFoundError(f"Provider {mapping.provider} is not available")
+            provider = cast("MusicProvider", provider)
+            streamdetails = await provider.get_stream_details(
+                mapping.item_id, MediaType.SOUND_EFFECT
+            )
+        except Exception as err:
+            self.logger.warning(
+                "Audio overlay source %s is unavailable (%s) - continuing without overlay",
+                mapping.uri,
+                str(err) or err.__class__.__name__,
+            )
+            return None
+        if streamdetails.stream_type not in (StreamType.LOCAL_FILE, StreamType.HTTP) or not (
+            isinstance(streamdetails.path, str)
+        ):
+            self.logger.warning(
+                "Audio overlay source %s uses unsupported stream type %s "
+                "- continuing without overlay",
+                mapping.uri,
+                streamdetails.stream_type,
+            )
+            return None
+        return streamdetails.path

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlparse
 
 import aiofiles
+import aiofiles.os
 import aiohttp
 import shortuuid
 from aiohttp import ClientConnectorSSLError, ClientResponseError, ClientTimeout
@@ -3268,6 +3269,16 @@ class StreamsAudio:
                 "- continuing without overlay",
                 mapping.uri,
                 streamdetails.stream_type,
+            )
+            return None
+        if streamdetails.stream_type == StreamType.LOCAL_FILE and not await aiofiles.os.path.isfile(
+            streamdetails.path
+        ):
+            # guard against stale sources: feeding a missing file to the mixer would
+            # kill the whole (music) stream instead of just the overlay
+            self.logger.warning(
+                "Audio overlay source %s does not exist - continuing without overlay",
+                streamdetails.path,
             )
             return None
         return streamdetails.path

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -65,7 +65,7 @@ from music_assistant.constants import (
     VERBOSE_LOG_LEVEL,
 )
 from music_assistant.controllers.players.helpers import AnnounceData
-from music_assistant.controllers.streams.audio import StreamsAudio
+from music_assistant.controllers.streams.audio import StreamsAudio, overlay_active
 from music_assistant.controllers.streams.audio_analysis import AudioAnalysisController
 from music_assistant.controllers.streams.constants import (
     CONF_ALLOW_CROSSFADE_SAME_ALBUM,
@@ -431,21 +431,24 @@ class StreamsController(CoreController):
         if not session_id or not queue_item_id:
             raise InvalidDataError("Can not resolve stream URL: Invalid PlayerMedia data")
         queue_id = media.source_id
+        queue = self.mass.player_queues.get(queue_id) if queue_id else None
         crossfade_needs_flow_mode = (
             # crossfade only applies to tracks; if the queue has it enabled but the player(protocol)
             # does not support gapless playback, we need to enforce flow mode
             media.media_type == MediaType.TRACK
-            and queue_id
-            and (queue := self.mass.player_queues.get(queue_id))
+            and queue is not None
             and queue.crossfade_enabled
             and protocol_player
             and not protocol_player.supports_gapless
         )
+        # the audio overlay is mixed into the queue's continuous (flow) stream;
+        # per-item requests would restart the overlay at every track boundary
+        overlay_needs_flow_mode = queue is not None and overlay_active(queue)
         # Determine flow_mode based on the actual player's capabilities.
         # This is done here (just-in-time) because the player's protocol determines this
         flow_mode = (
             protocol_player is not None
-            and (protocol_player.flow_mode or crossfade_needs_flow_mode)
+            and (protocol_player.flow_mode or crossfade_needs_flow_mode or overlay_needs_flow_mode)
             and media.media_type not in (MediaType.RADIO, MediaType.AUDIO_SOURCE)
         )
         base_path = "flow" if flow_mode else "single"
@@ -736,6 +739,10 @@ class StreamsController(CoreController):
                         "float", queue_item.extra_attributes.get("playback_speed", 1.0)
                     ),
                 )
+            if queue_item.media_type == MediaType.RADIO and overlay_active(queue):
+                # radio plays as a single long-lived stream (never in flow mode),
+                # so mix the audio overlay in here
+                audio_input = self.audio.get_overlay_mixed_stream(queue, audio_input, pcm_format)
             # stream the audio
             # this final ffmpeg process in the chain converts raw lossless PCM into
             # the desired output format for the player including any player specific
@@ -888,6 +895,7 @@ class StreamsController(CoreController):
             player,
             start_streamdetails=start_queue_item.streamdetails,
             crossfade_enabled=crossfade_mode != CrossfadeMode.DISABLED,
+            overlay_active=overlay_active(queue),
         )
 
         # work out output format/details
@@ -944,10 +952,13 @@ class StreamsController(CoreController):
         # Mark this player as actively streaming so audio analysis yields CPU to playback
         # for the duration of the flow stream (see audio_analysis.playback_active).
         self._active_output_streams += 1
+        flow_stream = self.audio.get_queue_flow_stream(
+            queue=queue, start_queue_item=start_queue_item, pcm_format=flow_pcm_format
+        )
+        if overlay_active(queue):
+            flow_stream = self.audio.get_overlay_mixed_stream(queue, flow_stream, flow_pcm_format)
         audio_bytes = get_ffmpeg_stream(
-            audio_input=self.audio.get_queue_flow_stream(
-                queue=queue, start_queue_item=start_queue_item, pcm_format=flow_pcm_format
-            ),
+            audio_input=flow_stream,
             input_format=flow_pcm_format,
             output_format=output_format,
             filter_params=self.audio.get_player_filter_params(
@@ -1165,27 +1176,30 @@ class StreamsController(CoreController):
             # or force it if explicitly requested (e.g., for multi-client streaming)
             protocol_player = self.mass.players.get_player(player_id) if player_id else None
             queue_id = media.source_id
+            queue = self.mass.player_queues.get(queue_id)
             crossfade_needs_flow_mode = (
                 # crossfade only applies to tracks; if the queue has it enabled but the
                 # player(protocol) does not support gapless playback, we need to enforce flow mode
                 media.media_type == MediaType.TRACK
-                and queue_id
-                and (queue := self.mass.player_queues.get(queue_id))
+                and queue is not None
                 and queue.crossfade_enabled
                 and protocol_player
                 and not protocol_player.supports_gapless
             )
+            # the audio overlay is mixed into the queue's continuous (flow) stream;
+            # per-item requests would restart the overlay at every track boundary
+            overlay_needs_flow_mode = queue is not None and overlay_active(queue)
             flow_mode = (
                 force_flow_mode
                 or (protocol_player is not None and protocol_player.flow_mode)
                 or crossfade_needs_flow_mode
+                or overlay_needs_flow_mode
             )
             if media.media_type in (MediaType.RADIO, MediaType.AUDIO_SOURCE):
                 # flow_mode for live/infinite streams is pointless
                 flow_mode = False
             if flow_mode:
                 # flow stream request
-                queue = self.mass.player_queues.get(media.source_id)
                 assert queue
                 start_queue_item = self.mass.player_queues.get_item(
                     media.source_id, media.queue_item_id
@@ -1194,6 +1208,10 @@ class StreamsController(CoreController):
                 flow_stream = self.audio.get_queue_flow_stream(
                     queue=queue, start_queue_item=start_queue_item, pcm_format=pcm_format
                 )
+                if overlay_active(queue):
+                    flow_stream = self.audio.get_overlay_mixed_stream(
+                        queue, flow_stream, pcm_format
+                    )
                 if use_flow_stream_buffering:
                     return buffered(flow_stream, buffer_size=30, min_buffer_before_yield=1)
                 return flow_stream
@@ -1207,6 +1225,13 @@ class StreamsController(CoreController):
                     "float", queue_item.extra_attributes.get("playback_speed", 1.0)
                 ),
             )
+            if (
+                queue is not None
+                and queue_item.media_type == MediaType.RADIO
+                and overlay_active(queue)
+            ):
+                # radio plays as a single long-lived stream, so mix the overlay in here
+                inner_stream = self.audio.get_overlay_mixed_stream(queue, inner_stream, pcm_format)
             # mirror the on_source_selected/unselected lifecycle the HTTP route
             # fires, so direct-PCM consumers (AirPlay, Snapcast, UGP) honour the
             # plugin contract too

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -389,6 +389,65 @@ async def get_ffmpeg_stream(
             raise AudioError(log_tail)
 
 
+async def get_ffmpeg_overlay_stream(
+    audio_input: AsyncGenerator[bytes],
+    overlay_input: str,
+    pcm_format: AudioFormat,
+    overlay_volume: int = 100,
+    chunk_size: int | None = None,
+) -> AsyncGenerator[bytes]:
+    """
+    Mix a looping audio overlay into a PCM audio stream.
+
+    The overlay is looped for the full duration of the main stream and the mixed
+    output has the exact same PCM format and duration as the main input. If the
+    overlay input fails mid-stream, the main audio continues unaffected.
+
+    :param audio_input: The main audio stream (raw PCM in ``pcm_format``).
+    :param overlay_input: File path or URL of the overlay audio.
+    :param overlay_volume: Overlay loudness relative to the main audio in
+        percent (100 = equally loud, max 200).
+    :param pcm_format: PCM format of both the main input and the mixed output.
+    :param chunk_size: Optional exact chunk size for the yielded audio.
+    """
+    # the overlay is passed as an extra (first) ffmpeg input, infinitely looped;
+    # the main audio arrives on stdin. amix with duration=first follows the main
+    # input's length, normalize=0 keeps the original levels (no averaging).
+    overlay_input_args = []
+    if overlay_input.startswith("http"):
+        overlay_input_args += [
+            "-reconnect",
+            "1",
+            "-reconnect_delay_max",
+            "10",
+            "-reconnect_streamed",
+            "1",
+        ]
+    overlay_input_args += ["-stream_loop", "-1", "-i", overlay_input]
+    channel_layout = "mono" if pcm_format.channels == 1 else "stereo"
+    filter_complex = (
+        f"[0:a]volume={overlay_volume / 100},"
+        f"aresample={pcm_format.sample_rate},"
+        f"aformat=channel_layouts={channel_layout}[overlay];"
+        "[1:a][overlay]amix=inputs=2:duration=first:normalize=0[mixed]"
+    )
+    async with FFMpeg(
+        audio_input=audio_input,
+        input_format=pcm_format,
+        output_format=pcm_format,
+        extra_input_args=overlay_input_args,
+        extra_output_args=["-filter_complex", filter_complex, "-map", "[mixed]"],
+        collect_log_history=True,
+    ) as ffmpeg_proc:
+        iterator = ffmpeg_proc.iter_chunked(chunk_size) if chunk_size else ffmpeg_proc.iter_any()
+        async for chunk in iterator:
+            yield chunk
+        if ffmpeg_proc.returncode not in (None, 0):
+            # unclean exit of ffmpeg - raise error with log tail
+            log_tail = "\n" + "\n".join(list(ffmpeg_proc.log_history)[-5:])
+            raise AudioError(log_tail)
+
+
 def get_ffmpeg_args(  # noqa: PLR0915
     input_format: AudioFormat,
     output_format: AudioFormat,

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -283,6 +283,7 @@ class SqueezelitePlayer(Player):
             self,
             start_streamdetails=start_queue_item.streamdetails if start_queue_item else None,
             crossfade_enabled=crossfade_enabled,
+            overlay_active=bool(queue and queue.overlay_enabled and queue.overlay_source),
         )
 
         # select audio source, we force flow mode

--- a/tests/controllers/player_queues/test_set_overlay.py
+++ b/tests/controllers/player_queues/test_set_overlay.py
@@ -1,0 +1,132 @@
+"""Tests for PlayerQueuesController.set_overlay."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+from music_assistant_models.enums import PlaybackState
+from music_assistant_models.errors import InvalidCommand, InvalidDataError
+from music_assistant_models.media_items import (
+    ItemMapping,
+    MediaItemType,
+    ProviderMapping,
+    SoundEffect,
+    Track,
+)
+from music_assistant_models.player_queue import PlayerQueue
+
+from music_assistant.controllers.player_queues import PlayerQueuesController
+from music_assistant.controllers.player_queues.state import PlayerQueueData
+
+QUEUE_ID = "q1"
+
+
+def _sound_effect(item_id: str = "rain") -> SoundEffect:
+    """Build a SoundEffect on the 'ambient' provider."""
+    return SoundEffect(
+        item_id=item_id,
+        provider="ambient",
+        name=f"Sound {item_id}",
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain="ambient", provider_instance="ambient")
+        },
+    )
+
+
+def _track() -> Track:
+    """Build a minimal Track (an invalid overlay source)."""
+    return Track(
+        item_id="track1",
+        provider="test",
+        name="Track",
+        provider_mappings={
+            ProviderMapping(item_id="track1", provider_domain="test", provider_instance="test")
+        },
+    )
+
+
+def _controller(resolved_item: MediaItemType | None = None) -> PlayerQueuesController:
+    """Build a bare controller with one queue and the collaborators stubbed out."""
+    ctrl = PlayerQueuesController.__new__(PlayerQueuesController)
+    ctrl.signal_update = Mock()  # type: ignore[method-assign]
+    ctrl.resume = AsyncMock()  # type: ignore[method-assign]
+    ctrl.mass = MagicMock()
+    ctrl.mass.music.get_item_by_uri = AsyncMock(return_value=resolved_item)
+    queue = PlayerQueue(
+        queue_id=QUEUE_ID, active=True, display_name="Queue", available=True, items=0
+    )
+    ctrl._queue_data = {QUEUE_ID: PlayerQueueData(queue=queue)}
+    return ctrl
+
+
+async def test_set_overlay_source_and_enable() -> None:
+    """Setting a source and enabling stores the mapping and signals an update."""
+    ctrl = _controller(resolved_item=_sound_effect())
+    await ctrl.set_overlay(QUEUE_ID, enabled=True, source="ambient://sound_effect/rain")
+    queue = ctrl._queue_data[QUEUE_ID].queue
+    assert queue.overlay_enabled is True
+    assert queue.overlay_source == ItemMapping.from_item(_sound_effect())
+    ctrl.signal_update.assert_called_once_with(QUEUE_ID)  # type: ignore[attr-defined]
+    # queue is idle: no playback restart
+    ctrl.resume.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+async def test_set_overlay_enable_without_source_raises() -> None:
+    """Enabling the overlay without a source selected is rejected."""
+    ctrl = _controller()
+    with pytest.raises(InvalidCommand):
+        await ctrl.set_overlay(QUEUE_ID, enabled=True)
+
+
+async def test_set_overlay_rejects_non_sound_effect_source() -> None:
+    """Only sound effect items are accepted as overlay source."""
+    ctrl = _controller(resolved_item=_track())
+    with pytest.raises(InvalidDataError):
+        await ctrl.set_overlay(QUEUE_ID, source="library://track/1")
+
+
+@pytest.mark.parametrize("volume", [-1, 201])
+async def test_set_overlay_rejects_out_of_range_volume(volume: int) -> None:
+    """Overlay volume outside 0-200 is rejected."""
+    ctrl = _controller()
+    with pytest.raises(InvalidDataError):
+        await ctrl.set_overlay(QUEUE_ID, volume=volume)
+
+
+async def test_set_overlay_restarts_playback_when_playing() -> None:
+    """An audible change while playing restarts playback from the current position."""
+    ctrl = _controller(resolved_item=_sound_effect())
+    queue = ctrl._queue_data[QUEUE_ID].queue
+    queue.state = PlaybackState.PLAYING
+    await ctrl.set_overlay(QUEUE_ID, enabled=True, source="ambient://sound_effect/rain")
+    ctrl.resume.assert_awaited_once_with(QUEUE_ID)  # type: ignore[attr-defined]
+
+
+async def test_set_overlay_inaudible_change_does_not_restart() -> None:
+    """Changing volume while the overlay is disabled never restarts playback."""
+    ctrl = _controller()
+    queue = ctrl._queue_data[QUEUE_ID].queue
+    queue.state = PlaybackState.PLAYING
+    await ctrl.set_overlay(QUEUE_ID, volume=50)
+    assert queue.overlay_volume == 50
+    ctrl.signal_update.assert_called_once_with(QUEUE_ID)  # type: ignore[attr-defined]
+    ctrl.resume.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+async def test_set_overlay_no_change_is_noop() -> None:
+    """A call that changes nothing does not signal or restart anything."""
+    ctrl = _controller()
+    await ctrl.set_overlay(QUEUE_ID, enabled=False, volume=100)
+    ctrl.signal_update.assert_not_called()  # type: ignore[attr-defined]
+    ctrl.resume.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+async def test_set_overlay_disable_keeps_source() -> None:
+    """Disabling the overlay keeps the selected source for later re-enabling."""
+    ctrl = _controller(resolved_item=_sound_effect())
+    await ctrl.set_overlay(QUEUE_ID, enabled=True, source="ambient://sound_effect/rain")
+    await ctrl.set_overlay(QUEUE_ID, enabled=False)
+    queue = ctrl._queue_data[QUEUE_ID].queue
+    assert queue.overlay_enabled is False
+    assert queue.overlay_source is not None

--- a/tests/controllers/streams/test_audio_overlay.py
+++ b/tests/controllers/streams/test_audio_overlay.py
@@ -1,0 +1,128 @@
+"""Tests for the audio overlay mixing in StreamsAudio."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import MediaType, StreamType
+from music_assistant_models.media_items import AudioFormat, ItemMapping
+
+from music_assistant.controllers.streams.audio import StreamsAudio, overlay_active
+
+if TYPE_CHECKING:
+    import pytest
+
+_PCM_FORMAT = AudioFormat(sample_rate=44100, bit_depth=16, channels=2)
+_MUSIC_CHUNKS = [b"chunk1", b"chunk2"]
+_OVERLAY_PATH = "/media/sounds/rain.wav"
+
+
+def _make_streams_audio(provider: MagicMock | None = None) -> StreamsAudio:
+    """Build a StreamsAudio whose mass resolves the overlay provider to the given mock."""
+    mass = MagicMock()
+    mass.get_provider = MagicMock(return_value=provider)
+    return StreamsAudio(mass)
+
+
+def _make_queue(
+    *, enabled: bool = True, source: ItemMapping | None = None, volume: int = 100
+) -> MagicMock:
+    """Build a PlayerQueue double carrying just the overlay fields."""
+    queue = MagicMock()
+    queue.overlay_enabled = enabled
+    queue.overlay_source = source
+    queue.overlay_volume = volume
+    return queue
+
+
+def _make_source_mapping() -> ItemMapping:
+    return ItemMapping(
+        media_type=MediaType.SOUND_EFFECT,
+        item_id="rain",
+        provider="ambient",
+        name="Rain",
+    )
+
+
+async def _music_stream() -> AsyncGenerator[bytes]:
+    for chunk in _MUSIC_CHUNKS:
+        yield chunk
+
+
+# --- overlay_active ---
+
+
+def test_overlay_active() -> None:
+    """The overlay is only active when enabled AND a source is selected."""
+    assert overlay_active(_make_queue(enabled=True, source=_make_source_mapping()))
+    assert not overlay_active(_make_queue(enabled=True, source=None))
+    assert not overlay_active(_make_queue(enabled=False, source=_make_source_mapping()))
+
+
+# --- get_overlay_mixed_stream ---
+
+
+async def test_passthrough_when_provider_unavailable() -> None:
+    """An unavailable overlay provider degrades to unmodified music playback."""
+    audio = _make_streams_audio(provider=None)
+    queue = _make_queue(source=_make_source_mapping())
+    result = [
+        chunk async for chunk in audio.get_overlay_mixed_stream(queue, _music_stream(), _PCM_FORMAT)
+    ]
+    assert result == _MUSIC_CHUNKS
+
+
+async def test_passthrough_when_streamdetails_fail() -> None:
+    """An error resolving the overlay source degrades to unmodified music playback."""
+    provider = MagicMock()
+    provider.get_stream_details = AsyncMock(side_effect=RuntimeError("boom"))
+    audio = _make_streams_audio(provider=provider)
+    queue = _make_queue(source=_make_source_mapping())
+    result = [
+        chunk async for chunk in audio.get_overlay_mixed_stream(queue, _music_stream(), _PCM_FORMAT)
+    ]
+    assert result == _MUSIC_CHUNKS
+
+
+async def test_passthrough_when_stream_type_unsupported() -> None:
+    """An overlay source with a non file/url stream type degrades to unmodified playback."""
+    provider = MagicMock()
+    provider.get_stream_details = AsyncMock(
+        return_value=MagicMock(stream_type=StreamType.CUSTOM, path=None)
+    )
+    audio = _make_streams_audio(provider=provider)
+    queue = _make_queue(source=_make_source_mapping())
+    result = [
+        chunk async for chunk in audio.get_overlay_mixed_stream(queue, _music_stream(), _PCM_FORMAT)
+    ]
+    assert result == _MUSIC_CHUNKS
+
+
+async def test_mixes_when_source_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A resolvable overlay source is handed to the ffmpeg mixer with the queue's volume."""
+    provider = MagicMock()
+    provider.get_stream_details = AsyncMock(
+        return_value=MagicMock(stream_type=StreamType.LOCAL_FILE, path=_OVERLAY_PATH)
+    )
+    audio = _make_streams_audio(provider=provider)
+    queue = _make_queue(source=_make_source_mapping(), volume=55)
+
+    mixer_kwargs: dict[str, Any] = {}
+
+    async def _fake_mixer(**kwargs: Any) -> AsyncGenerator[bytes]:
+        mixer_kwargs.update(kwargs)
+        async for chunk in kwargs["audio_input"]:
+            yield b"mixed:" + chunk
+
+    monkeypatch.setattr(
+        "music_assistant.controllers.streams.audio.get_ffmpeg_overlay_stream", _fake_mixer
+    )
+    result = [
+        chunk async for chunk in audio.get_overlay_mixed_stream(queue, _music_stream(), _PCM_FORMAT)
+    ]
+    assert result == [b"mixed:" + chunk for chunk in _MUSIC_CHUNKS]
+    assert mixer_kwargs["overlay_input"] == _OVERLAY_PATH
+    assert mixer_kwargs["overlay_volume"] == 55
+    assert mixer_kwargs["pcm_format"] is _PCM_FORMAT

--- a/tests/controllers/streams/test_audio_overlay.py
+++ b/tests/controllers/streams/test_audio_overlay.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 _PCM_FORMAT = AudioFormat(sample_rate=44100, bit_depth=16, channels=2)
 _MUSIC_CHUNKS = [b"chunk1", b"chunk2"]
-_OVERLAY_PATH = "/media/sounds/rain.wav"
+_OVERLAY_URL = "http://ambient.example/rain.mp3"
 
 
 def _make_streams_audio(provider: MagicMock | None = None) -> StreamsAudio:
@@ -100,11 +100,25 @@ async def test_passthrough_when_stream_type_unsupported() -> None:
     assert result == _MUSIC_CHUNKS
 
 
+async def test_passthrough_when_local_file_missing() -> None:
+    """An overlay source pointing at a non-existing file degrades to unmodified playback."""
+    provider = MagicMock()
+    provider.get_stream_details = AsyncMock(
+        return_value=MagicMock(stream_type=StreamType.LOCAL_FILE, path="/does/not/exist.wav")
+    )
+    audio = _make_streams_audio(provider=provider)
+    queue = _make_queue(source=_make_source_mapping())
+    result = [
+        chunk async for chunk in audio.get_overlay_mixed_stream(queue, _music_stream(), _PCM_FORMAT)
+    ]
+    assert result == _MUSIC_CHUNKS
+
+
 async def test_mixes_when_source_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
     """A resolvable overlay source is handed to the ffmpeg mixer with the queue's volume."""
     provider = MagicMock()
     provider.get_stream_details = AsyncMock(
-        return_value=MagicMock(stream_type=StreamType.LOCAL_FILE, path=_OVERLAY_PATH)
+        return_value=MagicMock(stream_type=StreamType.HTTP, path=_OVERLAY_URL)
     )
     audio = _make_streams_audio(provider=provider)
     queue = _make_queue(source=_make_source_mapping(), volume=55)
@@ -123,6 +137,6 @@ async def test_mixes_when_source_resolves(monkeypatch: pytest.MonkeyPatch) -> No
         chunk async for chunk in audio.get_overlay_mixed_stream(queue, _music_stream(), _PCM_FORMAT)
     ]
     assert result == [b"mixed:" + chunk for chunk in _MUSIC_CHUNKS]
-    assert mixer_kwargs["overlay_input"] == _OVERLAY_PATH
+    assert mixer_kwargs["overlay_input"] == _OVERLAY_URL
     assert mixer_kwargs["overlay_volume"] == 55
     assert mixer_kwargs["pcm_format"] is _PCM_FORMAT

--- a/tests/controllers/streams/test_flow_format.py
+++ b/tests/controllers/streams/test_flow_format.py
@@ -199,6 +199,21 @@ async def test_select_flow_pcm_format_uses_f32_when_crossfade_enabled() -> None:
 
 
 @pytest.mark.asyncio
+async def test_select_flow_pcm_format_uses_f32_when_overlay_active() -> None:
+    """An active audio overlay requires F32 headroom for clipping-free mixing."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (48000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    streamdetails = _make_streamdetails(sample_rate=44100, bit_depth=16)
+    fmt = await audio.select_flow_pcm_format(
+        player, start_streamdetails=streamdetails, overlay_active=True
+    )
+    assert fmt.bit_depth == 32
+
+
+@pytest.mark.asyncio
 async def test_select_flow_pcm_format_uses_f32_when_volume_normalization_active() -> None:
     """Active volume normalization on the start track triggers F32 headroom."""
     audio = _make_streams_audio()

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import subprocess
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+import pytest
 from music_assistant_models.enums import ContentType
+from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.helpers.ffmpeg import (
     FFMpegStreamInfo,
+    get_ffmpeg_overlay_stream,
     parse_ffmpeg_duration,
     parse_ffmpeg_stream_info,
 )
@@ -158,3 +165,70 @@ def test_parse_duration_unrelated_line_returns_none() -> None:
     """Random log lines must return None."""
     assert parse_ffmpeg_duration("Stream #0:0: Audio: mp3, 44100 Hz") is None
     assert parse_ffmpeg_duration("") is None
+
+
+# -- get_ffmpeg_overlay_stream (end-to-end with a real ffmpeg process) --
+
+_PCM_FORMAT = AudioFormat(
+    content_type=ContentType.PCM_S16LE, sample_rate=44100, bit_depth=16, channels=2
+)
+_BYTES_PER_SECOND = _PCM_FORMAT.pcm_sample_size  # 1 second of PCM audio
+
+
+@pytest.fixture
+def overlay_file(tmp_path: Path) -> Path:
+    """Generate a 1 second sine-tone wav file to use as overlay source."""
+    overlay_path = tmp_path / "overlay.wav"
+    subprocess.run(  # noqa: S603
+        ["ffmpeg", "-f", "lavfi", "-i", "sine=frequency=440:duration=1", str(overlay_path)],  # noqa: S607
+        check=True,
+        capture_output=True,
+    )
+    return overlay_path
+
+
+async def _silence(seconds: int) -> AsyncGenerator[bytes]:
+    """Yield the given amount of seconds of PCM silence in 1-second chunks."""
+    for _ in range(seconds):
+        yield b"\x00" * _BYTES_PER_SECOND
+
+
+async def _collect_chunks(stream: AsyncGenerator[bytes]) -> list[bytes]:
+    return [chunk async for chunk in stream]
+
+
+async def test_overlay_stream_mixes_loops_and_preserves_length(overlay_file: Path) -> None:
+    """The overlay is looped and mixed in while length, format and chunking stay intact."""
+    chunks = await _collect_chunks(
+        get_ffmpeg_overlay_stream(
+            audio_input=_silence(3),
+            overlay_input=str(overlay_file),
+            pcm_format=_PCM_FORMAT,
+            chunk_size=_BYTES_PER_SECOND,
+        )
+    )
+    output = b"".join(chunks)
+    # duration=first: output length exactly matches the 3s main input
+    assert len(output) == 3 * _BYTES_PER_SECOND
+    # all chunks except the last are exactly chunk_size
+    assert all(len(chunk) == _BYTES_PER_SECOND for chunk in chunks[:-1])
+    # the main input was pure silence, so any signal proves the overlay was mixed in;
+    # signal in the third second proves the 1s overlay file was looped
+    assert any(output[:_BYTES_PER_SECOND])
+    assert any(output[2 * _BYTES_PER_SECOND :])
+
+
+async def test_overlay_stream_applies_volume(overlay_file: Path) -> None:
+    """Overlay volume 0% silences the overlay entirely (gain is applied)."""
+    output = b"".join(
+        await _collect_chunks(
+            get_ffmpeg_overlay_stream(
+                audio_input=_silence(1),
+                overlay_input=str(overlay_file),
+                pcm_format=_PCM_FORMAT,
+                overlay_volume=0,
+            )
+        )
+    )
+    assert len(output) == _BYTES_PER_SECOND
+    assert not any(output)


### PR DESCRIPTION
# What does this implement/fix?

Adds the core **audio overlay** feature: a looping sound effect (rain, white noise, etc.) that can be mixed into a queue's playback — building on the sound effect media items introduced in #4669 and reshaping the concept from #3844 into a core queue feature.

Configure it with the new `player_queues/overlay` command: pick any `sound_effect` item as source, set the overlay volume relative to the music (0-200%) and toggle it on/off. Settings persist like shuffle/repeat and changing them while playing restarts playback from the current position so the change is heard immediately.

- New `player_queues/overlay` API command (enable/disable, source, volume) with playback restart on audible changes
- Mixing happens once per queue stream (ffmpeg `amix`, overlay looped infinitely), so synced players hear the identical mix; works for all delivery paths (HTTP flow/single, direct PCM like AirPlay/Sendspin/Squeezelite)
- An active overlay forces flow mode so the overlay plays continuously across track boundaries; radio streams are mixed per-request instead
- Internal PCM format is upgraded to F32 while the overlay is active (same clipping-headroom rule as crossfade/DSP)
- Failures degrade gracefully: an unavailable overlay source never interrupts music playback
- Tests for the mixer (end-to-end with real ffmpeg), format selection, degrade behavior and the new command; streams README updated

A follow-up PR adds a builtin "Ambient Sounds" provider with ready-to-use sounds; the frontend companion adds the queue toggle/picker.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/server/pull/3844

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked: music-assistant/models#295
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
