### PR TITLE
Add diagnostics sections for core controllers and common providers

### DIFF
--- a/music_assistant/controllers/cache/controller.py
+++ b/music_assistant/controllers/cache/controller.py
@@ -95,6 +95,14 @@ class CacheController(CoreController):
         if self.database:
             await self.database.close()
 
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this controller to include in diagnostics reports."""
+        return {
+            "db_schema_version": DB_SCHEMA_VERSION,
+            "db_size_mb": round(await self._get_cache_db_size_mb(), 1),
+            "entries": await self.database.get_count(DB_TABLE_CACHE) if self.database else None,
+        }
+
     async def get(
         self,
         key: str,
@@ -353,6 +361,16 @@ class CacheController(CoreController):
 
     async def _check_oversized_cache(self) -> None:
         """Warn if the cache database exceeds the recommended max size."""
+        db_size_mb = await self._get_cache_db_size_mb()
+        if db_size_mb > MAX_CACHE_DB_SIZE_MB:
+            self.logger.warning(
+                "Cache database size %.2f MB exceeds recommended maximum of %d MB",
+                db_size_mb,
+                MAX_CACHE_DB_SIZE_MB,
+            )
+
+    async def _get_cache_db_size_mb(self) -> float:
+        """Return the on-disk size of the cache database (in MB)."""
         db_path = os.path.join(self.mass.cache_path, "cache.db")
         # also include the write ahead log and shared memory db files
         db_files = [db_path + suffix for suffix in ("", "-wal", "-shm")]
@@ -364,13 +382,7 @@ class CacheController(CoreController):
                     total += Path(path).stat().st_size
             return total / (1024 * 1024)
 
-        db_size_mb = await asyncio.to_thread(_get_db_size)
-        if db_size_mb > MAX_CACHE_DB_SIZE_MB:
-            self.logger.warning(
-                "Cache database size %.2f MB exceeds recommended maximum of %d MB",
-                db_size_mb,
-                MAX_CACHE_DB_SIZE_MB,
-            )
+        return await asyncio.to_thread(_get_db_size)
 
     async def _setup_database(self) -> None:
         """Initialize database."""

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -60,6 +60,7 @@ from music_assistant.controllers.music.constants import (
     CONF_DELETED_PROVIDERS,
     CONF_RESET_DB,
     DATABASE_CLEANUP_TASK_ID,
+    DB_SCHEMA_VERSION,
     MUSIC_SYNC_COMPLETION_CHECK_TASK_ID,
     PROVIDER_MAPPING_CORRECTION_TASK_ID,
     RECOMMENDATIONS_PROVIDER_TIMEOUT,
@@ -101,6 +102,7 @@ if TYPE_CHECKING:
 
     from music_assistant import MusicAssistant
     from music_assistant.controllers.music.media.base import MediaControllerBase
+    from music_assistant.helpers.json import SerializableType
     from music_assistant.models import ProviderInstanceType
     from music_assistant.models.metadata_provider import MetadataProvider
     from music_assistant.models.provider import Provider
@@ -192,6 +194,13 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         """Cleanup on exit."""
         if self._database:
             await self._database.close()
+
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this controller to include in diagnostics reports."""
+        return {
+            "db_schema_version": DB_SCHEMA_VERSION,
+            "sync_tasks_active": len(self.active_sync_tasks),
+        }
 
     async def on_provider_loaded(self, provider: MusicProvider) -> None:
         """Handle logic when a provider is loaded."""

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -93,6 +93,7 @@ if TYPE_CHECKING:
     from music_assistant import MusicAssistant
     from music_assistant.constants import PlaylistPlayableItem
     from music_assistant.controllers.music.recency import RecencyWindows
+    from music_assistant.helpers.json import SerializableType
     from music_assistant.models.player import Player
 
 
@@ -145,6 +146,21 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         for queue in self.all():
             self.mass.cancel_timer(f"save_queue_cache_{queue.queue_id}")
             await self._save_queue_to_cache(queue.queue_id)
+
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this controller to include in diagnostics reports."""
+        queues = [queue_data.queue for queue_data in self._queue_data.values()]
+        by_state: dict[str, int] = {}
+        for queue in queues:
+            by_state[queue.state.value] = by_state.get(queue.state.value, 0) + 1
+        return {
+            "total": len(queues),
+            "active": sum(queue.active for queue in queues),
+            "by_state": by_state,
+            "flow_mode_active": sum(queue.flow_mode for queue in queues),
+            "dynamic_mode_active": sum(queue.is_dynamic for queue in queues),
+            "total_items": sum(queue.items for queue in queues),
+        }
 
     async def get_config_entries(
         self,

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -130,6 +130,7 @@ if TYPE_CHECKING:
     from music_assistant_models.player_queue import PlayerQueue
 
     from music_assistant import MusicAssistant
+    from music_assistant.helpers.json import SerializableType
 
 CACHE_CATEGORY_PLAYER_POWER = 1
 
@@ -276,6 +277,20 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         for player in self._players.values():
             if player.sleep_timer_expires_at is not None:
                 self.mass.cancel_timer(self._sleep_timer_task_id(player.player_id))
+
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this controller to include in diagnostics reports."""
+        players = list(self._players.values())
+        return {
+            "players_synced": sum(player.state.synced_to is not None for player in players),
+            "players_with_active_group": sum(
+                player.state.active_group is not None for player in players
+            ),
+            "announcements_in_progress": sum(
+                bool(player.extra_data.get(ATTR_ANNOUNCEMENT_IN_PROGRESS)) for player in players
+            ),
+            "pending_protocol_evaluations": len(self._pending_protocol_evaluations),
+        }
 
     async def on_provider_loaded(self, provider: PlayerProvider) -> None:
         """Handle logic when a provider is loaded."""

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -35,6 +35,7 @@ from music_assistant_models.errors import (
     MediaNotFoundError,
     ProviderUnavailableError,
 )
+from music_assistant_models.helpers import get_global_cache_value
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.constants import (
@@ -83,8 +84,13 @@ from music_assistant.helpers.audio import (
     store_content_length_in_cache,
 )
 from music_assistant.helpers.buffered_generator import buffered
+from music_assistant.helpers.ffmpeg import (
+    CACHE_ATTR_FFMPEG_VERSION,
+    CACHE_ATTR_LIBSOXR_PRESENT,
+    check_ffmpeg_version,
+    get_ffmpeg_stream,
+)
 from music_assistant.helpers.ffmpeg import LOGGER as FFMPEG_LOGGER
-from music_assistant.helpers.ffmpeg import check_ffmpeg_version, get_ffmpeg_stream
 from music_assistant.helpers.util import (
     format_ip_for_url,
     get_ip_addresses,
@@ -180,6 +186,8 @@ class StreamsController(CoreController):
     async def get_diagnostics(self) -> dict[str, SerializableType]:
         """Return diagnostics info for this controller to include in diagnostics reports."""
         return {
+            "ffmpeg_version": get_global_cache_value(CACHE_ATTR_FFMPEG_VERSION),
+            "libsoxr_support": get_global_cache_value(CACHE_ATTR_LIBSOXR_PRESENT),
             "active_output_streams": self._active_output_streams,
             "active_announcements": len(self.announcements),
         }

--- a/music_assistant/controllers/tasks/controller.py
+++ b/music_assistant/controllers/tasks/controller.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
     from music_assistant_models.config_entries import CoreConfig
 
     from music_assistant import MusicAssistant
+    from music_assistant.helpers.json import SerializableType
 
 
 class TasksController(CoreController):
@@ -96,6 +97,20 @@ class TasksController(CoreController):
         if self._log_handler is not None:
             logging.getLogger().removeHandler(self._log_handler)
             self._log_handler = None
+
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this controller to include in diagnostics reports."""
+        by_status: dict[str, int] = {}
+        for managed in self._tasks.values():
+            status = managed.task_info.status.value
+            by_status[status] = by_status.get(status, 0) + 1
+        return {
+            "total": len(self._tasks),
+            "by_status": by_status,
+            "scheduled": sum(managed.is_scheduled for managed in self._tasks.values()),
+            "pending_queue": len(self._pending_task_ids),
+            "max_concurrent": self._max_concurrent_tasks,
+        }
 
     @api_command("tasks/list", required_scope=Scope.SYSTEM_READ)
     def list_tasks(self) -> list[BackgroundTask]:

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger("ffmpeg")
 MINIMAL_FFMPEG_VERSION = 6
 CACHE_ATTR_LIBSOXR_PRESENT: Final[str] = "libsoxr_present"
+CACHE_ATTR_FFMPEG_VERSION: Final[str] = "ffmpeg_version"
 
 # Regex patterns to extract audio format details from ffmpeg's stderr output.
 # Examples of the lines we parse:
@@ -599,7 +600,9 @@ async def check_ffmpeg_version() -> None:
         )
     libsoxr_support = "enable-libsoxr" in output.decode()
     # use globals as in-memory cache
-    await set_global_cache_values({CACHE_ATTR_LIBSOXR_PRESENT: libsoxr_support})
+    await set_global_cache_values(
+        {CACHE_ATTR_LIBSOXR_PRESENT: libsoxr_support, CACHE_ATTR_FFMPEG_VERSION: version}
+    )
 
     major_version = int("".join(char for char in version.split(".")[0] if not char.isalpha()))
     if major_version < MINIMAL_FFMPEG_VERSION:

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -16,6 +16,7 @@ from zeroconf.asyncio import AsyncServiceInfo
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.datetime import utc
+from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.util import (
     get_ip_pton,
     get_primary_ip_address_from_zeroconf,
@@ -34,6 +35,7 @@ from .constants import (
 )
 from .helpers import convert_airplay_volume, get_model_info
 from .player import AirPlayPlayer
+from .protocols.airplay2 import AirPlay2Stream
 from .sendspin_bridge import SendspinBridgeManager
 
 # TODO: AirPlay provider
@@ -132,6 +134,20 @@ class AirPlayProvider(PlayerProvider):
         # shutdown DACP zeroconf service
         if self._dacp_info:
             await self.mass.discovery.aiozc.async_unregister_service(self._dacp_info)
+
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this provider to include in diagnostics reports."""
+        streams_by_type: dict[str, int] = {}
+        for player in self.get_players():
+            if not (player.stream and player.stream.running):
+                continue
+            stream_type = "airplay2" if isinstance(player.stream, AirPlay2Stream) else "raop"
+            streams_by_type[stream_type] = streams_by_type.get(stream_type, 0) + 1
+        return {
+            "dacp_server_running": self._dacp_server.is_serving(),
+            "active_streams": sum(streams_by_type.values()),
+            "streams_by_type": streams_by_type,
+        }
 
     def get_players(self) -> list[AirPlayPlayer]:
         """Return all airplay players belonging to this instance."""

--- a/music_assistant/providers/chromecast/provider.py
+++ b/music_assistant/providers/chromecast/provider.py
@@ -19,6 +19,7 @@ from music_assistant.constants import (
     CONF_ENTRY_MANUAL_DISCOVERY_IPS,
     VERBOSE_LOG_LEVEL,
 )
+from music_assistant.helpers.json import SerializableType
 from music_assistant.models.player_provider import PlayerProvider
 
 from .constants import MULTICHANNEL_RECHECK_INTERVAL
@@ -106,6 +107,25 @@ class ChromecastProvider(PlayerProvider):
                 self._discovery_running = False
 
             await self.mass.loop.run_in_executor(None, stop_discovery)
+
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this provider to include in diagnostics reports."""
+        cast_players = [player for player in self.players if isinstance(player, ChromecastPlayer)]
+        models: dict[str, int] = {}
+        for cast_player in cast_players:
+            model_name = cast_player.cast_info.model_name
+            models[model_name] = models.get(model_name, 0) + 1
+        return {
+            "discovery_running": self._discovery_running,
+            "pending_discoveries": len(self._pending_discoveries),
+            "cast_groups": sum(
+                cast_player.cast_info.is_audio_group for cast_player in cast_players
+            ),
+            "cast_speakers": sum(
+                not cast_player.cast_info.is_audio_group for cast_player in cast_players
+            ),
+            "models": models,
+        }
 
     ### Discovery callbacks
 

--- a/music_assistant/providers/dlna/provider.py
+++ b/music_assistant/providers/dlna/provider.py
@@ -57,7 +57,6 @@ class DLNAPlayerProvider(PlayerProvider):
                 "available": player.available,
                 "eventing": not player.force_poll,
                 "last_seen_age_sec": round(now - player.last_seen),
-                "bootid": player.bootid,
             }
             for player in self.players
             if isinstance(player, DLNAPlayer)

--- a/music_assistant/providers/dlna/provider.py
+++ b/music_assistant/providers/dlna/provider.py
@@ -1,6 +1,7 @@
 """DLNA Player Provider."""
 
 import asyncio
+import time
 from typing import TYPE_CHECKING
 
 from async_upnp_client.aiohttp import AiohttpSessionRequester
@@ -8,6 +9,7 @@ from async_upnp_client.client_factory import UpnpFactory
 from music_assistant_models.player import DeviceInfo
 
 from music_assistant.constants import CONF_PLAYERS
+from music_assistant.helpers.json import SerializableType
 from music_assistant.models.player_provider import PlayerProvider
 
 from .helpers import DLNANotifyServer
@@ -44,6 +46,26 @@ class DLNAPlayerProvider(PlayerProvider):
         """
         self.mass.streams.unregister_dynamic_route("/notify", "NOTIFY")
         self._ignored_udns = set()
+
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this provider to include in diagnostics reports."""
+        now = time.time()
+        devices: list[SerializableType] = [
+            {
+                "model": player.device_info.model,
+                "manufacturer": player.device_info.manufacturer,
+                "available": player.available,
+                "eventing": not player.force_poll,
+                "last_seen_age_sec": round(now - player.last_seen),
+                "bootid": player.bootid,
+            }
+            for player in self.players
+            if isinstance(player, DLNAPlayer)
+        ]
+        return {
+            "ignored_devices": len(self._ignored_udns),
+            "devices": devices,
+        }
 
     async def on_upnp_service_discovered(
         self, search_target: str, discovery_info: CaseInsensitiveDict

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -73,7 +73,7 @@ from music_assistant.controllers.tasks.context import (
     update_current_task_progress_text,
 )
 from music_assistant.helpers.compare import compare_strings, create_safe_string
-from music_assistant.helpers.json import json_loads
+from music_assistant.helpers.json import SerializableType, json_loads
 from music_assistant.helpers.playlists import parse_m3u, parse_pls
 from music_assistant.helpers.tags import AudioTags, async_parse_tags, split_items
 from music_assistant.helpers.util import (
@@ -139,6 +139,7 @@ if TYPE_CHECKING:
 
 isdir = wrap(os.path.isdir)
 isfile = wrap(os.path.isfile)
+ismount = wrap(os.path.ismount)
 exists = wrap(os.path.exists)
 makedirs = wrap(os.makedirs)
 scandir = wrap(os.scandir)
@@ -259,6 +260,14 @@ class LocalFileSystemProvider(MusicProvider):
                 translation_args=[self.base_path],
             )
         await self.check_write_access()
+
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this provider to include in diagnostics reports."""
+        return {
+            "sync_running": self.sync_running,
+            "write_access": self.write_access,
+            "content_type": self.media_content_type,
+        }
 
     async def search(
         self,

--- a/music_assistant/providers/filesystem_nfs/provider.py
+++ b/music_assistant/providers/filesystem_nfs/provider.py
@@ -8,10 +8,12 @@ from pathlib import PurePosixPath
 from music_assistant_models.errors import SetupFailedError
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
+from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.process import check_output
 from music_assistant.providers.filesystem_local import (
     LocalFileSystemProvider,
     exists,
+    ismount,
     makedirs,
 )
 
@@ -58,6 +60,13 @@ class NFSFileSystemProvider(LocalFileSystemProvider):
         Called when provider is deregistered (e.g. MA exiting or config reloading).
         """
         await self.unmount(ignore_error=True)
+
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this provider to include in diagnostics reports."""
+        return {
+            **await super().get_diagnostics(),
+            "mounted": await ismount(self.base_path),
+        }
 
     async def mount(self) -> None:
         """Mount the NFS export to a temporary folder."""

--- a/music_assistant/providers/filesystem_smb/__init__.py
+++ b/music_assistant/providers/filesystem_smb/__init__.py
@@ -12,9 +12,15 @@ from music_assistant_models.enums import ConfigEntryType
 from music_assistant_models.errors import LoginFailed
 
 from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME, VERBOSE_LOG_LEVEL
+from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.process import check_output
 from music_assistant.helpers.util import get_ip_from_host
-from music_assistant.providers.filesystem_local import LocalFileSystemProvider, exists, makedirs
+from music_assistant.providers.filesystem_local import (
+    LocalFileSystemProvider,
+    exists,
+    ismount,
+    makedirs,
+)
 from music_assistant.providers.filesystem_local.constants import (
     CONF_ENTRY_CONTENT_TYPE,
     CONF_ENTRY_CONTENT_TYPE_READ_ONLY,
@@ -195,6 +201,13 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
         Called when provider is deregistered (e.g. MA exiting or config reloading).
         """
         await self.unmount(ignore_error=True)
+
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this provider to include in diagnostics reports."""
+        return {
+            **await super().get_diagnostics(),
+            "mounted": await ismount(self.base_path),
+        }
 
     async def mount(self) -> None:
         """Mount the SMB location to a temporary folder."""

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -45,6 +45,7 @@ from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.constants import MASS_LOGO_ONLINE, VERBOSE_LOG_LEVEL
 from music_assistant.helpers.auth import AuthenticationHelper
+from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.util import try_parse_int
 from music_assistant.models.plugin import PluginProvider
 
@@ -375,6 +376,15 @@ class HomeAssistantProvider(PluginProvider):
         if self._listen_task and not self._listen_task.done():
             self._listen_task.cancel()
         await self.hass.disconnect()
+
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this provider to include in diagnostics reports."""
+        return {
+            "connected": self.hass.connected,
+            "ha_version": self.hass.version,
+            "listener_active": self._listen_task is not None and not self._listen_task.done(),
+            "player_controls": len(self._player_controls) if self._player_controls else 0,
+        }
 
     async def get_device_by_connection(
         self,

--- a/music_assistant/providers/snapcast/provider.py
+++ b/music_assistant/providers/snapcast/provider.py
@@ -21,6 +21,7 @@ from zeroconf.asyncio import AsyncServiceInfo
 
 from music_assistant.constants import CONF_ENABLED
 from music_assistant.helpers.compare import create_safe_string
+from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.process import AsyncProcess
 from music_assistant.helpers.util import get_ip_pton
 from music_assistant.models.player_provider import PlayerProvider
@@ -185,6 +186,20 @@ class SnapCastProvider(PlayerProvider):
 
         self._snapserver.stop()
         await self._stop_builtin_server()
+
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this provider to include in diagnostics reports."""
+        return {
+            "builtin_server": self._use_builtin_server,
+            "builtin_server_started": (
+                self._snapserver_started.is_set() if self._snapserver_started else None
+            ),
+            "clients_total": len(self._snapserver.clients),
+            "clients_connected": sum(client.connected for client in self._snapserver.clients),
+            "groups": len(self._snapserver.groups),
+            "streams": len(self._snapserver.streams),
+            "ma_streams": len(self._snapcast_ma_streams),
+        }
 
     async def refresh_server_status(self) -> None:
         """

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -22,6 +22,7 @@ from music_assistant.constants import (
     VERBOSE_LOG_LEVEL,
 )
 from music_assistant.helpers.audio import get_mime_type
+from music_assistant.helpers.json import SerializableType
 from music_assistant.models.player_provider import PlayerProvider
 
 from .helpers import get_primary_ip_address
@@ -65,6 +66,25 @@ class SonosPlayerProvider(PlayerProvider):
     async def unload(self, is_removed: bool = False) -> None:
         """Handle close/cleanup of the provider."""
         self.mass.streams.unregister_dynamic_route("/sonos_queue/*")
+
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this provider to include in diagnostics reports."""
+        sonos_players = [player for player in self.players if isinstance(player, SonosPlayer)]
+        # active_output_protocol holds "native" or the player id of the protocol player in use
+        active_protocols = [
+            player.active_output_protocol
+            for player in sonos_players
+            if player.active_output_protocol
+        ]
+        return {
+            "speakers_total": len(sonos_players),
+            "speakers_connected": sum(player.connected for player in sonos_players),
+            "coordinators": sum(
+                player.client.player.is_coordinator for player in sonos_players if player.connected
+            ),
+            "native_playback": sum(protocol == "native" for protocol in active_protocols),
+            "protocol_playback": sum(protocol != "native" for protocol in active_protocols),
+        }
 
     async def on_mdns_service_state_change(
         self, name: str, state_change: ServiceStateChange, info: AsyncServiceInfo | None

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -48,7 +48,7 @@ from orjson import JSONDecodeError
 
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.app_vars import app_var
-from music_assistant.helpers.json import json_loads
+from music_assistant.helpers.json import SerializableType, json_loads
 from music_assistant.helpers.process import check_output
 from music_assistant.helpers.throttle_retry import ThrottlerManager, throttle_with_retries
 from music_assistant.helpers.util import lock
@@ -162,6 +162,20 @@ class SpotifyProvider(MusicProvider):
         if self._sp_user:
             return str(self._sp_user["display_name"])
         return None
+
+    async def get_diagnostics(self) -> dict[str, SerializableType]:
+        """Return diagnostics info for this provider to include in diagnostics reports."""
+        return {
+            "logged_in": self._sp_user is not None,
+            "token_expires_in_sec": (
+                round(self._auth_info_global["expires_at"] - time.time())
+                if self._auth_info_global
+                else None
+            ),
+            "dev_session_active": self.dev_session_active,
+            "librespot_available": self._librespot_bin is not None,
+            "audiobooks_supported": self._audiobooks_supported,
+        }
 
     ## Library retrieval methods (generators)
     async def get_library_artists(self) -> AsyncGenerator[Artist]:

--- a/tests/core/test_diagnostics.py
+++ b/tests/core/test_diagnostics.py
@@ -257,6 +257,13 @@ async def test_get_report(mass: MusicAssistant) -> None:
     )
     # streams controller contributes its section through the get_diagnostics hook
     assert "active_output_streams" in report["sections"]["core.streams"]
+    assert "ffmpeg_version" in report["sections"]["core.streams"]
+    # core controllers each contribute their own section
+    assert "db_schema_version" in report["sections"]["core.music"]
+    assert "by_state" in report["sections"]["core.player_queues"]
+    assert "players_synced" in report["sections"]["core.players"]
+    assert "by_status" in report["sections"]["core.tasks"]
+    assert "db_size_mb" in report["sections"]["core.cache"]
     # log tail is opt-in
     assert "log_tail" not in report
     report_with_tail = await mass.diagnostics.get_report(include_log_tail=True)


### PR DESCRIPTION
# What does this implement/fix?

The diagnostics report (#4652) so far only contains a section from the streams controller. This adds diagnostics sections for the core controllers and the most issue-prone providers, so support requests come with the state we usually have to ask for: is a sync stuck, is the token expired, is the speaker's websocket connected, is ffmpeg too old, is the share mounted.

All sections follow the privacy rules of the report: only counts, booleans, durations and model/format names — no media titles, paths, hostnames or credentials.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Summary of changes

- Core: music (db schema version, active syncs), player queues (states, flow/dynamic mode, item counts), players (sync groups, announcements, pending protocol evaluations), tasks (status counts, pending queue), cache (db size, entry count)
- Streams: report the ffmpeg version and libsoxr support (version was already parsed at startup, now also cached)
- Spotify: login state, token expiry, librespot availability
- Sonos: connected speakers, coordinators, native vs protocol playback
- AirPlay: DACP server state, active streams by protocol (RAOP/AirPlay2)
- Snapcast: builtin vs external server, client/group/stream counts
- Home Assistant: connection state, HA version, listener health
- Chromecast: discovery state, groups vs speakers, device models
- DLNA: per-device model, eventing vs poll mode, last-seen age
- Filesystem (local/SMB/NFS): sync running, write access, content type, mount state

## Possible follow-ups (not in this PR)

Smaller-value sections deliberately left out to keep this PR focused: discovery (zeroconf state), config (pending saves/encryption state), webserver (sendspin proxy state), metadata (throttle window), squeezelite, spotify_connect, heos/plex/musiccast/mpd.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

