### PR TITLE
Faster library browsing: slim summary mode for list endpoints

### DIFF
--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -11,6 +11,7 @@ from music_assistant_models.enums import AlbumType, ExternalID, MediaType, Provi
 from music_assistant_models.errors import InvalidDataError, MediaNotFoundError, MusicAssistantError
 from music_assistant_models.media_items import (
     Album,
+    AlbumSummary,
     Artist,
     ItemMapping,
     MediaItemImage,
@@ -35,6 +36,8 @@ from music_assistant.models.music_provider import MusicProvider
 from .base import MediaControllerBase
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from music_assistant import MusicAssistant
 
 
@@ -44,6 +47,7 @@ class AlbumsController(MediaControllerBase[Album]):
     db_table = DB_TABLE_ALBUMS
     media_type = MediaType.ALBUM
     item_cls = Album
+    summary_item_cls = AlbumSummary
 
     def __init__(self, mass: MusicAssistant) -> None:
         """Initialize class."""
@@ -64,18 +68,7 @@ class AlbumsController(MediaControllerBase[Album]):
         SELECT
             albums.*,
             {self._external_ids_query()} AS external_ids,
-            (SELECT JSON_GROUP_ARRAY(
-                json_object(
-                'item_id', album_pm.provider_item_id,
-                    'provider_domain', album_pm.provider_domain,
-                        'provider_instance', album_pm.provider_instance,
-                        'available', album_pm.available,
-                        'audio_format', json(album_pm.audio_format),
-                        'url', album_pm.url,
-                        'details', album_pm.details,
-                        'in_library', album_pm.in_library,
-                        'is_unique', album_pm.is_unique
-                )) FROM provider_mappings album_pm WHERE album_pm.item_id = albums.item_id AND album_pm.media_type = 'album') AS provider_mappings,
+            {self._provider_mappings_query()} AS provider_mappings,
             (SELECT JSON_GROUP_ARRAY(
                 json_object(
                 'item_id', artists.item_id,
@@ -84,6 +77,21 @@ class AlbumsController(MediaControllerBase[Album]):
                     'sort_name', artists.sort_name,
                     'media_type', 'artist'
                 )) FROM artists JOIN album_artists on album_artists.album_id = albums.item_id  WHERE artists.item_id = album_artists.artist_id) AS artists
+            FROM albums"""
+        return query, {}
+
+    @property
+    def summary_query(self) -> tuple[str, dict[str, Any]]:
+        """Return the slim SELECT query used for album summary listings."""
+        artists_query = self._artist_mappings_summary_query(DB_TABLE_ALBUM_ARTISTS, "album_id")
+        query = f"""
+        SELECT
+            {self._summary_base_columns()},
+            albums.version,
+            albums.year,
+            albums.album_type,
+            {self._provider_mappings_summary_query()} AS provider_mappings,
+            {artists_query} AS artists
             FROM albums"""
         return query, {}
 
@@ -129,6 +137,8 @@ class AlbumsController(MediaControllerBase[Album]):
         genre: int | list[int] | None = None,
         played_only: bool = False,
         album_types: list[AlbumType] | None = None,
+        *,
+        summary: bool = False,
         **kwargs: Any,
     ) -> list[Album]:
         """
@@ -142,6 +152,8 @@ class AlbumsController(MediaControllerBase[Album]):
         :param provider: Filter by provider instance ID (single string or list).
         :param album_types: Filter by album types.
         :param genre: Filter by genre id(s).
+        :param summary: Return slim summary items (only the fields needed for a list view)
+            instead of full items.
         """
         extra_query_params: dict[str, Any] = {}
         extra_query_parts: list[str] = []
@@ -189,6 +201,7 @@ class AlbumsController(MediaControllerBase[Album]):
             extra_join_parts=extra_join_parts,
             played_only=played_only,
             in_library_only=True,
+            summary=summary,
         )
 
         # Calculate how many more items we need to reach the original limit
@@ -217,6 +230,7 @@ class AlbumsController(MediaControllerBase[Album]):
                 extra_query_params=extra_query_params,
                 extra_join_parts=extra_join_parts,
                 in_library_only=True,
+                summary=summary,
             ):
                 # prevent duplicates (when artist is also in the title)
                 if album.uri not in existing_uris:
@@ -665,3 +679,12 @@ class AlbumsController(MediaControllerBase[Album]):
                 "disc_number": track.disc_number,
             },
         )
+
+    def _parse_summary_row(self, db_row: Mapping[str, Any]) -> AlbumSummary:
+        """Parse a raw summary db row into an AlbumSummary object."""
+        item = cast("AlbumSummary", super()._parse_summary_row(db_row))
+        item.version = db_row["version"] or ""
+        item.year = db_row["year"]
+        item.album_type = AlbumType(db_row["album_type"])
+        item.artists = self._parse_summary_artist_mappings(db_row)
+        return item

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -23,6 +23,7 @@ from music_assistant_models.errors import (
 from music_assistant_models.media_items import (
     Album,
     Artist,
+    ArtistSummary,
     Audiobook,
     ItemMapping,
     ProviderMapping,
@@ -51,6 +52,8 @@ from music_assistant.models.music_provider import MusicProvider
 from .base import MediaControllerBase
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from music_assistant import MusicAssistant
     from music_assistant.models.metadata_provider import MetadataProvider
 
@@ -61,6 +64,7 @@ class ArtistsController(MediaControllerBase[Artist]):
     db_table = DB_TABLE_ARTISTS
     media_type = MediaType.ARTIST
     item_cls = Artist
+    summary_item_cls = ArtistSummary
 
     def __init__(self, mass: MusicAssistant) -> None:
         """Initialize class."""
@@ -91,6 +95,17 @@ class ArtistsController(MediaControllerBase[Artist]):
             required_scope=Scope.LIBRARY_READ,
         )
 
+    @property
+    def summary_query(self) -> tuple[str, dict[str, Any]]:
+        """Return the slim SELECT query used for artist summary listings."""
+        query = f"""
+        SELECT
+            {self._summary_base_columns()},
+            artists.artist_type,
+            {self._provider_mappings_summary_query()} AS provider_mappings
+            FROM artists"""
+        return query, {}
+
     async def library_count(
         self,
         favorite_only: bool = False,
@@ -113,7 +128,7 @@ class ArtistsController(MediaControllerBase[Artist]):
             sql_query += f" WHERE {' AND '.join(query_parts)}"
         return await self.mass.music.database.get_count_from_query(sql_query)
 
-    async def library_items(
+    async def library_items(  # noqa: PLR0913
         self,
         favorite: bool | None = None,
         search: str | None = None,
@@ -125,6 +140,8 @@ class ArtistsController(MediaControllerBase[Artist]):
         played_only: bool = False,
         album_artists_only: bool = False,
         artist_type: ArtistType | None = None,
+        *,
+        summary: bool = False,
         **kwargs: Any,
     ) -> list[Artist]:
         """
@@ -139,6 +156,8 @@ class ArtistsController(MediaControllerBase[Artist]):
         :param album_artists_only: Only return artists that have albums.
         :param genre: Filter by genre id(s).
         :param artist_type: The artist's type
+        :param summary: Return slim summary items (only the fields needed for a list view)
+            instead of full items.
         """
         extra_query_params: dict[str, Any] = {}
         extra_query_parts: list[str] = []
@@ -161,6 +180,7 @@ class ArtistsController(MediaControllerBase[Artist]):
             extra_query_params=extra_query_params,
             played_only=played_only,
             in_library_only=True,
+            summary=summary,
         )
 
     async def tracks(
@@ -1098,3 +1118,9 @@ class ArtistsController(MediaControllerBase[Artist]):
                 provider_filter=[provider_instance_id_or_domain],
             )
         return []
+
+    def _parse_summary_row(self, db_row: Mapping[str, Any]) -> ArtistSummary:
+        """Parse a raw summary db row into an ArtistSummary object."""
+        item = cast("ArtistSummary", super()._parse_summary_row(db_row))
+        item.artist_type = ArtistType(db_row["artist_type"])
+        return item

--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from json import loads as json_loads
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import ArtistType, MediaType, ProviderFeature
 from music_assistant_models.media_items import (
     Artist,
     Audiobook,
+    AudiobookSummary,
     ItemMapping,
+    ItemMappingSummary,
     ProviderMapping,
     UniqueList,
 )
@@ -52,6 +54,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
     db_table = DB_TABLE_AUDIOBOOKS
     media_type = MediaType.AUDIOBOOK
     item_cls = Audiobook
+    summary_item_cls = AudiobookSummary
 
     def __init__(self, mass: MusicAssistant) -> None:
         """Initialize class."""
@@ -85,18 +88,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         SELECT
             audiobooks.*,
             {self._external_ids_query()} AS external_ids,
-            (SELECT JSON_GROUP_ARRAY(
-                json_object(
-                'item_id', audiobook_pm.provider_item_id,
-                    'provider_domain', audiobook_pm.provider_domain,
-                        'provider_instance', audiobook_pm.provider_instance,
-                        'available', audiobook_pm.available,
-                        'audio_format', json(audiobook_pm.audio_format),
-                        'url', audiobook_pm.url,
-                        'details', audiobook_pm.details,
-                        'in_library', audiobook_pm.in_library,
-                        'is_unique', audiobook_pm.is_unique
-                )) FROM provider_mappings audiobook_pm WHERE audiobook_pm.item_id = audiobooks.item_id AND audiobook_pm.media_type = 'audiobook') AS provider_mappings,
+            {self._provider_mappings_query()} AS provider_mappings,
             (SELECT JSON_GROUP_ARRAY(
                 json_object(
                  'item_id', artists.item_id,
@@ -119,6 +111,43 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             """
         return query, params
 
+    @property
+    def summary_query(self) -> tuple[str, dict[str, Any]]:
+        """
+        Return the slim SELECT query used for audiobook summary listings.
+
+        Joins the playlog table the same way as the base query to hydrate the
+        per-user resume info (fully_played, resume_position_ms).
+        """
+        params: dict[str, Any] = {}
+        playlog_user_clause = ""
+        if session_user := get_current_user():
+            playlog_user_clause = "AND p2.userid = :playlog_userid "
+            params["playlog_userid"] = session_user.user_id
+        artists_query = self._artist_mappings_summary_query(
+            DB_TABLE_AUDIOBOOK_ARTISTS, "audiobook_id", include_artist_type=True
+        )
+        query = f"""
+        SELECT
+            {self._summary_base_columns()},
+            audiobooks.version,
+            audiobooks.publisher,
+            audiobooks.duration,
+            audiobooks.authors,
+            audiobooks.narrators,
+            {self._provider_mappings_summary_query()} AS provider_mappings,
+            {artists_query} AS audiobook_artists,
+            playlog.fully_played AS fully_played,
+            playlog.seconds_played * 1000 as resume_position_ms
+            FROM audiobooks
+            LEFT JOIN playlog ON playlog.id = (
+                SELECT p2.id FROM playlog p2
+                WHERE p2.item_id = CAST(audiobooks.item_id AS TEXT)
+                AND p2.media_type = 'audiobook'
+                {playlog_user_clause}ORDER BY p2.timestamp DESC LIMIT 1)
+            """
+        return query, params
+
     async def library_items(
         self,
         favorite: bool | None = None,
@@ -130,6 +159,8 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         genre: int | list[int] | None = None,
         played_only: bool = False,
         without_collections: bool | None = None,
+        *,
+        summary: bool = False,
         **kwargs: Any,
     ) -> list[Audiobook]:
         """
@@ -143,6 +174,8 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         :param provider: Filter by provider instance ID (single string or list).
         :param genre: Filter by genre id(s).
         :param without_collections: Do not return audiobooks which are part of a collection
+        :param summary: Return slim summary items (only the fields needed for a list view)
+            instead of full items.
         """
         extra_query_params: dict[str, Any] = {}
         extra_query_parts: list[str] = []
@@ -163,6 +196,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             extra_query_params=extra_query_params,
             played_only=played_only,
             in_library_only=True,
+            summary=summary,
         )
         if search and len(result) < 25 and not offset:
             # append author items to result
@@ -180,6 +214,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
                 extra_query_parts=extra_query_parts,
                 extra_query_params=extra_query_params,
                 in_library_only=True,
+                summary=summary,
             )
         return result
 
@@ -623,3 +658,32 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             fully_played=parse_optional_bool(db_row["fully_played"]),
             resume_position_ms=int(resume_position_ms) if resume_position_ms is not None else None,
         )
+
+    def _parse_summary_row(self, db_row: Mapping[str, Any]) -> AudiobookSummary:
+        """Parse a raw summary db row into an AudiobookSummary object."""
+        item = cast("AudiobookSummary", super()._parse_summary_row(db_row))
+        item.version = db_row["version"] or ""
+        item.publisher = db_row["publisher"]
+        item.duration = db_row["duration"] or 0
+        item.fully_played = parse_optional_bool(db_row["fully_played"])
+        item.resume_position_ms = db_row["resume_position_ms"]
+        # authors/narrators: prefer the linked artist records (as slim mappings),
+        # fall back to the plain string values stored on the audiobook itself
+        authors: list[ItemMappingSummary] = []
+        narrators: list[ItemMappingSummary] = []
+        if raw_audiobook_artists := db_row["audiobook_artists"]:
+            for artist in json_loads(raw_audiobook_artists):
+                mapping = ItemMappingSummary(
+                    media_type=MediaType.ARTIST,
+                    item_id=str(artist["item_id"]),
+                    provider="library",
+                    name=artist["name"],
+                    sort_name=artist["sort_name"],
+                )
+                if artist["artist_type"] == ArtistType.AUTHOR.value:
+                    authors.append(mapping)
+                elif artist["artist_type"] == ArtistType.NARRATOR.value:
+                    narrators.append(mapping)
+        item.authors = UniqueList(authors or json_loads(db_row["authors"] or "[]"))
+        item.narrators = UniqueList(narrators or json_loads(db_row["narrators"] or "[]"))
+        return item

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -16,6 +16,7 @@ from music_assistant_models.auth import Scope
 from music_assistant_models.enums import (
     EventType,
     ExternalID,
+    ImageType,
     MediaType,
     ProviderFeature,
     ProviderType,
@@ -25,10 +26,15 @@ from music_assistant_models.errors import (
     MediaNotFoundError,
     ProviderUnavailableError,
 )
+from music_assistant_models.helpers import get_global_cache_value
 from music_assistant_models.media_items import (
     AudioFormat,
     ItemMapping,
+    ItemMappingSummary,
+    MediaItemImage,
     MediaItemMetadata,
+    MediaItemMetadataSummary,
+    MediaItemSummaryType,
     MediaItemType,
     ProviderMapping,
     UniqueList,
@@ -147,6 +153,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
 
     media_type: MediaType
     item_cls: type[MediaItemType]
+    summary_item_cls: type[MediaItemSummaryType]
     db_table: str
 
     def __init__(self, mass: MusicAssistant) -> None:
@@ -203,19 +210,22 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         SELECT
             {self.db_table}.*,
             {self._external_ids_query()} AS external_ids,
-            (SELECT JSON_GROUP_ARRAY(
-                json_object(
-                'item_id', provider_mappings.provider_item_id,
-                    'provider_domain', provider_mappings.provider_domain,
-                        'provider_instance', provider_mappings.provider_instance,
-                        'available', provider_mappings.available,
-                        'audio_format', json(provider_mappings.audio_format),
-                        'url', provider_mappings.url,
-                        'details', provider_mappings.details,
-                        'in_library', provider_mappings.in_library,
-                        'is_unique', provider_mappings.is_unique
-                )) FROM provider_mappings WHERE provider_mappings.item_id = {self.db_table}.item_id
-                    AND provider_mappings.media_type = '{self.media_type.value}') AS provider_mappings
+            {self._provider_mappings_query()} AS provider_mappings
+            FROM {self.db_table} """
+        return query, {}
+
+    @property
+    def summary_query(self) -> tuple[str, dict[str, Any]]:
+        """
+        Return the slim SELECT query used for summary listings and its bound query params.
+
+        Selects only the columns needed to build summary items. Override in a subclass
+        to select additional per-type columns.
+        """
+        query = f"""
+        SELECT
+            {self._summary_base_columns()},
+            {self._provider_mappings_summary_query()} AS provider_mappings
             FROM {self.db_table} """
         return query, {}
 
@@ -353,6 +363,8 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
         played_only: bool = False,
+        *,
+        summary: bool = False,
         **kwargs: Any,
     ) -> list[ItemCls]:
         """
@@ -366,6 +378,8 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         :param provider: Filter by provider instance ID (single string or list).
         :param genre: Filter by genre id(s).
         :param played_only: Only include items that have been played (last_played > 0).
+        :param summary: Return slim summary items (only the fields needed for a list view)
+            instead of full items.
         """
         items = await self.get_library_items_by_query(
             favorite=favorite,
@@ -377,6 +391,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             genre_ids=genre,
             played_only=played_only,
             in_library_only=True,
+            summary=summary,
         )
         if (
             kwargs.get("_localized_fallback", True)
@@ -392,6 +407,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 order_by=order_by,
                 provider=provider,
                 genre=genre,
+                summary=summary,
             )
         return items
 
@@ -1101,6 +1117,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         genre_ids: int | list[int] | None = None,
         played_only: bool = False,
         in_library_only: bool = False,
+        summary: bool = False,
     ) -> list[ItemCls]:
         """Fetch MediaItem records from database by building the query."""
         query_params = dict(extra_query_params) if extra_query_params else {}
@@ -1135,16 +1152,21 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 in_library_only=in_library_only,
             )
         # build and execute final query
-        sql_query, base_query_params = self._build_final_query(query_parts, join_parts, order_by)
+        sql_query, base_query_params = self._build_final_query(
+            query_parts, join_parts, order_by, summary=summary
+        )
         # base query params act as defaults: callers may override them via extra_query_params
         for key, value in base_query_params.items():
             query_params.setdefault(key, value)
 
+        db_rows = await self.mass.music.database.get_rows_from_query(
+            sql_query, query_params, limit=limit, offset=offset
+        )
+        if summary:
+            return [cast("ItemCls", self._parse_summary_row(db_row)) for db_row in db_rows]
         return [
             cast("ItemCls", self.item_cls.from_dict(self._parse_db_row(db_row)))
-            for db_row in await self.mass.music.database.get_rows_from_query(
-                sql_query, query_params, limit=limit, offset=offset
-            )
+            for db_row in db_rows
         ]
 
     @final
@@ -1197,6 +1219,75 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             f"WHERE {DB_TABLE_EXTERNAL_ID_LOOKUP}.media_type = '{media_type.value}' "
             f"AND {DB_TABLE_EXTERNAL_ID_LOOKUP}.item_id = {table_alias}.item_id)"
         )
+
+    def _provider_mappings_query(self) -> str:
+        """Return a subquery that selects the provider mappings of a media item as a JSON array."""
+        return f"""(SELECT JSON_GROUP_ARRAY(
+            json_object(
+                'item_id', pm.provider_item_id,
+                'provider_domain', pm.provider_domain,
+                'provider_instance', pm.provider_instance,
+                'available', pm.available,
+                'audio_format', json(pm.audio_format),
+                'url', pm.url,
+                'details', pm.details,
+                'in_library', pm.in_library,
+                'is_unique', pm.is_unique
+            )) FROM {DB_TABLE_PROVIDER_MAPPINGS} pm
+            WHERE pm.item_id = {self.db_table}.item_id
+            AND pm.media_type = '{self.media_type.value}')"""
+
+    def _provider_mappings_summary_query(self) -> str:
+        """
+        Return a subquery selecting the slim provider mappings JSON of a summary row.
+
+        Only carries the fields needed to compute the availability flag; never
+        hydrated into ProviderMapping objects.
+        """
+        return f"""(SELECT JSON_GROUP_ARRAY(
+            json_object(
+                'provider_instance', pm.provider_instance,
+                'available', pm.available
+            )) FROM {DB_TABLE_PROVIDER_MAPPINGS} pm
+            WHERE pm.item_id = {self.db_table}.item_id
+            AND pm.media_type = '{self.media_type.value}')"""
+
+    def _artist_mappings_summary_query(
+        self, m2m_table: str, m2m_key: str, include_artist_type: bool = False
+    ) -> str:
+        """
+        Return a subquery selecting the slim artist mappings JSON of a summary row.
+
+        :param m2m_table: The many-to-many table linking artists to this media type.
+        :param m2m_key: The column in the m2m table referencing this media type's item id.
+        :param include_artist_type: Also select the artist_type of each artist.
+        """
+        artist_type_part = ",\n                'artist_type', artists.artist_type"
+        return f"""(SELECT JSON_GROUP_ARRAY(
+            json_object(
+                'item_id', artists.item_id,
+                'name', artists.name,
+                'sort_name', artists.sort_name{artist_type_part if include_artist_type else ""}
+            )) FROM artists
+            JOIN {m2m_table} ON artists.item_id = {m2m_table}.artist_id
+            WHERE {m2m_table}.{m2m_key} = {self.db_table}.item_id)"""
+
+    def _summary_base_columns(self) -> str:
+        """Return the SELECT columns shared by every summary query."""
+        # the search/sort/statistics columns are selected so ORDER BY (see SORT_KEYS)
+        # resolves them from the result set, like the full query's SELECT * does
+        return f"""
+            {self.db_table}.item_id,
+            {self.db_table}.name,
+            {self.db_table}.sort_name,
+            {self.db_table}.favorite,
+            {self.db_table}.search_name AS search_name,
+            {self.db_table}.search_sort_name AS search_sort_name,
+            {self.db_table}.play_count AS play_count,
+            {self.db_table}.last_played AS last_played,
+            {self.db_table}.timestamp_added AS timestamp_added,
+            {self.db_table}.timestamp_modified AS timestamp_modified,
+            json_extract({self.db_table}.metadata, '$.images') AS images"""
 
     async def _localized_search_fallback(
         self, search_query: str, limit: int, offset: int = 0, **call_kwargs: Any
@@ -1387,9 +1478,10 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         query_parts: list[str],
         join_parts: list[str],
         order_by: str | None,
+        summary: bool = False,
     ) -> tuple[str, dict[str, Any]]:
         """Build the final SQL query string and its (base) bound query params."""
-        sql_query, base_query_params = self.base_query
+        sql_query, base_query_params = self.summary_query if summary else self.base_query
 
         # Add joins
         if join_parts:
@@ -1609,3 +1701,70 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             )
             for raw_mapping in json_loads(db_row["provider_mappings"])
         }
+
+    def _parse_summary_row(self, db_row: Mapping[str, Any]) -> MediaItemSummaryType:
+        """
+        Parse a raw summary db row into a summary item of this controller's media type.
+
+        Override in a subclass to fill additional per-type fields (selected by the
+        subclass's summary_query).
+        """
+        return self.summary_item_cls(
+            item_id=str(db_row["item_id"]),
+            provider="library",
+            name=db_row["name"],
+            sort_name=db_row["sort_name"],
+            favorite=bool(db_row["favorite"]),
+            available=self._parse_summary_available(db_row),
+            metadata=self._parse_summary_metadata(db_row),
+        )
+
+    @final
+    @staticmethod
+    def _parse_summary_available(db_row: Mapping[str, Any]) -> bool:
+        """Compute the availability flag from the slim provider mappings of a summary row."""
+        if not (raw_mappings := db_row["provider_mappings"]):
+            return False
+        mappings = json_loads(raw_mappings)
+        # same semantics as the MediaItem.available property
+        if not (available_providers := get_global_cache_value("available_providers")):
+            return any(x["available"] for x in mappings)
+        if TYPE_CHECKING:
+            available_providers = cast("set[str]", available_providers)
+        return any(
+            x["available"] and x["provider_instance"] in available_providers for x in mappings
+        )
+
+    @final
+    @staticmethod
+    def _parse_summary_metadata(db_row: Mapping[str, Any]) -> MediaItemMetadataSummary:
+        """Build the slim metadata of a summary row, carrying only the (first) thumb image."""
+        thumb: MediaItemImage | None = None
+        if raw_images := db_row["images"]:
+            for image in json_loads(raw_images):
+                if image["type"] != ImageType.THUMB.value:
+                    continue
+                thumb = MediaItemImage(
+                    type=ImageType.THUMB,
+                    path=image["path"],
+                    provider=image["provider"],
+                    remotely_accessible=image.get("remotely_accessible", False),
+                )
+                break
+        return MediaItemMetadataSummary(images=UniqueList([thumb]) if thumb else None)
+
+    @final
+    def _parse_summary_artist_mappings(
+        self, db_row: Mapping[str, Any]
+    ) -> UniqueList[ItemMappingSummary]:
+        """Parse the aggregated slim artist mapping rows of a summary db row."""
+        return UniqueList(
+            ItemMappingSummary(
+                media_type=MediaType.ARTIST,
+                item_id=str(raw_mapping["item_id"]),
+                provider="library",
+                name=raw_mapping["name"],
+                sort_name=raw_mapping["sort_name"],
+            )
+            for raw_mapping in json_loads(db_row["artists"])
+        )

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -7,7 +7,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import Scope
 from music_assistant_models.background_task import BackgroundTask, TaskSchedule
@@ -17,6 +17,7 @@ from music_assistant_models.media_items import (
     Album,
     Artist,
     Genre,
+    GenreSummary,
     MediaItemImage,
     MediaItemMetadata,
     RecommendationFolder,
@@ -54,6 +55,8 @@ from music_assistant.helpers.json import json_loads, serialize_to_json
 from .base import MediaControllerBase
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from music_assistant_models.event import MassEvent
 
     from music_assistant import MusicAssistant
@@ -127,6 +130,7 @@ class GenreController(MediaControllerBase[Genre]):
     db_table = DB_TABLE_GENRES
     media_type = MediaType.GENRE
     item_cls = Genre
+    summary_item_cls = GenreSummary
 
     def __init__(self, mass: MusicAssistant) -> None:
         """Initialize class."""
@@ -263,6 +267,19 @@ class GenreController(MediaControllerBase[Genre]):
         FROM (SELECT * FROM {DB_TABLE_GENRES} WHERE is_excluded = 0) AS {DB_TABLE_GENRES}"""
         return query, {}
 
+    @property
+    def summary_query(self) -> tuple[str, dict[str, Any]]:
+        """Return the slim SELECT query used for genre summary listings."""
+        # Same derived table as the base query so excluded genres stay hidden.
+        query = f"""
+        SELECT
+            {self._summary_base_columns()},
+            {DB_TABLE_GENRES}.translation_key,
+            {DB_TABLE_GENRES}.content_type,
+            {self._provider_mappings_summary_query()} AS provider_mappings
+        FROM (SELECT * FROM {DB_TABLE_GENRES} WHERE is_excluded = 0) AS {DB_TABLE_GENRES}"""
+        return query, {}
+
     async def library_items(  # noqa: PLR0913
         self,
         favorite: bool | None = None,
@@ -276,6 +293,8 @@ class GenreController(MediaControllerBase[Genre]):
         hide_empty: bool | None = None,
         media_type: MediaType | None = None,
         content_type: str | None = None,
+        *,
+        summary: bool = False,
         **kwargs: Any,
     ) -> list[Genre]:
         """
@@ -292,6 +311,8 @@ class GenreController(MediaControllerBase[Genre]):
             general/music taxonomy, stored as NULL), "podcast" or "audiobook". Composes with
             hide_empty, so e.g. content_type="podcast" + hide_empty=None returns only the
             default podcast genres.
+        :param summary: Return slim summary items (only the fields needed for a list view)
+            instead of full items.
         """
         if genre is not None:
             msg = "genre parameter is not supported for Genre.library_items()"
@@ -337,6 +358,7 @@ class GenreController(MediaControllerBase[Genre]):
             extra_query_params=extra_params,
             extra_query_parts=extra_parts,
             played_only=played_only,
+            summary=summary,
         )
         if kwargs.get("_localized_fallback", True) and search and not items:
             # retry with the canonical name behind a localized query, so genres are findable
@@ -351,6 +373,7 @@ class GenreController(MediaControllerBase[Genre]):
                 hide_empty=hide_empty,
                 media_type=media_type,
                 content_type=content_type,
+                summary=summary,
             )
         return items
 
@@ -2122,3 +2145,13 @@ class GenreController(MediaControllerBase[Genre]):
                 str(err),
                 exc_info=err if self.logger.isEnabledFor(logging.DEBUG) else None,
             )
+
+    def _parse_summary_row(self, db_row: Mapping[str, Any]) -> GenreSummary:
+        """Parse a raw summary db row into a GenreSummary object."""
+        item = cast("GenreSummary", super()._parse_summary_row(db_row))
+        # only overwrite the (name-derived) translation key when explicitly stored
+        if translation_key := db_row["translation_key"]:
+            item.translation_key = translation_key
+        if content_type := db_row["content_type"]:
+            item.content_type = MediaType(content_type)
+        return item

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Sequence
 from contextlib import suppress
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import MediaType, ProviderFeature
@@ -14,7 +14,7 @@ from music_assistant_models.errors import (
     MediaNotFoundError,
     ProviderUnavailableError,
 )
-from music_assistant_models.media_items import Playlist
+from music_assistant_models.media_items import Playlist, PlaylistSummary
 
 from music_assistant.constants import DB_TABLE_PLAYLISTS, PLAYLIST_MEDIA_TYPES, PlaylistPlayableItem
 from music_assistant.controllers.tasks.context import (
@@ -24,7 +24,7 @@ from music_assistant.controllers.tasks.context import (
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.compare import create_safe_string
 from music_assistant.helpers.database import UNSET
-from music_assistant.helpers.json import serialize_to_json
+from music_assistant.helpers.json import json_loads, serialize_to_json
 from music_assistant.helpers.playlists import (
     PlaylistItem,
     generate_m3u,
@@ -41,6 +41,8 @@ from .radio import RadioController
 from .tracks import TracksController
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from music_assistant_models.background_task import BackgroundTask
 
     from music_assistant import MusicAssistant
@@ -68,6 +70,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
     db_table = DB_TABLE_PLAYLISTS
     media_type = MediaType.PLAYLIST
     item_cls = Playlist
+    summary_item_cls = PlaylistSummary
 
     def __init__(self, mass: MusicAssistant) -> None:
         """Initialize class."""
@@ -102,6 +105,22 @@ class PlaylistController(MediaControllerBase[Playlist]):
             self.import_playlist,
             required_scope=Scope.LIBRARY_WRITE,
         )
+
+    @property
+    def summary_query(self) -> tuple[str, dict[str, Any]]:
+        """Return the slim SELECT query used for playlist summary listings."""
+        query = f"""
+        SELECT
+            {self._summary_base_columns()},
+            playlists.owner,
+            playlists.is_editable,
+            playlists.is_dynamic,
+            playlists.supported_mediatypes,
+            playlists.translation_key,
+            playlists.translation_params,
+            {self._provider_mappings_summary_query()} AS provider_mappings
+            FROM playlists"""
+        return query, {}
 
     async def tracks(
         self,
@@ -751,3 +770,18 @@ class PlaylistController(MediaControllerBase[Playlist]):
         # in the next scheduled run of the playlist metadata task
         playlist.metadata.last_refresh = None
         await self.update_item_in_library(db_playlist_id, playlist)
+
+    def _parse_summary_row(self, db_row: Mapping[str, Any]) -> PlaylistSummary:
+        """Parse a raw summary db row into a PlaylistSummary object."""
+        item = cast("PlaylistSummary", super()._parse_summary_row(db_row))
+        item.owner = db_row["owner"]
+        item.is_editable = bool(db_row["is_editable"])
+        item.is_dynamic = bool(db_row["is_dynamic"])
+        item.supported_mediatypes = {
+            MediaType(x) for x in json_loads(db_row["supported_mediatypes"])
+        }
+        if translation_key := db_row["translation_key"]:
+            item.translation_key = translation_key
+        if translation_params := db_row["translation_params"]:
+            item.translation_params = json_loads(translation_params)
+        return item

--- a/music_assistant/controllers/music/media/podcasts.py
+++ b/music_assistant/controllers/music/media/podcasts.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import MediaNotFoundError, ProviderUnavailableError
-from music_assistant_models.media_items import Podcast, PodcastEpisode, ProviderMapping, UniqueList
+from music_assistant_models.media_items import (
+    Podcast,
+    PodcastEpisode,
+    PodcastSummary,
+    ProviderMapping,
+    UniqueList,
+)
 
 from music_assistant.constants import DB_TABLE_PLAYLOG, DB_TABLE_PODCASTS
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
@@ -25,6 +31,8 @@ from music_assistant.models.music_provider import MusicProvider
 from .base import MediaControllerBase
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from music_assistant_models.auth import User
 
     from music_assistant import MusicAssistant
@@ -36,6 +44,7 @@ class PodcastsController(MediaControllerBase[Podcast]):
     db_table = DB_TABLE_PODCASTS
     media_type = MediaType.PODCAST
     item_cls = Podcast
+    summary_item_cls = PodcastSummary
 
     def __init__(self, mass: MusicAssistant) -> None:
         """Initialize class."""
@@ -52,6 +61,19 @@ class PodcastsController(MediaControllerBase[Podcast]):
             f"music/{api_base}/podcast_versions", self.versions, required_scope=Scope.LIBRARY_READ
         )
 
+    @property
+    def summary_query(self) -> tuple[str, dict[str, Any]]:
+        """Return the slim SELECT query used for podcast summary listings."""
+        query = f"""
+        SELECT
+            {self._summary_base_columns()},
+            podcasts.version,
+            podcasts.publisher,
+            podcasts.total_episodes,
+            {self._provider_mappings_summary_query()} AS provider_mappings
+            FROM podcasts"""
+        return query, {}
+
     async def library_items(
         self,
         favorite: bool | None = None,
@@ -62,6 +84,8 @@ class PodcastsController(MediaControllerBase[Podcast]):
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
         played_only: bool = False,
+        *,
+        summary: bool = False,
         **kwargs: Any,
     ) -> list[Podcast]:
         """
@@ -74,6 +98,8 @@ class PodcastsController(MediaControllerBase[Podcast]):
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param provider: Filter by provider instance ID (single string or list).
         :param genre: Filter by genre id(s).
+        :param summary: Return slim summary items (only the fields needed for a list view)
+            instead of full items.
         """
         result = await self.get_library_items_by_query(
             favorite=favorite,
@@ -85,6 +111,7 @@ class PodcastsController(MediaControllerBase[Podcast]):
             provider_filter=self._ensure_provider_filter(provider),
             played_only=played_only,
             in_library_only=True,
+            summary=summary,
         )
         if search and len(result) < 25 and not offset:
             # append publisher items to result
@@ -104,6 +131,7 @@ class PodcastsController(MediaControllerBase[Podcast]):
                 extra_query_parts=extra_query_parts,
                 extra_query_params=extra_query_params,
                 in_library_only=True,
+                summary=summary,
             )
         return result
 
@@ -343,3 +371,11 @@ class PodcastsController(MediaControllerBase[Podcast]):
         async for item in prov.get_podcast_episodes(item_id):
             await set_resume_position(item)
             yield item
+
+    def _parse_summary_row(self, db_row: Mapping[str, Any]) -> PodcastSummary:
+        """Parse a raw summary db row into a PodcastSummary object."""
+        item = cast("PodcastSummary", super()._parse_summary_row(db_row))
+        item.version = db_row["version"] or ""
+        item.publisher = db_row["publisher"]
+        item.total_episodes = db_row["total_episodes"]
+        return item

--- a/music_assistant/controllers/music/media/radio.py
+++ b/music_assistant/controllers/music/media/radio.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, cast
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import ProviderUnavailableError
-from music_assistant_models.media_items import ProviderMapping, Radio
+from music_assistant_models.media_items import ProviderMapping, Radio, RadioSummary
 
 from music_assistant.constants import DB_TABLE_RADIOS
 from music_assistant.helpers.compare import (
@@ -35,6 +35,7 @@ class RadioController(MediaControllerBase[Radio]):
     db_table = DB_TABLE_RADIOS
     media_type = MediaType.RADIO
     item_cls = Radio
+    summary_item_cls = RadioSummary
 
     def __init__(self, mass: MusicAssistant) -> None:
         """Initialize class."""

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -8,7 +8,13 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import Scope
-from music_assistant_models.enums import ExternalID, MediaType, ProviderFeature, ProviderType
+from music_assistant_models.enums import (
+    ExternalID,
+    ImageType,
+    MediaType,
+    ProviderFeature,
+    ProviderType,
+)
 from music_assistant_models.errors import (
     InvalidDataError,
     MusicAssistantError,
@@ -18,8 +24,11 @@ from music_assistant_models.media_items import (
     Album,
     Artist,
     ItemMapping,
+    ItemMappingSummary,
+    MediaItemImage,
     ProviderMapping,
     Track,
+    TrackSummary,
     UniqueList,
 )
 
@@ -37,7 +46,7 @@ from music_assistant.helpers.compare import (
     loose_compare_strings,
 )
 from music_assistant.helpers.database import UNSET
-from music_assistant.helpers.json import serialize_to_json
+from music_assistant.helpers.json import json_loads, serialize_to_json
 from music_assistant.models.music_provider import MusicProvider
 
 from .base import MediaControllerBase, TrackSyncDetails
@@ -56,6 +65,7 @@ class TracksController(MediaControllerBase[Track]):
     db_table = DB_TABLE_TRACKS
     media_type = MediaType.TRACK
     item_cls = Track
+    summary_item_cls = TrackSummary
 
     def __init__(self, mass: MusicAssistant) -> None:
         """Initialize class."""
@@ -89,18 +99,7 @@ class TracksController(MediaControllerBase[Track]):
         SELECT
             tracks.*,
             {self._external_ids_query()} AS external_ids,
-            (SELECT JSON_GROUP_ARRAY(
-                json_object(
-                'item_id', track_pm.provider_item_id,
-                    'provider_domain', track_pm.provider_domain,
-                        'provider_instance', track_pm.provider_instance,
-                        'available', track_pm.available,
-                        'audio_format', json(track_pm.audio_format),
-                        'url', track_pm.url,
-                        'details', track_pm.details,
-                        'in_library', track_pm.in_library,
-                        'is_unique', track_pm.is_unique
-                )) FROM provider_mappings track_pm WHERE track_pm.item_id = tracks.item_id AND track_pm.media_type = 'track') AS provider_mappings,
+            {self._provider_mappings_query()} AS provider_mappings,
 
             (SELECT JSON_GROUP_ARRAY(
                 json_object(
@@ -118,6 +117,37 @@ class TracksController(MediaControllerBase[Track]):
                     'name', albums.name,
                     'sort_name', albums.sort_name,
                     'media_type', 'album',
+                    'year', albums.year,
+                    'disc_number', album_tracks.disc_number,
+                    'track_number', album_tracks.track_number,
+                    'images', json_extract(albums.metadata, '$.images')
+                ) FROM album_tracks
+                JOIN albums ON albums.item_id = album_tracks.album_id
+                WHERE album_tracks.track_id = tracks.item_id
+                ORDER BY (album_tracks.album_id IS :preferred_album_id) DESC, album_tracks.album_id
+                LIMIT 1) AS track_album
+            FROM tracks
+            """
+        return query, {"preferred_album_id": None}
+
+    @property
+    def summary_query(self) -> tuple[str, dict[str, Any]]:
+        """Return the slim SELECT query used for track summary listings."""
+        # the track_album subquery follows the same correlated pattern as in base_query
+        # (see the NOTE there), just with the few fields a list row needs
+        query = f"""
+        SELECT
+            {self._summary_base_columns()},
+            tracks.version,
+            tracks.duration,
+            json_extract(tracks.metadata, '$.explicit') AS explicit,
+            {self._provider_mappings_summary_query()} AS provider_mappings,
+            {self._artist_mappings_summary_query(DB_TABLE_TRACK_ARTISTS, "track_id")} AS artists,
+            (SELECT
+                json_object(
+                'item_id', albums.item_id,
+                    'name', albums.name,
+                    'sort_name', albums.sort_name,
                     'year', albums.year,
                     'disc_number', album_tracks.disc_number,
                     'track_number', album_tracks.track_number,
@@ -211,6 +241,8 @@ class TracksController(MediaControllerBase[Track]):
         genre: int | list[int] | None = None,
         played_only: bool = False,
         explicit: bool | None = None,
+        *,
+        summary: bool = False,
         **kwargs: Any,
     ) -> list[Track]:
         """
@@ -225,6 +257,8 @@ class TracksController(MediaControllerBase[Track]):
         :param genre: Filter by genre id(s).
         :param played_only: Filter to only played tracks.
         :param explicit: Filter by explicit content (True=only explicit, False=no explicit, None=all).
+        :param summary: Return slim summary items (only the fields needed for a list view)
+            instead of full items.
         """
         extra_query_params: dict[str, Any] = {}
         extra_query_parts: list[str] = []
@@ -269,6 +303,7 @@ class TracksController(MediaControllerBase[Track]):
             extra_join_parts=extra_join_parts,
             played_only=played_only,
             in_library_only=True,
+            summary=summary,
         )
         if search and len(result) < 25 and not offset:
             # append artist items to result
@@ -291,6 +326,7 @@ class TracksController(MediaControllerBase[Track]):
                 extra_query_params=extra_query_params,
                 extra_join_parts=extra_join_parts,
                 in_library_only=True,
+                summary=summary,
             ):
                 # prevent duplicates (when artist is also in the title)
                 if _track.uri not in existing_uris:
@@ -839,3 +875,40 @@ class TracksController(MediaControllerBase[Track]):
             provider_mappings=self._parse_sync_details_mappings(db_row),
             has_album=bool(db_row["has_album"]),
         )
+
+    def _parse_summary_row(self, db_row: Mapping[str, Any]) -> TrackSummary:
+        """Parse a raw summary db row into a TrackSummary object."""
+        item = cast("TrackSummary", super()._parse_summary_row(db_row))
+        item.version = db_row["version"] or ""
+        item.duration = db_row["duration"] or 0
+        item.metadata.explicit = None if db_row["explicit"] is None else bool(db_row["explicit"])
+        item.artists = self._parse_summary_artist_mappings(db_row)
+        if raw_album := db_row["track_album"]:
+            album: dict[str, Any] = json_loads(raw_album)
+            album_thumb: MediaItemImage | None = None
+            if album_images := album.get("images"):
+                for image in album_images:
+                    if image["type"] != ImageType.THUMB.value:
+                        continue
+                    album_thumb = MediaItemImage(
+                        type=ImageType.THUMB,
+                        path=image["path"],
+                        provider=image["provider"],
+                        remotely_accessible=image.get("remotely_accessible", False),
+                    )
+                    break
+            item.album = ItemMappingSummary(
+                media_type=MediaType.ALBUM,
+                item_id=str(album["item_id"]),
+                provider="library",
+                name=album["name"],
+                sort_name=album["sort_name"],
+                year=album["year"],
+                image=album_thumb,
+            )
+            item.disc_number = album["disc_number"] or 0
+            item.track_number = album["track_number"] or 0
+            if album_thumb:
+                # always prefer album image over track image
+                item.metadata.images = UniqueList([album_thumb])
+        return item

--- a/tests/integration/test_library_summary_items.py
+++ b/tests/integration/test_library_summary_items.py
@@ -1,0 +1,250 @@
+"""
+Parity test for the summary fast path of the library list endpoints.
+
+``library_items(summary=True)`` returns slim summary variants of the media item
+models, built directly from a slim SQL query instead of hydrating the full stored
+item JSON. Every field a summary item carries must match the full item, and the
+serialized (wire) form must be sparse: no null values and none of the heavy
+metadata fields.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from functools import partial
+from typing import TYPE_CHECKING, Any, cast
+
+from music_assistant_models.enums import ImageType
+from music_assistant_models.media_items import (
+    Audiobook,
+    ItemMapping,
+    MediaItemImage,
+    Playlist,
+    ProviderMapping,
+    Radio,
+    UniqueList,
+)
+from music_assistant_models.media_items.metadata import IMAGE_PROXY_ID_RESOLVER
+from music_assistant_models.translations import TRANSLATION_RESOLVER
+
+from tests.common import wait_for_sync_completion
+from tests.integration.conftest import wait_for
+
+if TYPE_CHECKING:
+    from music_assistant.controllers.music.media.base import MediaControllerBase
+    from music_assistant.mass import MusicAssistant
+
+# object-level fields a summary item may carry; compared against the full item when present
+COMPARED_FIELDS = (
+    "name",
+    "sort_name",
+    "favorite",
+    "available",
+    "version",
+    "duration",
+    "year",
+    "album_type",
+    "artist_type",
+    "owner",
+    "is_editable",
+    "is_dynamic",
+    "supported_mediatypes",
+    "publisher",
+    "total_episodes",
+    "translation_key",
+    "content_type",
+    "fully_played",
+    "resume_position_ms",
+    "disc_number",
+    "track_number",
+)
+
+
+def _assert_no_none_values(obj: Any, path: str) -> None:
+    """Recursively assert a serialized summary dict contains no null values."""
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            assert value is not None, f"unexpected null value at {path}.{key}"
+            _assert_no_none_values(value, f"{path}.{key}")
+    elif isinstance(obj, list):
+        for index, value in enumerate(obj):
+            _assert_no_none_values(value, f"{path}[{index}]")
+
+
+@contextmanager
+def _api_serialization_context(mass: MusicAssistant) -> Iterator[None]:
+    """Bind the per-request resolvers the API layer sets during serialization."""
+    token = IMAGE_PROXY_ID_RESOLVER.set(mass.metadata.compute_image_id)
+    token_loc = TRANSLATION_RESOLVER.set(partial(mass.translations.get_translation, locale="en_US"))
+    try:
+        yield
+    finally:
+        IMAGE_PROXY_ID_RESOLVER.reset(token)
+        TRANSLATION_RESOLVER.reset(token_loc)
+
+
+def _mapping_names(value: Any) -> list[tuple[str, str]]:
+    """Normalize a list of artist mappings/strings to comparable (item_id, name) pairs."""
+    result = []
+    for entry in value or []:
+        if isinstance(entry, str):
+            result.append(("", entry))
+        else:
+            result.append((str(entry.item_id), entry.name))
+    return result
+
+
+def _first_thumb(item: Any) -> MediaItemImage | None:
+    """Return the first thumb image of a media item (or None)."""
+    for image in item.metadata.images or []:
+        if image.type == ImageType.THUMB:
+            return cast("MediaItemImage", image)
+    return None
+
+
+async def _seed_playlist_and_radio(mass: MusicAssistant) -> None:
+    """Add a playlist and radio station to the library (the test provider syncs neither)."""
+    test_prov = mass.get_provider("test")
+    assert test_prov is not None
+    image = MediaItemImage(
+        type=ImageType.THUMB,
+        path="http://example.com/thumb.jpg",
+        provider=test_prov.instance_id,
+        remotely_accessible=True,
+    )
+    playlist = Playlist(
+        item_id="pl_1",
+        provider=test_prov.instance_id,
+        name="Test Playlist",
+        owner="tester",
+        is_editable=True,
+        provider_mappings={
+            ProviderMapping(
+                item_id="pl_1",
+                provider_domain="test",
+                provider_instance=test_prov.instance_id,
+                in_library=True,
+            )
+        },
+    )
+    playlist.metadata.images = UniqueList([image])
+    await mass.music.playlists.add_item_to_library(playlist)
+    radio = Radio(
+        item_id="radio_1",
+        provider=test_prov.instance_id,
+        name="Test Radio",
+        provider_mappings={
+            ProviderMapping(
+                item_id="radio_1",
+                provider_domain="test",
+                provider_instance=test_prov.instance_id,
+                in_library=True,
+            )
+        },
+    )
+    radio.metadata.images = UniqueList([image])
+    await mass.music.radio.add_item_to_library(radio)
+
+
+async def test_library_summary_items_parity(e2e_mass: MusicAssistant) -> None:
+    """Summary items must match their full counterparts on every retained field."""
+    mass = e2e_mass
+    # wait for the initial (auto-scheduled) sync of the test provider and the
+    # follow-up genre scan so the library is fully populated
+    async with wait_for_sync_completion(mass):
+        await mass.music.start_sync()
+    await wait_for(lambda: not mass.music.active_sync_tasks)
+    await _seed_playlist_and_radio(mass)
+
+    controllers: tuple[MediaControllerBase[Any], ...] = (
+        mass.music.artists,
+        mass.music.albums,
+        mass.music.tracks,
+        mass.music.playlists,
+        mass.music.radio,
+        mass.music.audiobooks,
+        mass.music.podcasts,
+        mass.music.genres,
+    )
+    for ctrl in controllers:
+        full_items = await ctrl.library_items(order_by="name")
+        summary_items = await ctrl.library_items(order_by="name", summary=True)
+        assert len(full_items) > 0, f"no library items for {ctrl.media_type.value}"
+        assert [x.item_id for x in summary_items] == [x.item_id for x in full_items]
+
+        for full, item in zip(full_items, summary_items, strict=True):
+            # same model type (summary subclass), same identity
+            assert isinstance(item, ctrl.item_cls)
+            assert type(item) is ctrl.summary_item_cls
+            assert item.provider == "library"
+            assert item.uri == full.uri
+            for field_name in COMPARED_FIELDS:
+                if not hasattr(item, field_name):
+                    continue
+                assert getattr(item, field_name) == getattr(full, field_name), (
+                    f"{ctrl.media_type.value} {item.item_id}: field {field_name} differs"
+                )
+            # artist/album/author mappings resolve to the same library items
+            if hasattr(item, "artists"):
+                assert _mapping_names(item.artists) == _mapping_names(full.artists)
+            if hasattr(item, "album") and full.album:
+                assert isinstance(item.album, ItemMapping)
+                assert item.album.item_id == full.album.item_id
+                assert item.album.name == full.album.name
+                assert item.album.year == full.album.year
+            if isinstance(item, Audiobook):
+                assert isinstance(full, Audiobook)
+                assert _mapping_names(item.authors) == _mapping_names(full.authors)
+                assert _mapping_names(item.narrators) == _mapping_names(full.narrators)
+            # the (single) summary image is the same image the full item shows first
+            full_thumb = _first_thumb(full)
+            summary_thumb = _first_thumb(item)
+            if full_thumb:
+                assert summary_thumb is not None
+                assert summary_thumb.path == full_thumb.path
+                assert summary_thumb.provider == full_thumb.provider
+
+            # wire format: sparse (no nulls), heavy metadata never present and the
+            # image dicts carry the same resolved proxy_id / localized names; bind
+            # the same resolvers the API layer sets while serializing a response
+            with _api_serialization_context(mass):
+                full_dict = full.to_dict()
+                summary_dict = item.to_dict()
+            _assert_no_none_values(summary_dict, ctrl.media_type.value)
+            assert summary_dict["name"] == full_dict["name"]
+            # summary metadata only carries the thumb image and the explicit flag;
+            # a description may be injected on top by the translation resolver
+            # (localizable items), in which case both modes carry the same value
+            assert set(summary_dict["metadata"]) <= {"images", "explicit", "description"}
+            if "description" in summary_dict["metadata"]:
+                assert (
+                    summary_dict["metadata"]["description"] == full_dict["metadata"]["description"]
+                )
+            if full_thumb:
+                assert summary_dict["metadata"]["images"][0] == full_dict["metadata"]["images"][0]
+                assert summary_dict["metadata"]["images"][0]["proxy_id"]
+
+
+async def test_library_summary_items_filters(e2e_mass: MusicAssistant) -> None:
+    """The summary fast path composes with the regular list filters and paging."""
+    mass = e2e_mass
+    async with wait_for_sync_completion(mass):
+        await mass.music.start_sync()
+    await wait_for(lambda: not mass.music.active_sync_tasks)
+
+    full_items = await mass.music.tracks.library_items(order_by="name")
+    assert len(full_items) > 2
+    # paging
+    page = await mass.music.tracks.library_items(order_by="name", limit=2, offset=1, summary=True)
+    assert [x.item_id for x in page] == [x.item_id for x in full_items[1:3]]
+    # search
+    needle = full_items[0].name
+    full_search = await mass.music.tracks.library_items(search=needle)
+    summary_search = await mass.music.tracks.library_items(search=needle, summary=True)
+    assert sorted(x.item_id for x in summary_search) == sorted(x.item_id for x in full_search)
+    # favorite filter
+    await mass.music.tracks.set_favorite(full_items[0].item_id, True)
+    favorites = await mass.music.tracks.library_items(favorite=True, summary=True)
+    assert [x.item_id for x in favorites] == [full_items[0].item_id]
+    assert favorites[0].favorite is True


### PR DESCRIPTION
# What does this implement/fix?

Listing library items returns full media item objects, while a list view only shows a handful of fields. Profiling (10k-track library, 500 items per page) shows the cost is not SQL but hydrating every row into nested models and serializing all of it straight back out — ~2.4KB per track for a single list row.

This adds an opt-in `summary: bool` argument to all `music/<type>s/library_items` API commands. With `summary=true` the endpoint returns slim summary variants of the same models (`TrackSummary`, `AlbumSummary`, ...): same shape on the wire, only the fields a list view needs, `null` values omitted. Default behavior is unchanged, so existing clients (HA, current frontend) are unaffected.

Measured on the perf harness (10k tracks, 500-row pages, median of 25 runs):

| Endpoint | Full | Summary |
|---|---|---|
| tracks | 25.8 ms / 1302 KB | **12.8 ms / 780 KB** |
| albums | 15.8 ms / 767 KB | **8.7 ms / 415 KB** |

Changes:
- `summary` argument on `library_items` for artists, albums, tracks, playlists, radio, audiobooks, podcasts and genres
- Slim SQL queries per media type that only select what the summary needs (no heavy metadata like lyrics/chapters off the DB)
- Summary rows are constructed directly into the summary model classes, skipping the expensive full hydration round-trip
- Summary items carry an explicit `available` field (provider mappings are not included)
- Deduplicated the provider/artist mapping SQL subqueries in the media controllers
- Integration test asserting field-level parity between summary and full items for all media types
- Bump music-assistant-models to 1.1.159 (adds the summary models, music-assistant/models#296)

Follow-ups (separate PRs): frontend adoption of the summary flag, and once clients have migrated, consider making summary the default for list views (schema version bump).

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
