### PR TITLE
Don't crash DLNA player update on malformed device metadata XML

### DIFF
--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -322,7 +322,9 @@ class DLNAPlayer(Player):
         try:
             now = time.time()
             do_ping = self.force_poll or (now - self.last_seen) > 60
-            with suppress(ValueError):
+            # ParseError: some devices (e.g. Bose SoundTouch) send malformed
+            # DIDL-Lite metadata which the library parses eagerly on update
+            with suppress(ValueError, ParseError):
                 await self.device.async_update(do_ping=do_ping)
             self.last_seen = now if do_ping else self.last_seen
         except UpnpError as err:

--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Concatenate
 from urllib.parse import urlparse
+from xml.etree.ElementTree import ParseError
 
 import defusedxml.ElementTree as DefusedET
 from async_upnp_client.exceptions import UpnpError, UpnpResponseError
@@ -145,16 +146,28 @@ class DLNAPlayer(Player):
         self._attr_playback_state = _playback_state
 
         _device_uri = self.device.current_track_uri or ""
+        try:
+            media_title = self.device.media_title
+            media_artist = self.device.media_artist
+            media_album = self.device.media_album_name
+            media_image_url = self.device.media_image_url
+            media_duration = self.device.media_duration
+        except ParseError as err:
+            # some devices (e.g. Bose SoundTouch) return malformed DIDL-Lite
+            # metadata XML - drop the metadata but keep the player updated
+            self.logger.debug(
+                "Ignoring malformed media metadata from device %s: %s", self.display_name, err
+            )
+            media_title = media_artist = media_album = media_image_url = None
+            media_duration = None
         self.set_current_media(
             uri=_device_uri,
             clear_all=True,
-            title=self.device.media_title,
-            artist=self.device.media_artist,
-            album=self.device.media_album_name,
-            image_url=self.device.media_image_url,
-            duration=int(self.device.media_duration)
-            if self.device.media_duration is not None
-            else None,
+            title=media_title,
+            artist=media_artist,
+            album=media_album,
+            image_url=media_image_url,
+            duration=int(media_duration) if media_duration is not None else None,
         )
 
         # Let player controller determine active source, only override for known external sources

--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -322,8 +322,6 @@ class DLNAPlayer(Player):
         try:
             now = time.time()
             do_ping = self.force_poll or (now - self.last_seen) > 60
-            # ParseError: some devices (e.g. Bose SoundTouch) send malformed
-            # DIDL-Lite metadata which the library parses eagerly on update
             with suppress(ValueError, ParseError):
                 await self.device.async_update(do_ping=do_ping)
             self.last_seen = now if do_ping else self.last_seen

--- a/tests/providers/dlna/test_malformed_metadata.py
+++ b/tests/providers/dlna/test_malformed_metadata.py
@@ -1,0 +1,57 @@
+"""
+Repro test for support#5787.
+
+Some DLNA devices (e.g. Bose SoundTouch) return malformed DIDL-Lite XML in
+their track metadata. Accessing the metadata properties on the underlying
+DmrDevice then raises an XML ParseError, which must not propagate out of
+set_dynamic_attributes (it would otherwise kill the player update task).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, PropertyMock
+from xml.etree.ElementTree import ParseError
+
+import pytest
+from async_upnp_client.profiles.dlna import TransportState
+
+from music_assistant.providers.dlna.player import DLNAPlayer
+from tests.common import MockProvider
+
+
+@pytest.mark.asyncio
+async def test_set_dynamic_attributes_survives_malformed_device_metadata() -> None:
+    """Malformed DIDL metadata from the device must not crash the player update."""
+    provider = MockProvider("dlna", instance_id="dlna_test")
+    provider.mass.streams.base_url = "http://192.168.1.2:8097"
+
+    device = MagicMock()
+    device.profile_device.available = True
+    device.name = "Bose SoundTouch"
+    device.volume_level = 0.5
+    device.is_volume_muted = False
+    device.transport_state = TransportState.PLAYING
+    device.current_track_uri = "http://192.168.1.10/stream.mp3"
+    device.media_position = None
+    # malformed XML in CurrentTrackMetaData raises on property access
+    for prop in ("media_title", "media_artist", "media_album_name", "media_image_url"):
+        setattr(
+            type(device),
+            prop,
+            PropertyMock(side_effect=ParseError("not well-formed (invalid token)")),
+        )
+
+    player = DLNAPlayer(
+        provider,  # type: ignore[arg-type]
+        "uuid:bose-player",
+        "http://192.168.1.10/description.xml",
+        device=device,
+    )
+
+    await player.set_dynamic_attributes()
+
+    # metadata is dropped, but the update must complete and keep core attributes
+    assert player.available is True
+    assert player.current_media is not None
+    assert player.current_media.uri == "http://192.168.1.10/stream.mp3"
+    assert player.current_media.title is None

--- a/tests/providers/dlna/test_malformed_metadata.py
+++ b/tests/providers/dlna/test_malformed_metadata.py
@@ -25,7 +25,11 @@ async def test_set_dynamic_attributes_survives_malformed_device_metadata() -> No
     provider = MockProvider("dlna", instance_id="dlna_test")
     provider.mass.streams.base_url = "http://192.168.1.2:8097"
 
-    device = MagicMock()
+    # subclass so the PropertyMocks stay local and don't leak into MagicMock itself
+    class MockDevice(MagicMock):
+        pass
+
+    device = MockDevice()
     device.profile_device.available = True
     device.name = "Bose SoundTouch"
     device.volume_level = 0.5
@@ -36,7 +40,7 @@ async def test_set_dynamic_attributes_survives_malformed_device_metadata() -> No
     # malformed XML in CurrentTrackMetaData raises on property access
     for prop in ("media_title", "media_artist", "media_album_name", "media_image_url"):
         setattr(
-            type(device),
+            MockDevice,
             prop,
             PropertyMock(side_effect=ParseError("not well-formed (invalid token)")),
         )

--- a/tests/providers/dlna/test_malformed_metadata.py
+++ b/tests/providers/dlna/test_malformed_metadata.py
@@ -9,6 +9,7 @@ set_dynamic_attributes (it would otherwise kill the player update task).
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 from xml.etree.ElementTree import ParseError
 
@@ -100,10 +101,12 @@ async def test_set_dynamic_attributes_propagates_valid_device_metadata() -> None
     device.transport_state = TransportState.PLAYING
     device.current_track_uri = "http://192.168.1.10/stream.mp3"
     device.media_position = 42
+    device.media_position_updated_at = datetime(2026, 7, 9, 12, 0, 0, tzinfo=UTC)
     device.media_title = "Test Title"
     device.media_artist = "Test Artist"
     device.media_album_name = "Test Album"
     device.media_image_url = "http://192.168.1.10/cover.jpg"
+    device.media_duration = 180
 
     player = DLNAPlayer(
         provider,  # type: ignore[arg-type]
@@ -120,3 +123,5 @@ async def test_set_dynamic_attributes_propagates_valid_device_metadata() -> None
     assert player.current_media.artist == "Test Artist"
     assert player.current_media.album == "Test Album"
     assert player.current_media.image_url == "http://192.168.1.10/cover.jpg"
+    assert player.current_media.duration == 180
+    assert player.elapsed_time == 42.0

--- a/tests/providers/dlna/test_malformed_metadata.py
+++ b/tests/providers/dlna/test_malformed_metadata.py
@@ -9,7 +9,7 @@ set_dynamic_attributes (it would otherwise kill the player update task).
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
 from xml.etree.ElementTree import ParseError
 
 import pytest
@@ -55,3 +55,28 @@ async def test_set_dynamic_attributes_survives_malformed_device_metadata() -> No
     assert player.current_media is not None
     assert player.current_media.uri == "http://192.168.1.10/stream.mp3"
     assert player.current_media.title is None
+
+
+@pytest.mark.asyncio
+async def test_poll_survives_malformed_device_metadata() -> None:
+    """A ParseError raised while polling the device must not crash the poll."""
+    provider = MockProvider("dlna", instance_id="dlna_test")
+    provider.mass.streams.base_url = "http://192.168.1.2:8097"
+
+    device = MagicMock()
+    device.profile_device.available = True
+    device.name = "Bose SoundTouch"
+    # async_update parses CurrentTrackMetaData eagerly and raises on bad XML
+    device.async_update = AsyncMock(side_effect=ParseError("not well-formed (invalid token)"))
+
+    player = DLNAPlayer(
+        provider,  # type: ignore[arg-type]
+        "uuid:bose-player",
+        "http://192.168.1.10/description.xml",
+        device=device,
+    )
+    player.force_poll = True
+
+    await player.poll()
+
+    device.async_update.assert_awaited_once()

--- a/tests/providers/dlna/test_malformed_metadata.py
+++ b/tests/providers/dlna/test_malformed_metadata.py
@@ -84,3 +84,39 @@ async def test_poll_survives_malformed_device_metadata() -> None:
     await player.poll()
 
     device.async_update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_set_dynamic_attributes_propagates_valid_device_metadata() -> None:
+    """Valid device metadata must be propagated into the player's current media."""
+    provider = MockProvider("dlna", instance_id="dlna_test")
+    provider.mass.streams.base_url = "http://192.168.1.2:8097"
+
+    device = MagicMock()
+    device.profile_device.available = True
+    device.name = "Bose SoundTouch"
+    device.volume_level = 0.5
+    device.is_volume_muted = False
+    device.transport_state = TransportState.PLAYING
+    device.current_track_uri = "http://192.168.1.10/stream.mp3"
+    device.media_position = 42
+    device.media_title = "Test Title"
+    device.media_artist = "Test Artist"
+    device.media_album_name = "Test Album"
+    device.media_image_url = "http://192.168.1.10/cover.jpg"
+
+    player = DLNAPlayer(
+        provider,  # type: ignore[arg-type]
+        "uuid:bose-player",
+        "http://192.168.1.10/description.xml",
+        device=device,
+    )
+
+    await player.set_dynamic_attributes()
+
+    assert player.current_media is not None
+    assert player.current_media.uri == "http://192.168.1.10/stream.mp3"
+    assert player.current_media.title == "Test Title"
+    assert player.current_media.artist == "Test Artist"
+    assert player.current_media.album == "Test Album"
+    assert player.current_media.image_url == "http://192.168.1.10/cover.jpg"


### PR DESCRIPTION
# What does this implement/fix?

Some DLNA devices (e.g. Bose SoundTouch) return malformed DIDL-Lite XML in their track metadata. Accessing the metadata properties then raises a `ParseError`, which killed the whole player update task and left the player stuck.

- Catch `ParseError` when reading media metadata from the device
- Drop the metadata (no track info shown) but keep the player state updating normally
- Added tests covering malformed and valid metadata

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5787

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
