### PR TITLE
Reconnect Sonos players automatically after a speaker reboot

### DIFF
--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
@@ -794,8 +795,16 @@ class SonosPlayer(Player):
     async def _disconnect(self) -> None:
         """Disconnect the client and cleanup."""
         self.connected = False
-        if self._listen_task and not self._listen_task.done():
-            self._listen_task.cancel()
+        if (
+            (listen_task := self._listen_task)
+            and not listen_task.done()
+            and listen_task is not asyncio.current_task()
+        ):
+            listen_task.cancel()
+            # await the cancellation so a subsequent (re)connect doesn't
+            # mistake the finishing task for a live connection
+            with suppress(asyncio.CancelledError):
+                await listen_task
         if self.client:
             await self.client.disconnect()
         self.logger.debug("Disconnected from player API")

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -719,7 +719,7 @@ class SonosPlayer(Player):
 
         async def _force_reconnect() -> None:
             await self._disconnect()
-            await self._connect(int(delay))
+            await self._connect(delay)
 
         if self.mass.closing:
             return
@@ -751,7 +751,7 @@ class SonosPlayer(Player):
                     # this may happen at race conditions
                     raise
 
-    async def _connect(self, retry_on_fail: int = 0) -> None:
+    async def _connect(self, retry_on_fail: float = 0) -> None:
         """Connect to the Sonos player."""
         if self.mass.closing:
             return

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -89,6 +89,7 @@ class SonosPlayer(Player):
         super().__init__(prov, player_id)
         self.discovery_info = discovery_info
         self.connected: bool = False
+        self.last_bootseq: int | None = None
         self._listen_task: asyncio.Task[None] | None = None
         self.sonos_queue: SonosQueue = SonosQueue()
 
@@ -711,6 +712,19 @@ class SonosPlayer(Player):
         # use a task_id to prevent multiple reconnects
         task_id = f"sonos_reconnect_{self.player_id}"
         self.mass.call_later(delay, self._connect, delay, task_id=task_id)
+
+    def force_reconnect(self, delay: float = 1) -> None:
+        """Drop the current (possibly stale) connection and reconnect the player."""
+
+        async def _force_reconnect() -> None:
+            await self._disconnect()
+            await self._connect(int(delay))
+
+        if self.mass.closing:
+            return
+        # use a task_id to prevent multiple reconnects
+        task_id = f"sonos_reconnect_{self.player_id}"
+        self.mass.call_later(delay, _force_reconnect, task_id=task_id)
 
     async def sync_play_modes(self, queue_id: str) -> None:
         """Sync the play modes between MA and Sonos."""

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -23,6 +23,7 @@ from music_assistant.constants import (
 )
 from music_assistant.helpers.audio import get_mime_type
 from music_assistant.helpers.json import SerializableType
+from music_assistant.helpers.util import try_parse_int
 from music_assistant.models.player_provider import PlayerProvider
 
 from .helpers import get_primary_ip_address
@@ -101,6 +102,7 @@ class SonosPlayerProvider(PlayerProvider):
         name = name.split("@", 1)[1] if "@" in name else name
         player_id = info.decoded_properties["uuid"]
         assert isinstance(player_id, str)  # for type checking
+        bootseq = try_parse_int(info.decoded_properties.get("bootseq"), None)
         # handle update for existing device
         if sonos_player := self.mass.players.get_player(player_id):
             assert isinstance(sonos_player, SonosPlayer), (
@@ -115,11 +117,25 @@ class SonosPlayerProvider(PlayerProvider):
                     cur_address,
                 )
                 sonos_player.device_info.add_identifier(IdentifierType.IP_ADDRESS, cur_address)
+            player_rebooted = (
+                bootseq is not None
+                and sonos_player.last_bootseq is not None
+                and bootseq > sonos_player.last_bootseq
+            )
+            sonos_player.last_bootseq = bootseq
             if not sonos_player.connected and cur_address:
                 self.logger.debug("Player back online: %s", sonos_player.display_name)
                 sonos_player.client.player_ip = cur_address
                 # schedule reconnect
                 sonos_player.reconnect()
+            elif player_rebooted:
+                # the player rebooted (e.g. firmware update) while we think we're still
+                # connected: the websocket may be dead without us noticing, so any
+                # playback events would silently no longer reach us - force a reconnect
+                self.logger.info("Player %s rebooted, reconnecting", sonos_player.display_name)
+                if cur_address:
+                    sonos_player.client.player_ip = cur_address
+                sonos_player.force_reconnect()
             self.mass.players.trigger_player_update(player_id)
             return
         # handle new player setup in a delayed task because mdns announcements

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -130,9 +130,8 @@ class SonosPlayerProvider(PlayerProvider):
                 # schedule reconnect
                 sonos_player.reconnect()
             elif player_rebooted:
-                # the player rebooted (e.g. firmware update) while we think we're still
-                # connected: the websocket may be dead without us noticing, so any
-                # playback events would silently no longer reach us - force a reconnect
+                # the websocket may have died without us noticing when the player
+                # rebooted (e.g. firmware update) - force a fresh connection
                 self.logger.info("Player %s rebooted, reconnecting", sonos_player.display_name)
                 if cur_address:
                     sonos_player.client.player_ip = cur_address

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -122,7 +122,8 @@ class SonosPlayerProvider(PlayerProvider):
                 and sonos_player.last_bootseq is not None
                 and bootseq > sonos_player.last_bootseq
             )
-            sonos_player.last_bootseq = bootseq
+            if bootseq is not None:
+                sonos_player.last_bootseq = bootseq
             if not sonos_player.connected and cur_address:
                 self.logger.debug("Player back online: %s", sonos_player.display_name)
                 sonos_player.client.player_ip = cur_address
@@ -168,6 +169,7 @@ class SonosPlayerProvider(PlayerProvider):
             return
         self.logger.debug("Discovered Sonos device %s on %s", name, address)
         sonos_player = SonosPlayer(self, player_id, discovery_info=discovery_info)
+        sonos_player.last_bootseq = try_parse_int(info.decoded_properties.get("bootseq"), None)
         sonos_player.device_info.add_identifier(IdentifierType.IP_ADDRESS, address)
         await sonos_player.setup()
 

--- a/tests/providers/sonos/__init__.py
+++ b/tests/providers/sonos/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Sonos provider."""

--- a/tests/providers/sonos/test_reboot_reconnect.py
+++ b/tests/providers/sonos/test_reboot_reconnect.py
@@ -1,0 +1,99 @@
+"""
+Test that a Sonos speaker reboot triggers a forced reconnect.
+
+Covers issue #5792: after a speaker restart (e.g. firmware update) the
+websocket to the player can die silently while MA still considers the
+player connected, so playback events never arrive and the queue freezes.
+The mDNS announcement of the rebooted speaker carries an increased
+``bootseq``, which must trigger a forced reconnect.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from zeroconf import ServiceStateChange
+
+from music_assistant.providers.sonos.player import SonosPlayer
+from music_assistant.providers.sonos.provider import SonosPlayerProvider
+
+PLAYER_ID = "RINCON_TEST123"
+PLAYER_IP = "192.168.1.50"
+
+
+def _mdns_info(bootseq: str) -> MagicMock:
+    info = MagicMock()
+    info.decoded_properties = {"uuid": PLAYER_ID, "bootseq": bootseq}
+    return info
+
+
+def _provider_with_player(*, connected: bool, last_bootseq: int | None) -> MagicMock:
+    provider = MagicMock()
+    sonos_player = MagicMock(spec=SonosPlayer)
+    sonos_player.connected = connected
+    sonos_player.last_bootseq = last_bootseq
+    sonos_player.client = MagicMock()
+    sonos_player.device_info.ip_address = PLAYER_IP
+    provider.mass.players.get_player.return_value = sonos_player
+    provider._sonos_player = sonos_player
+    return provider
+
+
+async def _handle_mdns(provider: MagicMock, bootseq: str) -> None:
+    with patch(
+        "music_assistant.providers.sonos.provider.get_primary_ip_address",
+        return_value=PLAYER_IP,
+    ):
+        await SonosPlayerProvider.on_mdns_service_state_change(
+            provider, "test._sonos._tcp.local.", ServiceStateChange.Updated, _mdns_info(bootseq)
+        )
+
+
+@pytest.mark.asyncio
+async def test_bootseq_increase_forces_reconnect() -> None:
+    """A bootseq increase while connected forces a reconnect of the stale connection."""
+    provider = _provider_with_player(connected=True, last_bootseq=10)
+
+    await _handle_mdns(provider, "11")
+
+    sonos_player = provider._sonos_player
+    sonos_player.force_reconnect.assert_called_once()
+    sonos_player.reconnect.assert_not_called()
+    assert sonos_player.last_bootseq == 11
+
+
+@pytest.mark.asyncio
+async def test_unchanged_bootseq_does_not_reconnect() -> None:
+    """An mDNS update without a bootseq change leaves the connection alone."""
+    provider = _provider_with_player(connected=True, last_bootseq=10)
+
+    await _handle_mdns(provider, "10")
+
+    sonos_player = provider._sonos_player
+    sonos_player.force_reconnect.assert_not_called()
+    sonos_player.reconnect.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_first_seen_bootseq_is_only_recorded() -> None:
+    """The first observed bootseq is recorded without triggering a reconnect."""
+    provider = _provider_with_player(connected=True, last_bootseq=None)
+
+    await _handle_mdns(provider, "10")
+
+    sonos_player = provider._sonos_player
+    sonos_player.force_reconnect.assert_not_called()
+    assert sonos_player.last_bootseq == 10
+
+
+@pytest.mark.asyncio
+async def test_disconnected_player_uses_regular_reconnect() -> None:
+    """A disconnected player keeps using the regular reconnect path."""
+    provider = _provider_with_player(connected=False, last_bootseq=10)
+
+    await _handle_mdns(provider, "11")
+
+    sonos_player = provider._sonos_player
+    sonos_player.reconnect.assert_called_once()
+    sonos_player.force_reconnect.assert_not_called()


### PR DESCRIPTION
# What does this implement/fix?

When a Sonos speaker reboots (e.g. after a firmware update), the websocket connection to it can die without the server noticing. The player then stays unresponsive in MA until the server is restarted.

Sonos mDNS announcements carry a `bootseq` property that increments on every reboot. This PR:

- Tracks the last seen `bootseq` per player (recorded at discovery, updated on every announcement)
- Forces a clean disconnect + reconnect when `bootseq` increases while we still think we're connected
- Makes `_disconnect` await the cancelled listener task so the follow-up connect doesn't mistake the finishing task for a live connection
- Adds tests for the reboot detection and reconnect logic

Verified on real hardware: simulated a reboot announcement (bootseq+1) for a live speaker and observed a clean automatic reconnect.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5792

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
