### PR TITLE
Show artwork for SiriusXM radio streams

### DIFF
--- a/music_assistant/providers/siriusxm/__init__.py
+++ b/music_assistant/providers/siriusxm/__init__.py
@@ -28,7 +28,7 @@ from music_assistant_models.media_items import (
     SearchResults,
     UniqueList,
 )
-from music_assistant_models.streamdetails import StreamDetails
+from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
 from tenacity import RetryError
 
 from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 
 import sxm.http
 from sxm import SXMClientAsync
-from sxm.models import QualitySize, RegionChoice, XMChannel, XMLiveChannel
+from sxm.models import QualitySize, RegionChoice, XMChannel, XMLiveChannel, XMSong
 
 CONF_SXM_USERNAME = "sxm_email_address"
 CONF_SXM_PASSWORD = "sxm_password"
@@ -302,7 +302,19 @@ class SiriusXMProvider(MusicProvider):
             latest_cut = latest_cut_marker.cut
             title = latest_cut.title
             artist = ", ".join([a.name for a in latest_cut.artists])
-            self._current_stream_details.stream_title = f"{artist} - {title}"
+            # prefer the album art of the current song, fall back to the channel logo
+            image_url: str | None = None
+            if isinstance(latest_cut, XMSong) and latest_cut.album:
+                image_url = next((art.url for art in latest_cut.album.arts), None)
+            if image_url is None and (channel := self._channels_by_id.get(current_channel)):
+                image_url = next(
+                    (i.url for i in channel.images if i.width == 300 and i.height == 300), None
+                )
+            self._current_stream_details.stream_metadata = StreamMetadata(
+                title=title,
+                artist=artist,
+                image_url=image_url,
+            )
 
     async def _refresh_channels(self) -> bool:
         self._channels = await self._client.channels

--- a/tests/providers/siriusxm/__init__.py
+++ b/tests/providers/siriusxm/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the SiriusXM provider."""

--- a/tests/providers/siriusxm/test_stream_metadata.py
+++ b/tests/providers/siriusxm/test_stream_metadata.py
@@ -14,6 +14,7 @@ from sxm.models import (
     XMArt,
     XMArtist,
     XMChannel,
+    XMCut,
     XMCutMarker,
     XMImage,
     XMLiveChannel,
@@ -55,14 +56,14 @@ def _make_channel() -> XMChannel:
     )
 
 
-def _make_live_channel(song: XMSong) -> XMLiveChannel:
+def _make_live_channel(cut: XMCut) -> XMLiveChannel:
     now = datetime.now(UTC)
     cut_marker = XMCutMarker(
         guid="cut-guid",
         time=now - timedelta(minutes=1),
         time_seconds=int((now - timedelta(minutes=1)).timestamp()),
         duration=timedelta(minutes=3),
-        cut=song,
+        cut=cut,
     )
     return XMLiveChannel(
         id=CHANNEL_ID,
@@ -120,6 +121,19 @@ def test_channel_update_falls_back_to_channel_logo() -> None:
 
     metadata = provider._current_stream_details.stream_metadata
     assert metadata is not None
+    assert metadata.image_url == CHANNEL_LOGO_URL
+
+
+def test_channel_update_non_song_cut_uses_channel_logo() -> None:
+    """A cut that is not a song has no album art, so the channel logo is used."""
+    provider = _make_provider()
+    cut = XMCut(title="Talk Segment", artists=[XMArtist(name="Test Host")])
+    _run_channel_updated(provider, _make_live_channel(cut))
+
+    metadata = provider._current_stream_details.stream_metadata
+    assert metadata is not None
+    assert metadata.title == "Talk Segment"
+    assert metadata.artist == "Test Host"
     assert metadata.image_url == CHANNEL_LOGO_URL
 
 

--- a/tests/providers/siriusxm/test_stream_metadata.py
+++ b/tests/providers/siriusxm/test_stream_metadata.py
@@ -1,0 +1,134 @@
+"""Test SiriusXM channel updates producing stream metadata with artwork."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.streamdetails import StreamDetails
+from sxm.models import (
+    XMAlbum,
+    XMArt,
+    XMArtist,
+    XMChannel,
+    XMCutMarker,
+    XMImage,
+    XMLiveChannel,
+    XMSong,
+)
+
+from music_assistant.providers.siriusxm import SiriusXMProvider
+
+CHANNEL_ID = "9420"
+ALBUM_ART_URL = "https://example.com/album-art.jpg"
+CHANNEL_LOGO_URL = "https://example.com/channel-logo.png"
+
+
+def _make_channel() -> XMChannel:
+    return XMChannel(
+        guid="guid",
+        id=CHANNEL_ID,
+        name="Test Channel",
+        streaming_name="Test Channel",
+        sort_order=1,
+        short_description="short",
+        medium_description="medium",
+        url="https://example.com/channel",
+        is_available=True,
+        is_favorite=False,
+        is_mature=False,
+        channel_number=42,
+        images=[
+            XMImage(
+                name=None,
+                url="https://example.com/other.png",
+                art_type="IMAGE",
+                width=100,
+                height=100,
+            ),
+            XMImage(name=None, url=CHANNEL_LOGO_URL, art_type="IMAGE", width=300, height=300),
+        ],
+        categories=[],
+    )
+
+
+def _make_live_channel(song: XMSong) -> XMLiveChannel:
+    now = datetime.now(UTC)
+    cut_marker = XMCutMarker(
+        guid="cut-guid",
+        time=now - timedelta(minutes=1),
+        time_seconds=int((now - timedelta(minutes=1)).timestamp()),
+        duration=timedelta(minutes=3),
+        cut=song,
+    )
+    return XMLiveChannel(
+        id=CHANNEL_ID,
+        hls_infos=[],
+        custom_hls_infos=[],
+        episode_markers=[],
+        cut_markers=[cut_marker],
+    )
+
+
+def _make_provider() -> Any:
+    provider = MagicMock()
+    provider._current_stream_details = StreamDetails(
+        item_id=CHANNEL_ID,
+        provider="siriusxm",
+        audio_format=AudioFormat(content_type=ContentType.AAC),
+        stream_type=StreamType.HLS,
+        media_type=MediaType.RADIO,
+        path="dummy",
+    )
+    provider._channels_by_id = {CHANNEL_ID: _make_channel()}
+    return provider
+
+
+def _run_channel_updated(provider: Any, live_channel: XMLiveChannel) -> None:
+    with patch.object(XMLiveChannel, "from_dict", return_value=live_channel):
+        SiriusXMProvider._channel_updated(provider, {})
+
+
+def test_channel_update_sets_song_album_art() -> None:
+    """The current song's album art is used as stream metadata image."""
+    provider = _make_provider()
+    song = XMSong(
+        title="Test Song",
+        artists=[XMArtist(name="Test Artist")],
+        album=XMAlbum(
+            title="Test Album",
+            arts=[XMArt(name=None, url=ALBUM_ART_URL, art_type="IMAGE")],
+        ),
+    )
+    _run_channel_updated(provider, _make_live_channel(song))
+
+    metadata = provider._current_stream_details.stream_metadata
+    assert metadata is not None
+    assert metadata.title == "Test Song"
+    assert metadata.artist == "Test Artist"
+    assert metadata.image_url == ALBUM_ART_URL
+
+
+def test_channel_update_falls_back_to_channel_logo() -> None:
+    """Without album art the channel logo is used as stream metadata image."""
+    provider = _make_provider()
+    song = XMSong(title="Test Song", artists=[XMArtist(name="Test Artist")], album=None)
+    _run_channel_updated(provider, _make_live_channel(song))
+
+    metadata = provider._current_stream_details.stream_metadata
+    assert metadata is not None
+    assert metadata.image_url == CHANNEL_LOGO_URL
+
+
+def test_channel_update_ignores_other_channel() -> None:
+    """An update for another channel does not touch the current stream metadata."""
+    provider = _make_provider()
+    song = XMSong(title="Test Song", artists=[XMArtist(name="Test Artist")], album=None)
+    live_channel = _make_live_channel(song)
+    live_channel.id = "other-channel"
+    _run_channel_updated(provider, live_channel)
+
+    assert provider._current_stream_details.stream_metadata is None


### PR DESCRIPTION
# What does this implement/fix?

SiriusXM radio streams showed no artwork in the UI or on players. The channel update handler only set `stream_title`, so the now-playing metadata never contained an image.

- Build full `StreamMetadata` (title, artist, image) in the channel update handler
- Prefer the current song's album art, fall back to the channel logo
- Added tests covering album art, the channel-logo fallback and non-song cuts

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5701

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
