### PR TITLE
Fix flow mode not switching sample rate between tracks on wrapped players

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2059,6 +2059,7 @@ class StreamsAudio:
         start_queue_item: QueueItem,
         pcm_format: AudioFormat,
         session_id: str | None = None,
+        flow_player: Player | None = None,
     ) -> AsyncGenerator[bytes]:
         """
         Get a flow stream of all tracks in the queue as raw PCM audio.
@@ -2069,6 +2070,10 @@ class StreamsAudio:
         :param start_queue_item: First queue item in the flow stream.
         :param pcm_format: Shared PCM format for the complete flow stream.
         :param session_id: Queue session that owns processing-detail updates.
+        :param flow_player: The (protocol) player actually consuming the flow stream.
+            Must be the same player that was used to select ``pcm_format`` so
+            restart decisions are made against the correct supported sample rates
+            and flow mode configuration. Falls back to the queue's player when omitted.
         """
         # ruff: noqa: PLR0915
         assert pcm_format.content_type.is_pcm()
@@ -2109,14 +2114,8 @@ class StreamsAudio:
             standard_crossfade_duration = self.mass.config.get_raw_core_config_value(
                 CONF_PLAYER_QUEUES, CONF_CROSSFADE_DURATION, 8
             )
-        flow_mode_sample_rate_conf = self.mass.config.get_raw_player_config_value(
-            queue.queue_id, CONF_FLOW_MODE_SAMPLE_RATE, FLOW_MODE_SAMPLE_RATE_SMART
-        )
-        flow_player = self.mass.players.get_player(queue.queue_id)
-        flow_supported_sample_rates = (
-            sorted({sr for sr, _ in flow_player.get_supported_sample_rates()})
-            if flow_player
-            else []
+        flow_mode_sample_rate_conf, flow_supported_sample_rates = self._flow_restart_context(
+            queue.queue_id, flow_player
         )
         # note: get_crossfade_mode() already falls back to standard when smart fades aren't
         # available (no analysis provider / minimal buffer), so crossfade_mode is safe to use.
@@ -3106,6 +3105,34 @@ class StreamsAudio:
             bit_depth=bit_depth,
             channels=streamdetails.audio_format.channels,
         )
+
+    def _flow_restart_context(
+        self, queue_id: str, flow_player: Player | None
+    ) -> tuple[str, list[int]]:
+        """
+        Resolve the flow mode config and supported sample rates for restart decisions.
+
+        Prefers the (protocol) player actually consuming the flow stream — the same
+        player the flow's PCM format was anchored on — over the queue's (wrapper)
+        player, whose config may lack the audio/protocol specific entries.
+
+        :param queue_id: The queue ID, used as fallback when no flow player is given.
+        :param flow_player: The (protocol) player consuming the flow stream, if known.
+        :return: Tuple of (flow mode sample rate config value, sorted supported rates).
+        """
+        if flow_player is None:
+            flow_player = self.mass.players.get_player(queue_id)
+        if flow_player is None:
+            flow_mode_sample_rate_conf = self.mass.config.get_raw_player_config_value(
+                queue_id, CONF_FLOW_MODE_SAMPLE_RATE, FLOW_MODE_SAMPLE_RATE_SMART
+            )
+            return flow_mode_sample_rate_conf, []
+        flow_mode_sample_rate_conf = cast(
+            "str",
+            flow_player.config.get_value(CONF_FLOW_MODE_SAMPLE_RATE, FLOW_MODE_SAMPLE_RATE_SMART),
+        )
+        supported_sample_rates = sorted({sr for sr, _ in flow_player.get_supported_sample_rates()})
+        return flow_mode_sample_rate_conf, supported_sample_rates
 
     def _flow_stream_needs_restart(
         self,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -3112,13 +3112,8 @@ class StreamsAudio:
         """
         Resolve the flow mode config and supported sample rates for restart decisions.
 
-        Prefers the (protocol) player actually consuming the flow stream — the same
-        player the flow's PCM format was anchored on — over the queue's (wrapper)
-        player, whose config may lack the audio/protocol specific entries.
-
-        :param queue_id: The queue ID, used as fallback when no protocol player is given.
-        :param protocol_player: The protocol player consuming the flow stream, if known.
-        :return: Tuple of (flow mode sample rate config value, sorted supported rates).
+        Prefers the protocol player actually consuming the flow stream over the
+        queue's (wrapper) player, whose config may lack the audio specific entries.
         """
         if protocol_player is None:
             protocol_player = self.mass.players.get_player(queue_id)

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2059,7 +2059,7 @@ class StreamsAudio:
         start_queue_item: QueueItem,
         pcm_format: AudioFormat,
         session_id: str | None = None,
-        flow_player: Player | None = None,
+        protocol_player: Player | None = None,
     ) -> AsyncGenerator[bytes]:
         """
         Get a flow stream of all tracks in the queue as raw PCM audio.
@@ -2070,7 +2070,7 @@ class StreamsAudio:
         :param start_queue_item: First queue item in the flow stream.
         :param pcm_format: Shared PCM format for the complete flow stream.
         :param session_id: Queue session that owns processing-detail updates.
-        :param flow_player: The (protocol) player actually consuming the flow stream.
+        :param protocol_player: The protocol player actually consuming the flow stream.
             Must be the same player that was used to select ``pcm_format`` so
             restart decisions are made against the correct supported sample rates
             and flow mode configuration. Falls back to the queue's player when omitted.
@@ -2115,7 +2115,7 @@ class StreamsAudio:
                 CONF_PLAYER_QUEUES, CONF_CROSSFADE_DURATION, 8
             )
         flow_mode_sample_rate_conf, flow_supported_sample_rates = self._flow_restart_context(
-            queue.queue_id, flow_player
+            queue.queue_id, protocol_player
         )
         # note: get_crossfade_mode() already falls back to standard when smart fades aren't
         # available (no analysis provider / minimal buffer), so crossfade_mode is safe to use.
@@ -3107,7 +3107,7 @@ class StreamsAudio:
         )
 
     def _flow_restart_context(
-        self, queue_id: str, flow_player: Player | None
+        self, queue_id: str, protocol_player: Player | None
     ) -> tuple[str, list[int]]:
         """
         Resolve the flow mode config and supported sample rates for restart decisions.
@@ -3116,22 +3116,26 @@ class StreamsAudio:
         player the flow's PCM format was anchored on — over the queue's (wrapper)
         player, whose config may lack the audio/protocol specific entries.
 
-        :param queue_id: The queue ID, used as fallback when no flow player is given.
-        :param flow_player: The (protocol) player consuming the flow stream, if known.
+        :param queue_id: The queue ID, used as fallback when no protocol player is given.
+        :param protocol_player: The protocol player consuming the flow stream, if known.
         :return: Tuple of (flow mode sample rate config value, sorted supported rates).
         """
-        if flow_player is None:
-            flow_player = self.mass.players.get_player(queue_id)
-        if flow_player is None:
+        if protocol_player is None:
+            protocol_player = self.mass.players.get_player(queue_id)
+        if protocol_player is None:
             flow_mode_sample_rate_conf = self.mass.config.get_raw_player_config_value(
                 queue_id, CONF_FLOW_MODE_SAMPLE_RATE, FLOW_MODE_SAMPLE_RATE_SMART
             )
             return flow_mode_sample_rate_conf, []
         flow_mode_sample_rate_conf = cast(
             "str",
-            flow_player.config.get_value(CONF_FLOW_MODE_SAMPLE_RATE, FLOW_MODE_SAMPLE_RATE_SMART),
+            protocol_player.config.get_value(
+                CONF_FLOW_MODE_SAMPLE_RATE, FLOW_MODE_SAMPLE_RATE_SMART
+            ),
         )
-        supported_sample_rates = sorted({sr for sr, _ in flow_player.get_supported_sample_rates()})
+        supported_sample_rates = sorted(
+            {sr for sr, _ in protocol_player.get_supported_sample_rates()}
+        )
         return flow_mode_sample_rate_conf, supported_sample_rates
 
     def _flow_stream_needs_restart(

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1009,7 +1009,7 @@ class StreamsController(CoreController):
             start_queue_item=start_queue_item,
             pcm_format=flow_pcm_format,
             session_id=session_id,
-            flow_player=player,
+            protocol_player=player,
         )
         if overlay_active(queue):
             flow_stream = self.audio.get_overlay_mixed_stream(queue, flow_stream, flow_pcm_format)
@@ -1281,7 +1281,7 @@ class StreamsController(CoreController):
                     start_queue_item=start_queue_item,
                     pcm_format=pcm_format,
                     session_id=queue_session_id,
-                    flow_player=protocol_player,
+                    protocol_player=protocol_player,
                 )
                 if overlay_active(queue):
                     flow_stream = self.audio.get_overlay_mixed_stream(

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1009,6 +1009,7 @@ class StreamsController(CoreController):
             start_queue_item=start_queue_item,
             pcm_format=flow_pcm_format,
             session_id=session_id,
+            flow_player=player,
         )
         if overlay_active(queue):
             flow_stream = self.audio.get_overlay_mixed_stream(queue, flow_stream, flow_pcm_format)
@@ -1280,6 +1281,7 @@ class StreamsController(CoreController):
                     start_queue_item=start_queue_item,
                     pcm_format=pcm_format,
                     session_id=queue_session_id,
+                    flow_player=protocol_player,
                 )
                 if overlay_active(queue):
                     flow_stream = self.audio.get_overlay_mixed_stream(

--- a/tests/controllers/streams/test_flow_format.py
+++ b/tests/controllers/streams/test_flow_format.py
@@ -510,6 +510,60 @@ def test_needs_restart_returns_false_when_streamdetails_missing() -> None:
     )
 
 
+# --- _flow_restart_context ---
+
+
+def test_flow_restart_context_prefers_flow_player() -> None:
+    """The given (protocol) player's config and rates win over the queue player's."""
+    audio = _make_streams_audio()
+    protocol_player = _make_player(
+        supported=[(44100, 16), (96000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_BIT_PERFECT,
+    )
+    # queue (wrapper) player without audio config entries: 44100-only fallback
+    wrapper_player = _make_player(supported=[(44100, 16)])
+    audio.mass.players.get_player = MagicMock(  # type: ignore[method-assign]
+        return_value=wrapper_player
+    )
+
+    conf, rates = audio._flow_restart_context("queue-1", protocol_player)
+
+    assert conf == FLOW_MODE_SAMPLE_RATE_BIT_PERFECT
+    assert rates == [44100, 96000]
+    audio.mass.players.get_player.assert_not_called()
+
+
+def test_flow_restart_context_falls_back_to_queue_player() -> None:
+    """Without a flow player, the queue's own player is used."""
+    audio = _make_streams_audio()
+    queue_player = _make_player(
+        supported=[(48000, 16)], flow_mode=FLOW_MODE_SAMPLE_RATE_BIT_PERFECT
+    )
+    audio.mass.players.get_player = MagicMock(  # type: ignore[method-assign]
+        return_value=queue_player
+    )
+
+    conf, rates = audio._flow_restart_context("queue-1", None)
+
+    assert conf == FLOW_MODE_SAMPLE_RATE_BIT_PERFECT
+    assert rates == [48000]
+    audio.mass.players.get_player.assert_called_once_with("queue-1")
+
+
+def test_flow_restart_context_without_any_player() -> None:
+    """When no player can be resolved, the raw queue config and empty rates are used."""
+    audio = _make_streams_audio()
+    audio.mass.players.get_player = MagicMock(return_value=None)  # type: ignore[method-assign]
+    audio.mass.config.get_raw_player_config_value = MagicMock(  # type: ignore[method-assign]
+        return_value=FLOW_MODE_SAMPLE_RATE_SMART
+    )
+
+    conf, rates = audio._flow_restart_context("queue-1", None)
+
+    assert conf == FLOW_MODE_SAMPLE_RATE_SMART
+    assert rates == []
+
+
 # --- helpers ---
 
 

--- a/tests/controllers/streams/test_flow_format.py
+++ b/tests/controllers/streams/test_flow_format.py
@@ -513,7 +513,7 @@ def test_needs_restart_returns_false_when_streamdetails_missing() -> None:
 # --- _flow_restart_context ---
 
 
-def test_flow_restart_context_prefers_flow_player() -> None:
+def test_flow_restart_context_prefers_protocol_player() -> None:
     """The given (protocol) player's config and rates win over the queue player's."""
     audio = _make_streams_audio()
     protocol_player = _make_player(
@@ -534,7 +534,7 @@ def test_flow_restart_context_prefers_flow_player() -> None:
 
 
 def test_flow_restart_context_falls_back_to_queue_player() -> None:
-    """Without a flow player, the queue's own player is used."""
+    """Without a protocol player, the queue's own player is used."""
     audio = _make_streams_audio()
     queue_player = _make_player(
         supported=[(48000, 16)], flow_mode=FLOW_MODE_SAMPLE_RATE_BIT_PERFECT


### PR DESCRIPTION
# What does this implement/fix?

Flow mode streams were stuck at the first track's sample rate on wrapped players (e.g. players behind a Universal Group): the mid-flow restart check re-resolved the player from the queue id, which returns the wrapper player. That wrapper has no audio/protocol config entries, so the check fell back to 44.1kHz/16bit defaults and the sample-rate switch never triggered.

- Pass the protocol player (the player actually requesting the flow stream, and the one the flow PCM format was anchored on) into `get_queue_flow_stream()`
- New `_flow_restart_context()` helper resolves the flow mode config and supported sample rates from that player, falling back to the queue's player when not given
- Add unit tests for the helper (protocol player preferred, queue-player fallback, no player at all)

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5748

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.