### PR TITLE
Recompute dynamic playlist metadata when its tracks are refreshed

### DIFF
--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -145,10 +145,12 @@ class PlaylistController(MediaControllerBase[Playlist]):
             page += 1
 
         if refresh_dynamic_metadata and library_item is not None:
-            # runs after the loop so it reads the freshly cached track sample
-            self.mass.create_task(
-                self.mass.metadata.update_metadata(library_item, force_refresh=True)
-            )
+            # dynamic playlists are excluded from the periodic metadata batch job, so
+            # recompute here from the freshly cached track sample. clearing last_refresh
+            # requests the recompute the way the add/remove track handlers do, without
+            # relying on force_refresh (whose purpose is to bypass caches).
+            library_item.metadata.last_refresh = None
+            self.mass.create_task(self.mass.metadata.update_metadata(library_item))
 
     async def create_playlist(
         self,

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -111,9 +111,17 @@ class PlaylistController(MediaControllerBase[Playlist]):
         allow_dynamic_tracks: bool = False,
     ) -> AsyncGenerator[PlaylistPlayableItem]:
         """Return playlist tracks for the given provider playlist id."""
+        library_item: Playlist | None = None
         if provider_instance_id_or_domain == "library":
             library_item = await self.get_library_item(item_id)
             provider_instance_id_or_domain, item_id = self._select_provider_id(library_item)
+
+        # An explicit (user-initiated) refresh of a dynamic playlist regenerates its
+        # content, so the stored playlist metadata (genres etc.) must be recomputed
+        # from the new tracks afterwards.
+        refresh_dynamic_metadata = (
+            force_refresh and library_item is not None and library_item.is_dynamic
+        )
 
         # Playback/refill requests for dynamic playlists need fresh tracks from the provider.
         # Browse requests may reuse cached tracks.
@@ -136,6 +144,13 @@ class PlaylistController(MediaControllerBase[Playlist]):
             for track in tracks:
                 yield track
             page += 1
+
+        if refresh_dynamic_metadata and library_item is not None:
+            # reads the freshly cached track sample, so the recomputed metadata
+            # matches the tracks just returned
+            self.mass.create_task(
+                self.mass.metadata.update_metadata(library_item, force_refresh=True)
+            )
 
     async def create_playlist(
         self,

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -116,9 +116,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
             library_item = await self.get_library_item(item_id)
             provider_instance_id_or_domain, item_id = self._select_provider_id(library_item)
 
-        # An explicit (user-initiated) refresh of a dynamic playlist regenerates its
-        # content, so the stored playlist metadata (genres etc.) must be recomputed
-        # from the new tracks afterwards.
+        # a user-initiated refresh of a dynamic playlist regenerates its content,
+        # so the stored metadata (genres etc.) must be recomputed afterwards
         refresh_dynamic_metadata = (
             force_refresh and library_item is not None and library_item.is_dynamic
         )
@@ -146,8 +145,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
             page += 1
 
         if refresh_dynamic_metadata and library_item is not None:
-            # reads the freshly cached track sample, so the recomputed metadata
-            # matches the tracks just returned
+            # runs after the loop so it reads the freshly cached track sample
             self.mass.create_task(
                 self.mass.metadata.update_metadata(library_item, force_refresh=True)
             )

--- a/tests/controllers/music/test_dynamic_playlist_metadata.py
+++ b/tests/controllers/music/test_dynamic_playlist_metadata.py
@@ -36,7 +36,9 @@ async def test_force_refresh_dynamic_playlist_updates_metadata() -> None:
     await _consume(ctrl, force_refresh=True)
 
     ctrl.mass.create_task.assert_called_once()
-    ctrl.mass.metadata.update_metadata.assert_called_once_with(library_item, force_refresh=True)
+    # recompute is requested by clearing last_refresh; force_refresh is not passed
+    assert library_item.metadata.last_refresh is None
+    ctrl.mass.metadata.update_metadata.assert_called_once_with(library_item)
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/music/test_dynamic_playlist_metadata.py
+++ b/tests/controllers/music/test_dynamic_playlist_metadata.py
@@ -1,0 +1,69 @@
+"""Tests for dynamic playlist metadata refresh on track regeneration."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from music_assistant.controllers.music.media.playlists import PlaylistController
+
+
+def _make_ctrl(*, is_dynamic: bool) -> tuple[MagicMock, MagicMock]:
+    """Create a mock PlaylistController self plus its library playlist item."""
+    library_item = MagicMock()
+    library_item.is_dynamic = is_dynamic
+    ctrl = MagicMock()
+    ctrl.get_library_item = AsyncMock(return_value=library_item)
+    ctrl._select_provider_id = MagicMock(return_value=("builtin", "random_album"))
+    ctrl._get_provider_playlist_tracks = AsyncMock(side_effect=[[MagicMock(), MagicMock()], []])
+    ctrl.mass = MagicMock()
+    # close the scheduled coroutine to avoid "never awaited" warnings
+    ctrl.mass.create_task = MagicMock(side_effect=lambda coro: coro.close())
+    ctrl.mass.metadata.update_metadata = AsyncMock()
+    return ctrl, library_item
+
+
+async def _consume(ctrl: MagicMock, **kwargs: bool) -> None:
+    """Fully consume the tracks generator for a library playlist."""
+    async for _ in PlaylistController.tracks(ctrl, "1", "library", **kwargs):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_force_refresh_dynamic_playlist_updates_metadata() -> None:
+    """A user-initiated refresh of a dynamic playlist must recompute its metadata."""
+    ctrl, library_item = _make_ctrl(is_dynamic=True)
+
+    await _consume(ctrl, force_refresh=True)
+
+    ctrl.mass.create_task.assert_called_once()
+    ctrl.mass.metadata.update_metadata.assert_called_once_with(library_item, force_refresh=True)
+
+
+@pytest.mark.asyncio
+async def test_browse_dynamic_playlist_keeps_metadata() -> None:
+    """A plain browse request (no refresh) must not touch playlist metadata."""
+    ctrl, _ = _make_ctrl(is_dynamic=True)
+
+    await _consume(ctrl)
+
+    ctrl.mass.create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_playback_refill_dynamic_playlist_keeps_metadata() -> None:
+    """A playback refill (allow_dynamic_tracks) must not trigger a metadata update."""
+    ctrl, _ = _make_ctrl(is_dynamic=True)
+
+    await _consume(ctrl, allow_dynamic_tracks=True)
+
+    ctrl.mass.create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_force_refresh_static_playlist_keeps_metadata() -> None:
+    """A forced refresh of a regular playlist must not trigger a metadata update."""
+    ctrl, _ = _make_ctrl(is_dynamic=False)
+
+    await _consume(ctrl, force_refresh=True)
+
+    ctrl.mass.create_task.assert_not_called()


### PR DESCRIPTION
# What does this implement/fix?

The genres (and other metadata) of dynamic builtin playlists like "Random Album (from Library)" never updated: dynamic playlists are excluded from the periodic metadata batch job and nothing recomputed their metadata when their content regenerated, so the genre chips stayed stale forever.

- Schedule `update_metadata(force_refresh=True)` for a dynamic playlist after a user-initiated refresh of its tracks, so metadata is recomputed from the freshly generated content
- Browse requests, playback refills and refreshes of regular playlists are unaffected
- Add unit tests covering all four cases

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/3899

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.