### PR TITLE
Fix Spotify authentication failing after recent token changes

### DIFF
--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -129,7 +129,7 @@ class ConfigController(
             parent = parent[subkey]
         return default
 
-    def set(self, key: str, value: Any) -> None:
+    def set(self, key: str, value: Any, immediate: bool = False) -> None:
         """Set value(s) for a specific key/path in persistent storage."""
         assert self.initialized, "Not yet (async) initialized"
         # we support a multi level hierarchy by providing the key as path,
@@ -142,7 +142,7 @@ class ConfigController(
             else:
                 parent.setdefault(subkey, {})
                 parent = parent[subkey]
-        self.save()
+        self.save(immediate=immediate)
 
     def set_default(self, key: str, default_value: Any) -> None:
         """Set default value(s) for a specific key/path in persistent storage."""

--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -65,7 +65,7 @@ class ProviderConfigMixin:
 
         def get(self, key: str, default: Any = None) -> Any: ...  # noqa: D102
 
-        def set(self, key: str, value: Any) -> None: ...  # noqa: D102
+        def set(self, key: str, value: Any, immediate: bool = False) -> None: ...  # noqa: D102
 
         def set_default(self, key: str, default_value: Any) -> None: ...  # noqa: D102
 
@@ -395,11 +395,15 @@ class ProviderConfigMixin:
         key: str,
         value: ConfigValueType,
         encrypted: bool = False,
+        immediate: bool = False,
     ) -> None:
         """
         Set (raw) single config(entry) value for a provider.
 
         Note that this only stores the (raw) value without any validation or default.
+        When immediate is set the value is flushed to disk right away instead of on the
+        debounced save timer, so a critical value (e.g. a rotated auth token) is not lost
+        if the process is killed within the debounce window.
         """
         if not self.get(f"{CONF_PROVIDERS}/{provider_instance}"):
             # only allow setting raw values if main entry exists
@@ -411,9 +415,9 @@ class ProviderConfigMixin:
                 raise ValueError(msg)
             value = self.encrypt_string(value)
         if key in BASE_KEYS:
-            self.set(f"{CONF_PROVIDERS}/{provider_instance}/{key}", value)
+            self.set(f"{CONF_PROVIDERS}/{provider_instance}/{key}", value, immediate=immediate)
             return
-        self.set(f"{CONF_PROVIDERS}/{provider_instance}/values/{key}", value)
+        self.set(f"{CONF_PROVIDERS}/{provider_instance}/values/{key}", value, immediate=immediate)
         # also update the provider's in-place config copy (if loaded) so
         # object-local value reads stay in sync with raw writes
         if (provider := self.mass.get_provider(provider_instance)) and (
@@ -449,8 +453,6 @@ class ProviderConfigMixin:
         conf_key = f"{CONF_PROVIDERS}/{config.instance_id}"
         raw_conf = config.to_raw()
         self.set(conf_key, raw_conf)
-        if config.enabled and prov_instance is None:
-            await self.mass.load_provider_config(config)
         if config.enabled and prov_instance and available:
             # update config for existing/loaded provider instance
             await prov_instance.update_config(config, changed_keys)

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -745,13 +745,21 @@ class MusicAssistant:
         self,
         prov_conf: ProviderConfig,
     ) -> None:
-        """Try to load a provider and catch errors."""
+        """Load (or reload) a provider from its config, recording any load failure."""
         # cancel existing (re)load timer if needed
         task_id = f"load_provider_{prov_conf.instance_id}"
         if existing := self._tracked_timers.pop(task_id, None):
             existing.cancel()
 
-        await self._load_provider(prov_conf)
+        try:
+            await self._load_provider(prov_conf)
+        except Exception as exc:
+            # persist the failure so the provider surfaces a clear status (e.g. auth_required)
+            # to the UI instead of appearing stuck loading, then propagate to the caller
+            self.config.update_provider_last_error(
+                prov_conf.instance_id, _provider_error_from_exc(exc)
+            )
+            raise
 
         # (re)load any dependants
         prov_configs = await self.config.get_provider_configs(include_values=True)

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -264,10 +264,19 @@ class Provider:
         """
         return self.config.get_value(key, default)
 
-    def _update_config_value(self, key: str, value: Any, encrypted: bool = False) -> None:
-        """Update a config value."""
+    def _update_config_value(
+        self, key: str, value: Any, encrypted: bool = False, immediate: bool = False
+    ) -> None:
+        """
+        Update a config value.
+
+        :param immediate: Persist to disk right away instead of on the debounced save timer;
+            use for critical values (e.g. a rotated auth token) that must survive a crash.
+        """
         # the config controller also updates the cached copy within this provider instance
-        self.mass.config.set_raw_provider_config_value(self.instance_id, key, value, encrypted)
+        self.mass.config.set_raw_provider_config_value(
+            self.instance_id, key, value, encrypted, immediate
+        )
 
     def _set_log_level_from_config(self, config: ProviderConfig) -> None:
         """Set log level from config."""

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -275,7 +275,7 @@ class Provider:
         """
         # the config controller also updates the cached copy within this provider instance
         self.mass.config.set_raw_provider_config_value(
-            self.instance_id, key, value, encrypted, immediate
+            self.instance_id, key, value, encrypted=encrypted, immediate=immediate
         )
 
     def _set_log_level_from_config(self, config: ProviderConfig) -> None:

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -849,10 +849,15 @@ class SpotifyProvider(MusicProvider):
             self.logger.debug("Successfully refreshed global access token")
         except LoginFailed as err:
             if "revoked" in str(err) or "invalid_grant" in str(err):
-                # clear refresh token if it's revoked or expired
-                self._update_config_value(CONF_REFRESH_TOKEN_GLOBAL, None)
-                if self.available:
-                    self.unload_with_error(str(err))
+                # Spotify rotates the refresh token on refresh and revokes the previous one.
+                # If the stored token was rotated while this refresh was in flight, the token
+                # we tried is merely stale, so keep the newer one instead of forcing re-auth.
+                if not self._refresh_token_superseded(
+                    CONF_REFRESH_TOKEN_GLOBAL, cast("str", refresh_token)
+                ):
+                    self._update_config_value(CONF_REFRESH_TOKEN_GLOBAL, None)
+                    if self.available:
+                        self.unload_with_error(str(err))
             elif self.available:
                 self.mass.create_task(
                     self.mass.unload_provider_with_error(self.instance_id, str(err))
@@ -861,8 +866,10 @@ class SpotifyProvider(MusicProvider):
 
         # make sure that our updated creds get stored in memory + config
         self._auth_info_global = auth_info
+        # persist immediately: Spotify revokes the previous refresh token on rotation, so the
+        # new one must survive a crash within the debounced-save window to avoid a forced re-auth
         self._update_config_value(
-            CONF_REFRESH_TOKEN_GLOBAL, auth_info["refresh_token"], encrypted=True
+            CONF_REFRESH_TOKEN_GLOBAL, auth_info["refresh_token"], encrypted=True, immediate=True
         )
 
         # Setup librespot with global token only if dev token is not configured
@@ -910,9 +917,14 @@ class SpotifyProvider(MusicProvider):
             self.logger.debug("Successfully refreshed developer access token")
         except LoginFailed as err:
             if "revoked" in str(err) or "invalid_grant" in str(err):
-                # clear refresh token if it's revoked or expired
-                self._update_config_value(CONF_REFRESH_TOKEN_DEV, None)
-                self._update_config_value(CONF_CLIENT_ID, None)
+                # Spotify rotates the refresh token on refresh and revokes the previous one.
+                # If the stored token was rotated while this refresh was in flight, the token
+                # we tried is merely stale, so keep the newer one instead of forcing re-auth.
+                if not self._refresh_token_superseded(
+                    CONF_REFRESH_TOKEN_DEV, cast("str", refresh_token)
+                ):
+                    self._update_config_value(CONF_REFRESH_TOKEN_DEV, None)
+                    self._update_config_value(CONF_CLIENT_ID, None)
             # Don't unload - we can still use the global session
             self.dev_session_active = False
             self.logger.warning(str(err))
@@ -920,8 +932,10 @@ class SpotifyProvider(MusicProvider):
 
         # make sure that our updated creds get stored in memory + config
         self._auth_info_dev = auth_info
+        # persist immediately: Spotify revokes the previous refresh token on rotation, so the
+        # new one must survive a crash within the debounced-save window to avoid a forced re-auth
         self._update_config_value(
-            CONF_REFRESH_TOKEN_DEV, auth_info["refresh_token"], encrypted=True
+            CONF_REFRESH_TOKEN_DEV, auth_info["refresh_token"], encrypted=True, immediate=True
         )
 
         # Setup librespot with dev token (preferred over global token)
@@ -1485,3 +1499,16 @@ class SpotifyProvider(MusicProvider):
             raise  # Re-raise other HTTP errors
         except MediaNotFoundError, ProviderUnavailableError:
             return False
+
+    def _refresh_token_superseded(self, key: str, used_token: str) -> bool:
+        """
+        Return whether the stored refresh token differs from the one just used.
+
+        :param key: Config key of the refresh token to check.
+        :param used_token: The refresh token value that was just used to refresh.
+        """
+        raw_stored = self.mass.config.get_raw_provider_config_value(self.instance_id, key)
+        if not raw_stored:
+            return False
+        stored_token = self.mass.config.decrypt_string(cast("str", raw_stored))
+        return stored_token != used_token

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -866,10 +866,15 @@ class SpotifyProvider(MusicProvider):
 
         # make sure that our updated creds get stored in memory + config
         self._auth_info_global = auth_info
-        # persist immediately: Spotify revokes the previous refresh token on rotation, so the
-        # new one must survive a crash within the debounced-save window to avoid a forced re-auth
+        # Spotify revokes the previous refresh token only when it rotates one, so on rotation
+        # persist immediately to ensure the new token survives a crash within the debounced-save
+        # window and avoids a forced re-auth; an unchanged token uses the normal debounced save.
+        token_rotated = auth_info["refresh_token"] != refresh_token
         self._update_config_value(
-            CONF_REFRESH_TOKEN_GLOBAL, auth_info["refresh_token"], encrypted=True, immediate=True
+            CONF_REFRESH_TOKEN_GLOBAL,
+            auth_info["refresh_token"],
+            encrypted=True,
+            immediate=token_rotated,
         )
 
         # Setup librespot with global token only if dev token is not configured
@@ -932,10 +937,15 @@ class SpotifyProvider(MusicProvider):
 
         # make sure that our updated creds get stored in memory + config
         self._auth_info_dev = auth_info
-        # persist immediately: Spotify revokes the previous refresh token on rotation, so the
-        # new one must survive a crash within the debounced-save window to avoid a forced re-auth
+        # Spotify revokes the previous refresh token only when it rotates one, so on rotation
+        # persist immediately to ensure the new token survives a crash within the debounced-save
+        # window and avoids a forced re-auth; an unchanged token uses the normal debounced save.
+        token_rotated = auth_info["refresh_token"] != refresh_token
         self._update_config_value(
-            CONF_REFRESH_TOKEN_DEV, auth_info["refresh_token"], encrypted=True, immediate=True
+            CONF_REFRESH_TOKEN_DEV,
+            auth_info["refresh_token"],
+            encrypted=True,
+            immediate=token_rotated,
         )
 
         # Setup librespot with dev token (preferred over global token)

--- a/tests/controllers/config/test_provider_config_load.py
+++ b/tests/controllers/config/test_provider_config_load.py
@@ -1,0 +1,88 @@
+"""
+Regression tests for the provider config save -> (re)load flow.
+
+Covers three fixes for the Spotify auth failures caused by refresh-token rotation:
+- Saving an enabled-but-unloaded provider triggers exactly one (re)load. A second,
+  redundant load reused the same (already rotated and revoked) refresh token, which
+  wiped the credentials right after a successful auth.
+- A failed (re)load records ``last_error`` so the provider surfaces a clear status
+  (e.g. auth_required) instead of appearing stuck loading (a spinning hourglass).
+- A raw provider value stored with ``immediate=True`` is flushed straight away instead of
+  on the debounced timer, so a rotated (and thus revoked) token is not lost on a crash.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from music_assistant_models.config_entries import ProviderConfig, ProviderError
+from music_assistant_models.enums import ProviderStatus, ProviderType
+from music_assistant_models.errors import LoginFailed
+
+from music_assistant.constants import CONF_PROVIDERS
+from music_assistant.controllers.config.helpers import _provider_status
+from music_assistant.mass import MusicAssistant
+
+
+def _prov_conf(instance_id: str) -> ProviderConfig:
+    return ProviderConfig(
+        values={},
+        type=ProviderType.MUSIC,
+        domain="spotify",
+        instance_id=instance_id,
+        enabled=True,
+    )
+
+
+async def test_save_enabled_unloaded_provider_loads_once(mass_minimal: MusicAssistant) -> None:
+    """Saving config for an enabled provider that isn't loaded yet triggers a single load."""
+    config = mass_minimal.config
+    instance = "spotify--test"
+    prov_conf = _prov_conf(instance)
+    with (
+        patch.object(config, "get_provider_config", AsyncMock(return_value=prov_conf)),
+        patch.object(mass_minimal, "load_provider_config", AsyncMock()) as mock_load,
+    ):
+        await config.save_provider_config("spotify", {"enabled": True}, instance_id=instance)
+    mock_load.assert_awaited_once()
+
+
+async def test_failed_reload_records_auth_error(mass_minimal: MusicAssistant) -> None:
+    """A load failure is persisted as last_error so the UI shows auth_required, not a spinner."""
+    config = mass_minimal.config
+    instance = "spotify--test"
+    # the provider config must exist for last_error to be persisted (see #5728)
+    config.set(
+        f"{CONF_PROVIDERS}/{instance}",
+        {"domain": "spotify", "type": "music", "instance_id": instance, "enabled": True},
+    )
+    with (
+        patch.object(
+            mass_minimal, "_load_provider", AsyncMock(side_effect=LoginFailed("bad token"))
+        ),
+        pytest.raises(LoginFailed),
+    ):
+        await mass_minimal.load_provider_config(_prov_conf(instance))
+
+    stored = config.get(f"{CONF_PROVIDERS}/{instance}/last_error")
+    assert stored is not None
+    assert stored["error_code"] == LoginFailed.error_code
+    prov_conf = _prov_conf(instance)
+    prov_conf.last_error = ProviderError.from_dict(stored)
+    assert _provider_status(prov_conf, is_loaded=False) == ProviderStatus.AUTH_REQUIRED
+
+
+async def test_immediate_flush_for_rotated_token(mass_minimal: MusicAssistant) -> None:
+    """Storing a raw provider value with immediate=True flushes without waiting for the debounce."""
+    config = mass_minimal.config
+    instance = "spotify--test"
+    config.set(
+        f"{CONF_PROVIDERS}/{instance}",
+        {"domain": "spotify", "type": "music", "instance_id": instance, "enabled": True},
+    )
+    with patch.object(config, "save", MagicMock()) as mock_save:
+        config.set_raw_provider_config_value(
+            instance, "refresh_token_global", "token_b", immediate=True
+        )
+    mock_save.assert_called_once_with(immediate=True)

--- a/tests/providers/mpd/test_provider.py
+++ b/tests/providers/mpd/test_provider.py
@@ -38,7 +38,7 @@ async def test_remove_player_prunes_manual_host_config() -> None:
         "mpd_test",
         "manual_discovery_ip_addresses",
         ["kitchen.local:6600", "bedroom.local"],
-        False,
-        False,
+        encrypted=False,
+        immediate=False,
     )
     provider.mass.players.unregister.assert_awaited_once_with("mpd_office.local_6601", True)

--- a/tests/providers/mpd/test_provider.py
+++ b/tests/providers/mpd/test_provider.py
@@ -39,5 +39,6 @@ async def test_remove_player_prunes_manual_host_config() -> None:
         "manual_discovery_ip_addresses",
         ["kitchen.local:6600", "bedroom.local"],
         False,
+        False,
     )
     provider.mass.players.unregister.assert_awaited_once_with("mpd_office.local_6601", True)

--- a/tests/providers/spotify/test_auth.py
+++ b/tests/providers/spotify/test_auth.py
@@ -1,0 +1,82 @@
+"""
+Tests for the Spotify provider's refresh-token handling.
+
+Spotify rotates the refresh token on every refresh and revokes the previous one. If a
+token was rotated while a refresh was in flight, the token we tried is merely stale, so
+the stored (newer) one must be kept instead of wiping the credentials and forcing re-auth.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.errors import LoginFailed
+
+from music_assistant.providers.spotify.constants import CONF_REFRESH_TOKEN_GLOBAL
+from music_assistant.providers.spotify.provider import SpotifyProvider
+
+USED_TOKEN = "token_a"
+
+
+def _make_provider(stored_token: str | None) -> SpotifyProvider:
+    """Return a SpotifyProvider (bypassing __init__) with a mocked config store."""
+    prov = object.__new__(SpotifyProvider)
+    config = MagicMock(instance_id="spotify--test")
+    config.get_value = MagicMock(
+        side_effect=lambda key, default=None: (
+            USED_TOKEN if key == CONF_REFRESH_TOKEN_GLOBAL else default
+        )
+    )
+    prov.config = config
+    prov.manifest = MagicMock(domain="spotify")
+    prov.logger = MagicMock()
+    prov.available = True
+    prov._auth_info_global = None
+
+    mass = MagicMock()
+    mass.config.get_raw_provider_config_value = MagicMock(return_value=stored_token)
+    # the raw store keeps the value encrypted; decrypt is an identity map for the test
+    mass.config.decrypt_string = MagicMock(side_effect=lambda value: value)
+    prov.mass = mass
+    return prov
+
+
+def test_refresh_token_superseded_no_stored_token() -> None:
+    """With no stored token there is nothing newer to protect, so it is not superseded."""
+    prov = _make_provider(stored_token=None)
+    assert prov._refresh_token_superseded(CONF_REFRESH_TOKEN_GLOBAL, USED_TOKEN) is False
+
+
+async def test_login_keeps_rotated_token_on_revoked(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A revoked error is ignored when the stored token was rotated meanwhile."""
+    prov = _make_provider(stored_token="token_b")
+    update_config = MagicMock()
+    unload = MagicMock()
+    monkeypatch.setattr(prov, "_update_config_value", update_config)
+    monkeypatch.setattr(prov, "unload_with_error", unload)
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.provider.get_spotify_token",
+        AsyncMock(side_effect=LoginFailed("invalid_grant: Refresh token revoked")),
+    )
+    with pytest.raises(LoginFailed):
+        await prov.login()
+    update_config.assert_not_called()
+    unload.assert_not_called()
+
+
+async def test_login_wipes_token_on_genuine_revoke(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A revoked error clears the credentials when the stored token is the one we tried."""
+    prov = _make_provider(stored_token=USED_TOKEN)
+    update_config = MagicMock()
+    unload = MagicMock()
+    monkeypatch.setattr(prov, "_update_config_value", update_config)
+    monkeypatch.setattr(prov, "unload_with_error", unload)
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.provider.get_spotify_token",
+        AsyncMock(side_effect=LoginFailed("invalid_grant: Refresh token revoked")),
+    )
+    with pytest.raises(LoginFailed):
+        await prov.login()
+    update_config.assert_called_once_with(CONF_REFRESH_TOKEN_GLOBAL, None)
+    unload.assert_called_once()

--- a/tests/providers/spotify/test_auth.py
+++ b/tests/providers/spotify/test_auth.py
@@ -80,3 +80,49 @@ async def test_login_wipes_token_on_genuine_revoke(monkeypatch: pytest.MonkeyPat
         await prov.login()
     update_config.assert_called_once_with(CONF_REFRESH_TOKEN_GLOBAL, None)
     unload.assert_called_once()
+
+
+async def test_login_persists_rotated_token_immediately(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A rotated refresh token is flushed to disk immediately so it survives a crash."""
+    prov = _make_provider(stored_token=USED_TOKEN)
+    prov._sp_user = {"display_name": "tester"}  # already populated -> skip the user-info fetch
+    update_config = MagicMock()
+    monkeypatch.setattr(prov, "_update_config_value", update_config)
+    monkeypatch.setattr(prov, "_setup_librespot_auth", AsyncMock())
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.provider.get_spotify_token",
+        AsyncMock(
+            return_value={
+                "access_token": "access",
+                "refresh_token": "token_rotated",
+                "expires_at": 9999999999,
+            }
+        ),
+    )
+    await prov.login()
+    update_config.assert_called_once_with(
+        CONF_REFRESH_TOKEN_GLOBAL, "token_rotated", encrypted=True, immediate=True
+    )
+
+
+async def test_login_debounces_save_when_token_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unchanged refresh token uses the normal debounced save instead of an immediate flush."""
+    prov = _make_provider(stored_token=USED_TOKEN)
+    prov._sp_user = {"display_name": "tester"}
+    update_config = MagicMock()
+    monkeypatch.setattr(prov, "_update_config_value", update_config)
+    monkeypatch.setattr(prov, "_setup_librespot_auth", AsyncMock())
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.provider.get_spotify_token",
+        AsyncMock(
+            return_value={
+                "access_token": "access",
+                "refresh_token": USED_TOKEN,
+                "expires_at": 9999999999,
+            }
+        ),
+    )
+    await prov.login()
+    update_config.assert_called_once_with(
+        CONF_REFRESH_TOKEN_GLOBAL, USED_TOKEN, encrypted=True, immediate=False
+    )


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Spotify recently changed how refresh tokens work: every refresh now returns a new token and immediately revokes the previous one. As a result some users could no longer authenticate Spotify — the provider either stayed stuck loading, or asked to re-authenticate and then failed right after pressing save.

The root cause was that saving an enabled provider kicked off a second, redundant load that reused the old (now revoked) token and wiped the stored credentials.

**Changes:**

- Remove the duplicate provider load when saving an enabled provider
- Keep the newer refresh token if it was rotated during a refresh
- Show a clear "needs authentication" state on a failed load instead of a stuck spinner
- Save rotated tokens straight away so they survive a restart

**Related issue (if applicable):**

- Follow-up to #4494

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.