### PR TITLE
Stabilize CodSpeed benchmark runs

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -52,10 +52,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
+        # Pin an exact patch (not .python-version's "3.14") so the interpreter is
+        # identical across runs and CodSpeed's instruction counts stay comparable;
+        # check-latest is omitted so a new 3.14.x can't silently change the runtime.
         uses: actions/setup-python@v6.3.0
         with:
-          python-version-file: ".python-version"
-          check-latest: true
+          python-version: "3.14.6"
 
       - name: Install uv
         run: pip install uv
@@ -72,9 +74,14 @@ jobs:
         run: uv pip install --system --index-strategy unsafe-best-match . .[test] -r requirements_all.txt
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286  # v4.18.5
         with:
           mode: simulation
+          # Run only the pure-function helper benchmarks: their instruction counts are
+          # deterministic. The async macro benchmarks (server boot / sync / library reads)
+          # execute a variable number of instructions per run (event-loop scheduling, poll
+          # loops, the aiosqlite worker thread), which simulation mode reports as false
+          # regressions; they still run as functional tests in the normal pytest job.
           # -o addopts="" clears the default "--cov music_assistant" so coverage
           # instrumentation does not interfere with the CodSpeed measurements.
-          run: pytest tests/benchmarks/ --codspeed -o addopts=""
+          run: pytest tests/benchmarks/test_bench_helpers.py --codspeed -o addopts=""


### PR DESCRIPTION
# What does this implement/fix?

CodSpeed benchmark runs were flaky, with frequent false regressions and reports of a different runtime between runs. Two root causes:

- The job installed the newest `3.14.x` patch on every run (`check-latest: true`), so the interpreter changed between runs and CodSpeed flagged a different runtime.
- The async macro benchmarks boot a full server and rely on event-loop scheduling / poll loops / a background DB thread, so the number of executed instructions varies per run — which CodSpeed's simulation mode reports as large false regressions.

Changes:

- Pin an exact Python patch (`3.14.6`) and drop `check-latest` so every run uses the same interpreter.
- Run only the deterministic pure-function helper benchmarks under CodSpeed; the macro benchmarks keep running as functional tests in the normal pytest job.
- Pin the CodSpeed action to a fixed commit SHA (v4.18.5).

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.