### PR TITLE
Fix Spotify authentication failing after recent token changes

### DIFF
--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -1654,8 +1654,6 @@ class ConfigController:
         conf_key = f"{CONF_PROVIDERS}/{config.instance_id}"
         raw_conf = config.to_raw()
         self.set(conf_key, raw_conf)
-        if config.enabled and prov_instance is None:
-            await self.mass.load_provider_config(config)
         if config.enabled and prov_instance and available:
             # update config for existing/loaded provider instance
             await prov_instance.update_config(config, changed_keys)

--- a/tests/core/test_provider_config_load.py
+++ b/tests/core/test_provider_config_load.py
@@ -1,0 +1,34 @@
+"""Regression test for the provider config save -> (re)load flow."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from music_assistant_models.config_entries import ProviderConfig
+from music_assistant_models.enums import ProviderType
+
+from music_assistant.mass import MusicAssistant
+
+
+async def test_save_enabled_unloaded_provider_loads_once(mass_minimal: MusicAssistant) -> None:
+    """
+    Saving an enabled provider that isn't loaded yet triggers exactly one (re)load.
+
+    A redundant second load reuses the same refresh token, which Spotify rotates and
+    revokes on first use, wiping the credentials right after a successful auth.
+    """
+    config = mass_minimal.config
+    instance_id = "spotify--test"
+    prov_conf = ProviderConfig(
+        values={},
+        type=ProviderType.MUSIC,
+        domain="spotify",
+        instance_id=instance_id,
+        enabled=True,
+    )
+    with (
+        patch.object(config, "get_provider_config", AsyncMock(return_value=prov_conf)),
+        patch.object(mass_minimal, "load_provider_config", AsyncMock()) as mock_load,
+    ):
+        await config.save_provider_config("spotify", {"enabled": True}, instance_id=instance_id)
+    mock_load.assert_awaited_once()


### PR DESCRIPTION
# What does this implement/fix?

Spotify authentication could break after saving the provider config. Depending on timing, the provider got stuck loading (spinning hourglass) or reported that authentication was required, and re-authenticating from settings then failed with an expired/revoked token.

Root cause: saving an enabled provider that wasn't loaded yet triggered two loads in a row. Spotify now rotates refresh tokens (revoking the old one the moment it is first used), so the second load reused the just-revoked token and wiped the stored credentials right after a successful login.

Minimal root-cause fix, backported from #4688 on `dev`.

**Changes:**

- Load a provider only once when saving its config (the redundant second load was reusing an already-rotated, revoked token).
- Add a regression test for the single-load behaviour.

**Related issue (if applicable):**

- Backport of #4688

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
