### PR TITLE
Library list endpoints return slim summary items by default

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -706,7 +706,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
     @api_command("music/recently_added_tracks", required_scope=Scope.LIBRARY_READ)
     async def recently_added_tracks(self, limit: int = 10) -> list[Track]:
         """Return a list of the last added tracks."""
-        return await self.tracks.library_items(limit=limit, order_by="timestamp_added_desc")
+        return await self.tracks.library_items(
+            limit=limit, order_by="timestamp_added_desc", summary=False
+        )
 
     @api_command("music/in_progress_items", required_scope=Scope.LIBRARY_READ)
     async def in_progress_items(
@@ -2387,7 +2389,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 icon="music-note-plus",
                 items=cast(
                     "UniqueList[MediaItemType | ItemMapping | BrowseFolder]",
-                    await self.tracks.library_items(limit=10, order_by="timestamp_added_desc"),
+                    await self.tracks.library_items(
+                        limit=10, order_by="timestamp_added_desc", summary=False
+                    ),
                 ),
             ),
             RecommendationFolder(
@@ -2398,7 +2402,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 icon="music-note-plus",
                 items=cast(
                     "UniqueList[MediaItemType | ItemMapping | BrowseFolder]",
-                    await self.albums.library_items(limit=10, order_by="timestamp_added_desc"),
+                    await self.albums.library_items(
+                        limit=10, order_by="timestamp_added_desc", summary=False
+                    ),
                 ),
             ),
             RecommendationFolder(
@@ -2409,7 +2415,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 icon="mdi-account-music",
                 items=cast(
                     "UniqueList[MediaItemType | ItemMapping | BrowseFolder]",
-                    await self.artists.library_items(limit=10, order_by="random_play_count"),
+                    await self.artists.library_items(
+                        limit=10, order_by="random_play_count", summary=False
+                    ),
                 ),
             ),
             RecommendationFolder(
@@ -2420,7 +2428,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 icon="mdi-album",
                 items=cast(
                     "UniqueList[MediaItemType | ItemMapping | BrowseFolder]",
-                    await self.albums.library_items(limit=10, order_by="random_play_count"),
+                    await self.albums.library_items(
+                        limit=10, order_by="random_play_count", summary=False
+                    ),
                 ),
             ),
             RecommendationFolder(
@@ -2432,7 +2442,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 items=cast(
                     "UniqueList[MediaItemType | ItemMapping | BrowseFolder]",
                     await self.tracks.library_items(
-                        favorite=True, limit=10, order_by="timestamp_modified_desc"
+                        favorite=True, limit=10, order_by="timestamp_modified_desc", summary=False
                     ),
                 ),
             ),
@@ -2444,7 +2454,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 icon="mdi-playlist-music",
                 items=cast(
                     "UniqueList[MediaItemType | ItemMapping | BrowseFolder]",
-                    await self.playlists.library_items(favorite=True, limit=10, order_by="random"),
+                    await self.playlists.library_items(
+                        favorite=True, limit=10, order_by="random", summary=False
+                    ),
                 ),
             ),
             RecommendationFolder(
@@ -2456,7 +2468,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 items=cast(
                     "UniqueList[MediaItemType | ItemMapping | BrowseFolder]",
                     await self.radio.library_items(
-                        favorite=True, limit=10, order_by="play_count_desc"
+                        favorite=True, limit=10, order_by="play_count_desc", summary=False
                     ),
                 ),
             ),

--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -139,7 +139,7 @@ class AlbumsController(MediaControllerBase[Album]):
         played_only: bool = False,
         album_types: list[AlbumType] | None = None,
         *,
-        summary: bool = False,
+        summary: bool = True,
         **kwargs: Any,
     ) -> list[Album]:
         """
@@ -153,8 +153,8 @@ class AlbumsController(MediaControllerBase[Album]):
         :param provider: Filter by provider instance ID (single string or list).
         :param album_types: Filter by album types.
         :param genre: Filter by genre id(s).
-        :param summary: Return slim summary items (only the fields needed for a list view)
-            instead of full items.
+        :param summary: When True (default), return slim summary items containing only the
+            fields needed for a list view. Set to False to get fully hydrated items.
         """
         extra_query_params: dict[str, Any] = {}
         extra_query_parts: list[str] = []

--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -91,7 +91,7 @@ class AlbumsController(MediaControllerBase[Album]):
             albums.version,
             albums.year,
             albums.album_type,
-            {self._provider_mappings_summary_query()} AS provider_mappings,
+            {self._provider_mappings_query()} AS provider_mappings,
             {artists_query} AS artists
             FROM albums"""
         return query, {}

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -141,7 +141,7 @@ class ArtistsController(MediaControllerBase[Artist]):
         album_artists_only: bool = False,
         artist_type: ArtistType | None = None,
         *,
-        summary: bool = False,
+        summary: bool = True,
         **kwargs: Any,
     ) -> list[Artist]:
         """
@@ -156,8 +156,8 @@ class ArtistsController(MediaControllerBase[Artist]):
         :param album_artists_only: Only return artists that have albums.
         :param genre: Filter by genre id(s).
         :param artist_type: The artist's type
-        :param summary: Return slim summary items (only the fields needed for a list view)
-            instead of full items.
+        :param summary: When True (default), return slim summary items containing only the
+            fields needed for a list view. Set to False to get fully hydrated items.
         """
         extra_query_params: dict[str, Any] = {}
         extra_query_parts: list[str] = []

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -102,7 +102,7 @@ class ArtistsController(MediaControllerBase[Artist]):
         SELECT
             {self._summary_base_columns()},
             artists.artist_type,
-            {self._provider_mappings_summary_query()} AS provider_mappings
+            {self._provider_mappings_query()} AS provider_mappings
             FROM artists"""
         return query, {}
 

--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -160,7 +160,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         played_only: bool = False,
         without_collections: bool | None = None,
         *,
-        summary: bool = False,
+        summary: bool = True,
         **kwargs: Any,
     ) -> list[Audiobook]:
         """
@@ -174,8 +174,8 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         :param provider: Filter by provider instance ID (single string or list).
         :param genre: Filter by genre id(s).
         :param without_collections: Do not return audiobooks which are part of a collection
-        :param summary: Return slim summary items (only the fields needed for a list view)
-            instead of full items.
+        :param summary: When True (default), return slim summary items containing only the
+            fields needed for a list view. Set to False to get fully hydrated items.
         """
         extra_query_params: dict[str, Any] = {}
         extra_query_parts: list[str] = []

--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -135,7 +135,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             audiobooks.duration,
             audiobooks.authors,
             audiobooks.narrators,
-            {self._provider_mappings_summary_query()} AS provider_mappings,
+            {self._provider_mappings_query()} AS provider_mappings,
             {artists_query} AS audiobook_artists,
             playlog.fully_played AS fully_played,
             playlog.seconds_played * 1000 as resume_position_ms

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -226,7 +226,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         query = f"""
         SELECT
             {self._summary_base_columns()},
-            {self._provider_mappings_summary_query()} AS provider_mappings
+            {self._provider_mappings_query()} AS provider_mappings
             FROM {self.db_table} """
         return query, {}
 
@@ -1238,21 +1238,6 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             WHERE pm.item_id = {self.db_table}.item_id
             AND pm.media_type = '{self.media_type.value}')"""
 
-    def _provider_mappings_summary_query(self) -> str:
-        """
-        Return a subquery selecting the slim provider mappings JSON of a summary row.
-
-        Only carries the fields needed to compute the availability flag; never
-        hydrated into ProviderMapping objects.
-        """
-        return f"""(SELECT JSON_GROUP_ARRAY(
-            json_object(
-                'provider_instance', pm.provider_instance,
-                'available', pm.available
-            )) FROM {DB_TABLE_PROVIDER_MAPPINGS} pm
-            WHERE pm.item_id = {self.db_table}.item_id
-            AND pm.media_type = '{self.media_type.value}')"""
-
     def _artist_mappings_summary_query(
         self, m2m_table: str, m2m_key: str, include_artist_type: bool = False
     ) -> str:
@@ -1706,30 +1691,37 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         Override in a subclass to fill additional per-type fields (selected by the
         subclass's summary_query).
         """
+        provider_mappings = self._parse_summary_provider_mappings(db_row)
         return self.summary_item_cls(
             item_id=str(db_row["item_id"]),
             provider="library",
             name=db_row["name"],
             sort_name=db_row["sort_name"],
             favorite=bool(db_row["favorite"]),
-            available=self._parse_summary_available(db_row),
+            provider_mappings=provider_mappings,
+            available=self._summary_available(provider_mappings),
             metadata=self._parse_summary_metadata(db_row),
         )
 
     @final
     @staticmethod
-    def _parse_summary_available(db_row: Mapping[str, Any]) -> bool:
-        """Compute the availability flag from the slim provider mappings of a summary row."""
+    def _parse_summary_provider_mappings(db_row: Mapping[str, Any]) -> set[ProviderMapping]:
+        """Hydrate the provider mappings of a summary row into ProviderMapping objects."""
         if not (raw_mappings := db_row["provider_mappings"]):
-            return False
-        mappings = json_loads(raw_mappings)
+            return set()
+        return {ProviderMapping.from_dict(x) for x in json_loads(raw_mappings)}
+
+    @final
+    @staticmethod
+    def _summary_available(provider_mappings: set[ProviderMapping]) -> bool:
+        """Compute the availability flag from a summary item's provider mappings."""
         # same semantics as the MediaItem.available property
         if not (available_providers := get_global_cache_value("available_providers")):
-            return any(x["available"] for x in mappings)
+            return any(x.available for x in provider_mappings)
         if TYPE_CHECKING:
             available_providers = cast("set[str]", available_providers)
         return any(
-            x["available"] and x["provider_instance"] in available_providers for x in mappings
+            x.available and x.provider_instance in available_providers for x in provider_mappings
         )
 
     @final

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -365,7 +365,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         genre: int | list[int] | None = None,
         played_only: bool = False,
         *,
-        summary: bool = False,
+        summary: bool = True,
         **kwargs: Any,
     ) -> list[ItemCls]:
         """
@@ -379,8 +379,8 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         :param provider: Filter by provider instance ID (single string or list).
         :param genre: Filter by genre id(s).
         :param played_only: Only include items that have been played (last_played > 0).
-        :param summary: Return slim summary items (only the fields needed for a list view)
-            instead of full items.
+        :param summary: When True (default), return slim summary items containing only the
+            fields needed for a list view. Set to False to get fully hydrated items.
         """
         items = await self.get_library_items_by_query(
             favorite=favorite,
@@ -490,7 +490,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         # create safe search string
         search_query = search_query.replace("/", " ").replace("'", "")
         if provider_instance_id_or_domain == "library":
-            return await self.library_items(search=search_query, limit=limit)
+            return await self.library_items(search=search_query, limit=limit, summary=False)
         if not (prov := self.mass.get_provider(provider_instance_id_or_domain)):
             return []
         prov = cast("MusicProvider", prov)

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -295,7 +295,7 @@ class GenreController(MediaControllerBase[Genre]):
         media_type: MediaType | None = None,
         content_type: str | None = None,
         *,
-        summary: bool = False,
+        summary: bool = True,
         **kwargs: Any,
     ) -> list[Genre]:
         """
@@ -312,8 +312,8 @@ class GenreController(MediaControllerBase[Genre]):
             general/music taxonomy, stored as NULL), "podcast" or "audiobook". Composes with
             hide_empty, so e.g. content_type="podcast" + hide_empty=None returns only the
             default podcast genres.
-        :param summary: Return slim summary items (only the fields needed for a list view)
-            instead of full items.
+        :param summary: When True (default), return slim summary items containing only the
+            fields needed for a list view. Set to False to get fully hydrated items.
         """
         if genre is not None:
             msg = "genre parameter is not supported for Genre.library_items()"

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -277,7 +277,7 @@ class GenreController(MediaControllerBase[Genre]):
             {self._summary_base_columns()},
             {DB_TABLE_GENRES}.translation_key,
             {DB_TABLE_GENRES}.content_type,
-            {self._provider_mappings_summary_query()} AS provider_mappings
+            {self._provider_mappings_query()} AS provider_mappings
         FROM (SELECT * FROM {DB_TABLE_GENRES} WHERE is_excluded = 0) AS {DB_TABLE_GENRES}"""
         return query, {}
 

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -118,7 +118,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
             playlists.supported_mediatypes,
             playlists.translation_key,
             playlists.translation_params,
-            {self._provider_mappings_summary_query()} AS provider_mappings
+            json_extract(playlists.metadata, '$.description') AS description,
+            {self._provider_mappings_query()} AS provider_mappings
             FROM playlists"""
         return query, {}
 
@@ -777,6 +778,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         item.owner = db_row["owner"]
         item.is_editable = bool(db_row["is_editable"])
         item.is_dynamic = bool(db_row["is_dynamic"])
+        item.metadata.description = db_row["description"]
         item.supported_mediatypes = {
             MediaType(x) for x in json_loads(db_row["supported_mediatypes"])
         }

--- a/music_assistant/controllers/music/media/podcasts.py
+++ b/music_assistant/controllers/music/media/podcasts.py
@@ -70,7 +70,7 @@ class PodcastsController(MediaControllerBase[Podcast]):
             podcasts.version,
             podcasts.publisher,
             podcasts.total_episodes,
-            {self._provider_mappings_summary_query()} AS provider_mappings
+            {self._provider_mappings_query()} AS provider_mappings
             FROM podcasts"""
         return query, {}
 

--- a/music_assistant/controllers/music/media/podcasts.py
+++ b/music_assistant/controllers/music/media/podcasts.py
@@ -85,7 +85,7 @@ class PodcastsController(MediaControllerBase[Podcast]):
         genre: int | list[int] | None = None,
         played_only: bool = False,
         *,
-        summary: bool = False,
+        summary: bool = True,
         **kwargs: Any,
     ) -> list[Podcast]:
         """
@@ -98,8 +98,8 @@ class PodcastsController(MediaControllerBase[Podcast]):
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param provider: Filter by provider instance ID (single string or list).
         :param genre: Filter by genre id(s).
-        :param summary: Return slim summary items (only the fields needed for a list view)
-            instead of full items.
+        :param summary: When True (default), return slim summary items containing only the
+            fields needed for a list view. Set to False to get fully hydrated items.
         """
         result = await self.get_library_items_by_query(
             favorite=favorite,

--- a/music_assistant/controllers/music/media/radio.py
+++ b/music_assistant/controllers/music/media/radio.py
@@ -56,7 +56,7 @@ class RadioController(MediaControllerBase[Radio]):
 
     async def export_radios(self) -> str:
         """Export all library radio stations to M3U8 format."""
-        radios = await self.library_items(limit=10000, offset=0)
+        radios = await self.library_items(limit=10000, offset=0, summary=False)
         items = [media_item_to_playlist_item(radio) for radio in radios]
         return generate_m3u("Radio Stations", items)
 

--- a/music_assistant/controllers/music/media/radio.py
+++ b/music_assistant/controllers/music/media/radio.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import MediaType, ProviderFeature
@@ -25,6 +25,8 @@ from music_assistant.models.music_provider import MusicProvider
 from .base import MediaControllerBase
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from music_assistant import MusicAssistant
     from music_assistant.providers.builtin import BuiltinProvider
 
@@ -53,6 +55,17 @@ class RadioController(MediaControllerBase[Radio]):
             self.import_radios,
             required_scope=Scope.LIBRARY_WRITE,
         )
+
+    @property
+    def summary_query(self) -> tuple[str, dict[str, Any]]:
+        """Return the slim SELECT query used for radio summary listings."""
+        query = f"""
+        SELECT
+            {self._summary_base_columns()},
+            json_extract({self.db_table}.metadata, '$.description') AS description,
+            {self._provider_mappings_query()} AS provider_mappings
+            FROM {self.db_table}"""
+        return query, {}
 
     async def export_radios(self) -> str:
         """Export all library radio stations to M3U8 format."""
@@ -225,3 +238,9 @@ class RadioController(MediaControllerBase[Radio]):
         )
         await self.set_provider_mappings(db_id, provider_mappings, overwrite)
         self.logger.debug("updated %s in database: (id %s)", update.name, db_id)
+
+    def _parse_summary_row(self, db_row: Mapping[str, Any]) -> RadioSummary:
+        """Parse a raw summary db row into a RadioSummary object."""
+        item = cast("RadioSummary", super()._parse_summary_row(db_row))
+        item.metadata.description = db_row["description"]
+        return item

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -142,7 +142,8 @@ class TracksController(MediaControllerBase[Track]):
             tracks.version,
             tracks.duration,
             json_extract(tracks.metadata, '$.explicit') AS explicit,
-            {self._provider_mappings_summary_query()} AS provider_mappings,
+            json_extract(tracks.metadata, '$.release_date') AS release_date,
+            {self._provider_mappings_query()} AS provider_mappings,
             {self._artist_mappings_summary_query(DB_TABLE_TRACK_ARTISTS, "track_id")} AS artists,
             (SELECT
                 json_object(
@@ -888,6 +889,8 @@ class TracksController(MediaControllerBase[Track]):
         item.version = db_row["version"] or ""
         item.duration = db_row["duration"] or 0
         item.metadata.explicit = None if db_row["explicit"] is None else bool(db_row["explicit"])
+        if raw_release_date := db_row["release_date"]:
+            item.metadata.release_date = datetime.fromisoformat(raw_release_date)
         item.artists = self._parse_summary_artist_mappings(db_row)
         if raw_album := db_row["track_album"]:
             album: dict[str, Any] = json_loads(raw_album)

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -243,7 +243,7 @@ class TracksController(MediaControllerBase[Track]):
         played_only: bool = False,
         explicit: bool | None = None,
         *,
-        summary: bool = False,
+        summary: bool = True,
         **kwargs: Any,
     ) -> list[Track]:
         """
@@ -258,8 +258,8 @@ class TracksController(MediaControllerBase[Track]):
         :param genre: Filter by genre id(s).
         :param played_only: Filter to only played tracks.
         :param explicit: Filter by explicit content (True=only explicit, False=no explicit, None=all).
-        :param summary: Return slim summary items (only the fields needed for a list view)
-            instead of full items.
+        :param summary: When True (default), return slim summary items containing only the
+            fields needed for a list view. Set to False to get fully hydrated items.
         """
         extra_query_params: dict[str, Any] = {}
         extra_query_parts: list[str] = []

--- a/music_assistant/controllers/player_queues/autoplay.py
+++ b/music_assistant/controllers/player_queues/autoplay.py
@@ -97,6 +97,7 @@ class Autoplay:
                     genre=genre_ids,
                     limit=AUTOPLAY_BATCH_SIZE * 3,
                     order_by="random_play_count",
+                    summary=False,
                 )
         # top up with a whole-library random mix when the genre selection yields too few usable
         # tracks (gauge on the deduped result so unavailable/excluded matches don't mask a shortfall)
@@ -106,6 +107,7 @@ class Autoplay:
                 candidates += await self.mass.music.tracks.library_items(
                     limit=AUTOPLAY_BATCH_SIZE * 3,
                     order_by="random_play_count",
+                    summary=False,
                 )
             result = self._dedupe(candidates, exclude)
         return result

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -548,6 +548,7 @@ class MusicProvider(Provider):
         if subpath == "artists":
             if artists := await self.mass.music.artists.library_items(
                 provider=self.instance_id,
+                summary=False,
             ):
                 return artists
             # library items not (yet) synced, fallback to direct retrieval
@@ -555,6 +556,7 @@ class MusicProvider(Provider):
         if subpath == "albums":
             if albums := await self.mass.music.albums.library_items(
                 provider=self.instance_id,
+                summary=False,
             ):
                 return albums
             # library items not (yet) synced, fallback to direct retrieval
@@ -562,6 +564,7 @@ class MusicProvider(Provider):
         if subpath == "tracks":
             if tracks := await self.mass.music.tracks.library_items(
                 provider=self.instance_id,
+                summary=False,
             ):
                 return tracks
             # library items not (yet) synced, fallback to direct retrieval
@@ -569,6 +572,7 @@ class MusicProvider(Provider):
         if subpath == "radios":
             if radios := await self.mass.music.radio.library_items(
                 provider=self.instance_id,
+                summary=False,
             ):
                 return radios
             # library items not (yet) synced, fallback to direct retrieval
@@ -576,6 +580,7 @@ class MusicProvider(Provider):
         if subpath == "playlists":
             if playlists := await self.mass.music.playlists.library_items(
                 provider=self.instance_id,
+                summary=False,
             ):
                 return playlists
             # library items not (yet) synced, fallback to direct retrieval
@@ -583,6 +588,7 @@ class MusicProvider(Provider):
         if subpath == "audiobooks":
             if audiobooks := await self.mass.music.audiobooks.library_items(
                 provider=self.instance_id,
+                summary=False,
             ):
                 return audiobooks
             # library items not (yet) synced, fallback to direct retrieval
@@ -590,6 +596,7 @@ class MusicProvider(Provider):
         if subpath == "podcasts":
             if podcasts := await self.mass.music.podcasts.library_items(
                 provider=self.instance_id,
+                summary=False,
             ):
                 return podcasts
             # library items not (yet) synced, fallback to direct retrieval

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1086,7 +1086,7 @@ class BuiltinProvider(MusicProvider):
     async def _get_builtin_playlist_random_favorite_tracks(self) -> list[Track]:
         result: list[Track] = []
         res = await self.mass.music.tracks.library_items(
-            favorite=True, limit=250000, order_by="random_play_count"
+            favorite=True, limit=250000, order_by="random_play_count", summary=False
         )
         for idx, item in enumerate(res, 1):
             item.position = idx
@@ -1096,7 +1096,9 @@ class BuiltinProvider(MusicProvider):
     @use_cache(expiration=120, category=CACHE_CATEGORY_PLAYLISTS)
     async def _get_builtin_playlist_random_tracks(self) -> list[Track]:
         result: list[Track] = []
-        res = await self.mass.music.tracks.library_items(limit=500, order_by="random_play_count")
+        res = await self.mass.music.tracks.library_items(
+            limit=500, order_by="random_play_count", summary=False
+        )
         for idx, item in enumerate(res, 1):
             item.position = idx
             result.append(item)
@@ -1123,7 +1125,7 @@ class BuiltinProvider(MusicProvider):
         for source in ("library", "top"):
             for min_tracks_required in (25, 10, 5, 1):
                 for random_artist in await self.mass.music.artists.library_items(
-                    limit=25, order_by="random"
+                    limit=25, order_by="random", summary=False
                 ):
                     if source == "library":
                         tracks = await self.mass.music.artists.tracks(
@@ -1193,7 +1195,7 @@ class BuiltinProvider(MusicProvider):
         limit = 25 * 3 if get_track_filter() is not None else 25
         candidates = list(
             await self.mass.music.tracks.library_items(
-                favorite=favorite, limit=limit, order_by="random"
+                favorite=favorite, limit=limit, order_by="random", summary=False
             )
         )
         tracks = filter_tracks(candidates)[:25]

--- a/music_assistant/providers/fastmcp_server/tools/library.py
+++ b/music_assistant/providers/fastmcp_server/tools/library.py
@@ -340,7 +340,7 @@ def build_library_server(mass: MusicAssistant) -> FastMCP:
         :param limit: Page size (clamped to ``[1, 200]``).
         """
         offset, limit = page_args(offset, limit)
-        items = await mass.music.tracks.library_items(limit=limit, offset=offset)
+        items = await mass.music.tracks.library_items(limit=limit, offset=offset, summary=False)
         return [to_brief_track(t) for t in items]
 
     @sub.tool(
@@ -359,7 +359,7 @@ def build_library_server(mass: MusicAssistant) -> FastMCP:
         :param limit: Page size (clamped to ``[1, 200]``).
         """
         offset, limit = page_args(offset, limit)
-        items = await mass.music.albums.library_items(limit=limit, offset=offset)
+        items = await mass.music.albums.library_items(limit=limit, offset=offset, summary=False)
         return [to_brief_album(a) for a in items]
 
     @sub.tool(
@@ -378,7 +378,7 @@ def build_library_server(mass: MusicAssistant) -> FastMCP:
         :param limit: Page size (clamped to ``[1, 200]``).
         """
         offset, limit = page_args(offset, limit)
-        items = await mass.music.artists.library_items(limit=limit, offset=offset)
+        items = await mass.music.artists.library_items(limit=limit, offset=offset, summary=False)
         return [to_brief_artist(a) for a in items]
 
     @sub.tool(
@@ -396,7 +396,7 @@ def build_library_server(mass: MusicAssistant) -> FastMCP:
         :param limit: Page size (clamped to ``[1, 200]``).
         """
         offset, limit = page_args(offset, limit)
-        items = await mass.music.playlists.library_items(limit=limit, offset=offset)
+        items = await mass.music.playlists.library_items(limit=limit, offset=offset, summary=False)
         return [to_brief_playlist(p) for p in items]
 
     @sub.tool(
@@ -414,7 +414,7 @@ def build_library_server(mass: MusicAssistant) -> FastMCP:
         :param limit: Page size (clamped to ``[1, 200]``).
         """
         offset, limit = page_args(offset, limit)
-        items = await mass.music.radio.library_items(limit=limit, offset=offset)
+        items = await mass.music.radio.library_items(limit=limit, offset=offset, summary=False)
         return [to_brief_radio(r) for r in items]
 
     @sub.tool(

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -325,9 +325,13 @@ class LocalFileSystemProvider(MusicProvider):
         """
         # for audiobooks and podcasts we just return all library items
         if self.media_content_type == "podcasts":
-            return await self.mass.music.podcasts.library_items(provider=self.instance_id)
+            return await self.mass.music.podcasts.library_items(
+                provider=self.instance_id, summary=False
+            )
         if self.media_content_type == "audiobooks":
-            return await self.mass.music.audiobooks.library_items(provider=self.instance_id)
+            return await self.mass.music.audiobooks.library_items(
+                provider=self.instance_id, summary=False
+            )
         items: list[MediaItemType | ItemMapping | BrowseFolder] = []
         item_path = path.split("://", 1)[1]
         if not item_path:

--- a/music_assistant/providers/lastfm_recommendations/recommendations.py
+++ b/music_assistant/providers/lastfm_recommendations/recommendations.py
@@ -165,7 +165,7 @@ class LastFMRecommendationManager:
         if media_type == MediaType.ARTIST:
             if name:
                 artist_results = await self.mass.music.artists.library_items(
-                    search=name, limit=LIBRARY_MATCH_SCAN_LIMIT
+                    search=name, limit=LIBRARY_MATCH_SCAN_LIMIT, summary=False
                 )
                 artist_match = next(
                     (a for a in artist_results if compare_strings(name, a.name, strict=False)),
@@ -180,7 +180,7 @@ class LastFMRecommendationManager:
         elif media_type == MediaType.ALBUM:
             if name:
                 album_results = await self.mass.music.albums.library_items(
-                    search=name, limit=LIBRARY_MATCH_SCAN_LIMIT
+                    search=name, limit=LIBRARY_MATCH_SCAN_LIMIT, summary=False
                 )
                 album_match = next(
                     (a for a in album_results if compare_strings(name, a.name, strict=False)),
@@ -204,7 +204,7 @@ class LastFMRecommendationManager:
                 # "Artist - Title" format so the tracks controller searches both fields
                 search_query = f"{artist_name} - {clean_name}"
                 track_results = await self.mass.music.tracks.library_items(
-                    search=search_query, limit=LIBRARY_MATCH_SCAN_LIMIT
+                    search=search_query, limit=LIBRARY_MATCH_SCAN_LIMIT, summary=False
                 )
                 # Match both title and artist; a title-only check would treat a same-named
                 # track by a different artist as owned. Differing recording MBIDs identify
@@ -423,7 +423,7 @@ class LastFMRecommendationManager:
                 )
 
         top_tracks = await self.mass.music.tracks.library_items(
-            limit=TOP_TRACKS_LIMIT, order_by="play_count_desc"
+            limit=TOP_TRACKS_LIMIT, order_by="play_count_desc", summary=False
         )
         # only seed from tracks actually played, so a new library of unplayed tracks
         # doesn't produce a row from arbitrary zero-play seeds
@@ -740,7 +740,7 @@ class LastFMRecommendationManager:
         # appearances across the user's most recently played tracks instead. Ordering happens
         # in the DB; ties fall to the more recently played artist via insertion order.
         recent_tracks = await self.mass.music.tracks.library_items(
-            limit=RECENT_TRACKS_SCAN_LIMIT, order_by="last_played_desc"
+            limit=RECENT_TRACKS_SCAN_LIMIT, order_by="last_played_desc", summary=False
         )
         counts: dict[str | int, int] = {}
         for track in recent_tracks:

--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -461,7 +461,9 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         offset = _int_param(request.query, "offset", 0)
         try:
             albums = await asyncio.wait_for(
-                self.provider.mass.music.albums.library_items(limit=limit, offset=offset),
+                self.provider.mass.music.albums.library_items(
+                    limit=limit, offset=offset, summary=False
+                ),
                 timeout=10.0,
             )
         except Exception:
@@ -490,7 +492,9 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         offset = _int_param(request.query, "offset", 0)
         try:
             artists = await asyncio.wait_for(
-                self.provider.mass.music.artists.library_items(limit=limit, offset=offset),
+                self.provider.mass.music.artists.library_items(
+                    limit=limit, offset=offset, summary=False
+                ),
                 timeout=10.0,
             )
         except Exception:
@@ -517,7 +521,9 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         offset = _int_param(request.query, "offset", 0)
         try:
             playlists = await asyncio.wait_for(
-                self.provider.mass.music.playlists.library_items(limit=limit, offset=offset),
+                self.provider.mass.music.playlists.library_items(
+                    limit=limit, offset=offset, summary=False
+                ),
                 timeout=10.0,
             )
         except Exception:
@@ -544,7 +550,9 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         offset = _int_param(request.query, "offset", 0)
         try:
             tracks = await asyncio.wait_for(
-                self.provider.mass.music.tracks.library_items(limit=limit, offset=offset),
+                self.provider.mass.music.tracks.library_items(
+                    limit=limit, offset=offset, summary=False
+                ),
                 timeout=10.0,
             )
         except Exception:
@@ -582,7 +590,9 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         prefix = self._get_prefix(request)
         try:
             tracks = await asyncio.wait_for(
-                self.provider.mass.music.tracks.library_items(limit=50, order_by="last_played"),
+                self.provider.mass.music.tracks.library_items(
+                    limit=50, order_by="last_played", summary=False
+                ),
                 timeout=10.0,
             )
         except Exception:
@@ -912,7 +922,9 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         limit = _int_param(request.query, "limit", 50)
         offset = _int_param(request.query, "offset", 0)
         start = _int_param(request.query, "start", 0)
-        tracks = await self.provider.mass.music.tracks.library_items(limit=limit, offset=offset)
+        tracks = await self.provider.mass.music.tracks.library_items(
+            limit=limit, offset=offset, summary=False
+        )
         playlist = map_tracks_to_msx_playlist(
             list(tracks),
             start,
@@ -929,7 +941,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         prefix = self._get_prefix(request)
         start = _int_param(request.query, "start", 0)
         tracks = await self.provider.mass.music.tracks.library_items(
-            limit=50, order_by="last_played"
+            limit=50, order_by="last_played", summary=False
         )
         playlist = map_tracks_to_msx_playlist(
             list(tracks),
@@ -1792,7 +1804,9 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         """List albums."""
         limit = _int_param(request.query, "limit", 50)
         offset = _int_param(request.query, "offset", 0)
-        albums = await self.provider.mass.music.albums.library_items(limit=limit, offset=offset)
+        albums = await self.provider.mass.music.albums.library_items(
+            limit=limit, offset=offset, summary=False
+        )
         return web.json_response(
             {
                 "items": [
@@ -1823,7 +1837,9 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         """List artists."""
         limit = _int_param(request.query, "limit", 50)
         offset = _int_param(request.query, "offset", 0)
-        artists = await self.provider.mass.music.artists.library_items(limit=limit, offset=offset)
+        artists = await self.provider.mass.music.artists.library_items(
+            limit=limit, offset=offset, summary=False
+        )
         return web.json_response(
             {
                 "items": [
@@ -1863,7 +1879,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         limit = _int_param(request.query, "limit", 50)
         offset = _int_param(request.query, "offset", 0)
         playlists = await self.provider.mass.music.playlists.library_items(
-            limit=limit, offset=offset
+            limit=limit, offset=offset, summary=False
         )
         return web.json_response(
             {
@@ -1894,7 +1910,9 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         """List tracks."""
         limit = _int_param(request.query, "limit", 50)
         offset = _int_param(request.query, "offset", 0)
-        tracks = await self.provider.mass.music.tracks.library_items(limit=limit, offset=offset)
+        tracks = await self.provider.mass.music.tracks.library_items(
+            limit=limit, offset=offset, summary=False
+        )
         return web.json_response(
             {
                 "items": [self._format_track(track) for track in tracks],
@@ -1947,7 +1965,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         """Return recently played items."""
         limit = _int_param(request.query, "limit", 20)
         tracks = await self.provider.mass.music.tracks.library_items(
-            limit=limit, order_by="last_played"
+            limit=limit, order_by="last_played", summary=False
         )
         return web.json_response(
             {

--- a/music_assistant/providers/playlist_metadata/__init__.py
+++ b/music_assistant/providers/playlist_metadata/__init__.py
@@ -676,6 +676,7 @@ class PlaylistMetadataProvider(MetadataProvider):
             results = await self.mass.music.artists.library_items(
                 search=artist.name,
                 limit=1,
+                summary=False,
             )
             if results and results[0].image:
                 return results[0].image

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -934,6 +934,7 @@ class SmartPlaylistProvider(PluginProvider):
                 album_types=album_type_enums,
                 limit=chunk,
                 offset=offset,
+                summary=False,
             )
             for a in page:
                 if a.item_id and str(a.item_id).isdigit():
@@ -1250,6 +1251,7 @@ class SmartPlaylistProvider(PluginProvider):
             limit=limit,
             order_by="random",
             provider=user_provider_filter,
+            summary=False,
         )
 
     async def _tracks_from_seeds(self, seed_uris: list[str], target_size: int) -> list[Track]:

--- a/music_assistant/providers/test/__init__.py
+++ b/music_assistant/providers/test/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import random
 from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from music_assistant_models.config_entries import ConfigEntry
@@ -192,7 +193,11 @@ class TestProvider(MusicProvider):
                     provider_instance=self.instance_id,
                 ),
             },
-            metadata=MediaItemMetadata(images=UniqueList([DEFAULT_THUMB]), genres={genre}),
+            metadata=MediaItemMetadata(
+                images=UniqueList([DEFAULT_THUMB]),
+                genres={genre},
+                release_date=datetime(2021, 6, 15, tzinfo=UTC),
+            ),
             disc_number=1,
             track_number=int(track_idx),
         )

--- a/tests/controllers/music/test_genres.py
+++ b/tests/controllers/music/test_genres.py
@@ -1279,7 +1279,9 @@ class TestRestoreDefaultGenres:
         if not entries_with_aliases:
             pytest.skip("No default genres with aliases configured")
         entry = entries_with_aliases[0]
-        items = await genre_ctrl.library_items(search=entry["genre"], hide_empty=False)
+        items = await genre_ctrl.library_items(
+            search=entry["genre"], hide_empty=False, summary=False
+        )
         assert len(items) > 0
         genre = items[0]
         assert genre.genre_aliases is not None
@@ -1530,8 +1532,8 @@ class TestBaseClassIntegration:
         """genre_aliases column populates genre_aliases on fetched Genre."""
         genre = await genre_ctrl.add_item_to_library(_make_genre("InlineTest"))
         await genre_ctrl.add_alias(genre.item_id, "Inline Alias")
-        # Fetch via library_items (uses base_query)
-        items = await genre_ctrl.library_items(search="InlineTest", hide_empty=False)
+        # Fetch via library_items (uses base_query); request full items so genre_aliases hydrates
+        items = await genre_ctrl.library_items(search="InlineTest", hide_empty=False, summary=False)
         assert len(items) >= 1
         fetched = items[0]
         assert fetched.genre_aliases is not None

--- a/tests/integration/test_library_summary_items.py
+++ b/tests/integration/test_library_summary_items.py
@@ -3,9 +3,10 @@ Parity test for the summary fast path of the library list endpoints.
 
 ``library_items(summary=True)`` returns slim summary variants of the media item
 models, built directly from a slim SQL query instead of hydrating the full stored
-item JSON. Every field a summary item carries must match the full item, and the
-serialized (wire) form must be sparse: no null values and none of the heavy
-metadata fields.
+item JSON. Every field a summary item carries must match the full item. Provider
+mappings are carried in full (so clients keep the quality badge, availability,
+provider icon and in-library state); the rest of the serialized (wire) form stays
+sparse: no null values and none of the heavy metadata fields.
 """
 
 from __future__ import annotations
@@ -103,6 +104,12 @@ def _first_thumb(item: Any) -> MediaItemImage | None:
     return None
 
 
+def _sorted_provider_mappings(item_dict: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return a serialized item's provider mappings, sorted for stable comparison."""
+    mappings = item_dict.get("provider_mappings") or []
+    return sorted(mappings, key=lambda m: (m["provider_instance"], m["item_id"]))
+
+
 async def _seed_playlist_and_radio(mass: MusicAssistant) -> None:
     """Add a playlist and radio station to the library (the test provider syncs neither)."""
     test_prov = mass.get_provider("test")
@@ -129,6 +136,7 @@ async def _seed_playlist_and_radio(mass: MusicAssistant) -> None:
         },
     )
     playlist.metadata.images = UniqueList([image])
+    playlist.metadata.description = "A hand-curated test playlist."
     await mass.music.playlists.add_item_to_library(playlist)
     radio = Radio(
         item_id="radio_1",
@@ -144,6 +152,7 @@ async def _seed_playlist_and_radio(mass: MusicAssistant) -> None:
         },
     )
     radio.metadata.images = UniqueList([image])
+    radio.metadata.description = "A test radio station."
     await mass.music.radio.add_item_to_library(radio)
 
 
@@ -205,22 +214,33 @@ async def test_library_summary_items_parity(e2e_mass: MusicAssistant) -> None:
                 assert summary_thumb.path == full_thumb.path
                 assert summary_thumb.provider == full_thumb.provider
 
-            # wire format: sparse (no nulls), heavy metadata never present and the
-            # image dicts carry the same resolved proxy_id / localized names; bind
+            # wire format: provider mappings are carried in full and must match the
+            # full item exactly (the frontend reads audio_format for the quality badge,
+            # availability, the provider icon and in-library state from here); the rest
+            # of the wire form stays sparse (no nulls) and free of heavy metadata, and
+            # the image dicts carry the same resolved proxy_id / localized names; bind
             # the same resolvers the API layer sets while serializing a response
             with _api_serialization_context(mass):
                 full_dict = full.to_dict()
                 summary_dict = item.to_dict()
-            _assert_no_none_values(summary_dict, ctrl.media_type.value)
+            assert _sorted_provider_mappings(summary_dict) == _sorted_provider_mappings(full_dict)
+            wire = {k: v for k, v in summary_dict.items() if k != "provider_mappings"}
+            _assert_no_none_values(wire, ctrl.media_type.value)
             assert summary_dict["name"] == full_dict["name"]
-            # summary metadata only carries the thumb image and the explicit flag;
-            # a description may be injected on top by the translation resolver
-            # (localizable items), in which case both modes carry the same value
-            assert set(summary_dict["metadata"]) <= {"images", "explicit", "description"}
-            if "description" in summary_dict["metadata"]:
-                assert (
-                    summary_dict["metadata"]["description"] == full_dict["metadata"]["description"]
-                )
+            # summary metadata carries only the thumb image plus the few descriptive
+            # fields the list rows render: the explicit flag and release date (tracks) and
+            # the description (radio/playlist). A description may also be injected by the
+            # translation resolver for localizable items; either way both modes must carry
+            # the same value.
+            assert set(summary_dict["metadata"]) <= {
+                "images",
+                "explicit",
+                "release_date",
+                "description",
+            }
+            for meta_field in ("description", "release_date"):
+                if meta_field in summary_dict["metadata"]:
+                    assert summary_dict["metadata"][meta_field] == full_dict["metadata"][meta_field]
             if full_thumb:
                 assert summary_dict["metadata"]["images"][0] == full_dict["metadata"]["images"][0]
                 assert summary_dict["metadata"]["images"][0]["proxy_id"]

--- a/tests/providers/builtin/test_infinite_mix.py
+++ b/tests/providers/builtin/test_infinite_mix.py
@@ -92,7 +92,7 @@ async def test_infinite_mix_returns_25_tracks_with_positions() -> None:
     result = await provider._get_builtin_playlist_infinite_mix()
 
     provider.mass.music.tracks.library_items.assert_called_once_with(
-        favorite=None, limit=25, order_by="random"
+        favorite=None, limit=25, order_by="random", summary=False
     )
     assert len(result) == 25
     for expected_pos, track in enumerate(result, 1):
@@ -109,7 +109,7 @@ async def test_infinite_mix_favorites_passes_favorite_filter() -> None:
     result = await provider._get_builtin_playlist_infinite_mix_favorites()
 
     provider.mass.music.tracks.library_items.assert_called_once_with(
-        favorite=True, limit=25, order_by="random"
+        favorite=True, limit=25, order_by="random", summary=False
     )
     assert len(result) == 25
     for expected_pos, track in enumerate(result, 1):
@@ -159,7 +159,7 @@ async def test_infinite_mix_over_fetches_and_drops_filtered_tracks() -> None:
         result = await provider._get_builtin_playlist_infinite_mix()
 
     provider.mass.music.tracks.library_items.assert_called_once_with(
-        favorite=None, limit=75, order_by="random"
+        favorite=None, limit=75, order_by="random", summary=False
     )
     assert len(result) == 25
     assert all(int(track.item_id) % 2 == 0 for track in result)

--- a/tests/providers/jellyfin/test_init.py
+++ b/tests/providers/jellyfin/test_init.py
@@ -49,7 +49,7 @@ async def jellyfin_provider(mass: MusicAssistant) -> AsyncGenerator[ProviderConf
 @pytest.mark.usefixtures("jellyfin_provider")
 async def test_get_artist_albums(mass: MusicAssistant) -> None:
     """Test that get_artist_albums returns albums for a real artist ID."""
-    artists = await mass.music.artists.library_items(search="Ash")
+    artists = await mass.music.artists.library_items(search="Ash", summary=False)
     ash = artists[0]
     prov_mapping = next(m for m in ash.provider_mappings if m.provider_domain == "jellyfin")
     albums = await mass.music.artists.get_provider_artist_albums(

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -875,6 +875,19 @@ async def test_library_items_default_filters_in_library_only() -> None:
     assert call_kwargs["in_library_only"] is True
 
 
+async def test_library_items_defaults_to_summary() -> None:
+    """library_items defaults to summary=True so list endpoints return slim rows."""
+    ctrl = Mock(spec=MediaControllerBase)
+    ctrl._ensure_provider_filter = Mock(return_value=None)
+    ctrl.get_library_items_by_query = AsyncMock(return_value=[])
+    ctrl.library_items = MediaControllerBase.library_items.__get__(ctrl)
+
+    await ctrl.library_items()
+
+    call_kwargs = ctrl.get_library_items_by_query.call_args[1]
+    assert call_kwargs["summary"] is True
+
+
 def test_ensure_provider_filter_keeps_plugin_provider_mappings() -> None:
     """Test that plugin providers are kept when a user music-provider filter is active."""
     ctrl = Mock(spec=MediaControllerBase)


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #4679, which added an opt-in `summary` mode to the `library_items` endpoints. This flips the default so listing library media returns slim summary items out of the box. Full items stay available per-item via `get_item` / `get_item_by_uri`.

Listing a page of tracks/albums no longer pays the full model round-trip (hydrate every nested object, then serialize it all straight back). Summary rows still carry the full provider mappings — so the quality badge, availability, provider icon and in-library state keep working — but drop the heavy metadata a list row never shows. The current frontend renders identically.

Measured on a 10k-track / 500-album library, 500-row page (M-series Mac):

| | Full | Summary |
|---|---|---|
| Tracks | 15.6 ms / 1231 KB | 10.7 ms / 800 KB (1.46× faster, −35%) |
| Albums | 10.4 ms / 772 KB | 6.8 ms / 552 KB (1.52× faster, −29%) |

**Changes**
- Flip the `summary` default to `True` on all `library_items` endpoints (tracks/albums/artists/playlists/podcasts/audiobooks/radio/genres).
- Carry full `provider_mappings` on summary items, plus the release date (tracks) and description (playlists/radio) the list rows render.
- Pin every internal caller (recommendations, autoplay, MSX bridge, MCP, smart playlists, browse fallbacks, library matching, exports) to `summary=False`, so their behaviour is unchanged.
- Add a parity test asserting summary items match full items on every retained field; adjust tests that assert full-only fields to request full items.

**Follow-up**
Frontend can adopt the explicit `available` field so we can later slim the provider mappings down and shrink list payloads further.

**Related issue (if applicable):**

- Follow-up to #4679

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a — summary models already released in 1.1.159 via #4679)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a — the current frontend renders summary items identically; no UI change required)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (n/a — the `summary` arg is signature-driven in the generated API docs)