### PR TITLE
Expose party join URL and playback mode to guests

### DIFF
--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -133,6 +133,9 @@ class PartyConfig(DataClassDictMixin):
     hide_back_button: bool
     show_progress_bar: bool
     prevent_duplicate_tracks: bool
+    # Shared playback mode: "venue" (a real player plays out loud) or "remote"
+    # (silent disco; every guest device is its own receiver). Drives the listen-in default.
+    mode: str
 
 
 async def setup(
@@ -415,9 +418,11 @@ class PartyPlugin(PluginProvider):
     async def loaded_in_mass(self) -> None:
         """Call after the provider has been loaded."""
         # Register API commands and store unregister handles
+        # PROVIDERS_READ (held by guests) lets a guest fetch the join URL to display/share
+        # the QR; get_party_url returns None when guest access is disabled, so nothing leaks.
         self._unregister_handles.append(
             self.mass.register_api_command(
-                "party/url", self.get_party_url, required_scope=Scope.USERS_INVITE
+                "party/url", self.get_party_url, required_scope=Scope.PROVIDERS_READ
             )
         )
         self._unregister_handles.append(
@@ -426,7 +431,9 @@ class PartyPlugin(PluginProvider):
             )
         )
         self._unregister_handles.append(
-            self.mass.register_api_command("party/config", self.get_party_config)
+            self.mass.register_api_command(
+                "party/config", self.get_party_config, required_scope=Scope.PROVIDERS_READ
+            )
         )
         # Guest action commands - these are called by the guest frontend
         self._unregister_handles.append(
@@ -588,6 +595,7 @@ class PartyPlugin(PluginProvider):
             prevent_duplicate_tracks=cast(
                 "bool", self.config.get_value(CONF_PREVENT_DUPLICATE_TRACKS)
             ),
+            mode=cast("str", self.config.get_value(CONF_PARTY_MODE)),
         )
 
     # ==================== Guest Action API Commands ====================

--- a/tests/providers/party/test_party_plugin.py
+++ b/tests/providers/party/test_party_plugin.py
@@ -8,6 +8,7 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from music_assistant_models.auth import Scope
 from music_assistant_models.enums import MediaType, PlaybackState
 from music_assistant_models.errors import InvalidDataError
 
@@ -153,3 +154,31 @@ async def test_listen_in_attaches_guest_player() -> None:
 
     assert result == {"success": True, "queue_id": "sendspin_virtual_party"}
     session.add_guest_listener.assert_awaited_once_with("web_player_1")
+
+
+@pytest.mark.parametrize("mode", [SharedPlaybackMode.VENUE.value, SharedPlaybackMode.REMOTE.value])
+@pytest.mark.asyncio
+async def test_get_party_config_exposes_mode(mode: str) -> None:
+    """get_party_config surfaces the configured playback mode to the guest frontend."""
+    plugin = _create_party_plugin()
+    cast("MagicMock", plugin.config.get_value).side_effect = {CONF_PARTY_MODE: mode}.get
+
+    config = await plugin.get_party_config()
+
+    assert config.mode == mode
+
+
+@pytest.mark.asyncio
+async def test_guest_readable_commands_use_guest_scope() -> None:
+    """party/url and party/config stay on a guest-readable scope, never a host-only one."""
+    plugin = _create_party_plugin()
+    plugin._unregister_handles = []
+
+    await plugin.loaded_in_mass()
+
+    scopes = {
+        call.args[0]: call.kwargs["required_scope"]
+        for call in cast("MagicMock", plugin.mass.register_api_command).call_args_list
+    }
+    assert scopes["party/url"] == Scope.PROVIDERS_READ
+    assert scopes["party/config"] == Scope.PROVIDERS_READ


### PR DESCRIPTION
# What does this implement/fix?

Party guests get a spurious "you are not allowed to perform this action" error on the guest view, and the guest frontend has no way to tell whether a party runs in venue or remote mode. This gives guests the info they need to show the join QR and to offer the "listen in" experience with the right default.

- Scope `party/url` and `party/config` to `PROVIDERS_READ` (a read scope every guest role holds) so the guest view can fetch them, removing the spurious "not allowed" error, without exposing host-only actions. `get_party_url` still returns `None` when guest access is disabled, so nothing leaks.
- Include the shared playback `mode` (venue/remote) in the party guest config so the frontend can offer "listen in" with the correct default (opt-in for venue, opt-out for remote).

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes. Added a `get_party_config` mode-passthrough test.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (N/A)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (party "listen in" UI PR consumes these; will link once open)
- [x] I have read and complied with the project's AI Policy for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository. (N/A)
