### PR TITLE
Add issue chooser redirecting to the support repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "\U0001F41B Report a bug"
+    url: https://github.com/music-assistant/support/issues/new/choose
+    about: All Music Assistant bug reports are tracked in our central support repository.
+  - name: "\U0001F4AC Discord community & support"
+    url: https://discord.gg/kaVm8hGpne
+    about: Chat with the community and get help from other users.
+  - name: "❓ Questions & how-to (Q&A)"
+    url: https://github.com/music-assistant/support/discussions/categories/q-a
+    about: Ask how-to questions and search previous answers.
+  - name: "\U0001F4A1 Feature requests & ideas"
+    url: https://github.com/music-assistant/support/discussions/categories/feature-requests-and-ideas
+    about: Suggest and vote on new features and enhancements.


### PR DESCRIPTION
# What does this implement/fix?

This repo has Issues disabled today. We're re-enabling Issues purely as a **signpost**: a chooser with external links and no issue forms, so anyone clicking "New issue" is redirected to where things actually get tracked. All bug reports continue to live in the central `music-assistant/support` repo.

- Add `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false` and four contact links:
  - 🐛 Report a bug → `music-assistant/support` issues
  - 💬 Discord community & support
  - ❓ Questions & how-to (Q&A) → support discussions
  - 💡 Feature requests & ideas → support discussions
- No issue forms are added (chooser-only is intentional).

Note: the repository's Settings → Issues toggle is intentionally left untouched — a maintainer will enable it after this lands on `dev`, since the config must be on the default branch first.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.