### PR TITLE
Include party playback mode in the guest config

### DIFF
--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -105,6 +105,8 @@ SUPPORTED_FEATURES: set[ProviderFeature] = set()
 class PartyConfig(DataClassDictMixin):
     """Configuration data returned to the party guest frontend."""
 
+    # Shared-audio experience mode: "venue" (opt-in) or "remote" (silent disco).
+    mode: str
     # Feature toggles
     enable_rate_limiting: bool
     enable_add_queue: bool
@@ -560,6 +562,7 @@ class PartyPlugin(PluginProvider):
         :returns: PartyConfig with feature toggles, token limits, refill rates, and colors.
         """
         return PartyConfig(
+            mode=cast("str", self.config.get_value(CONF_PARTY_MODE)),
             enable_rate_limiting=cast("bool", self.config.get_value(CONF_ENABLE_RATE_LIMITING)),
             enable_add_queue=cast("bool", self.config.get_value(CONF_ENABLE_ADD_QUEUE)),
             add_queue_limit=cast("int", self.config.get_value(CONF_PARTY_ADD_QUEUE_LIMIT)),

--- a/tests/providers/party/test_party_plugin.py
+++ b/tests/providers/party/test_party_plugin.py
@@ -84,6 +84,24 @@ async def test_add_to_queue_rechecks_duplicates_during_priority_insert() -> None
     player_queues.load.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_get_party_config_includes_mode() -> None:
+    """Expose the configured shared-playback mode in the guest config payload."""
+    plugin = _create_party_plugin()
+
+    def get_value(key: str) -> object:
+        if key == CONF_PARTY_MODE:
+            return SharedPlaybackMode.VENUE.value
+        return MagicMock()
+
+    config = cast("MagicMock", plugin.config)
+    config.get_value.side_effect = get_value
+
+    party_config = await plugin.get_party_config()
+
+    assert party_config.mode == SharedPlaybackMode.VENUE.value
+
+
 def _create_session_test_plugin(mode: str) -> PartyPlugin:
     """Create a party plugin with a real get_party_player for session tests."""
     plugin = PartyPlugin.__new__(PartyPlugin)


### PR DESCRIPTION
# What does this implement/fix?

The party guest view needs to know whether playback runs in venue or remote (silent-disco) mode so it can adapt the guest experience (e.g. offering "listen in"), but the server never sent it. This surfaces the already-configured mode in the guest config.

- Add a `mode` field to the party guest config (`PartyConfig`).
- Populate it from the existing party `mode` setting in `get_party_config()`.
- Add a focused test for the new field.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.