### PR TITLE
Add downloadable diagnostics report (backport)

### DIFF
--- a/music_assistant/__main__.py
+++ b/music_assistant/__main__.py
@@ -20,6 +20,7 @@ from typing import Any, Final
 from colorlog import ColoredFormatter
 
 from music_assistant.constants import MASS_LOGGER_NAME, VERBOSE_LOG_LEVEL
+from music_assistant.helpers.diagnostics import install_diagnostics_log_handler
 from music_assistant.helpers.json import json_loads
 from music_assistant.helpers.logging import activate_log_queue_handler
 from music_assistant.mass import MusicAssistant
@@ -107,6 +108,10 @@ def setup_logger(data_path: str, level: str = "DEBUG") -> logging.Logger:
     # The standard destination for them is stderr, which may end up unnoticed.
     # This way they're where other messages are, and can be filtered as usual.
     logging.captureWarnings(True)
+
+    # install the always-on diagnostics capture handler as early as possible
+    # so boot-time warnings/errors end up in the diagnostics report
+    install_diagnostics_log_handler()
 
     # setup file handler
     log_filename = os.path.join(data_path, "musicassistant.log")

--- a/music_assistant/controllers/diagnostics/__init__.py
+++ b/music_assistant/controllers/diagnostics/__init__.py
@@ -1,0 +1,434 @@
+"""
+Diagnostics controller: on-demand, privacy-safe troubleshooting reports.
+
+Serves a single downloadable report (JSON or markdown) combining the always-on
+exception/log capture (see helpers/diagnostics.py) with system info, an install
+census and pluggable sections contributed by core controllers, providers and
+external registrants. All report building happens on request only; every string
+that ends up in the report is sanitized so it can safely be attached to a public
+GitHub issue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import platform
+import resource
+import shutil
+import sys
+import threading
+import time
+from collections import Counter
+from typing import TYPE_CHECKING, Any
+
+from aiohttp import web
+
+from music_assistant.controllers.webserver.helpers.auth_middleware import require_admin
+from music_assistant.helpers.api import api_command
+from music_assistant.helpers.datetime import from_utc_timestamp, utc
+from music_assistant.helpers.diagnostics import (
+    REDACTION_NOTICE,
+    install_diagnostics_log_handler,
+    sanitize_data,
+    sanitize_text,
+)
+from music_assistant.helpers.json import json_dumps, json_loads
+from music_assistant.models.core_controller import CoreController
+from music_assistant.models.provider import Provider
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from music_assistant_models.config_entries import CoreConfig
+
+    from music_assistant.mass import MusicAssistant
+
+SCHEMA_VERSION = 1
+# maximum time one section contributor may take before it is dropped from the report
+SECTION_TIMEOUT = 2.0
+
+# core controller attributes on MusicAssistant that may implement get_diagnostics
+CORE_CONTROLLER_ATTRS = (
+    "cache",
+    "discovery",
+    "metadata",
+    "music",
+    "player_queues",
+    "players",
+    "streams",
+    "tasks",
+    "translations",
+    "webserver",
+)
+
+type DiagnosticsSectionCallback = Callable[
+    [], dict[str, Any] | None | Awaitable[dict[str, Any] | None]
+]
+
+
+class DiagnosticsController(CoreController):
+    """Core controller that assembles privacy-safe diagnostics reports on demand."""
+
+    domain: str = "diagnostics"
+
+    def __init__(self, mass: MusicAssistant) -> None:
+        """Initialize the diagnostics controller."""
+        super().__init__(mass)
+        self.manifest.name = "Diagnostics"
+        self.manifest.description = (
+            "Provides a downloadable, privacy-safe diagnostics report for troubleshooting."
+        )
+        self.manifest.icon = "stethoscope"
+        # adopt the always-on capture handler (installed even earlier when booted
+        # through __main__, otherwise installed right here)
+        self._log_handler = install_diagnostics_log_handler()
+        self._sections: dict[str, DiagnosticsSectionCallback] = {}
+        self._started_at = time.monotonic()
+
+    async def setup(self, config: CoreConfig) -> None:
+        """Async initialize of module."""
+
+    async def close(self) -> None:
+        """Handle logic on server stop."""
+        self._sections.clear()
+
+    def register_section(
+        self, name: str, callback: DiagnosticsSectionCallback
+    ) -> Callable[[], None]:
+        """
+        Register a callback that contributes a named section to the diagnostics report.
+
+        The callback is invoked whenever a report is requested and may be sync or
+        async. Async callbacks run with a timeout; sync callbacks run on the event
+        loop and must return quickly without blocking I/O. Returns a function to
+        unregister the section again.
+
+        :param name: Unique name for the section within the report.
+        :param callback: Callable returning the section data as a (JSON-safe) dict.
+        """
+        if name in self._sections:
+            raise ValueError(f"A diagnostics section named '{name}' is already registered")
+        self._sections[name] = callback
+
+        def unregister() -> None:
+            # only remove if this exact registration still owns the name
+            if self._sections.get(name) is callback:
+                self._sections.pop(name)
+
+        return unregister
+
+    @api_command("diagnostics/get", required_role="admin")
+    async def get_report(self, include_log_tail: bool = False) -> dict[str, Any]:
+        """
+        Return a full (sanitized) diagnostics report.
+
+        :param include_log_tail: Include the recent warning/error log excerpt.
+        """
+        return await self._build_report(include_log_tail=include_log_tail)
+
+    async def handle_http_download(self, request: web.Request) -> web.Response:
+        """
+        Serve the diagnostics report as a downloadable file (webserver route handler).
+
+        Supports query parameters `format` (json|md) and `include_log_tail` (true|false).
+
+        :param request: The incoming aiohttp request.
+        """
+        await require_admin(request)
+        include_log_tail = request.query.get("include_log_tail", "").lower() in ("1", "true")
+        report = await self._build_report(include_log_tail=include_log_tail)
+        filename = f"music-assistant-diagnostics-{utc().strftime('%Y-%m-%d-%H%M%S')}"
+        if request.query.get("format", "json").lower() in ("md", "markdown"):
+            body = self._render_markdown(report)
+            content_type = "text/markdown"
+            filename += ".md"
+        else:
+            body = json_dumps(report, indent=True)
+            content_type = "application/json"
+            filename += ".json"
+        return web.Response(
+            text=body,
+            content_type=content_type,
+            charset="utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    async def _build_report(self, include_log_tail: bool = False) -> dict[str, Any]:
+        """Assemble the full report; every part is isolated so the report never fails."""
+        report: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": utc().isoformat(timespec="seconds"),
+            "redaction_notice": REDACTION_NOTICE,
+        }
+        for key, builder in (
+            ("system", self._build_system_info),
+            ("install", self._build_install_census),
+            ("exceptions", self._build_exception_summary),
+            ("sections", self._collect_sections),
+        ):
+            try:
+                report[key] = await builder()
+            except Exception as err:
+                report[key] = {"error": sanitize_text(f"{type(err).__name__}: {err}")}
+        if include_log_tail:
+            report["log_tail"] = self._build_log_tail()
+        return report
+
+    async def _build_system_info(self) -> dict[str, Any]:
+        """Collect a point-in-time snapshot of system/runtime info."""
+        disk_info, memory_info = await asyncio.to_thread(self._probe_system_blocking)
+        return {
+            "version": self.mass.version,
+            "python_version": platform.python_version(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "hass_addon": self.mass.running_as_hass_addon,
+            "safe_mode": self.mass.safe_mode,
+            "uptime_seconds": round(time.monotonic() - self._started_at),
+            "event_loop_lag_ms": await self._measure_loop_lag(),
+            "memory": memory_info,
+            "data_dir_disk": disk_info,
+            "counts": {
+                "threads": threading.active_count(),
+                "asyncio_tasks": len(asyncio.all_tasks()),
+                "tracked_tasks": len(self.mass._tracked_tasks),
+                "tracked_timers": len(self.mass._tracked_timers),
+                "event_subscribers": len(self.mass._subscribers),
+                "websocket_clients": len(self.mass.webserver.clients),
+            },
+        }
+
+    async def _build_install_census(self) -> dict[str, Any]:
+        """Collect install structure (never configuration values or credentials)."""
+        census: dict[str, Any] = {}
+        for key, builder in (
+            ("providers", self._census_providers),
+            ("players", self._census_players),
+            ("library", self._census_library),
+            ("core_config_non_default", self._census_core_config),
+        ):
+            try:
+                result = builder()
+                census[key] = await result if inspect.isawaitable(result) else result
+            except Exception as err:
+                census[key] = {"error": sanitize_text(f"{type(err).__name__}: {err}")}
+        return census
+
+    async def _census_providers(self) -> list[dict[str, Any]]:
+        """Return the configured providers with their load/availability state."""
+        providers: list[dict[str, Any]] = []
+        for prov_conf in await self.mass.config.get_provider_configs():
+            loaded = self.mass.get_provider(prov_conf.instance_id, return_unavailable=True)
+            entry: dict[str, Any] = {
+                "domain": prov_conf.domain,
+                "instance_id": prov_conf.instance_id,
+                "type": prov_conf.type.value,
+                "enabled": prov_conf.enabled,
+                "loaded": loaded is not None,
+                "available": loaded.available if loaded else False,
+            }
+            if prov_conf.last_error is not None:
+                entry["last_error"] = sanitize_text(prov_conf.last_error)
+            providers.append(entry)
+        providers.sort(key=lambda entry: (entry["domain"], entry["instance_id"]))
+        return providers
+
+    def _census_players(self) -> dict[str, Any]:
+        """Return player counts grouped by provider and type."""
+        by_provider: Counter[str] = Counter()
+        by_type: Counter[str] = Counter()
+        total = available = 0
+        for player in self.mass.players.all_players(
+            return_unavailable=True, return_disabled=True, return_protocol_players=True
+        ):
+            total += 1
+            available += int(player.available)
+            by_provider[player.provider.domain] += 1
+            by_type[player.type.value] += 1
+        return {
+            "total": total,
+            "available": available,
+            "by_provider": dict(sorted(by_provider.items())),
+            "by_type": dict(sorted(by_type.items())),
+        }
+
+    async def _census_library(self) -> dict[str, int]:
+        """Return the library item counts per media type."""
+        music = self.mass.music
+        return {
+            name: await controller.library_count()
+            for name, controller in (
+                ("albums", music.albums),
+                ("artists", music.artists),
+                ("audiobooks", music.audiobooks),
+                ("genres", music.genres),
+                ("playlists", music.playlists),
+                ("podcasts", music.podcasts),
+                ("radio", music.radio),
+                ("tracks", music.tracks),
+            )
+        }
+
+    async def _census_core_config(self) -> dict[str, list[str]]:
+        """Return per core module which config keys differ from default (key names only)."""
+        result: dict[str, list[str]] = {}
+        for core_conf in await self.mass.config.get_core_configs(include_values=True):
+            changed_keys = [
+                key
+                for key, entry in core_conf.values.items()
+                if entry.value is not None and entry.value != entry.default_value
+            ]
+            if changed_keys:
+                result[core_conf.domain] = sorted(changed_keys)
+        return result
+
+    async def _build_exception_summary(self) -> list[dict[str, Any]]:
+        """Return the aggregated (sanitized) exceptions, most recent first."""
+        _, exceptions = self._log_handler.snapshot()
+        exceptions.sort(key=lambda entry: entry.last_seen, reverse=True)
+        # rendering traceback text may read source files (linecache), so run off-loop
+        rendered = await asyncio.get_running_loop().run_in_executor(
+            None, lambda: [entry.render_traceback() for entry in exceptions]
+        )
+        return [
+            {
+                "type": entry.exc_type,
+                "fingerprint": entry.fingerprint,
+                "count": entry.count,
+                "first_seen": _format_timestamp(entry.first_seen),
+                "last_seen": _format_timestamp(entry.last_seen),
+                "logger": sanitize_text(entry.logger_name),
+                "level": entry.level,
+                "origin": sanitize_text(entry.origin),
+                "message": sanitize_text(entry.message),
+                "traceback": sanitize_text(traceback_text),
+            }
+            for entry, traceback_text in zip(exceptions, rendered, strict=True)
+        ]
+
+    async def _collect_sections(self) -> dict[str, Any]:
+        """Collect all pluggable sections (isolated, each bounded by a timeout)."""
+        producers: list[tuple[str, DiagnosticsSectionCallback]] = []
+        for attr_name in CORE_CONTROLLER_ATTRS:
+            controller = getattr(self.mass, attr_name, None)
+            if controller is None:
+                continue
+            # skip controllers that don't implement the optional hook
+            if type(controller).get_diagnostics is CoreController.get_diagnostics:
+                continue
+            producers.append((f"core.{attr_name}", controller.get_diagnostics))
+        for provider in sorted(self.mass.providers, key=lambda prov: prov.instance_id):
+            if type(provider).get_diagnostics is Provider.get_diagnostics:
+                continue
+            producers.append((f"provider.{provider.instance_id}", provider.get_diagnostics))
+        producers.extend(self._sections.items())
+        results = await asyncio.gather(
+            *(self._collect_section(name, producer) for name, producer in producers)
+        )
+        return {name: data for name, data in results if data is not None}
+
+    async def _collect_section(
+        self, name: str, producer: DiagnosticsSectionCallback
+    ) -> tuple[str, Any]:
+        """Run one section contributor with timeout/failure isolation and sanitize it."""
+        try:
+            async with asyncio.timeout(SECTION_TIMEOUT):
+                raw_result = producer()
+                result = await raw_result if inspect.isawaitable(raw_result) else raw_result
+            if result is None:
+                return name, None
+            # roundtrip through JSON to normalize (and validate) the data,
+            # then sanitize all string values in the result
+            return name, sanitize_data(json_loads(json_dumps(result)))
+        except Exception as err:
+            return name, {"error": sanitize_text(f"{type(err).__name__}: {err}")}
+
+    def _build_log_tail(self) -> list[dict[str, str]]:
+        """Return the sanitized recent warning/error log excerpt."""
+        records, _ = self._log_handler.snapshot()
+        return [
+            {
+                "time": _format_timestamp(record.created),
+                "level": record.level,
+                "logger": sanitize_text(record.logger_name),
+                "message": sanitize_text(record.message),
+            }
+            for record in records
+        ]
+
+    async def _measure_loop_lag(self) -> float:
+        """Spot-sample the event loop lag in milliseconds."""
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        await asyncio.sleep(0.1)
+        return max(0.0, round((loop.time() - start - 0.1) * 1000, 1))
+
+    def _probe_system_blocking(self) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Collect disk and memory info (blocking, run in executor)."""
+        usage = shutil.disk_usage(self.mass.storage_path)
+        disk_info = {
+            "free_mb": usage.free // (1024 * 1024),
+            "total_mb": usage.total // (1024 * 1024),
+        }
+        return disk_info, _get_memory_info()
+
+    def _render_markdown(self, report: dict[str, Any]) -> str:
+        """Render the report as markdown for direct pasting into (GitHub) issues."""
+        lines = [
+            "# Music Assistant diagnostics report",
+            "",
+            f"- Generated: {report.get('generated_at')}",
+            f"- Schema version: {report.get('schema_version')}",
+            "",
+            f"> {report.get('redaction_notice')}",
+            "",
+        ]
+        for key, title in (("system", "System"), ("install", "Install")):
+            if (data := report.get(key)) is None:
+                continue
+            lines += [f"## {title}", "", "```json", json_dumps(data, indent=True), "```", ""]
+        exceptions = report.get("exceptions") or []
+        lines += [f"## Exceptions ({len(exceptions)} unique)", ""]
+        for entry in exceptions:
+            lines += [
+                f"### {entry['type']} (seen {entry['count']}x)",
+                "",
+                f"- Logger: `{entry['logger']}` (level {entry['level']})",
+                f"- Origin: `{entry['origin']}`",
+                f"- First seen: {entry['first_seen']} — last seen: {entry['last_seen']}",
+                "",
+                "```",
+                str(entry["traceback"]).rstrip(),
+                "```",
+                "",
+            ]
+        if sections := report.get("sections"):
+            lines += ["## Sections", "", "```json", json_dumps(sections, indent=True), "```", ""]
+        if log_tail := report.get("log_tail"):
+            lines += ["## Log tail", "", "```"]
+            lines += [
+                f"{record['time']} {record['level']} {record['logger']}: {record['message']}"
+                for record in log_tail
+            ]
+            lines += ["```", ""]
+        return "\n".join(lines)
+
+
+def _format_timestamp(timestamp: float) -> str:
+    """Format a unix timestamp as a compact UTC ISO string."""
+    return from_utc_timestamp(timestamp).isoformat(timespec="seconds")
+
+
+def _get_memory_info() -> dict[str, Any]:
+    """Return the process memory usage (rss on Linux, peak rss elsewhere)."""
+    try:
+        with open("/proc/self/status", encoding="ascii") as status_file:
+            for line in status_file:
+                if line.startswith("VmRSS:"):
+                    return {"rss_mb": round(int(line.split()[1]) / 1024, 1)}
+    except OSError, ValueError, IndexError:
+        pass
+    # ru_maxrss is in bytes on macOS, kilobytes on other platforms
+    divisor = 1024 * 1024 if sys.platform == "darwin" else 1024
+    return {"peak_rss_mb": round(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / divisor, 1)}

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -14,7 +14,7 @@ import os
 import struct
 import time
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 from aiofiles.os import wrap
@@ -166,6 +166,13 @@ class StreamsController(CoreController):
     def output_stream_active(self) -> bool:
         """Return whether a queue stream (single item or flow) is actively serving a player."""
         return self._active_output_streams > 0
+
+    async def get_diagnostics(self) -> dict[str, Any]:
+        """Return diagnostics info for this controller to include in diagnostics reports."""
+        return {
+            "active_output_streams": self._active_output_streams,
+            "active_announcements": len(self.announcements),
+        }
 
     @property
     def base_url(self) -> str:

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -282,6 +282,8 @@ class WebserverController(CoreController):
         routes.append(("GET", "/preview", self.serve_preview_stream))
         # add jsonrpc api
         routes.append(("POST", "/api", self._handle_jsonrpc_api_command))
+        # add diagnostics report download (handler enforces authentication itself)
+        routes.append(("GET", "/diagnostics", self.mass.diagnostics.handle_http_download))
         # add api documentation
         routes.append(("GET", "/api-docs", self._handle_api_intro))
         routes.append(("GET", "/api-docs/", self._handle_api_intro))

--- a/music_assistant/helpers/diagnostics.py
+++ b/music_assistant/helpers/diagnostics.py
@@ -1,0 +1,312 @@
+"""
+Always-on diagnostics capture and sanitization helpers.
+
+This module is intentionally stdlib-only and free of any Music Assistant imports so the
+capture handler can be installed at the earliest possible moment (before the server core
+is even constructed) and adopted later by the diagnostics controller. The always-on cost
+is limited to one logging handler doing bounded, in-memory ring buffer appends;
+sanitization and report building only happen when a report is explicitly requested.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import logging
+import re
+import time
+import traceback
+from collections import OrderedDict, deque
+from dataclasses import dataclass, replace
+from typing import NamedTuple
+
+# bounds for the captured data (everything in memory, so keep it small)
+LOG_RING_MAXLEN = 300
+MAX_EXCEPTION_FINGERPRINTS = 100
+MAX_TRACEBACK_CHARS = 6000
+MAX_MESSAGE_CHARS = 500
+TRACEBACK_FRAME_LIMIT = 50
+
+REDACTION_NOTICE = (
+    "This report is automatically redacted: home directories, media file paths/names, "
+    "URL credentials and query strings, passwords/tokens/secrets, e-mail addresses, "
+    "non-local IP addresses and MAC addresses are replaced by placeholders. Absolute "
+    "code paths are shortened to be relative to the application root. Media paths and "
+    "MAC addresses are reduced to a stable hash so identical values can still be "
+    "correlated within the report."
+)
+
+# file extensions that reveal (music) library content when they appear in a path
+_MEDIA_FILE_EXTENSIONS = (
+    "aac|aif|aiff|alac|ape|asx|avi|cue|dff|dsf|flac|gif|jpeg|jpg|m3u|m3u8|m4a|m4b|m4v|"
+    "mka|mkv|mov|mp3|mp4|nfo|oga|ogg|opus|pls|png|wav|webm|webp|wma|wv|xspf"
+)
+
+# absolute code paths -> relative to site-packages / music_assistant root
+_RE_SITE_PACKAGES_PATH = re.compile(r"(?:[A-Za-z]:)?[^\s\"']*[/\\]site-packages[/\\]")
+_RE_MASS_ROOT_PATH = re.compile(r"(?:[A-Za-z]:)?[^\s\"']*[/\\]music_assistant[/\\]")
+# URL userinfo (user:pass@host) and query strings (tokens/signatures live there)
+_RE_URL_USERINFO = re.compile(r"(\w+://)[^/\s@\"']+@")
+_RE_URL_QUERY = re.compile(r"(\w+://[^\s\"'<>]*?)\?[^\s\"'<>]*")
+# query strings on path-style (relative) request URLs, e.g. OAuth callbacks
+_RE_PATH_QUERY = re.compile(r"(?<!\w)(/[^\s\"'<>?]*)\?[^\s\"'<>]+")
+# secrets: JWT's, Authorization header schemes, key=value assignments, long token blobs
+_RE_JWT = re.compile(r"\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]*")
+_RE_AUTH_SCHEME = re.compile(r"(?i)\b(bearer|basic|digest)\s+[A-Za-z0-9\-._~+/=]{16,}")
+_RE_SECRET_ASSIGNMENT = re.compile(
+    r"(?i)\b([\w-]*(?:password|passwd|pwd|secret|token|api[_-]?key|apikey|auth|"
+    r"authorization|credentials?|access[_-]?key|private[_-]?key|cookie|csrf))\b"
+    r"(\"?'?\s*[=:]\s*)(\"[^\"\r\n]*\"|'[^'\r\n]*'|[^\s\"',;&]+)"
+)
+# long token blobs: 32+ chars of token-ish alphabet containing at least one digit
+# (the digit requirement spares long snake_case identifiers and module paths)
+_RE_LONG_TOKEN = re.compile(
+    r"(?<![A-Za-z0-9+_-])(?=[A-Za-z0-9+_-]*\d)[A-Za-z0-9+_-]{32,}(?![A-Za-z0-9+_-])"
+)
+# media library paths: full paths (at least one path separator) and bare filenames;
+# bare filenames may contain spaces, so unquoted/undelimited prose directly in front
+# of a media filename is redacted along with it (privacy beats message fidelity here)
+_RE_MEDIA_PATH = re.compile(
+    rf"(?<!\w)(?:[A-Za-z]:)?(?:[/\\][^/\\\r\n]*?)+\.(?:{_MEDIA_FILE_EXTENSIONS})\b",
+    re.IGNORECASE,
+)
+_RE_MEDIA_FILENAME = re.compile(
+    rf"(?<![\w/\\.])[^\s/\\:*?\"'<>|(][^/\\:*?\"'<>|\r\n]*\.(?:{_MEDIA_FILE_EXTENSIONS})\b",
+    re.IGNORECASE,
+)
+_RE_EMAIL = re.compile(r"\b[\w.+-]+@[\w-]+(?:\.[\w-]+)+\b")
+# MAC addresses (also common as/inside player ids), colon or dash separated
+_RE_MAC_ADDRESS = re.compile(
+    r"(?<![0-9A-Fa-f:-])[0-9A-Fa-f]{2}(?:([:-])[0-9A-Fa-f]{2}){5}(?![0-9A-Fa-f:-])"
+)
+# IPv6 first (so IPv4-mapped addresses are redacted as a whole), candidates are
+# verified with the ipaddress module to avoid eating timestamps and MAC addresses
+_RE_IPV6_CANDIDATE = re.compile(
+    r"(?<![\w.:])(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}(?![\w:])"
+    r"|(?<![\w.:])[0-9A-Fa-f:]*::[0-9A-Fa-f:.]*(?![\w:.])"
+)
+_RE_IPV4 = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_RE_HOME_DIR = re.compile(r"(?:/(?:Users|home)/|[A-Za-z]:\\Users\\)[^/\\\s:;,'\"]+")
+
+
+def sanitize_text(text: str) -> str:
+    """
+    Redact privacy-sensitive data from a text snippet.
+
+    Applied to every string that ends up in a diagnostics report (log messages,
+    tracebacks, error strings): redacts home directories, media file paths, URL
+    credentials/query strings, secrets/tokens, e-mail addresses, IP addresses and
+    MAC addresses, and shortens absolute code paths to be relative to the
+    application root.
+
+    :param text: The raw text to sanitize.
+    """
+    text = _RE_SITE_PACKAGES_PATH.sub("", text)
+    text = _RE_MASS_ROOT_PATH.sub("music_assistant/", text)
+    text = _RE_URL_QUERY.sub(r"\1?<redacted-query>", text)
+    text = _RE_URL_USERINFO.sub(r"\1<redacted>@", text)
+    text = _RE_PATH_QUERY.sub(r"\1?<redacted-query>", text)
+    text = _RE_JWT.sub("<redacted-token>", text)
+    text = _RE_AUTH_SCHEME.sub(r"\1 <redacted>", text)
+    text = _RE_SECRET_ASSIGNMENT.sub(r"\1\2<redacted>", text)
+    text = _RE_LONG_TOKEN.sub("<redacted-token>", text)
+    text = _RE_MEDIA_PATH.sub(_redact_media_path, text)
+    text = _RE_MEDIA_FILENAME.sub(_redact_media_path, text)
+    text = _RE_EMAIL.sub("<redacted-email>", text)
+    text = _RE_MAC_ADDRESS.sub(_redact_mac, text)
+    text = _RE_IPV6_CANDIDATE.sub(_redact_ip, text)
+    text = _RE_IPV4.sub(_redact_ip, text)
+    return _RE_HOME_DIR.sub("~", text)
+
+
+def sanitize_data[DataT](data: DataT) -> DataT:
+    """
+    Recursively sanitize all strings (including dict keys) inside a data structure.
+
+    :param data: Plain data (dicts/lists/tuples/scalars) to sanitize in depth.
+    """
+    if isinstance(data, str):
+        return sanitize_text(data)  # type: ignore[return-value]
+    if isinstance(data, dict):
+        return {sanitize_data(key): sanitize_data(value) for key, value in data.items()}  # type: ignore[return-value]
+    if isinstance(data, tuple):
+        return tuple(sanitize_data(value) for value in data)  # type: ignore[return-value]
+    if isinstance(data, list):
+        return [sanitize_data(value) for value in data]  # type: ignore[return-value]
+    return data
+
+
+class CapturedLogRecord(NamedTuple):
+    """A single captured (WARNING or higher) log record."""
+
+    created: float
+    level: str
+    logger_name: str
+    message: str
+
+
+@dataclass
+class CapturedException:
+    """Aggregated info for one unique exception fingerprint."""
+
+    fingerprint: str
+    exc_type: str
+    origin: str
+    logger_name: str
+    level: str
+    message: str
+    traceback_exc: traceback.TracebackException
+    first_seen: float
+    last_seen: float
+    count: int = 1
+
+    def render_traceback(self) -> str:
+        """Render the representative traceback as text (may read source files)."""
+        try:
+            return "".join(self.traceback_exc.format())[-MAX_TRACEBACK_CHARS:]
+        except Exception as err:
+            return f"<traceback rendering failed: {err!r}>"
+
+
+class DiagnosticsLogHandler(logging.Handler):
+    """
+    Root-logger handler that captures warnings/errors for the diagnostics report.
+
+    Keeps a bounded ring of recent WARNING+ records plus exception aggregates keyed by
+    fingerprint (exception type + raise site + topmost music_assistant frame). All data
+    stays in memory as-is; sanitization happens only when a report is built.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the capture handler."""
+        super().__init__(level=logging.WARNING)
+        self.installed_at = time.monotonic()
+        self.log_ring: deque[CapturedLogRecord] = deque(maxlen=LOG_RING_MAXLEN)
+        self.exceptions: OrderedDict[str, CapturedException] = OrderedDict()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Capture a single log record (may never raise or block)."""
+        try:
+            message = record.getMessage()[:MAX_MESSAGE_CHARS]
+            self.log_ring.append(
+                CapturedLogRecord(record.created, record.levelname, record.name, message)
+            )
+            if record.exc_info and record.exc_info[0] is not None:
+                self._capture_exception(record, message)
+        except Exception:  # noqa: S110 - capturing diagnostics may never break logging itself
+            pass
+
+    def snapshot(self) -> tuple[list[CapturedLogRecord], list[CapturedException]]:
+        """Return a point-in-time copy of the captured log ring and exception aggregates."""
+        self.acquire()
+        try:
+            return list(self.log_ring), [replace(entry) for entry in self.exceptions.values()]
+        finally:
+            self.release()
+
+    def clear(self) -> None:
+        """Clear all captured data (intended for tests)."""
+        self.acquire()
+        try:
+            self.log_ring.clear()
+            self.exceptions.clear()
+        finally:
+            self.release()
+
+    def _capture_exception(self, record: logging.LogRecord, message: str) -> None:
+        """Aggregate an exception attached to a log record by fingerprint."""
+        assert record.exc_info is not None  # guarded by caller
+        exc_type, exc_value, exc_tb = record.exc_info
+        if exc_type is None or exc_value is None:
+            return
+        # walk the raw traceback frames without touching linecache/source files,
+        # keeping this always-on path cheap
+        raise_site = ""
+        raise_site_key = ""
+        origin = ""
+        origin_key = ""
+        frame_tb = exc_tb
+        while frame_tb is not None:
+            code = frame_tb.tb_frame.f_code
+            raise_site = f"{code.co_filename}:{frame_tb.tb_lineno} in {code.co_name}"
+            raise_site_key = f"{code.co_filename}:{code.co_name}"
+            if "music_assistant" in code.co_filename:
+                origin = raise_site
+                origin_key = raise_site_key
+            frame_tb = frame_tb.tb_next
+        exc_type_name = exc_type.__qualname__ if exc_type else "UnknownError"
+        # fingerprint on function granularity (not line numbers) so retries/loops aggregate
+        fingerprint_source = f"{exc_type_name}|{raise_site_key}|{origin_key}"
+        fingerprint = hashlib.sha256(fingerprint_source.encode()).hexdigest()[:12]
+        if entry := self.exceptions.get(fingerprint):
+            entry.count += 1
+            entry.last_seen = record.created
+            self.exceptions.move_to_end(fingerprint)
+            return
+        # capture structured traceback metadata once per unique fingerprint;
+        # lookup_lines=False defers all source file (linecache) reads to report time
+        traceback_exc = traceback.TracebackException(
+            exc_type,
+            exc_value,
+            exc_tb,
+            limit=TRACEBACK_FRAME_LIMIT,
+            lookup_lines=False,
+            compact=True,
+        )
+        self.exceptions[fingerprint] = CapturedException(
+            fingerprint=fingerprint,
+            exc_type=exc_type_name,
+            origin=origin or raise_site,
+            logger_name=record.name,
+            level=record.levelname,
+            message=message,
+            traceback_exc=traceback_exc,
+            first_seen=record.created,
+            last_seen=record.created,
+        )
+        while len(self.exceptions) > MAX_EXCEPTION_FINGERPRINTS:
+            self.exceptions.popitem(last=False)
+
+
+def install_diagnostics_log_handler() -> DiagnosticsLogHandler:
+    """
+    Install (or return the already installed) diagnostics capture handler.
+
+    Idempotent: attaches a single handler instance to the root logger so warnings,
+    errors and exceptions are captured from the earliest moment possible, independent
+    of controller setup order (also covers embedded usage where __main__ is not used).
+    """
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        if isinstance(handler, DiagnosticsLogHandler):
+            return handler
+    handler = DiagnosticsLogHandler()
+    root_logger.addHandler(handler)
+    return handler
+
+
+def _redact_media_path(match: re.Match[str]) -> str:
+    """Replace a matched media file path with a stable hash placeholder plus extension."""
+    path = match.group(0)
+    extension = path.rsplit(".", 1)[-1].lower()
+    digest = hashlib.sha256(path.encode()).hexdigest()[:8]
+    return f"<path-{digest}>.{extension}"
+
+
+def _redact_mac(match: re.Match[str]) -> str:
+    """Replace a matched MAC address with a stable hash placeholder."""
+    digest = hashlib.sha256(match.group(0).lower().encode()).hexdigest()[:8]
+    return f"<mac-{digest}>"
+
+
+def _redact_ip(match: re.Match[str]) -> str:
+    """Replace a matched IP address candidate, keeping localhost and invalid candidates."""
+    candidate = match.group(0)
+    try:
+        ip_address = ipaddress.ip_address(candidate)
+    except ValueError:
+        # not an actual IP address (e.g. a timestamp or MAC address lookalike)
+        return candidate
+    if ip_address.is_loopback or ip_address.is_unspecified:
+        return candidate
+    return "<redacted-ip>"

--- a/music_assistant/helpers/logging.py
+++ b/music_assistant/helpers/logging.py
@@ -18,6 +18,8 @@ from collections.abc import Callable, Coroutine
 from functools import partial, wraps
 from typing import Any, cast, overload
 
+from music_assistant.helpers.diagnostics import DiagnosticsLogHandler
+
 
 class LoggingQueueHandler(logging.handlers.QueueHandler):
     """Process the log in another thread."""
@@ -75,6 +77,11 @@ def activate_log_queue_handler() -> None:
     migrated_handlers: list[logging.Handler] = []
     for handler in logging.root.handlers[:]:
         if handler is queue_handler:
+            continue
+        # the diagnostics capture handler stays attached directly to the root logger:
+        # the queue handler copies records and strips exc_info, which would break
+        # its exception aggregation (and it never blocks anyway)
+        if isinstance(handler, DiagnosticsLogHandler):
             continue
         logging.root.removeHandler(handler)
         migrated_handlers.append(handler)

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -35,6 +35,7 @@ from music_assistant.constants import (
 )
 from music_assistant.controllers.cache import CacheController
 from music_assistant.controllers.config import ConfigController
+from music_assistant.controllers.diagnostics import DiagnosticsController
 from music_assistant.controllers.discovery import DiscoveryController
 from music_assistant.controllers.metadata import MetaDataController
 from music_assistant.controllers.music import MusicController
@@ -46,6 +47,7 @@ from music_assistant.controllers.webserver import WebserverController
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.aiohttp_client import create_clientsession
 from music_assistant.helpers.api import APICommandHandler, api_command
+from music_assistant.helpers.diagnostics import install_diagnostics_log_handler
 from music_assistant.helpers.images import get_icon_string
 from music_assistant.helpers.util import (
     TaskManager,
@@ -120,6 +122,7 @@ class MusicAssistant:
     player_queues: PlayerQueuesController
     discovery: DiscoveryController
     streams: StreamsController
+    diagnostics: DiagnosticsController
 
     def __init__(self, storage_path: str, cache_path: str, safe_mode: bool = False) -> None:
         """Initialize the MusicAssistant Server."""
@@ -152,6 +155,10 @@ class MusicAssistant:
         """Start running the Music Assistant server."""
         self.loop = asyncio.get_running_loop()
         self.loop_thread_id = getattr(self.loop, "_thread_id")  # noqa: B009
+        # ensure the always-on diagnostics capture handler is installed as early as
+        # possible so boot-time errors are captured (idempotent, also installed by
+        # __main__ but embedded usage boots the server directly)
+        install_diagnostics_log_handler()
         self.running_as_hass_addon = await is_hass_supervisor()
         self.version = await get_package_version("music_assistant") or "0.0.0"
         # setup config controller first and fetch important config values
@@ -171,6 +178,7 @@ class MusicAssistant:
         )
         await warn_if_missing_x86_64_v2(LOGGER)
         # setup other core controllers
+        self.diagnostics = DiagnosticsController(self)
         self.cache = CacheController(self)
         self.tasks = TasksController(self)
         self.webserver = WebserverController(self)
@@ -197,6 +205,7 @@ class MusicAssistant:
             tg.create_task(setup_controller(self.metadata))
             tg.create_task(setup_controller(self.players))
             tg.create_task(setup_controller(self.player_queues))
+            tg.create_task(setup_controller(self.diagnostics))
 
         for controller_name in (
             "cache",
@@ -246,6 +255,7 @@ class MusicAssistant:
         await self.music.close()
         await self.player_queues.close()
         await self.players.close()
+        await self.diagnostics.close()
         # cleanup cache and config
         await self.config.close()
         await self.cache.close()
@@ -860,6 +870,7 @@ class MusicAssistant:
             self.webserver,
             self.webserver.auth,
             self.streams.audio_analysis,
+            self.diagnostics,
         ):
             for attr_name in dir(cls):
                 if attr_name.startswith("__"):

--- a/music_assistant/models/core_controller.py
+++ b/music_assistant/models/core_controller.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import ProviderStage, ProviderType
 from music_assistant_models.provider import ProviderManifest
@@ -47,6 +47,15 @@ class CoreController:
     ) -> tuple[ConfigEntry, ...]:
         """Return all Config Entries for this core module (if any)."""
         return ()
+
+    async def get_diagnostics(self) -> dict[str, Any] | None:
+        """
+        Return optional diagnostics info for this controller to include in diagnostics reports.
+
+        Return None (the default) when this controller has nothing to contribute.
+        Keep the returned data small, JSON serializable and free of sensitive values.
+        """
+        return None
 
     async def setup(self, config: CoreConfig) -> None:
         """Async initialize of module."""

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -97,6 +97,15 @@ class Provider:
             task_id = f"provider_reload_{self.instance_id}"
             self.mass.call_later(1, self.mass.load_provider_config, config, task_id=task_id)
 
+    async def get_diagnostics(self) -> dict[str, Any] | None:
+        """
+        Return optional diagnostics info for this provider to include in diagnostics reports.
+
+        Return None (the default) when this provider has nothing to contribute.
+        Keep the returned data small, JSON serializable and free of sensitive values.
+        """
+        return None
+
     async def on_mdns_service_state_change(
         self, name: str, state_change: ServiceStateChange, info: AsyncServiceInfo | None
     ) -> None:

--- a/tests/core/test_diagnostics.py
+++ b/tests/core/test_diagnostics.py
@@ -1,0 +1,419 @@
+"""Tests for the always-on diagnostics facility."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+from music_assistant_models.auth import User, UserRole
+
+from music_assistant.controllers.diagnostics import DiagnosticsController
+from music_assistant.controllers.webserver.helpers.auth_middleware import USER_CONTEXT_KEY
+from music_assistant.helpers.diagnostics import (
+    LOG_RING_MAXLEN,
+    MAX_EXCEPTION_FINGERPRINTS,
+    DiagnosticsLogHandler,
+    install_diagnostics_log_handler,
+    sanitize_data,
+    sanitize_text,
+)
+from music_assistant.helpers.json import json_dumps
+
+if TYPE_CHECKING:
+    from music_assistant.mass import MusicAssistant
+
+
+@pytest.mark.parametrize(
+    ("raw", "must_not_contain", "must_contain"),
+    [
+        # home directories
+        ("error in /Users/johndoe/.musicassistant/file", ["johndoe"], ["~/.musicassistant"]),
+        ("error in /home/johndoe/music-assistant/data", ["johndoe"], ["~"]),
+        (r"error in C:\Users\johndoe\AppData", ["johndoe"], ["~"]),
+        # media file paths reveal library content
+        (
+            "failed to open /media/Pink Floyd/The Wall/01 - In The Flesh.flac",
+            ["Pink Floyd", "The Wall", "In The Flesh"],
+            [".flac", "<path-"],
+        ),
+        ("cannot read Highway to Hell.mp3", ["Highway", "Hell"], [".mp3", "<path-"]),
+        ("failed: '01 - In The Flesh.flac' not found", ["In The Flesh"], ["failed:", "not found"]),
+        # URL credentials and query strings
+        (
+            "GET http://admin:hunter2@192.168.1.10/api?token=s3cr3t&x=1",
+            ["admin:hunter2", "s3cr3t", "192.168.1.10"],
+            ["<redacted>@", "<redacted-query>"],
+        ),
+        # query strings on relative request paths (e.g. OAuth callbacks)
+        (
+            "GET /callback?code=s3cr3tcode&state=abc failed",
+            ["s3cr3tcode"],
+            ["/callback?<redacted-query>", "failed"],
+        ),
+        # secret assignments in all common shapes
+        ("password=hunter2", ["hunter2"], ["password=<redacted>"]),
+        ('"api_key": "abc-def-123"', ["abc-def-123"], ["<redacted>"]),
+        ("Authorization: Bearer SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV", ["SflKxwRJ"], ["<redacted>"]),
+        (
+            "token eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.SflKxwRJSMeKKF2QT4fwpM",
+            ["eyJhbGci"],
+            ["<redacted-token>"],
+        ),
+        # long token blobs
+        ("blob A1b2C3d4E5f6A1b2C3d4E5f6A1b2C3d4E5f6", ["A1b2C3d4"], ["<redacted-token>"]),
+        # e-mail addresses
+        (
+            "user john.doe+spam@example.com failed",
+            ["john.doe", "example.com"],
+            ["<redacted-email>"],
+        ),
+        # IP addresses (loopback stays)
+        ("connect to 192.168.1.100 failed", ["192.168.1.100"], ["<redacted-ip>"]),
+        ("connect to 2001:db8:85a3::8a2e:370:7334 failed", ["2001:db8"], ["<redacted-ip>"]),
+        ("listening on 127.0.0.1 and ::1", [], ["127.0.0.1", "::1"]),
+        ("connection.20:F8:3B:09:03:E2 closed", ["20:F8:3B"], ["<mac-"]),
+        ("device 20-f8-3b-09-03-e2 offline", ["20-f8-3b"], ["<mac-"]),
+        ("scan done at 01:06:02 (took 12:34:56)", [], ["01:06:02", "12:34:56"]),
+        # timestamps and version numbers must survive
+        ("at 12:34:56.789 version 1.2.3 happened", [], ["12:34:56.789", "1.2.3"]),
+    ],
+)
+def test_sanitize_text(raw: str, must_not_contain: list[str], must_contain: list[str]) -> None:
+    """
+    Test the sanitizer against adversarial fixtures.
+
+    :param raw: The raw input text.
+    :param must_not_contain: Substrings that may not survive sanitization.
+    :param must_contain: Substrings that must be present after sanitization.
+    """
+    result = sanitize_text(raw)
+    for fragment in must_not_contain:
+        assert fragment not in result, f"{fragment!r} leaked into {result!r}"
+    for fragment in must_contain:
+        assert fragment in result, f"{fragment!r} missing from {result!r}"
+
+
+def test_sanitize_text_code_paths() -> None:
+    """Test that absolute code paths are rewritten to be relative to the app root."""
+    raw = 'File "/opt/venv/lib/python3.13/site-packages/aiohttp/web.py", line 12'
+    assert "/opt/venv" not in sanitize_text(raw)
+    assert 'File "aiohttp/web.py", line 12' in sanitize_text(raw)
+    raw = 'File "/opt/app/music_assistant/controllers/music.py", line 5'
+    assert "/opt/app" not in sanitize_text(raw)
+    assert 'File "music_assistant/controllers/music.py", line 5' in sanitize_text(raw)
+
+
+def test_sanitize_data_recurses() -> None:
+    """Test that sanitize_data sanitizes string values in nested structures."""
+    data: dict[str, Any] = {
+        "outer": [{"msg": "password=hunter2"}, "mail me at a@b.com"],
+        "count": 42,
+        "flag": True,
+        "point": (1, "b@c.com"),
+        "/home/marcel/Music/secret song.mp3": "path as key",
+    }
+    result = sanitize_data(data)
+    assert result["outer"][0]["msg"] == "password=<redacted>"
+    assert "a@b.com" not in result["outer"][1]
+    assert result["count"] == 42
+    assert result["flag"] is True
+    assert result["point"] == (1, "<redacted-email>")
+    # dict keys must be sanitized too
+    assert not any("secret song" in key for key in result)
+
+
+def _emit_exception(handler: DiagnosticsLogHandler, message: str = "it broke") -> None:
+    """Raise a ValueError and emit it as an exception log record to the given handler."""
+    logger = logging.getLogger("test.diagnostics")
+    logger.propagate = False
+    logger.addHandler(handler)
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        logger.exception(message)
+    finally:
+        logger.removeHandler(handler)
+
+
+def test_exception_aggregation() -> None:
+    """Test that repeated exceptions aggregate on one fingerprint with count."""
+    handler = DiagnosticsLogHandler()
+    _emit_exception(handler)
+    _emit_exception(handler)
+    _, exceptions = handler.snapshot()
+    assert len(exceptions) == 1
+    entry = exceptions[0]
+    assert entry.count == 2
+    assert entry.exc_type == "ValueError"
+    assert entry.logger_name == "test.diagnostics"
+    assert "ValueError: boom" in entry.render_traceback()
+    assert entry.last_seen >= entry.first_seen
+
+
+def test_exception_lru_bound() -> None:
+    """Test that the exception aggregation stays bounded (LRU eviction)."""
+    handler = DiagnosticsLogHandler()
+    for index in range(MAX_EXCEPTION_FINGERPRINTS + 20):
+        # unique exception type per iteration -> unique fingerprint
+        exc_type = type(f"CustomError{index}", (Exception,), {})
+        try:
+            raise exc_type("boom")
+        except Exception:
+            record = logging.LogRecord(
+                "test", logging.ERROR, __file__, 1, "failed", None, sys.exc_info()
+            )
+            handler.emit(record)
+    _, exceptions = handler.snapshot()
+    assert len(exceptions) == MAX_EXCEPTION_FINGERPRINTS
+
+
+def test_log_ring_bound_and_level() -> None:
+    """Test that the log ring is bounded and only captures WARNING and above."""
+    handler = DiagnosticsLogHandler()
+    logger = logging.getLogger("test.diagnostics.ring")
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    try:
+        logger.info("not captured")
+        for index in range(LOG_RING_MAXLEN + 50):
+            logger.warning("warning %s", index)
+    finally:
+        logger.removeHandler(handler)
+    records, _ = handler.snapshot()
+    assert len(records) == LOG_RING_MAXLEN
+    assert all(record.level == "WARNING" for record in records)
+    assert records[-1].message == f"warning {LOG_RING_MAXLEN + 49}"
+
+
+def test_emit_never_raises() -> None:
+    """Test that a poisoned log record cannot break the capture handler."""
+    handler = DiagnosticsLogHandler()
+    # args/format mismatch makes record.getMessage() raise
+    record = logging.LogRecord("test", logging.ERROR, __file__, 1, "%d", ("nan",), None)
+    handler.emit(record)  # must not raise
+
+
+def test_emit_does_no_sanitization_work() -> None:
+    """Test that the always-on capture path never invokes the (expensive) sanitizer."""
+    handler = DiagnosticsLogHandler()
+    with patch("music_assistant.helpers.diagnostics.sanitize_text") as mock_sanitize:
+        _emit_exception(handler)
+        mock_sanitize.assert_not_called()
+
+
+def test_emit_does_no_disk_io() -> None:
+    """Test that capturing an exception never reads source files (linecache)."""
+    handler = DiagnosticsLogHandler()
+    with (
+        patch("linecache.getline", side_effect=AssertionError("linecache hit on emit")),
+        patch("linecache.updatecache", side_effect=AssertionError("linecache hit on emit")),
+    ):
+        _emit_exception(handler)
+    _, exceptions = handler.snapshot()
+    assert len(exceptions) == 1
+
+
+def test_install_diagnostics_log_handler_idempotent() -> None:
+    """Test that installing the capture handler twice returns the same instance."""
+    handler = install_diagnostics_log_handler()
+    try:
+        assert install_diagnostics_log_handler() is handler
+        assert logging.getLogger().handlers.count(handler) == 1
+    finally:
+        logging.getLogger().removeHandler(handler)
+
+
+async def test_get_report(mass: MusicAssistant) -> None:
+    """
+    Test the full report: shape, bounded size, sanitization and JSON serializability.
+
+    :param mass: Full Music Assistant test instance.
+    """
+    logging.getLogger("music_assistant.test").warning("test warning for the ring")
+    # device identifiers embedded in logger names must be redacted too
+    logging.getLogger("aiosendspin.server.connection.20:F8:3B:09:03:E2").warning("closed")
+    try:
+        raise RuntimeError("report traceback probe")
+    except RuntimeError:
+        logging.getLogger("music_assistant.test").exception("probe failed")
+    report = await mass.diagnostics.get_report()
+    assert report["schema_version"] == 1
+    assert "redaction_notice" in report
+    assert report["system"]["python_version"]
+    assert report["system"]["counts"]["threads"] > 0
+    assert isinstance(report["install"]["providers"], list)
+    assert isinstance(report["install"]["library"]["tracks"], int)
+    assert isinstance(report["exceptions"], list)
+    assert any(
+        entry["type"] == "RuntimeError" and "report traceback probe" in entry["traceback"]
+        for entry in report["exceptions"]
+    )
+    # streams controller contributes its section through the get_diagnostics hook
+    assert "active_output_streams" in report["sections"]["core.streams"]
+    # log tail is opt-in
+    assert "log_tail" not in report
+    report_with_tail = await mass.diagnostics.get_report(include_log_tail=True)
+    messages = [record["message"] for record in report_with_tail["log_tail"]]
+    assert "test warning for the ring" in messages
+    loggers = [record["logger"] for record in report_with_tail["log_tail"]]
+    assert "aiosendspin.server.connection.<mac-7f85b52c>" in loggers
+    # the whole report must be JSON serializable and stay small
+    assert len(json_dumps(report_with_tail)) < 100_000
+
+
+async def test_get_report_command_admin_only(mass: MusicAssistant) -> None:
+    """
+    Test that the diagnostics/get API command is registered with admin-only scope.
+
+    :param mass: Full Music Assistant test instance.
+    """
+    handler = mass.command_handlers["diagnostics/get"]
+    assert handler.required_role == "admin"
+
+
+async def test_register_section(mass: MusicAssistant) -> None:
+    """
+    Test section registration: contribution, duplicates and unregistration.
+
+    :param mass: Full Music Assistant test instance.
+    """
+
+    async def async_section() -> dict[str, Any]:
+        return {"queued_jobs": 3}
+
+    unregister = mass.diagnostics.register_section("profiler", async_section)
+    unregister_sync = mass.diagnostics.register_section("sync_section", lambda: {"value": 1})
+    with pytest.raises(ValueError, match="already registered"):
+        mass.diagnostics.register_section("profiler", async_section)
+    report = await mass.diagnostics.get_report()
+    assert report["sections"]["profiler"] == {"queued_jobs": 3}
+    assert report["sections"]["sync_section"] == {"value": 1}
+    unregister()
+    unregister_sync()
+    report = await mass.diagnostics.get_report()
+    assert "profiler" not in report["sections"]
+    assert "sync_section" not in report["sections"]
+    # a stale unregister handle must not remove a newer registration with the same name
+    mass.diagnostics.register_section("profiler", lambda: {"value": 2})
+    unregister()
+    report = await mass.diagnostics.get_report()
+    assert report["sections"]["profiler"] == {"value": 2}
+
+
+async def test_section_failure_isolation(mass: MusicAssistant) -> None:
+    """
+    Test that a broken or slow section cannot break the report.
+
+    :param mass: Full Music Assistant test instance.
+    """
+
+    def broken_section() -> dict[str, Any]:
+        raise RuntimeError("contributor exploded with secret password=hunter2")
+
+    async def slow_section() -> dict[str, Any]:
+        await asyncio.sleep(30)
+        return {}
+
+    unregister_broken = mass.diagnostics.register_section("broken", broken_section)
+    unregister_slow = mass.diagnostics.register_section("slow", slow_section)
+    try:
+        with patch("music_assistant.controllers.diagnostics.SECTION_TIMEOUT", 0.1):
+            report = await mass.diagnostics.get_report()
+        assert "hunter2" not in report["sections"]["broken"]["error"]
+        assert "RuntimeError" in report["sections"]["broken"]["error"]
+        assert "error" in report["sections"]["slow"]
+        # healthy sections are unaffected
+        assert "core.streams" in report["sections"]
+    finally:
+        unregister_broken()
+        unregister_slow()
+
+
+async def test_section_sanitization(mass: MusicAssistant) -> None:
+    """
+    Test that section content is sanitized in depth.
+
+    :param mass: Full Music Assistant test instance.
+    """
+    unregister = mass.diagnostics.register_section(
+        "leaky", lambda: {"nested": ["mail a@b.com", {"file": "/music/Artist/song.flac"}]}
+    )
+    try:
+        report = await mass.diagnostics.get_report()
+        leaky = json_dumps(report["sections"]["leaky"])
+        assert "a@b.com" not in leaky
+        assert "Artist" not in leaky
+    finally:
+        unregister()
+
+
+async def test_http_download_requires_auth(mass: MusicAssistant) -> None:
+    """
+    Test that the diagnostics download route rejects unauthenticated requests.
+
+    :param mass: Full Music Assistant test instance.
+    """
+    request = make_mocked_request("GET", "/diagnostics", app={"mass": mass})
+    with pytest.raises(web.HTTPUnauthorized):
+        await mass.diagnostics.handle_http_download(request)
+
+
+async def test_http_download_requires_admin(mass: MusicAssistant) -> None:
+    """
+    Test that the diagnostics download route rejects non-admin users.
+
+    :param mass: Full Music Assistant test instance.
+    """
+    request = make_mocked_request("GET", "/diagnostics", app={"mass": mass})
+    request[USER_CONTEXT_KEY] = User(user_id="u1", username="regular", role=UserRole.USER)
+    with pytest.raises(web.HTTPForbidden):
+        await mass.diagnostics.handle_http_download(request)
+
+
+async def test_http_download_json_and_markdown(mass: MusicAssistant) -> None:
+    """
+    Test the authenticated download in both JSON and markdown format.
+
+    :param mass: Full Music Assistant test instance.
+    """
+    admin = User(user_id="u2", username="admin", role=UserRole.ADMIN)
+    request = make_mocked_request("GET", "/diagnostics", app={"mass": mass})
+    request[USER_CONTEXT_KEY] = admin
+    response = await mass.diagnostics.handle_http_download(request)
+    assert response.status == 200
+    assert response.content_type == "application/json"
+    assert (
+        'attachment; filename="music-assistant-diagnostics-'
+        in (response.headers["Content-Disposition"])
+    )
+    assert response.headers["Content-Disposition"].endswith('.json"')
+
+    request = make_mocked_request(
+        "GET", "/diagnostics?format=md&include_log_tail=true", app={"mass": mass}
+    )
+    request[USER_CONTEXT_KEY] = admin
+    response = await mass.diagnostics.handle_http_download(request)
+    assert response.status == 200
+    assert response.content_type == "text/markdown"
+    assert response.headers["Content-Disposition"].endswith('.md"')
+    assert response.text is not None
+    assert response.text.startswith("# Music Assistant diagnostics report")
+    assert "## Log tail" in response.text
+
+
+async def test_no_background_work(mass: MusicAssistant) -> None:
+    """
+    Test that the diagnostics facility schedules no background work of its own.
+
+    :param mass: Full Music Assistant test instance.
+    """
+    assert isinstance(mass.diagnostics, DiagnosticsController)
+    assert not [task for task in mass._tracked_tasks if "diagnostics" in task.lower()]
+    assert not [timer for timer in mass._tracked_timers if "diagnostics" in timer.lower()]


### PR DESCRIPTION
# What does this implement/fix?

Backports the always-on diagnostics facility from dev (#4652) so it ships in the 2.9.6 patch release. This lets users on stable capture a privacy-safe troubleshooting report without moving to a beta/dev build.

Server-side only: there is no "Download diagnostics" button in the frontend on stable. Users retrieve the report by browsing directly to the `GET /diagnostics` URL.

Included:

- `diagnostics/get` websocket command and `GET /diagnostics` HTTP route (both admin only) that serve a downloadable JSON or markdown report.
- `DiagnosticsController` that assembles system info, an install census and pluggable per-controller/provider sections, built on demand.
- Always-on, low-overhead log/exception capture with a sanitizer so reports are safe to attach to a public GitHub issue.
- Test suite under `tests/core/test_diagnostics.py`.

**Related issue (if applicable):**

- Backport of #4652

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
