### PR TITLE
Fix guest listen-in race conditions in the party and quiz plugins

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -262,9 +262,11 @@ class MusicQuizPlugin(PluginProvider):
         self._unregister_handles.clear()
         self._cancel_timers()
         self._cancel_next_round_task()
-        await self._close_playback_session()
+        # clear game state before tearing down the session so a guest listen-in
+        # racing with unload cannot (re)create or join a session mid-teardown
         self._game = None
         self._quiz_type = None
+        await self._close_playback_session()
         if is_removed:
             await guest_access.revoke_guest_access(self.mass, MUSIC_QUIZ_GUEST_USER)
         await super().unload(is_removed)
@@ -324,8 +326,11 @@ class MusicQuizPlugin(PluginProvider):
 
     async def get_game(self) -> dict[str, Any]:
         """Return the host-visible state of the current game."""
-        self._require_game()
-        return await self._host_state()
+        # take the game lock so the snapshot cannot tear against a concurrent
+        # reveal/reset while _host_state awaits the join URL
+        async with self._game_lock:
+            self._require_game()
+            return await self._host_state()
 
     async def start_game(self) -> dict[str, Any]:
         """Start the first round of the current game."""
@@ -370,12 +375,14 @@ class MusicQuizPlugin(PluginProvider):
             self._require_game()
             self._cancel_timers()
             self._cancel_next_round_task()
+            # clear game state before tearing down the session so a guest listen-in
+            # racing with delete cannot (re)create or join a session mid-teardown
+            self._game = None
+            self._quiz_type = None
             await self._stop_playback()
             # tear down the shared session so its virtual player / listen-in
             # guests do not linger once the game is gone
             await self._close_playback_session()
-            self._game = None
-            self._quiz_type = None
             self.signal_provider_event({"event": "game_removed"})
 
     # ==================== Guest API Commands ====================
@@ -483,11 +490,14 @@ class MusicQuizPlugin(PluginProvider):
         :param web_player_id: The player_id of the guest's web player.
         """
         self._validate_guest_access()
-        self._require_game()
-        session = await self._get_playback_session()
-        if session is None:
-            raise MusicQuizNoPlaybackTargetError("Listen-in is not available for this game")
-        await session.add_guest_listener(web_player_id)
+        # hold the playback lock across resolving and joining the session so a
+        # guest can never be attached to a session that is being torn down
+        async with self._playback_lock:
+            self._require_game()
+            session = await self._get_or_create_session_locked()
+            if session is None:
+                raise MusicQuizNoPlaybackTargetError("Listen-in is not available for this game")
+            await session.add_guest_listener(web_player_id)
 
     async def stop_listen_in(self, web_player_id: str) -> None:
         """
@@ -496,8 +506,9 @@ class MusicQuizPlugin(PluginProvider):
         :param web_player_id: The player_id of the guest's web player.
         """
         self._validate_guest_access()
-        if self._playback_session is not None:
-            await self._playback_session.remove_guest_listener(web_player_id)
+        async with self._playback_lock:
+            if self._playback_session is not None:
+                await self._playback_session.remove_guest_listener(web_player_id)
 
     async def can_listen_in(self, web_player_id: str) -> bool:
         """
@@ -506,10 +517,9 @@ class MusicQuizPlugin(PluginProvider):
         :param web_player_id: The player_id of the guest's web player.
         """
         self._validate_guest_access()
-        if self._game is None:
-            return False
-        session = await self._get_playback_session()
-        return session is not None and session.can_listen_in(web_player_id)
+        async with self._playback_lock:
+            session = await self._get_or_create_session_locked()
+            return session is not None and session.can_listen_in(web_player_id)
 
     # ==================== Internals ====================
 
@@ -769,35 +779,52 @@ class MusicQuizPlugin(PluginProvider):
         :return: The session, or None when no session is available.
         """
         async with self._playback_lock:
-            # drop a stale session whose player no longer exists
-            if self._playback_session is not None and (
-                self.mass.players.get_player(self._playback_session.player_id) is None
-            ):
-                await self._playback_session.close()
-                self._playback_session = None
+            return await self._get_or_create_session_locked()
 
-            if self._playback_session is not None:
-                return self._playback_session
+    async def _get_or_create_session_locked(self) -> SharedPlaybackSession | None:
+        """
+        Get or (re)create the shared playback session.
 
-            if self.config.get_value(CONF_MODE) == SharedPlaybackMode.REMOTE.value:
-                game_name = self._game.config.name if self._game else None
-                try:
-                    self._playback_session = await SharedPlaybackSession.create_remote(
-                        self.mass,
-                        owner_instance_id=self.instance_id,
-                        display_name=game_name or "Music Quiz",
-                        session_id=self.instance_id,
-                    )
-                except SetupFailedError as err:
-                    self.logger.warning("Unable to create remote quiz session: %s", err)
-            elif player_id := self._resolve_venue_player_id():
-                try:
-                    self._playback_session = await SharedPlaybackSession.create_venue(
-                        self.mass, player_id
-                    )
-                except SetupFailedError as err:
-                    self.logger.warning("Unable to create venue quiz session: %s", err)
+        The caller must hold ``_playback_lock``; guest listen-in and session
+        teardown share the lock so a session is never created or joined while it
+        is being closed.
+
+        :return: The session, or None when no game is active or none is available.
+        """
+        # a session only makes sense while a game is active; without one, never
+        # (re)create it - this also stops a guest listen-in that races with game
+        # teardown from leaking a fresh session / virtual player
+        if self._game is None:
+            return None
+        # drop a stale session whose player no longer exists
+        if self._playback_session is not None and (
+            self.mass.players.get_player(self._playback_session.player_id) is None
+        ):
+            await self._playback_session.close()
+            self._playback_session = None
+
+        if self._playback_session is not None:
             return self._playback_session
+
+        if self.config.get_value(CONF_MODE) == SharedPlaybackMode.REMOTE.value:
+            game_name = self._game.config.name if self._game else None
+            try:
+                self._playback_session = await SharedPlaybackSession.create_remote(
+                    self.mass,
+                    owner_instance_id=self.instance_id,
+                    display_name=game_name or "Music Quiz",
+                    session_id=self.instance_id,
+                )
+            except SetupFailedError as err:
+                self.logger.warning("Unable to create remote quiz session: %s", err)
+        elif player_id := self._resolve_venue_player_id():
+            try:
+                self._playback_session = await SharedPlaybackSession.create_venue(
+                    self.mass, player_id
+                )
+            except SetupFailedError as err:
+                self.logger.warning("Unable to create venue quiz session: %s", err)
+        return self._playback_session
 
     def _resolve_venue_player_id(self) -> str | None:
         """

--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -949,15 +949,19 @@ class PartyPlugin(PluginProvider):
         if not self.config.get_value(CONF_ENABLE_GUEST_ACCESS):
             raise InvalidDataError("Party guest access is disabled")
 
-        session = await self._get_session()
-        if not session:
-            raise InvalidDataError("Listen-in is not available for this party")
-        await session.add_guest_listener(web_player_id)
+        # hold the session lock across resolving and joining the session so a
+        # guest can never be attached to a session that is being torn down
+        async with self._session_lock:
+            session = await self._get_or_create_session_locked()
+            if not session:
+                raise InvalidDataError("Listen-in is not available for this party")
+            await session.add_guest_listener(web_player_id)
+            queue_id = session.queue_id
 
         self.logger.info("Guest player %s is now listening in", web_player_id)
         return {
             "success": True,
-            "queue_id": session.queue_id,
+            "queue_id": queue_id,
         }
 
     async def stop_listen_in(self, web_player_id: str) -> dict[str, Any]:
@@ -986,8 +990,9 @@ class PartyPlugin(PluginProvider):
         if not self.config.get_value(CONF_ENABLE_GUEST_ACCESS):
             return False
 
-        session = await self._get_session()
-        return session is not None and session.can_listen_in(web_player_id)
+        async with self._session_lock:
+            session = await self._get_or_create_session_locked()
+            return session is not None and session.can_listen_in(web_player_id)
 
     # ==================== Helper Methods ====================
 
@@ -1004,37 +1009,49 @@ class PartyPlugin(PluginProvider):
         :returns: The session, or None when no session is available.
         """
         async with self._session_lock:
-            # drop a stale session whose player no longer exists
-            if self._session is not None and (
-                self.mass.players.get_player(self._session.player_id) is None
-            ):
-                await self._session.close()
-                self._session = None
+            return await self._get_or_create_session_locked()
 
-            if self._session is not None:
-                return self._session
+    async def _get_or_create_session_locked(self) -> SharedPlaybackSession | None:
+        """
+        Get or (re)create the shared playback session.
 
-            if self.config.get_value(CONF_PARTY_MODE) == SharedPlaybackMode.REMOTE.value:
-                party_name = cast("str | None", self.config.get_value(CONF_PARTY_NAME))
+        The caller must hold ``_session_lock``; guest listen-in and session
+        teardown share the lock so a session is never created or joined while it
+        is being closed.
+
+        :returns: The session, or None when no session is available.
+        """
+        # drop a stale session whose player no longer exists
+        if self._session is not None and (
+            self.mass.players.get_player(self._session.player_id) is None
+        ):
+            await self._session.close()
+            self._session = None
+
+        if self._session is not None:
+            return self._session
+
+        if self.config.get_value(CONF_PARTY_MODE) == SharedPlaybackMode.REMOTE.value:
+            party_name = cast("str | None", self.config.get_value(CONF_PARTY_NAME))
+            try:
+                self._session = await SharedPlaybackSession.create_remote(
+                    self.mass,
+                    owner_instance_id=self.instance_id,
+                    display_name=party_name or "Party",
+                    session_id=self.instance_id,
+                )
+            except SetupFailedError as err:
+                self.logger.warning("Unable to create remote party session: %s", err)
+        else:
+            player_id = self.config.get_value(CONF_PARTY_PLAYER)
+            if player_id and str(player_id) != CONF_PARTY_PLAYER_AUTO:
                 try:
-                    self._session = await SharedPlaybackSession.create_remote(
-                        self.mass,
-                        owner_instance_id=self.instance_id,
-                        display_name=party_name or "Party",
-                        session_id=self.instance_id,
+                    self._session = await SharedPlaybackSession.create_venue(
+                        self.mass, str(player_id)
                     )
                 except SetupFailedError as err:
-                    self.logger.warning("Unable to create remote party session: %s", err)
-            else:
-                player_id = self.config.get_value(CONF_PARTY_PLAYER)
-                if player_id and str(player_id) != CONF_PARTY_PLAYER_AUTO:
-                    try:
-                        self._session = await SharedPlaybackSession.create_venue(
-                            self.mass, str(player_id)
-                        )
-                    except SetupFailedError as err:
-                        self.logger.warning("Unable to create venue party session: %s", err)
-            return self._session
+                    self.logger.warning("Unable to create venue party session: %s", err)
+        return self._session
 
     async def _revoke_guest_tokens(self) -> None:
         """

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -22,6 +22,7 @@ from music_assistant.providers.music_quiz.errors import (
     MusicQuizUnknownPlayerError,
 )
 from music_assistant.providers.music_quiz.models import (
+    MusicQuizGame,
     MusicQuizPhase,
     MusicQuizRound,
     MusicQuizSuggestion,
@@ -108,6 +109,11 @@ def _create_plugin(mode: str = "venue", player: str | None = "venue_player") -> 
     plugin._stop_playback = AsyncMock()  # type: ignore[method-assign]
     plugin._get_join_url = AsyncMock(return_value="http://ma/join")  # type: ignore[method-assign]
     return plugin
+
+
+def _fake_game() -> MusicQuizGame:
+    """Return a minimal active-game stub for playback-session tests."""
+    return cast("MusicQuizGame", SimpleNamespace(config=SimpleNamespace(name=None)))
 
 
 def _guest_user() -> SimpleNamespace:
@@ -443,6 +449,7 @@ async def test_config_validation() -> None:
 async def test_playback_session_remote_mode() -> None:
     """Remote mode creates a virtual-player session keyed to the instance."""
     plugin = _create_plugin(mode="remote")
+    plugin._game = _fake_game()
     cast("MagicMock", plugin.mass).players.get_player.return_value = None
     session = MagicMock()
     with patch(
@@ -462,6 +469,7 @@ async def test_playback_session_remote_mode() -> None:
 async def test_playback_session_recreated_when_player_vanished() -> None:
     """A session whose player disappeared (e.g. sendspin reload) is recreated."""
     plugin = _create_plugin(mode="remote")
+    plugin._game = _fake_game()
     stale_session = MagicMock()
     stale_session.player_id = "gone"
     stale_session.close = AsyncMock()
@@ -480,6 +488,7 @@ async def test_playback_session_recreated_when_player_vanished() -> None:
 async def test_playback_session_venue_mode() -> None:
     """Venue mode creates a session on the configured player."""
     plugin = _create_plugin(mode="venue", player="venue_player")
+    plugin._game = _fake_game()
     session = MagicMock()
     with patch(
         "music_assistant.providers.music_quiz.SharedPlaybackSession.create_venue",
@@ -493,6 +502,7 @@ async def test_playback_session_venue_mode() -> None:
 async def test_playback_session_venue_mode_auto_prefers_playing_player() -> None:
     """Venue mode with the auto player picks a currently playing player."""
     plugin = _create_plugin(mode="venue", player="__auto__")
+    plugin._game = _fake_game()
     paused = SimpleNamespace(player_id="paused_player", playback_state=PlaybackState.PAUSED)
     playing = SimpleNamespace(player_id="playing_player", playback_state=PlaybackState.PLAYING)
     cast("MagicMock", plugin.mass).players.all_players.return_value = [paused, playing]
@@ -509,6 +519,7 @@ async def test_playback_session_venue_mode_auto_prefers_playing_player() -> None
 async def test_playback_session_venue_mode_auto_without_players() -> None:
     """Venue mode with the auto player yields no session when no player is available."""
     plugin = _create_plugin(mode="venue", player="__auto__")
+    plugin._game = _fake_game()
     cast("MagicMock", plugin.mass).players.all_players.return_value = []
     with patch(
         "music_assistant.providers.music_quiz.SharedPlaybackSession.create_venue",
@@ -516,6 +527,39 @@ async def test_playback_session_venue_mode_auto_without_players() -> None:
     ) as create_venue:
         assert await plugin._get_playback_session() is None
     create_venue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_playback_session_requires_active_game() -> None:
+    """No playback session is created without an active game (guards the listen-in race)."""
+    plugin = _create_plugin(mode="remote")
+    plugin._game = None
+    with patch(
+        "music_assistant.providers.music_quiz.SharedPlaybackSession.create_remote",
+        new=AsyncMock(),
+    ) as create_remote:
+        assert await plugin._get_playback_session() is None
+    create_remote.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_listen_in_joins_session_under_playback_lock() -> None:
+    """listen_in joins the guest while holding the playback lock so teardown cannot race it."""
+    plugin = _create_plugin(mode="remote")
+    plugin._game = _fake_game()
+    session = MagicMock()
+
+    async def _assert_locked(_web_player_id: str) -> None:
+        assert plugin._playback_lock.locked()
+
+    session.add_guest_listener = AsyncMock(side_effect=_assert_locked)
+    plugin._playback_session = session
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=SimpleNamespace(username=MUSIC_QUIZ_GUEST_USER),
+    ):
+        await plugin.listen_in("web-1")
+    session.add_guest_listener.assert_awaited_once_with("web-1")
 
 
 @pytest.mark.asyncio

--- a/tests/providers/party/test_party_plugin.py
+++ b/tests/providers/party/test_party_plugin.py
@@ -125,7 +125,7 @@ async def test_get_party_player_remote_mode_no_session() -> None:
 async def test_listen_in_without_session_raises() -> None:
     """Listen-in is rejected when no session is available (venue auto mode)."""
     plugin = _create_session_test_plugin(SharedPlaybackMode.VENUE.value)
-    plugin._get_session = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    plugin._get_or_create_session_locked = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     with (
         patch(
@@ -143,8 +143,12 @@ async def test_listen_in_attaches_guest_player() -> None:
     plugin = _create_session_test_plugin(SharedPlaybackMode.REMOTE.value)
     session = MagicMock()
     session.queue_id = "sendspin_virtual_party"
-    session.add_guest_listener = AsyncMock()
-    plugin._get_session = AsyncMock(return_value=session)  # type: ignore[method-assign]
+
+    async def _assert_locked(_web_player_id: str) -> None:
+        assert plugin._session_lock.locked()
+
+    session.add_guest_listener = AsyncMock(side_effect=_assert_locked)
+    plugin._get_or_create_session_locked = AsyncMock(return_value=session)  # type: ignore[method-assign]
 
     with patch(
         "music_assistant.providers.party.get_current_user",


### PR DESCRIPTION
# What does this implement/fix?

Fixes concurrency edge cases in guest "listen in" for the party and Music Quiz plugins, spotted while reviewing the just-merged shared-listening feature.

Guest listen-in resolved the shared playback session under the session lock but then joined the guest player *after* releasing it. If a host deleted the game (or the provider unloaded) at that exact moment, a guest could stay grouped to the venue player after teardown, or a hidden virtual player could be left behind. Separately, the quiz host-state snapshot could tear against a concurrent reveal/reset.

- Join and leave listen-in now run entirely under the session lock in both plugins, so a session can't be created or joined while it's being torn down.
- The quiz never (re)creates a playback session when no game is active.
- The quiz host state is built under the game lock, so it can't return an inconsistent snapshot.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (N/A)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (N/A)
- [x] I have read and complied with the project's AI Policy for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository. (N/A)
