### PR TITLE
Speed up artwork loading and refresh artwork when local files change

### DIFF
--- a/music_assistant/controllers/metadata/images.py
+++ b/music_assistant/controllers/metadata/images.py
@@ -33,13 +33,14 @@ from music_assistant_models.media_items import (
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.api import api_command
-from music_assistant.helpers.colors import get_palette
+from music_assistant.helpers.colors import get_palette, invalidate_cached_palette
 from music_assistant.helpers.images import (
     create_collage,
     create_thumb_hash,
     detect_image_content_format,
     get_image_data,
     get_image_thumb,
+    invalidate_cached_image,
 )
 from music_assistant.helpers.security import is_safe_path
 
@@ -279,6 +280,21 @@ class ImageProxyMixin:
             return await get_palette(self.mass, path, provider)
         except MediaNotFoundError, OSError:
             return None
+
+    async def invalidate_image_cache(self, provider: str, path: str) -> None:
+        """
+        Drop every cached artifact for an image so the next request re-fetches it.
+
+        Removes the cached source bytes, all thumbnail size/format variants
+        (memory + disk) and the extracted color palette. Call this when the
+        image content behind an unchanged (provider, path) identity has
+        changed, e.g. a local file whose (embedded) artwork was replaced.
+
+        :param provider: Provider (instance) id that owns / can resolve the image.
+        :param path: Image path or URL exactly as referenced by media items.
+        """
+        await invalidate_cached_image(self.mass, provider, path)
+        await invalidate_cached_palette(self.mass, provider, path)
 
     async def get_thumbnail(
         self,

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -266,26 +266,18 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
     ) -> ItemCls:
         """Update existing library record in the library database."""
         self.mass.music.match_provider_instances(update)
-        suppress_updates = SUPPRESS_MEDIA_ITEM_UPDATES.get()
-        prev_images: set[tuple[str, str]] = set()
-        if not suppress_updates:
-            # snapshot the current images so cached artwork of images replaced
-            # or removed by this (user-initiated) update can be invalidated
-            with suppress(MediaNotFoundError):
-                prev_item = await self.get_library_item(item_id)
-                prev_images = {(img.provider, img.path) for img in prev_item.metadata.images or []}
         # batch the many writes of an item update into a single commit
         async with self.mass.music.database.deferred_commit():
             await self._update_library_item(item_id, update, overwrite=overwrite)
         # return the updated object
         library_item = await self.get_library_item(item_id)
-        if suppress_updates:
+        if SUPPRESS_MEDIA_ITEM_UPDATES.get():
             # during a sync the update originates from the provider itself,
             # so skip both the event and the write-back to that provider
             return library_item
-        new_images = {(img.provider, img.path) for img in library_item.metadata.images or []}
-        for img_provider, img_path in prev_images - new_images:
-            await self.mass.metadata.invalidate_image_cache(img_provider, img_path)
+        # drop cached artwork for the updated item so replaced art is served fresh
+        for img in library_item.metadata.images or []:
+            await self.mass.metadata.invalidate_image_cache(img.provider, img.path)
         self.mass.signal_event(
             EventType.MEDIA_ITEM_UPDATED,
             library_item.uri,
@@ -355,6 +347,9 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         )
         # NOTE: this does not delete any references to this item in other records,
         # this is handled/overridden in the mediatype specific controllers
+        # drop cached artwork for the removed item
+        for img in library_item.metadata.images or []:
+            await self.mass.metadata.invalidate_image_cache(img.provider, img.path)
         self.mass.signal_event(EventType.MEDIA_ITEM_DELETED, library_item.uri, library_item)
         self.logger.debug("deleted item with id %s from database", db_id)
 

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -266,15 +266,26 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
     ) -> ItemCls:
         """Update existing library record in the library database."""
         self.mass.music.match_provider_instances(update)
+        suppress_updates = SUPPRESS_MEDIA_ITEM_UPDATES.get()
+        prev_images: set[tuple[str, str]] = set()
+        if not suppress_updates:
+            # snapshot the current images so cached artwork of images replaced
+            # or removed by this (user-initiated) update can be invalidated
+            with suppress(MediaNotFoundError):
+                prev_item = await self.get_library_item(item_id)
+                prev_images = {(img.provider, img.path) for img in prev_item.metadata.images or []}
         # batch the many writes of an item update into a single commit
         async with self.mass.music.database.deferred_commit():
             await self._update_library_item(item_id, update, overwrite=overwrite)
         # return the updated object
         library_item = await self.get_library_item(item_id)
-        if SUPPRESS_MEDIA_ITEM_UPDATES.get():
+        if suppress_updates:
             # during a sync the update originates from the provider itself,
             # so skip both the event and the write-back to that provider
             return library_item
+        new_images = {(img.provider, img.path) for img in library_item.metadata.images or []}
+        for img_provider, img_path in prev_images - new_images:
+            await self.mass.metadata.invalidate_image_cache(img_provider, img_path)
         self.mass.signal_event(
             EventType.MEDIA_ITEM_UPDATED,
             library_item.uri,

--- a/music_assistant/helpers/colors.py
+++ b/music_assistant/helpers/colors.py
@@ -266,6 +266,17 @@ async def get_palette(
     return await asyncio.shield(task)
 
 
+async def invalidate_cached_palette(mass: MusicAssistant, provider: str, path_or_url: str) -> None:
+    """
+    Remove the cached palette for an image so the next request re-extracts it.
+
+    :param mass: The MusicAssistant instance.
+    :param provider: Provider identifier for the image source.
+    :param path_or_url: Image path or URL (same format as get_palette).
+    """
+    await mass.cache.delete(key=create_thumb_hash(provider, path_or_url), provider=_CACHE_PROVIDER)
+
+
 async def get_palette_for_url(
     mass: MusicAssistant, image_url: str | None
 ) -> MediaItemPalette | None:

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import itertools
 import os
 import random
 import re
+import time
 import urllib.parse
 from base64 import b64decode
 from collections import OrderedDict
@@ -18,6 +20,7 @@ from typing import TYPE_CHECKING, cast
 
 import aiofiles
 from aiohttp.client_exceptions import ClientError
+from music_assistant_models.errors import MusicAssistantError
 from PIL import Image, UnidentifiedImageError
 
 from music_assistant.constants import APPLICATION_NAME
@@ -50,6 +53,21 @@ _THUMB_CACHE_VERSION = 2
 _THUMB_FILENAME_RE = re.compile(r"^[0-9a-f]{64}_\d+_v\d+(?:_flat)?\.(?:jpg|png)$")
 
 _thumb_memory_cache: OrderedDict[str, bytes] = OrderedDict()
+
+# Source-image cache: the raw origin bytes (remote download, local file read or
+# ffmpeg-extracted embedded art) that every derived artifact (thumb sizes/formats,
+# color palette, collage tiles) is generated from. Without it, first display of a
+# single item fetches the same source several times within seconds. The memory
+# tier is byte-budgeted (originals can be multi-MB); expensive fetches also get an
+# on-disk `<hash>_src` entry in the thumbnail cache dir so multi-variant
+# generation after a restart doesn't re-fetch either.
+_SOURCE_CACHE_SUFFIX = "_src"
+# remote urls can serve new content behind a stable url, so keep the TTL modest;
+# local files don't rely on it as invalidate_cached_image busts them on change
+_SOURCE_CACHE_TTL = 3600
+_SOURCE_MEMORY_MAX_BYTES = 32 * 1024 * 1024
+# a single huge original would evict everything else, so cap the entry size
+_SOURCE_MEMORY_ENTRY_MAX_BYTES = 8 * 1024 * 1024
 
 _MAX_IMAGEPROXY_RECURSION_DEPTH = 5
 
@@ -119,6 +137,50 @@ def _put_in_memory_cache(key: str, data: bytes) -> None:
         _thumb_memory_cache.popitem(last=False)
 
 
+class _SourceMemoryCache:
+    """In-memory byte-budgeted LRU tier of the source-image cache."""
+
+    def __init__(self) -> None:
+        self.entries: OrderedDict[str, tuple[bytes, float]] = OrderedDict()
+        self.total_bytes = 0
+
+    def get(self, key: str) -> bytes | None:
+        """Return cached source bytes for key, or None on miss/expiry."""
+        entry = self.entries.get(key)
+        if entry is None:
+            return None
+        data, stored_at = entry
+        if time.monotonic() - stored_at > _SOURCE_CACHE_TTL:
+            self.pop(key)
+            return None
+        self.entries.move_to_end(key)
+        return data
+
+    def put(self, key: str, data: bytes) -> None:
+        """Store source bytes for key, evicting oldest entries over the byte budget."""
+        if len(data) > _SOURCE_MEMORY_ENTRY_MAX_BYTES:
+            return
+        self.pop(key)
+        self.entries[key] = (data, time.monotonic())
+        self.total_bytes += len(data)
+        while self.total_bytes > _SOURCE_MEMORY_MAX_BYTES and self.entries:
+            _, (evicted, _stored_at) = self.entries.popitem(last=False)
+            self.total_bytes -= len(evicted)
+
+    def pop(self, key: str) -> None:
+        """Remove the entry for key (if present)."""
+        if entry := self.entries.pop(key, None):
+            self.total_bytes -= len(entry[0])
+
+    def clear(self) -> None:
+        """Remove all entries."""
+        self.entries.clear()
+        self.total_bytes = 0
+
+
+_source_memory_cache = _SourceMemoryCache()
+
+
 def _has_alpha(img: ImageClass) -> bool:
     """Return True if the image actually uses transparency."""
     if img.mode == "P":
@@ -183,6 +245,11 @@ async def get_image_data(
     """
     Retrieve image data from a path or URL.
 
+    Source bytes are cached (in-memory, plus on-disk for expensive fetches) so
+    that deriving multiple artifacts from one image (thumb sizes/formats,
+    palette, collage tiles) only fetches the origin once. Concurrent requests
+    for the same source share a single fetch.
+
     :param mass: The MusicAssistant instance.
     :param path_or_url: The image path, URL, or base64 data URI.
     :param provider: The provider ID that can resolve the image.
@@ -191,55 +258,172 @@ async def get_image_data(
     if _depth >= _MAX_IMAGEPROXY_RECURSION_DEPTH:
         msg = f"Maximum recursion depth exceeded when fetching image: {path_or_url}"
         raise FileNotFoundError(msg)
-    # TODO: add local cache here !
+    # base64 data URIs carry their content inline; just decode them
+    if path_or_url.startswith("data:image"):
+        return b64decode(path_or_url.rsplit(",", maxsplit=1)[-1])
+    # imageproxy URLs pointing at our own server are resolved to their underlying
+    # (provider, path) before anything is cached: an alias-keyed cache entry
+    # would keep serving after the underlying image was invalidated
+    if path_or_url.startswith("http") and (
+        resolved := await _resolve_own_imageproxy_url(mass, path_or_url)
+    ):
+        extracted_provider, extracted_path = resolved
+        return await get_image_data(mass, extracted_path, extracted_provider, _depth=_depth + 1)
+    cache_key = create_thumb_hash(provider, path_or_url)
+    if (cached := _source_memory_cache.get(cache_key)) is not None:
+        return cached
+    # fetch de-duplicated across concurrent requests for the same source
+    task: asyncio.Task[bytes] = mass.create_task(
+        _fetch_and_cache_source_image,
+        mass,
+        path_or_url,
+        provider,
+        cache_key,
+        _depth,
+        task_id=f"imgsrc.{cache_key}",
+        abort_existing=False,
+    )
+    return await asyncio.shield(task)
+
+
+async def _resolve_own_imageproxy_url(mass: MusicAssistant, url: str) -> tuple[str, str] | None:
+    """
+    Resolve an imageproxy URL pointing at our own server to its (provider, path).
+
+    Returns None when the URL does not point at this server at all; raises
+    FileNotFoundError for own-server URLs that carry an invalid or unknown id.
+
+    :param mass: The MusicAssistant instance.
+    :param url: The (http/https) URL to inspect.
+    """
+    parsed_url = urllib.parse.urlparse(url)
+    url_origin = f"{parsed_url.scheme}://{parsed_url.netloc}"
+    server_origins = {
+        f"{p.scheme}://{p.netloc}"
+        for b in (mass.webserver.base_url, mass.streams.base_url)
+        if (p := urllib.parse.urlparse(b)).netloc
+    }
+    if url_origin not in server_origins:
+        return None
+    # opaque-id form: /imageproxy/<image_id>?size=...&fmt=...
+    if image_id := _extract_imageproxy_id(url):
+        resolved = await mass.metadata.resolve_image_id(image_id)
+        if resolved is None:
+            msg = f"Unknown image id in URL: {url}"
+            raise FileNotFoundError(msg)
+        return resolved
+    msg = f"Invalid imageproxy URL: {url}"
+    raise FileNotFoundError(msg)
+
+
+def _source_cache_filepath(mass: MusicAssistant, cache_key: str) -> str:
+    """Return the on-disk path for a cached source image, validating containment."""
+    thumb_dir = os.path.realpath(os.path.join(mass.cache_path, _THUMB_CACHE_DIR))
+    filepath = os.path.realpath(os.path.join(thumb_dir, f"{cache_key}{_SOURCE_CACHE_SUFFIX}"))
+    if not filepath.startswith(thumb_dir + os.sep):
+        msg = f"Cache path escapes thumbnail directory: {filepath}"
+        raise OSError(msg)
+    return filepath
+
+
+async def _fetch_and_cache_source_image(
+    mass: MusicAssistant, path_or_url: str, provider: str, cache_key: str, depth: int
+) -> bytes:
+    """
+    Fetch source image bytes, store them in the source cache tiers and return them.
+
+    :param mass: The MusicAssistant instance.
+    :param path_or_url: The image path or URL.
+    :param provider: The provider ID that can resolve the image.
+    :param cache_key: Source cache key (create_thumb_hash of provider + path).
+    :param depth: Recursion depth of the originating get_image_data call.
+    """
+    filepath = _source_cache_filepath(mass, cache_key)
+
+    def _read_disk_entry() -> bytes | None:
+        # remote urls only count as fresh within the TTL (a CDN can serve new
+        # content behind a stable url); local files rely on invalidation instead
+        try:
+            if not os.path.isfile(filepath):
+                return None
+            if (
+                path_or_url.startswith("http")
+                and time.time() - Path(filepath).stat().st_mtime > _SOURCE_CACHE_TTL
+            ):
+                return None
+            with open(filepath, "rb") as _file:
+                return _file.read()
+        except OSError:
+            return None
+
+    if disk_data := await asyncio.to_thread(_read_disk_entry):
+        _source_memory_cache.put(cache_key, disk_data)
+        return disk_data
+
+    img_data, disk_worthy = await _fetch_source_image(mass, path_or_url, provider, depth)
+    _source_memory_cache.put(cache_key, img_data)
+    if disk_worthy:
+        # persist to disk cache (best-effort, don't fail on I/O errors)
+        try:
+            await asyncio.to_thread(os.makedirs, os.path.dirname(filepath), exist_ok=True)
+            async with aiofiles.open(filepath, "wb") as _file:
+                await _file.write(img_data)
+        except OSError:
+            pass
+    return img_data
+
+
+async def _fetch_source_image(
+    mass: MusicAssistant, path_or_url: str, provider: str, depth: int
+) -> tuple[bytes, bool]:
+    """
+    Fetch image bytes from their origin.
+
+    Returns the raw bytes plus whether the fetch was expensive enough to justify
+    an on-disk cache entry (remote downloads and ffmpeg-extracted embedded art;
+    a direct local file read is already as cheap as its cache copy would be).
+
+    :param mass: The MusicAssistant instance.
+    :param path_or_url: The image path or URL.
+    :param provider: The provider ID that can resolve the image.
+    :param depth: Recursion depth of the originating get_image_data call.
+    """
     if prov := mass.get_provider(provider):
         assert isinstance(prov, MusicProvider | MetadataProvider | PluginProvider)
         if resolved_image := await prov.resolve_image(path_or_url):
             if isinstance(resolved_image, bytes):
-                return resolved_image
+                return resolved_image, True
             if isinstance(resolved_image, str):
                 path_or_url = resolved_image
     # handle HTTP location
     if path_or_url.startswith("http"):
-        # Handle imageproxy URLs pointing to our own server
-        parsed_url = urllib.parse.urlparse(path_or_url)
-        url_origin = f"{parsed_url.scheme}://{parsed_url.netloc}"
-        server_origins = {
-            f"{p.scheme}://{p.netloc}"
-            for b in (mass.webserver.base_url, mass.streams.base_url)
-            if (p := urllib.parse.urlparse(b)).netloc
-        }
-        if url_origin in server_origins:
-            # opaque-id form: /imageproxy/<image_id>?size=...&fmt=...
-            if image_id := _extract_imageproxy_id(path_or_url):
-                resolved = await mass.metadata.resolve_image_id(image_id)
-                if resolved is None:
-                    msg = f"Unknown image id in URL: {path_or_url}"
-                    raise FileNotFoundError(msg)
-                extracted_provider, extracted_path = resolved
-                return await get_image_data(
-                    mass, extracted_path, extracted_provider, _depth=_depth + 1
-                )
-            msg = f"Invalid imageproxy URL: {path_or_url}"
-            raise FileNotFoundError(msg)
+        # handle imageproxy URLs pointing to our own server
+        if resolved := await _resolve_own_imageproxy_url(mass, path_or_url):
+            extracted_provider, extracted_path = resolved
+            # route through the public entrypoint so the result is cached under
+            # the resolved key; don't persist it under this alias key as well
+            return (
+                await get_image_data(mass, extracted_path, extracted_provider, _depth=depth + 1),
+                False,
+            )
         try:
-            return await _fetch_remote_image(mass, path_or_url)
+            return await _fetch_remote_image(mass, path_or_url), True
         except ClientError as err:
             msg = f"Failed to fetch image from {path_or_url}: {err}"
             raise FileNotFoundError(msg) from err
     # handle base64 embedded images
     if path_or_url.startswith("data:image"):
-        return b64decode(path_or_url.split(",")[-1])
+        return b64decode(path_or_url.split(",")[-1]), False
     # handle FILE location (of type image)
     if path_or_url.endswith(("jpg", "JPG", "png", "PNG", "jpeg", "svg", "SVG")) and is_safe_path(
         path_or_url
     ):
         if await asyncio.to_thread(os.path.isfile, path_or_url):
             async with aiofiles.open(path_or_url, "rb") as _file:
-                return cast("bytes", await _file.read())
+                return cast("bytes", await _file.read()), False
     # use ffmpeg for embedded images
     if is_safe_path(path_or_url) and (img_data := await get_embedded_image(path_or_url)):
-        return img_data
+        return img_data, True
     msg = f"Image not found: {path_or_url}"
     raise FileNotFoundError(msg)
 
@@ -444,6 +628,37 @@ async def cleanup_thumb_cache(cache_path: str, max_size_bytes: int) -> int:
     return await asyncio.to_thread(_cleanup)
 
 
+async def invalidate_cached_image(mass: MusicAssistant, provider: str, path_or_url: str) -> None:
+    """
+    Remove all cached artifacts (thumbnails + source bytes) for an image.
+
+    Used when the image content behind an unchanged (provider, path) identity
+    has changed, e.g. a local file whose (embedded) artwork was replaced.
+
+    :param mass: The MusicAssistant instance.
+    :param provider: Provider id exactly as used when the image was requested.
+    :param path_or_url: Image path or URL exactly as used when the image was requested.
+    """
+    thumb_hash = create_thumb_hash(provider, path_or_url)
+    prefix = f"{thumb_hash}_"
+    for key in [key for key in _thumb_memory_cache if key.startswith(prefix)]:
+        _thumb_memory_cache.pop(key, None)
+    _source_memory_cache.pop(thumb_hash)
+
+    thumb_dir = os.path.realpath(os.path.join(mass.cache_path, _THUMB_CACHE_DIR))
+
+    def _remove_disk_entries() -> None:
+        # covers every size/format/flatten thumb variant plus the `_src` entry
+        if not os.path.isdir(thumb_dir):
+            return
+        for entry in os.scandir(thumb_dir):
+            if entry.name.startswith(prefix) and entry.is_file():
+                with contextlib.suppress(OSError):
+                    Path(entry.path).unlink()
+
+    await asyncio.to_thread(_remove_disk_entries)
+
+
 async def create_collage(
     mass: MusicAssistant,
     images: Iterable[MediaItemImage],
@@ -466,18 +681,39 @@ async def create_collage(
 
     # prevent duplicates with a set
     images = list(set(images))
-    random.shuffle(images)
-    iter_images = itertools.cycle(images)
+    # warm the source cache with bounded concurrency and drop images that can't
+    # be fetched, so the (serial) tile loop below is served from cache
+    fetch_limiter = asyncio.Semaphore(8)
+
+    async def _warm_source_cache(img: MediaItemImage) -> MediaItemImage | None:
+        async with fetch_limiter:
+            try:
+                await get_image_data(mass, img.path, img.provider)
+            except FileNotFoundError, MusicAssistantError:
+                return None
+            return img
+
+    usable_images = [
+        img for img in await asyncio.gather(*map(_warm_source_cache, images)) if img is not None
+    ]
+    if not usable_images:
+        msg = "None of the collage images could be fetched"
+        raise FileNotFoundError(msg)
+    random.shuffle(usable_images)
+    iter_images = itertools.cycle(usable_images)
 
     for x_co in range(0, dimensions[0], image_size):
         for y_co in range(0, dimensions[1], image_size):
+            # try a few candidates per tile: a fetched image can still fail to decode
             for _ in range(5):
                 img = next(iter_images)
-                img_data = await get_image_data(mass, img.path, img.provider)
-                if img_data:
+                try:
+                    img_data = await get_image_data(mass, img.path, img.provider)
                     await asyncio.to_thread(_add_to_collage, img_data, x_co, y_co)
-                    del img_data
-                    break
+                except FileNotFoundError, MusicAssistantError, UnidentifiedImageError:
+                    continue
+                del img_data
+                break
 
     def _save_collage() -> bytes:
         final_data = BytesIO()

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -58,9 +58,9 @@ _thumb_memory_cache: OrderedDict[str, bytes] = OrderedDict()
 # ffmpeg-extracted embedded art) that every derived artifact (thumb sizes/formats,
 # color palette, collage tiles) is generated from. Without it, first display of a
 # single item fetches the same source several times within seconds. The memory
-# tier is byte-budgeted (originals can be multi-MB); expensive fetches also get an
-# on-disk `<hash>_src` entry in the thumbnail cache dir so multi-variant
-# generation after a restart doesn't re-fetch either.
+# tier is byte-budgeted (originals can be multi-MB); sources also get an on-disk
+# `<hash>_src` entry in the thumbnail cache dir so multi-variant generation
+# after a restart doesn't re-fetch either.
 _SOURCE_CACHE_SUFFIX = "_src"
 # remote urls can serve new content behind a stable url, so keep the TTL modest;
 # local files don't rely on it as invalidate_cached_image busts them on change
@@ -245,10 +245,10 @@ async def get_image_data(
     """
     Retrieve image data from a path or URL.
 
-    Source bytes are cached (in-memory, plus on-disk for expensive fetches) so
-    that deriving multiple artifacts from one image (thumb sizes/formats,
-    palette, collage tiles) only fetches the origin once. Concurrent requests
-    for the same source share a single fetch.
+    Source bytes are cached (in memory and on disk) so that deriving multiple
+    artifacts from one image (thumb sizes/formats, palette, collage tiles)
+    only fetches the origin once. Concurrent requests for the same source
+    share a single fetch.
 
     :param mass: The MusicAssistant instance.
     :param path_or_url: The image path, URL, or base64 data URI.
@@ -360,9 +360,9 @@ async def _fetch_and_cache_source_image(
         _source_memory_cache.put(cache_key, disk_data)
         return disk_data
 
-    img_data, disk_worthy = await _fetch_source_image(mass, path_or_url, provider, depth)
+    img_data, disk_cacheable = await _fetch_source_image(mass, path_or_url, provider, depth)
     _source_memory_cache.put(cache_key, img_data)
-    if disk_worthy:
+    if disk_cacheable:
         # persist to disk cache (best-effort, don't fail on I/O errors)
         try:
             await asyncio.to_thread(os.makedirs, os.path.dirname(filepath), exist_ok=True)
@@ -379,9 +379,11 @@ async def _fetch_source_image(
     """
     Fetch image bytes from their origin.
 
-    Returns the raw bytes plus whether the fetch was expensive enough to justify
-    an on-disk cache entry (remote downloads and ffmpeg-extracted embedded art;
-    a direct local file read is already as cheap as its cache copy would be).
+    Returns the raw bytes plus whether they may be persisted on disk under this
+    (provider, path) cache key. That is True for every origin except results
+    resolved under a different key (imageproxy URLs pointing at our own server):
+    an alias-keyed copy would keep being served after the underlying image is
+    invalidated.
 
     :param mass: The MusicAssistant instance.
     :param path_or_url: The image path or URL.
@@ -413,14 +415,14 @@ async def _fetch_source_image(
             raise FileNotFoundError(msg) from err
     # handle base64 embedded images
     if path_or_url.startswith("data:image"):
-        return b64decode(path_or_url.split(",")[-1]), False
+        return b64decode(path_or_url.split(",")[-1]), True
     # handle FILE location (of type image)
     if path_or_url.endswith(("jpg", "JPG", "png", "PNG", "jpeg", "svg", "SVG")) and is_safe_path(
         path_or_url
     ):
         if await asyncio.to_thread(os.path.isfile, path_or_url):
             async with aiofiles.open(path_or_url, "rb") as _file:
-                return cast("bytes", await _file.read()), False
+                return cast("bytes", await _file.read()), True
     # use ffmpeg for embedded images
     if is_safe_path(path_or_url) and (img_data := await get_embedded_image(path_or_url)):
         return img_data, True

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -1116,6 +1116,17 @@ class LocalFileSystemProvider(MusicProvider):
         try:
             self.logger.log(VERBOSE_LOG_LEVEL, "Processing: %s", item.relative_path)
 
+            if prev_checksum is not None:
+                # the file changed on disk: drop cached artwork derived from it
+                # (thumbnails, source bytes, palette) so re-read embedded art is
+                # served fresh, for both reference forms of the image path
+                await self.mass.metadata.invalidate_image_cache(
+                    self.instance_id, item.relative_path
+                )
+                await self.mass.metadata.invalidate_image_cache(
+                    self.instance_id, self._versioned_image_path(item.relative_path, prev_checksum)
+                )
+
             if item.ext in CUE_EXTENSIONS and self.media_content_type == "music":
                 tracks = await self._cue.parse_tracks(item)
                 for track in tracks:

--- a/tests/controllers/metadata/test_image_proxy.py
+++ b/tests/controllers/metadata/test_image_proxy.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import hashlib
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -27,6 +28,8 @@ from music_assistant.controllers.metadata.constants import (
 from music_assistant.controllers.metadata.helpers import (
     _normalize_imageproxy_format,
 )
+from music_assistant.helpers import images as images_helper
+from music_assistant.helpers.colors import get_palette
 from music_assistant.helpers.images import (
     _THUMB_CACHE_VERSION,
     _THUMB_FILENAME_RE,
@@ -35,6 +38,7 @@ from music_assistant.helpers.images import (
     _thumb_cache_filename,
     create_thumb_hash,
     detect_image_content_format,
+    get_image_thumb,
     is_svg_data,
     player_image_url,
 )
@@ -542,6 +546,56 @@ async def test_serve_thumbnail_sets_csp_for_svg(
     jpg_resp = await metadata_controller._serve_thumbnail("p", "builtin", 256, "jpeg")
     assert "Content-Security-Policy" not in jpg_resp.headers
     assert "X-Content-Type-Options" not in jpg_resp.headers
+
+
+async def test_invalidate_image_cache_end_to_end(
+    metadata_controller: MetaDataController, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Invalidation drops thumbs, source bytes and palette; the next request re-fetches.
+
+    This is the retag scenario: a local file's artwork is replaced while its
+    (provider, path) identity stays the same, so every derived artifact keyed
+    on that identity must be regenerated.
+    """
+    image_path = str(tmp_path / "cover.png")
+    Image.new("RGB", (300, 300), (200, 30, 30)).save(image_path, "PNG")
+    mass = metadata_controller.mass
+    fetches = 0
+    real_fetch = images_helper._fetch_source_image
+
+    async def counting_fetch(*args: Any, **kwargs: Any) -> tuple[bytes, bool]:
+        nonlocal fetches
+        fetches += 1
+        return await real_fetch(*args, **kwargs)
+
+    monkeypatch.setattr(images_helper, "_fetch_source_image", counting_fetch)
+
+    # derive two thumb variants and a palette from one single source fetch
+    await get_image_thumb(mass, image_path, 80, "builtin")
+    await get_image_thumb(mass, image_path, 256, "builtin")
+    palette = await get_palette(mass, image_path, "builtin")
+    assert palette is not None
+    assert palette.primary is not None
+    assert fetches == 1
+
+    thumb_hash = create_thumb_hash("builtin", image_path)
+    thumb_dir = Path(mass.cache_path, "thumbnails")
+    assert [f for f in thumb_dir.iterdir() if f.name.startswith(thumb_hash)]
+    assert await mass.cache.get(thumb_hash, provider="palette") is not None
+
+    await metadata_controller.invalidate_image_cache("builtin", image_path)
+
+    assert not [f for f in thumb_dir.iterdir() if f.name.startswith(thumb_hash)]
+    assert thumb_hash not in images_helper._source_memory_cache.entries
+    assert not any(key.startswith(f"{thumb_hash}_") for key in images_helper._thumb_memory_cache)
+    assert await mass.cache.get(thumb_hash, provider="palette") is None
+
+    # replace the artwork on disk: the next request serves the new content
+    Image.new("RGB", (300, 300), (30, 30, 200)).save(image_path, "PNG")
+    new_palette = await get_palette(mass, image_path, "builtin")
+    assert new_palette is not None
+    assert new_palette.primary != palette.primary
 
 
 def test_player_image_url_forces_jpeg_on_imageproxy_urls() -> None:

--- a/tests/controllers/music/test_update_item_image_invalidation.py
+++ b/tests/controllers/music/test_update_item_image_invalidation.py
@@ -1,0 +1,91 @@
+"""Tests for image-cache invalidation on explicit library item updates."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import ImageType
+from music_assistant_models.media_items import (
+    MediaItemImage,
+    MediaItemMetadata,
+    ProviderMapping,
+    Track,
+)
+from music_assistant_models.unique_list import UniqueList
+
+from music_assistant.controllers.music.media.base import SUPPRESS_MEDIA_ITEM_UPDATES
+from music_assistant.controllers.music.media.tracks import TracksController
+
+
+def _image(path: str) -> MediaItemImage:
+    """Build a MediaItemImage for the given path."""
+    return MediaItemImage(
+        type=ImageType.THUMB, path=path, provider="test--1", remotely_accessible=False
+    )
+
+
+def _track(images: list[MediaItemImage]) -> Track:
+    """Build a minimal library Track carrying the given images."""
+    return Track(
+        item_id="1",
+        provider="library",
+        name="Test Track",
+        provider_mappings={
+            ProviderMapping(item_id="1", provider_domain="test", provider_instance="test--1")
+        },
+        metadata=MediaItemMetadata(images=UniqueList(images) or None),
+    )
+
+
+def _controller_returning(*items: Track) -> tuple[TracksController, AsyncMock, AsyncMock]:
+    """Build a TracksController with mocked db plus its invalidation/get mocks."""
+    mass = MagicMock()
+    invalidate_mock = AsyncMock()
+    mass.metadata.invalidate_image_cache = invalidate_mock
+    mass.get_provider.return_value = None
+    controller = TracksController(mass)
+    get_item_mock = AsyncMock(side_effect=list(items))
+    controller.get_library_item = get_item_mock  # type: ignore[method-assign]
+    controller._update_library_item = AsyncMock()  # type: ignore[method-assign]
+    return controller, invalidate_mock, get_item_mock
+
+
+async def test_replaced_image_is_invalidated() -> None:
+    """Replacing an item's image invalidates the cached artwork of the old image."""
+    prev_item = _track([_image("Artist/old-cover.jpg")])
+    updated_item = _track([_image("Artist/new-cover.jpg")])
+    controller, invalidate_mock, _ = _controller_returning(prev_item, updated_item)
+    await controller.update_item_in_library("1", updated_item)
+    invalidate_mock.assert_awaited_once_with("test--1", "Artist/old-cover.jpg")
+
+
+async def test_unchanged_images_are_not_invalidated() -> None:
+    """An update that keeps the same images busts nothing."""
+    prev_item = _track([_image("Artist/cover.jpg")])
+    updated_item = _track([_image("Artist/cover.jpg")])
+    controller, invalidate_mock, _ = _controller_returning(prev_item, updated_item)
+    await controller.update_item_in_library("1", updated_item)
+    invalidate_mock.assert_not_awaited()
+
+
+async def test_added_image_is_not_invalidated() -> None:
+    """Merely adding an image (e.g. metadata enrichment) busts nothing."""
+    prev_item = _track([])
+    updated_item = _track([_image("Artist/fresh-cover.jpg")])
+    controller, invalidate_mock, _ = _controller_returning(prev_item, updated_item)
+    await controller.update_item_in_library("1", updated_item)
+    invalidate_mock.assert_not_awaited()
+
+
+async def test_suppressed_update_skips_snapshot_and_invalidation() -> None:
+    """During a provider sync neither the pre-fetch nor any invalidation runs."""
+    updated_item = _track([_image("Artist/new-cover.jpg")])
+    controller, invalidate_mock, get_item_mock = _controller_returning(updated_item)
+    token = SUPPRESS_MEDIA_ITEM_UPDATES.set(True)
+    try:
+        await controller.update_item_in_library("1", updated_item)
+    finally:
+        SUPPRESS_MEDIA_ITEM_UPDATES.reset(token)
+    # only the post-update read happened; no snapshot read, no invalidation
+    assert get_item_mock.await_count == 1
+    invalidate_mock.assert_not_awaited()

--- a/tests/controllers/music/test_update_item_image_invalidation.py
+++ b/tests/controllers/music/test_update_item_image_invalidation.py
@@ -1,4 +1,4 @@
-"""Tests for image-cache invalidation on explicit library item updates."""
+"""Tests for image-cache invalidation on library item updates and removals."""
 
 from __future__ import annotations
 
@@ -37,55 +37,52 @@ def _track(images: list[MediaItemImage]) -> Track:
     )
 
 
-def _controller_returning(*items: Track) -> tuple[TracksController, AsyncMock, AsyncMock]:
-    """Build a TracksController with mocked db plus its invalidation/get mocks."""
+def _controller_returning(item: Track) -> tuple[TracksController, AsyncMock]:
+    """Build a TracksController with mocked db plus its invalidation mock."""
     mass = MagicMock()
+    mass.music.database = AsyncMock()
+    # deferred_commit is used as (sync-called) async context manager
+    mass.music.database.deferred_commit = MagicMock()
     invalidate_mock = AsyncMock()
     mass.metadata.invalidate_image_cache = invalidate_mock
     mass.get_provider.return_value = None
     controller = TracksController(mass)
-    get_item_mock = AsyncMock(side_effect=list(items))
-    controller.get_library_item = get_item_mock  # type: ignore[method-assign]
+    controller.get_library_item = AsyncMock(return_value=item)  # type: ignore[method-assign]
     controller._update_library_item = AsyncMock()  # type: ignore[method-assign]
-    return controller, invalidate_mock, get_item_mock
+    return controller, invalidate_mock
 
 
-async def test_replaced_image_is_invalidated() -> None:
-    """Replacing an item's image invalidates the cached artwork of the old image."""
-    prev_item = _track([_image("Artist/old-cover.jpg")])
-    updated_item = _track([_image("Artist/new-cover.jpg")])
-    controller, invalidate_mock, _ = _controller_returning(prev_item, updated_item)
-    await controller.update_item_in_library("1", updated_item)
-    invalidate_mock.assert_awaited_once_with("test--1", "Artist/old-cover.jpg")
-
-
-async def test_unchanged_images_are_not_invalidated() -> None:
-    """An update that keeps the same images busts nothing."""
-    prev_item = _track([_image("Artist/cover.jpg")])
+async def test_updated_item_artwork_is_invalidated() -> None:
+    """Updating an item drops its cached artwork so replaced art is served fresh."""
     updated_item = _track([_image("Artist/cover.jpg")])
-    controller, invalidate_mock, _ = _controller_returning(prev_item, updated_item)
+    controller, invalidate_mock = _controller_returning(updated_item)
+    await controller.update_item_in_library("1", updated_item)
+    invalidate_mock.assert_awaited_once_with("test--1", "Artist/cover.jpg")
+
+
+async def test_update_without_images_invalidates_nothing() -> None:
+    """An item without any images busts nothing."""
+    updated_item = _track([])
+    controller, invalidate_mock = _controller_returning(updated_item)
     await controller.update_item_in_library("1", updated_item)
     invalidate_mock.assert_not_awaited()
 
 
-async def test_added_image_is_not_invalidated() -> None:
-    """Merely adding an image (e.g. metadata enrichment) busts nothing."""
-    prev_item = _track([])
-    updated_item = _track([_image("Artist/fresh-cover.jpg")])
-    controller, invalidate_mock, _ = _controller_returning(prev_item, updated_item)
-    await controller.update_item_in_library("1", updated_item)
-    invalidate_mock.assert_not_awaited()
-
-
-async def test_suppressed_update_skips_snapshot_and_invalidation() -> None:
-    """During a provider sync neither the pre-fetch nor any invalidation runs."""
+async def test_suppressed_update_skips_invalidation() -> None:
+    """During a provider sync no invalidation runs for updated items."""
     updated_item = _track([_image("Artist/new-cover.jpg")])
-    controller, invalidate_mock, get_item_mock = _controller_returning(updated_item)
+    controller, invalidate_mock = _controller_returning(updated_item)
     token = SUPPRESS_MEDIA_ITEM_UPDATES.set(True)
     try:
         await controller.update_item_in_library("1", updated_item)
     finally:
         SUPPRESS_MEDIA_ITEM_UPDATES.reset(token)
-    # only the post-update read happened; no snapshot read, no invalidation
-    assert get_item_mock.await_count == 1
     invalidate_mock.assert_not_awaited()
+
+
+async def test_removed_item_artwork_is_invalidated() -> None:
+    """Removing an item drops its cached artwork."""
+    library_item = _track([_image("Artist/cover.jpg")])
+    controller, invalidate_mock = _controller_returning(library_item)
+    await controller.remove_item_from_library("1", recursive=False)
+    invalidate_mock.assert_awaited_once_with("test--1", "Artist/cover.jpg")

--- a/tests/helpers/test_images.py
+++ b/tests/helpers/test_images.py
@@ -1,0 +1,378 @@
+"""Tests for the source-image cache in the images helper."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import time
+from base64 import b64encode
+from io import BytesIO
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import ImageType
+from music_assistant_models.media_items import MediaItemImage
+from PIL import Image
+
+from music_assistant.helpers import images
+from music_assistant.helpers.images import (
+    _SOURCE_CACHE_TTL,
+    create_thumb_hash,
+    get_image_data,
+    get_image_thumb,
+    invalidate_cached_image,
+)
+from music_assistant.models.metadata_provider import MetadataProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from music_assistant.mass import MusicAssistant
+
+
+@pytest.fixture(autouse=True)
+def _reset_image_caches() -> Iterator[None]:
+    """Isolate the module-level image caches between tests."""
+    images._thumb_memory_cache.clear()
+    images._source_memory_cache.clear()
+    yield
+    images._thumb_memory_cache.clear()
+    images._source_memory_cache.clear()
+
+
+@pytest.fixture
+def fetch_calls(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+    """Spy on origin fetches; returns the list of (provider, path) fetch calls."""
+    calls: list[tuple[str, str]] = []
+    real_fetch = images._fetch_source_image
+
+    async def counting_fetch(
+        mass: MusicAssistant, path_or_url: str, provider: str, depth: int
+    ) -> tuple[bytes, bool]:
+        calls.append((provider, path_or_url))
+        return await real_fetch(mass, path_or_url, provider, depth)
+
+    monkeypatch.setattr(images, "_fetch_source_image", counting_fetch)
+    return calls
+
+
+def _make_png_bytes(color: tuple[int, int, int] = (200, 30, 30), size: int = 400) -> bytes:
+    """Create raw PNG bytes of a solid-color square."""
+    img = Image.new("RGB", (size, size), color)
+    buf = BytesIO()
+    img.save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _make_png_file(tmp_path: Path, name: str = "art.png") -> str:
+    """Create a PNG file on disk and return its absolute path."""
+    filepath = tmp_path / name
+    filepath.write_bytes(_make_png_bytes())
+    return str(filepath)
+
+
+async def test_multiple_thumb_sizes_fetch_source_once(
+    mass_minimal: MusicAssistant, tmp_path: Path, fetch_calls: list[tuple[str, str]]
+) -> None:
+    """Generating several thumb variants of one image must fetch the source once."""
+    image_path = _make_png_file(tmp_path)
+    thumb_80 = await get_image_thumb(mass_minimal, image_path, 80, "builtin")
+    thumb_256 = await get_image_thumb(mass_minimal, image_path, 256, "builtin")
+    jpeg_flat = await get_image_thumb(
+        mass_minimal, image_path, 256, "builtin", image_format="JPEG", flatten_transparency=True
+    )
+    assert thumb_80
+    assert thumb_256
+    assert jpeg_flat
+    assert fetch_calls == [("builtin", image_path)]
+
+
+async def test_concurrent_requests_share_one_fetch(
+    mass_minimal: MusicAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Concurrent get_image_data calls for the same source coalesce into one fetch."""
+    gate = asyncio.Event()
+    calls: list[str] = []
+
+    async def gated_fetch(
+        _mass: MusicAssistant, path_or_url: str, _provider: str, _depth: int
+    ) -> tuple[bytes, bool]:
+        calls.append(path_or_url)
+        await gate.wait()
+        return b"image-bytes", False
+
+    monkeypatch.setattr(images, "_fetch_source_image", gated_fetch)
+    tasks = [
+        asyncio.create_task(get_image_data(mass_minimal, "/some/image.png", "builtin"))
+        for _ in range(3)
+    ]
+    await asyncio.sleep(0)
+    gate.set()
+    results = await asyncio.gather(*tasks)
+    assert results == [b"image-bytes"] * 3
+    assert calls == ["/some/image.png"]
+
+
+async def test_data_uri_is_decoded_without_caching(
+    mass_minimal: MusicAssistant, fetch_calls: list[tuple[str, str]]
+) -> None:
+    """Inline base64 data URIs are decoded directly and never enter the cache."""
+    payload = b"\x89PNG\r\n\x1a\nfakepngdata"
+    data_uri = f"data:image/png;base64,{b64encode(payload).decode()}"
+    result = await get_image_data(mass_minimal, data_uri, "builtin")
+    assert result == payload
+    assert fetch_calls == []
+    assert not images._source_memory_cache.entries
+
+
+async def test_provider_bytes_use_disk_cache_across_restart(
+    mass_minimal: MusicAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    fetch_calls: list[tuple[str, str]],
+) -> None:
+    """An expensive fetch is persisted on disk and reused after a (simulated) restart."""
+    fake_provider = MagicMock(spec=MetadataProvider)
+    fake_provider.resolve_image = AsyncMock(return_value=b"expensive-image-bytes")
+    monkeypatch.setattr(mass_minimal, "get_provider", lambda _prov: fake_provider)
+
+    data = await get_image_data(mass_minimal, "some/prov/path.jpg", "fake--1")
+    assert data == b"expensive-image-bytes"
+    assert len(fetch_calls) == 1
+    cache_key = create_thumb_hash("fake--1", "some/prov/path.jpg")
+    src_file = os.path.join(mass_minimal.cache_path, "thumbnails", f"{cache_key}_src")
+    assert os.path.isfile(src_file)
+
+    # simulate a restart: memory tier gone, disk entry remains
+    images._source_memory_cache.clear()
+    data = await get_image_data(mass_minimal, "some/prov/path.jpg", "fake--1")
+    assert data == b"expensive-image-bytes"
+    assert len(fetch_calls) == 1
+
+
+async def test_local_file_read_skips_disk_cache(
+    mass_minimal: MusicAssistant, tmp_path: Path, fetch_calls: list[tuple[str, str]]
+) -> None:
+    """A direct local file read is cached in memory only (no redundant disk copy)."""
+    image_path = _make_png_file(tmp_path)
+    await get_image_data(mass_minimal, image_path, "builtin")
+    assert len(fetch_calls) == 1
+    cache_key = create_thumb_hash("builtin", image_path)
+    assert cache_key in images._source_memory_cache.entries
+    src_file = os.path.join(mass_minimal.cache_path, "thumbnails", f"{cache_key}_src")
+    assert not os.path.exists(src_file)
+
+
+async def test_remote_disk_entry_expires_after_ttl(
+    mass_minimal: MusicAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    fetch_calls: list[tuple[str, str]],
+) -> None:
+    """A stale on-disk entry for a remote url is refetched after the TTL."""
+    mass_minimal.webserver = MagicMock(base_url="http://127.0.0.1:8095")
+    mass_minimal.streams = MagicMock(base_url="http://127.0.0.1:8097")
+    remote_url = "http://cdn.example.com/artwork.jpg"
+
+    async def fake_remote_fetch(_mass: MusicAssistant, _url: str) -> bytes:
+        return b"remote-image-bytes"
+
+    monkeypatch.setattr(images, "_fetch_remote_image", fake_remote_fetch)
+    await get_image_data(mass_minimal, remote_url, "builtin")
+    assert len(fetch_calls) == 1
+    cache_key = create_thumb_hash("builtin", remote_url)
+    src_file = os.path.join(mass_minimal.cache_path, "thumbnails", f"{cache_key}_src")
+    assert os.path.isfile(src_file)
+
+    # a fresh disk entry is used after a restart...
+    images._source_memory_cache.clear()
+    await get_image_data(mass_minimal, remote_url, "builtin")
+    assert len(fetch_calls) == 1
+    # ...but an expired one is not
+    images._source_memory_cache.clear()
+    expired = time.time() - _SOURCE_CACHE_TTL - 10
+    os.utime(src_file, (expired, expired))
+    await get_image_data(mass_minimal, remote_url, "builtin")
+    assert len(fetch_calls) == 2
+
+
+async def test_own_imageproxy_url_cached_under_resolved_key_only(
+    mass_minimal: MusicAssistant, tmp_path: Path, fetch_calls: list[tuple[str, str]]
+) -> None:
+    """Imageproxy URLs to our own server never create an alias cache entry."""
+    image_path = _make_png_file(tmp_path)
+    mass_minimal.webserver = MagicMock(base_url="http://127.0.0.1:8095")
+    mass_minimal.streams = MagicMock(base_url="http://127.0.0.1:8097")
+    image_id = create_thumb_hash("builtin", image_path)
+    mass_minimal.metadata = MagicMock(
+        resolve_image_id=AsyncMock(return_value=("builtin", image_path))
+    )
+    proxy_url = f"http://127.0.0.1:8095/imageproxy/{image_id}?size=256"
+
+    await get_image_data(mass_minimal, proxy_url, "builtin")
+    assert fetch_calls == [("builtin", image_path)]
+    assert create_thumb_hash("builtin", image_path) in images._source_memory_cache.entries
+    assert create_thumb_hash("builtin", proxy_url) not in images._source_memory_cache.entries
+    # a repeated request through the proxy url form hits the resolved cache entry
+    await get_image_data(mass_minimal, proxy_url, "builtin")
+    assert len(fetch_calls) == 1
+
+
+async def test_invalidate_cached_image_clears_all_tiers(
+    mass_minimal: MusicAssistant, tmp_path: Path, fetch_calls: list[tuple[str, str]]
+) -> None:
+    """Invalidation removes every thumb variant plus source bytes, then refetches."""
+    image_path = _make_png_file(tmp_path, "target.png")
+    other_path = _make_png_file(tmp_path, "other.png")
+    for path in (image_path, other_path):
+        await get_image_thumb(mass_minimal, path, 80, "builtin")
+        await get_image_thumb(mass_minimal, path, 256, "builtin")
+    assert len(fetch_calls) == 2
+
+    thumb_dir = Path(mass_minimal.cache_path, "thumbnails")
+    target_hash = create_thumb_hash("builtin", image_path)
+    other_hash = create_thumb_hash("builtin", other_path)
+    assert len([f for f in thumb_dir.iterdir() if f.name.startswith(target_hash)]) == 2
+
+    await invalidate_cached_image(mass_minimal, "builtin", image_path)
+
+    # all artifacts of the target image are gone, the other image is untouched
+    assert not [f for f in thumb_dir.iterdir() if f.name.startswith(target_hash)]
+    assert len([f for f in thumb_dir.iterdir() if f.name.startswith(other_hash)]) == 2
+    assert target_hash not in images._source_memory_cache.entries
+    assert not any(key.startswith(f"{target_hash}_") for key in images._thumb_memory_cache)
+    assert any(key.startswith(f"{other_hash}_") for key in images._thumb_memory_cache)
+
+    # the next request must hit the origin again
+    await get_image_thumb(mass_minimal, image_path, 80, "builtin")
+    assert len(fetch_calls) == 3
+
+
+async def test_source_memory_cache_respects_byte_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The memory tier evicts oldest entries once the byte budget is exceeded."""
+    monkeypatch.setattr(images, "_SOURCE_MEMORY_MAX_BYTES", 1000)
+    monkeypatch.setattr(images, "_SOURCE_MEMORY_ENTRY_MAX_BYTES", 600)
+    cache = images._source_memory_cache
+    cache.put("aa", b"x" * 400)
+    cache.put("bb", b"y" * 400)
+    assert cache.get("aa") is not None
+    # third entry pushes total over budget: oldest entry is evicted
+    cache.put("cc", b"z" * 400)
+    assert cache.get("bb") is None
+    assert cache.get("aa") is not None  # refreshed by the get above
+    assert cache.get("cc") is not None
+    # an entry larger than the per-entry cap is not stored at all
+    cache.put("dd", b"w" * 601)
+    assert cache.get("dd") is None
+    assert cache.total_bytes == 800
+
+
+async def test_source_memory_cache_entries_expire(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Memory entries older than the TTL are treated as a miss."""
+    cache = images._source_memory_cache
+    cache.put("aa", b"payload")
+    assert cache.get("aa") == b"payload"
+    # shrink the TTL so the stored entry is immediately considered expired
+    monkeypatch.setattr(images, "_SOURCE_CACHE_TTL", -1)
+    assert cache.get("aa") is None
+    assert cache.total_bytes == 0
+
+
+def _create_mp3_with_cover(track_path: str, cover_path: str) -> None:
+    """Create a short mp3 file with the given image embedded as cover art."""
+    subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "ffmpeg",
+            "-y",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-t",
+            "0.1",
+            "-i",
+            "anullsrc=r=44100:cl=mono",
+            "-i",
+            cover_path,
+            "-map",
+            "0:a",
+            "-map",
+            "1:v",
+            "-c:a",
+            "libmp3lame",
+            "-c:v",
+            "mjpeg",
+            "-id3v2_version",
+            "3",
+            track_path,
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+
+async def test_embedded_art_retag_flow(
+    mass_minimal: MusicAssistant, tmp_path: Path, fetch_calls: list[tuple[str, str]]
+) -> None:
+    """
+    The full retag scenario against a real audio file.
+
+    Embedded art (an expensive ffmpeg extraction) is cached in memory and on
+    disk; replacing the artwork in the file goes unnoticed until the cache is
+    invalidated, after which the new artwork is extracted and served.
+    """
+    red_cover = str(tmp_path / "red.png")
+    blue_cover = str(tmp_path / "blue.png")
+    Image.new("RGB", (64, 64), (255, 0, 0)).save(red_cover, "PNG")
+    Image.new("RGB", (64, 64), (0, 0, 255)).save(blue_cover, "PNG")
+    track_path = str(tmp_path / "track.mp3")
+    _create_mp3_with_cover(track_path, red_cover)
+
+    original_art = await get_image_data(mass_minimal, track_path, "builtin")
+    assert original_art.startswith(b"\xff\xd8")  # extracted as JPEG
+    assert len(fetch_calls) == 1
+    cache_key = create_thumb_hash("builtin", track_path)
+    src_file = os.path.join(mass_minimal.cache_path, "thumbnails", f"{cache_key}_src")
+    assert os.path.isfile(src_file)  # ffmpeg extraction is disk-cache worthy
+
+    # a restart later, the disk entry avoids re-running ffmpeg
+    images._source_memory_cache.clear()
+    assert await get_image_data(mass_minimal, track_path, "builtin") == original_art
+    assert len(fetch_calls) == 1
+
+    # "retag" the file with new artwork: the cache still serves the old art...
+    _create_mp3_with_cover(track_path, blue_cover)
+    assert await get_image_data(mass_minimal, track_path, "builtin") == original_art
+    assert len(fetch_calls) == 1
+    # ...until it is invalidated, after which the new art is extracted
+    await invalidate_cached_image(mass_minimal, "builtin", track_path)
+    assert not os.path.exists(src_file)
+    new_art = await get_image_data(mass_minimal, track_path, "builtin")
+    assert len(fetch_calls) == 2
+    assert new_art != original_art
+
+
+async def test_create_collage_fetches_each_unique_image_once(
+    mass_minimal: MusicAssistant, tmp_path: Path, fetch_calls: list[tuple[str, str]]
+) -> None:
+    """A collage fetches each unique image once and skips unfetchable ones."""
+    paths = [
+        str((tmp_path / name).absolute())
+        for name in ("one.png", "two.png", "three.png", "missing.png")
+    ]
+    for path, color in zip(paths[:3], ((200, 30, 30), (30, 200, 30), (30, 30, 200)), strict=True):
+        Image.new("RGB", (300, 300), color).save(path, "PNG")
+    collage_images = [
+        MediaItemImage(
+            type=ImageType.THUMB, path=path, provider="builtin", remotely_accessible=False
+        )
+        for path in paths
+    ]
+    collage = await images.create_collage(mass_minimal, collage_images, dimensions=(500, 500))
+    assert collage.startswith(b"\xff\xd8")  # JPEG magic
+    # each unique image was fetched exactly once (incl. the one failed attempt)
+    assert sorted(path for _prov, path in fetch_calls) == sorted(paths)

--- a/tests/helpers/test_images.py
+++ b/tests/helpers/test_images.py
@@ -152,17 +152,23 @@ async def test_provider_bytes_use_disk_cache_across_restart(
     assert len(fetch_calls) == 1
 
 
-async def test_local_file_read_skips_disk_cache(
+async def test_local_file_read_cached_on_disk(
     mass_minimal: MusicAssistant, tmp_path: Path, fetch_calls: list[tuple[str, str]]
 ) -> None:
-    """A direct local file read is cached in memory only (no redundant disk copy)."""
+    """A local file read lands in both cache tiers and is served from disk after restart."""
     image_path = _make_png_file(tmp_path)
-    await get_image_data(mass_minimal, image_path, "builtin")
+    data = await get_image_data(mass_minimal, image_path, "builtin")
     assert len(fetch_calls) == 1
     cache_key = create_thumb_hash("builtin", image_path)
     assert cache_key in images._source_memory_cache.entries
     src_file = os.path.join(mass_minimal.cache_path, "thumbnails", f"{cache_key}_src")
-    assert not os.path.exists(src_file)
+    assert os.path.isfile(src_file)
+
+    # after a restart the disk entry serves the bytes without touching the origin
+    # (which may live on a network mount) - local entries have no TTL
+    images._source_memory_cache.clear()
+    assert await get_image_data(mass_minimal, image_path, "builtin") == data
+    assert len(fetch_calls) == 1
 
 
 async def test_remote_disk_entry_expires_after_ttl(
@@ -233,13 +239,14 @@ async def test_invalidate_cached_image_clears_all_tiers(
     thumb_dir = Path(mass_minimal.cache_path, "thumbnails")
     target_hash = create_thumb_hash("builtin", image_path)
     other_hash = create_thumb_hash("builtin", other_path)
-    assert len([f for f in thumb_dir.iterdir() if f.name.startswith(target_hash)]) == 2
+    # two thumb variants plus the source entry per image
+    assert len([f for f in thumb_dir.iterdir() if f.name.startswith(target_hash)]) == 3
 
     await invalidate_cached_image(mass_minimal, "builtin", image_path)
 
     # all artifacts of the target image are gone, the other image is untouched
     assert not [f for f in thumb_dir.iterdir() if f.name.startswith(target_hash)]
-    assert len([f for f in thumb_dir.iterdir() if f.name.startswith(other_hash)]) == 2
+    assert len([f for f in thumb_dir.iterdir() if f.name.startswith(other_hash)]) == 3
     assert target_hash not in images._source_memory_cache.entries
     assert not any(key.startswith(f"{target_hash}_") for key in images._thumb_memory_cache)
     assert any(key.startswith(f"{other_hash}_") for key in images._thumb_memory_cache)

--- a/tests/providers/filesystem/test_image_invalidation.py
+++ b/tests/providers/filesystem/test_image_invalidation.py
@@ -1,0 +1,49 @@
+"""Tests for image-cache invalidation when a local file changes during sync."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from music_assistant.providers.filesystem_local import LocalFileSystemProvider
+
+
+def _create_provider() -> tuple[LocalFileSystemProvider, AsyncMock]:
+    """Create a bare LocalFileSystemProvider plus the invalidation mock it calls."""
+    with patch.object(LocalFileSystemProvider, "__init__", lambda *_a, **_kw: None):
+        provider = LocalFileSystemProvider.__new__(LocalFileSystemProvider)
+    provider.logger = MagicMock()
+    invalidate_mock = AsyncMock()
+    provider.mass = MagicMock()
+    provider.mass.metadata.invalidate_image_cache = invalidate_mock
+    provider.media_content_type = "music"
+    provider.config = MagicMock(instance_id="filesystem_local--test")
+    return provider, invalidate_mock
+
+
+def _file_item(relative_path: str) -> MagicMock:
+    """Build a minimal FileSystemItem stand-in for _process_item_async."""
+    item = MagicMock()
+    item.relative_path = relative_path
+    item.absolute_path = f"/music/{relative_path}"
+    # unhandled extension: the sync branches are skipped, only the shared
+    # invalidation logic at the top of _process_item_async runs
+    item.ext = "unhandled"
+    return item
+
+
+async def test_changed_file_invalidates_both_image_path_forms() -> None:
+    """A file with a previous checksum (= changed) busts both image path forms."""
+    provider, invalidate_mock = _create_provider()
+    item = _file_item("Artist/Album/track.mp3")
+    await provider._process_item_async(item, prev_checksum="12345")
+    assert invalidate_mock.await_count == 2
+    invalidate_mock.assert_any_await("filesystem_local--test", "Artist/Album/track.mp3")
+    invalidate_mock.assert_any_await("filesystem_local--test", "Artist/Album/track.mp3?cs=12345")
+
+
+async def test_new_file_does_not_invalidate() -> None:
+    """A file seen for the first time (no previous checksum) busts nothing."""
+    provider, invalidate_mock = _create_provider()
+    item = _file_item("Artist/Album/new-track.mp3")
+    await provider._process_item_async(item, prev_checksum=None)
+    invalidate_mock.assert_not_awaited()

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -75,6 +75,7 @@ def create_mock_album(
     album.media_type = MediaType.ALBUM
     album.favorite = favorite
     album.provider_mappings = UniqueList(provider_mappings or [])
+    album.metadata = Mock(images=None)
     return album
 
 
@@ -1066,6 +1067,7 @@ async def test_update_item_in_library_skips_non_music_providers() -> None:
                     item_id="abc",
                 )
             ],
+            metadata=Mock(images=None),
         )
     )
 


### PR DESCRIPTION
# What does this implement/fix?

Displaying a single item could fetch the same original image several times in a row: every thumbnail size, the color palette and collage tiles each downloaded the original again (or re-ran ffmpeg to extract embedded art from a local file). And when the artwork inside a local file was replaced (retag), the old thumbnails kept being served forever because the cache never noticed the change.

Changes:

- The original image is now fetched only once and cached: in memory with a size budget, and on disk alongside the thumbnails. Simultaneous requests for the same image share a single fetch.
- New `invalidate_image_cache` on the metadata controller that removes every cached artifact of an image: all thumbnail variants, the cached original and the extracted color palette.
- The filesystem provider invalidates cached artwork when it detects a changed file during sync, so retagged artwork shows up right away. Updating or removing a library item also drops its cached artwork, so a manual edit doubles as an artwork refresh.
- Collage images now fetch their unique tiles concurrently and skip images that can't be fetched instead of failing.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
