### PR TITLE
Credit the original Music Quiz author in codeowners

### DIFF
--- a/music_assistant/providers/music_quiz/manifest.json
+++ b/music_assistant/providers/music_quiz/manifest.json
@@ -5,7 +5,8 @@
   "name": "Music Quiz",
   "description": "Host a multiplayer music quiz game where guests join with a QR code.",
   "codeowners": [
-    "@music-assistant"
+    "@music-assistant",
+    "@TimoPtr"
   ],
   "requirements": [],
   "documentation": "https://music-assistant.io/plugins/music-quiz",


### PR DESCRIPTION
# What does this implement/fix?

The Music Quiz plugin's codeowners was set to the Music Assistant team during the rework. This also credits Timo (@TimoPtr), the plugin's original author, as a codeowner alongside the team.

- Add `@TimoPtr` to the `music_quiz` manifest codeowners.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes. (N/A — manifest-only change, no tests affected)
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (N/A)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (N/A)
- [x] I have read and complied with the project's AI Policy for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository. (N/A)
