### PR TITLE
Remove HTTP diagnostics download endpoint

### DIFF
--- a/music_assistant/controllers/diagnostics/__init__.py
+++ b/music_assistant/controllers/diagnostics/__init__.py
@@ -1,12 +1,12 @@
 """
 Diagnostics controller: on-demand, privacy-safe troubleshooting reports.
 
-Serves a single downloadable report (JSON or markdown) combining the always-on
-exception/log capture (see helpers/diagnostics.py) with system info, an install
-census and pluggable sections contributed by core controllers, providers and
-external registrants. All report building happens on request only; every string
-that ends up in the report is sanitized so it can safely be attached to a public
-GitHub issue.
+Builds a single report combining the always-on exception/log capture (see
+helpers/diagnostics.py) with system info, an install census and pluggable
+sections contributed by core controllers, providers and external registrants.
+The report is returned on request via the `diagnostics/get` API command. All
+report building happens on request only; every string that ends up in the
+report is sanitized so it can safely be attached to a public GitHub issue.
 """
 
 from __future__ import annotations
@@ -22,9 +22,6 @@ import time
 from collections import Counter
 from typing import TYPE_CHECKING, Any
 
-from aiohttp import web
-
-from music_assistant.controllers.webserver.helpers.auth_middleware import require_admin
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.datetime import from_utc_timestamp, utc
 from music_assistant.helpers.diagnostics import (
@@ -126,33 +123,6 @@ class DiagnosticsController(CoreController):
         :param include_log_tail: Include the recent warning/error log excerpt.
         """
         return await self._build_report(include_log_tail=include_log_tail)
-
-    async def handle_http_download(self, request: web.Request) -> web.Response:
-        """
-        Serve the diagnostics report as a downloadable file (webserver route handler).
-
-        Supports query parameters `format` (json|md) and `include_log_tail` (true|false).
-
-        :param request: The incoming aiohttp request.
-        """
-        await require_admin(request)
-        include_log_tail = request.query.get("include_log_tail", "").lower() in ("1", "true")
-        report = await self._build_report(include_log_tail=include_log_tail)
-        filename = f"music-assistant-diagnostics-{utc().strftime('%Y-%m-%d-%H%M%S')}"
-        if request.query.get("format", "json").lower() in ("md", "markdown"):
-            body = self._render_markdown(report)
-            content_type = "text/markdown"
-            filename += ".md"
-        else:
-            body = json_dumps(report, indent=True)
-            content_type = "application/json"
-            filename += ".json"
-        return web.Response(
-            text=body,
-            content_type=content_type,
-            charset="utf-8",
-            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
-        )
 
     async def _build_report(self, include_log_tail: bool = False) -> dict[str, Any]:
         """Assemble the full report; every part is isolated so the report never fails."""
@@ -372,47 +342,6 @@ class DiagnosticsController(CoreController):
             "total_mb": usage.total // (1024 * 1024),
         }
         return disk_info, _get_memory_info()
-
-    def _render_markdown(self, report: dict[str, Any]) -> str:
-        """Render the report as markdown for direct pasting into (GitHub) issues."""
-        lines = [
-            "# Music Assistant diagnostics report",
-            "",
-            f"- Generated: {report.get('generated_at')}",
-            f"- Schema version: {report.get('schema_version')}",
-            "",
-            f"> {report.get('redaction_notice')}",
-            "",
-        ]
-        for key, title in (("system", "System"), ("install", "Install")):
-            if (data := report.get(key)) is None:
-                continue
-            lines += [f"## {title}", "", "```json", json_dumps(data, indent=True), "```", ""]
-        exceptions = report.get("exceptions") or []
-        lines += [f"## Exceptions ({len(exceptions)} unique)", ""]
-        for entry in exceptions:
-            lines += [
-                f"### {entry['type']} (seen {entry['count']}x)",
-                "",
-                f"- Logger: `{entry['logger']}` (level {entry['level']})",
-                f"- Origin: `{entry['origin']}`",
-                f"- First seen: {entry['first_seen']} — last seen: {entry['last_seen']}",
-                "",
-                "```",
-                str(entry["traceback"]).rstrip(),
-                "```",
-                "",
-            ]
-        if sections := report.get("sections"):
-            lines += ["## Sections", "", "```json", json_dumps(sections, indent=True), "```", ""]
-        if log_tail := report.get("log_tail"):
-            lines += ["## Log tail", "", "```"]
-            lines += [
-                f"{record['time']} {record['level']} {record['logger']}: {record['message']}"
-                for record in log_tail
-            ]
-            lines += ["```", ""]
-        return "\n".join(lines)
 
 
 def _format_timestamp(timestamp: float) -> str:

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -284,8 +284,6 @@ class WebserverController(CoreController):
         routes.append(("GET", "/preview", self.serve_preview_stream))
         # add jsonrpc api
         routes.append(("POST", "/api", self._handle_jsonrpc_api_command))
-        # add diagnostics report download (handler enforces authentication itself)
-        routes.append(("GET", "/diagnostics", self.mass.diagnostics.handle_http_download))
         # add api documentation
         routes.append(("GET", "/api-docs", self._handle_api_intro))
         routes.append(("GET", "/api-docs/", self._handle_api_intro))

--- a/tests/core/test_diagnostics.py
+++ b/tests/core/test_diagnostics.py
@@ -9,12 +9,8 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
-from aiohttp import web
-from aiohttp.test_utils import make_mocked_request
-from music_assistant_models.auth import User, UserRole
 
 from music_assistant.controllers.diagnostics import DiagnosticsController
-from music_assistant.controllers.webserver.helpers.auth_middleware import USER_CONTEXT_KEY
 from music_assistant.helpers.diagnostics import (
     LOG_RING_MAXLEN,
     MAX_EXCEPTION_FINGERPRINTS,
@@ -352,60 +348,6 @@ async def test_section_sanitization(mass: MusicAssistant) -> None:
         assert "Artist" not in leaky
     finally:
         unregister()
-
-
-async def test_http_download_requires_auth(mass: MusicAssistant) -> None:
-    """
-    Test that the diagnostics download route rejects unauthenticated requests.
-
-    :param mass: Full Music Assistant test instance.
-    """
-    request = make_mocked_request("GET", "/diagnostics", app={"mass": mass})
-    with pytest.raises(web.HTTPUnauthorized):
-        await mass.diagnostics.handle_http_download(request)
-
-
-async def test_http_download_requires_admin(mass: MusicAssistant) -> None:
-    """
-    Test that the diagnostics download route rejects non-admin users.
-
-    :param mass: Full Music Assistant test instance.
-    """
-    request = make_mocked_request("GET", "/diagnostics", app={"mass": mass})
-    request[USER_CONTEXT_KEY] = User(user_id="u1", username="regular", role=UserRole.USER)
-    with pytest.raises(web.HTTPForbidden):
-        await mass.diagnostics.handle_http_download(request)
-
-
-async def test_http_download_json_and_markdown(mass: MusicAssistant) -> None:
-    """
-    Test the authenticated download in both JSON and markdown format.
-
-    :param mass: Full Music Assistant test instance.
-    """
-    admin = User(user_id="u2", username="admin", role=UserRole.ADMIN)
-    request = make_mocked_request("GET", "/diagnostics", app={"mass": mass})
-    request[USER_CONTEXT_KEY] = admin
-    response = await mass.diagnostics.handle_http_download(request)
-    assert response.status == 200
-    assert response.content_type == "application/json"
-    assert (
-        'attachment; filename="music-assistant-diagnostics-'
-        in (response.headers["Content-Disposition"])
-    )
-    assert response.headers["Content-Disposition"].endswith('.json"')
-
-    request = make_mocked_request(
-        "GET", "/diagnostics?format=md&include_log_tail=true", app={"mass": mass}
-    )
-    request[USER_CONTEXT_KEY] = admin
-    response = await mass.diagnostics.handle_http_download(request)
-    assert response.status == 200
-    assert response.content_type == "text/markdown"
-    assert response.headers["Content-Disposition"].endswith('.md"')
-    assert response.text is not None
-    assert response.text.startswith("# Music Assistant diagnostics report")
-    assert "## Log tail" in response.text
 
 
 async def test_no_background_work(mass: MusicAssistant) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The diagnostics report is retrieved via the `diagnostics/get` WebSocket API command (which the frontend uses). The separate `GET /diagnostics` HTTP endpoint duplicated that and is unused, so this removes it.

Stable counterpart of #4709 (same change on `dev`).

- Remove the `GET /diagnostics` route and its `handle_http_download` handler
- Remove the markdown renderer that only existed for the HTTP download
- Drop the obsolete HTTP endpoint tests

**Related issue (if applicable):**

- Follow-up to the diagnostics backport #4699

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
