### PR TITLE
Fix Spotify authentication failing until server restart

### DIFF
--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -418,9 +418,11 @@ class ProviderConfigMixin:
             self.set(f"{CONF_PROVIDERS}/{provider_instance}/{key}", value, immediate=immediate)
             return
         self.set(f"{CONF_PROVIDERS}/{provider_instance}/values/{key}", value, immediate=immediate)
-        # also update the provider's in-place config copy (if loaded) so
-        # object-local value reads stay in sync with raw writes
-        if (provider := self.mass.get_provider(provider_instance)) and (
+        # also update the loaded provider's in-place config copy so object-local value
+        # reads stay in sync with raw writes; include unavailable instances, since values
+        # like a rotated auth token can be written while the provider is temporarily
+        # unavailable and its copy must not lag behind the stored value
+        if (provider := self.mass.get_provider(provider_instance, return_unavailable=True)) and (
             entry := provider.config.values.get(key)
         ):
             entry.value = value

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -186,7 +186,7 @@ class Provider:
 
     def unload_with_error(self, error: str) -> None:
         """Unload provider with error message."""
-        self.mass.call_later(1, self.mass.unload_provider, self.instance_id, error)
+        self.mass.call_later(1, self.mass.unload_provider_with_error, self.instance_id, error)
 
     def to_dict(self) -> dict[str, Any]:
         """Return Provider(instance) as serializable dict."""

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -828,22 +828,23 @@ class SpotifyProvider(MusicProvider):
 
         This uses MA's global client ID which has full API access but heavy rate limits.
         """
-        # return existing token if we have one in memory
+        # return the cached access token while it is still valid (refreshed before expiry)
         if (
             not force_refresh
             and self._auth_info_global
-            and (self._auth_info_global["expires_at"] > (time.time() - 600))
+            and (self._auth_info_global["expires_at"] > (time.time() + 600))
         ):
             return self._auth_info_global
-        # request new access token using the refresh token
-        if not (refresh_token := self.config.get_value(CONF_REFRESH_TOKEN_GLOBAL)):
+        # read the refresh token from the persisted store rather than the in-memory config copy,
+        # which can lag a rotation and would make us refresh with a stale (revoked) token
+        if not (refresh_token := self._stored_refresh_token(CONF_REFRESH_TOKEN_GLOBAL)):
             raise LoginFailed("Authentication required")
 
         try:
             auth_info = await get_spotify_token(
                 self.mass.http_session,
                 app_var("spotify_client_id"),  # Always use MA's global client ID
-                cast("str", refresh_token),
+                refresh_token,
                 "global",
             )
             self.logger.debug("Successfully refreshed global access token")
@@ -852,9 +853,7 @@ class SpotifyProvider(MusicProvider):
                 # Spotify rotates the refresh token on refresh and revokes the previous one.
                 # If the stored token was rotated while this refresh was in flight, the token
                 # we tried is merely stale, so keep the newer one instead of forcing re-auth.
-                if not self._refresh_token_superseded(
-                    CONF_REFRESH_TOKEN_GLOBAL, cast("str", refresh_token)
-                ):
+                if not self._refresh_token_superseded(CONF_REFRESH_TOKEN_GLOBAL, refresh_token):
                     self._update_config_value(CONF_REFRESH_TOKEN_GLOBAL, None)
                     if self.available:
                         self.unload_with_error(str(err))
@@ -899,15 +898,16 @@ class SpotifyProvider(MusicProvider):
 
         This uses the user's custom client ID which has less rate limits but limited API access.
         """
-        # return existing token if we have one in memory
+        # return the cached access token while it is still valid (refreshed before expiry)
         if (
             not force_refresh
             and self._auth_info_dev
-            and (self._auth_info_dev["expires_at"] > (time.time() - 600))
+            and (self._auth_info_dev["expires_at"] > (time.time() + 600))
         ):
             return self._auth_info_dev
-        # request new access token using the refresh token
-        refresh_token = self.config.get_value(CONF_REFRESH_TOKEN_DEV)
+        # read the refresh token from the persisted store rather than the in-memory config copy,
+        # which can lag a rotation and would make us refresh with a stale (revoked) token
+        refresh_token = self._stored_refresh_token(CONF_REFRESH_TOKEN_DEV)
         client_id = self.config.get_value(CONF_CLIENT_ID)
         if not refresh_token or not client_id:
             raise LoginFailed("Developer authentication not configured")
@@ -916,7 +916,7 @@ class SpotifyProvider(MusicProvider):
             auth_info = await get_spotify_token(
                 self.mass.http_session,
                 cast("str", client_id),
-                cast("str", refresh_token),
+                refresh_token,
                 "developer",
             )
             self.logger.debug("Successfully refreshed developer access token")
@@ -925,9 +925,7 @@ class SpotifyProvider(MusicProvider):
                 # Spotify rotates the refresh token on refresh and revokes the previous one.
                 # If the stored token was rotated while this refresh was in flight, the token
                 # we tried is merely stale, so keep the newer one instead of forcing re-auth.
-                if not self._refresh_token_superseded(
-                    CONF_REFRESH_TOKEN_DEV, cast("str", refresh_token)
-                ):
+                if not self._refresh_token_superseded(CONF_REFRESH_TOKEN_DEV, refresh_token):
                     self._update_config_value(CONF_REFRESH_TOKEN_DEV, None)
                     self._update_config_value(CONF_CLIENT_ID, None)
             # Don't unload - we can still use the global session
@@ -1510,6 +1508,17 @@ class SpotifyProvider(MusicProvider):
         except MediaNotFoundError, ProviderUnavailableError:
             return False
 
+    def _stored_refresh_token(self, key: str) -> str | None:
+        """
+        Return the currently persisted refresh token, or None if not set.
+
+        :param key: Config key of the refresh token to read.
+        """
+        raw_stored = self.mass.config.get_raw_provider_config_value(self.instance_id, key)
+        if not raw_stored:
+            return None
+        return self.mass.config.decrypt_string(cast("str", raw_stored))
+
     def _refresh_token_superseded(self, key: str, used_token: str) -> bool:
         """
         Return whether the stored refresh token differs from the one just used.
@@ -1517,8 +1526,7 @@ class SpotifyProvider(MusicProvider):
         :param key: Config key of the refresh token to check.
         :param used_token: The refresh token value that was just used to refresh.
         """
-        raw_stored = self.mass.config.get_raw_provider_config_value(self.instance_id, key)
-        if not raw_stored:
+        stored_token = self._stored_refresh_token(key)
+        if not stored_token:
             return False
-        stored_token = self.mass.config.decrypt_string(cast("str", raw_stored))
         return stored_token != used_token

--- a/tests/controllers/config/test_config_copy_lifecycle.py
+++ b/tests/controllers/config/test_config_copy_lifecycle.py
@@ -115,3 +115,34 @@ async def test_set_raw_provider_config_value_updates_provider_copy(
         PROVIDER_INSTANCE, "api_secret", "s3cret", encrypted=True
     )
     assert provider.config.get_value("api_secret") == "s3cret"
+
+
+async def test_set_raw_provider_config_value_syncs_unavailable_provider(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A raw write syncs the in-place copy even when the provider is currently unavailable."""
+    provider = MagicMock()
+    provider.config = cast(
+        "ProviderConfig",
+        ProviderConfig.parse(
+            [_entry("api_token", ConfigEntryType.STRING, None)],
+            {
+                "type": ProviderType.MUSIC,
+                "domain": "test",
+                "instance_id": PROVIDER_INSTANCE,
+            },
+        ),
+    )
+
+    # mimic get_provider: an unavailable instance is only returned with return_unavailable=True
+    def _get_provider(
+        _instance: str, return_unavailable: bool = False, **_kwargs: object
+    ) -> object | None:
+        return provider if return_unavailable else None
+
+    mass_minimal.get_provider = MagicMock(side_effect=_get_provider)  # type: ignore[method-assign]
+    mass_minimal.config.set(
+        f"{CONF_PROVIDERS}/{PROVIDER_INSTANCE}", {"instance_id": PROVIDER_INSTANCE}
+    )
+    mass_minimal.config.set_raw_provider_config_value(PROVIDER_INSTANCE, "api_token", "abc")
+    assert provider.config.get_value("api_token") == "abc"

--- a/tests/models/test_provider.py
+++ b/tests/models/test_provider.py
@@ -49,3 +49,13 @@ def test_signal_provider_event_with_sub_scope() -> None:
     cast("MagicMock", provider.mass).signal_event.assert_called_once_with(
         EventType.PROVIDER_EVENT, object_id="test_instance/game_state", data={"round": 1}
     )
+
+
+def test_unload_with_error_schedules_error_unload() -> None:
+    """unload_with_error schedules unload_provider_with_error so the error is recorded."""
+    provider = _make_base_provider()
+    provider.unload_with_error("boom")
+    mass = cast("MagicMock", provider.mass)
+    mass.call_later.assert_called_once_with(
+        1, mass.unload_provider_with_error, "test_instance", "boom"
+    )

--- a/tests/providers/spotify/test_auth.py
+++ b/tests/providers/spotify/test_auth.py
@@ -1,13 +1,17 @@
 """
 Tests for the Spotify provider's refresh-token handling.
 
-Spotify rotates the refresh token on every refresh and revokes the previous one. If a
-token was rotated while a refresh was in flight, the token we tried is merely stale, so
-the stored (newer) one must be kept instead of wiping the credentials and forcing re-auth.
+The global refresh token is always read from the persisted store, so an in-memory config
+copy that lagged a rotation can never make us refresh with a stale (revoked) token. Spotify
+rotates the refresh token on every refresh and revokes the previous one; if a newer token
+was persisted while a refresh was in flight, the stored (newer) one is kept instead of
+wiping the credentials and forcing re-auth.
 """
 
 from __future__ import annotations
 
+import time
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -22,12 +26,10 @@ USED_TOKEN = "token_a"
 def _make_provider(stored_token: str | None) -> SpotifyProvider:
     """Return a SpotifyProvider (bypassing __init__) with a mocked config store."""
     prov = object.__new__(SpotifyProvider)
+    # the in-memory config copy has no dev token configured; the global refresh token is
+    # read from the persisted store below, not from this object-local copy
     config = MagicMock(instance_id="spotify--test")
-    config.get_value = MagicMock(
-        side_effect=lambda key, default=None: (
-            USED_TOKEN if key == CONF_REFRESH_TOKEN_GLOBAL else default
-        )
-    )
+    config.get_value = MagicMock(return_value=None)
     prov.config = config
     prov.manifest = MagicMock(domain="spotify")
     prov.logger = MagicMock()
@@ -48,9 +50,43 @@ def test_refresh_token_superseded_no_stored_token() -> None:
     assert prov._refresh_token_superseded(CONF_REFRESH_TOKEN_GLOBAL, USED_TOKEN) is False
 
 
-async def test_login_keeps_rotated_token_on_revoked(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A revoked error is ignored when the stored token was rotated meanwhile."""
-    prov = _make_provider(stored_token="token_b")
+def test_stored_refresh_token_decrypts_stored_value() -> None:
+    """_stored_refresh_token returns the decrypted persisted token, or None when unset."""
+    prov = _make_provider(stored_token="token_x")
+    assert prov._stored_refresh_token(CONF_REFRESH_TOKEN_GLOBAL) == "token_x"
+    assert (
+        _make_provider(stored_token=None)._stored_refresh_token(CONF_REFRESH_TOKEN_GLOBAL) is None
+    )
+
+
+async def test_login_reads_token_from_persisted_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The refresh token is read from the persisted store, not a stale in-memory config copy."""
+    prov = _make_provider(stored_token="fresh_token")
+    prov._sp_user = {"display_name": "tester"}
+    token_call = AsyncMock(
+        return_value={
+            "access_token": "access",
+            "refresh_token": "fresh_token",
+            "expires_at": 9999999999,
+        }
+    )
+    monkeypatch.setattr(prov, "_update_config_value", MagicMock())
+    monkeypatch.setattr(prov, "_setup_librespot_auth", AsyncMock())
+    monkeypatch.setattr("music_assistant.providers.spotify.provider.get_spotify_token", token_call)
+    await prov.login()
+    # the token sent to Spotify must come from the persisted store
+    assert token_call.await_args is not None
+    assert token_call.await_args.args[2] == "fresh_token"
+
+
+async def test_login_keeps_token_when_rotated_in_flight(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A revoked error is ignored when a newer token was persisted during the refresh."""
+    prov = _make_provider(stored_token=USED_TOKEN)
+    # the initial read uses token_a; the superseded re-check sees a newer token_b that was
+    # persisted while the refresh was in flight
+    cast("MagicMock", prov.mass.config).get_raw_provider_config_value = MagicMock(
+        side_effect=[USED_TOKEN, "token_b"]
+    )
     update_config = MagicMock()
     unload = MagicMock()
     monkeypatch.setattr(prov, "_update_config_value", update_config)
@@ -63,6 +99,44 @@ async def test_login_keeps_rotated_token_on_revoked(monkeypatch: pytest.MonkeyPa
         await prov.login()
     update_config.assert_not_called()
     unload.assert_not_called()
+
+
+async def test_login_returns_cached_token_while_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cached access token that is still valid is returned without contacting Spotify."""
+    prov = _make_provider(stored_token=USED_TOKEN)
+    cached = {
+        "access_token": "cached",
+        "refresh_token": USED_TOKEN,
+        "expires_at": time.time() + 3600,
+    }
+    prov._auth_info_global = cached
+    token_call = AsyncMock()
+    monkeypatch.setattr("music_assistant.providers.spotify.provider.get_spotify_token", token_call)
+    assert await prov.login() is cached
+    token_call.assert_not_awaited()
+
+
+async def test_login_refreshes_when_cached_token_expired(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An expired cached access token triggers a refresh instead of being served."""
+    prov = _make_provider(stored_token=USED_TOKEN)
+    prov._sp_user = {"display_name": "tester"}
+    prov._auth_info_global = {
+        "access_token": "old",
+        "refresh_token": USED_TOKEN,
+        "expires_at": time.time() - 10,
+    }
+    token_call = AsyncMock(
+        return_value={
+            "access_token": "new",
+            "refresh_token": USED_TOKEN,
+            "expires_at": time.time() + 3600,
+        }
+    )
+    monkeypatch.setattr(prov, "_update_config_value", MagicMock())
+    monkeypatch.setattr(prov, "_setup_librespot_auth", AsyncMock())
+    monkeypatch.setattr("music_assistant.providers.spotify.provider.get_spotify_token", token_call)
+    await prov.login()
+    token_call.assert_awaited_once()
 
 
 async def test_login_wipes_token_on_genuine_revoke(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #4688.

Some users found Spotify would stop working after running for a while: the provider showed as needing authentication, and re-authenticating didn't stick until the server was restarted.

Spotify issues a new refresh token on every refresh and revokes the previous one. Login was reading the refresh token from an in-memory copy of the provider config, which could lag behind the freshly stored token and keep retrying with an old (already revoked) one — restarting "fixed" it because it reloaded the current token from disk.

### Changes

- Read the Spotify refresh token from the stored config so we always refresh with the current token
- Keep a provider's in-memory config copy in sync even while it is temporarily unavailable, so a token rotated during a failed refresh isn't lost until restart
- On a genuine revoke, drop the provider back to re-authentication (and record the error) instead of silently removing it
- Fix an inverted expiry check so a cached access token that's about to expire is actually refreshed

**Related issue (if applicable):**

- Follow-up to #4688

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.