### PR TITLE
Align ya-passport-auth on 1.7.0[ma] across Yandex providers

### DIFF
--- a/music_assistant/providers/yandex_music/manifest.json
+++ b/music_assistant/providers/yandex_music/manifest.json
@@ -7,6 +7,6 @@
   "codeowners": ["@TrudenBoy"],
   "credits": ["[yandex-music-api](https://github.com/MarshalX/yandex-music-api)"],
   "documentation": "https://music-assistant.io/music-providers/yandex-music/",
-  "requirements": ["yandex-music==3.0.0", "ya-passport-auth==1.4.1"],
+  "requirements": ["yandex-music==3.0.0", "ya-passport-auth[ma]==1.7.0"],
   "multi_instance": true
 }

--- a/music_assistant/providers/yandex_smarthome/manifest.json
+++ b/music_assistant/providers/yandex_smarthome/manifest.json
@@ -7,7 +7,7 @@
   "credits": [
     "[dext0r/yandex_smart_home](https://github.com/dext0r/yandex_smart_home)"
   ],
-  "requirements": ["ya-passport-auth==1.3.0"],
+  "requirements": ["ya-passport-auth[ma]==1.7.0"],
   "documentation": "https://github.com/trudenboy/ma-provider-yandex-smarthome",
   "stage": "beta",
   "multi_instance": false,

--- a/music_assistant/providers/yandex_ynison/manifest.json
+++ b/music_assistant/providers/yandex_ynison/manifest.json
@@ -5,7 +5,7 @@
   "name": "Yandex Music Connect (Ynison)",
   "description": "Makes a Music Assistant player appear as a device in the Yandex Music app via the Ynison protocol.",
   "codeowners": ["@TrudenBoy"],
-  "requirements": ["ya-passport-auth==1.4.1"],
+  "requirements": ["ya-passport-auth[ma]==1.7.0"],
   "depends_on": "yandex_music",
   "documentation": "https://music-assistant.io/plugins/yandex-ynison/",
   "multi_instance": true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -101,7 +101,7 @@ uv>=0.8.0
 websocket-client==1.9.0
 wiim==0.1.5
 xmltodict==1.0.4
-ya-passport-auth==1.4.1
+ya-passport-auth[ma]==1.7.0
 yandex-music==3.0.0
 yappi==1.7.6
 ytmusicapi==1.12.1

--- a/tests/providers/yandex_smarthome/test_basic.py
+++ b/tests/providers/yandex_smarthome/test_basic.py
@@ -39,7 +39,7 @@ def test_manifest_valid() -> None:
     assert data["multi_instance"] is False
     assert data["builtin"] is False
     assert isinstance(data["requirements"], list)
-    assert "ya-passport-auth==1.3.0" in data["requirements"]
+    assert "ya-passport-auth[ma]==1.7.0" in data["requirements"]
 
 
 def test_manifest_has_codeowners() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Aligns the `ya-passport-auth` pin on **`ya-passport-auth[ma]==1.7.0`** across all inlined Yandex providers that use it (`yandex_music`, `yandex_smarthome`, `yandex_ynison`) and regenerates `requirements_all.txt` accordingly.

**Why one shared pin.** MA installs each provider's requirements from its own `manifest.json` at load time, so two Yandex providers pinning different versions of the same library would downgrade/upgrade it back and forth in the shared environment. On the CI side, `scripts/gen_requirements_all.py` deduplicates first-pin-wins across manifests, so a version drift between the manifests silently ships a pin that contradicts one of the providers.

**Compatibility.** 1.3.0/1.4.1 → 1.7.0 is additive: 1.5.0+ introduced the optional `ma` integration layer (the `[ma]` extra, used by the upcoming provider updates below), 1.6.0/1.7.0 extended it; no existing APIs were changed or removed. The 1.4.x-era call sites in the current inlined providers work unchanged — CI on this PR verifies that.

**Related PRs** (this bump unblocks their dependency alignment independently of their review order):

- #4690 — Yandex Music v3.8.2 update; carries this same pin as part of the provider update.
- #3834 — Yandex Smart Home update; its branch rebuild is currently blocked exactly by this pin alignment.
- #3605 — Yandex Station (new provider); currently pins `[ma]==1.6.0` and will be refreshed to 1.7.0.
- #3843 — Yandex Alice (new provider); already pins `[ma]==1.7.0`, consistent with this PR.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [x] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
