### PR TITLE
Expose quiz type in game state

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -22,8 +22,8 @@ contract (all payloads are JSON objects)::
 
 The public game state is guest-safe by construction and contains:
 
-- always: ``phase`` (lobby/answering/reveal/finished), ``name``, ``mode``
-  (the configured playback mode: venue/remote), ``round_count``,
+- always: ``phase`` (lobby/answering/reveal/finished), ``name``, ``quiz_type``,
+  ``mode`` (the configured playback mode: venue/remote), ``round_count``,
   ``suggestion_count``, ``answer_duration`` and
   ``players``: a list of ``{name, score, ready, answered}`` entries
   (players are keyed by their unique display name; private player IDs
@@ -328,10 +328,11 @@ class MusicQuizPlugin(PluginProvider):
             self._cancel_next_round_task()
             self._game = MusicQuizGame(
                 config=game_config,
+                quiz_type=quiz_type,
                 sources=await self._resolve_sources(game_config.source_uris),
                 created_at=time.time(),
             )
-            self._quiz_type = QUIZ_TYPES[quiz_type](self.mass, game_config)
+            self._quiz_type = QUIZ_TYPES[self._game.quiz_type](self.mass, game_config)
             self._prefetch_round(0)
             self._signal_game_updated()
             return await self._host_state()
@@ -405,6 +406,7 @@ class MusicQuizPlugin(PluginProvider):
             return None
         return {
             "name": self._game.config.name,
+            "quiz_type": self._game.quiz_type,
             "phase": self._game.phase.value,
             "mode": self._mode,
             "player_count": len(self._game.players),
@@ -1001,6 +1003,7 @@ def _public_state(game: MusicQuizGame, mode: str) -> dict[str, Any]:
     return {
         "phase": game.phase.value,
         "name": game.config.name,
+        "quiz_type": game.quiz_type,
         "mode": mode,
         "round_count": game.config.round_count,
         "suggestion_count": game.config.suggestion_count,

--- a/music_assistant/providers/music_quiz/models.py
+++ b/music_assistant/providers/music_quiz/models.py
@@ -107,6 +107,7 @@ class MusicQuizGame(DataClassDictMixin):
     """A Music Quiz game."""
 
     config: MusicQuizConfig
+    quiz_type: str
     phase: MusicQuizPhase = MusicQuizPhase.LOBBY
     created_at: float = 0
     players: dict[str, MusicQuizPlayer] = field(default_factory=dict)

--- a/tests/providers/music_quiz/test_game.py
+++ b/tests/providers/music_quiz/test_game.py
@@ -45,6 +45,7 @@ def _game() -> MusicQuizGame:
     """Return a test game with one active round."""
     return MusicQuizGame(
         config=MusicQuizConfig(),
+        quiz_type="guess_the_song",
         phase=MusicQuizPhase.ANSWERING,
         current_round_index=0,
         rounds=[
@@ -241,7 +242,7 @@ def test_active_players_for_round_excludes_late_joiners_until_next_round() -> No
 
 
 def test_reset_game_keeps_players_and_config_for_new_game() -> None:
-    """Reset rounds, scores, readiness and late-join state for a fresh game."""
+    """Reset transient state while preserving game settings and identity."""
     game = _game()
     add_player(game, _player("p1", "Alice", active_from_round=0))
     add_player(game, _player("p2", "Bob", active_from_round=1))
@@ -253,6 +254,7 @@ def test_reset_game_keeps_players_and_config_for_new_game() -> None:
     reset_game(game)
 
     assert game.phase == MusicQuizPhase.LOBBY
+    assert game.quiz_type == "guess_the_song"
     assert game.current_round_index is None
     assert game.rounds == []
     assert {player.name for player in game.players.values()} == {"Alice", "Bob"}

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -281,6 +281,7 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
     assert payload["event"] == "game_updated"
     state = payload["state"]
     assert state["phase"] == "answering"
+    assert state["quiz_type"] == "guess_the_song"
     assert state["mode"] == "venue"
     current_round = state["current_round"]
     assert set(current_round) == {
@@ -308,8 +309,8 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
 
 
 @pytest.mark.asyncio
-async def test_game_info_exposes_playback_mode() -> None:
-    """The join-screen info includes the configured playback mode."""
+async def test_game_info_exposes_game_identity_and_playback_mode() -> None:
+    """The join-screen info includes the game identity and playback mode."""
     plugin = _create_plugin(mode="remote", player=None)
     assert await plugin.get_game_info() is None
     await plugin.create_game(source_uris=["library://playlist/1"], name="Test Quiz")
@@ -317,11 +318,59 @@ async def test_game_info_exposes_playback_mode() -> None:
     info = await plugin.get_game_info()
     assert info == {
         "name": "Test Quiz",
+        "quiz_type": "guess_the_song",
         "phase": "lobby",
         "mode": "remote",
         "player_count": 0,
         "round_count": 5,
     }
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_expose_persisted_quiz_type() -> None:
+    """Create and host state use the quiz type persisted on the game."""
+    plugin = _create_plugin()
+
+    created = await plugin.create_game(
+        quiz_type="guess_the_song",
+        source_uris=["library://playlist/1"],
+    )
+    game = plugin._game
+    assert game is not None
+    assert game.quiz_type == "guess_the_song"
+    assert created["quiz_type"] == game.quiz_type
+    assert (await plugin.get_game())["quiz_type"] == game.quiz_type
+
+
+@pytest.mark.asyncio
+async def test_join_and_player_state_expose_persisted_quiz_type() -> None:
+    """Join and personalized state include the persisted quiz type."""
+    plugin = _create_plugin()
+    await plugin.create_game(source_uris=["library://playlist/1"])
+
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        joined = await plugin.join_game("Alice")
+        assert joined["state"]["quiz_type"] == "guess_the_song"
+        state = await plugin.get_player_state(joined["player_id"])
+
+    assert state["quiz_type"] == "guess_the_song"
+
+
+@pytest.mark.asyncio
+async def test_reset_preserves_quiz_type_in_state_and_events() -> None:
+    """Reset preserves the selected quiz type in returned and broadcast state."""
+    plugin = _create_plugin()
+    await _create_started_game(plugin)
+
+    state = await plugin.reset()
+
+    assert state["phase"] == "lobby"
+    assert state["quiz_type"] == "guess_the_song"
+    payload = cast("MagicMock", plugin.signal_provider_event).call_args[0][0]
+    assert payload["state"]["quiz_type"] == "guess_the_song"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Music Quiz clients need the selected game type as stable game identity for future multi-game support.

- Persist the selected quiz type on the game model.
- Include it in host, public event, game info, join, personalized player, and reset state.
- Keep existing guess-the-song behavior and protected answer data unchanged.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.