### PR TITLE
Add reusable Music Quiz answer types

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -83,6 +83,7 @@ from music_assistant.providers.music_quiz.errors import (
     TRANSLATION_OWNER,
     MusicQuizGameActiveError,
     MusicQuizGameFullError,
+    MusicQuizInvalidAnswerError,
     MusicQuizNoGameError,
     MusicQuizNoPlaybackTargetError,
     MusicQuizUnknownPlayerError,
@@ -482,10 +483,12 @@ class MusicQuizPlugin(PluginProvider):
             game, _, answer_type = self._require_game_strategies()
             submission_type = submission.get("answer_type")
             if not isinstance(submission_type, str):
-                raise InvalidDataError("Answer submission requires an answer_type string")
+                raise MusicQuizInvalidAnswerError(
+                    "Answer submission requires an answer_type string"
+                )
             submitted_answer_type = get_answer_type(submission_type)
             if submitted_answer_type.answer_type != game.answer_type:
-                raise InvalidDataError("Submission answer type does not match the game")
+                raise MusicQuizInvalidAnswerError("Submission answer type does not match the game")
             parsed_submission = answer_type.parse_submission(submission)
             player = _get_player(game, player_id)
             return self._submit_player_answer(game, player, parsed_submission, answer_type)
@@ -501,7 +504,9 @@ class MusicQuizPlugin(PluginProvider):
         async with self._game_lock:
             game, _, answer_type = self._require_game_strategies()
             if game.answer_type != MusicQuizAnswerType.MULTIPLE_CHOICE:
-                raise InvalidDataError("The compatibility answer command requires multiple_choice")
+                raise MusicQuizInvalidAnswerError(
+                    "The compatibility answer command requires multiple_choice"
+                )
             player = _get_player(game, player_id)
             submission = MultipleChoiceSubmission(suggestion_id=suggestion_id)
             return self._submit_player_answer(game, player, submission, answer_type)

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -23,7 +23,7 @@ contract (all payloads are JSON objects)::
 The public game state is guest-safe by construction and contains:
 
 - always: ``phase`` (lobby/answering/reveal/finished), ``name``, ``quiz_type``,
-  ``mode`` (the configured playback mode: venue/remote), ``round_count``,
+  ``answer_type``, ``mode`` (the configured playback mode: venue/remote), ``round_count``,
   ``suggestion_count``, ``answer_duration`` and
   ``players``: a list of ``{name, score, ready, answered}`` entries
   (players are keyed by their unique display name; private player IDs
@@ -68,8 +68,17 @@ from music_assistant_models.media_items import Track
 
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers import guest_access
+from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.shared_playback import SharedPlaybackMode, SharedPlaybackSession
 from music_assistant.models.plugin import PluginProvider
+from music_assistant.providers.music_quiz.answer_types import get_answer_type
+from music_assistant.providers.music_quiz.answer_types.base import (
+    QuizAnswerSubmission,
+    QuizAnswerType,
+)
+from music_assistant.providers.music_quiz.answer_types.multiple_choice import (
+    MultipleChoiceSubmission,
+)
 from music_assistant.providers.music_quiz.errors import (
     TRANSLATION_OWNER,
     MusicQuizGameActiveError,
@@ -81,7 +90,7 @@ from music_assistant.providers.music_quiz.errors import (
 )
 from music_assistant.providers.music_quiz.game import (
     add_player,
-    all_active_players_answered,
+    all_active_players_complete,
     are_active_players_ready,
     finish_game,
     get_current_round,
@@ -89,9 +98,12 @@ from music_assistant.providers.music_quiz.game import (
     reset_game,
     reveal_round,
     start_round,
-    submit_answer,
+)
+from music_assistant.providers.music_quiz.game import (
+    submit_answer as submit_game_answer,
 )
 from music_assistant.providers.music_quiz.models import (
+    MusicQuizAnswerType,
     MusicQuizConfig,
     MusicQuizDifficulty,
     MusicQuizGame,
@@ -100,8 +112,8 @@ from music_assistant.providers.music_quiz.models import (
     MusicQuizRound,
     MusicQuizSource,
 )
+from music_assistant.providers.music_quiz.quiz_types import get_quiz_type
 from music_assistant.providers.music_quiz.quiz_types.base import QuizType
-from music_assistant.providers.music_quiz.quiz_types.guess_the_song import GuessTheSongQuizType
 
 if TYPE_CHECKING:
     from music_assistant_models.enums import ProviderFeature
@@ -121,10 +133,6 @@ CONF_USE_AI_DISTRACTORS = "use_ai_distractors"
 
 MUSIC_QUIZ_GUEST_USER = "music_quiz_guest"
 MUSIC_QUIZ_GUEST_DISPLAY_NAME = "Music Quiz Guest"
-
-QUIZ_TYPES: dict[str, type[QuizType]] = {
-    "guess_the_song": GuessTheSongQuizType,
-}
 
 # defence-in-depth caps: a leaked join URL or malformed host request must not
 # be able to flood a game with players or background work
@@ -214,6 +222,7 @@ class MusicQuizPlugin(PluginProvider):
         super().__init__(mass, manifest, config, supported_features)
         self._game: MusicQuizGame | None = None
         self._quiz_type: QuizType | None = None
+        self._answer_type: QuizAnswerType | None = None
         self._game_lock = asyncio.Lock()
         self._playback_session: SharedPlaybackSession | None = None
         self._playback_lock = asyncio.Lock()
@@ -241,6 +250,7 @@ class MusicQuizPlugin(PluginProvider):
             ("music_quiz/info", self.get_game_info),
             ("music_quiz/join", self.join_game),
             ("music_quiz/state", self.get_player_state),
+            ("music_quiz/submit_answer", self.submit_answer),
             ("music_quiz/answer", self.answer),
             ("music_quiz/ready", self.ready),
         )
@@ -274,6 +284,7 @@ class MusicQuizPlugin(PluginProvider):
         # racing with unload cannot (re)create or join a session mid-teardown
         self._game = None
         self._quiz_type = None
+        self._answer_type = None
         await self._close_playback_session()
         if is_removed:
             await guest_access.revoke_guest_access(self.mass, MUSIC_QUIZ_GUEST_USER)
@@ -302,12 +313,8 @@ class MusicQuizPlugin(PluginProvider):
         :param name: Optional game name.
         :param difficulty: Guess-the-song difficulty ("easy", "normal" or "hard").
         """
-        if quiz_type not in QUIZ_TYPES:
-            raise InvalidDataError(
-                f"Unknown quiz type: {quiz_type}",
-                translation_key="music_quiz_unknown_quiz_type",
-                translation_owner=TRANSLATION_OWNER,
-            )
+        quiz_type_class = get_quiz_type(quiz_type)
+        get_answer_type(quiz_type_class.answer_type)
         game_config = MusicQuizConfig(
             round_count=round_count,
             suggestion_count=suggestion_count,
@@ -329,10 +336,11 @@ class MusicQuizPlugin(PluginProvider):
             self._game = MusicQuizGame(
                 config=game_config,
                 quiz_type=quiz_type,
+                answer_type=quiz_type_class.answer_type,
                 sources=await self._resolve_sources(game_config.source_uris),
                 created_at=time.time(),
             )
-            self._quiz_type = QUIZ_TYPES[self._game.quiz_type](self.mass, game_config)
+            self._quiz_type, self._answer_type = self._resolve_game_strategies(self._game)
             self._prefetch_round(0)
             self._signal_game_updated()
             return await self._host_state()
@@ -392,6 +400,7 @@ class MusicQuizPlugin(PluginProvider):
             # racing with delete cannot (re)create or join a session mid-teardown
             self._game = None
             self._quiz_type = None
+            self._answer_type = None
             await self._stop_playback()
             # tear down the shared session so its virtual player / listen-in
             # guests do not linger once the game is gone
@@ -407,6 +416,7 @@ class MusicQuizPlugin(PluginProvider):
         return {
             "name": self._game.config.name,
             "quiz_type": self._game.quiz_type,
+            "answer_type": self._game.answer_type.value,
             "phase": self._game.phase.value,
             "mode": self._mode,
             "player_count": len(self._game.players),
@@ -423,7 +433,7 @@ class MusicQuizPlugin(PluginProvider):
         """
         self._validate_guest_access()
         async with self._game_lock:
-            game = self._require_game()
+            game, _, answer_type = self._require_game_strategies()
             player_name = name.strip()[:MAX_PLAYER_NAME_LENGTH]
             if not player_name:
                 raise InvalidDataError(
@@ -443,7 +453,7 @@ class MusicQuizPlugin(PluginProvider):
             self._signal_game_updated()
             return {
                 "player_id": player.player_id,
-                "state": _player_state(game, player, self._mode),
+                "state": _player_state(game, player, self._mode, answer_type),
             }
 
     async def get_player_state(self, player_id: str) -> dict[str, Any]:
@@ -453,8 +463,32 @@ class MusicQuizPlugin(PluginProvider):
         :param player_id: The player's private player_id.
         """
         self._validate_guest_access()
-        game = self._require_game()
-        return _player_state(game, _get_player(game, player_id), self._mode)
+        game, _, answer_type = self._require_game_strategies()
+        return _player_state(game, _get_player(game, player_id), self._mode, answer_type)
+
+    async def submit_answer(
+        self,
+        player_id: str,
+        submission: dict[str, object],
+    ) -> dict[str, SerializableType]:
+        """
+        Submit a typed answer for the current round.
+
+        :param player_id: The player's private player_id.
+        :param submission: Discriminated answer submission.
+        """
+        self._validate_guest_access()
+        async with self._game_lock:
+            game, _, answer_type = self._require_game_strategies()
+            submission_type = submission.get("answer_type")
+            if not isinstance(submission_type, str):
+                raise InvalidDataError("Answer submission requires an answer_type string")
+            submitted_answer_type = get_answer_type(submission_type)
+            if submitted_answer_type.answer_type != game.answer_type:
+                raise InvalidDataError("Submission answer type does not match the game")
+            parsed_submission = answer_type.parse_submission(submission)
+            player = _get_player(game, player_id)
+            return self._submit_player_answer(game, player, parsed_submission, answer_type)
 
     async def answer(self, player_id: str, suggestion_id: str) -> dict[str, Any]:
         """
@@ -465,15 +499,12 @@ class MusicQuizPlugin(PluginProvider):
         """
         self._validate_guest_access()
         async with self._game_lock:
-            game = self._require_game()
+            game, _, answer_type = self._require_game_strategies()
+            if game.answer_type != MusicQuizAnswerType.MULTIPLE_CHOICE:
+                raise InvalidDataError("The compatibility answer command requires multiple_choice")
             player = _get_player(game, player_id)
-            submit_answer(game, player.player_id, suggestion_id, time.time())
-            # end the round early when every active player has locked an answer
-            if all_active_players_answered(game):
-                self._do_reveal()
-            else:
-                self._signal_game_updated()
-            return _player_state(game, player, self._mode)
+            submission = MultipleChoiceSubmission(suggestion_id=suggestion_id)
+            return self._submit_player_answer(game, player, submission, answer_type)
 
     async def ready(self, player_id: str) -> dict[str, Any]:
         """
@@ -483,19 +514,19 @@ class MusicQuizPlugin(PluginProvider):
         """
         self._validate_guest_access()
         async with self._game_lock:
-            game = self._require_game()
+            game, _, answer_type = self._require_game_strategies()
             player = _get_player(game, player_id)
             # a repeat ready is a no-op: it cannot newly satisfy the all-ready
             # check, so return current state without re-broadcasting
             if game.phase != MusicQuizPhase.REVEAL or player.ready:
-                return _player_state(game, player, self._mode)
+                return _player_state(game, player, self._mode, answer_type)
             mark_player_ready(game, player.player_id)
             # advance early when every player is ready for the next round
             if are_active_players_ready(game):
                 await self._advance_from_reveal()
             else:
                 self._signal_game_updated()
-            return _player_state(game, player, self._mode)
+            return _player_state(game, player, self._mode, answer_type)
 
     async def listen_in(self, web_player_id: str) -> None:
         """
@@ -543,6 +574,35 @@ class MusicQuizPlugin(PluginProvider):
             raise MusicQuizNoGameError("There is no active Music Quiz game")
         return self._game
 
+    def _resolve_game_strategies(self, game: MusicQuizGame) -> tuple[QuizType, QuizAnswerType]:
+        """
+        Resolve the strategies declared by game state.
+
+        :param game: Game whose strategy identities should be resolved.
+        """
+        quiz_type_class = get_quiz_type(game.quiz_type)
+        answer_type_class = get_answer_type(game.answer_type)
+        if quiz_type_class.answer_type != game.answer_type:
+            raise InvalidDataError("Quiz type answer type does not match the game")
+        return quiz_type_class(self.mass, game.config), answer_type_class()
+
+    def _require_game_strategies(
+        self,
+    ) -> tuple[MusicQuizGame, QuizType, QuizAnswerType]:
+        """Return the game and matching cached strategies."""
+        game = self._require_game()
+        if self._quiz_type is None or self._answer_type is None:
+            raise InvalidDataError("Music Quiz game strategies are unavailable")
+        quiz_type_class = get_quiz_type(game.quiz_type)
+        answer_type_class = get_answer_type(game.answer_type)
+        if (
+            quiz_type_class.answer_type != game.answer_type
+            or type(self._quiz_type) is not quiz_type_class
+            or type(self._answer_type) is not answer_type_class
+        ):
+            raise InvalidDataError("Music Quiz game strategy identity mismatch")
+        return game, self._quiz_type, self._answer_type
+
     @property
     def _mode(self) -> str:
         """Return the configured playback mode (venue/remote)."""
@@ -563,11 +623,33 @@ class MusicQuizPlugin(PluginProvider):
                 translation_owner=TRANSLATION_OWNER,
             )
 
+    def _submit_player_answer(
+        self,
+        game: MusicQuizGame,
+        player: MusicQuizPlayer,
+        submission: QuizAnswerSubmission,
+        answer_type: QuizAnswerType,
+    ) -> dict[str, SerializableType]:
+        """
+        Apply a typed submission and return personalized state.
+
+        :param game: Game receiving the submission.
+        :param player: Player submitting the answer.
+        :param submission: Validated answer submission.
+        :param answer_type: Answer strategy for the game.
+        """
+        submit_game_answer(game, player.player_id, submission, time.time(), answer_type)
+        if all_active_players_complete(game, answer_type):
+            self._do_reveal()
+        else:
+            self._signal_game_updated()
+        return _player_state(game, player, self._mode, answer_type)
+
     async def _host_state(self) -> dict[str, Any]:
         """Return the host-visible state of the current game."""
-        game = self._require_game()
+        game, _, answer_type = self._require_game_strategies()
         return {
-            **_public_state(game, self._mode),
+            **_public_state(game, self._mode, answer_type),
             "created_at": game.created_at,
             "sources": [source.to_dict() for source in game.sources],
             "join_url": await self._get_join_url(),
@@ -588,8 +670,9 @@ class MusicQuizPlugin(PluginProvider):
         """Broadcast the public game state to all connected clients."""
         if self._game is None:
             return
+        game, _, answer_type = self._require_game_strategies()
         self.signal_provider_event(
-            {"event": "game_updated", "state": _public_state(self._game, self._mode)}
+            {"event": "game_updated", "state": _public_state(game, self._mode, answer_type)}
         )
 
     async def _resolve_sources(self, source_uris: list[str]) -> list[MusicQuizSource]:
@@ -617,12 +700,12 @@ class MusicQuizPlugin(PluginProvider):
 
     async def _start_next_round(self) -> None:
         """Prepare the next round, start its playback (if any) and open the answering phase."""
-        game = self._require_game()
+        game, _, answer_type = self._require_game_strategies()
         round_index = len(game.rounds)
         next_round = await self._get_prepared_round(round_index)
         if next_round.track_uri:
             await self._play_track(next_round.track_uri)
-        start_round(game, next_round, time.time())
+        start_round(game, next_round, time.time(), answer_type)
         answer_window = _answer_window(game, next_round)
         self.mass.call_later(
             answer_window,
@@ -637,8 +720,8 @@ class MusicQuizPlugin(PluginProvider):
 
     def _do_reveal(self) -> None:
         """Reveal the current round, apply scoring and schedule the auto-advance."""
-        game = self._require_game()
-        reveal_round(game)
+        game, _, answer_type = self._require_game_strategies()
+        reveal_round(game, answer_type)
         self.mass.cancel_timer(self._reveal_timer_id)
         current_round = get_current_round(game)
         # let the revealed track play out before auto-advancing; without a
@@ -695,18 +778,16 @@ class MusicQuizPlugin(PluginProvider):
     def _prefetch_round(self, round_index: int) -> None:
         """Prepare an upcoming round in the background."""
         self._cancel_next_round_task()
-        game, quiz_type = self._game, self._quiz_type
-        if game is None or quiz_type is None or round_index >= game.config.round_count:
+        if self._game is None or round_index >= self._game.config.round_count:
             return
+        game, quiz_type, _ = self._require_game_strategies()
         self._next_round_task = self.mass.create_task(
             quiz_type.prepare_round(round_index, list(game.rounds))
         )
 
     async def _get_prepared_round(self, round_index: int) -> MusicQuizRound:
         """Return the (prefetched) round with the given index."""
-        game = self._require_game()
-        quiz_type = self._quiz_type
-        assert quiz_type is not None  # set together with self._game
+        game, quiz_type, _ = self._require_game_strategies()
         task = self._next_round_task
         self._next_round_task = None
         if task is not None:
@@ -979,7 +1060,7 @@ def _answer_window(game: MusicQuizGame, game_round: MusicQuizRound) -> float:
     return answer_window
 
 
-def _public_state(game: MusicQuizGame, mode: str) -> dict[str, Any]:
+def _public_state(game: MusicQuizGame, mode: str, answer_type: QuizAnswerType) -> dict[str, Any]:
     """Return the guest-safe public game state (see the module docstring)."""
     current_round = (
         game.rounds[game.current_round_index] if game.current_round_index is not None else None
@@ -991,30 +1072,38 @@ def _public_state(game: MusicQuizGame, mode: str) -> dict[str, Any]:
             "name": player.name,
             "score": player.score,
             "ready": player.ready,
-            "answered": bool(current_round and player.player_id in current_round.answers),
+            **answer_type.serialize_public_player(
+                current_round,
+                player.player_id,
+                revealed=revealed,
+            ),
         }
-        if revealed and current_round and (answer := current_round.answers.get(player.player_id)):
-            entry["last_answer"] = {
-                "suggestion_id": answer.suggestion_id,
-                "correct": answer.is_correct,
-                "points": answer.points,
-            }
         players.append(entry)
     return {
         "phase": game.phase.value,
         "name": game.config.name,
         "quiz_type": game.quiz_type,
+        "answer_type": game.answer_type.value,
         "mode": mode,
         "round_count": game.config.round_count,
         "suggestion_count": game.config.suggestion_count,
         "answer_duration": game.config.answer_duration,
         "players": players,
-        "current_round": _public_round(game, current_round, revealed=revealed),
+        "current_round": _public_round(
+            game,
+            current_round,
+            answer_type,
+            revealed=revealed,
+        ),
     }
 
 
 def _public_round(
-    game: MusicQuizGame, game_round: MusicQuizRound | None, *, revealed: bool
+    game: MusicQuizGame,
+    game_round: MusicQuizRound | None,
+    answer_type: QuizAnswerType,
+    *,
+    revealed: bool,
 ) -> dict[str, Any] | None:
     """Return the guest-safe view of a round, redacted while unrevealed."""
     if game_round is None:
@@ -1024,21 +1113,9 @@ def _public_round(
         "started_at": game_round.started_at,
         "deadline": (game_round.started_at or 0) + _answer_window(game, game_round),
         "question": game_round.question,
-        # suggestion IDs are opaque: label + id never identify the answer
-        "suggestions": [
-            {"suggestion_id": suggestion.suggestion_id, "label": suggestion.label}
-            for suggestion in game_round.suggestions
-        ],
+        **answer_type.serialize_round(game_round, revealed=revealed),
     }
     if revealed:
-        state["correct_suggestion_id"] = next(
-            (
-                suggestion.suggestion_id
-                for suggestion in game_round.suggestions
-                if suggestion.is_correct
-            ),
-            None,
-        )
         state["answer_label"] = game_round.answer_label
         state["track_uri"] = game_round.track_uri
         state["image_url"] = game_round.image_url
@@ -1047,7 +1124,12 @@ def _public_round(
     return state
 
 
-def _player_state(game: MusicQuizGame, player: MusicQuizPlayer, mode: str) -> dict[str, Any]:
+def _player_state(
+    game: MusicQuizGame,
+    player: MusicQuizPlayer,
+    mode: str,
+    answer_type: QuizAnswerType,
+) -> dict[str, Any]:
     """Return the personalized (still guest-safe) game state for a player."""
     current_round = (
         game.rounds[game.current_round_index] if game.current_round_index is not None else None
@@ -1058,13 +1140,10 @@ def _player_state(game: MusicQuizGame, player: MusicQuizPlayer, mode: str) -> di
         "score": player.score,
         "ready": player.ready,
         "active_from_round": player.active_from_round,
+        **answer_type.serialize_personal_player(
+            current_round,
+            player.player_id,
+            revealed=revealed,
+        ),
     }
-    if current_round and (answer := current_round.answers.get(player.player_id)):
-        # players see their own locked pick right away, but whether it was
-        # right only after the reveal
-        you["answer"] = {
-            "suggestion_id": answer.suggestion_id,
-            "answered_at": answer.answered_at,
-            **({"correct": answer.is_correct, "points": answer.points} if revealed else {}),
-        }
-    return {**_public_state(game, mode), "you": you}
+    return {**_public_state(game, mode, answer_type), "you": you}

--- a/music_assistant/providers/music_quiz/answer_types/__init__.py
+++ b/music_assistant/providers/music_quiz/answer_types/__init__.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from music_assistant_models.errors import InvalidDataError
-
 from music_assistant.providers.music_quiz.answer_types.base import QuizAnswerType
 from music_assistant.providers.music_quiz.answer_types.multiple_choice import (
     MultipleChoiceAnswerType,
 )
+from music_assistant.providers.music_quiz.errors import MusicQuizInvalidAnswerError
 from music_assistant.providers.music_quiz.models import MusicQuizAnswerType
 
 ANSWER_TYPES: dict[MusicQuizAnswerType, type[QuizAnswerType]] = {
@@ -25,4 +24,4 @@ def get_answer_type(answer_type: MusicQuizAnswerType | str) -> type[QuizAnswerTy
         answer_type_id = MusicQuizAnswerType(answer_type)
         return ANSWER_TYPES[answer_type_id]
     except (KeyError, ValueError) as err:
-        raise InvalidDataError(f"Unknown answer type: {answer_type}") from err
+        raise MusicQuizInvalidAnswerError(f"Unknown answer type: {answer_type}") from err

--- a/music_assistant/providers/music_quiz/answer_types/__init__.py
+++ b/music_assistant/providers/music_quiz/answer_types/__init__.py
@@ -1,0 +1,28 @@
+"""Answer types for the Music Quiz provider."""
+
+from __future__ import annotations
+
+from music_assistant_models.errors import InvalidDataError
+
+from music_assistant.providers.music_quiz.answer_types.base import QuizAnswerType
+from music_assistant.providers.music_quiz.answer_types.multiple_choice import (
+    MultipleChoiceAnswerType,
+)
+from music_assistant.providers.music_quiz.models import MusicQuizAnswerType
+
+ANSWER_TYPES: dict[MusicQuizAnswerType, type[QuizAnswerType]] = {
+    MusicQuizAnswerType.MULTIPLE_CHOICE: MultipleChoiceAnswerType,
+}
+
+
+def get_answer_type(answer_type: MusicQuizAnswerType | str) -> type[QuizAnswerType]:
+    """
+    Return the registered answer strategy class.
+
+    :param answer_type: Answer type identity to resolve.
+    """
+    try:
+        answer_type_id = MusicQuizAnswerType(answer_type)
+        return ANSWER_TYPES[answer_type_id]
+    except (KeyError, ValueError) as err:
+        raise InvalidDataError(f"Unknown answer type: {answer_type}") from err

--- a/music_assistant/providers/music_quiz/answer_types/base.py
+++ b/music_assistant/providers/music_quiz/answer_types/base.py
@@ -1,0 +1,140 @@
+"""Base contract for Music Quiz answer types."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Collection
+from dataclasses import dataclass
+from typing import ClassVar
+
+from music_assistant.helpers.json import SerializableType
+from music_assistant.providers.music_quiz.models import (
+    MusicQuizAnswerType,
+    MusicQuizGame,
+    MusicQuizPlayer,
+    MusicQuizRound,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class QuizAnswerSubmission(ABC):
+    """A validated Music Quiz answer submission."""
+
+    answer_type: ClassVar[MusicQuizAnswerType]
+
+
+class QuizAnswerType(ABC):
+    """Strategy for a reusable Music Quiz answer type."""
+
+    answer_type: ClassVar[MusicQuizAnswerType]
+
+    @abstractmethod
+    def parse_submission(self, payload: dict[str, object]) -> QuizAnswerSubmission:
+        """
+        Parse an answer submission received from the API.
+
+        :param payload: Raw JSON object submitted by a player.
+        :return: A strictly validated answer submission.
+        """
+
+    @abstractmethod
+    def validate_round(self, game: MusicQuizGame, game_round: MusicQuizRound) -> None:
+        """
+        Validate answer-specific round requirements.
+
+        :param game: Game the round belongs to.
+        :param game_round: Prepared round to validate.
+        """
+
+    @abstractmethod
+    def submit(
+        self,
+        game: MusicQuizGame,
+        game_round: MusicQuizRound,
+        player: MusicQuizPlayer,
+        submission: QuizAnswerSubmission,
+        submitted_at: float,
+    ) -> None:
+        """
+        Apply one validated player submission.
+
+        :param game: Game receiving the submission.
+        :param game_round: Current answering round.
+        :param player: Player submitting the answer.
+        :param submission: Validated answer submission.
+        :param submitted_at: Server timestamp of the submission.
+        """
+
+    @abstractmethod
+    def is_player_complete(self, game_round: MusicQuizRound, player_id: str) -> bool:
+        """
+        Return whether a player completed the answer requirements.
+
+        :param game_round: Round to inspect.
+        :param player_id: Player to inspect.
+        """
+
+    @abstractmethod
+    def is_round_complete(
+        self,
+        game_round: MusicQuizRound,
+        active_players: Collection[MusicQuizPlayer],
+    ) -> bool:
+        """
+        Return whether every active player completed the round.
+
+        :param game_round: Round to inspect.
+        :param active_players: Players eligible for the round.
+        """
+
+    @abstractmethod
+    def reveal(self, game: MusicQuizGame, game_round: MusicQuizRound) -> None:
+        """
+        Finalize answer state and apply scoring.
+
+        :param game: Game being revealed.
+        :param game_round: Round being revealed.
+        """
+
+    @abstractmethod
+    def serialize_round(
+        self, game_round: MusicQuizRound, *, revealed: bool
+    ) -> dict[str, SerializableType]:
+        """
+        Serialize answer-specific round state.
+
+        :param game_round: Round to serialize.
+        :param revealed: Whether protected answer data may be exposed.
+        """
+
+    @abstractmethod
+    def serialize_public_player(
+        self,
+        game_round: MusicQuizRound | None,
+        player_id: str,
+        *,
+        revealed: bool,
+    ) -> dict[str, SerializableType]:
+        """
+        Serialize answer progress safe for every guest.
+
+        :param game_round: Current round, if one exists.
+        :param player_id: Player represented by the public entry.
+        :param revealed: Whether protected answer data may be exposed.
+        """
+
+    @abstractmethod
+    def serialize_personal_player(
+        self,
+        game_round: MusicQuizRound | None,
+        player_id: str,
+        *,
+        revealed: bool,
+    ) -> dict[str, SerializableType]:
+        """
+        Serialize answer state visible to its submitting player.
+
+        :param game_round: Current round, if one exists.
+        :param player_id: Player receiving the state.
+        :param revealed: Whether protected answer data may be exposed.
+        """

--- a/music_assistant/providers/music_quiz/answer_types/multiple_choice.py
+++ b/music_assistant/providers/music_quiz/answer_types/multiple_choice.py
@@ -15,6 +15,7 @@ from music_assistant.providers.music_quiz.answer_types.base import (
 )
 from music_assistant.providers.music_quiz.errors import (
     MusicQuizAlreadyAnsweredError,
+    MusicQuizInvalidAnswerError,
     MusicQuizUnknownSuggestionError,
 )
 from music_assistant.providers.music_quiz.models import (
@@ -49,15 +50,15 @@ class MultipleChoiceAnswerType(QuizAnswerType):
         """
         expected_keys = {"answer_type", "suggestion_id"}
         if payload.keys() != expected_keys:
-            raise InvalidDataError(
+            raise MusicQuizInvalidAnswerError(
                 "Multiple-choice submissions require answer_type and suggestion_id"
             )
         answer_type = payload["answer_type"]
         if not isinstance(answer_type, str) or answer_type != self.answer_type:
-            raise InvalidDataError("Answer type must be multiple_choice")
+            raise MusicQuizInvalidAnswerError("Answer type must be multiple_choice")
         suggestion_id = payload["suggestion_id"]
         if not isinstance(suggestion_id, str) or not suggestion_id:
-            raise InvalidDataError("Suggestion ID must be a non-empty string")
+            raise MusicQuizInvalidAnswerError("Suggestion ID must be a non-empty string")
         return MultipleChoiceSubmission(suggestion_id=suggestion_id)
 
     def validate_round(self, game: MusicQuizGame, game_round: MusicQuizRound) -> None:
@@ -90,7 +91,9 @@ class MultipleChoiceAnswerType(QuizAnswerType):
         :param submitted_at: Server timestamp of the submission.
         """
         if not isinstance(submission, MultipleChoiceSubmission):
-            raise InvalidDataError("Submission does not match the multiple-choice answer type")
+            raise MusicQuizInvalidAnswerError(
+                "Submission does not match the multiple-choice answer type"
+            )
         if player.player_id in game_round.answers:
             raise MusicQuizAlreadyAnsweredError("Player already answered this round")
         suggestion = next(

--- a/music_assistant/providers/music_quiz/answer_types/multiple_choice.py
+++ b/music_assistant/providers/music_quiz/answer_types/multiple_choice.py
@@ -1,0 +1,231 @@
+"""Multiple-choice answer strategy for Music Quiz."""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from dataclasses import dataclass
+from typing import ClassVar
+
+from music_assistant_models.errors import InvalidDataError
+
+from music_assistant.helpers.json import SerializableType
+from music_assistant.providers.music_quiz.answer_types.base import (
+    QuizAnswerSubmission,
+    QuizAnswerType,
+)
+from music_assistant.providers.music_quiz.errors import (
+    MusicQuizAlreadyAnsweredError,
+    MusicQuizUnknownSuggestionError,
+)
+from music_assistant.providers.music_quiz.models import (
+    MusicQuizAnswer,
+    MusicQuizAnswerType,
+    MusicQuizGame,
+    MusicQuizPlayer,
+    MusicQuizRound,
+)
+from music_assistant.providers.music_quiz.scoring import calculate_linear_scores
+
+
+@dataclass(frozen=True, slots=True)
+class MultipleChoiceSubmission(QuizAnswerSubmission):
+    """A validated multiple-choice selection."""
+
+    answer_type: ClassVar[MusicQuizAnswerType] = MusicQuizAnswerType.MULTIPLE_CHOICE
+    suggestion_id: str
+
+
+class MultipleChoiceAnswerType(QuizAnswerType):
+    """Multiple-choice answer strategy."""
+
+    answer_type = MusicQuizAnswerType.MULTIPLE_CHOICE
+
+    def parse_submission(self, payload: dict[str, object]) -> MultipleChoiceSubmission:
+        """
+        Parse a multiple-choice submission.
+
+        :param payload: Raw JSON object submitted by a player.
+        :return: A validated multiple-choice selection.
+        """
+        expected_keys = {"answer_type", "suggestion_id"}
+        if payload.keys() != expected_keys:
+            raise InvalidDataError(
+                "Multiple-choice submissions require answer_type and suggestion_id"
+            )
+        answer_type = payload["answer_type"]
+        if not isinstance(answer_type, str) or answer_type != self.answer_type:
+            raise InvalidDataError("Answer type must be multiple_choice")
+        suggestion_id = payload["suggestion_id"]
+        if not isinstance(suggestion_id, str) or not suggestion_id:
+            raise InvalidDataError("Suggestion ID must be a non-empty string")
+        return MultipleChoiceSubmission(suggestion_id=suggestion_id)
+
+    def validate_round(self, game: MusicQuizGame, game_round: MusicQuizRound) -> None:
+        """
+        Validate a multiple-choice round.
+
+        :param game: Game the round belongs to.
+        :param game_round: Prepared round to validate.
+        """
+        if sum(1 for suggestion in game_round.suggestions if suggestion.is_correct) != 1:
+            raise InvalidDataError("Round requires exactly one correct suggestion")
+        if len(game_round.suggestions) != game.config.suggestion_count:
+            raise InvalidDataError("Round suggestion count does not match the game config")
+
+    def submit(
+        self,
+        game: MusicQuizGame,
+        game_round: MusicQuizRound,
+        player: MusicQuizPlayer,
+        submission: QuizAnswerSubmission,
+        submitted_at: float,
+    ) -> None:
+        """
+        Lock a player's first multiple-choice selection.
+
+        :param game: Game receiving the submission.
+        :param game_round: Current answering round.
+        :param player: Player submitting the answer.
+        :param submission: Validated multiple-choice selection.
+        :param submitted_at: Server timestamp of the submission.
+        """
+        if not isinstance(submission, MultipleChoiceSubmission):
+            raise InvalidDataError("Submission does not match the multiple-choice answer type")
+        if player.player_id in game_round.answers:
+            raise MusicQuizAlreadyAnsweredError("Player already answered this round")
+        suggestion = next(
+            (
+                item
+                for item in game_round.suggestions
+                if item.suggestion_id == submission.suggestion_id
+            ),
+            None,
+        )
+        if suggestion is None:
+            raise MusicQuizUnknownSuggestionError("Unknown suggestion")
+        game_round.answers[player.player_id] = MusicQuizAnswer(
+            player_id=player.player_id,
+            suggestion_id=submission.suggestion_id,
+            answered_at=submitted_at,
+            is_correct=suggestion.is_correct,
+        )
+
+    def is_player_complete(self, game_round: MusicQuizRound, player_id: str) -> bool:
+        """
+        Return whether a player locked a selection.
+
+        :param game_round: Round to inspect.
+        :param player_id: Player to inspect.
+        """
+        return player_id in game_round.answers
+
+    def is_round_complete(
+        self,
+        game_round: MusicQuizRound,
+        active_players: Collection[MusicQuizPlayer],
+    ) -> bool:
+        """
+        Return whether every active player locked a selection.
+
+        :param game_round: Round to inspect.
+        :param active_players: Players eligible for the round.
+        """
+        return bool(active_players) and all(
+            self.is_player_complete(game_round, player.player_id) for player in active_players
+        )
+
+    def reveal(self, game: MusicQuizGame, game_round: MusicQuizRound) -> None:
+        """
+        Score correct selections by submission speed.
+
+        :param game: Game being revealed.
+        :param game_round: Round being revealed.
+        """
+        correct_answer_order = [
+            answer.player_id
+            for answer in sorted(game_round.answers.values(), key=lambda item: item.answered_at)
+            if answer.is_correct
+        ]
+        scores = calculate_linear_scores(correct_answer_order)
+        for answer in game_round.answers.values():
+            answer.points = scores.get(answer.player_id, 0)
+            game.players[answer.player_id].score += answer.points
+        game_round.ended_at = max(
+            [answer.answered_at for answer in game_round.answers.values()],
+            default=game_round.started_at or 0,
+        )
+
+    def serialize_round(
+        self, game_round: MusicQuizRound, *, revealed: bool
+    ) -> dict[str, SerializableType]:
+        """
+        Serialize multiple-choice round state.
+
+        :param game_round: Round to serialize.
+        :param revealed: Whether protected answer data may be exposed.
+        """
+        state: dict[str, SerializableType] = {
+            "suggestions": [
+                {"suggestion_id": suggestion.suggestion_id, "label": suggestion.label}
+                for suggestion in game_round.suggestions
+            ]
+        }
+        if revealed:
+            state["correct_suggestion_id"] = next(
+                (
+                    suggestion.suggestion_id
+                    for suggestion in game_round.suggestions
+                    if suggestion.is_correct
+                ),
+                None,
+            )
+        return state
+
+    def serialize_public_player(
+        self,
+        game_round: MusicQuizRound | None,
+        player_id: str,
+        *,
+        revealed: bool,
+    ) -> dict[str, SerializableType]:
+        """
+        Serialize a player's public multiple-choice progress.
+
+        :param game_round: Current round, if one exists.
+        :param player_id: Player represented by the public entry.
+        :param revealed: Whether protected answer data may be exposed.
+        """
+        answer = game_round.answers.get(player_id) if game_round else None
+        state: dict[str, SerializableType] = {"answered": answer is not None}
+        if revealed and answer:
+            state["last_answer"] = {
+                "suggestion_id": answer.suggestion_id,
+                "correct": answer.is_correct,
+                "points": answer.points,
+            }
+        return state
+
+    def serialize_personal_player(
+        self,
+        game_round: MusicQuizRound | None,
+        player_id: str,
+        *,
+        revealed: bool,
+    ) -> dict[str, SerializableType]:
+        """
+        Serialize a player's personal multiple-choice answer.
+
+        :param game_round: Current round, if one exists.
+        :param player_id: Player receiving the state.
+        :param revealed: Whether protected answer data may be exposed.
+        """
+        answer = game_round.answers.get(player_id) if game_round else None
+        if answer is None:
+            return {}
+        serialized_answer: dict[str, SerializableType] = {
+            "suggestion_id": answer.suggestion_id,
+            "answered_at": answer.answered_at,
+        }
+        if revealed:
+            serialized_answer.update(correct=answer.is_correct, points=answer.points)
+        return {"answer": serialized_answer}

--- a/music_assistant/providers/music_quiz/errors.py
+++ b/music_assistant/providers/music_quiz/errors.py
@@ -92,3 +92,11 @@ class MusicQuizUnknownSuggestionError(InvalidDataError):
     error_code = 1010
     translation_key = "music_quiz_unknown_suggestion"
     translation_owner = TRANSLATION_OWNER
+
+
+class MusicQuizInvalidAnswerError(InvalidDataError):
+    """Raised when an answer submission is malformed or mismatched."""
+
+    error_code = 1011
+    translation_key = "music_quiz_invalid_answer"
+    translation_owner = TRANSLATION_OWNER

--- a/music_assistant/providers/music_quiz/game.py
+++ b/music_assistant/providers/music_quiz/game.py
@@ -4,22 +4,22 @@ from __future__ import annotations
 
 from music_assistant_models.errors import InvalidDataError
 
+from music_assistant.providers.music_quiz.answer_types.base import (
+    QuizAnswerSubmission,
+    QuizAnswerType,
+)
 from music_assistant.providers.music_quiz.errors import (
-    MusicQuizAlreadyAnsweredError,
     MusicQuizNameTakenError,
     MusicQuizNotActiveThisRoundError,
     MusicQuizUnknownPlayerError,
-    MusicQuizUnknownSuggestionError,
     MusicQuizWrongPhaseError,
 )
 from music_assistant.providers.music_quiz.models import (
-    MusicQuizAnswer,
     MusicQuizGame,
     MusicQuizPhase,
     MusicQuizPlayer,
     MusicQuizRound,
 )
-from music_assistant.providers.music_quiz.scoring import calculate_linear_scores
 
 
 def add_player(
@@ -43,64 +43,41 @@ def add_player(
 def submit_answer(
     game: MusicQuizGame,
     player_id: str,
-    suggestion_id: str,
-    answered_at: float,
-) -> MusicQuizAnswer:
+    submission: QuizAnswerSubmission,
+    submitted_at: float,
+    answer_type: QuizAnswerType,
+) -> None:
     """
-    Submit and lock a player answer for the current round.
+    Submit a validated player answer for the current round.
 
     :param game: Game to mutate.
     :param player_id: Player submitting the answer.
-    :param suggestion_id: Selected suggestion ID.
-    :param answered_at: Answer timestamp.
+    :param submission: Validated answer submission.
+    :param submitted_at: Server timestamp of the submission.
+    :param answer_type: Answer strategy for the game.
     """
     if game.phase != MusicQuizPhase.ANSWERING:
         raise MusicQuizWrongPhaseError("Answers can only be submitted during the answering phase")
     current_round = get_current_round(game)
-    if player_id in current_round.answers:
-        raise MusicQuizAlreadyAnsweredError("Player already answered this round")
     if player_id not in game.players:
         raise MusicQuizUnknownPlayerError("Unknown player")
-    if game.players[player_id].active_from_round > current_round.round_index:
+    player = game.players[player_id]
+    if player.active_from_round > current_round.round_index:
         raise MusicQuizNotActiveThisRoundError("Player is not active for this round")
-    suggestion = next(
-        (item for item in current_round.suggestions if item.suggestion_id == suggestion_id),
-        None,
-    )
-    if suggestion is None:
-        raise MusicQuizUnknownSuggestionError("Unknown suggestion")
-    answer = MusicQuizAnswer(
-        player_id=player_id,
-        suggestion_id=suggestion_id,
-        answered_at=answered_at,
-        is_correct=suggestion.is_correct,
-    )
-    current_round.answers[player_id] = answer
-    return answer
+    answer_type.submit(game, current_round, player, submission, submitted_at)
 
 
-def reveal_round(game: MusicQuizGame) -> None:
+def reveal_round(game: MusicQuizGame, answer_type: QuizAnswerType) -> None:
     """
     Reveal the current round and apply scores.
 
     :param game: Game to mutate.
+    :param answer_type: Answer strategy for the game.
     """
     current_round = get_current_round(game)
     if game.phase != MusicQuizPhase.ANSWERING:
         raise MusicQuizWrongPhaseError("Round can only be revealed during the answering phase")
-    correct_answer_order = [
-        answer.player_id
-        for answer in sorted(current_round.answers.values(), key=lambda item: item.answered_at)
-        if answer.is_correct
-    ]
-    scores = calculate_linear_scores(correct_answer_order)
-    for answer in current_round.answers.values():
-        answer.points = scores.get(answer.player_id, 0)
-        game.players[answer.player_id].score += answer.points
-    current_round.ended_at = max(
-        [answer.answered_at for answer in current_round.answers.values()],
-        default=current_round.started_at or 0,
-    )
+    answer_type.reveal(game, current_round)
     game.phase = MusicQuizPhase.REVEAL
     for player in game.players.values():
         player.ready = False
@@ -110,6 +87,7 @@ def start_round(
     game: MusicQuizGame,
     music_quiz_round: MusicQuizRound,
     started_at: float,
+    answer_type: QuizAnswerType,
 ) -> None:
     """
     Start a new answering round.
@@ -117,6 +95,7 @@ def start_round(
     :param game: Game to mutate.
     :param music_quiz_round: Round to append and make current.
     :param started_at: Round start timestamp.
+    :param answer_type: Answer strategy for the game.
     """
     if game.phase not in (MusicQuizPhase.LOBBY, MusicQuizPhase.REVEAL):
         raise InvalidDataError("A round cannot be started from the current phase")
@@ -125,10 +104,7 @@ def start_round(
     expected_index = len(game.rounds)
     if music_quiz_round.round_index != expected_index:
         raise InvalidDataError("Round index does not match the game state")
-    if sum(1 for suggestion in music_quiz_round.suggestions if suggestion.is_correct) != 1:
-        raise InvalidDataError("Round requires exactly one correct suggestion")
-    if len(music_quiz_round.suggestions) != game.config.suggestion_count:
-        raise InvalidDataError("Round suggestion count does not match the game config")
+    answer_type.validate_round(game, music_quiz_round)
     music_quiz_round.started_at = started_at
     music_quiz_round.ended_at = None
     game.rounds.append(music_quiz_round)
@@ -167,17 +143,18 @@ def are_active_players_ready(game: MusicQuizGame) -> bool:
     return bool(players) and all(player.ready for player in players)
 
 
-def all_active_players_answered(game: MusicQuizGame) -> bool:
+def all_active_players_complete(game: MusicQuizGame, answer_type: QuizAnswerType) -> bool:
     """
-    Return whether every player of the current round has locked an answer.
+    Return whether every active player completed the current round.
 
     :param game: Game to inspect.
+    :param answer_type: Answer strategy for the game.
     """
     if game.phase != MusicQuizPhase.ANSWERING:
         return False
     current_round = get_current_round(game)
     players = active_players_for_round(game, current_round.round_index)
-    return bool(players) and all(player.player_id in current_round.answers for player in players)
+    return answer_type.is_round_complete(current_round, players)
 
 
 def finish_game(game: MusicQuizGame) -> None:

--- a/music_assistant/providers/music_quiz/models.py
+++ b/music_assistant/providers/music_quiz/models.py
@@ -17,6 +17,12 @@ class MusicQuizPhase(StrEnum):
     FINISHED = "finished"
 
 
+class MusicQuizAnswerType(StrEnum):
+    """Supported Music Quiz answer types."""
+
+    MULTIPLE_CHOICE = "multiple_choice"
+
+
 class MusicQuizDifficulty(StrEnum):
     """Difficulty levels for the guess-the-song quiz type."""
 
@@ -108,6 +114,7 @@ class MusicQuizGame(DataClassDictMixin):
 
     config: MusicQuizConfig
     quiz_type: str
+    answer_type: MusicQuizAnswerType
     phase: MusicQuizPhase = MusicQuizPhase.LOBBY
     created_at: float = 0
     players: dict[str, MusicQuizPlayer] = field(default_factory=dict)

--- a/music_assistant/providers/music_quiz/quiz_types/__init__.py
+++ b/music_assistant/providers/music_quiz/quiz_types/__init__.py
@@ -1,1 +1,29 @@
 """Quiz types for the Music Quiz provider."""
+
+from __future__ import annotations
+
+from music_assistant_models.errors import InvalidDataError
+
+from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
+from music_assistant.providers.music_quiz.quiz_types.base import QuizType
+from music_assistant.providers.music_quiz.quiz_types.guess_the_song import GuessTheSongQuizType
+
+QUIZ_TYPES: dict[str, type[QuizType]] = {
+    "guess_the_song": GuessTheSongQuizType,
+}
+
+
+def get_quiz_type(quiz_type: str) -> type[QuizType]:
+    """
+    Return the registered quiz strategy class.
+
+    :param quiz_type: Quiz type identity to resolve.
+    """
+    try:
+        return QUIZ_TYPES[quiz_type]
+    except KeyError as err:
+        raise InvalidDataError(
+            f"Unknown quiz type: {quiz_type}",
+            translation_key="music_quiz_unknown_quiz_type",
+            translation_owner=TRANSLATION_OWNER,
+        ) from err

--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
+
+from music_assistant.providers.music_quiz.models import MusicQuizAnswerType
 
 if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
@@ -17,6 +19,8 @@ class QuizType(ABC):
     A quiz type generates the question material (rounds) for a game;
     the plugin itself drives phases, scoring and playback.
     """
+
+    answer_type: ClassVar[MusicQuizAnswerType]
 
     def __init__(self, mass: MusicAssistant, config: MusicQuizConfig) -> None:
         """

--- a/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
+++ b/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
@@ -12,7 +12,11 @@ from music_assistant_models.media_items import Playlist, Track
 
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
-from music_assistant.providers.music_quiz.models import MusicQuizDifficulty, MusicQuizRound
+from music_assistant.providers.music_quiz.models import (
+    MusicQuizAnswerType,
+    MusicQuizDifficulty,
+    MusicQuizRound,
+)
 from music_assistant.providers.music_quiz.quiz_types.base import QuizType
 from music_assistant.providers.music_quiz.suggestions import (
     SuggestionCandidate,
@@ -32,6 +36,8 @@ LOGGER = logging.getLogger(__name__)
 
 class GuessTheSongQuizType(QuizType):
     """Quiz type where players guess the currently playing track."""
+
+    answer_type = MusicQuizAnswerType.MULTIPLE_CHOICE
 
     def __init__(self, mass: MusicAssistant, config: MusicQuizConfig) -> None:
         """

--- a/music_assistant/providers/music_quiz/strings.json
+++ b/music_assistant/providers/music_quiz/strings.json
@@ -48,6 +48,7 @@
     "music_quiz_guest_only": "This action is only available to Music Quiz guests.",
     "music_quiz_unknown_quiz_type": "This quiz type is not available.",
     "music_quiz_unknown_player": "This Music Quiz player is not in the game.",
-    "music_quiz_unknown_suggestion": "This answer option is not available."
+    "music_quiz_unknown_suggestion": "This answer option is not available.",
+    "music_quiz_invalid_answer": "This answer is not valid for the current game."
   }
 }

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1395,6 +1395,7 @@
   "provider.music_quiz.errors.music_quiz_game_active": "A Music Quiz game is already in progress.",
   "provider.music_quiz.errors.music_quiz_game_full": "The Music Quiz game is full.",
   "provider.music_quiz.errors.music_quiz_guest_only": "This action is only available to Music Quiz guests.",
+  "provider.music_quiz.errors.music_quiz_invalid_answer": "This answer is not valid for the current game.",
   "provider.music_quiz.errors.music_quiz_invalid_difficulty": "The selected difficulty is not valid.",
   "provider.music_quiz.errors.music_quiz_name_required": "A player name is required.",
   "provider.music_quiz.errors.music_quiz_name_taken": "This player name is already taken.",

--- a/tests/providers/music_quiz/test_game.py
+++ b/tests/providers/music_quiz/test_game.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import pytest
 from music_assistant_models.errors import InvalidDataError
 
+from music_assistant.providers.music_quiz.answer_types.multiple_choice import (
+    MultipleChoiceAnswerType,
+    MultipleChoiceSubmission,
+)
 from music_assistant.providers.music_quiz.errors import (
     MusicQuizAlreadyAnsweredError,
     MusicQuizNameTakenError,
@@ -13,7 +17,7 @@ from music_assistant.providers.music_quiz.errors import (
 from music_assistant.providers.music_quiz.game import (
     active_players_for_round,
     add_player,
-    all_active_players_answered,
+    all_active_players_complete,
     are_active_players_ready,
     finish_game,
     reset_game,
@@ -22,6 +26,7 @@ from music_assistant.providers.music_quiz.game import (
     submit_answer,
 )
 from music_assistant.providers.music_quiz.models import (
+    MusicQuizAnswerType,
     MusicQuizConfig,
     MusicQuizGame,
     MusicQuizPhase,
@@ -29,6 +34,8 @@ from music_assistant.providers.music_quiz.models import (
     MusicQuizRound,
     MusicQuizSuggestion,
 )
+
+ANSWER_TYPE = MultipleChoiceAnswerType()
 
 
 def _player(player_id: str, name: str, active_from_round: int = 0) -> MusicQuizPlayer:
@@ -46,6 +53,7 @@ def _game() -> MusicQuizGame:
     return MusicQuizGame(
         config=MusicQuizConfig(),
         quiz_type="guess_the_song",
+        answer_type=MusicQuizAnswerType.MULTIPLE_CHOICE,
         phase=MusicQuizPhase.ANSWERING,
         current_round_index=0,
         rounds=[
@@ -112,11 +120,11 @@ def test_start_round_requires_exactly_one_correct_suggestion() -> None:
         )
 
     with pytest.raises(InvalidDataError, match="exactly one correct"):
-        start_round(game, _round(True, True, False, False), started_at=1)
+        start_round(game, _round(True, True, False, False), 1, ANSWER_TYPE)
     with pytest.raises(InvalidDataError, match="exactly one correct"):
-        start_round(game, _round(False, False, False, False), started_at=1)
+        start_round(game, _round(False, False, False, False), 1, ANSWER_TYPE)
 
-    start_round(game, _round(True, False, False, False), started_at=1)
+    start_round(game, _round(True, False, False, False), 1, ANSWER_TYPE)
     assert game.phase == MusicQuizPhase.ANSWERING
 
 
@@ -136,7 +144,7 @@ def test_ready_gate_includes_players_joining_next_round() -> None:
     """During reveal the upcoming round belongs to late joiners too."""
     game = _game()
     add_player(game, _player("p1", "Alice"))
-    reveal_round(game)
+    reveal_round(game, ANSWER_TYPE)
     add_player(game, _player("p2", "Bob", active_from_round=1))
 
     game.players["p1"].ready = True
@@ -151,7 +159,7 @@ def test_ready_gate_on_final_round_ignores_spectators_of_a_round_that_never_come
     game = _game()
     game.config.round_count = 1
     add_player(game, _player("p1", "Alice"))
-    reveal_round(game)
+    reveal_round(game, ANSWER_TYPE)
     # joins during the final reveal: their "first active round" will never play
     add_player(game, _player("p2", "Bob", active_from_round=1))
 
@@ -164,12 +172,25 @@ def test_submit_answer_locks_first_answer() -> None:
     game = _game()
     add_player(game, _player("p1", "Alice"))
 
-    answer = submit_answer(game, "p1", "wrong_1", 10)
+    submit_answer(
+        game,
+        "p1",
+        MultipleChoiceSubmission(suggestion_id="wrong_1"),
+        10,
+        ANSWER_TYPE,
+    )
+    answer = game.rounds[0].answers["p1"]
 
     assert answer.suggestion_id == "wrong_1"
     assert answer.is_correct is False
     with pytest.raises(MusicQuizAlreadyAnsweredError, match="already answered"):
-        submit_answer(game, "p1", "correct", 11)
+        submit_answer(
+            game,
+            "p1",
+            MultipleChoiceSubmission(suggestion_id="correct"),
+            11,
+            ANSWER_TYPE,
+        )
 
 
 def test_submit_answer_rejects_unknown_suggestion() -> None:
@@ -178,7 +199,13 @@ def test_submit_answer_rejects_unknown_suggestion() -> None:
     add_player(game, _player("p1", "Alice"))
 
     with pytest.raises(InvalidDataError, match="Unknown suggestion"):
-        submit_answer(game, "p1", "missing", 10)
+        submit_answer(
+            game,
+            "p1",
+            MultipleChoiceSubmission(suggestion_id="missing"),
+            10,
+            ANSWER_TYPE,
+        )
 
 
 def test_submit_answer_rejects_outside_answering_phase() -> None:
@@ -188,22 +215,40 @@ def test_submit_answer_rejects_outside_answering_phase() -> None:
     add_player(game, _player("p1", "Alice"))
 
     with pytest.raises(MusicQuizWrongPhaseError, match="answering phase"):
-        submit_answer(game, "p1", "correct", 10)
+        submit_answer(
+            game,
+            "p1",
+            MultipleChoiceSubmission(suggestion_id="correct"),
+            10,
+            ANSWER_TYPE,
+        )
 
 
-def test_all_active_players_answered_tracks_current_round() -> None:
+def test_all_active_players_complete_tracks_current_round() -> None:
     """Report completion only when every active player locked an answer."""
     game = _game()
     add_player(game, _player("p1", "Alice"))
     add_player(game, _player("p2", "Bob"))
     add_player(game, _player("p3", "Late", active_from_round=1))
 
-    assert all_active_players_answered(game) is False
-    submit_answer(game, "p1", "correct", 10)
-    assert all_active_players_answered(game) is False
+    assert all_active_players_complete(game, ANSWER_TYPE) is False
+    submit_answer(
+        game,
+        "p1",
+        MultipleChoiceSubmission(suggestion_id="correct"),
+        10,
+        ANSWER_TYPE,
+    )
+    assert all_active_players_complete(game, ANSWER_TYPE) is False
     # the late joiner is not active this round and must not block completion
-    submit_answer(game, "p2", "wrong_1", 11)
-    assert all_active_players_answered(game) is True
+    submit_answer(
+        game,
+        "p2",
+        MultipleChoiceSubmission(suggestion_id="wrong_1"),
+        11,
+        ANSWER_TYPE,
+    )
+    assert all_active_players_complete(game, ANSWER_TYPE) is True
 
 
 def test_reveal_round_applies_scores_to_correct_answers_in_order() -> None:
@@ -212,11 +257,29 @@ def test_reveal_round_applies_scores_to_correct_answers_in_order() -> None:
     add_player(game, _player("p1", "Alice"))
     add_player(game, _player("p2", "Bob"))
     add_player(game, _player("p3", "Charlie"))
-    submit_answer(game, "p2", "correct", 10)
-    submit_answer(game, "p1", "wrong_1", 11)
-    submit_answer(game, "p3", "correct", 12)
+    submit_answer(
+        game,
+        "p2",
+        MultipleChoiceSubmission(suggestion_id="correct"),
+        10,
+        ANSWER_TYPE,
+    )
+    submit_answer(
+        game,
+        "p1",
+        MultipleChoiceSubmission(suggestion_id="wrong_1"),
+        11,
+        ANSWER_TYPE,
+    )
+    submit_answer(
+        game,
+        "p3",
+        MultipleChoiceSubmission(suggestion_id="correct"),
+        12,
+        ANSWER_TYPE,
+    )
 
-    reveal_round(game)
+    reveal_round(game, ANSWER_TYPE)
 
     current_round = game.rounds[0]
     assert game.phase == MusicQuizPhase.REVEAL
@@ -255,6 +318,7 @@ def test_reset_game_keeps_players_and_config_for_new_game() -> None:
 
     assert game.phase == MusicQuizPhase.LOBBY
     assert game.quiz_type == "guess_the_song"
+    assert game.answer_type == MusicQuizAnswerType.MULTIPLE_CHOICE
     assert game.current_round_index is None
     assert game.rounds == []
     assert {player.name for player in game.players.values()} == {"Alice", "Bob"}

--- a/tests/providers/music_quiz/test_multiple_choice.py
+++ b/tests/providers/music_quiz/test_multiple_choice.py
@@ -1,0 +1,131 @@
+"""Tests for the Music Quiz multiple-choice answer strategy."""
+
+from __future__ import annotations
+
+import pytest
+from music_assistant_models.errors import InvalidDataError
+
+from music_assistant.providers.music_quiz.answer_types.multiple_choice import (
+    MultipleChoiceAnswerType,
+    MultipleChoiceSubmission,
+)
+from music_assistant.providers.music_quiz.models import (
+    MusicQuizAnswer,
+    MusicQuizRound,
+    MusicQuizSuggestion,
+)
+
+ANSWER_TYPE = MultipleChoiceAnswerType()
+
+
+def _round() -> MusicQuizRound:
+    """Return a multiple-choice round."""
+    return MusicQuizRound(
+        round_index=0,
+        track_uri="library://track/1",
+        answer_label="Daft Punk - One More Time",
+        suggestions=[
+            MusicQuizSuggestion(
+                suggestion_id="correct",
+                label="Daft Punk - One More Time",
+                is_correct=True,
+            ),
+            MusicQuizSuggestion(
+                suggestion_id="wrong",
+                label="Justice - D.A.N.C.E.",
+            ),
+        ],
+        image_url="https://example.test/artwork.jpg",
+        duration=180,
+        started_at=10,
+    )
+
+
+def test_parse_submission_returns_typed_request() -> None:
+    """Parse the strict wire payload into a typed multiple-choice submission."""
+    submission = ANSWER_TYPE.parse_submission(
+        {
+            "answer_type": "multiple_choice",
+            "suggestion_id": "correct",
+        }
+    )
+
+    assert submission == MultipleChoiceSubmission(suggestion_id="correct")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"suggestion_id": "correct"},
+        {"answer_type": "multiple_choice"},
+        {"answer_type": "timeline", "suggestion_id": "correct"},
+        {"answer_type": 1, "suggestion_id": "correct"},
+        {"answer_type": "multiple_choice", "suggestion_id": 1},
+        {"answer_type": "multiple_choice", "suggestion_id": ""},
+        {
+            "answer_type": "multiple_choice",
+            "suggestion_id": "correct",
+            "extra": True,
+        },
+    ],
+)
+def test_parse_submission_rejects_malformed_payload(payload: dict[str, object]) -> None:
+    """Reject missing, mismatched, incorrectly typed and extra fields."""
+    with pytest.raises(InvalidDataError):
+        ANSWER_TYPE.parse_submission(payload)
+
+
+def test_round_serialization_redacts_answer_until_reveal() -> None:
+    """Expose suggestion choices without revealing which one is correct."""
+    game_round = _round()
+
+    hidden = ANSWER_TYPE.serialize_round(game_round, revealed=False)
+    revealed = ANSWER_TYPE.serialize_round(game_round, revealed=True)
+
+    assert hidden == {
+        "suggestions": [
+            {"suggestion_id": "correct", "label": "Daft Punk - One More Time"},
+            {"suggestion_id": "wrong", "label": "Justice - D.A.N.C.E."},
+        ]
+    }
+    assert "correct_suggestion_id" not in hidden
+    assert revealed["correct_suggestion_id"] == "correct"
+    assert "answer_label" not in revealed
+
+
+def test_player_serialization_separates_public_and_personal_state() -> None:
+    """Keep a locked answer private and its correctness hidden before reveal."""
+    game_round = _round()
+    game_round.answers["p1"] = MusicQuizAnswer(
+        player_id="p1",
+        suggestion_id="correct",
+        answered_at=12,
+        is_correct=True,
+        points=1000,
+    )
+
+    assert ANSWER_TYPE.serialize_public_player(game_round, "p1", revealed=False) == {
+        "answered": True
+    }
+    assert ANSWER_TYPE.serialize_personal_player(game_round, "p1", revealed=False) == {
+        "answer": {
+            "suggestion_id": "correct",
+            "answered_at": 12,
+        }
+    }
+    assert ANSWER_TYPE.serialize_public_player(game_round, "p1", revealed=True) == {
+        "answered": True,
+        "last_answer": {
+            "suggestion_id": "correct",
+            "correct": True,
+            "points": 1000,
+        },
+    }
+    assert ANSWER_TYPE.serialize_personal_player(game_round, "p1", revealed=True) == {
+        "answer": {
+            "suggestion_id": "correct",
+            "answered_at": 12,
+            "correct": True,
+            "points": 1000,
+        }
+    }

--- a/tests/providers/music_quiz/test_multiple_choice.py
+++ b/tests/providers/music_quiz/test_multiple_choice.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import pytest
-from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.providers.music_quiz.answer_types.multiple_choice import (
     MultipleChoiceAnswerType,
     MultipleChoiceSubmission,
 )
+from music_assistant.providers.music_quiz.errors import MusicQuizInvalidAnswerError
 from music_assistant.providers.music_quiz.models import (
     MusicQuizAnswer,
     MusicQuizRound,
@@ -71,7 +71,7 @@ def test_parse_submission_returns_typed_request() -> None:
 )
 def test_parse_submission_rejects_malformed_payload(payload: dict[str, object]) -> None:
     """Reject missing, mismatched, incorrectly typed and extra fields."""
-    with pytest.raises(InvalidDataError):
+    with pytest.raises(MusicQuizInvalidAnswerError):
         ANSWER_TYPE.parse_submission(payload)
 
 

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -17,6 +17,7 @@ from music_assistant.providers.music_quiz import (
     MusicQuizPlugin,
     get_config_entries,
 )
+from music_assistant.providers.music_quiz.answer_types import get_answer_type
 from music_assistant.providers.music_quiz.errors import (
     MusicQuizGameActiveError,
     MusicQuizNoGameError,
@@ -44,6 +45,7 @@ GUEST_COMMANDS = (
     "music_quiz/info",
     "music_quiz/join",
     "music_quiz/state",
+    "music_quiz/submit_answer",
     "music_quiz/answer",
     "music_quiz/ready",
 )
@@ -97,6 +99,7 @@ def _create_plugin(
     }.__getitem__
     plugin._game = None
     plugin._quiz_type = None
+    plugin._answer_type = None
     plugin._game_lock = asyncio.Lock()
     plugin._playback_session = None
     plugin._playback_lock = asyncio.Lock()
@@ -164,7 +167,8 @@ async def _create_started_game(
 def _deterministic_rounds() -> Any:
     """Patch round preparation to deterministic rounds without music lookups."""
     with patch(
-        "music_assistant.providers.music_quiz.GuessTheSongQuizType.prepare_round",
+        "music_assistant.providers.music_quiz.quiz_types.guess_the_song."
+        "GuessTheSongQuizType.prepare_round",
         new=AsyncMock(side_effect=lambda round_index, _used: _make_round(round_index)),
     ):
         yield
@@ -255,6 +259,97 @@ async def test_full_game_flow() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generic_submit_answer_uses_discriminated_payload() -> None:
+    """The generic command accepts a strict typed multiple-choice submission."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",))
+
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        state = cast(
+            "dict[str, Any]",
+            await plugin.submit_answer(
+                player_ids["Alice"],
+                {
+                    "answer_type": "multiple_choice",
+                    "suggestion_id": "correct_0",
+                },
+            ),
+        )
+
+    assert state["phase"] == "reveal"
+    assert state["you"]["answer"]["correct"] is True
+    assert state["you"]["answer"]["points"] == 1000
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "submission",
+    [
+        {"suggestion_id": "correct_0"},
+        {"answer_type": "unknown", "suggestion_id": "correct_0"},
+        {"answer_type": "multiple_choice", "suggestion_id": 1},
+        {
+            "answer_type": "multiple_choice",
+            "suggestion_id": "correct_0",
+            "extra": True,
+        },
+    ],
+)
+async def test_generic_submit_answer_rejects_invalid_payload(
+    submission: dict[str, object],
+) -> None:
+    """Malformed generic submissions fail without mutating round state."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",))
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+        pytest.raises(InvalidDataError),
+    ):
+        await plugin.submit_answer(player_ids["Alice"], submission)
+
+    game = plugin._game
+    assert game is not None
+    assert game.rounds[0].answers == {}
+    assert game.phase == MusicQuizPhase.ANSWERING
+
+
+@pytest.mark.asyncio
+async def test_generic_submit_answer_rejects_game_type_mismatch() -> None:
+    """Reject a known discriminator that does not match persisted game identity."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",))
+    mismatched_type = SimpleNamespace(answer_type="other")
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+        patch(
+            "music_assistant.providers.music_quiz.get_answer_type",
+            side_effect=lambda answer_type: (
+                mismatched_type if answer_type == "other" else get_answer_type(answer_type)
+            ),
+        ),
+        pytest.raises(InvalidDataError, match="does not match"),
+    ):
+        await plugin.submit_answer(
+            player_ids["Alice"],
+            {
+                "answer_type": "other",
+                "suggestion_id": "correct_0",
+            },
+        )
+
+
+@pytest.mark.asyncio
 async def test_answer_with_unknown_player_is_rejected() -> None:
     """A guest answering with an unknown player_id gets a localized Music Quiz error."""
     plugin = _create_plugin()
@@ -282,6 +377,7 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
     state = payload["state"]
     assert state["phase"] == "answering"
     assert state["quiz_type"] == "guess_the_song"
+    assert state["answer_type"] == "multiple_choice"
     assert state["mode"] == "venue"
     current_round = state["current_round"]
     assert set(current_round) == {
@@ -298,6 +394,22 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
         assert player_id not in serialized
     assert "is_correct" not in serialized
     assert "track_uri" not in serialized
+
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        personal_state = await plugin.answer(player_ids["Alice"], "correct_0")
+
+    own_answer = personal_state["you"]["answer"]
+    assert own_answer["suggestion_id"] == "correct_0"
+    assert "correct" not in own_answer
+    assert "points" not in own_answer
+    assert "track_uri" not in str(personal_state)
+    public_state = signal.call_args[0][0]["state"]
+    alice = next(player for player in public_state["players"] if player["name"] == "Alice")
+    assert alice["answered"] is True
+    assert "last_answer" not in alice
 
     # after the reveal the same payload exposes the answer
     await plugin.reveal()
@@ -319,6 +431,7 @@ async def test_game_info_exposes_game_identity_and_playback_mode() -> None:
     assert info == {
         "name": "Test Quiz",
         "quiz_type": "guess_the_song",
+        "answer_type": "multiple_choice",
         "phase": "lobby",
         "mode": "remote",
         "player_count": 0,
@@ -338,8 +451,22 @@ async def test_create_and_get_expose_persisted_quiz_type() -> None:
     game = plugin._game
     assert game is not None
     assert game.quiz_type == "guess_the_song"
+    assert game.answer_type == "multiple_choice"
     assert created["quiz_type"] == game.quiz_type
+    assert created["answer_type"] == game.answer_type
     assert (await plugin.get_game())["quiz_type"] == game.quiz_type
+    assert (await plugin.get_game())["answer_type"] == game.answer_type
+
+
+@pytest.mark.asyncio
+async def test_cached_strategy_mismatch_is_rejected() -> None:
+    """Strategy caches cannot diverge from persisted game identity."""
+    plugin = _create_plugin()
+    await plugin.create_game(source_uris=["library://playlist/1"])
+    plugin._answer_type = MagicMock()
+
+    with pytest.raises(InvalidDataError, match="identity mismatch"):
+        await plugin.get_game()
 
 
 @pytest.mark.asyncio
@@ -354,9 +481,11 @@ async def test_join_and_player_state_expose_persisted_quiz_type() -> None:
     ):
         joined = await plugin.join_game("Alice")
         assert joined["state"]["quiz_type"] == "guess_the_song"
+        assert joined["state"]["answer_type"] == "multiple_choice"
         state = await plugin.get_player_state(joined["player_id"])
 
     assert state["quiz_type"] == "guess_the_song"
+    assert state["answer_type"] == "multiple_choice"
 
 
 @pytest.mark.asyncio
@@ -369,8 +498,10 @@ async def test_reset_preserves_quiz_type_in_state_and_events() -> None:
 
     assert state["phase"] == "lobby"
     assert state["quiz_type"] == "guess_the_song"
+    assert state["answer_type"] == "multiple_choice"
     payload = cast("MagicMock", plugin.signal_provider_event).call_args[0][0]
     assert payload["state"]["quiz_type"] == "guess_the_song"
+    assert payload["state"]["answer_type"] == "multiple_choice"
 
 
 @pytest.mark.asyncio
@@ -460,6 +591,8 @@ async def test_delete_game_signals_removal() -> None:
 
     await plugin.delete_game()
     assert plugin._game is None
+    assert plugin._quiz_type is None
+    assert plugin._answer_type is None
     cast("AsyncMock", plugin._stop_playback).assert_awaited()
     session.close.assert_awaited_once()
     payload = cast("MagicMock", plugin.signal_provider_event).call_args[0][0]

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -20,6 +20,7 @@ from music_assistant.providers.music_quiz import (
 from music_assistant.providers.music_quiz.answer_types import get_answer_type
 from music_assistant.providers.music_quiz.errors import (
     MusicQuizGameActiveError,
+    MusicQuizInvalidAnswerError,
     MusicQuizNoGameError,
     MusicQuizUnknownPlayerError,
 )
@@ -310,7 +311,7 @@ async def test_generic_submit_answer_rejects_invalid_payload(
             "music_assistant.providers.music_quiz.get_current_user",
             return_value=_guest_user(),
         ),
-        pytest.raises(InvalidDataError),
+        pytest.raises(MusicQuizInvalidAnswerError),
     ):
         await plugin.submit_answer(player_ids["Alice"], submission)
 
@@ -338,7 +339,7 @@ async def test_generic_submit_answer_rejects_game_type_mismatch() -> None:
                 mismatched_type if answer_type == "other" else get_answer_type(answer_type)
             ),
         ),
-        pytest.raises(InvalidDataError, match="does not match"),
+        pytest.raises(MusicQuizInvalidAnswerError, match="does not match"),
     ):
         await plugin.submit_answer(
             player_ids["Alice"],


### PR DESCRIPTION
# What does this implement/fix?

Adds a reusable answer-type foundation to Music Quiz while preserving the existing Guess the Song behavior.

- Separates multiple-choice validation, submissions, completion, scoring, and redaction from the generic game lifecycle.
- Adds a strict generic answer command while keeping the existing answer command compatible with current frontends.
- Exposes the selected answer type in game identity and state payloads.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project AI Policy for AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.