### PR TITLE
Make audio overlays audible immediately

### DIFF
--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -426,8 +426,13 @@ async def get_ffmpeg_overlay_stream(
         ]
     overlay_input_args += ["-stream_loop", "-1", "-i", overlay_input]
     channel_layout = "mono" if pcm_format.channels == 1 else "stereo"
+    # silenceremove strips a near-silent intro from the overlay source (e.g. a soft
+    # fade-in) so it becomes audible right away; it is a no-op for sources that
+    # already start at full level. It runs before volume so detection is based on
+    # the source's own levels rather than the scaled output.
     filter_complex = (
-        f"[0:a]volume={overlay_volume / 100},"
+        f"[0:a]silenceremove=start_periods=1:start_threshold=-40dB,"
+        f"volume={overlay_volume / 100},"
         f"aresample={pcm_format.sample_rate},"
         f"aformat=channel_layouts={channel_layout}[overlay];"
         "[1:a][overlay]amix=inputs=2:duration=first:normalize=0[mixed]"

--- a/music_assistant/providers/rain_mood/__init__.py
+++ b/music_assistant/providers/rain_mood/__init__.py
@@ -80,8 +80,9 @@ class RainyMoodProvider(MusicProvider):
         return StreamDetails(
             provider=self.instance_id,
             item_id=item_id,
-            # remote source is a continuous ambience; let ffmpeg detect the codec
-            audio_format=AudioFormat(content_type=ContentType.UNKNOWN),
+            # rainymood serves an MP3 stream; declare it explicitly instead of
+            # leaving the container type to be probed
+            audio_format=AudioFormat(content_type=ContentType.MP3),
             media_type=MediaType.SOUND_EFFECT,
             stream_type=StreamType.HTTP,
             path=RAIN_URL,

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -187,6 +187,27 @@ def overlay_file(tmp_path: Path) -> Path:
     return overlay_path
 
 
+@pytest.fixture
+def overlay_file_with_silent_intro(tmp_path: Path) -> Path:
+    """Generate a 2 second overlay wav that starts with 1s of silence then a 1s tone."""
+    overlay_path = tmp_path / "overlay_silent_intro.wav"
+    subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "ffmpeg",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=1",
+            "-af",
+            "adelay=1000:all=1",
+            str(overlay_path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return overlay_path
+
+
 async def _silence(seconds: int) -> AsyncGenerator[bytes]:
     """Yield the given amount of seconds of PCM silence in 1-second chunks."""
     for _ in range(seconds):
@@ -232,3 +253,22 @@ async def test_overlay_stream_applies_volume(overlay_file: Path) -> None:
     )
     assert len(output) == _BYTES_PER_SECOND
     assert not any(output)
+
+
+async def test_overlay_stream_trims_leading_silence(
+    overlay_file_with_silent_intro: Path,
+) -> None:
+    """A near-silent intro on the overlay source is trimmed so it plays immediately."""
+    output = b"".join(
+        await _collect_chunks(
+            get_ffmpeg_overlay_stream(
+                audio_input=_silence(1),
+                overlay_input=str(overlay_file_with_silent_intro),
+                pcm_format=_PCM_FORMAT,
+            )
+        )
+    )
+    assert len(output) == _BYTES_PER_SECOND
+    # without trimming, the first second would be the overlay's silent intro;
+    # the trim makes the tone play from the start, so the first second has signal
+    assert any(output)

--- a/tests/providers/rain_mood/test_provider.py
+++ b/tests/providers/rain_mood/test_provider.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import MediaType, ProviderFeature, StreamType
+from music_assistant_models.enums import ContentType, MediaType, ProviderFeature, StreamType
 from music_assistant_models.errors import MediaNotFoundError
 
 from music_assistant.providers import rain_mood
@@ -62,6 +62,7 @@ async def test_stream_details() -> None:
     assert stream_details.stream_type == StreamType.HTTP
     assert stream_details.media_type == MediaType.SOUND_EFFECT
     assert stream_details.path == RAIN_URL
+    assert stream_details.audio_format.content_type == ContentType.MP3
 
 
 async def test_stream_details_unknown() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Audio overlays (a looping sound effect mixed into a queue) could take a moment to become audible when the overlay source starts with a near-silent intro. This was most noticeable with the Rainy Mood source, whose remote stream fades in over the first second, whereas locally rendered sounds like Ambient Sounds start instantly — so the difference felt like a delay.

- Trim a near-silent intro from the overlay source in the mixer so any overlay is heard right away (a no-op for sounds that already start at full level).
- Declare the Rainy Mood stream as MP3 instead of leaving the container type to be probed.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
