### PR TITLE
Lock in the provider config store/snapshot consistency guarantee

### DIFF
--- a/tests/controllers/config/test_config_copy_lifecycle.py
+++ b/tests/controllers/config/test_config_copy_lifecycle.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from music_assistant_models.config_entries import (
     ConfigEntry,
@@ -14,7 +14,12 @@ from music_assistant_models.config_entries import (
 )
 from music_assistant_models.enums import ConfigEntryType, PlayerType, ProviderType
 
-from music_assistant.constants import CONF_PROVIDERS, CONF_VOLUME_NORMALIZATION_TARGET
+from music_assistant.constants import (
+    CONF_ENTRY_LOG_LEVEL,
+    CONF_PROVIDERS,
+    CONF_VOLUME_NORMALIZATION_TARGET,
+)
+from music_assistant.models.provider import Provider
 
 if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
@@ -146,3 +151,104 @@ async def test_set_raw_provider_config_value_syncs_unavailable_provider(
     )
     mass_minimal.config.set_raw_provider_config_value(PROVIDER_INSTANCE, "api_token", "abc")
     assert provider.config.get_value("api_token") == "abc"
+
+
+def _provider_config_entries() -> list[ConfigEntry]:
+    return [CONF_ENTRY_LOG_LEVEL, _entry("api_token", ConfigEntryType.STRING, "old")]
+
+
+def _raw_provider_conf(instance_id: str, api_token: str) -> dict[str, object]:
+    return {
+        "type": ProviderType.MUSIC.value,
+        "domain": "test",
+        "instance_id": instance_id,
+        "enabled": True,
+        "values": {"api_token": api_token},
+    }
+
+
+async def test_save_provider_config_syncs_loaded_available_provider(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """
+    The bulk config-save path keeps a loaded, available provider's copy in sync too.
+
+    Regression test for the store<->snapshot invariant: whichever write path persists a
+    provider config change, a loaded provider's in-place config copy must reflect it.
+    """
+    instance = PROVIDER_INSTANCE
+    entries = _provider_config_entries()
+    mass_minimal.config.set(f"{CONF_PROVIDERS}/{instance}", _raw_provider_conf(instance, "old"))
+    manifest = MagicMock(domain="test", type=ProviderType.MUSIC)
+    provider = Provider(
+        mass_minimal,
+        manifest,
+        cast("ProviderConfig", ProviderConfig.parse(entries, _raw_provider_conf(instance, "old"))),
+    )
+    provider.available = True
+    mass_minimal.get_provider = MagicMock(return_value=provider)  # type: ignore[method-assign]
+    mass_minimal.call_later = MagicMock()  # type: ignore[method-assign] # don't schedule a real reload
+
+    async def _get_provider_config(_instance_id: str) -> ProviderConfig:
+        raw_conf = mass_minimal.config.get(f"{CONF_PROVIDERS}/{instance}")
+        return cast("ProviderConfig", ProviderConfig.parse(entries, raw_conf))
+
+    with patch.object(mass_minimal.config, "get_provider_config", side_effect=_get_provider_config):
+        await mass_minimal.config.save_provider_config(
+            "test", {"api_token": "new"}, instance_id=instance
+        )
+
+    assert provider.config.get_value("api_token") == "new"
+    assert mass_minimal.config.get_raw_provider_config_value(instance, "api_token") == "new"
+
+
+async def test_save_provider_config_reloads_loaded_unavailable_provider(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """
+    The bulk config-save path reloads (rather than patches) an unavailable loaded provider.
+
+    An unavailable provider instance never receives a direct config-copy sync; instead the
+    save must trigger a full reload with the freshly persisted values, so the replacement
+    provider instance can never end up with a stale copy.
+    """
+    instance = PROVIDER_INSTANCE
+    entries = _provider_config_entries()
+    mass_minimal.config.set(f"{CONF_PROVIDERS}/{instance}", _raw_provider_conf(instance, "old"))
+    manifest = MagicMock(domain="test", type=ProviderType.MUSIC)
+    provider = Provider(
+        mass_minimal,
+        manifest,
+        cast("ProviderConfig", ProviderConfig.parse(entries, _raw_provider_conf(instance, "old"))),
+    )
+    provider.available = False  # loaded, but currently unavailable (e.g. failed token refresh)
+
+    def _get_provider(
+        _instance: str, return_unavailable: bool = False, **_kwargs: object
+    ) -> object | None:
+        return provider if return_unavailable else None
+
+    mass_minimal.get_provider = MagicMock(side_effect=_get_provider)  # type: ignore[method-assign]
+
+    async def _get_provider_config(_instance_id: str) -> ProviderConfig:
+        raw_conf = mass_minimal.config.get(f"{CONF_PROVIDERS}/{instance}")
+        return cast("ProviderConfig", ProviderConfig.parse(entries, raw_conf))
+
+    with (
+        patch.object(mass_minimal.config, "get_provider_config", side_effect=_get_provider_config),
+        patch.object(mass_minimal, "load_provider_config", AsyncMock()) as mock_load,
+    ):
+        await mass_minimal.config.save_provider_config(
+            "test", {"api_token": "new"}, instance_id=instance
+        )
+
+    # the value is persisted before the reload is triggered...
+    assert mass_minimal.config.get_raw_provider_config_value(instance, "api_token") == "new"
+    # ...and the reload receives that same, up-to-date value, so the replacement
+    # provider instance created by the reload can never end up with a stale copy
+    mock_load.assert_awaited_once()
+    assert mock_load.await_args is not None
+    reloaded_config = mock_load.await_args.args[0]
+    assert reloaded_config.get_value("api_token") == "new"
+    # the stale (unavailable) instance itself is never patched in place
+    assert provider.config.get_value("api_token") == "old"

--- a/tests/controllers/config/test_config_copy_lifecycle.py
+++ b/tests/controllers/config/test_config_copy_lifecycle.py
@@ -153,20 +153,6 @@ async def test_set_raw_provider_config_value_syncs_unavailable_provider(
     assert provider.config.get_value("api_token") == "abc"
 
 
-def _provider_config_entries() -> list[ConfigEntry]:
-    return [CONF_ENTRY_LOG_LEVEL, _entry("api_token", ConfigEntryType.STRING, "old")]
-
-
-def _raw_provider_conf(instance_id: str, api_token: str) -> dict[str, object]:
-    return {
-        "type": ProviderType.MUSIC.value,
-        "domain": "test",
-        "instance_id": instance_id,
-        "enabled": True,
-        "values": {"api_token": api_token},
-    }
-
-
 async def test_save_provider_config_syncs_loaded_available_provider(
     mass_minimal: MusicAssistant,
 ) -> None:
@@ -252,3 +238,17 @@ async def test_save_provider_config_reloads_loaded_unavailable_provider(
     assert reloaded_config.get_value("api_token") == "new"
     # the stale (unavailable) instance itself is never patched in place
     assert provider.config.get_value("api_token") == "old"
+
+
+def _provider_config_entries() -> list[ConfigEntry]:
+    return [CONF_ENTRY_LOG_LEVEL, _entry("api_token", ConfigEntryType.STRING, "old")]
+
+
+def _raw_provider_conf(instance_id: str, api_token: str) -> dict[str, object]:
+    return {
+        "type": ProviderType.MUSIC.value,
+        "domain": "test",
+        "instance_id": instance_id,
+        "enabled": True,
+        "values": {"api_token": api_token},
+    }


### PR DESCRIPTION
### What does this implement/fix?

Follow-up to #4711 (Spotify stale-token fix). Audited the provider config save flow to make sure a loaded provider's in-memory config can never drift from what's actually persisted — including when the provider is temporarily unavailable (e.g. mid token refresh).

The audit confirmed the guarantee already holds for every save path: config saves either update the loaded provider's config in place or trigger a full reload with the freshly persisted values. To make sure this can't silently regress, this PR adds tests that lock it in.

- Added regression tests covering the bulk config-save path for both an available and a temporarily unavailable loaded provider
- No production code changes — this closes a test-coverage gap identified while investigating the Spotify auth issue

**Related issue (if applicable):**

- follow-up to #4711

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
