### PR TITLE
Show re-authentication prompt when a provider's login fails

### DIFF
--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -884,9 +884,18 @@ class MusicAssistant:
                 await self._update_available_providers_cache()
                 self.signal_event(EventType.PROVIDERS_UPDATED, data=self.get_providers())
 
-    async def unload_provider_with_error(self, instance_id: str, error: str) -> None:
-        """Unload a provider when it got into trouble which needs user interaction."""
-        prov_error = ProviderError(error_code=999, message=error)
+    async def unload_provider_with_error(self, instance_id: str, error: str | Exception) -> None:
+        """
+        Unload a provider that hit a problem which needs user interaction.
+
+        :param error: The originating exception (preferred, so e.g. a LoginFailed surfaces as an
+            auth-required status with a localized message) or a plain string for a generic error.
+        """
+        prov_error = (
+            _provider_error_from_exc(error)
+            if isinstance(error, Exception)
+            else ProviderError(error_code=999, message=error)
+        )
         self.config.update_provider_last_error(instance_id, prov_error)
         await self.unload_provider(instance_id)
 

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -184,8 +184,13 @@ class Provider:
         """Return the stage of this provider."""
         return self.manifest.stage
 
-    def unload_with_error(self, error: str) -> None:
-        """Unload provider with error message."""
+    def unload_with_error(self, error: str | Exception) -> None:
+        """
+        Unload this provider and record an error for the user to act on.
+
+        :param error: The originating exception (preferred, so its error code and localized
+            message are preserved) or a plain string for a generic error message.
+        """
         self.mass.call_later(1, self.mass.unload_provider_with_error, self.instance_id, error)
 
     def to_dict(self) -> dict[str, Any]:

--- a/music_assistant/providers/spotify/__init__.py
+++ b/music_assistant/providers/spotify/__init__.py
@@ -258,12 +258,13 @@ async def setup(
             mass.config.set_raw_provider_config_value(
                 config.instance_id, CONF_REFRESH_TOKEN_GLOBAL, legacy_token, encrypted=True
             )
+            # reflect the migrated token locally; the provider isn't registered yet, so the store
+            # write above can't sync this config snapshot and a re-read would still come back empty
+            global_token = legacy_token
         # Remove the deprecated legacy token from config
         mass.config.set_raw_provider_config_value(
             config.instance_id, CONF_REFRESH_TOKEN_DEPRECATED, None
         )
-        # Re-fetch the updated config value
-        global_token = config.get_value(CONF_REFRESH_TOKEN_GLOBAL)
 
     if global_token in (None, ""):
         msg = "Re-Authentication required"

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -856,11 +856,9 @@ class SpotifyProvider(MusicProvider):
                 if not self._refresh_token_superseded(CONF_REFRESH_TOKEN_GLOBAL, refresh_token):
                     self._update_config_value(CONF_REFRESH_TOKEN_GLOBAL, None)
                     if self.available:
-                        self.unload_with_error(str(err))
+                        self.unload_with_error(err)
             elif self.available:
-                self.mass.create_task(
-                    self.mass.unload_provider_with_error(self.instance_id, str(err))
-                )
+                self.mass.create_task(self.mass.unload_provider_with_error(self.instance_id, err))
             raise
 
         # make sure that our updated creds get stored in memory + config

--- a/tests/core/test_provider_unload.py
+++ b/tests/core/test_provider_unload.py
@@ -1,0 +1,51 @@
+"""Tests for MusicAssistant.unload_provider_with_error error preservation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.errors import LoginFailed
+
+from music_assistant.mass import MusicAssistant
+
+if TYPE_CHECKING:
+    import pytest
+    from music_assistant_models.config_entries import ProviderError
+
+
+def _make_mass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[MusicAssistant, list[ProviderError], AsyncMock]:
+    """Return a bare MusicAssistant (bypassing __init__) recording last-error writes."""
+    mass = object.__new__(MusicAssistant)
+    recorded: list[ProviderError] = []
+    config = MagicMock()
+    config.update_provider_last_error = MagicMock(
+        side_effect=lambda _instance_id, error: recorded.append(error)
+    )
+    unload = AsyncMock()
+    monkeypatch.setattr(mass, "config", config, raising=False)
+    monkeypatch.setattr(mass, "unload_provider", unload)
+    return mass, recorded, unload
+
+
+async def test_unload_provider_with_error_preserves_auth_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A LoginFailed keeps its error code + translation so the provider shows AUTH_REQUIRED."""
+    mass, recorded, unload = _make_mass(monkeypatch)
+    await mass.unload_provider_with_error("spotify--1", LoginFailed("token revoked"))
+    assert recorded[0].error_code == LoginFailed.error_code
+    assert recorded[0].translation_key == LoginFailed.translation_key
+    unload.assert_awaited_once_with("spotify--1")
+
+
+async def test_unload_provider_with_error_string_is_generic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plain string message is recorded as a generic error (code 999)."""
+    mass, recorded, _unload = _make_mass(monkeypatch)
+    await mass.unload_provider_with_error("airplay--1", "daemon failed to start")
+    assert recorded[0].error_code == 999
+    assert recorded[0].message == "daemon failed to start"

--- a/tests/models/test_provider.py
+++ b/tests/models/test_provider.py
@@ -7,6 +7,7 @@ from typing import cast
 from unittest.mock import MagicMock
 
 from music_assistant_models.enums import EventType, ProviderType
+from music_assistant_models.errors import LoginFailed
 from music_assistant_models.provider import ProviderInstance
 
 from music_assistant.models.provider import Provider
@@ -58,4 +59,15 @@ def test_unload_with_error_schedules_error_unload() -> None:
     mass = cast("MagicMock", provider.mass)
     mass.call_later.assert_called_once_with(
         1, mass.unload_provider_with_error, "test_instance", "boom"
+    )
+
+
+def test_unload_with_error_forwards_exception() -> None:
+    """An exception is forwarded unchanged so its error code + localized message are preserved."""
+    provider = _make_base_provider()
+    err = LoginFailed("token revoked")
+    provider.unload_with_error(err)
+    mass = cast("MagicMock", provider.mass)
+    mass.call_later.assert_called_once_with(
+        1, mass.unload_provider_with_error, "test_instance", err
     )

--- a/tests/providers/spotify/test_setup.py
+++ b/tests/providers/spotify/test_setup.py
@@ -1,0 +1,38 @@
+"""Tests for the Spotify provider setup and legacy-token migration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from music_assistant.providers.spotify import setup
+from music_assistant.providers.spotify.constants import (
+    CONF_REFRESH_TOKEN_DEPRECATED,
+    CONF_REFRESH_TOKEN_GLOBAL,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+async def test_setup_migrates_legacy_global_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    A legacy token (no custom client id) is migrated to the global key without forcing re-auth.
+
+    The provider isn't registered during setup, so the raw store write can't sync the in-memory
+    config snapshot; setup must use the migrated value rather than re-reading the stale snapshot.
+    """
+    values = {CONF_REFRESH_TOKEN_DEPRECATED: "legacy_tok"}
+    config = MagicMock(instance_id="spotify--test")
+    config.get_value = MagicMock(side_effect=lambda key: values.get(key))
+    mass = MagicMock()
+    mass.config.set_raw_provider_config_value = MagicMock()
+    sentinel = object()
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.SpotifyProvider", MagicMock(return_value=sentinel)
+    )
+    result = await setup(mass, MagicMock(), config)
+    assert result is sentinel
+    mass.config.set_raw_provider_config_value.assert_any_call(
+        "spotify--test", CONF_REFRESH_TOKEN_GLOBAL, "legacy_tok", encrypted=True
+    )


### PR DESCRIPTION
# What does this implement/fix?

When a provider's login fails while it's running (for example Spotify after its refresh token was revoked), Music Assistant recorded a generic error, so the provider showed a plain error instead of telling you it needs re-authentication. It now surfaces the login failure as "authentication required" with the proper message, so the provider clearly asks to be re-authenticated.

This also fixes a case where Spotify wrongly asked you to re-authenticate on the first start after upgrading from an older version (it worked again only after a restart).

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Preserve the original error when a provider unloads after a login failure, so it shows as "authentication required" instead of a generic error.
- Fix the Spotify legacy-token migration that re-read a stale config snapshot and falsely forced re-authentication until a restart.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
