### PR TITLE
Prepare Music Quiz rounds for more answer types

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -658,7 +658,7 @@ class MusicQuizPlugin(PluginProvider):
             "created_at": game.created_at,
             "sources": [source.to_dict() for source in game.sources],
             "join_url": await self._get_join_url(),
-            "rounds": [game_round.to_dict() for game_round in game.rounds],
+            "rounds": [_host_round(game_round, answer_type) for game_round in game.rounds],
         }
 
     async def _get_join_url(self) -> str:
@@ -1065,11 +1065,30 @@ def _answer_window(game: MusicQuizGame, game_round: MusicQuizRound) -> float:
     return answer_window
 
 
+def _host_round(
+    game_round: MusicQuizRound,
+    answer_type: QuizAnswerType,
+) -> dict[str, SerializableType]:
+    """Return the host-visible flat representation of a round."""
+    return {
+        "round_index": game_round.round_index,
+        "answer_label": game_round.answer_label,
+        **answer_type.serialize_host_round(game_round.answer_state),
+        "track_uri": game_round.track_uri,
+        "question": game_round.question,
+        "image_url": game_round.image_url,
+        "duration": game_round.duration,
+        "started_at": game_round.started_at,
+        "ended_at": game_round.ended_at,
+    }
+
+
 def _public_state(game: MusicQuizGame, mode: str, answer_type: QuizAnswerType) -> dict[str, Any]:
     """Return the guest-safe public game state (see the module docstring)."""
     current_round = (
         game.rounds[game.current_round_index] if game.current_round_index is not None else None
     )
+    answer_state = current_round.answer_state if current_round else None
     revealed = game.phase in (MusicQuizPhase.REVEAL, MusicQuizPhase.FINISHED)
     players = []
     for player in sorted(game.players.values(), key=lambda item: item.joined_at):
@@ -1078,7 +1097,7 @@ def _public_state(game: MusicQuizGame, mode: str, answer_type: QuizAnswerType) -
             "score": player.score,
             "ready": player.ready,
             **answer_type.serialize_public_player(
-                current_round,
+                answer_state,
                 player.player_id,
                 revealed=revealed,
             ),
@@ -1118,7 +1137,7 @@ def _public_round(
         "started_at": game_round.started_at,
         "deadline": (game_round.started_at or 0) + _answer_window(game, game_round),
         "question": game_round.question,
-        **answer_type.serialize_round(game_round, revealed=revealed),
+        **answer_type.serialize_round(game_round.answer_state, revealed=revealed),
     }
     if revealed:
         state["answer_label"] = game_round.answer_label
@@ -1139,6 +1158,7 @@ def _player_state(
     current_round = (
         game.rounds[game.current_round_index] if game.current_round_index is not None else None
     )
+    answer_state = current_round.answer_state if current_round else None
     revealed = game.phase in (MusicQuizPhase.REVEAL, MusicQuizPhase.FINISHED)
     you: dict[str, Any] = {
         "name": player.name,
@@ -1146,7 +1166,7 @@ def _player_state(
         "ready": player.ready,
         "active_from_round": player.active_from_round,
         **answer_type.serialize_personal_player(
-            current_round,
+            answer_state,
             player.player_id,
             revealed=revealed,
         ),

--- a/music_assistant/providers/music_quiz/answer_types/base.py
+++ b/music_assistant/providers/music_quiz/answer_types/base.py
@@ -12,7 +12,7 @@ from music_assistant.providers.music_quiz.models import (
     MusicQuizAnswerType,
     MusicQuizGame,
     MusicQuizPlayer,
-    MusicQuizRound,
+    QuizRoundAnswerState,
 )
 
 
@@ -38,19 +38,19 @@ class QuizAnswerType(ABC):
         """
 
     @abstractmethod
-    def validate_round(self, game: MusicQuizGame, game_round: MusicQuizRound) -> None:
+    def validate_round(self, game: MusicQuizGame, state: QuizRoundAnswerState) -> None:
         """
         Validate answer-specific round requirements.
 
         :param game: Game the round belongs to.
-        :param game_round: Prepared round to validate.
+        :param state: Prepared answer state to validate.
         """
 
     @abstractmethod
     def submit(
         self,
         game: MusicQuizGame,
-        game_round: MusicQuizRound,
+        state: QuizRoundAnswerState,
         player: MusicQuizPlayer,
         submission: QuizAnswerSubmission,
         submitted_at: float,
@@ -59,58 +59,67 @@ class QuizAnswerType(ABC):
         Apply one validated player submission.
 
         :param game: Game receiving the submission.
-        :param game_round: Current answering round.
+        :param state: Current round answer state.
         :param player: Player submitting the answer.
         :param submission: Validated answer submission.
         :param submitted_at: Server timestamp of the submission.
         """
 
     @abstractmethod
-    def is_player_complete(self, game_round: MusicQuizRound, player_id: str) -> bool:
+    def is_player_complete(self, state: QuizRoundAnswerState, player_id: str) -> bool:
         """
         Return whether a player completed the answer requirements.
 
-        :param game_round: Round to inspect.
+        :param state: Round answer state to inspect.
         :param player_id: Player to inspect.
         """
 
     @abstractmethod
     def is_round_complete(
         self,
-        game_round: MusicQuizRound,
+        state: QuizRoundAnswerState,
         active_players: Collection[MusicQuizPlayer],
     ) -> bool:
         """
         Return whether every active player completed the round.
 
-        :param game_round: Round to inspect.
+        :param state: Round answer state to inspect.
         :param active_players: Players eligible for the round.
         """
 
     @abstractmethod
-    def reveal(self, game: MusicQuizGame, game_round: MusicQuizRound) -> None:
+    def reveal(self, game: MusicQuizGame, state: QuizRoundAnswerState) -> float | None:
         """
         Finalize answer state and apply scoring.
 
         :param game: Game being revealed.
-        :param game_round: Round being revealed.
+        :param state: Round answer state being revealed.
+        :return: Timestamp of the latest submitted answer, if any.
+        """
+
+    @abstractmethod
+    def serialize_host_round(self, state: QuizRoundAnswerState) -> dict[str, SerializableType]:
+        """
+        Serialize answer state for the host's flat round payload.
+
+        :param state: Round answer state to serialize.
         """
 
     @abstractmethod
     def serialize_round(
-        self, game_round: MusicQuizRound, *, revealed: bool
+        self, state: QuizRoundAnswerState, *, revealed: bool
     ) -> dict[str, SerializableType]:
         """
         Serialize answer-specific round state.
 
-        :param game_round: Round to serialize.
+        :param state: Round answer state to serialize.
         :param revealed: Whether protected answer data may be exposed.
         """
 
     @abstractmethod
     def serialize_public_player(
         self,
-        game_round: MusicQuizRound | None,
+        state: QuizRoundAnswerState | None,
         player_id: str,
         *,
         revealed: bool,
@@ -118,7 +127,7 @@ class QuizAnswerType(ABC):
         """
         Serialize answer progress safe for every guest.
 
-        :param game_round: Current round, if one exists.
+        :param state: Current round answer state, if one exists.
         :param player_id: Player represented by the public entry.
         :param revealed: Whether protected answer data may be exposed.
         """
@@ -126,7 +135,7 @@ class QuizAnswerType(ABC):
     @abstractmethod
     def serialize_personal_player(
         self,
-        game_round: MusicQuizRound | None,
+        state: QuizRoundAnswerState | None,
         player_id: str,
         *,
         revealed: bool,
@@ -134,7 +143,7 @@ class QuizAnswerType(ABC):
         """
         Serialize answer state visible to its submitting player.
 
-        :param game_round: Current round, if one exists.
+        :param state: Current round answer state, if one exists.
         :param player_id: Player receiving the state.
         :param revealed: Whether protected answer data may be exposed.
         """

--- a/music_assistant/providers/music_quiz/answer_types/multiple_choice.py
+++ b/music_assistant/providers/music_quiz/answer_types/multiple_choice.py
@@ -19,11 +19,12 @@ from music_assistant.providers.music_quiz.errors import (
     MusicQuizUnknownSuggestionError,
 )
 from music_assistant.providers.music_quiz.models import (
-    MusicQuizAnswer,
+    MultipleChoiceAnswer,
+    MultipleChoiceRoundState,
     MusicQuizAnswerType,
     MusicQuizGame,
     MusicQuizPlayer,
-    MusicQuizRound,
+    QuizRoundAnswerState,
 )
 from music_assistant.providers.music_quiz.scoring import calculate_linear_scores
 
@@ -41,7 +42,7 @@ class MultipleChoiceAnswerType(QuizAnswerType):
 
     answer_type = MusicQuizAnswerType.MULTIPLE_CHOICE
 
-    def parse_submission(self, payload: dict[str, object]) -> MultipleChoiceSubmission:
+    def parse_submission(self, payload: dict[str, object]) -> QuizAnswerSubmission:
         """
         Parse a multiple-choice submission.
 
@@ -61,22 +62,23 @@ class MultipleChoiceAnswerType(QuizAnswerType):
             raise MusicQuizInvalidAnswerError("Suggestion ID must be a non-empty string")
         return MultipleChoiceSubmission(suggestion_id=suggestion_id)
 
-    def validate_round(self, game: MusicQuizGame, game_round: MusicQuizRound) -> None:
+    def validate_round(self, game: MusicQuizGame, state: QuizRoundAnswerState) -> None:
         """
         Validate a multiple-choice round.
 
         :param game: Game the round belongs to.
-        :param game_round: Prepared round to validate.
+        :param state: Prepared answer state to validate.
         """
-        if sum(1 for suggestion in game_round.suggestions if suggestion.is_correct) != 1:
+        multiple_choice_state = self._get_state(state)
+        if sum(1 for suggestion in multiple_choice_state.suggestions if suggestion.is_correct) != 1:
             raise InvalidDataError("Round requires exactly one correct suggestion")
-        if len(game_round.suggestions) != game.config.suggestion_count:
+        if len(multiple_choice_state.suggestions) != game.config.suggestion_count:
             raise InvalidDataError("Round suggestion count does not match the game config")
 
     def submit(
         self,
         game: MusicQuizGame,
-        game_round: MusicQuizRound,
+        state: QuizRoundAnswerState,
         player: MusicQuizPlayer,
         submission: QuizAnswerSubmission,
         submitted_at: float,
@@ -85,108 +87,145 @@ class MultipleChoiceAnswerType(QuizAnswerType):
         Lock a player's first multiple-choice selection.
 
         :param game: Game receiving the submission.
-        :param game_round: Current answering round.
+        :param state: Current round answer state.
         :param player: Player submitting the answer.
         :param submission: Validated multiple-choice selection.
         :param submitted_at: Server timestamp of the submission.
         """
+        multiple_choice_state = self._get_state(state)
         if not isinstance(submission, MultipleChoiceSubmission):
             raise MusicQuizInvalidAnswerError(
                 "Submission does not match the multiple-choice answer type"
             )
-        if player.player_id in game_round.answers:
+        if player.player_id in multiple_choice_state.answers:
             raise MusicQuizAlreadyAnsweredError("Player already answered this round")
         suggestion = next(
             (
                 item
-                for item in game_round.suggestions
+                for item in multiple_choice_state.suggestions
                 if item.suggestion_id == submission.suggestion_id
             ),
             None,
         )
         if suggestion is None:
             raise MusicQuizUnknownSuggestionError("Unknown suggestion")
-        game_round.answers[player.player_id] = MusicQuizAnswer(
+        multiple_choice_state.answers[player.player_id] = MultipleChoiceAnswer(
             player_id=player.player_id,
             suggestion_id=submission.suggestion_id,
             answered_at=submitted_at,
             is_correct=suggestion.is_correct,
         )
 
-    def is_player_complete(self, game_round: MusicQuizRound, player_id: str) -> bool:
+    def is_player_complete(self, state: QuizRoundAnswerState, player_id: str) -> bool:
         """
         Return whether a player locked a selection.
 
-        :param game_round: Round to inspect.
+        :param state: Round answer state to inspect.
         :param player_id: Player to inspect.
         """
-        return player_id in game_round.answers
+        multiple_choice_state = self._get_state(state)
+        return player_id in multiple_choice_state.answers
 
     def is_round_complete(
         self,
-        game_round: MusicQuizRound,
+        state: QuizRoundAnswerState,
         active_players: Collection[MusicQuizPlayer],
     ) -> bool:
         """
         Return whether every active player locked a selection.
 
-        :param game_round: Round to inspect.
+        :param state: Round answer state to inspect.
         :param active_players: Players eligible for the round.
         """
+        multiple_choice_state = self._get_state(state)
         return bool(active_players) and all(
-            self.is_player_complete(game_round, player.player_id) for player in active_players
+            player.player_id in multiple_choice_state.answers for player in active_players
         )
 
-    def reveal(self, game: MusicQuizGame, game_round: MusicQuizRound) -> None:
+    def reveal(self, game: MusicQuizGame, state: QuizRoundAnswerState) -> float | None:
         """
         Score correct selections by submission speed.
 
         :param game: Game being revealed.
-        :param game_round: Round being revealed.
+        :param state: Round answer state being revealed.
+        :return: Timestamp of the latest submitted answer, if any.
         """
+        multiple_choice_state = self._get_state(state)
         correct_answer_order = [
             answer.player_id
-            for answer in sorted(game_round.answers.values(), key=lambda item: item.answered_at)
+            for answer in sorted(
+                multiple_choice_state.answers.values(), key=lambda item: item.answered_at
+            )
             if answer.is_correct
         ]
         scores = calculate_linear_scores(correct_answer_order)
-        for answer in game_round.answers.values():
+        for answer in multiple_choice_state.answers.values():
             answer.points = scores.get(answer.player_id, 0)
             game.players[answer.player_id].score += answer.points
-        game_round.ended_at = max(
-            [answer.answered_at for answer in game_round.answers.values()],
-            default=game_round.started_at or 0,
+        return max(
+            (answer.answered_at for answer in multiple_choice_state.answers.values()),
+            default=None,
         )
 
+    def serialize_host_round(self, state: QuizRoundAnswerState) -> dict[str, SerializableType]:
+        """
+        Serialize multiple-choice state for the host's flat round payload.
+
+        :param state: Round answer state to serialize.
+        """
+        multiple_choice_state = self._get_state(state)
+        return {
+            "suggestions": [
+                {
+                    "suggestion_id": suggestion.suggestion_id,
+                    "label": suggestion.label,
+                    "uri": suggestion.uri,
+                    "is_correct": suggestion.is_correct,
+                }
+                for suggestion in multiple_choice_state.suggestions
+            ],
+            "answers": {
+                player_id: {
+                    "player_id": answer.player_id,
+                    "suggestion_id": answer.suggestion_id,
+                    "answered_at": answer.answered_at,
+                    "is_correct": answer.is_correct,
+                    "points": answer.points,
+                }
+                for player_id, answer in multiple_choice_state.answers.items()
+            },
+        }
+
     def serialize_round(
-        self, game_round: MusicQuizRound, *, revealed: bool
+        self, state: QuizRoundAnswerState, *, revealed: bool
     ) -> dict[str, SerializableType]:
         """
         Serialize multiple-choice round state.
 
-        :param game_round: Round to serialize.
+        :param state: Round answer state to serialize.
         :param revealed: Whether protected answer data may be exposed.
         """
-        state: dict[str, SerializableType] = {
+        multiple_choice_state = self._get_state(state)
+        serialized_state: dict[str, SerializableType] = {
             "suggestions": [
                 {"suggestion_id": suggestion.suggestion_id, "label": suggestion.label}
-                for suggestion in game_round.suggestions
+                for suggestion in multiple_choice_state.suggestions
             ]
         }
         if revealed:
-            state["correct_suggestion_id"] = next(
+            serialized_state["correct_suggestion_id"] = next(
                 (
                     suggestion.suggestion_id
-                    for suggestion in game_round.suggestions
+                    for suggestion in multiple_choice_state.suggestions
                     if suggestion.is_correct
                 ),
                 None,
             )
-        return state
+        return serialized_state
 
     def serialize_public_player(
         self,
-        game_round: MusicQuizRound | None,
+        state: QuizRoundAnswerState | None,
         player_id: str,
         *,
         revealed: bool,
@@ -194,23 +233,26 @@ class MultipleChoiceAnswerType(QuizAnswerType):
         """
         Serialize a player's public multiple-choice progress.
 
-        :param game_round: Current round, if one exists.
+        :param state: Current round answer state, if one exists.
         :param player_id: Player represented by the public entry.
         :param revealed: Whether protected answer data may be exposed.
         """
-        answer = game_round.answers.get(player_id) if game_round else None
-        state: dict[str, SerializableType] = {"answered": answer is not None}
+        if state is None:
+            return {"answered": False}
+        multiple_choice_state = self._get_state(state)
+        answer = multiple_choice_state.answers.get(player_id)
+        serialized_state: dict[str, SerializableType] = {"answered": answer is not None}
         if revealed and answer:
-            state["last_answer"] = {
+            serialized_state["last_answer"] = {
                 "suggestion_id": answer.suggestion_id,
                 "correct": answer.is_correct,
                 "points": answer.points,
             }
-        return state
+        return serialized_state
 
     def serialize_personal_player(
         self,
-        game_round: MusicQuizRound | None,
+        state: QuizRoundAnswerState | None,
         player_id: str,
         *,
         revealed: bool,
@@ -218,11 +260,14 @@ class MultipleChoiceAnswerType(QuizAnswerType):
         """
         Serialize a player's personal multiple-choice answer.
 
-        :param game_round: Current round, if one exists.
+        :param state: Current round answer state, if one exists.
         :param player_id: Player receiving the state.
         :param revealed: Whether protected answer data may be exposed.
         """
-        answer = game_round.answers.get(player_id) if game_round else None
+        if state is None:
+            return {}
+        multiple_choice_state = self._get_state(state)
+        answer = multiple_choice_state.answers.get(player_id)
         if answer is None:
             return {}
         serialized_answer: dict[str, SerializableType] = {
@@ -232,3 +277,9 @@ class MultipleChoiceAnswerType(QuizAnswerType):
         if revealed:
             serialized_answer.update(correct=answer.is_correct, points=answer.points)
         return {"answer": serialized_answer}
+
+    def _get_state(self, state: QuizRoundAnswerState) -> MultipleChoiceRoundState:
+        """Return validated multiple-choice round state."""
+        if state.answer_type != self.answer_type or not isinstance(state, MultipleChoiceRoundState):
+            raise InvalidDataError("Round state does not match the multiple-choice answer type")
+        return state

--- a/music_assistant/providers/music_quiz/game.py
+++ b/music_assistant/providers/music_quiz/game.py
@@ -64,7 +64,7 @@ def submit_answer(
     player = game.players[player_id]
     if player.active_from_round > current_round.round_index:
         raise MusicQuizNotActiveThisRoundError("Player is not active for this round")
-    answer_type.submit(game, current_round, player, submission, submitted_at)
+    answer_type.submit(game, current_round.answer_state, player, submission, submitted_at)
 
 
 def reveal_round(game: MusicQuizGame, answer_type: QuizAnswerType) -> None:
@@ -77,7 +77,10 @@ def reveal_round(game: MusicQuizGame, answer_type: QuizAnswerType) -> None:
     current_round = get_current_round(game)
     if game.phase != MusicQuizPhase.ANSWERING:
         raise MusicQuizWrongPhaseError("Round can only be revealed during the answering phase")
-    answer_type.reveal(game, current_round)
+    answer_timestamp = answer_type.reveal(game, current_round.answer_state)
+    current_round.ended_at = (
+        answer_timestamp if answer_timestamp is not None else current_round.started_at or 0
+    )
     game.phase = MusicQuizPhase.REVEAL
     for player in game.players.values():
         player.ready = False
@@ -104,7 +107,7 @@ def start_round(
     expected_index = len(game.rounds)
     if music_quiz_round.round_index != expected_index:
         raise InvalidDataError("Round index does not match the game state")
-    answer_type.validate_round(game, music_quiz_round)
+    answer_type.validate_round(game, music_quiz_round.answer_state)
     music_quiz_round.started_at = started_at
     music_quiz_round.ended_at = None
     game.rounds.append(music_quiz_round)
@@ -154,7 +157,7 @@ def all_active_players_complete(game: MusicQuizGame, answer_type: QuizAnswerType
         return False
     current_round = get_current_round(game)
     players = active_players_for_round(game, current_round.round_index)
-    return answer_type.is_round_complete(current_round, players)
+    return answer_type.is_round_complete(current_round.answer_state, players)
 
 
 def finish_game(game: MusicQuizGame) -> None:

--- a/music_assistant/providers/music_quiz/models.py
+++ b/music_assistant/providers/music_quiz/models.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import Literal
 
 from mashumaro import DataClassDictMixin
+from mashumaro.config import BaseConfig
+from mashumaro.types import Discriminator
 
 
 class MusicQuizPhase(StrEnum):
@@ -70,24 +73,59 @@ class MusicQuizPlayer(DataClassDictMixin):
 
 
 @dataclass
-class MusicQuizSuggestion(DataClassDictMixin):
-    """A possible answer for a Music Quiz round."""
+class QuizRoundAnswerState(DataClassDictMixin):
+    """Answer state persisted for a Music Quiz round."""
+
+    answer_type: MusicQuizAnswerType
+
+    class Config(BaseConfig):
+        """Mashumaro configuration."""
+
+        discriminator = Discriminator(field="answer_type", include_subtypes=True)
+        forbid_extra_keys = True
+
+
+@dataclass
+class MultipleChoiceSuggestion(DataClassDictMixin):
+    """A possible answer for a multiple-choice round."""
 
     suggestion_id: str
     label: str
     uri: str | None = None
     is_correct: bool = False
 
+    class Config(BaseConfig):
+        """Mashumaro configuration."""
+
+        forbid_extra_keys = True
+
 
 @dataclass
-class MusicQuizAnswer(DataClassDictMixin):
-    """A locked player answer for a Music Quiz round."""
+class MultipleChoiceAnswer(DataClassDictMixin):
+    """A locked player answer for a multiple-choice round."""
 
     player_id: str
     suggestion_id: str
     answered_at: float
     is_correct: bool
     points: int = 0
+
+    class Config(BaseConfig):
+        """Mashumaro configuration."""
+
+        forbid_extra_keys = True
+
+
+@dataclass
+class MultipleChoiceRoundState(QuizRoundAnswerState):
+    """Persisted state for a multiple-choice round."""
+
+    answer_type: Literal[MusicQuizAnswerType.MULTIPLE_CHOICE] = field(
+        default=MusicQuizAnswerType.MULTIPLE_CHOICE,
+        init=False,
+    )
+    suggestions: list[MultipleChoiceSuggestion]
+    answers: dict[str, MultipleChoiceAnswer] = field(default_factory=dict)
 
 
 @dataclass
@@ -96,7 +134,7 @@ class MusicQuizRound(DataClassDictMixin):
 
     round_index: int
     answer_label: str
-    suggestions: list[MusicQuizSuggestion]
+    answer_state: QuizRoundAnswerState
     # a round plays a track (audio round) and/or poses a text question;
     # non-audio quiz types leave track_uri unset
     track_uri: str | None = None
@@ -105,7 +143,11 @@ class MusicQuizRound(DataClassDictMixin):
     duration: float | None = None
     started_at: float | None = None
     ended_at: float | None = None
-    answers: dict[str, MusicQuizAnswer] = field(default_factory=dict)
+
+    class Config(BaseConfig):
+        """Mashumaro configuration."""
+
+        forbid_extra_keys = True
 
 
 @dataclass

--- a/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
+++ b/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
@@ -13,6 +13,7 @@ from music_assistant_models.media_items import Playlist, Track
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
 from music_assistant.providers.music_quiz.models import (
+    MultipleChoiceRoundState,
     MusicQuizAnswerType,
     MusicQuizDifficulty,
     MusicQuizRound,
@@ -86,7 +87,7 @@ class GuessTheSongQuizType(QuizType):
             round_index=round_index,
             track_uri=track.uri,
             answer_label=correct.label,
-            suggestions=suggestions,
+            answer_state=MultipleChoiceRoundState(suggestions=suggestions),
             image_url=await self.mass.metadata.get_image_url_for_item(track),
             duration=track.duration,
         )

--- a/music_assistant/providers/music_quiz/suggestions.py
+++ b/music_assistant/providers/music_quiz/suggestions.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 
-from music_assistant.providers.music_quiz.models import MusicQuizSuggestion
+from music_assistant.providers.music_quiz.models import MultipleChoiceSuggestion
 
 # collapse runs of non-word characters and underscores so filename-style titles
 # ("Foo_Bar") normalize like their spaced form ("Foo Bar"); \W keeps this
@@ -122,7 +122,7 @@ def build_suggestions(
     suggestion_count: int,
     *,
     rng: random.Random | None = None,
-) -> list[MusicQuizSuggestion]:
+) -> list[MultipleChoiceSuggestion]:
     """
     Build shuffled suggestions containing exactly one correct answer.
 
@@ -139,14 +139,14 @@ def build_suggestions(
     # suggestion IDs are sent to guests while the answer is still secret: they
     # must be opaque, never semantic ("correct"/"wrong_x" would leak the answer)
     suggestions = [
-        MusicQuizSuggestion(
+        MultipleChoiceSuggestion(
             suggestion_id=secrets.token_hex(8),
             label=correct.label,
             uri=correct.uri,
             is_correct=True,
         ),
         *[
-            MusicQuizSuggestion(
+            MultipleChoiceSuggestion(
                 suggestion_id=secrets.token_hex(8),
                 label=candidate.label,
                 uri=candidate.uri,

--- a/tests/providers/music_quiz/test_game.py
+++ b/tests/providers/music_quiz/test_game.py
@@ -26,13 +26,14 @@ from music_assistant.providers.music_quiz.game import (
     submit_answer,
 )
 from music_assistant.providers.music_quiz.models import (
+    MultipleChoiceRoundState,
+    MultipleChoiceSuggestion,
     MusicQuizAnswerType,
     MusicQuizConfig,
     MusicQuizGame,
     MusicQuizPhase,
     MusicQuizPlayer,
     MusicQuizRound,
-    MusicQuizSuggestion,
 )
 
 ANSWER_TYPE = MultipleChoiceAnswerType()
@@ -61,17 +62,19 @@ def _game() -> MusicQuizGame:
                 round_index=0,
                 track_uri="library://track/1",
                 answer_label="Daft Punk - One More Time",
-                suggestions=[
-                    MusicQuizSuggestion(
-                        suggestion_id="correct",
-                        label="Daft Punk - One More Time",
-                        is_correct=True,
-                    ),
-                    MusicQuizSuggestion(
-                        suggestion_id="wrong_1",
-                        label="Justice - D.A.N.C.E.",
-                    ),
-                ],
+                answer_state=MultipleChoiceRoundState(
+                    suggestions=[
+                        MultipleChoiceSuggestion(
+                            suggestion_id="correct",
+                            label="Daft Punk - One More Time",
+                            is_correct=True,
+                        ),
+                        MultipleChoiceSuggestion(
+                            suggestion_id="wrong_1",
+                            label="Justice - D.A.N.C.E.",
+                        ),
+                    ]
+                ),
             )
         ],
     )
@@ -109,14 +112,16 @@ def test_start_round_requires_exactly_one_correct_suggestion() -> None:
             round_index=0,
             track_uri="library://track/1",
             answer_label="Daft Punk - One More Time",
-            suggestions=[
-                MusicQuizSuggestion(
-                    suggestion_id=f"s{index}",
-                    label=f"Suggestion {index}",
-                    is_correct=flag,
-                )
-                for index, flag in enumerate(correct_flags)
-            ],
+            answer_state=MultipleChoiceRoundState(
+                suggestions=[
+                    MultipleChoiceSuggestion(
+                        suggestion_id=f"s{index}",
+                        label=f"Suggestion {index}",
+                        is_correct=flag,
+                    )
+                    for index, flag in enumerate(correct_flags)
+                ]
+            ),
         )
 
     with pytest.raises(InvalidDataError, match="exactly one correct"):
@@ -179,7 +184,7 @@ def test_submit_answer_locks_first_answer() -> None:
         10,
         ANSWER_TYPE,
     )
-    answer = game.rounds[0].answers["p1"]
+    answer = _answer_state(game.rounds[0]).answers["p1"]
 
     assert answer.suggestion_id == "wrong_1"
     assert answer.is_correct is False
@@ -282,10 +287,12 @@ def test_reveal_round_applies_scores_to_correct_answers_in_order() -> None:
     reveal_round(game, ANSWER_TYPE)
 
     current_round = game.rounds[0]
+    answers = _answer_state(current_round).answers
     assert game.phase == MusicQuizPhase.REVEAL
-    assert current_round.answers["p2"].points == 1000
-    assert current_round.answers["p3"].points == 500
-    assert current_round.answers["p1"].points == 0
+    assert answers["p2"].points == 1000
+    assert answers["p3"].points == 500
+    assert answers["p1"].points == 0
+    assert current_round.ended_at == 12
     assert game.players["p2"].score == 1000
     assert game.players["p3"].score == 500
     assert game.players["p1"].score == 0
@@ -325,3 +332,19 @@ def test_reset_game_keeps_players_and_config_for_new_game() -> None:
     assert all(player.score == 0 for player in game.players.values())
     assert all(player.ready is False for player in game.players.values())
     assert all(player.active_from_round == 0 for player in game.players.values())
+
+
+def test_reveal_round_uses_start_time_when_no_answers_exist() -> None:
+    """Use the common round start time when an answer type has no timestamp."""
+    game = _game()
+    game.rounds[0].started_at = 5
+
+    reveal_round(game, ANSWER_TYPE)
+
+    assert game.rounds[0].ended_at == 5
+
+
+def _answer_state(game_round: MusicQuizRound) -> MultipleChoiceRoundState:
+    """Return multiple-choice state from a test round."""
+    assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+    return game_round.answer_state

--- a/tests/providers/music_quiz/test_guess_the_song.py
+++ b/tests/providers/music_quiz/test_guess_the_song.py
@@ -11,7 +11,10 @@ from music_assistant_models.media_items import ItemMapping, ProviderMapping, Tra
 from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.models.plugin import PluginProvider
-from music_assistant.providers.music_quiz.models import MusicQuizConfig
+from music_assistant.providers.music_quiz.models import (
+    MultipleChoiceRoundState,
+    MusicQuizConfig,
+)
 from music_assistant.providers.music_quiz.quiz_types.guess_the_song import GuessTheSongQuizType
 from music_assistant.providers.music_quiz.suggestions import SuggestionCandidate
 
@@ -279,6 +282,8 @@ async def test_prepare_round_builds_suggestions_from_similar_tracks() -> None:
     game_round = await quiz_type.prepare_round(0, [])
 
     assert game_round.track_uri == correct_track.uri
-    assert len(game_round.suggestions) == 4
-    assert sum(item.is_correct for item in game_round.suggestions) == 1
-    assert [item.label for item in game_round.suggestions if item.is_correct] == [CORRECT_LABEL]
+    assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+    suggestions = game_round.answer_state.suggestions
+    assert len(suggestions) == 4
+    assert sum(item.is_correct for item in suggestions) == 1
+    assert [item.label for item in suggestions if item.is_correct] == [CORRECT_LABEL]

--- a/tests/providers/music_quiz/test_models.py
+++ b/tests/providers/music_quiz/test_models.py
@@ -1,0 +1,202 @@
+"""Tests for Music Quiz persisted models."""
+
+from __future__ import annotations
+
+import inspect
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from mashumaro.exceptions import ExtraKeysError, InvalidFieldValue
+
+from music_assistant.providers.music_quiz.models import (
+    MultipleChoiceAnswer,
+    MultipleChoiceRoundState,
+    MultipleChoiceSuggestion,
+    MusicQuizAnswerType,
+    MusicQuizRound,
+)
+
+
+def test_round_answer_state_round_trips_with_discriminator() -> None:
+    """Round-trip strict multiple-choice state through the common round model."""
+    game_round = MusicQuizRound(
+        round_index=0,
+        answer_label="Daft Punk - One More Time",
+        answer_state=MultipleChoiceRoundState(
+            suggestions=[
+                MultipleChoiceSuggestion(
+                    suggestion_id="correct",
+                    label="Daft Punk - One More Time",
+                    uri="library://track/1",
+                    is_correct=True,
+                )
+            ],
+            answers={
+                "p1": MultipleChoiceAnswer(
+                    player_id="p1",
+                    suggestion_id="correct",
+                    answered_at=12.0,
+                    is_correct=True,
+                    points=1000,
+                )
+            },
+        ),
+        track_uri="library://track/1",
+        image_url="https://example.test/artwork.jpg",
+        duration=180.0,
+        started_at=10.0,
+        ended_at=12.0,
+    )
+
+    serialized = game_round.to_dict()
+    restored = MusicQuizRound.from_dict(serialized)
+
+    assert serialized == {
+        "round_index": 0,
+        "answer_label": "Daft Punk - One More Time",
+        "answer_state": {
+            "answer_type": "multiple_choice",
+            "suggestions": [
+                {
+                    "suggestion_id": "correct",
+                    "label": "Daft Punk - One More Time",
+                    "uri": "library://track/1",
+                    "is_correct": True,
+                }
+            ],
+            "answers": {
+                "p1": {
+                    "player_id": "p1",
+                    "suggestion_id": "correct",
+                    "answered_at": 12.0,
+                    "is_correct": True,
+                    "points": 1000,
+                }
+            },
+        },
+        "track_uri": "library://track/1",
+        "question": None,
+        "image_url": "https://example.test/artwork.jpg",
+        "duration": 180.0,
+        "started_at": 10.0,
+        "ended_at": 12.0,
+    }
+    assert restored == game_round
+    assert isinstance(restored.answer_state, MultipleChoiceRoundState)
+    assert restored.answer_state.answer_type is MusicQuizAnswerType.MULTIPLE_CHOICE
+
+
+@pytest.mark.parametrize(
+    "answer_state",
+    [
+        {
+            "suggestions": [],
+            "answers": {},
+        },
+        {
+            "answer_type": "timeline",
+            "suggestions": [],
+            "answers": {},
+        },
+        {
+            "answer_type": "multiple_choice",
+            "suggestions": [],
+            "answers": {},
+            "extra": True,
+        },
+        {
+            "answer_type": "multiple_choice",
+            "suggestions": [
+                {
+                    "suggestion_id": "correct",
+                    "label": "Correct",
+                    "uri": None,
+                    "is_correct": True,
+                    "extra": True,
+                }
+            ],
+            "answers": {},
+        },
+        {
+            "answer_type": "multiple_choice",
+            "suggestions": [],
+            "answers": {
+                "p1": {
+                    "player_id": "p1",
+                    "suggestion_id": "correct",
+                    "answered_at": 12.0,
+                    "is_correct": True,
+                    "points": 1000,
+                    "extra": True,
+                }
+            },
+        },
+    ],
+)
+def test_round_answer_state_rejects_invalid_nested_data(
+    answer_state: dict[str, object],
+) -> None:
+    """Reject missing, unknown, and extra nested answer-state data."""
+    with pytest.raises(InvalidFieldValue):
+        MusicQuizRound.from_dict(
+            {
+                "round_index": 0,
+                "answer_label": "Correct",
+                "answer_state": answer_state,
+            }
+        )
+
+
+def test_round_rejects_extra_common_data() -> None:
+    """Reject unknown fields on the common persisted round."""
+    with pytest.raises(ExtraKeysError):
+        MusicQuizRound.from_dict(
+            {
+                "round_index": 0,
+                "answer_label": "Correct",
+                "answer_state": {
+                    "answer_type": "multiple_choice",
+                    "suggestions": [],
+                    "answers": {},
+                },
+                "extra": True,
+            }
+        )
+
+
+def test_round_deserializes_without_importing_answer_strategy() -> None:
+    """Deserialize the model module without answer-strategy registration."""
+    models_path = Path(inspect.getfile(MusicQuizRound))
+    script = f"""
+import importlib.util
+import sys
+
+module_name = "_music_quiz_models_clean_import"
+spec = importlib.util.spec_from_file_location(module_name, {str(models_path)!r})
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[module_name] = module
+spec.loader.exec_module(module)
+assert "music_assistant.providers.music_quiz.answer_types.multiple_choice" not in sys.modules
+game_round = module.MusicQuizRound.from_dict(
+    {{
+        "round_index": 0,
+        "answer_label": "Correct",
+        "answer_state": {{
+            "answer_type": "multiple_choice",
+            "suggestions": [],
+            "answers": {{}},
+        }},
+    }}
+)
+assert isinstance(game_round.answer_state, module.MultipleChoiceRoundState)
+"""
+
+    subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )

--- a/tests/providers/music_quiz/test_multiple_choice.py
+++ b/tests/providers/music_quiz/test_multiple_choice.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.providers.music_quiz.answer_types.multiple_choice import (
     MultipleChoiceAnswerType,
@@ -10,34 +11,30 @@ from music_assistant.providers.music_quiz.answer_types.multiple_choice import (
 )
 from music_assistant.providers.music_quiz.errors import MusicQuizInvalidAnswerError
 from music_assistant.providers.music_quiz.models import (
-    MusicQuizAnswer,
-    MusicQuizRound,
-    MusicQuizSuggestion,
+    MultipleChoiceAnswer,
+    MultipleChoiceRoundState,
+    MultipleChoiceSuggestion,
+    MusicQuizAnswerType,
+    QuizRoundAnswerState,
 )
 
 ANSWER_TYPE = MultipleChoiceAnswerType()
 
 
-def _round() -> MusicQuizRound:
-    """Return a multiple-choice round."""
-    return MusicQuizRound(
-        round_index=0,
-        track_uri="library://track/1",
-        answer_label="Daft Punk - One More Time",
+def _state() -> MultipleChoiceRoundState:
+    """Return multiple-choice round state."""
+    return MultipleChoiceRoundState(
         suggestions=[
-            MusicQuizSuggestion(
+            MultipleChoiceSuggestion(
                 suggestion_id="correct",
                 label="Daft Punk - One More Time",
                 is_correct=True,
             ),
-            MusicQuizSuggestion(
+            MultipleChoiceSuggestion(
                 suggestion_id="wrong",
                 label="Justice - D.A.N.C.E.",
             ),
         ],
-        image_url="https://example.test/artwork.jpg",
-        duration=180,
-        started_at=10,
     )
 
 
@@ -77,10 +74,10 @@ def test_parse_submission_rejects_malformed_payload(payload: dict[str, object]) 
 
 def test_round_serialization_redacts_answer_until_reveal() -> None:
     """Expose suggestion choices without revealing which one is correct."""
-    game_round = _round()
+    state = _state()
 
-    hidden = ANSWER_TYPE.serialize_round(game_round, revealed=False)
-    revealed = ANSWER_TYPE.serialize_round(game_round, revealed=True)
+    hidden = ANSWER_TYPE.serialize_round(state, revealed=False)
+    revealed = ANSWER_TYPE.serialize_round(state, revealed=True)
 
     assert hidden == {
         "suggestions": [
@@ -95,8 +92,8 @@ def test_round_serialization_redacts_answer_until_reveal() -> None:
 
 def test_player_serialization_separates_public_and_personal_state() -> None:
     """Keep a locked answer private and its correctness hidden before reveal."""
-    game_round = _round()
-    game_round.answers["p1"] = MusicQuizAnswer(
+    state = _state()
+    state.answers["p1"] = MultipleChoiceAnswer(
         player_id="p1",
         suggestion_id="correct",
         answered_at=12,
@@ -104,16 +101,14 @@ def test_player_serialization_separates_public_and_personal_state() -> None:
         points=1000,
     )
 
-    assert ANSWER_TYPE.serialize_public_player(game_round, "p1", revealed=False) == {
-        "answered": True
-    }
-    assert ANSWER_TYPE.serialize_personal_player(game_round, "p1", revealed=False) == {
+    assert ANSWER_TYPE.serialize_public_player(state, "p1", revealed=False) == {"answered": True}
+    assert ANSWER_TYPE.serialize_personal_player(state, "p1", revealed=False) == {
         "answer": {
             "suggestion_id": "correct",
             "answered_at": 12,
         }
     }
-    assert ANSWER_TYPE.serialize_public_player(game_round, "p1", revealed=True) == {
+    assert ANSWER_TYPE.serialize_public_player(state, "p1", revealed=True) == {
         "answered": True,
         "last_answer": {
             "suggestion_id": "correct",
@@ -121,7 +116,7 @@ def test_player_serialization_separates_public_and_personal_state() -> None:
             "points": 1000,
         },
     }
-    assert ANSWER_TYPE.serialize_personal_player(game_round, "p1", revealed=True) == {
+    assert ANSWER_TYPE.serialize_personal_player(state, "p1", revealed=True) == {
         "answer": {
             "suggestion_id": "correct",
             "answered_at": 12,
@@ -129,3 +124,49 @@ def test_player_serialization_separates_public_and_personal_state() -> None:
             "points": 1000,
         }
     }
+
+
+def test_host_serialization_preserves_full_flat_answer_state() -> None:
+    """Serialize full multiple-choice state for the host round payload."""
+    state = _state()
+    state.answers["p1"] = MultipleChoiceAnswer(
+        player_id="p1",
+        suggestion_id="correct",
+        answered_at=12,
+        is_correct=True,
+        points=1000,
+    )
+
+    assert ANSWER_TYPE.serialize_host_round(state) == {
+        "suggestions": [
+            {
+                "suggestion_id": "correct",
+                "label": "Daft Punk - One More Time",
+                "uri": None,
+                "is_correct": True,
+            },
+            {
+                "suggestion_id": "wrong",
+                "label": "Justice - D.A.N.C.E.",
+                "uri": None,
+                "is_correct": False,
+            },
+        ],
+        "answers": {
+            "p1": {
+                "player_id": "p1",
+                "suggestion_id": "correct",
+                "answered_at": 12,
+                "is_correct": True,
+                "points": 1000,
+            }
+        },
+    }
+
+
+def test_strategy_rejects_matching_discriminator_on_wrong_state_class() -> None:
+    """Reject state whose discriminator matches but concrete model does not."""
+    state = QuizRoundAnswerState(answer_type=MusicQuizAnswerType.MULTIPLE_CHOICE)
+
+    with pytest.raises(InvalidDataError, match="does not match"):
+        ANSWER_TYPE.serialize_round(state, revealed=False)

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -25,10 +25,11 @@ from music_assistant.providers.music_quiz.errors import (
     MusicQuizUnknownPlayerError,
 )
 from music_assistant.providers.music_quiz.models import (
+    MultipleChoiceRoundState,
+    MultipleChoiceSuggestion,
     MusicQuizGame,
     MusicQuizPhase,
     MusicQuizRound,
-    MusicQuizSuggestion,
 )
 
 INSTANCE_ID = "music_quiz--test"
@@ -60,13 +61,13 @@ LISTEN_IN_COMMANDS = (
 def _make_round(round_index: int, suggestion_count: int = 4) -> MusicQuizRound:
     """Return a deterministic prepared round for the given index."""
     suggestions = [
-        MusicQuizSuggestion(
+        MultipleChoiceSuggestion(
             suggestion_id=f"correct_{round_index}",
             label=f"Artist - Correct {round_index}",
             is_correct=True,
         )
     ] + [
-        MusicQuizSuggestion(
+        MultipleChoiceSuggestion(
             suggestion_id=f"wrong_{round_index}_{index}",
             label=f"Artist - Wrong {round_index}.{index}",
         )
@@ -76,7 +77,7 @@ def _make_round(round_index: int, suggestion_count: int = 4) -> MusicQuizRound:
         round_index=round_index,
         track_uri=f"library://track/{round_index}",
         answer_label=f"Artist - Correct {round_index}",
-        suggestions=suggestions,
+        answer_state=MultipleChoiceRoundState(suggestions=suggestions),
         image_url=f"https://img/{round_index}",
         duration=180.0,
     )
@@ -139,6 +140,12 @@ def _phase(plugin: MusicQuizPlugin) -> MusicQuizPhase:
     game = plugin._game
     assert game is not None
     return game.phase
+
+
+def _answer_state(game_round: MusicQuizRound) -> MultipleChoiceRoundState:
+    """Return multiple-choice state from a test round."""
+    assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+    return game_round.answer_state
 
 
 async def _create_started_game(
@@ -317,7 +324,7 @@ async def test_generic_submit_answer_rejects_invalid_payload(
 
     game = plugin._game
     assert game is not None
-    assert game.rounds[0].answers == {}
+    assert _answer_state(game.rounds[0]).answers == {}
     assert game.phase == MusicQuizPhase.ANSWERING
 
 
@@ -376,6 +383,18 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
     payload = signal.call_args[0][0]
     assert payload["event"] == "game_updated"
     state = payload["state"]
+    assert set(state) == {
+        "phase",
+        "name",
+        "quiz_type",
+        "answer_type",
+        "mode",
+        "round_count",
+        "suggestion_count",
+        "answer_duration",
+        "players",
+        "current_round",
+    }
     assert state["phase"] == "answering"
     assert state["quiz_type"] == "guess_the_song"
     assert state["answer_type"] == "multiple_choice"
@@ -403,6 +422,15 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
         personal_state = await plugin.answer(player_ids["Alice"], "correct_0")
 
     own_answer = personal_state["you"]["answer"]
+    assert set(personal_state) == {*state, "you"}
+    assert set(personal_state["you"]) == {
+        "name",
+        "score",
+        "ready",
+        "active_from_round",
+        "answer",
+    }
+    assert set(own_answer) == {"suggestion_id", "answered_at"}
     assert own_answer["suggestion_id"] == "correct_0"
     assert "correct" not in own_answer
     assert "points" not in own_answer
@@ -416,9 +444,25 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
     await plugin.reveal()
     state = signal.call_args[0][0]["state"]
     current_round = state["current_round"]
+    assert set(current_round) == {
+        "round_index",
+        "started_at",
+        "deadline",
+        "question",
+        "suggestions",
+        "correct_suggestion_id",
+        "answer_label",
+        "track_uri",
+        "image_url",
+        "duration",
+        "ended_at",
+    }
     assert current_round["correct_suggestion_id"] == "correct_0"
     assert current_round["track_uri"] == "library://track/0"
     assert current_round["answer_label"] == "Artist - Correct 0"
+    alice = next(player for player in state["players"] if player["name"] == "Alice")
+    assert set(alice) == {"name", "score", "ready", "answered", "last_answer"}
+    assert set(alice["last_answer"]) == {"suggestion_id", "correct", "points"}
 
 
 @pytest.mark.asyncio
@@ -457,6 +501,43 @@ async def test_create_and_get_expose_persisted_quiz_type() -> None:
     assert created["answer_type"] == game.answer_type
     assert (await plugin.get_game())["quiz_type"] == game.quiz_type
     assert (await plugin.get_game())["answer_type"] == game.answer_type
+
+
+@pytest.mark.asyncio
+async def test_host_rounds_preserve_flat_wire_shape() -> None:
+    """Keep nested persisted answer state flat in host round payloads."""
+    plugin = _create_plugin()
+    await _create_started_game(plugin, player_names=("Alice",))
+    game = plugin._game
+    assert game is not None
+    game_round = game.rounds[0]
+    answer_state = _answer_state(game_round)
+
+    host_state = await plugin.get_game()
+
+    assert host_state["rounds"] == [
+        {
+            "round_index": game_round.round_index,
+            "answer_label": game_round.answer_label,
+            "suggestions": [
+                {
+                    "suggestion_id": suggestion.suggestion_id,
+                    "label": suggestion.label,
+                    "uri": suggestion.uri,
+                    "is_correct": suggestion.is_correct,
+                }
+                for suggestion in answer_state.suggestions
+            ],
+            "answers": {},
+            "track_uri": game_round.track_uri,
+            "question": game_round.question,
+            "image_url": game_round.image_url,
+            "duration": game_round.duration,
+            "started_at": game_round.started_at,
+            "ended_at": game_round.ended_at,
+        }
+    ]
+    assert "answer_state" not in host_state["rounds"][0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Music Quiz rounds still stored multiple-choice answers directly, which made adding other answer types require changing the common game model again.

- Move answer-specific data into strict typed round state.
- Keep existing host, guest, event, personalized, and legacy API payloads unchanged.
- Add strict deserialization and wire compatibility coverage.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.