### PR TITLE
Recover from corrupt audio analysis cache

### DIFF
--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -89,16 +89,24 @@ if TYPE_CHECKING:
     from music_assistant.controllers.streams.controller import StreamsController
 
 
+def _get_row_value(row: Mapping[str, Any], key: str) -> Any:
+    """Return a database row value without assuming dict-only helpers."""
+    try:
+        return row[key]
+    except IndexError, KeyError, TypeError:
+        return None
+
+
 def _parse_row(row: Mapping[str, Any]) -> AudioAnalysisData | None:
     """Parse a single audio_analysis row's analysis_data, logging and skipping on error."""
     try:
         return AudioAnalysisData.from_dict(json_loads(row["analysis_data"]))
-    except (ValueError, TypeError, KeyError) as err:
+    except (IndexError, KeyError, TypeError, ValueError) as err:
         LOGGER.warning(
-            "Skipping unparsable audio_analysis row (id=%s, aa_provider_domain=%s): %s",
-            row.get("id"),
-            row.get("aa_provider_domain"),
-            err,
+            "Skipping unparsable audio_analysis row (id=%s, domain=%s, error=%s)",
+            _get_row_value(row, "id"),
+            _get_row_value(row, "aa_provider_domain"),
+            type(err).__name__,
         )
         return None
 

--- a/music_assistant/providers/sonic_analysis/helpers.py
+++ b/music_assistant/providers/sonic_analysis/helpers.py
@@ -266,12 +266,14 @@ def collapse_to_analysis(accumulated: BlockFeatures, sample_rate: int) -> AudioA
     :param accumulated: All block features accumulated during streaming.
     :param sample_rate: Sample rate used during extraction.
     """
-    onset_env = np.concatenate([[0.0], np.concatenate(accumulated.onset_env_frames)])
-    chroma = np.concatenate(accumulated.chroma_frames, axis=1)
-    rms = np.concatenate(accumulated.rms_frames, axis=1).squeeze()
-    centroid = np.concatenate(accumulated.centroid_frames, axis=1).squeeze()
-    contrast = np.concatenate(accumulated.contrast_frames, axis=1)
-    flatness = np.concatenate(accumulated.flatness_frames, axis=1).squeeze()
+    onset_env = _replace_non_finite(
+        np.concatenate([[0.0], np.concatenate(accumulated.onset_env_frames)])
+    )
+    chroma = _replace_non_finite(np.concatenate(accumulated.chroma_frames, axis=1))
+    rms = _replace_non_finite(np.concatenate(accumulated.rms_frames, axis=1).squeeze())
+    centroid = _replace_non_finite(np.concatenate(accumulated.centroid_frames, axis=1).squeeze())
+    contrast = _replace_non_finite(np.concatenate(accumulated.contrast_frames, axis=1))
+    flatness = _replace_non_finite(np.concatenate(accumulated.flatness_frames, axis=1).squeeze())
 
     energy = _derive_energy(rms)
     loudness_integrated, loudness_range = _derive_loudness(rms)
@@ -294,6 +296,12 @@ def collapse_to_analysis(accumulated: BlockFeatures, sample_rate: int) -> AudioA
         rms_energy=rms_energy_series.tolist(),
         spectral_centroid=spectral_centroid_series.tolist(),
     )
+
+
+def _replace_non_finite(values: np.ndarray) -> np.ndarray:
+    """Replace non-finite feature values with neutral zeros."""
+    np.nan_to_num(values, copy=False, nan=0.0, posinf=0.0, neginf=0.0)
+    return values
 
 
 def _clamp(value: float) -> float:

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import sqlite3
 from collections.abc import AsyncGenerator, Mapping
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any
+from contextlib import closing
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
@@ -1281,7 +1283,9 @@ def _track_with_mapping(item_id: str = "track-1", provider: str = "test-provider
     )
 
 
-def _analysis_controller_with_rows(rows: list[dict[str, Any]]) -> AudioAnalysisController:
+def _analysis_controller_with_rows(
+    rows: list[Mapping[str, Any]],
+) -> AudioAnalysisController:
     """Build a stub controller whose DB returns the given analysis rows for any track."""
     c, db = _stub_controller()
     db.get_rows = AsyncMock(return_value=rows)
@@ -1296,6 +1300,46 @@ def _analysis_controller_with_rows(rows: list[dict[str, Any]]) -> AudioAnalysisC
         ]
     )
     return c
+
+
+@pytest.mark.asyncio
+async def test_get_track_audio_metadata_skips_corrupt_sqlite_row(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A corrupt sqlite3.Row is logged and skipped without hiding valid analysis."""
+    corrupt_data = json_dumps({"spectral_centroid": [100.0, None]})
+    valid_data = json_dumps(AudioAnalysisData(bpm=128.0).to_dict())
+    with closing(sqlite3.connect(":memory:")) as db:
+        db.row_factory = sqlite3.Row
+        rows = cast(
+            "list[Mapping[str, Any]]",
+            db.execute(
+                """
+                SELECT 1 AS id, ? AS aa_provider_domain, ? AS analysis_data
+                UNION ALL
+                SELECT 2, ?, ?
+                """,
+                (
+                    SONIC_ANALYSIS_DOMAIN,
+                    corrupt_data,
+                    SMART_FADES_ANALYSIS_DOMAIN,
+                    valid_data,
+                ),
+            ).fetchall(),
+        )
+
+    controller = _analysis_controller_with_rows(rows)
+    with caplog.at_level("WARNING", logger=audio_analysis_mod.LOGGER.name):
+        result = await controller.get_track_audio_metadata(_track_with_mapping())
+
+    assert result is not None
+    assert result.bpm == 128.0
+    warning = next(
+        record for record in caplog.records if record.name == audio_analysis_mod.LOGGER.name
+    )
+    assert "id=1, domain=sonic_analysis" in warning.getMessage()
+    assert corrupt_data not in warning.getMessage()
+    assert warning.exc_info is None
 
 
 @pytest.mark.asyncio

--- a/tests/providers/sonic_analysis/test_helpers.py
+++ b/tests/providers/sonic_analysis/test_helpers.py
@@ -4,6 +4,7 @@ import math
 
 import numpy as np
 
+from music_assistant.helpers.json import json_dumps, json_loads
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.providers.sonic_analysis.helpers import (
     MIN_BLOCK_SAMPLES,
@@ -123,6 +124,35 @@ def test_collapse_to_analysis_time_series_populated() -> None:
 
     assert result.spectral_centroid is not None
     assert len(result.spectral_centroid) > 0
+
+
+def test_collapse_to_analysis_replaces_non_finite_features() -> None:
+    """All Sonic numeric output remains finite and survives a JSON round-trip."""
+    features = extract_block_features(_make_sine(), 22050)
+    assert features is not None
+    non_finite = np.array([np.nan, np.inf, -np.inf], dtype=np.float32)
+    for frames in (
+        features.chroma_frames,
+        features.contrast_frames,
+        features.centroid_frames,
+        features.flatness_frames,
+        features.rms_frames,
+        features.onset_env_frames,
+    ):
+        frames[0] = frames[0].copy()
+        frames[0].flat[: len(non_finite)] = non_finite
+
+    result = collapse_to_analysis(features, 22050)
+    payload = result.to_dict()
+    numeric_values = [value for value in payload.values() if isinstance(value, int | float)]
+    numeric_values.extend(
+        item for value in payload.values() if isinstance(value, list) for item in value
+    )
+
+    assert numeric_values
+    assert all(math.isfinite(float(value)) for value in numeric_values)
+    restored = AudioAnalysisData.from_dict(json_loads(json_dumps(payload)))
+    assert restored == result
 
 
 def test_collapse_to_analysis_deterministic() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Corrupt cached audio analysis could prevent playback and Music Quiz from starting. This change skips invalid rows safely and prevents Sonic Analysis from storing non-finite feature values.

- Handles SQLite rows without relying on dict-only helpers.
- Sanitizes non-finite Sonic features before deriving stored values.
- Adds regression coverage for cache recovery and serialization.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.