### PR TITLE
Add Music Quiz player presence

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -815,15 +815,7 @@ class MusicQuizPlugin(PluginProvider):
                     self._signal_game_updated()
             elif game.players and game.phase == MusicQuizPhase.REVEAL:
                 if are_active_players_ready(game):
-                    try:
-                        await self._advance_from_reveal()
-                    except Exception as err:
-                        self.logger.error(
-                            "Could not advance Music Quiz game after player expiry: %s",
-                            err,
-                            exc_info=err,
-                        )
-                        self._signal_game_updated()
+                    await self._advance_from_reveal()
                 else:
                     self._signal_game_updated()
             else:

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -43,8 +43,8 @@ The public game state is guest-safe by construction and contains:
 Guests authenticate through the standard guest access flow (join code in
 the join URL) and register themselves as quiz player via ``music_quiz/join``,
 which returns their private ``player_id``. That ID acts as the player's
-credential for ``music_quiz/answer``, ``music_quiz/ready`` and
-``music_quiz/state`` and must be kept client-side.
+credential for ``music_quiz/answer``, ``music_quiz/ready``,
+``music_quiz/heartbeat`` and ``music_quiz/state`` and must be kept client-side.
 """
 
 from __future__ import annotations
@@ -101,6 +101,9 @@ from music_assistant.providers.music_quiz.game import (
     start_round,
 )
 from music_assistant.providers.music_quiz.game import (
+    remove_player as remove_game_player,
+)
+from music_assistant.providers.music_quiz.game import (
     submit_answer as submit_game_answer,
 )
 from music_assistant.providers.music_quiz.models import (
@@ -144,6 +147,7 @@ MAX_SOURCE_COUNT = 200
 MAX_PLAYER_COUNT = 100
 # the joined name is broadcast to every client on each state update; bound it
 MAX_PLAYER_NAME_LENGTH = 40
+PLAYER_RECONNECT_GRACE_SECONDS = 60.0
 
 # minimum time players get to see the reveal/scoreboard before the game
 # advances, even when the round track has (almost) finished playing
@@ -251,6 +255,7 @@ class MusicQuizPlugin(PluginProvider):
             ("music_quiz/info", self.get_game_info),
             ("music_quiz/join", self.join_game),
             ("music_quiz/state", self.get_player_state),
+            ("music_quiz/heartbeat", self.heartbeat),
             ("music_quiz/submit_answer", self.submit_answer),
             ("music_quiz/answer", self.answer),
             ("music_quiz/ready", self.ready),
@@ -279,13 +284,14 @@ class MusicQuizPlugin(PluginProvider):
         for unregister in self._unregister_handles:
             unregister()
         self._unregister_handles.clear()
-        self._cancel_timers()
-        self._cancel_next_round_task()
-        # clear game state before tearing down the session so a guest listen-in
-        # racing with unload cannot (re)create or join a session mid-teardown
-        self._game = None
-        self._quiz_type = None
-        self._answer_type = None
+        async with self._game_lock:
+            self._cancel_timers()
+            self._cancel_next_round_task()
+            # clear game state before tearing down the session so a guest listen-in
+            # racing with unload cannot (re)create or join a session mid-teardown
+            self._game = None
+            self._quiz_type = None
+            self._answer_type = None
         await self._close_playback_session()
         if is_removed:
             await guest_access.revoke_guest_access(self.mass, MUSIC_QUIZ_GUEST_USER)
@@ -393,6 +399,7 @@ class MusicQuizPlugin(PluginProvider):
             await self._stop_playback()
             reset_game(game)
             self._prefetch_round(0)
+            self._schedule_presence_expiry()
             self._signal_game_updated()
             return await self._host_state()
 
@@ -449,13 +456,16 @@ class MusicQuizPlugin(PluginProvider):
                 )
             if len(game.players) >= MAX_PLAYER_COUNT:
                 raise MusicQuizGameFullError("Music Quiz game is full")
+            joined_at = time.time()
             player = MusicQuizPlayer(
                 player_id=secrets.token_urlsafe(24),
                 name=player_name,
-                joined_at=time.time(),
+                joined_at=joined_at,
                 active_from_round=_get_join_round(game),
+                last_seen=joined_at,
             )
             add_player(game, player)
+            self._schedule_presence_expiry(joined_at)
             self._signal_game_updated()
             return {
                 "player_id": player.player_id,
@@ -469,8 +479,25 @@ class MusicQuizPlugin(PluginProvider):
         :param player_id: The player's private player_id.
         """
         self._validate_guest_access()
-        game, _, answer_type = self._require_game_strategies()
-        return _player_state(game, _get_player(game, player_id), self._mode, answer_type)
+        async with self._game_lock:
+            game, _, answer_type = self._require_game_strategies()
+            player = _get_player(game, player_id)
+            self._refresh_player_presence(player)
+            return _player_state(game, player, self._mode, answer_type)
+
+    async def heartbeat(self, player_id: str) -> bool:
+        """
+        Refresh a player's reconnect grace period.
+
+        :param player_id: The player's private player_id.
+        :return: True when the player still exists, otherwise False.
+        """
+        self._validate_guest_access()
+        async with self._game_lock:
+            if self._game is None or (player := _find_player(self._game, player_id)) is None:
+                return False
+            self._refresh_player_presence(player)
+            return True
 
     async def submit_answer(
         self,
@@ -526,6 +553,7 @@ class MusicQuizPlugin(PluginProvider):
         async with self._game_lock:
             game, _, answer_type = self._require_game_strategies()
             player = _get_player(game, player_id)
+            self._refresh_player_presence(player)
             # a repeat ready is a no-op: it cannot newly satisfy the all-ready
             # check, so return current state without re-broadcasting
             if game.phase != MusicQuizPhase.REVEAL or player.ready:
@@ -648,7 +676,9 @@ class MusicQuizPlugin(PluginProvider):
         :param submission: Validated answer submission.
         :param answer_type: Answer strategy for the game.
         """
-        submit_game_answer(game, player.player_id, submission, time.time(), answer_type)
+        submitted_at = time.time()
+        submit_game_answer(game, player.player_id, submission, submitted_at, answer_type)
+        self._refresh_player_presence(player, submitted_at)
         if all_active_players_complete(game, answer_type):
             self._do_reveal()
         else:
@@ -753,9 +783,52 @@ class MusicQuizPlugin(PluginProvider):
         if len(game.rounds) >= game.config.round_count:
             await self._stop_playback()
             finish_game(game)
+            self._cancel_presence_expiry()
             self._signal_game_updated()
             return
         await self._start_next_round()
+
+    async def _expire_inactive_players(self) -> None:
+        """Remove players whose reconnect grace period elapsed."""
+        async with self._game_lock:
+            if self._game is None or self._game.phase == MusicQuizPhase.FINISHED:
+                self._cancel_presence_expiry()
+                return
+            game, _, answer_type = self._require_game_strategies()
+            now = time.time()
+            expired_player_ids = [
+                player.player_id
+                for player in game.players.values()
+                if player.last_seen + PLAYER_RECONNECT_GRACE_SECONDS <= now
+            ]
+            if not expired_player_ids:
+                self._schedule_presence_expiry(now)
+                return
+
+            for player_id in expired_player_ids:
+                remove_game_player(game, player_id, answer_type)
+
+            if game.players and game.phase == MusicQuizPhase.ANSWERING:
+                if all_active_players_complete(game, answer_type):
+                    self._do_reveal()
+                else:
+                    self._signal_game_updated()
+            elif game.players and game.phase == MusicQuizPhase.REVEAL:
+                if are_active_players_ready(game):
+                    try:
+                        await self._advance_from_reveal()
+                    except Exception as err:
+                        self.logger.error(
+                            "Could not advance Music Quiz game after player expiry: %s",
+                            err,
+                            exc_info=err,
+                        )
+                        self._signal_game_updated()
+                else:
+                    self._signal_game_updated()
+            else:
+                self._signal_game_updated()
+            self._schedule_presence_expiry()
 
     async def _on_answer_deadline(self, round_index: int) -> None:
         """Reveal the round when the answering deadline passed."""
@@ -954,6 +1027,54 @@ class MusicQuizPlugin(PluginProvider):
 
     # ---------- timers ----------
 
+    def _refresh_player_presence(
+        self,
+        player: MusicQuizPlayer,
+        seen_at: float | None = None,
+    ) -> None:
+        """
+        Refresh a player's reconnect grace period.
+
+        :param player: Player whose presence should be refreshed.
+        :param seen_at: Server timestamp of the activity.
+        """
+        player.last_seen = seen_at if seen_at is not None else time.time()
+        self._schedule_presence_expiry(player.last_seen)
+
+    def _schedule_presence_expiry(self, now: float | None = None) -> None:
+        """
+        Schedule the next inactive-player expiry.
+
+        :param now: Current server timestamp.
+        """
+        if (
+            self._game is None
+            or self._game.phase == MusicQuizPhase.FINISHED
+            or not self._game.players
+        ):
+            self.mass.cancel_timer(self._presence_timer_id)
+            return
+        current_time = now if now is not None else time.time()
+        expires_at = min(
+            player.last_seen + PLAYER_RECONNECT_GRACE_SECONDS
+            for player in self._game.players.values()
+        )
+        self.mass.call_later(
+            max(expires_at - current_time, 0),
+            self._expire_inactive_players,
+            task_id=self._presence_timer_id,
+        )
+
+    def _cancel_presence_expiry(self, *, cancel_task: bool = False) -> None:
+        """
+        Cancel scheduled player expiry work.
+
+        :param cancel_task: Also cancel an expiry callback that already started.
+        """
+        self.mass.cancel_timer(self._presence_timer_id)
+        if cancel_task:
+            self.mass.cancel_task(self._presence_timer_id)
+
     @property
     def _reveal_timer_id(self) -> str:
         """Return the task_id of the answering deadline timer."""
@@ -964,10 +1085,16 @@ class MusicQuizPlugin(PluginProvider):
         """Return the task_id of the reveal auto-advance timer."""
         return f"music_quiz_advance_{self.instance_id}"
 
+    @property
+    def _presence_timer_id(self) -> str:
+        """Return the task_id of the player presence timer."""
+        return f"music_quiz_presence_{self.instance_id}"
+
     def _cancel_timers(self) -> None:
-        """Cancel all scheduled game progression timers."""
+        """Cancel all scheduled game timers."""
         self.mass.cancel_timer(self._reveal_timer_id)
         self.mass.cancel_timer(self._advance_timer_id)
+        self._cancel_presence_expiry(cancel_task=True)
 
 
 def _validate_config(config: MusicQuizConfig) -> None:
@@ -1056,10 +1183,17 @@ def _get_join_round(game: MusicQuizGame) -> int:
 
 def _get_player(game: MusicQuizGame, player_id: str) -> MusicQuizPlayer:
     """Return a player by their private player_id."""
+    if player := _find_player(game, player_id):
+        return player
+    raise MusicQuizUnknownPlayerError("Unknown Music Quiz player")
+
+
+def _find_player(game: MusicQuizGame, player_id: str) -> MusicQuizPlayer | None:
+    """Return a player by their private player_id, if present."""
     for player in game.players.values():
         if secrets.compare_digest(player.player_id, player_id):
             return player
-    raise MusicQuizUnknownPlayerError("Unknown Music Quiz player")
+    return None
 
 
 def _answer_window(game: MusicQuizGame, game_round: MusicQuizRound) -> float:

--- a/music_assistant/providers/music_quiz/answer_types/base.py
+++ b/music_assistant/providers/music_quiz/answer_types/base.py
@@ -66,6 +66,15 @@ class QuizAnswerType(ABC):
         """
 
     @abstractmethod
+    def remove_player(self, state: QuizRoundAnswerState, player_id: str) -> None:
+        """
+        Remove answer-specific state owned by a player.
+
+        :param state: Round answer state to mutate.
+        :param player_id: Player whose state should be removed.
+        """
+
+    @abstractmethod
     def is_player_complete(self, state: QuizRoundAnswerState, player_id: str) -> bool:
         """
         Return whether a player completed the answer requirements.

--- a/music_assistant/providers/music_quiz/answer_types/multiple_choice.py
+++ b/music_assistant/providers/music_quiz/answer_types/multiple_choice.py
@@ -116,6 +116,16 @@ class MultipleChoiceAnswerType(QuizAnswerType):
             is_correct=suggestion.is_correct,
         )
 
+    def remove_player(self, state: QuizRoundAnswerState, player_id: str) -> None:
+        """
+        Remove a player's multiple-choice answer.
+
+        :param state: Round answer state to mutate.
+        :param player_id: Player whose answer should be removed.
+        """
+        multiple_choice_state = self._get_state(state)
+        multiple_choice_state.answers.pop(player_id, None)
+
     def is_player_complete(self, state: QuizRoundAnswerState, player_id: str) -> bool:
         """
         Return whether a player locked a selection.

--- a/music_assistant/providers/music_quiz/game.py
+++ b/music_assistant/providers/music_quiz/game.py
@@ -176,7 +176,9 @@ def all_active_players_complete(game: MusicQuizGame, answer_type: QuizAnswerType
         return False
     current_round = get_current_round(game)
     players = active_players_for_round(game, current_round.round_index)
-    return answer_type.is_round_complete(current_round.answer_state, players)
+    return bool(game.players) and (
+        not players or answer_type.is_round_complete(current_round.answer_state, players)
+    )
 
 
 def finish_game(game: MusicQuizGame) -> None:

--- a/music_assistant/providers/music_quiz/game.py
+++ b/music_assistant/providers/music_quiz/game.py
@@ -40,6 +40,25 @@ def add_player(
     game.players[player.player_id] = player
 
 
+def remove_player(
+    game: MusicQuizGame,
+    player_id: str,
+    answer_type: QuizAnswerType,
+) -> None:
+    """
+    Remove a player and their answer-specific round state.
+
+    :param game: Game to mutate.
+    :param player_id: Player to remove.
+    :param answer_type: Answer strategy for the game.
+    """
+    if player_id not in game.players:
+        raise MusicQuizUnknownPlayerError("Unknown player")
+    for game_round in game.rounds:
+        answer_type.remove_player(game_round.answer_state, player_id)
+    del game.players[player_id]
+
+
 def submit_answer(
     game: MusicQuizGame,
     player_id: str,

--- a/music_assistant/providers/music_quiz/models.py
+++ b/music_assistant/providers/music_quiz/models.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Literal
 
-from mashumaro import DataClassDictMixin
+from mashumaro import DataClassDictMixin, field_options
 from mashumaro.config import BaseConfig
 from mashumaro.types import Discriminator
 
@@ -70,6 +70,12 @@ class MusicQuizPlayer(DataClassDictMixin):
     active_from_round: int
     score: int = 0
     ready: bool = False
+    last_seen: float = field(
+        default=0,
+        compare=False,
+        repr=False,
+        metadata=field_options(serialize="omit"),
+    )
 
 
 @dataclass

--- a/tests/providers/music_quiz/test_game.py
+++ b/tests/providers/music_quiz/test_game.py
@@ -256,6 +256,17 @@ def test_all_active_players_complete_tracks_current_round() -> None:
     assert all_active_players_complete(game, ANSWER_TYPE) is True
 
 
+def test_all_active_players_complete_when_only_future_players_remain() -> None:
+    """Allow a round to reveal when participants remain but none can answer it."""
+    game = _game()
+    add_player(game, _player("late", "Late", active_from_round=1))
+
+    assert all_active_players_complete(game, ANSWER_TYPE) is True
+
+    game.players.clear()
+    assert all_active_players_complete(game, ANSWER_TYPE) is False
+
+
 def test_reveal_round_applies_scores_to_correct_answers_in_order() -> None:
     """Apply linear scores when a round is revealed."""
     game = _game()

--- a/tests/providers/music_quiz/test_models.py
+++ b/tests/providers/music_quiz/test_models.py
@@ -15,6 +15,7 @@ from music_assistant.providers.music_quiz.models import (
     MultipleChoiceRoundState,
     MultipleChoiceSuggestion,
     MusicQuizAnswerType,
+    MusicQuizPlayer,
     MusicQuizRound,
 )
 
@@ -86,6 +87,26 @@ def test_round_answer_state_round_trips_with_discriminator() -> None:
     assert restored == game_round
     assert isinstance(restored.answer_state, MultipleChoiceRoundState)
     assert restored.answer_state.answer_type is MusicQuizAnswerType.MULTIPLE_CHOICE
+
+
+def test_player_presence_is_not_serialized() -> None:
+    """Keep internal presence timestamps out of serialized player state."""
+    player = MusicQuizPlayer(
+        player_id="private",
+        name="Alice",
+        joined_at=10.0,
+        active_from_round=0,
+        last_seen=20.0,
+    )
+
+    assert player.to_dict() == {
+        "player_id": "private",
+        "name": "Alice",
+        "joined_at": 10.0,
+        "active_from_round": 0,
+        "score": 0,
+        "ready": False,
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/providers/music_quiz/test_multiple_choice.py
+++ b/tests/providers/music_quiz/test_multiple_choice.py
@@ -126,6 +126,22 @@ def test_player_serialization_separates_public_and_personal_state() -> None:
     }
 
 
+def test_remove_player_discards_multiple_choice_answer() -> None:
+    """Remove all multiple-choice state owned by a departed player."""
+    state = _state()
+    state.answers["p1"] = MultipleChoiceAnswer(
+        player_id="p1",
+        suggestion_id="correct",
+        answered_at=12,
+        is_correct=True,
+    )
+
+    ANSWER_TYPE.remove_player(state, "p1")
+    ANSWER_TYPE.remove_player(state, "missing")
+
+    assert state.answers == {}
+
+
 def test_host_serialization_preserves_full_flat_answer_state() -> None:
     """Serialize full multiple-choice state for the host round payload."""
     state = _state()

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -949,6 +949,41 @@ async def test_expiry_unblocks_reveal_readiness() -> None:
 
 
 @pytest.mark.asyncio
+async def test_expiry_propagates_reveal_advance_failure() -> None:
+    """Surface unexpected expiry-driven advance failures to task error handling."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin)
+    await plugin.reveal()
+
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        await plugin.ready(player_ids["Alice"])
+
+    game = plugin._game
+    assert game is not None
+    game.players[player_ids["Alice"]].last_seen = 200.0
+    game.players[player_ids["Bob"]].last_seen = 100.0
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.time.time",
+            return_value=160.0,
+        ),
+        patch.object(
+            plugin,
+            "_advance_from_reveal",
+            new=AsyncMock(side_effect=RuntimeError("advance failed")),
+        ),
+        pytest.raises(RuntimeError, match="advance failed"),
+    ):
+        await plugin._expire_inactive_players()
+
+    assert player_ids["Bob"] not in game.players
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("phase", [MusicQuizPhase.ANSWERING, MusicQuizPhase.REVEAL])
 async def test_expiry_with_zero_remaining_players_does_not_auto_transition(
     phase: MusicQuizPhase,

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -14,6 +14,7 @@ from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.providers.music_quiz import (
     MUSIC_QUIZ_GUEST_USER,
+    PLAYER_RECONNECT_GRACE_SECONDS,
     MusicQuizPlugin,
     get_config_entries,
 )
@@ -47,6 +48,7 @@ GUEST_COMMANDS = (
     "music_quiz/info",
     "music_quiz/join",
     "music_quiz/state",
+    "music_quiz/heartbeat",
     "music_quiz/submit_answer",
     "music_quiz/answer",
     "music_quiz/ready",
@@ -148,6 +150,14 @@ def _answer_state(game_round: MusicQuizRound) -> MultipleChoiceRoundState:
     return game_round.answer_state
 
 
+def _presence_timer_call(plugin: MusicQuizPlugin) -> tuple[float, Any]:
+    """Return the most recently scheduled player presence timer."""
+    for timer_call in reversed(cast("MagicMock", plugin.mass.call_later).call_args_list):
+        if timer_call.kwargs.get("task_id") == plugin._presence_timer_id:
+            return cast("float", timer_call.args[0]), timer_call.args[1]
+    raise AssertionError("No player presence timer was scheduled")
+
+
 async def _create_started_game(
     plugin: MusicQuizPlugin,
     player_names: tuple[str, ...] = ("Alice", "Bob"),
@@ -224,6 +234,15 @@ async def test_guest_commands_reject_non_guest_users() -> None:
     ):
         await plugin.answer("some_player", "some_suggestion")
 
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=SimpleNamespace(username="admin"),
+        ),
+        pytest.raises(InvalidDataError, match="guests"),
+    ):
+        await plugin.heartbeat("some_player")
+
 
 @pytest.mark.asyncio
 async def test_full_game_flow() -> None:
@@ -271,10 +290,16 @@ async def test_generic_submit_answer_uses_discriminated_payload() -> None:
     """The generic command accepts a strict typed multiple-choice submission."""
     plugin = _create_plugin()
     player_ids = await _create_started_game(plugin, player_names=("Alice",))
+    game = plugin._game
+    assert game is not None
+    game.players[player_ids["Alice"]].last_seen = 100.0
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+        patch("music_assistant.providers.music_quiz.time.time", return_value=120.0),
     ):
         state = cast(
             "dict[str, Any]",
@@ -290,6 +315,7 @@ async def test_generic_submit_answer_uses_discriminated_payload() -> None:
     assert state["phase"] == "reveal"
     assert state["you"]["answer"]["correct"] is True
     assert state["you"]["answer"]["points"] == 1000
+    assert game.players[player_ids["Alice"]].last_seen == 120.0
 
 
 @pytest.mark.asyncio
@@ -611,6 +637,347 @@ async def test_join_and_player_state_expose_persisted_quiz_type() -> None:
 
 
 @pytest.mark.asyncio
+async def test_presence_expiry_honors_reconnect_grace_boundary() -> None:
+    """Keep a player just before the grace deadline and remove them just after it."""
+    plugin = _create_plugin()
+    await plugin.create_game(source_uris=["library://playlist/1"])
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+        patch("music_assistant.providers.music_quiz.time.time", return_value=100.0),
+    ):
+        joined = await plugin.join_game("Alice")
+
+    game = plugin._game
+    assert game is not None
+    player_id = joined["player_id"]
+    assert game.players[player_id].last_seen == 100.0
+
+    with patch(
+        "music_assistant.providers.music_quiz.time.time",
+        return_value=100.0 + PLAYER_RECONNECT_GRACE_SECONDS - 0.001,
+    ):
+        await plugin._expire_inactive_players()
+
+    assert player_id in game.players
+    delay, _ = _presence_timer_call(plugin)
+    assert delay == pytest.approx(0.001)
+
+    with patch(
+        "music_assistant.providers.music_quiz.time.time",
+        return_value=100.0 + PLAYER_RECONNECT_GRACE_SECONDS + 0.001,
+    ):
+        await plugin._expire_inactive_players()
+
+    assert player_id not in game.players
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+        patch("music_assistant.providers.music_quiz.time.time", return_value=161.0),
+    ):
+        assert await plugin.heartbeat(player_id) is False
+        rejoined = await plugin.join_game("Alice")
+    assert rejoined["player_id"] != player_id
+    assert rejoined["state"]["you"]["active_from_round"] == 0
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_reschedules_player_expiry() -> None:
+    """A heartbeat gives an existing player a fresh reconnect grace period."""
+    plugin = _create_plugin()
+    await plugin.create_game(source_uris=["library://playlist/1"])
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+        patch("music_assistant.providers.music_quiz.time.time", return_value=100.0),
+    ):
+        joined = await plugin.join_game("Alice")
+
+    player_id = joined["player_id"]
+    game = plugin._game
+    assert game is not None
+    cast("MagicMock", plugin.mass.call_later).reset_mock()
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+        patch("music_assistant.providers.music_quiz.time.time", return_value=130.0),
+    ):
+        assert await plugin.heartbeat(player_id) is True
+
+    assert game.players[player_id].last_seen == 130.0
+    delay, expiry_callback = _presence_timer_call(plugin)
+    assert delay == PLAYER_RECONNECT_GRACE_SECONDS
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=160.0):
+        await expiry_callback()
+    assert player_id in game.players
+    delay, _ = _presence_timer_call(plugin)
+    assert delay == 30.0
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=190.001):
+        await expiry_callback()
+    assert player_id not in game.players
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_returns_false_for_missing_game_or_player() -> None:
+    """Expected reconnect misses return false instead of raising an API error."""
+    plugin = _create_plugin()
+
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        assert await plugin.heartbeat("missing") is False
+        await plugin.create_game(source_uris=["library://playlist/1"])
+        assert await plugin.heartbeat("missing") is False
+        joined = await plugin.join_game("Alice")
+        await plugin.delete_game()
+        assert await plugin.heartbeat(joined["player_id"]) is False
+
+
+@pytest.mark.asyncio
+async def test_player_state_fetch_refreshes_presence() -> None:
+    """A successful personalized state fetch refreshes reconnect presence."""
+    plugin = _create_plugin()
+    await plugin.create_game(source_uris=["library://playlist/1"])
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+        patch("music_assistant.providers.music_quiz.time.time", return_value=100.0),
+    ):
+        joined = await plugin.join_game("Alice")
+
+    player_id = joined["player_id"]
+    game = plugin._game
+    assert game is not None
+    cast("MagicMock", plugin.mass.call_later).reset_mock()
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+        patch("music_assistant.providers.music_quiz.time.time", return_value=125.0),
+    ):
+        state = await plugin.get_player_state(player_id)
+
+    assert game.players[player_id].last_seen == 125.0
+    assert "last_seen" not in str(state)
+    delay, _ = _presence_timer_call(plugin)
+    assert delay == PLAYER_RECONNECT_GRACE_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_answer_and_ready_refresh_presence() -> None:
+    """Successful answer and ready actions refresh player presence."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin)
+    game = plugin._game
+    assert game is not None
+    alice = game.players[player_ids["Alice"]]
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+        patch("music_assistant.providers.music_quiz.time.time", return_value=120.0),
+    ):
+        await plugin.answer(alice.player_id, "correct_0")
+    assert alice.last_seen == 120.0
+
+    await plugin.reveal()
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+        patch("music_assistant.providers.music_quiz.time.time", return_value=130.0),
+    ):
+        await plugin.ready(alice.player_id)
+    assert alice.last_seen == 130.0
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+        patch("music_assistant.providers.music_quiz.time.time", return_value=140.0),
+    ):
+        await plugin.ready(alice.player_id)
+    assert alice.last_seen == 140.0
+
+
+@pytest.mark.asyncio
+async def test_expiry_removes_player_answer_state_from_every_round() -> None:
+    """Removing a player clears their answer-owned state from all played rounds."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin)
+
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        await plugin.answer(player_ids["Alice"], "correct_0")
+        await plugin.answer(player_ids["Bob"], "wrong_0_1")
+        await plugin.ready(player_ids["Alice"])
+        await plugin.ready(player_ids["Bob"])
+        await plugin.answer(player_ids["Alice"], "correct_1")
+
+    game = plugin._game
+    assert game is not None
+    assert all(
+        player_ids["Alice"] in _answer_state(game_round).answers for game_round in game.rounds
+    )
+    game.players[player_ids["Alice"]].last_seen = 100.0
+    game.players[player_ids["Bob"]].last_seen = 200.0
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=160.0):
+        await plugin._expire_inactive_players()
+
+    assert player_ids["Alice"] not in game.players
+    assert all(
+        player_ids["Alice"] not in _answer_state(game_round).answers for game_round in game.rounds
+    )
+    assert game.phase == MusicQuizPhase.ANSWERING
+
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        await plugin.answer(player_ids["Bob"], "correct_1")
+    assert game.players[player_ids["Bob"]].score == 1000
+
+
+@pytest.mark.asyncio
+async def test_expiry_unblocks_answer_completion_and_keeps_events_private() -> None:
+    """Removing an inactive holdout reveals without leaking private presence state."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin)
+
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        await plugin.answer(player_ids["Alice"], "correct_0")
+
+    game = plugin._game
+    assert game is not None
+    game.players[player_ids["Alice"]].last_seen = 200.0
+    game.players[player_ids["Bob"]].last_seen = 100.0
+    cast("MagicMock", plugin.signal_provider_event).reset_mock()
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=160.0):
+        await plugin._expire_inactive_players()
+
+    assert game.phase == MusicQuizPhase.REVEAL
+    assert player_ids["Bob"] not in game.players
+    assert game.players[player_ids["Alice"]].score == 1000
+    payload = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]
+    serialized = str(payload)
+    assert payload["state"]["players"][0]["name"] == "Alice"
+    assert "last_seen" not in serialized
+    for player_id in player_ids.values():
+        assert player_id not in serialized
+
+
+@pytest.mark.asyncio
+async def test_expiry_unblocks_reveal_readiness() -> None:
+    """Removing an inactive holdout advances when every remaining player is ready."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin)
+    await plugin.reveal()
+
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        await plugin.ready(player_ids["Alice"])
+
+    game = plugin._game
+    assert game is not None
+    game.players[player_ids["Alice"]].last_seen = 200.0
+    game.players[player_ids["Bob"]].last_seen = 100.0
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=160.0):
+        await plugin._expire_inactive_players()
+
+    assert player_ids["Bob"] not in game.players
+    assert game.phase == MusicQuizPhase.ANSWERING
+    assert game.current_round_index == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("phase", [MusicQuizPhase.ANSWERING, MusicQuizPhase.REVEAL])
+async def test_expiry_with_zero_remaining_players_does_not_auto_transition(
+    phase: MusicQuizPhase,
+) -> None:
+    """Removing the final player leaves the current phase stable."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",))
+    if phase == MusicQuizPhase.REVEAL:
+        await plugin.reveal()
+
+    game = plugin._game
+    assert game is not None
+    game.players[player_ids["Alice"]].last_seen = 100.0
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=160.0):
+        await plugin._expire_inactive_players()
+
+    assert game.players == {}
+    assert game.phase == phase
+    payload = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]
+    assert payload["state"]["players"] == []
+
+
+@pytest.mark.asyncio
+async def test_finished_game_stops_presence_expiry() -> None:
+    """Finished standings and answer history remain intact without presence expiry."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(
+        plugin,
+        player_names=("Alice",),
+        round_count=1,
+    )
+    game = plugin._game
+    assert game is not None
+
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        await plugin.answer(player_ids["Alice"], "correct_0")
+    await plugin.next_round()
+
+    assert game.phase == MusicQuizPhase.FINISHED
+    assert game.players[player_ids["Alice"]].score == 1000
+    cast("MagicMock", plugin.mass.cancel_timer).assert_any_call(plugin._presence_timer_id)
+    game.players[player_ids["Alice"]].last_seen = 0
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=10_000.0):
+        await plugin._expire_inactive_players()
+
+    assert player_ids["Alice"] in game.players
+    assert player_ids["Alice"] in _answer_state(game.rounds[0]).answers
+
+
+@pytest.mark.asyncio
 async def test_reset_preserves_quiz_type_in_state_and_events() -> None:
     """Reset preserves the selected quiz type in returned and broadcast state."""
     plugin = _create_plugin()
@@ -624,6 +991,28 @@ async def test_reset_preserves_quiz_type_in_state_and_events() -> None:
     payload = cast("MagicMock", plugin.signal_provider_event).call_args[0][0]
     assert payload["state"]["quiz_type"] == "guess_the_song"
     assert payload["state"]["answer_type"] == "multiple_choice"
+
+
+@pytest.mark.asyncio
+async def test_reset_restarts_presence_timer_without_refreshing_players() -> None:
+    """Reset replaces presence work while preserving each player's last activity."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",))
+    game = plugin._game
+    assert game is not None
+    game.players[player_ids["Alice"]].last_seen = 100.0
+    cast("MagicMock", plugin.mass.cancel_timer).reset_mock()
+    cast("MagicMock", plugin.mass.cancel_task).reset_mock()
+    cast("MagicMock", plugin.mass.call_later).reset_mock()
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=120.0):
+        await plugin.reset()
+
+    cast("MagicMock", plugin.mass.cancel_timer).assert_any_call(plugin._presence_timer_id)
+    cast("MagicMock", plugin.mass.cancel_task).assert_called_once_with(plugin._presence_timer_id)
+    delay, _ = _presence_timer_call(plugin)
+    assert delay == 40.0
+    assert game.players[player_ids["Alice"]].last_seen == 100.0
 
 
 @pytest.mark.asyncio
@@ -697,9 +1086,11 @@ async def test_create_game_replaces_finished_game() -> None:
     await plugin.next_round()
     assert game.phase == MusicQuizPhase.FINISHED
 
+    cast("MagicMock", plugin.mass.cancel_task).reset_mock()
     result = await plugin.create_game(source_uris=["library://playlist/2"])
     assert result["phase"] == "lobby"
     assert plugin._game is not game
+    cast("MagicMock", plugin.mass.cancel_task).assert_called_once_with(plugin._presence_timer_id)
 
 
 @pytest.mark.asyncio
@@ -730,6 +1121,8 @@ async def test_delete_game_signals_removal() -> None:
     session = MagicMock()
     session.close = AsyncMock()
     plugin._playback_session = session
+    cast("MagicMock", plugin.mass.cancel_timer).reset_mock()
+    cast("MagicMock", plugin.mass.cancel_task).reset_mock()
 
     await plugin.delete_game()
     assert plugin._game is None
@@ -737,6 +1130,8 @@ async def test_delete_game_signals_removal() -> None:
     assert plugin._answer_type is None
     cast("AsyncMock", plugin._stop_playback).assert_awaited()
     session.close.assert_awaited_once()
+    cast("MagicMock", plugin.mass.cancel_timer).assert_any_call(plugin._presence_timer_id)
+    cast("MagicMock", plugin.mass.cancel_task).assert_called_once_with(plugin._presence_timer_id)
     payload = cast("MagicMock", plugin.signal_provider_event).call_args[0][0]
     assert payload == {"event": "game_removed"}
     assert await plugin.get_game() is None
@@ -903,6 +1298,8 @@ async def test_unload_cleans_up() -> None:
     session = MagicMock()
     session.close = AsyncMock()
     plugin._playback_session = session
+    cast("MagicMock", plugin.mass.cancel_timer).reset_mock()
+    cast("MagicMock", plugin.mass.cancel_task).reset_mock()
 
     with patch(
         "music_assistant.helpers.guest_access.revoke_guest_access",
@@ -913,6 +1310,8 @@ async def test_unload_cleans_up() -> None:
     unregister.assert_called_once()
     session.close.assert_awaited_once()
     assert plugin._game is None
+    cast("MagicMock", plugin.mass.cancel_timer).assert_any_call(plugin._presence_timer_id)
+    cast("MagicMock", plugin.mass.cancel_task).assert_called_once_with(plugin._presence_timer_id)
     revoke.assert_awaited_once_with(plugin.mass, MUSIC_QUIZ_GUEST_USER)
 
 

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -897,6 +897,32 @@ async def test_expiry_unblocks_answer_completion_and_keeps_events_private() -> N
 
 
 @pytest.mark.asyncio
+async def test_expiry_reveals_when_only_late_joiners_remain() -> None:
+    """Reveal immediately when expiry leaves no player eligible for the current round."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",))
+
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        late_join = await plugin.join_game("Late")
+
+    game = plugin._game
+    assert game is not None
+    late_player_id = late_join["player_id"]
+    assert game.players[late_player_id].active_from_round == 1
+    game.players[player_ids["Alice"]].last_seen = 100.0
+    game.players[late_player_id].last_seen = 200.0
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=160.0):
+        await plugin._expire_inactive_players()
+
+    assert set(game.players) == {late_player_id}
+    assert game.phase == MusicQuizPhase.REVEAL
+
+
+@pytest.mark.asyncio
 async def test_expiry_unblocks_reveal_readiness() -> None:
     """Removing an inactive holdout advances when every remaining player is ready."""
     plugin = _create_plugin()


### PR DESCRIPTION
# What does this implement/fix?

Adds reliable cross-game player presence with a 60-second reconnect grace.

- Adds a guest heartbeat and refreshes presence on player activity.
- Removes expired players and their answer-specific state without exposing private presence data.
- Safely unblocks round completion and readiness while preserving finished standings.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (Not applicable.)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (Not applicable.)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (Not applicable.)
