### PR TITLE
Keep provider config values current

### DIFF
--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -8,7 +8,7 @@ import logging
 from typing import TYPE_CHECKING, Any, TypeVar, final, overload
 
 from music_assistant_models.config_entries import ConfigValueType
-from music_assistant_models.enums import EventType
+from music_assistant_models.enums import ConfigEntryType, EventType
 from music_assistant_models.errors import UnsupportedFeaturedException
 
 from music_assistant.constants import CONF_LOG_LEVEL, MASS_LOGGER_NAME
@@ -255,22 +255,29 @@ class Provider:
         return_type: builtins.type[_ConfigValueT | ConfigValueType] | None = None,
     ) -> _ConfigValueT | ConfigValueType:
         """
-        Return a single config value from this provider's active configuration.
+        Return the current persisted config value for this provider.
 
-        Entry defaults are already applied to the active configuration, so the
-        default is only returned when the key itself is not present.
+        Falls back to the active config entry value or default when no value is persisted.
 
         :param key: The config key to retrieve.
-        :param default: Value to return when the key is not present in the config.
+        :param default: Value to return when the key is not present in the active config.
         :param return_type: Optional type hint for type inference (e.g., str, int, bool).
             Note: This parameter is used purely for static type checking and does not
             perform runtime type validation. Callers are responsible for ensuring the
             specified type matches the actual config value type.
         """
-        return self.config.get_value(key, default)
+        if (entry := self.config.values.get(key)) is None:
+            return self.config.get_value(key, default)
+        value = self.mass.config.get_raw_provider_config_value(self.instance_id, key)
+        if value is None:
+            return self.config.get_value(key, default)
+        if entry.type == ConfigEntryType.SECURE_STRING:
+            assert isinstance(value, str)
+            return self.mass.config.decrypt_string(value)
+        return value
 
     def _update_config_value(
-        self, key: str, value: Any, encrypted: bool = False, immediate: bool = False
+        self, key: str, value: ConfigValueType, encrypted: bool = False, immediate: bool = False
     ) -> None:
         """
         Update a config value.
@@ -278,10 +285,11 @@ class Provider:
         :param immediate: Persist to disk right away instead of on the debounced save timer;
             use for critical values (e.g. a rotated auth token) that must survive a crash.
         """
-        # the config controller also updates the cached copy within this provider instance
         self.mass.config.set_raw_provider_config_value(
             self.instance_id, key, value, encrypted=encrypted, immediate=immediate
         )
+        if (entry := self.config.values.get(key)) is not None:
+            entry.value = self.mass.config.get_raw_provider_config_value(self.instance_id, key)
 
     def _set_log_level_from_config(self, config: ProviderConfig) -> None:
         """Set log level from config."""

--- a/tests/controllers/config/test_config_copy_lifecycle.py
+++ b/tests/controllers/config/test_config_copy_lifecycle.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from music_assistant_models.config_entries import (
     ConfigEntry,
+    ConfigValueType,
     CoreConfig,
     PlayerConfig,
     ProviderConfig,
@@ -29,8 +30,8 @@ PLAYER_ID = "test_copy_player"
 PROVIDER_INSTANCE = "test_copy_provider"
 
 
-def _entry(key: str, entry_type: ConfigEntryType, default: object) -> ConfigEntry:
-    return ConfigEntry(key=key, type=entry_type, default_value=default, required=False)  # type: ignore[arg-type]
+def _entry(key: str, entry_type: ConfigEntryType, default: ConfigValueType) -> ConfigEntry:
+    return ConfigEntry(key=key, type=entry_type, default_value=default, required=False)
 
 
 async def test_core_controllers_hold_active_config(mass: MusicAssistant) -> None:
@@ -153,6 +154,107 @@ async def test_set_raw_provider_config_value_syncs_unavailable_provider(
     assert provider.config.get_value("api_token") == "abc"
 
 
+async def test_provider_get_config_value_prefers_persisted_value(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A provider reads a persisted value instead of its stale config snapshot."""
+    entries = _provider_config_entries()
+    mass_minimal.config.set(
+        f"{CONF_PROVIDERS}/{PROVIDER_INSTANCE}",
+        _raw_provider_conf(PROVIDER_INSTANCE, "persisted"),
+    )
+    provider = _create_provider(mass_minimal, entries, api_token="stale")
+
+    assert provider.get_config_value("api_token") == "persisted"
+
+
+async def test_provider_get_config_value_decrypts_persisted_secure_value(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A provider transparently decrypts a persisted secure config value."""
+    entries = [
+        CONF_ENTRY_LOG_LEVEL,
+        _entry("api_secret", ConfigEntryType.SECURE_STRING, None),
+    ]
+    mass_minimal.config.set(
+        f"{CONF_PROVIDERS}/{PROVIDER_INSTANCE}",
+        _raw_provider_conf(PROVIDER_INSTANCE),
+    )
+    mass_minimal.config.set_raw_provider_config_value(
+        PROVIDER_INSTANCE, "api_secret", "persisted-secret", encrypted=True
+    )
+    provider = _create_provider(mass_minimal, entries, api_secret="stale-secret")
+
+    assert provider.get_config_value("api_secret") == "persisted-secret"
+
+
+async def test_provider_get_config_value_falls_back_to_active_config(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A provider uses active values and defaults when no persisted value exists."""
+    entries = [
+        CONF_ENTRY_LOG_LEVEL,
+        _entry("active_value", ConfigEntryType.STRING, None),
+        _entry("active_default", ConfigEntryType.STRING, "entry-default"),
+    ]
+    mass_minimal.config.set(
+        f"{CONF_PROVIDERS}/{PROVIDER_INSTANCE}",
+        _raw_provider_conf(PROVIDER_INSTANCE, unknown="store-only"),
+    )
+    provider = _create_provider(mass_minimal, entries, active_value="snapshot-value")
+
+    assert provider.get_config_value("active_value") == "snapshot-value"
+    assert provider.get_config_value("active_default") == "entry-default"
+    assert provider.get_config_value("unknown", "explicit-default") == "explicit-default"
+
+
+async def test_provider_update_config_value_syncs_initializing_snapshot(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A provider-originated write updates its snapshot before registration completes."""
+    entries = _provider_config_entries()
+    mass_minimal.config.set(
+        f"{CONF_PROVIDERS}/{PROVIDER_INSTANCE}",
+        _raw_provider_conf(PROVIDER_INSTANCE, "old"),
+    )
+    provider = _create_provider(mass_minimal, entries, api_token="old")
+    get_provider = MagicMock(return_value=None)
+    mass_minimal.get_provider = get_provider  # type: ignore[method-assign]
+
+    provider._update_config_value("api_token", "new")
+
+    assert (
+        mass_minimal.config.get_raw_provider_config_value(PROVIDER_INSTANCE, "api_token") == "new"
+    )
+    assert provider.config.values["api_token"].value == "new"
+    get_provider.assert_called_once_with(PROVIDER_INSTANCE, return_unavailable=True)
+
+
+async def test_provider_encrypted_update_keeps_raw_snapshot_value(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """An encrypted provider write stores raw ciphertext while reads return plaintext."""
+    entries = [
+        CONF_ENTRY_LOG_LEVEL,
+        _entry("api_secret", ConfigEntryType.SECURE_STRING, None),
+    ]
+    mass_minimal.config.set(
+        f"{CONF_PROVIDERS}/{PROVIDER_INSTANCE}",
+        _raw_provider_conf(PROVIDER_INSTANCE),
+    )
+    provider = _create_provider(mass_minimal, entries)
+    get_provider = MagicMock(return_value=None)
+    mass_minimal.get_provider = get_provider  # type: ignore[method-assign]
+
+    provider._update_config_value("api_secret", "new-secret", encrypted=True)
+
+    raw_value = mass_minimal.config.get_raw_provider_config_value(PROVIDER_INSTANCE, "api_secret")
+    assert isinstance(raw_value, str)
+    assert raw_value != "new-secret"
+    assert provider.config.values["api_secret"].value == raw_value
+    assert provider.get_config_value("api_secret") == "new-secret"
+
+
 async def test_save_provider_config_syncs_loaded_available_provider(
     mass_minimal: MusicAssistant,
 ) -> None:
@@ -244,11 +346,29 @@ def _provider_config_entries() -> list[ConfigEntry]:
     return [CONF_ENTRY_LOG_LEVEL, _entry("api_token", ConfigEntryType.STRING, "old")]
 
 
-def _raw_provider_conf(instance_id: str, api_token: str) -> dict[str, object]:
+def _create_provider(
+    mass: MusicAssistant,
+    entries: list[ConfigEntry],
+    **values: ConfigValueType,
+) -> Provider:
+    """Create a provider with an active config snapshot."""
+    manifest = MagicMock(domain="test", type=ProviderType.MUSIC)
+    config = cast(
+        "ProviderConfig",
+        ProviderConfig.parse(entries, _raw_provider_conf(PROVIDER_INSTANCE, **values)),
+    )
+    return Provider(mass, manifest, config)
+
+
+def _raw_provider_conf(
+    instance_id: str, api_token: ConfigValueType = None, **values: ConfigValueType
+) -> dict[str, object]:
+    if api_token is not None:
+        values["api_token"] = api_token
     return {
         "type": ProviderType.MUSIC.value,
         "domain": "test",
         "instance_id": instance_id,
         "enabled": True,
-        "values": {"api_token": api_token},
+        "values": values,
     }


### PR DESCRIPTION
# What does this implement/fix?

Provider runtime config reads could use a stale initialization snapshot instead of the latest persisted value.

- Read persisted provider values first while retaining active defaults.
- Decrypt secure values transparently.
- Keep provider-owned snapshots aligned during initialization.
- Add focused regression coverage.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
