### PR TITLE
Prevent lost Podcast Index library changes

### DIFF
--- a/music_assistant/providers/podcast_index/provider.py
+++ b/music_assistant/providers/podcast_index/provider.py
@@ -155,8 +155,6 @@ class PodcastIndexProvider(MusicProvider):
         if not isinstance(item, Podcast):
             return await super().library_add(item)
 
-        stored_podcasts = cast("list[str]", self.config.get_value(CONF_STORED_PODCASTS))
-
         # Get the RSS URL from the podcast via API
         try:
             feed_url = await self._get_feed_url_for_podcast(item.item_id)
@@ -172,12 +170,12 @@ class PodcastIndexProvider(MusicProvider):
             )
             return False
 
+        stored_podcasts = cast("list[str]", self.get_config_value(CONF_STORED_PODCASTS))
         if feed_url in stored_podcasts:
             return False
 
         self.logger.debug("Adding podcast %s to library", item.name)
-        stored_podcasts.append(feed_url)
-        self._update_config_value(CONF_STORED_PODCASTS, stored_podcasts)
+        self._update_config_value(CONF_STORED_PODCASTS, [*stored_podcasts, feed_url])
         return True
 
     async def library_remove(self, prov_item_id: str, media_type: MediaType) -> bool:
@@ -189,8 +187,6 @@ class PodcastIndexProvider(MusicProvider):
         logs a warning but still returns True to maintain the idempotent contract
         as required by MA convention.
         """
-        stored_podcasts = cast("list[str]", self.config.get_value(CONF_STORED_PODCASTS))
-
         # Get the RSS URL for this podcast
         try:
             feed_url = await self._get_feed_url_for_podcast(prov_item_id)
@@ -204,7 +200,11 @@ class PodcastIndexProvider(MusicProvider):
             # Still return True for idempotent operation
             return True
 
-        if not feed_url or feed_url not in stored_podcasts:
+        if not feed_url:
+            return True
+
+        stored_podcasts = cast("list[str]", self.get_config_value(CONF_STORED_PODCASTS))
+        if feed_url not in stored_podcasts:
             return True
 
         self.logger.debug("Removing podcast %s from library", prov_item_id)

--- a/tests/providers/podcast_index/test_library.py
+++ b/tests/providers/podcast_index/test_library.py
@@ -1,0 +1,131 @@
+"""Tests for Podcast Index library operations."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+from music_assistant_models.enums import ConfigEntryType, MediaType, ProviderType
+from music_assistant_models.media_items import Podcast
+
+from music_assistant.providers.podcast_index.constants import CONF_STORED_PODCASTS
+from music_assistant.providers.podcast_index.provider import PodcastIndexProvider
+
+
+async def test_concurrent_add_and_remove_preserve_both_updates() -> None:
+    """Concurrent library changes retain every intended stored-podcast update."""
+    removed_feed = "https://example.com/removed.xml"
+    added_feed = "https://example.com/added.xml"
+    provider, config_store = _provider([removed_feed])
+    lookup_barrier = _LookupBarrier(
+        {"remove": removed_feed, "add": added_feed},
+        operation_count=2,
+    )
+    with patch.object(
+        PodcastIndexProvider,
+        "_get_feed_url_for_podcast",
+        side_effect=lookup_barrier.lookup,
+    ):
+        remove_task = asyncio.create_task(provider.library_remove("remove", MediaType.PODCAST))
+        add_task = asyncio.create_task(provider.library_add(_podcast("add")))
+
+        await lookup_barrier.wait_until_blocked()
+        lookup_barrier.release()
+
+        remove_result, add_result = await asyncio.gather(remove_task, add_task)
+        assert remove_result is True
+        assert add_result is True
+    assert config_store.stored_podcasts == [added_feed]
+
+
+class _ConfigStore:
+    """Store Podcast Index configuration values for provider tests."""
+
+    def __init__(self, stored_podcasts: list[str]) -> None:
+        self.stored_podcasts = list(stored_podcasts)
+
+    def get_raw_provider_config_value(
+        self, provider_instance: str, key: str, default: ConfigValueType = None
+    ) -> ConfigValueType:
+        """Return the current stored configuration value."""
+        assert provider_instance == "podcast_index--test"
+        assert key == CONF_STORED_PODCASTS
+        return list(self.stored_podcasts)
+
+    def set_raw_provider_config_value(
+        self,
+        provider_instance: str,
+        key: str,
+        value: ConfigValueType,
+        encrypted: bool = False,
+        immediate: bool = False,
+    ) -> None:
+        """Persist a provider configuration value."""
+        assert provider_instance == "podcast_index--test"
+        assert key == CONF_STORED_PODCASTS
+        assert isinstance(value, list)
+        assert all(isinstance(item, str) for item in value)
+        self.stored_podcasts = cast("list[str]", value)
+
+
+class _LookupBarrier:
+    """Block feed lookups until every concurrent operation has reached the lookup."""
+
+    def __init__(self, feed_urls: dict[str, str], operation_count: int) -> None:
+        self._feed_urls = feed_urls
+        self._operation_count = operation_count
+        self._blocked_count = 0
+        self._all_blocked = asyncio.Event()
+        self._release = asyncio.Event()
+
+    async def lookup(self, podcast_id: str) -> str:
+        """Return a feed URL after all expected lookups are blocked."""
+        self._blocked_count += 1
+        if self._blocked_count == self._operation_count:
+            self._all_blocked.set()
+        await self._release.wait()
+        return self._feed_urls[podcast_id]
+
+    async def wait_until_blocked(self) -> None:
+        """Wait until all expected operations are blocked in their feed lookup."""
+        await asyncio.wait_for(self._all_blocked.wait(), timeout=1)
+
+    def release(self) -> None:
+        """Release every blocked feed lookup."""
+        self._release.set()
+
+
+def _provider(stored_podcasts: list[str]) -> tuple[PodcastIndexProvider, _ConfigStore]:
+    """Create a Podcast Index provider backed by an in-memory configuration store."""
+    config_store = _ConfigStore(stored_podcasts)
+    config = ProviderConfig(
+        values={
+            CONF_STORED_PODCASTS: ConfigEntry(
+                key=CONF_STORED_PODCASTS,
+                type=ConfigEntryType.STRING,
+                multi_value=True,
+                value=list(stored_podcasts),
+            )
+        },
+        type=ProviderType.MUSIC,
+        domain="podcast_index",
+        instance_id="podcast_index--test",
+    )
+    provider = object.__new__(PodcastIndexProvider)
+    provider.mass = MagicMock()
+    provider.mass.config = config_store
+    provider.config = config
+    provider.logger = MagicMock()
+    return provider, config_store
+
+
+def _podcast(item_id: str) -> Podcast:
+    """Create a Podcast Index podcast for library tests."""
+    return Podcast(
+        item_id=item_id,
+        provider="podcast_index--test",
+        name=f"Podcast {item_id}",
+        provider_mappings=set(),
+    )


### PR DESCRIPTION
# What does this implement/fix?

Concurrent Podcast Index library changes could overwrite each other's stored feed updates.

- Read the latest persisted podcast list after feed lookups complete.
- Update stored podcasts without mutating the configuration snapshot.
- Add deterministic concurrent add/remove regression coverage.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.