### PR TITLE
Keep Music Quiz ListenIn audio-only

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -179,6 +179,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         self._state_update_subscribers: list[
             Callable[[Player, dict[str, tuple[Any, Any]]], None]
         ] = []
+        self._audio_only_player_ids: dict[str, int] = {}
 
     @contextlib.asynccontextmanager
     async def get_player_lock(
@@ -395,6 +396,41 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             msg = f"Player {player_id} is not available"
             raise PlayerUnavailableError(msg)
         return None
+
+    def register_audio_only_player(self, player_id: str) -> None:
+        """
+        Register a player that may expose audio without media metadata.
+
+        :param player_id: ID of the player.
+        """
+        registrations = self._audio_only_player_ids.get(player_id, 0)
+        self._audio_only_player_ids[player_id] = registrations + 1
+        if registrations == 0 and (player := self.get_player(player_id)):
+            player.refresh_state()
+
+    def unregister_audio_only_player(self, player_id: str) -> None:
+        """
+        Remove one audio-only registration for a player.
+
+        :param player_id: ID of the player.
+        """
+        registrations = self._audio_only_player_ids.get(player_id, 0)
+        if registrations == 0:
+            return
+        if registrations > 1:
+            self._audio_only_player_ids[player_id] = registrations - 1
+            return
+        del self._audio_only_player_ids[player_id]
+        if player := self.get_player(player_id):
+            player.refresh_state()
+
+    def is_player_audio_only(self, player_id: str) -> bool:
+        """
+        Return whether a player may expose audio without media metadata.
+
+        :param player_id: ID of the player.
+        """
+        return player_id in self._audio_only_player_ids
 
     @api_command("players/get", required_scope=Scope.PLAYERS_READ)
     def get_player_state(

--- a/music_assistant/controllers/webserver/remote_access/__init__.py
+++ b/music_assistant/controllers/webserver/remote_access/__init__.py
@@ -198,6 +198,7 @@ class RemoteAccessManager:
             ice_servers_callback=self.get_ice_servers if ha_cloud_available else None,
             # Pass callback to set sendspin player on websocket client
             set_sendspin_player_callback=self.webserver.set_sendspin_player_for_webrtc_session,
+            is_sendspin_player_audio_only=self.mass.players.is_player_audio_only,
         )
 
         await self.gateway.start()

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -22,6 +22,10 @@ from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection, RTCSession
 from aiortc.sdp import candidate_from_sdp
 
 from music_assistant.constants import MASS_LOGGER_NAME, VERBOSE_LOG_LEVEL
+from music_assistant.helpers.sendspin import (
+    filter_audio_only_sendspin_message,
+    get_sendspin_client_id,
+)
 from music_assistant.helpers.webrtc_certificate import create_peer_connection_with_certificate
 
 if TYPE_CHECKING:
@@ -89,6 +93,7 @@ class WebRTCGateway:
         ice_servers: list[dict[str, Any]] | None = None,
         ice_servers_callback: Callable[[], Awaitable[list[dict[str, Any]]]] | None = None,
         set_sendspin_player_callback: Callable[[str, str], None] | None = None,
+        is_sendspin_player_audio_only: Callable[[str], bool] | None = None,
     ) -> None:
         """
         Initialize the WebRTC Gateway.
@@ -102,6 +107,7 @@ class WebRTCGateway:
         :param ice_servers: List of ICE server configurations (used at registration time).
         :param ice_servers_callback: Optional callback to fetch fresh ICE servers for each session.
         :param set_sendspin_player_callback: Callback to set sendspin player for a session.
+        :param is_sendspin_player_audio_only: Callback to check whether metadata is redacted.
         """
         self.http_session = http_session
         self.signaling_url = signaling_url
@@ -112,6 +118,7 @@ class WebRTCGateway:
         self.logger = LOGGER
         self._ice_servers_callback = ice_servers_callback
         self._set_sendspin_player_callback = set_sendspin_player_callback
+        self._is_sendspin_player_audio_only = is_sendspin_player_audio_only
 
         # Static ICE servers used at registration time (relayed to clients via signaling server)
         self.ice_servers = ice_servers or self.DEFAULT_ICE_SERVERS
@@ -820,24 +827,15 @@ class WebRTCGateway:
         :param session: The WebRTC session.
         :param message: The first sendspin message (expected to be auth).
         """
-        try:
-            data = json.loads(message)
-            if data.get("type") != "auth":
-                return  # Not an auth message
-
-            # This is an auth message - extract client_id if present
-            if client_id := data.get("client_id"):
-                session.sendspin_player_id = client_id
-                self.logger.debug(
-                    "Extracted sendspin player %s for session %s",
-                    client_id,
-                    session.session_id,
-                )
-                # Use callback to set sendspin player on the websocket client
-                if self._set_sendspin_player_callback:
-                    self._set_sendspin_player_callback(session.session_id, client_id)
-        except json.JSONDecodeError, TypeError:
-            pass  # Not valid JSON, ignore
+        if client_id := get_sendspin_client_id(message):
+            session.sendspin_player_id = client_id
+            self.logger.debug(
+                "Extracted sendspin player %s for session %s",
+                client_id,
+                session.session_id,
+            )
+            if self._set_sendspin_player_callback:
+                self._set_sendspin_player_callback(session.session_id, client_id)
 
     async def _forward_sendspin_from_local(self, session: WebRTCSession) -> None:
         """
@@ -852,7 +850,9 @@ class WebRTCGateway:
             async for msg in session.sendspin_ws:
                 if msg.type in {aiohttp.WSMsgType.TEXT, aiohttp.WSMsgType.BINARY}:
                     if session.sendspin_channel and session.sendspin_channel.readyState == "open":
-                        session.sendspin_channel.send(msg.data)
+                        data = self._filter_sendspin_message(session, msg.data)
+                        if data is not None:
+                            session.sendspin_channel.send(data)
                 elif msg.type in (aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSED):
                     break
         except asyncio.CancelledError:
@@ -863,3 +863,15 @@ class WebRTCGateway:
             raise
         except Exception:
             self.logger.exception("Error forwarding sendspin from local")
+
+    def _filter_sendspin_message(
+        self, session: WebRTCSession, message: str | bytes
+    ) -> str | bytes | None:
+        """Return the Sendspin message allowed for a remote session."""
+        if (
+            session.sendspin_player_id is None
+            or self._is_sendspin_player_audio_only is None
+            or not self._is_sendspin_player_audio_only(session.sendspin_player_id)
+        ):
+            return message
+        return filter_audio_only_sendspin_message(message)

--- a/music_assistant/controllers/webserver/sendspin_proxy.py
+++ b/music_assistant/controllers/webserver/sendspin_proxy.py
@@ -12,6 +12,7 @@ import asyncio
 import contextlib
 import json
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import aiohttp
@@ -22,6 +23,10 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_authenticated_user,
     is_request_from_ingress,
 )
+from music_assistant.helpers.sendspin import (
+    filter_audio_only_sendspin_message,
+    get_sendspin_client_id,
+)
 from music_assistant.helpers.util import format_ip_for_url
 
 if TYPE_CHECKING:
@@ -30,6 +35,13 @@ if TYPE_CHECKING:
     from music_assistant.controllers.webserver import WebserverController
 
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.sendspin_proxy")
+
+
+@dataclass
+class _SendspinConnectionContext:
+    """Mutable state shared by both forwarding directions."""
+
+    player_id: str | None = None
 
 
 class SendspinProxyHandler:
@@ -78,6 +90,7 @@ class SendspinProxyHandler:
         self.logger.debug("Sendspin proxy connection from %s", request.remote)
 
         # Check for ingress authentication (HA handles auth via headers)
+        sendspin_player_id: str | None = None
         if is_request_from_ingress(request):
             user = await get_authenticated_user(request)
             if not user:
@@ -90,7 +103,7 @@ class SendspinProxyHandler:
         else:
             # Regular auth via first message
             try:
-                user = await self._authenticate(wsock)
+                user, sendspin_player_id = await self._authenticate(wsock)
                 if not user:
                     return wsock
             except TimeoutError:
@@ -129,7 +142,7 @@ class SendspinProxyHandler:
         self.logger.debug("Sendspin proxy authenticated and connected for %s", request.remote)
 
         try:
-            await self._proxy_messages(wsock, internal_ws)
+            await self._proxy_messages(wsock, internal_ws, sendspin_player_id)
         finally:
             if not internal_ws.closed:
                 await internal_ws.close()
@@ -138,39 +151,39 @@ class SendspinProxyHandler:
 
         return wsock
 
-    async def _authenticate(self, wsock: web.WebSocketResponse) -> User | None:
+    async def _authenticate(self, wsock: web.WebSocketResponse) -> tuple[User | None, str | None]:
         """
         Wait for and validate authentication message.
 
         :param wsock: The client WebSocket connection.
-        :return: The authenticated user, or None if authentication failed.
+        :return: The authenticated user and Sendspin player ID.
         """
         async with asyncio.timeout(10):
             msg = await wsock.receive()
 
         if msg.type != WSMsgType.TEXT:
             await wsock.close(code=4001, message=b"Expected text message for auth")
-            return None
+            return None, None
 
         try:
             auth_data = json.loads(msg.data)
         except json.JSONDecodeError:
             await wsock.close(code=4001, message=b"Invalid JSON in auth message")
-            return None
+            return None, None
 
         if auth_data.get("type") != "auth":
             await wsock.close(code=4001, message=b"First message must be auth")
-            return None
+            return None, None
 
         token = auth_data.get("token")
         if not token:
             await wsock.close(code=4001, message=b"Token required in auth message")
-            return None
+            return None, None
 
         user = await self.webserver.auth.authenticate_with_token(token)
         if not user:
             await wsock.close(code=4001, message=b"Invalid or expired token")
-            return None
+            return None, None
 
         # Set the sendspin player_id on the user's websocket client(s)
         # This allows the player controller to auto-whitelist this (web)player
@@ -182,24 +195,27 @@ class SendspinProxyHandler:
 
         self.logger.debug("Sendspin proxy authenticated user: %s", user.username)
         await wsock.send_str('{"type": "auth_ok"}')
-        return user
+        return user, client_id if isinstance(client_id, str) else None
 
     async def _proxy_messages(
         self,
         client_ws: web.WebSocketResponse,
         internal_ws: aiohttp.ClientWebSocketResponse,
+        player_id: str | None = None,
     ) -> None:
         """
         Proxy messages bidirectionally between client and internal Sendspin server.
 
         :param client_ws: The client WebSocket connection.
         :param internal_ws: The internal Sendspin server WebSocket connection.
+        :param player_id: The authenticated Sendspin player ID, if known.
         """
+        context = _SendspinConnectionContext(player_id)
         client_to_internal = asyncio.create_task(
-            self._forward_client_to_internal(client_ws, internal_ws)
+            self._forward_client_to_internal(client_ws, internal_ws, context)
         )
         internal_to_client = asyncio.create_task(
-            self._forward_internal_to_client(client_ws, internal_ws)
+            self._forward_internal_to_client(client_ws, internal_ws, context)
         )
 
         done, pending = await asyncio.wait(
@@ -249,15 +265,19 @@ class SendspinProxyHandler:
         self,
         client_ws: web.WebSocketResponse,
         internal_ws: aiohttp.ClientWebSocketResponse,
+        context: _SendspinConnectionContext,
     ) -> None:
         """
         Forward messages from client to internal Sendspin server.
 
         :param client_ws: The client WebSocket connection.
         :param internal_ws: The internal Sendspin server WebSocket connection.
+        :param context: Shared connection state.
         """
         async for msg in client_ws:
             if msg.type == WSMsgType.TEXT:
+                if player_id := get_sendspin_client_id(msg.data):
+                    context.player_id = player_id
                 await internal_ws.send_str(msg.data)
             elif msg.type == WSMsgType.BINARY:
                 await internal_ws.send_bytes(msg.data)
@@ -270,19 +290,35 @@ class SendspinProxyHandler:
         self,
         client_ws: web.WebSocketResponse,
         internal_ws: aiohttp.ClientWebSocketResponse,
+        context: _SendspinConnectionContext,
     ) -> None:
         """
         Forward messages from internal Sendspin server to client.
 
         :param client_ws: The client WebSocket connection.
         :param internal_ws: The internal Sendspin server WebSocket connection.
+        :param context: Shared connection state.
         """
         async for msg in internal_ws:
             if msg.type == WSMsgType.TEXT:
-                await client_ws.send_str(msg.data)
+                data = self._filter_outbound_message(context, msg.data)
+                if isinstance(data, str):
+                    await client_ws.send_str(data)
             elif msg.type == WSMsgType.BINARY:
-                await client_ws.send_bytes(msg.data)
+                data = self._filter_outbound_message(context, msg.data)
+                if isinstance(data, bytes):
+                    await client_ws.send_bytes(data)
             elif msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.ERROR):
                 if msg.type == WSMsgType.ERROR:
                     self.logger.debug("Sendspin proxy internal transport error: %s", msg.data)
                 break
+
+    def _filter_outbound_message(
+        self, context: _SendspinConnectionContext, message: str | bytes
+    ) -> str | bytes | None:
+        """Return the outbound message allowed for this connection."""
+        if context.player_id is None or not self.mass.players.is_player_audio_only(
+            context.player_id
+        ):
+            return message
+        return filter_audio_only_sendspin_message(message)

--- a/music_assistant/controllers/webserver/sendspin_proxy.py
+++ b/music_assistant/controllers/webserver/sendspin_proxy.py
@@ -170,14 +170,22 @@ class SendspinProxyHandler:
         except json.JSONDecodeError:
             await wsock.close(code=4001, message=b"Invalid JSON in auth message")
             return None, None
+        if not isinstance(auth_data, dict):
+            await wsock.close(code=4001, message=b"Invalid auth message")
+            return None, None
 
         if auth_data.get("type") != "auth":
             await wsock.close(code=4001, message=b"First message must be auth")
             return None, None
 
         token = auth_data.get("token")
-        if not token:
+        if not isinstance(token, str) or not token:
             await wsock.close(code=4001, message=b"Token required in auth message")
+            return None, None
+
+        client_id = auth_data.get("client_id")
+        if client_id is not None and not isinstance(client_id, str):
+            await wsock.close(code=4001, message=b"Invalid client ID")
             return None, None
 
         user = await self.webserver.auth.authenticate_with_token(token)
@@ -188,10 +196,6 @@ class SendspinProxyHandler:
         # Set the sendspin player_id on the user's websocket client(s)
         # This allows the player controller to auto-whitelist this (web)player
         # without modifying the user's player_filter list
-        client_id = auth_data.get("client_id")
-        if client_id is not None and not isinstance(client_id, str):
-            await wsock.close(code=4001, message=b"Invalid client ID")
-            return None, None
         if client_id:
             self.webserver.set_sendspin_player_for_user(user.user_id, client_id)
             self.logger.debug("Registered sendspin player %s for user %s", client_id, user.username)

--- a/music_assistant/controllers/webserver/sendspin_proxy.py
+++ b/music_assistant/controllers/webserver/sendspin_proxy.py
@@ -189,13 +189,16 @@ class SendspinProxyHandler:
         # This allows the player controller to auto-whitelist this (web)player
         # without modifying the user's player_filter list
         client_id = auth_data.get("client_id")
+        if client_id is not None and not isinstance(client_id, str):
+            await wsock.close(code=4001, message=b"Invalid client ID")
+            return None, None
         if client_id:
             self.webserver.set_sendspin_player_for_user(user.user_id, client_id)
             self.logger.debug("Registered sendspin player %s for user %s", client_id, user.username)
 
         self.logger.debug("Sendspin proxy authenticated user: %s", user.username)
         await wsock.send_str('{"type": "auth_ok"}')
-        return user, client_id if isinstance(client_id, str) else None
+        return user, client_id or None
 
     async def _proxy_messages(
         self,
@@ -276,7 +279,7 @@ class SendspinProxyHandler:
         """
         async for msg in client_ws:
             if msg.type == WSMsgType.TEXT:
-                if player_id := get_sendspin_client_id(msg.data):
+                if context.player_id is None and (player_id := get_sendspin_client_id(msg.data)):
                     context.player_id = player_id
                 await internal_ws.send_str(msg.data)
             elif msg.type == WSMsgType.BINARY:

--- a/music_assistant/helpers/sendspin.py
+++ b/music_assistant/helpers/sendspin.py
@@ -1,0 +1,86 @@
+"""Helpers for handling Sendspin protocol messages."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+SENDSPIN_AUDIO_MESSAGE_TYPE = 4
+SENDSPIN_BINARY_HEADER_SIZE = 9
+
+_SAFE_SERVER_MESSAGE_TYPES = frozenset(
+    {
+        "group/update",
+        "server/command",
+        "server/hello",
+        "server/time",
+    }
+)
+
+
+def get_sendspin_client_id(message: str) -> str | None:
+    """
+    Return the client ID from a Sendspin authentication or hello message.
+
+    :param message: Serialized Sendspin client message.
+    :return: The client ID, if present.
+    """
+    try:
+        data: Any = json.loads(message)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("type") == "auth":
+        client_id = data.get("client_id")
+    elif data.get("type") == "client/hello" and isinstance(data.get("payload"), dict):
+        client_id = data["payload"].get("client_id")
+    else:
+        return None
+    return client_id if isinstance(client_id, str) and client_id else None
+
+
+def filter_audio_only_sendspin_message(message: str | bytes) -> str | bytes | None:
+    """
+    Remove non-audio role data from an outbound Sendspin message.
+
+    :param message: Serialized Sendspin server message.
+    :return: The safe message, or ``None`` when it must not be forwarded.
+    """
+    if isinstance(message, bytes):
+        if len(message) < SENDSPIN_BINARY_HEADER_SIZE:
+            return None
+        return message if message[0] == SENDSPIN_AUDIO_MESSAGE_TYPE else None
+
+    try:
+        data: Any = json.loads(message)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict) or not isinstance(data.get("type"), str):
+        return None
+
+    message_type = data["type"]
+    if message_type in _SAFE_SERVER_MESSAGE_TYPES:
+        return message
+    if not isinstance(data.get("payload"), dict):
+        return None
+
+    payload = data["payload"]
+    if message_type == "server/state":
+        controller = payload.get("controller")
+        if controller is None:
+            return None
+        data["payload"] = {"controller": controller}
+    elif message_type == "stream/start":
+        player = payload.get("player")
+        if player is None:
+            return None
+        data["payload"] = {"player": player}
+    elif message_type in {"stream/clear", "stream/end"}:
+        roles = payload.get("roles")
+        if roles is not None and (not isinstance(roles, list) or "player" not in roles):
+            return None
+        data["payload"] = {"roles": ["player"]}
+    else:
+        return None
+    return json.dumps(data, separators=(",", ":"))

--- a/music_assistant/helpers/shared_playback.py
+++ b/music_assistant/helpers/shared_playback.py
@@ -50,16 +50,27 @@ class SharedPlaybackSession:
     :meth:`close` when the session ends.
     """
 
-    def __init__(self, mass: MusicAssistant, mode: SharedPlaybackMode, player_id: str) -> None:
+    def __init__(
+        self,
+        mass: MusicAssistant,
+        mode: SharedPlaybackMode,
+        player_id: str,
+        audio_only: bool = False,
+    ) -> None:
         """Initialize the session. Use the create_venue/create_remote factories instead."""
         self.mass = mass
         self._mode = mode
         self._player_id = player_id
+        self._audio_only = audio_only
         self._guest_listeners: set[str] = set()
 
     @classmethod
     async def create_venue(
-        cls, mass: MusicAssistant, venue_player_id: str
+        cls,
+        mass: MusicAssistant,
+        venue_player_id: str,
+        *,
+        audio_only: bool = False,
     ) -> SharedPlaybackSession:
         """
         Create a session hosted by an existing (real) player.
@@ -67,12 +78,13 @@ class SharedPlaybackSession:
         :param mass: MusicAssistant instance.
         :param venue_player_id: The player_id of the player that owns the queue
             and plays out loud.
+        :param audio_only: Redact media metadata from attached guest players.
         :raises SetupFailedError: If the venue player is unknown.
         :return: The created session.
         """
         if mass.players.get_player(venue_player_id) is None:
             raise SetupFailedError(f"Venue player {venue_player_id} is not available")
-        return cls(mass, SharedPlaybackMode.VENUE, venue_player_id)
+        return cls(mass, SharedPlaybackMode.VENUE, venue_player_id, audio_only)
 
     @classmethod
     async def create_remote(
@@ -81,6 +93,8 @@ class SharedPlaybackSession:
         owner_instance_id: str,
         display_name: str,
         session_id: str | None = None,
+        *,
+        audio_only: bool = False,
     ) -> SharedPlaybackSession:
         """
         Create a session hosted by a hidden Sendspin virtual player.
@@ -91,6 +105,7 @@ class SharedPlaybackSession:
         :param display_name: Human readable name for the virtual player.
         :param session_id: Optional stable id for the virtual player so the
             owner can re-create the session with the same player_id.
+        :param audio_only: Redact media metadata from attached guest players.
         :raises SetupFailedError: If the Sendspin provider is not loaded.
         :return: The created session.
         """
@@ -102,7 +117,7 @@ class SharedPlaybackSession:
             display_name=display_name,
             player_id=session_id,
         )
-        return cls(mass, SharedPlaybackMode.REMOTE, player_id)
+        return cls(mass, SharedPlaybackMode.REMOTE, player_id, audio_only)
 
     @property
     def mode(self) -> SharedPlaybackMode:
@@ -145,11 +160,23 @@ class SharedPlaybackSession:
         :raises UnsupportedFeaturedException: If the session host does not
             support grouping with the given player.
         """
+        if web_player_id in self._guest_listeners:
+            return
         if not self.can_listen_in(web_player_id):
             raise UnsupportedFeaturedException(
                 f"Player {web_player_id} can not listen in on this session"
             )
-        await self.mass.players.cmd_set_members(self._player_id, player_ids_to_add=[web_player_id])
+        grouping_succeeded = False
+        if self._audio_only:
+            self.mass.players.register_audio_only_player(web_player_id)
+        try:
+            await self.mass.players.cmd_set_members(
+                self._player_id, player_ids_to_add=[web_player_id]
+            )
+            grouping_succeeded = True
+        finally:
+            if self._audio_only and not grouping_succeeded:
+                self.mass.players.unregister_audio_only_player(web_player_id)
         self._guest_listeners.add(web_player_id)
 
     async def remove_guest_listener(self, web_player_id: str) -> None:
@@ -158,12 +185,15 @@ class SharedPlaybackSession:
 
         :param web_player_id: The player_id of the guest's web player.
         """
-        self._guest_listeners.discard(web_player_id)
-        if self._get_host_player() is None:
+        if web_player_id not in self._guest_listeners:
             return
-        await self.mass.players.cmd_set_members(
-            self._player_id, player_ids_to_remove=[web_player_id]
-        )
+        if self._get_host_player() is not None:
+            await self.mass.players.cmd_set_members(
+                self._player_id, player_ids_to_remove=[web_player_id]
+            )
+        self._guest_listeners.remove(web_player_id)
+        if self._audio_only:
+            self.mass.players.unregister_audio_only_player(web_player_id)
 
     async def close(self) -> None:
         """
@@ -177,12 +207,13 @@ class SharedPlaybackSession:
             sendspin = cast("SendspinProvider | None", self.mass.get_provider(SENDSPIN_DOMAIN))
             if sendspin is not None and sendspin.is_virtual_player(self._player_id):
                 await sendspin.remove_virtual_player(self._player_id)
-            self._guest_listeners.clear()
-            return
-        if self._guest_listeners and self._get_host_player() is not None:
+        elif self._guest_listeners and self._get_host_player() is not None:
             await self.mass.players.cmd_set_members(
                 self._player_id, player_ids_to_remove=list(self._guest_listeners)
             )
+        if self._audio_only:
+            for web_player_id in self._guest_listeners:
+                self.mass.players.unregister_audio_only_player(web_player_id)
         self._guest_listeners.clear()
 
     def _get_host_player(self) -> Player | None:

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -2323,7 +2323,7 @@ class Player(ABC):
     @final
     def __final_current_media(self) -> PlayerMedia | None:
         """Return the FINAL current media for the player."""
-        if self.mass.players.is_player_audio_only(self.player_id):
+        if self.mass.players.is_player_audio_only(self.player_id) is True:
             return None
         # if the player is grouped/synced, use the current_media of the group/parent player
         if parent_player_id := (self.__final_active_group or self.__final_synced_to):

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -2323,6 +2323,8 @@ class Player(ABC):
     @final
     def __final_current_media(self) -> PlayerMedia | None:
         """Return the FINAL current media for the player."""
+        if self.mass.players.is_player_audio_only(self.player_id):
+            return None
         # if the player is grouped/synced, use the current_media of the group/parent player
         if parent_player_id := (self.__final_active_group or self.__final_synced_to):
             if parent_player_id != self.player_id and (

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1002,13 +1002,14 @@ class MusicQuizPlugin(PluginProvider):
                     owner_instance_id=self.instance_id,
                     display_name=game_name or "Music Quiz",
                     session_id=self.instance_id,
+                    audio_only=True,
                 )
             except SetupFailedError as err:
                 self.logger.warning("Unable to create remote quiz session: %s", err)
         elif player_id := self._resolve_venue_player_id():
             try:
                 self._playback_session = await SharedPlaybackSession.create_venue(
-                    self.mass, player_id
+                    self.mass, player_id, audio_only=True
                 )
             except SetupFailedError as err:
                 self.logger.warning("Unable to create venue quiz session: %s", err)

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
+from music_assistant_models.enums import MediaType, PlaybackState, PlayerFeature, PlayerType
+from music_assistant_models.player import PlayerMedia
 
 from music_assistant.controllers.players import PlayerController
 from tests.common import MockPlayer, MockProvider
@@ -193,6 +194,36 @@ class TestSyncedPlayers:
         # Leader should be able to see its own members (for ungrouping)
         assert "member_a" in leader.state.can_group_with
         assert "member_b" in leader.state.can_group_with
+
+    def test_audio_only_member_does_not_inherit_group_media(self, mock_mass: MagicMock) -> None:
+        """Only a marked grouped child has current media redacted."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        mock_mass.player_queues.get.return_value = None
+        leader = MockPlayer(provider, "leader", "Leader")
+        leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader._attr_group_members = ["leader", "member"]
+        leader._attr_current_media = PlayerMedia(
+            uri="library://track/answer",
+            media_type=MediaType.TRACK,
+            title="Answer",
+            artist="Artist",
+        )
+        member = MockPlayer(provider, "member", "Member")
+        leader.initialized.set()
+        member.initialized.set()
+        controller._players = {"leader": leader, "member": member}
+        mock_mass.players = controller
+        leader.update_state(signal_event=False)
+        member.update_state(signal_event=False)
+        assert member.state.current_media is leader.state.current_media
+
+        controller.register_audio_only_player("member")
+
+        assert member.state.current_media is None
+        assert leader.state.current_media is not None
+        controller.unregister_audio_only_player("member")
+        assert member.state.current_media is leader.state.current_media
 
 
 class TestSyncLeaderBehavior:

--- a/tests/helpers/test_sendspin.py
+++ b/tests/helpers/test_sendspin.py
@@ -1,0 +1,89 @@
+"""Tests for Sendspin protocol helpers."""
+
+from __future__ import annotations
+
+import json
+
+from music_assistant.helpers.sendspin import (
+    filter_audio_only_sendspin_message,
+    get_sendspin_client_id,
+)
+
+
+def test_get_sendspin_client_id() -> None:
+    """Client IDs are accepted from proxy authentication and protocol hello messages."""
+    assert get_sendspin_client_id('{"type":"auth","client_id":"web_player"}') == "web_player"
+    assert (
+        get_sendspin_client_id('{"type":"client/hello","payload":{"client_id":"web_player"}}')
+        == "web_player"
+    )
+    assert get_sendspin_client_id('{"type":"client/time"}') is None
+
+
+def test_audio_only_state_keeps_controller_controls() -> None:
+    """Metadata and color are removed while controller state remains available."""
+    message = json.dumps(
+        {
+            "type": "server/state",
+            "payload": {
+                "metadata": {
+                    "title": "Answer",
+                    "artist": "Artist",
+                    "album": "Album",
+                    "year": 1999,
+                    "artwork_url": "https://example.test/cover.jpg",
+                },
+                "controller": {"volume": 50, "muted": False},
+                "color": {"primary": [1, 2, 3]},
+            },
+        }
+    )
+
+    filtered = filter_audio_only_sendspin_message(message)
+
+    assert isinstance(filtered, str)
+    assert json.loads(filtered) == {
+        "type": "server/state",
+        "payload": {"controller": {"volume": 50, "muted": False}},
+    }
+
+
+def test_audio_only_metadata_only_state_is_dropped() -> None:
+    """Metadata catch-up and update messages are not forwarded."""
+    message = '{"type":"server/state","payload":{"metadata":{"title":"Answer"}}}'
+
+    assert filter_audio_only_sendspin_message(message) is None
+
+
+def test_audio_only_stream_start_keeps_player_only() -> None:
+    """Artwork and visualizer stream configuration is removed from audio stream setup."""
+    message = json.dumps(
+        {
+            "type": "stream/start",
+            "payload": {
+                "player": {"codec": "opus", "sample_rate": 48000},
+                "artwork": {"channels": [{"source": "album"}]},
+                "visualizer": {"types": ["spectrum"]},
+            },
+        }
+    )
+
+    filtered = filter_audio_only_sendspin_message(message)
+
+    assert isinstance(filtered, str)
+    assert json.loads(filtered) == {
+        "type": "stream/start",
+        "payload": {"player": {"codec": "opus", "sample_rate": 48000}},
+    }
+
+
+def test_audio_only_binary_allows_only_audio_chunks() -> None:
+    """Only complete audio chunk messages pass the binary filter."""
+    audio = bytes([4]) + b"\0" * 8 + b"audio"
+    artwork = bytes([8]) + b"\0" * 8 + b"artwork"
+    visualizer = bytes([16]) + b"\0" * 8 + b"visualizer"
+
+    assert filter_audio_only_sendspin_message(audio) == audio
+    assert filter_audio_only_sendspin_message(artwork) is None
+    assert filter_audio_only_sendspin_message(visualizer) is None
+    assert filter_audio_only_sendspin_message(bytes([4])) is None

--- a/tests/helpers/test_shared_playback.py
+++ b/tests/helpers/test_shared_playback.py
@@ -21,6 +21,8 @@ def _create_mock_mass(venue_player: MagicMock | None) -> MagicMock:
     mass = MagicMock()
     mass.players.get_player.return_value = venue_player
     mass.players.cmd_set_members = AsyncMock()
+    mass.players.register_audio_only_player = MagicMock()
+    mass.players.unregister_audio_only_player = MagicMock()
     return mass
 
 
@@ -104,6 +106,78 @@ async def test_venue_add_and_remove_guest_listener() -> None:
     mass.players.cmd_set_members.assert_awaited_with(
         "venue_player", player_ids_to_remove=["web_player_1"]
     )
+    mass.players.register_audio_only_player.assert_not_called()
+    mass.players.unregister_audio_only_player.assert_not_called()
+
+
+async def test_audio_only_registration_wraps_group_membership() -> None:
+    """Audio-only registration starts before grouping and ends after ungrouping."""
+    venue_player = _create_venue_player(can_group_with={"web_player_1"})
+    mass = _create_mock_mass(venue_player)
+    events: list[tuple[str, bool | None]] = []
+    mass.players.register_audio_only_player.side_effect = lambda _player_id: events.append(
+        ("audio_only", True)
+    )
+    mass.players.unregister_audio_only_player.side_effect = lambda _player_id: events.append(
+        ("audio_only", False)
+    )
+
+    async def record_grouping(
+        _player_id: str,
+        *,
+        player_ids_to_add: list[str] | None = None,
+        player_ids_to_remove: list[str] | None = None,
+    ) -> None:
+        assert (player_ids_to_add is None) != (player_ids_to_remove is None)
+        events.append(("group", player_ids_to_remove is None))
+
+    mass.players.cmd_set_members.side_effect = record_grouping
+    session = await SharedPlaybackSession.create_venue(mass, "venue_player", audio_only=True)
+
+    await session.add_guest_listener("web_player_1")
+    await session.add_guest_listener("web_player_1")
+    await session.remove_guest_listener("web_player_1")
+    await session.remove_guest_listener("web_player_1")
+
+    assert events == [
+        ("audio_only", True),
+        ("group", True),
+        ("group", False),
+        ("audio_only", False),
+    ]
+
+
+async def test_audio_only_registration_rolls_back_on_grouping_failure() -> None:
+    """A failed group operation immediately restores normal metadata behavior."""
+    venue_player = _create_venue_player(can_group_with={"web_player_1"})
+    mass = _create_mock_mass(venue_player)
+    mass.players.cmd_set_members.side_effect = RuntimeError("grouping failed")
+    session = await SharedPlaybackSession.create_venue(mass, "venue_player", audio_only=True)
+
+    with pytest.raises(RuntimeError, match="grouping failed"):
+        await session.add_guest_listener("web_player_1")
+
+    mass.players.register_audio_only_player.assert_called_once_with("web_player_1")
+    mass.players.unregister_audio_only_player.assert_called_once_with("web_player_1")
+
+
+async def test_audio_only_close_restores_listeners_after_detach() -> None:
+    """Closing an audio-only venue session restores every tracked guest."""
+    venue_player = _create_venue_player(can_group_with={"web_player_1", "web_player_2"})
+    mass = _create_mock_mass(venue_player)
+    session = await SharedPlaybackSession.create_venue(mass, "venue_player", audio_only=True)
+    await session.add_guest_listener("web_player_1")
+    await session.add_guest_listener("web_player_2")
+    mass.players.unregister_audio_only_player.reset_mock()
+
+    await session.close()
+
+    removed = mass.players.cmd_set_members.await_args.kwargs["player_ids_to_remove"]
+    assert set(removed) == {"web_player_1", "web_player_2"}
+    assert {call.args for call in mass.players.unregister_audio_only_player.call_args_list} == {
+        ("web_player_1",),
+        ("web_player_2",),
+    }
 
 
 async def test_venue_add_guest_listener_unsupported() -> None:

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -2016,6 +2016,7 @@ async def test_playback_session_remote_mode() -> None:
         owner_instance_id=INSTANCE_ID,
         display_name="Music Quiz",
         session_id=INSTANCE_ID,
+        audio_only=True,
     )
 
 
@@ -2049,7 +2050,7 @@ async def test_playback_session_venue_mode() -> None:
         new=AsyncMock(return_value=session),
     ) as create_venue:
         assert await plugin._get_playback_session() is session
-    create_venue.assert_awaited_once_with(plugin.mass, "venue_player")
+    create_venue.assert_awaited_once_with(plugin.mass, "venue_player", audio_only=True)
 
 
 @pytest.mark.asyncio
@@ -2066,7 +2067,7 @@ async def test_playback_session_venue_mode_auto_prefers_playing_player() -> None
         new=AsyncMock(return_value=session),
     ) as create_venue:
         assert await plugin._get_playback_session() is session
-    create_venue.assert_awaited_once_with(plugin.mass, "playing_player")
+    create_venue.assert_awaited_once_with(plugin.mass, "playing_player", audio_only=True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -1,9 +1,12 @@
 """Tests for remote access feature."""
 
 import base64
-from unittest.mock import AsyncMock, Mock, patch
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, call, patch
 from urllib.parse import urlparse
 
+import aiohttp
 import pytest
 from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection
 from aiortc.rtcdtlstransport import RTCCertificate
@@ -435,3 +438,51 @@ async def test_http_proxy_request_cannot_change_host(
     assert parsed.port == 8095
     assert parsed.username is None
     assert "evil.com" not in (parsed.netloc or "")
+
+
+async def test_sendspin_forwarding_uses_dynamic_audio_only_registry(
+    mock_certificate: Mock,
+) -> None:
+    """An existing WebRTC path starts filtering when its player is marked audio-only."""
+    audio_only = False
+    metadata = '{"type":"server/state","payload":{"metadata":{"title":"Answer"}}}'
+    audio = bytes([4]) + b"\0" * 8 + b"audio"
+    artwork = bytes([8]) + b"\0" * 8 + b"artwork"
+    visualizer = bytes([16]) + b"\0" * 8 + b"visualizer"
+
+    async def messages() -> AsyncIterator[SimpleNamespace]:
+        nonlocal audio_only
+        yield SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data=metadata)
+        audio_only = True
+        yield SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data=metadata)
+        yield SimpleNamespace(type=aiohttp.WSMsgType.BINARY, data=artwork)
+        yield SimpleNamespace(type=aiohttp.WSMsgType.BINARY, data=visualizer)
+        yield SimpleNamespace(type=aiohttp.WSMsgType.BINARY, data=audio)
+
+    class MessageStream:
+        """Async message stream with the WebSocket state used by the gateway."""
+
+        closed = False
+
+        def __aiter__(self) -> AsyncIterator[SimpleNamespace]:
+            return messages()
+
+    gateway = WebRTCGateway(
+        http_session=Mock(),
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+        is_sendspin_player_audio_only=lambda _player_id: audio_only,
+    )
+    channel = Mock()
+    channel.readyState = "open"
+    session = WebRTCSession(
+        session_id="s1",
+        peer_connection=Mock(),
+        sendspin_channel=channel,
+        sendspin_ws=MessageStream(),
+        sendspin_player_id="web_player",
+    )
+
+    await gateway._forward_sendspin_from_local(session)
+
+    assert channel.send.call_args_list == [call(metadata), call(audio)]

--- a/tests/test_sendspin_proxy.py
+++ b/tests/test_sendspin_proxy.py
@@ -1,14 +1,20 @@
 """Tests for the Sendspin WebSocket proxy handler."""
 
 import asyncio
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
-from aiohttp import ClientConnectorError, web
+from aiohttp import ClientConnectorError, WSMsgType, web
 from aiohttp.test_utils import make_mocked_request
 
-from music_assistant.controllers.webserver.sendspin_proxy import SendspinProxyHandler
+from music_assistant.controllers.webserver.sendspin_proxy import (
+    SendspinProxyHandler,
+    _SendspinConnectionContext,
+)
 
 
 @pytest.fixture
@@ -50,7 +56,7 @@ class TestSendspinProxyRetry:
         )
 
         with (
-            patch.object(handler, "_authenticate", return_value=MagicMock()),
+            patch.object(handler, "_authenticate", return_value=(MagicMock(), "web_player")),
             patch.object(handler, "_proxy_messages", new_callable=AsyncMock),
             patch("aiohttp.web.WebSocketResponse", return_value=mock_ws_response),
             patch.object(handler.mass, "http_session", create=True) as mock_session,
@@ -82,7 +88,7 @@ class TestSendspinProxyRetry:
         mock_ws_connect = AsyncMock(side_effect=connector_error)
 
         with (
-            patch.object(handler, "_authenticate", return_value=MagicMock()),
+            patch.object(handler, "_authenticate", return_value=(MagicMock(), "web_player")),
             patch("aiohttp.web.WebSocketResponse", return_value=mock_ws_response),
             patch.object(handler.mass, "http_session", create=True) as mock_session,
             patch(
@@ -110,7 +116,7 @@ class TestSendspinProxyRetry:
         mock_ws_connect = AsyncMock(side_effect=TypeError("unexpected error"))
 
         with (
-            patch.object(handler, "_authenticate", return_value=MagicMock()),
+            patch.object(handler, "_authenticate", return_value=(MagicMock(), "web_player")),
             patch("aiohttp.web.WebSocketResponse", return_value=mock_ws_response),
             patch.object(handler.mass, "http_session", create=True) as mock_session,
             patch(
@@ -207,3 +213,37 @@ class TestSendspinProxyMessages:
             patch.object(handler, "_forward_client_to_internal", new=wait_forever),
         ):
             await handler._proxy_messages(MagicMock(), MagicMock())
+
+    async def test_outbound_redaction_uses_dynamic_registry(
+        self, handler: SendspinProxyHandler
+    ) -> None:
+        """An existing local proxy connection starts filtering as soon as it is marked."""
+        audio_only = False
+        metadata = '{"type":"server/state","payload":{"metadata":{"title":"Answer"}}}'
+        audio = bytes([4]) + b"\0" * 8 + b"audio"
+        artwork = bytes([8]) + b"\0" * 8 + b"artwork"
+        visualizer = bytes([16]) + b"\0" * 8 + b"visualizer"
+
+        async def messages() -> AsyncIterator[SimpleNamespace]:
+            nonlocal audio_only
+            yield SimpleNamespace(type=WSMsgType.TEXT, data=metadata)
+            audio_only = True
+            yield SimpleNamespace(type=WSMsgType.TEXT, data=metadata)
+            yield SimpleNamespace(type=WSMsgType.BINARY, data=artwork)
+            yield SimpleNamespace(type=WSMsgType.BINARY, data=visualizer)
+            yield SimpleNamespace(type=WSMsgType.BINARY, data=audio)
+
+        cast("MagicMock", handler.mass.players.is_player_audio_only).side_effect = (
+            lambda _player_id: audio_only
+        )
+        client_ws = AsyncMock()
+        context = _SendspinConnectionContext("web_player")
+
+        await handler._forward_internal_to_client(
+            client_ws,
+            cast("aiohttp.ClientWebSocketResponse", messages()),
+            context,
+        )
+
+        client_ws.send_str.assert_awaited_once_with(metadata)
+        client_ws.send_bytes.assert_awaited_once_with(audio)

--- a/tests/test_sendspin_proxy.py
+++ b/tests/test_sendspin_proxy.py
@@ -247,3 +247,45 @@ class TestSendspinProxyMessages:
 
         client_ws.send_str.assert_awaited_once_with(metadata)
         client_ws.send_bytes.assert_awaited_once_with(audio)
+
+    async def test_client_cannot_replace_connection_player_id(
+        self, handler: SendspinProxyHandler
+    ) -> None:
+        """Later client messages cannot replace the authenticated player identity."""
+        hello = SimpleNamespace(
+            type=WSMsgType.TEXT,
+            data='{"type":"client/hello","payload":{"client_id":"other_player"}}',
+        )
+
+        async def messages() -> AsyncIterator[SimpleNamespace]:
+            yield hello
+
+        internal_ws = AsyncMock()
+        context = _SendspinConnectionContext("web_player")
+
+        await handler._forward_client_to_internal(
+            cast("web.WebSocketResponse", messages()),
+            internal_ws,
+            context,
+        )
+
+        assert context.player_id == "web_player"
+        internal_ws.send_str.assert_awaited_once_with(hello.data)
+
+
+async def test_authenticate_rejects_non_string_client_id(
+    handler: SendspinProxyHandler,
+) -> None:
+    """Proxy authentication rejects invalid player identifiers."""
+    wsock = AsyncMock(spec=web.WebSocketResponse)
+    wsock.receive.return_value = SimpleNamespace(
+        type=WSMsgType.TEXT,
+        data='{"type":"auth","token":"token","client_id":{"invalid":true}}',
+    )
+    mock_auth = cast("MagicMock", handler.webserver.auth)
+    mock_auth.authenticate_with_token = AsyncMock(return_value=MagicMock())
+
+    result = await handler._authenticate(wsock)
+
+    assert result == (None, None)
+    wsock.close.assert_awaited_once_with(code=4001, message=b"Invalid client ID")

--- a/tests/test_sendspin_proxy.py
+++ b/tests/test_sendspin_proxy.py
@@ -289,3 +289,25 @@ async def test_authenticate_rejects_non_string_client_id(
 
     assert result == (None, None)
     wsock.close.assert_awaited_once_with(code=4001, message=b"Invalid client ID")
+
+
+@pytest.mark.parametrize(
+    ("data", "error"),
+    [
+        ("[]", b"Invalid auth message"),
+        ('{"type":"auth","token":{"invalid":true}}', b"Token required in auth message"),
+    ],
+)
+async def test_authenticate_rejects_invalid_payload_types(
+    handler: SendspinProxyHandler,
+    data: str,
+    error: bytes,
+) -> None:
+    """Proxy authentication rejects invalid JSON shapes and token types."""
+    wsock = AsyncMock(spec=web.WebSocketResponse)
+    wsock.receive.return_value = SimpleNamespace(type=WSMsgType.TEXT, data=data)
+
+    result = await handler._authenticate(wsock)
+
+    assert result == (None, None)
+    wsock.close.assert_awaited_once_with(code=4001, message=error)


### PR DESCRIPTION
# What does this implement/fix?

Music Quiz ListenIn could expose unrevealed answers through player and Sendspin metadata. This keeps attached quiz guests audio-only until they disconnect.

- Redact metadata, artwork, colors, visualizer data, and other non-audio Sendspin role messages for quiz listeners.
- Hide inherited grouped media from the listener's PlayerState.
- Restore normal metadata after detach while leaving Party sessions unchanged.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.