### PR TITLE
Hide Music Quiz answers until reveal

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -14,7 +14,9 @@ but it can also be something else, hence the loose coupling.
 from __future__ import annotations
 
 import asyncio
+import hmac
 import random
+import secrets
 import time
 from typing import TYPE_CHECKING, Any, Final, cast
 
@@ -74,7 +76,7 @@ from music_assistant.controllers.player_queues.media_resolver import MediaResolv
 from music_assistant.controllers.player_queues.playback_tracker import PlaybackTrackerMixin
 from music_assistant.controllers.player_queues.queue_loader import QueueLoaderMixin
 from music_assistant.controllers.player_queues.smart_shuffle import SmartShuffle
-from music_assistant.controllers.player_queues.state import PlayerQueueData
+from music_assistant.controllers.player_queues.state import PlayerQueueData, QueueMediaPresentation
 from music_assistant.controllers.player_queues.stream_feeder import StreamFeederMixin
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_current_user,
@@ -242,6 +244,109 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
     def queue_data_or_none(self, queue_id: str) -> PlayerQueueData | None:
         """Return the server-side record for a queue, or None if it is not registered."""
         return self._queue_data.get(queue_id)
+
+    def set_media_presentation(self, queue_id: str, owner_token: object, title: str) -> None:
+        """
+        Conceal media identity exposed by a queue for the given owner.
+
+        :param queue_id: Queue whose media presentation should be concealed.
+        :param owner_token: Opaque token that exclusively owns the presentation lease.
+        :param title: Neutral title to expose while the lease is active.
+        """
+        if (queue_data := self._queue_data.get(queue_id)) is None:
+            raise PlayerUnavailableError(f"Queue {queue_id} is not available")
+        if (
+            presentation := queue_data.media_presentation
+        ) is not None and presentation.owner_token is not owner_token:
+            raise InvalidCommand(f"Queue {queue_id} already has an active media presentation")
+        queue_data.media_presentation = QueueMediaPresentation(
+            owner_token=owner_token,
+            title=title,
+            identity_key=secrets.token_bytes(32),
+        )
+        self._refresh_media_presentation_player(queue_id)
+
+    def clear_media_presentation(self, queue_id: str, owner_token: object) -> bool:
+        """
+        Release this owner's media presentation lease.
+
+        :param queue_id: Queue whose presentation lease should be released.
+        :param owner_token: Opaque token that owns the presentation lease.
+        :return: True when the matching lease was released.
+        """
+        if (
+            (queue_data := self._queue_data.get(queue_id)) is None
+            or (presentation := queue_data.media_presentation) is None
+            or presentation.owner_token is not owner_token
+        ):
+            return False
+        queue_data.media_presentation = None
+        self._refresh_media_presentation_player(queue_id)
+        return True
+
+    def has_media_presentation(self, queue_id: str, owner_token: object) -> bool:
+        """
+        Return whether this owner holds the queue's media presentation lease.
+
+        :param queue_id: Queue to inspect.
+        :param owner_token: Opaque token expected to own the lease.
+        """
+        return (
+            (queue_data := self._queue_data.get(queue_id)) is not None
+            and (presentation := queue_data.media_presentation) is not None
+            and presentation.owner_token is owner_token
+        )
+
+    def apply_media_presentation(
+        self, queue_id: str, media: PlayerMedia, *, preserve_playback_data: bool = False
+    ) -> PlayerMedia:
+        """
+        Return media projected through the queue's active presentation lease.
+
+        :param queue_id: Queue whose presentation should be applied.
+        :param media: Source media to project.
+        :param preserve_playback_data: Preserve fields required to load media on a device.
+        """
+        queue_data = self._queue_data.get(queue_id)
+        presentation = queue_data.media_presentation if queue_data is not None else None
+        if presentation is None:
+            return PlayerMedia(
+                uri=media.uri,
+                media_type=media.media_type,
+                title=media.title,
+                artist=media.artist,
+                album=media.album,
+                album_artist=media.album_artist,
+                image_url=media.image_url,
+                palette=media.palette,
+                duration=media.duration,
+                source_id=media.source_id,
+                queue_item_id=media.queue_item_id,
+                custom_data=dict(media.custom_data) if media.custom_data is not None else None,
+                elapsed_time=media.elapsed_time,
+                elapsed_time_last_updated=media.elapsed_time_last_updated,
+            )
+        if preserve_playback_data:
+            return PlayerMedia(
+                uri=media.uri,
+                media_type=media.media_type,
+                title=presentation.title,
+                duration=media.duration,
+                source_id=media.source_id,
+                queue_item_id=media.queue_item_id,
+                custom_data=dict(media.custom_data) if media.custom_data is not None else None,
+                elapsed_time=media.elapsed_time,
+                elapsed_time_last_updated=media.elapsed_time_last_updated,
+            )
+        identity = f"{media.queue_item_id or ''}\0{media.uri}".encode()
+        opaque_uri = f"media-presentation://{hmac.digest(presentation.identity_key, identity, 'sha256').hex()}"
+        return PlayerMedia(
+            uri=opaque_uri,
+            media_type=MediaType.UNKNOWN,
+            title=presentation.title,
+            elapsed_time=media.elapsed_time,
+            elapsed_time_last_updated=media.elapsed_time_last_updated,
+        )
 
     @api_command("player_queues/items", required_scope=Scope.QUEUES_READ)
     def items_for_api(self, queue_id: str, limit: int = 500, offset: int = 0) -> list[QueueItem]:
@@ -1556,6 +1661,10 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                 "original_uri": queue_item.uri,
             },
         )
+        if queue_data.media_presentation is not None:
+            return self.apply_media_presentation(
+                queue_item.queue_id, media, preserve_playback_data=True
+            )
         if queue_item.media_item:
             media.title = queue_item.media_item.name
             media.artist = getattr(queue_item.media_item, "artist_str", "")
@@ -1716,3 +1825,14 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         """Mark (or clear) whether a queue is mid-transition (no-op if it is not registered)."""
         if (queue_data := self._queue_data.get(queue_id)) is not None:
             queue_data.transitioning = value
+
+    def _refresh_media_presentation_player(self, queue_id: str) -> None:
+        """Refresh the queue owner after its media presentation changes."""
+        if queue_player := self.mass.players.get_player(queue_id):
+            parent_player_id = queue_player.state.active_group or queue_player.state.synced_to
+            if parent_player_id and (
+                parent_player := self.mass.players.get_player(parent_player_id)
+            ):
+                parent_player.refresh_state()
+                return
+            queue_player.refresh_state()

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -603,6 +603,19 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
     @api_command(
         "player_queues/play_media", required_scope=Scope.QUEUES_CONTROL, allow_impersonation=True
     )
+    async def play_media_for_api(
+        self,
+        queue_id: str,
+        media: MediaItemType | ItemMapping | str | list[MediaItemType | ItemMapping | str],
+        option: QueueOption | None = None,
+        radio_mode: bool = False,
+        start_item: PlayableMediaItemType | str | None = None,
+        sort_by: str | None = None,
+    ) -> None:
+        """Validate queue access and play media from an API request."""
+        self._check_player_permission(queue_id)
+        await self.play_media(queue_id, media, option, radio_mode, start_item, sort_by)
+
     async def play_media(
         self,
         queue_id: str,
@@ -623,7 +636,6 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         :param start_item: Optional item to start the playlist or album from.
         :param sort_by: Optional sort key to order tracks before applying start_item.
         """
-        self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
         # Lock is acquired by the @handle_play_action decorator on the internal handler
@@ -710,6 +722,11 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         self.update_items(queue_id, queue_items)
 
     @api_command("player_queues/clear", required_scope=Scope.QUEUES_CONTROL)
+    def clear_for_api(self, queue_id: str, skip_stop: bool = False) -> None:
+        """Validate queue access and clear a queue from an API request."""
+        self._check_player_permission(queue_id)
+        self.clear(queue_id, skip_stop)
+
     def clear(self, queue_id: str, skip_stop: bool = False) -> None:
         """Clear all items in the queue."""
         queue = self._queue_data[queue_id].queue
@@ -749,6 +766,11 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         return await self.mass.music.playlists.add_playlist_tracks(playlist.item_id, uris)
 
     @api_command("player_queues/stop", required_scope=Scope.QUEUES_CONTROL)
+    async def stop_for_api(self, queue_id: str) -> None:
+        """Validate queue access and stop playback from an API request."""
+        self._check_player_permission(queue_id)
+        await self.stop(queue_id)
+
     @handle_play_action
     async def stop(self, queue_id: str) -> None:
         """
@@ -756,7 +778,6 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
 
         - queue_id: queue_id of the playerqueue to handle the command.
         """
-        self._check_player_permission(queue_id)
         # cancel any pending play_index calls for this queue to prevent conflicts
         self.mass.cancel_timer(f"queue_play_index_{queue_id}")
         # cancel in-flight preload/enqueue-next so it can't enqueue after stop
@@ -1127,6 +1148,17 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             self._set_transitioning(queue_id, False)
 
     @api_command("player_queues/transfer", required_scope=Scope.QUEUES_CONTROL)
+    async def transfer_queue_for_api(
+        self,
+        source_queue_id: str,
+        target_queue_id: str,
+        auto_play: bool | None = None,
+    ) -> None:
+        """Validate queue access and transfer a queue from an API request."""
+        self._check_player_permission(source_queue_id)
+        self._check_player_permission(target_queue_id)
+        await self.transfer_queue(source_queue_id, target_queue_id, auto_play)
+
     async def transfer_queue(
         self,
         source_queue_id: str,

--- a/music_assistant/controllers/player_queues/state.py
+++ b/music_assistant/controllers/player_queues/state.py
@@ -36,6 +36,15 @@ _VOLATILE_CACHE_FIELDS = ("elapsed_time", "elapsed_time_last_updated", "playback
 
 
 @dataclass(slots=True)
+class QueueMediaPresentation:
+    """Runtime presentation override for media exposed by a queue."""
+
+    owner_token: object
+    title: str
+    identity_key: bytes
+
+
+@dataclass(slots=True)
 class PlayerQueueData:
     """The complete server-side record for a queue: the wire `PlayerQueue` plus all server-only state."""
 
@@ -70,6 +79,7 @@ class PlayerQueueData:
     # the significant part of the state last written to cache (volatile playback-progress fields
     # stripped); lets the debounced saver skip a redundant write when nothing meaningful changed
     last_saved_state: dict[str, Any] | None = None
+    media_presentation: QueueMediaPresentation | None = None
 
     def to_cache(self) -> dict[str, Any]:
         """

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -576,7 +576,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         player = self._get_player_with_redirect(player_id)
         # Redirect to queue controller if it is active (skip if already in queue command context)
         if active_queue := self.get_active_queue(player):
-            await self.mass.player_queues.stop(active_queue.queue_id)
+            await self.mass.player_queues.stop_for_api(active_queue.queue_id)
             return
         # Delegate to internal handler for actual implementation
         await self._handle_cmd_stop(player.player_id)

--- a/music_assistant/controllers/webserver/sendspin_proxy.py
+++ b/music_assistant/controllers/webserver/sendspin_proxy.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 from aiohttp import ClientConnectorError, WSMsgType, web
+from music_assistant_models.auth import UserRole
 
 from music_assistant.constants import MASS_LOGGER_NAME
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
@@ -129,7 +130,7 @@ class SendspinProxyHandler:
         self.logger.debug("Sendspin proxy authenticated and connected for %s", request.remote)
 
         try:
-            await self._proxy_messages(wsock, internal_ws)
+            await self._proxy_messages(wsock, internal_ws, user)
         finally:
             if not internal_ws.closed:
                 await internal_ws.close()
@@ -158,13 +159,20 @@ class SendspinProxyHandler:
             await wsock.close(code=4001, message=b"Invalid JSON in auth message")
             return None
 
+        if not isinstance(auth_data, dict):
+            await wsock.close(code=4001, message=b"Invalid auth message")
+            return None
         if auth_data.get("type") != "auth":
             await wsock.close(code=4001, message=b"First message must be auth")
             return None
 
         token = auth_data.get("token")
-        if not token:
+        if not isinstance(token, str) or not token:
             await wsock.close(code=4001, message=b"Token required in auth message")
+            return None
+        client_id = auth_data.get("client_id")
+        if "client_id" in auth_data and (not isinstance(client_id, str) or not client_id):
+            await wsock.close(code=4001, message=b"Invalid client_id in auth message")
             return None
 
         user = await self.webserver.auth.authenticate_with_token(token)
@@ -175,8 +183,7 @@ class SendspinProxyHandler:
         # Set the sendspin player_id on the user's websocket client(s)
         # This allows the player controller to auto-whitelist this (web)player
         # without modifying the user's player_filter list
-        client_id = auth_data.get("client_id")
-        if client_id:
+        if client_id is not None:
             self.webserver.set_sendspin_player_for_user(user.user_id, client_id)
             self.logger.debug("Registered sendspin player %s for user %s", client_id, user.username)
 
@@ -188,15 +195,18 @@ class SendspinProxyHandler:
         self,
         client_ws: web.WebSocketResponse,
         internal_ws: aiohttp.ClientWebSocketResponse,
+        user: User,
     ) -> None:
         """
         Proxy messages bidirectionally between client and internal Sendspin server.
 
         :param client_ws: The client WebSocket connection.
         :param internal_ws: The internal Sendspin server WebSocket connection.
+        :param user: The user authenticated for this proxy connection.
         """
+        allowed_roles = ("player@v1",) if user.role == UserRole.GUEST else None
         client_to_internal = asyncio.create_task(
-            self._forward_client_to_internal(client_ws, internal_ws)
+            self._forward_client_to_internal(client_ws, internal_ws, allowed_roles)
         )
         internal_to_client = asyncio.create_task(
             self._forward_internal_to_client(client_ws, internal_ws)
@@ -249,16 +259,21 @@ class SendspinProxyHandler:
         self,
         client_ws: web.WebSocketResponse,
         internal_ws: aiohttp.ClientWebSocketResponse,
+        allowed_roles: tuple[str, ...] | None,
     ) -> None:
         """
         Forward messages from client to internal Sendspin server.
 
         :param client_ws: The client WebSocket connection.
         :param internal_ws: The internal Sendspin server WebSocket connection.
+        :param allowed_roles: Roles the client may advertise, or None for pass-through.
         """
         async for msg in client_ws:
             if msg.type == WSMsgType.TEXT:
-                await internal_ws.send_str(msg.data)
+                raw_message = msg.data
+                if allowed_roles is not None:
+                    raw_message = self._restrict_client_hello_roles(raw_message, allowed_roles)
+                await internal_ws.send_str(raw_message)
             elif msg.type == WSMsgType.BINARY:
                 await internal_ws.send_bytes(msg.data)
             elif msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.ERROR):
@@ -286,3 +301,25 @@ class SendspinProxyHandler:
                 if msg.type == WSMsgType.ERROR:
                     self.logger.debug("Sendspin proxy internal transport error: %s", msg.data)
                 break
+
+    @staticmethod
+    def _restrict_client_hello_roles(raw_message: str, allowed_roles: tuple[str, ...]) -> str:
+        """
+        Restrict the roles advertised by a structurally valid Sendspin client hello.
+
+        :param raw_message: Raw text message received from the client.
+        :param allowed_roles: Exact roles the client may advertise.
+        :return: The rewritten hello or the original message when it is not a valid hello.
+        """
+        try:
+            message = json.loads(raw_message)
+        except json.JSONDecodeError:
+            return raw_message
+        if (
+            not isinstance(message, dict)
+            or message.get("type") != "client/hello"
+            or not isinstance((payload := message.get("payload")), dict)
+        ):
+            return raw_message
+        payload["supported_roles"] = list(allowed_roles)
+        return json.dumps(message, separators=(",", ":"))

--- a/music_assistant/helpers/shared_playback.py
+++ b/music_assistant/helpers/shared_playback.py
@@ -56,6 +56,7 @@ class SharedPlaybackSession:
         self._mode = mode
         self._player_id = player_id
         self._guest_listeners: set[str] = set()
+        self._media_presentation_owner = object()
 
     @classmethod
     async def create_venue(
@@ -120,6 +121,36 @@ class SharedPlaybackSession:
         # a player-owned queue always has the same id as the player
         return self._player_id
 
+    def set_media_presentation(self, title: str) -> None:
+        """
+        Conceal media identity exposed by this session's queue.
+
+        :param title: Neutral title to expose while presentation is concealed.
+        """
+        self.mass.player_queues.set_media_presentation(
+            self.queue_id, self._media_presentation_owner, title
+        )
+
+    def clear_media_presentation(self) -> bool:
+        """Release this session's media presentation lease."""
+        return self.mass.player_queues.clear_media_presentation(
+            self.queue_id, self._media_presentation_owner
+        )
+
+    async def clear_playback(self) -> None:
+        """
+        Stop and clear this session's queue before releasing its presentation lease.
+
+        Any playback cleanup failure leaves the lease installed and is propagated.
+        """
+        queue = self.mass.player_queues.get(self.queue_id)
+        if queue is None:
+            self.clear_media_presentation()
+            return
+        await self.mass.player_queues.stop(self.queue_id)
+        self.mass.player_queues.clear(self.queue_id, skip_stop=True)
+        self.clear_media_presentation()
+
     def can_listen_in(self, web_player_id: str) -> bool:
         """
         Return whether the given guest web player can listen in on this session.
@@ -173,6 +204,10 @@ class SharedPlaybackSession:
         In VENUE mode only the guest listeners added through this session are
         detached; the venue player itself is left untouched.
         """
+        if self.mass.player_queues.has_media_presentation(
+            self.queue_id, self._media_presentation_owner
+        ):
+            await self.clear_playback()
         if self._mode == SharedPlaybackMode.REMOTE:
             sendspin = cast("SendspinProvider | None", self.mass.get_provider(SENDSPIN_DOMAIN))
             if sendspin is not None and sendspin.is_virtual_player(self._player_id):

--- a/music_assistant/helpers/shared_playback.py
+++ b/music_assistant/helpers/shared_playback.py
@@ -204,21 +204,21 @@ class SharedPlaybackSession:
         In VENUE mode only the guest listeners added through this session are
         detached; the venue player itself is left untouched.
         """
-        if self.mass.player_queues.has_media_presentation(
-            self.queue_id, self._media_presentation_owner
-        ):
-            await self.clear_playback()
-        if self._mode == SharedPlaybackMode.REMOTE:
-            sendspin = cast("SendspinProvider | None", self.mass.get_provider(SENDSPIN_DOMAIN))
-            if sendspin is not None and sendspin.is_virtual_player(self._player_id):
-                await sendspin.remove_virtual_player(self._player_id)
+        try:
+            if self.mass.player_queues.has_media_presentation(
+                self.queue_id, self._media_presentation_owner
+            ):
+                await self.clear_playback()
+        finally:
+            if self._mode == SharedPlaybackMode.REMOTE:
+                sendspin = cast("SendspinProvider | None", self.mass.get_provider(SENDSPIN_DOMAIN))
+                if sendspin is not None and sendspin.is_virtual_player(self._player_id):
+                    await sendspin.remove_virtual_player(self._player_id)
+            elif self._guest_listeners and self._get_host_player() is not None:
+                await self.mass.players.cmd_set_members(
+                    self._player_id, player_ids_to_remove=list(self._guest_listeners)
+                )
             self._guest_listeners.clear()
-            return
-        if self._guest_listeners and self._get_host_player() is not None:
-            await self.mass.players.cmd_set_members(
-                self._player_id, player_ids_to_remove=list(self._guest_listeners)
-            )
-        self._guest_listeners.clear()
 
     def _get_host_player(self) -> Player | None:
         """Return the (available) player hosting this session, if any."""

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -2356,7 +2356,7 @@ class Player(ABC):
             ):
                 # handle stream metadata in streamdetails (e.g. for radio stream)
                 image_url = stream_metadata.image_url or item_image_url
-                return PlayerMedia(
+                media = PlayerMedia(
                     uri=current_item.uri,
                     media_type=current_item.media_type,
                     title=stream_metadata.title or current_item.name,
@@ -2371,7 +2371,7 @@ class Player(ABC):
                     elapsed_time_last_updated=stream_metadata.elapsed_time_last_updated
                     or active_queue.elapsed_time_last_updated,
                 )
-            if media_item := current_item.media_item:
+            elif media_item := current_item.media_item:
                 # normal media item
                 # we use getattr here to avoid issues with different media item types
                 version = getattr(media_item, "version", None)
@@ -2388,7 +2388,7 @@ class Player(ABC):
                     if current_item.media_item.image
                     else item_image_url
                 )
-                return PlayerMedia(
+                media = PlayerMedia(
                     uri=str(media_item.uri),
                     media_type=media_item.media_type,
                     title=f"{media_item.name} ({version})" if version else media_item.name,
@@ -2403,20 +2403,21 @@ class Player(ABC):
                     elapsed_time=int(active_queue.elapsed_time),
                     elapsed_time_last_updated=active_queue.elapsed_time_last_updated,
                 )
-
-            # fallback to basic current item details
-            return PlayerMedia(
-                uri=current_item.uri,
-                media_type=current_item.media_type,
-                title=current_item.name,
-                image_url=item_image_url,
-                palette=self._resolved_palette(item_image_url),
-                duration=current_item.duration,
-                source_id=active_queue.queue_id,
-                queue_item_id=current_item.queue_item_id,
-                elapsed_time=int(active_queue.elapsed_time),
-                elapsed_time_last_updated=active_queue.elapsed_time_last_updated,
-            )
+            else:
+                # fallback to basic current item details
+                media = PlayerMedia(
+                    uri=current_item.uri,
+                    media_type=current_item.media_type,
+                    title=current_item.name,
+                    image_url=item_image_url,
+                    palette=self._resolved_palette(item_image_url),
+                    duration=current_item.duration,
+                    source_id=active_queue.queue_id,
+                    queue_item_id=current_item.queue_item_id,
+                    elapsed_time=int(active_queue.elapsed_time),
+                    elapsed_time_last_updated=active_queue.elapsed_time_last_updated,
+                )
+            return self.mass.player_queues.apply_media_presentation(active_queue.queue_id, media)
         if active_queue:
             # queue is active but no current item
             return None

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1062,10 +1062,14 @@ class MusicQuizPlugin(PluginProvider):
 
     async def _cleanup_failed_play_locked(self, session: SharedPlaybackSession) -> None:
         """Clear and close a playback session after its media failed to start."""
-        await session.clear_playback()
-        await session.close()
-        if self._playback_session is session:
-            self._playback_session = None
+        try:
+            await session.clear_playback()
+        finally:
+            try:
+                await session.close()
+            finally:
+                if self._playback_session is session:
+                    self._playback_session = None
 
     # ---------- timers ----------
 

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -284,11 +284,17 @@ class MusicQuizPlugin(PluginProvider):
             self._game = None
             self._quiz_type = None
             self._answer_type = None
-        await self._stop_playback()
-        await self._close_playback_session()
-        if is_removed:
-            await guest_access.revoke_guest_access(self.mass, MUSIC_QUIZ_GUEST_USER)
-        await super().unload(is_removed)
+        try:
+            try:
+                await self._stop_playback()
+            finally:
+                await self._close_playback_session()
+        finally:
+            try:
+                if is_removed:
+                    await guest_access.revoke_guest_access(self.mass, MUSIC_QUIZ_GUEST_USER)
+            finally:
+                await super().unload(is_removed)
 
     # ==================== Host API Commands ====================
 
@@ -433,11 +439,15 @@ class MusicQuizPlugin(PluginProvider):
             self._game = None
             self._quiz_type = None
             self._answer_type = None
-            await self._stop_playback()
-            # tear down the shared session so its virtual player / listen-in
-            # guests do not linger once the game is gone
-            await self._close_playback_session()
-            self.signal_provider_event({"event": "game_removed"})
+            try:
+                try:
+                    await self._stop_playback()
+                finally:
+                    # tear down the shared session so its virtual player / listen-in
+                    # guests do not linger once the game is gone
+                    await self._close_playback_session()
+            finally:
+                self.signal_provider_event({"event": "game_removed"})
 
     # ==================== Guest API Commands ====================
 
@@ -963,9 +973,12 @@ class MusicQuizPlugin(PluginProvider):
         # use the same lock that guards session creation/refresh so a concurrent
         # _get_playback_session() cannot resurrect a session we are tearing down
         async with self._playback_lock:
-            if self._playback_session is not None:
-                await self._playback_session.close()
-                self._playback_session = None
+            if (session := self._playback_session) is not None:
+                try:
+                    await session.close()
+                finally:
+                    if self._playback_session is session:
+                        self._playback_session = None
 
     async def _get_playback_session(self) -> SharedPlaybackSession | None:
         """

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -284,6 +284,7 @@ class MusicQuizPlugin(PluginProvider):
             self._game = None
             self._quiz_type = None
             self._answer_type = None
+        await self._stop_playback()
         await self._close_playback_session()
         if is_removed:
             await guest_access.revoke_guest_access(self.mass, MUSIC_QUIZ_GUEST_USER)
@@ -356,6 +357,7 @@ class MusicQuizPlugin(PluginProvider):
             )
             quiz_strategy, answer_strategy = self._resolve_game_strategies(game)
             await quiz_strategy.initialize()
+            await self._stop_playback()
             self._cancel_timers()
             self._cancel_next_round_task()
             self._game = game
@@ -796,6 +798,8 @@ class MusicQuizPlugin(PluginProvider):
                 task_id=self._advance_timer_id,
             )
         self._signal_game_updated()
+        if self._playback_session is not None:
+            self._playback_session.clear_media_presentation()
 
     async def _advance_from_reveal(self) -> None:
         """Advance a revealed game to the next round or finish it."""
@@ -929,25 +933,30 @@ class MusicQuizPlugin(PluginProvider):
 
     async def _play_track(self, track_uri: str) -> None:
         """Play the given track on the game's playback session."""
-        session = await self._get_playback_session()
-        if session is None:
-            raise MusicQuizNoPlaybackTargetError(
-                "No playback target is available for the Music Quiz game"
-            )
-        await self.mass.player_queues.play_media(
-            session.queue_id, track_uri, option=QueueOption.REPLACE
-        )
+        async with self._playback_lock:
+            session = await self._get_or_create_session_locked()
+            if session is None:
+                raise MusicQuizNoPlaybackTargetError(
+                    "No playback target is available for the Music Quiz game"
+                )
+            game = self._require_game()
+            session.set_media_presentation(game.config.name or "Music Quiz")
+            try:
+                await self.mass.player_queues.play_media(
+                    session.queue_id, track_uri, option=QueueOption.REPLACE
+                )
+            except asyncio.CancelledError:
+                await self._cleanup_failed_play_locked(session)
+                raise
+            except Exception:
+                await self._cleanup_failed_play_locked(session)
+                raise
 
     async def _stop_playback(self) -> None:
-        """Stop playback on the game's playback session, if any."""
-        if self._playback_session is None:
-            return
-        if self.mass.players.get_player(self._playback_session.player_id) is None:
-            return
-        try:
-            await self.mass.player_queues.stop(self._playback_session.queue_id)
-        except Exception as err:
-            self.logger.warning("Could not stop Music Quiz playback: %s", err)
+        """Stop and clear playback on the game's playback session, if any."""
+        async with self._playback_lock:
+            if self._playback_session is not None:
+                await self._playback_session.clear_playback()
 
     async def _close_playback_session(self) -> None:
         """Close and drop the shared playback session under the playback lock."""
@@ -1037,6 +1046,13 @@ class MusicQuizPlugin(PluginProvider):
             elif fallback_priority < 0:
                 fallback, fallback_priority = player.player_id, 0
         return fallback
+
+    async def _cleanup_failed_play_locked(self, session: SharedPlaybackSession) -> None:
+        """Clear and close a playback session after its media failed to start."""
+        await session.clear_playback()
+        await session.close()
+        if self._playback_session is session:
+            self._playback_session = None
 
     # ---------- timers ----------
 

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -904,11 +904,15 @@ class SendspinPlayer(SendspinBasePlayer):
 
         return artwork_url
 
-    async def _send_artist_artwork(self, current_item: QueueItem) -> None:
+    async def _send_artist_artwork(self, current_item: QueueItem | None) -> None:
         """Send artist artwork to the sendspin group."""
         artist_artwork_url: str | None = None
 
-        if current_item.media_item is not None and is_track(current_item.media_item):
+        if (
+            current_item is not None
+            and current_item.media_item is not None
+            and is_track(current_item.media_item)
+        ):
             artists = current_item.media_item.artists
             if artists:
                 primary_artist = artists[0]
@@ -1062,8 +1066,7 @@ class SendspinPlayer(SendspinBasePlayer):
 
         # Runs even without a queue item so radio / Spotify Connect streams still get art.
         await self._send_album_artwork(current_media)
-        if queue_item:
-            await self._send_artist_artwork(queue_item)
+        await self._send_artist_artwork(queue_item)
 
         track_number: int | None = None
         year: int | None = None
@@ -1085,7 +1088,7 @@ class SendspinPlayer(SendspinBasePlayer):
                 if full_album and full_album.artists:
                     album_artist = full_album.artist_str
 
-        track_duration = current_media.duration or 0
+        track_duration = current_media.duration
         if controller_role := self._controller_role:
             controller_role.set_seek_max_ms(int(track_duration * 1000) if track_duration else None)
         repeat = SendspinRepeatMode.OFF
@@ -1106,7 +1109,7 @@ class SendspinPlayer(SendspinBasePlayer):
             artwork_url=current_media.image_url,
             year=year,
             track=track_number,
-            track_duration=track_duration * 1000 if track_duration is not None else None,
+            track_duration=track_duration * 1000 if track_duration else None,
             track_progress=track_progress,
             playback_speed=1000 if is_playing else 0,
             repeat=repeat,

--- a/tests/controllers/player_queues/test_media_presentation.py
+++ b/tests/controllers/player_queues/test_media_presentation.py
@@ -1,0 +1,304 @@
+"""Tests for runtime queue media presentation leases."""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import ImageType, MediaType
+from music_assistant_models.errors import InvalidCommand, PlayerUnavailableError
+from music_assistant_models.media_items import MediaItemImage, ProviderMapping, Track
+from music_assistant_models.player import PlayerMedia
+from music_assistant_models.player_queue import PlayerQueue
+from music_assistant_models.queue_item import QueueItem
+from music_assistant_models.unique_list import UniqueList
+
+from music_assistant.controllers.player_queues.controller import PlayerQueuesController
+from music_assistant.controllers.player_queues.state import PlayerQueueData
+
+
+class _AlwaysEqual:
+    """Token whose equality cannot be used to establish lease ownership."""
+
+    def __eq__(self, other: object) -> bool:
+        return True
+
+    def __hash__(self) -> int:
+        return 0
+
+
+def _controller() -> tuple[PlayerQueuesController, MagicMock]:
+    """Build a controller with one queue and owner player."""
+    controller = PlayerQueuesController.__new__(PlayerQueuesController)
+    controller.mass = MagicMock()
+    player = MagicMock()
+    player.state.active_group = None
+    player.state.synced_to = None
+    controller.mass.players.get_player.return_value = player
+    controller._managed_pool = MagicMock()
+    controller._queue_data = {
+        "q1": PlayerQueueData(
+            queue=PlayerQueue(
+                queue_id="q1",
+                active=True,
+                display_name="Queue",
+                available=True,
+                items=0,
+            )
+        )
+    }
+    return controller, player
+
+
+def _media(uri: str = "provider://track/secret", queue_item_id: str = "secret-id") -> PlayerMedia:
+    """Build fully populated media whose descriptive fields must be concealed."""
+    return PlayerMedia(
+        uri=uri,
+        media_type=MediaType.TRACK,
+        title="Secret title",
+        artist="Secret artist",
+        album="Secret album",
+        album_artist="Secret album artist",
+        image_url="https://example.test/secret.jpg",
+        palette=MagicMock(),
+        duration=123,
+        source_id="q1",
+        queue_item_id=queue_item_id,
+        custom_data={"session_id": "session", "original_uri": uri},
+        elapsed_time=17,
+        elapsed_time_last_updated=1234.5,
+    )
+
+
+def _track_queue_item() -> QueueItem:
+    """Build a track queue item with artwork."""
+    track = Track(
+        item_id="secret",
+        provider="test",
+        name="Secret title",
+        duration=123,
+        provider_mappings={
+            ProviderMapping(
+                item_id="secret",
+                provider_domain="test",
+                provider_instance="test",
+            )
+        },
+    )
+    track.metadata.images = UniqueList(
+        [
+            MediaItemImage(
+                type=ImageType.THUMB,
+                path="secret.jpg",
+                provider="test",
+                remotely_accessible=False,
+            )
+        ]
+    )
+    return QueueItem.from_media_item("q1", track)
+
+
+def test_set_requires_existing_queue() -> None:
+    """Setting a presentation on an unknown queue fails precisely."""
+    controller, _ = _controller()
+
+    with pytest.raises(PlayerUnavailableError, match="Queue missing is not available"):
+        controller.set_media_presentation("missing", object(), "Music Quiz")
+
+
+def test_owner_identity_conflict_and_clear_isolation() -> None:
+    """Only the identical owner token can replace or clear an active lease."""
+    controller, player = _controller()
+    owner = _AlwaysEqual()
+    other_owner = _AlwaysEqual()
+
+    controller.set_media_presentation("q1", owner, "Music Quiz")
+
+    with pytest.raises(InvalidCommand, match="active media presentation"):
+        controller.set_media_presentation("q1", other_owner, "Other")
+    assert controller.has_media_presentation("q1", owner) is True
+    assert controller.has_media_presentation("q1", other_owner) is False
+    assert controller.clear_media_presentation("q1", other_owner) is False
+    assert controller.clear_media_presentation("missing", owner) is False
+    assert controller.clear_media_presentation("q1", owner) is True
+    assert controller.clear_media_presentation("q1", owner) is False
+    assert player.refresh_state.call_count == 2
+    get_player = cast("MagicMock", controller.mass.players.get_player)
+    get_player.assert_called_with("q1")
+
+
+def test_same_owner_rotates_identity_and_queue_removal_drops_lease() -> None:
+    """A round reset rotates the key and removing the queue drops runtime state."""
+    controller, player = _controller()
+    owner = object()
+
+    controller.set_media_presentation("q1", owner, "Music Quiz")
+    first_key = controller._queue_data["q1"].media_presentation
+    controller.set_media_presentation("q1", owner, "Music Quiz")
+    second_key = controller._queue_data["q1"].media_presentation
+
+    assert first_key is not None
+    assert second_key is not None
+    assert first_key.identity_key != second_key.identity_key
+    assert player.refresh_state.call_count == 2
+
+    controller.on_player_remove("q1", permanent=False)
+
+    assert controller.has_media_presentation("q1", owner) is False
+
+
+def test_presentation_refreshes_redirected_playback_owner() -> None:
+    """Presentation changes refresh the parent that publishes the queue media."""
+    controller, queue_player = _controller()
+    parent_player = MagicMock()
+    queue_player.state.active_group = None
+    queue_player.state.synced_to = "parent"
+    get_player = cast("MagicMock", controller.mass.players.get_player)
+    get_player.side_effect = lambda player_id: queue_player if player_id == "q1" else parent_player
+
+    owner = object()
+    controller.set_media_presentation("q1", owner, "Music Quiz")
+    controller.clear_media_presentation("q1", owner)
+
+    assert parent_player.refresh_state.call_count == 2
+    queue_player.refresh_state.assert_not_called()
+
+
+def test_default_projection_returns_fresh_equivalent_media() -> None:
+    """Queues without a lease retain the complete media presentation."""
+    controller, _ = _controller()
+    source = _media()
+
+    projected = controller.apply_media_presentation("q1", source)
+
+    assert projected is not source
+    for field in (
+        "uri",
+        "media_type",
+        "title",
+        "artist",
+        "album",
+        "album_artist",
+        "image_url",
+        "palette",
+        "duration",
+        "source_id",
+        "queue_item_id",
+        "elapsed_time",
+        "elapsed_time_last_updated",
+    ):
+        assert getattr(projected, field) == getattr(source, field)
+    assert projected.custom_data == source.custom_data
+    assert projected.custom_data is not source.custom_data
+
+
+def test_public_projection_is_opaque_stable_and_minimal() -> None:
+    """Public media retains only a neutral title, opaque identity, and elapsed anchor."""
+    controller, _ = _controller()
+    owner = object()
+    controller.set_media_presentation("q1", owner, "Music Quiz")
+
+    first = controller.apply_media_presentation("q1", _media())
+    repeated = controller.apply_media_presentation("q1", _media())
+    next_item = controller.apply_media_presentation(
+        "q1", _media("provider://track/other", "other-id")
+    )
+
+    assert first.uri == repeated.uri
+    assert first.uri != next_item.uri
+    assert first.uri.startswith("media-presentation://")
+    assert "secret" not in first.uri
+    assert first.media_type == MediaType.UNKNOWN
+    assert first.title == "Music Quiz"
+    assert first.elapsed_time == 17
+    assert first.elapsed_time_last_updated == 1234.5
+    for field in (
+        "artist",
+        "album",
+        "album_artist",
+        "image_url",
+        "palette",
+        "duration",
+        "source_id",
+        "queue_item_id",
+        "custom_data",
+    ):
+        assert getattr(first, field) is None
+
+    controller.set_media_presentation("q1", owner, "Music Quiz")
+    rotated = controller.apply_media_presentation("q1", _media())
+    assert rotated.uri != first.uri
+
+
+def test_transport_projection_preserves_loading_fields_only() -> None:
+    """Device media keeps transport/session fields while removing descriptive metadata."""
+    controller, _ = _controller()
+    controller.set_media_presentation("q1", object(), "Music Quiz")
+
+    projected = controller.apply_media_presentation("q1", _media(), preserve_playback_data=True)
+
+    assert projected.uri == "provider://track/secret"
+    assert projected.media_type == MediaType.TRACK
+    assert projected.title == "Music Quiz"
+    assert projected.duration == 123
+    assert projected.source_id == "q1"
+    assert projected.queue_item_id == "secret-id"
+    assert projected.custom_data == {
+        "session_id": "session",
+        "original_uri": "provider://track/secret",
+    }
+    assert projected.elapsed_time == 17
+    assert projected.elapsed_time_last_updated == 1234.5
+    assert projected.artist is None
+    assert projected.album is None
+    assert projected.album_artist is None
+    assert projected.image_url is None
+    assert projected.palette is None
+
+
+async def test_outbound_queue_media_skips_artwork_resolution_when_concealed() -> None:
+    """Concealed outbound media remains playable without resolving or exposing artwork."""
+    controller, _ = _controller()
+    queue_data = controller._queue_data["q1"]
+    queue_data.session_id = "session"
+    queue_item = _track_queue_item()
+    controller.set_media_presentation("q1", object(), "Music Quiz")
+
+    media = await controller.player_media_from_queue_item(queue_item)
+
+    assert media.uri == queue_item.uri
+    assert media.media_type == MediaType.TRACK
+    assert media.title == "Music Quiz"
+    assert media.duration == 123
+    assert media.source_id == "q1"
+    assert media.queue_item_id == queue_item.queue_item_id
+    assert media.custom_data == {
+        "session_id": "session",
+        "original_uri": queue_item.uri,
+    }
+    assert media.artist is None
+    assert media.album is None
+    assert media.image_url is None
+    metadata = cast("MagicMock", controller.mass.metadata)
+    metadata.get_image_url.assert_not_called()
+
+
+async def test_outbound_queue_media_is_unchanged_without_lease() -> None:
+    """Default outbound media retains its existing descriptive metadata and artwork."""
+    controller, _ = _controller()
+    controller._queue_data["q1"].session_id = "session"
+    metadata = cast("MagicMock", controller.mass.metadata)
+    metadata.get_image_url.return_value = "https://stream.test/image.jpg"
+    queue_item = _track_queue_item()
+
+    media = await controller.player_media_from_queue_item(queue_item)
+
+    assert media.uri == queue_item.uri
+    assert media.media_type == MediaType.TRACK
+    assert media.title == "Secret title"
+    assert media.duration == 123
+    assert media.source_id == "q1"
+    assert media.queue_item_id == queue_item.queue_item_id
+    assert media.image_url == "https://stream.test/image.jpg"
+    metadata.get_image_url.assert_called_once()

--- a/tests/controllers/player_queues/test_permissions.py
+++ b/tests/controllers/player_queues/test_permissions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from typing import cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.auth import User, UserRole
@@ -197,6 +197,83 @@ def test_raw_queue_methods_remain_available_to_internal_callers() -> None:
     assert controller.all()
     assert controller.get("host") is not None
     assert controller.items("host")
+
+
+async def test_play_media_api_denies_guest_but_raw_method_remains_available() -> None:
+    """Only the API wrapper authorizes play-media requests."""
+    controller = _create_controller("host")
+    _set_user(UserRole.GUEST, [GUEST_ACCESS_RESTRICTED_PLAYER_ID])
+    handle_play_media = AsyncMock()
+
+    with patch.object(controller, "_handle_play_media", new=handle_play_media):
+        with pytest.raises(InsufficientPermissions):
+            await controller.play_media_for_api("host", "library://track/1")
+
+        await controller.play_media("host", "library://track/1")
+
+    handle_play_media.assert_awaited_once_with("host", "library://track/1", None, False, None, None)
+
+
+async def test_stop_api_denies_guest_but_raw_method_remains_available() -> None:
+    """Only the API wrapper authorizes stop requests."""
+    controller = _create_controller("host")
+    _set_user(UserRole.GUEST, [GUEST_ACCESS_RESTRICTED_PLAYER_ID])
+    players = cast("MagicMock", controller.mass.players)
+    players.get_player.return_value = MagicMock()
+    players._handle_cmd_stop = AsyncMock()
+
+    with (
+        patch.object(controller, "_cleanup_queue_audio_data", return_value=None),
+        pytest.raises(InsufficientPermissions),
+    ):
+        await controller.stop_for_api("host")
+
+    await controller.stop("host")
+
+    players._handle_cmd_stop.assert_awaited_once_with("host")
+
+
+def test_clear_api_denies_guest_but_raw_method_remains_available() -> None:
+    """Only the API wrapper authorizes clear requests."""
+    controller = _create_controller("host")
+    _set_user(UserRole.GUEST, [GUEST_ACCESS_RESTRICTED_PLAYER_ID])
+
+    with pytest.raises(InsufficientPermissions):
+        controller.clear_for_api("host")
+
+    with (
+        patch.object(controller, "store_sources"),
+        patch.object(controller, "_cleanup_queue_audio_data", return_value=None),
+        patch.object(controller, "update_items") as update_items,
+    ):
+        controller.clear("host", skip_stop=True)
+
+    update_items.assert_called_once_with("host", [])
+
+
+@pytest.mark.parametrize(
+    ("source_queue_id", "target_queue_id"),
+    [("host", "allowed"), ("allowed", "host")],
+)
+async def test_transfer_api_authorizes_both_queues_but_raw_method_remains_available(
+    source_queue_id: str,
+    target_queue_id: str,
+) -> None:
+    """The API authorizes both transfer endpoints while trusted callers use the raw method."""
+    controller = _create_controller("host", "allowed")
+    _set_user(
+        UserRole.GUEST,
+        [GUEST_ACCESS_RESTRICTED_PLAYER_ID, "allowed"],
+    )
+    transfer_queue = AsyncMock()
+
+    with patch.object(controller, "transfer_queue", new=transfer_queue):
+        with pytest.raises(InsufficientPermissions):
+            await controller.transfer_queue_for_api(source_queue_id, target_queue_id)
+
+        await controller.transfer_queue(source_queue_id, target_queue_id)
+
+    transfer_queue.assert_awaited_once_with(source_queue_id, target_queue_id)
 
 
 def test_missing_user_keeps_existing_access() -> None:

--- a/tests/controllers/player_queues/test_player_queue_data.py
+++ b/tests/controllers/player_queues/test_player_queue_data.py
@@ -9,7 +9,10 @@ from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
 
 from music_assistant.controllers.player_queues.constants import CACHE_FORMAT_VERSION
-from music_assistant.controllers.player_queues.state import PlayerQueueData
+from music_assistant.controllers.player_queues.state import (
+    PlayerQueueData,
+    QueueMediaPresentation,
+)
 
 
 def _track(item_id: str) -> Track:
@@ -69,6 +72,7 @@ def _data_with_dynamic_source() -> PlayerQueueData:
         play_action_refcount=3,
         last_counted_play="t1",
         flow_buffer_completed="sess-1",
+        media_presentation=QueueMediaPresentation(object(), "Music Quiz", b"secret"),
     )
 
 
@@ -96,6 +100,8 @@ def test_cache_round_trip_restores_queue_items_and_sources() -> None:
     assert restored.play_action_refcount == 0
     assert restored.last_counted_play is None
     assert restored.flow_buffer_completed is None
+    assert restored.media_presentation is None
+    assert "media_presentation" not in data.to_cache()
 
 
 def test_cache_round_trip_non_dynamic_has_no_sources() -> None:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -78,6 +78,26 @@ def test_reserved_guest_filter_player_id_is_rejected(provider: MockProvider) -> 
         MockPlayer(provider, GUEST_ACCESS_RESTRICTED_PLAYER_ID, "Reserved")
 
 
+async def test_cmd_stop_authorizes_resolved_active_queue(
+    mock_mass: MagicMock,
+    controller: PlayerController,
+    provider: MockProvider,
+) -> None:
+    """Stopping a player authorizes the active queue selected after redirection."""
+    player = MockPlayer(provider, "allowed", "Allowed")
+    controller._players = {"allowed": player}
+    mock_mass.players = controller
+    player.update_state(signal_event=False)
+    active_queue = SimpleNamespace(queue_id="hidden")
+    controller.get_active_queue = MagicMock(return_value=active_queue)  # type: ignore[method-assign]
+    mock_mass.player_queues.stop_for_api = AsyncMock()
+
+    await controller.cmd_stop("allowed")
+
+    mock_mass.player_queues.stop_for_api.assert_awaited_once_with("hidden")
+    mock_mass.player_queues.stop.assert_not_called()
+
+
 class TestSetMembersValidation:
     """Test cmd_set_members validation logic."""
 

--- a/tests/controllers/webserver/test_event_dispatch.py
+++ b/tests/controllers/webserver/test_event_dispatch.py
@@ -159,6 +159,35 @@ async def test_restricted_guest_events_exclude_dynamic_queues(
     assert all("Web Queue" not in message for message in messages)
 
 
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        EventType.QUEUE_ADDED,
+        EventType.QUEUE_ITEMS_UPDATED,
+        EventType.QUEUE_TIME_UPDATED,
+        EventType.QUEUE_UPDATED,
+    ],
+)
+async def test_restricted_guest_cannot_claim_host_queue_events_with_sendspin_player(
+    mass_minimal: MusicAssistant,
+    webserver: WebserverController,
+    event_type: EventType,
+) -> None:
+    """A managed guest cannot claim host queue events through its Sendspin player ID."""
+    guest = create_ws_client(
+        webserver,
+        "guest1",
+        role=UserRole.GUEST,
+        player_filter=[GUEST_ACCESS_RESTRICTED_PLAYER_ID],
+        sendspin_player_id="host_player",
+    )
+
+    mass_minimal.signal_event(event_type, "host_player", {"name": "Host Queue"})
+    await drain_event_callbacks()
+
+    assert guest._to_write.empty()
+
+
 async def test_filtered_user_receives_own_sendspin_queue_event(
     mass_minimal: MusicAssistant,
     webserver: WebserverController,

--- a/tests/helpers/test_shared_playback.py
+++ b/tests/helpers/test_shared_playback.py
@@ -244,6 +244,25 @@ async def test_venue_close_clears_owned_presentation_before_detach() -> None:
     )
 
 
+async def test_venue_close_detaches_listeners_when_playback_cleanup_fails() -> None:
+    """Closing still detaches listeners while propagating playback cleanup failure."""
+    venue_player = _create_venue_player(can_group_with={"web_player_1"})
+    mass = _create_mock_mass(venue_player)
+    mass.player_queues.has_media_presentation.return_value = True
+    mass.player_queues.stop.side_effect = RuntimeError("stop failed")
+    session = await SharedPlaybackSession.create_venue(mass, "venue_player")
+    await session.add_guest_listener("web_player_1")
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        await session.close()
+
+    mass.player_queues.clear.assert_not_called()
+    mass.player_queues.clear_media_presentation.assert_not_called()
+    mass.players.cmd_set_members.assert_awaited_with(
+        "venue_player", player_ids_to_remove=["web_player_1"]
+    )
+
+
 async def test_venue_close_does_not_clear_different_presentation_owner() -> None:
     """Closing a non-owning venue session leaves another owner's playback untouched."""
     mass = _create_mock_mass(_create_venue_player())

--- a/tests/helpers/test_shared_playback.py
+++ b/tests/helpers/test_shared_playback.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.enums import PlayerFeature
+from music_assistant_models.enums import PlaybackState, PlayerFeature
 from music_assistant_models.errors import SetupFailedError, UnsupportedFeaturedException
 
 from music_assistant.helpers.shared_playback import SharedPlaybackMode, SharedPlaybackSession
@@ -21,6 +21,12 @@ def _create_mock_mass(venue_player: MagicMock | None) -> MagicMock:
     mass = MagicMock()
     mass.players.get_player.return_value = venue_player
     mass.players.cmd_set_members = AsyncMock()
+    queue = MagicMock()
+    queue.state = PlaybackState.IDLE
+    mass.player_queues.get.return_value = queue
+    mass.player_queues.stop = AsyncMock()
+    mass.player_queues.clear_media_presentation.return_value = True
+    mass.player_queues.has_media_presentation.return_value = False
     return mass
 
 
@@ -106,6 +112,22 @@ async def test_venue_add_and_remove_guest_listener() -> None:
     )
 
 
+async def test_venue_listener_can_regroup_after_disconnect() -> None:
+    """A listener removed by disconnect can be attached again after reconnect."""
+    venue_player = _create_venue_player(can_group_with={"web_player_1"})
+    mass = _create_mock_mass(venue_player)
+    session = await SharedPlaybackSession.create_venue(mass, "venue_player")
+
+    await session.add_guest_listener("web_player_1")
+    await session.remove_guest_listener("web_player_1")
+    await session.add_guest_listener("web_player_1")
+
+    assert mass.players.cmd_set_members.await_count == 3
+    mass.players.cmd_set_members.assert_awaited_with(
+        "venue_player", player_ids_to_add=["web_player_1"]
+    )
+
+
 async def test_venue_add_guest_listener_unsupported() -> None:
     """Attaching an incompatible web player raises."""
     venue_player = _create_venue_player(can_group_with=set())
@@ -139,6 +161,100 @@ async def test_venue_close_without_listeners() -> None:
     await session.close()
 
     mass.players.cmd_set_members.assert_not_awaited()
+
+
+async def test_media_presentation_owner_is_private_per_session() -> None:
+    """Each session uses a distinct private token for presentation ownership."""
+    mass = _create_mock_mass(_create_venue_player())
+    first = await SharedPlaybackSession.create_venue(mass, "venue_player")
+    second = await SharedPlaybackSession.create_venue(mass, "venue_player")
+
+    first.set_media_presentation("Music Quiz")
+    first_token = mass.player_queues.set_media_presentation.call_args.args[1]
+    second.set_media_presentation("Other")
+    second_token = mass.player_queues.set_media_presentation.call_args.args[1]
+    assert first_token is not second_token
+
+    assert first.clear_media_presentation() is True
+    mass.player_queues.clear_media_presentation.assert_called_with("venue_player", first_token)
+
+
+async def test_clear_playback_releases_presentation_after_queue_cleanup() -> None:
+    """Playback stops and clears before the presentation lease is released."""
+    mass = _create_mock_mass(_create_venue_player())
+    mass.player_queues.get.return_value.state = PlaybackState.PLAYING
+    calls: list[str] = []
+    mass.player_queues.stop.side_effect = lambda _queue_id: calls.append("stop")
+    mass.player_queues.clear.side_effect = lambda *_args, **_kwargs: calls.append("clear")
+
+    def _release(*_args: object) -> bool:
+        calls.append("release")
+        return True
+
+    mass.player_queues.clear_media_presentation.side_effect = _release
+    session = await SharedPlaybackSession.create_venue(mass, "venue_player")
+
+    await session.clear_playback()
+
+    assert calls == ["stop", "clear", "release"]
+    mass.player_queues.clear.assert_called_once_with("venue_player", skip_stop=True)
+
+
+async def test_clear_playback_stops_before_state_reports_playing() -> None:
+    """Cleanup always sends stop so a just-started device cannot outpace queue state."""
+    mass = _create_mock_mass(_create_venue_player())
+    mass.player_queues.get.return_value.state = PlaybackState.IDLE
+    session = await SharedPlaybackSession.create_venue(mass, "venue_player")
+
+    await session.clear_playback()
+
+    mass.player_queues.stop.assert_awaited_once_with("venue_player")
+    mass.player_queues.clear.assert_called_once_with("venue_player", skip_stop=True)
+    mass.player_queues.clear_media_presentation.assert_called_once()
+
+
+async def test_clear_playback_failure_keeps_presentation() -> None:
+    """A stop failure is propagated without clearing the queue or lease."""
+    mass = _create_mock_mass(_create_venue_player())
+    mass.player_queues.get.return_value.state = PlaybackState.PLAYING
+    mass.player_queues.stop.side_effect = RuntimeError("stop failed")
+    session = await SharedPlaybackSession.create_venue(mass, "venue_player")
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        await session.clear_playback()
+
+    mass.player_queues.clear.assert_not_called()
+    mass.player_queues.clear_media_presentation.assert_not_called()
+
+
+async def test_venue_close_clears_owned_presentation_before_detach() -> None:
+    """Closing an owning session fail-safely clears playback before listener teardown."""
+    venue_player = _create_venue_player(can_group_with={"web_player_1"})
+    mass = _create_mock_mass(venue_player)
+    mass.player_queues.has_media_presentation.return_value = True
+    session = await SharedPlaybackSession.create_venue(mass, "venue_player")
+    await session.add_guest_listener("web_player_1")
+
+    await session.close()
+
+    mass.player_queues.clear.assert_called_once_with("venue_player", skip_stop=True)
+    mass.player_queues.clear_media_presentation.assert_called_once()
+    mass.players.cmd_set_members.assert_awaited_with(
+        "venue_player", player_ids_to_remove=["web_player_1"]
+    )
+
+
+async def test_venue_close_does_not_clear_different_presentation_owner() -> None:
+    """Closing a non-owning venue session leaves another owner's playback untouched."""
+    mass = _create_mock_mass(_create_venue_player())
+    mass.player_queues.has_media_presentation.return_value = False
+    session = await SharedPlaybackSession.create_venue(mass, "venue_player")
+
+    await session.close()
+
+    mass.player_queues.stop.assert_not_awaited()
+    mass.player_queues.clear.assert_not_called()
+    mass.player_queues.clear_media_presentation.assert_not_called()
 
 
 # ==================== REMOTE mode ====================

--- a/tests/models/test_player_media_presentation.py
+++ b/tests/models/test_player_media_presentation.py
@@ -1,0 +1,223 @@
+"""Tests for queue presentation in final player media state."""
+
+from __future__ import annotations
+
+import time
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import MediaType, PlaybackState, PlayerType
+from music_assistant_models.media_items import ProviderMapping, Track
+from music_assistant_models.player_queue import PlayerQueue
+from music_assistant_models.queue_item import QueueItem
+
+from music_assistant.controllers.player_queues.controller import PlayerQueuesController
+from music_assistant.controllers.player_queues.state import PlayerQueueData
+from music_assistant.controllers.players import PlayerController
+from tests.common import MockPlayer, MockProvider
+
+
+def _mass() -> MagicMock:
+    """Build the player and queue controllers needed for final-state projection."""
+    mass = MagicMock()
+    mass.closing = False
+    mass.config.get.return_value = []
+    mass.config.get_raw_player_config_value.return_value = "auto"
+    mass.config.get_raw_core_config_value.return_value = "GLOBAL"
+    mass.metadata.get_image_url.return_value = "https://example.test/secret.jpg"
+    players = PlayerController(mass)
+    mass.players = players
+    queues = PlayerQueuesController.__new__(PlayerQueuesController)
+    queues.mass = mass
+    queues._queue_data = {}
+    queues._managed_pool = MagicMock()
+    mass.player_queues = queues
+    return mass
+
+
+def _track() -> Track:
+    """Build a complete track for final-state projection."""
+    return Track(
+        item_id="secret",
+        provider="test",
+        name="Secret title",
+        duration=123,
+        provider_mappings={
+            ProviderMapping(
+                item_id="secret",
+                provider_domain="test",
+                provider_instance="test",
+            )
+        },
+    )
+
+
+def _queue_item(branch: str) -> QueueItem:
+    """Build a queue item for one final-current-media branch."""
+    if branch == "media_item":
+        return QueueItem.from_media_item("q1", _track())
+    queue_item = QueueItem(
+        queue_id="q1",
+        queue_item_id="secret-id",
+        name="Secret title",
+        duration=123,
+    )
+    if branch == "stream_metadata":
+        stream_metadata = MagicMock(
+            title="Secret stream title",
+            artist="Secret artist",
+            album="Secret album",
+            description=None,
+            image_url="https://example.test/stream.jpg",
+            duration=122,
+            elapsed_time=11,
+            elapsed_time_last_updated=1234.5,
+        )
+        queue_item.streamdetails = MagicMock(
+            media_type=MediaType.RADIO,
+            stream_metadata=stream_metadata,
+        )
+    return queue_item
+
+
+def _owner_player(
+    mass: MagicMock,
+    queue_item: QueueItem,
+    player_type: PlayerType = PlayerType.PLAYER,
+) -> MockPlayer:
+    """Register a queue owner playing the given item."""
+    provider = MockProvider("test_provider", instance_id="test", mass=mass)
+    player = MockPlayer(provider, "q1", "Queue owner", player_type=player_type)
+    player._attr_active_source = "q1"
+    player._attr_playback_state = PlaybackState.PLAYING
+    player._attr_elapsed_time = 17
+    player._attr_elapsed_time_last_updated = time.time()
+    player.initialized.set()
+    mass.players._players = {"q1": player}
+    queue = PlayerQueue(
+        queue_id="q1",
+        active=True,
+        display_name="Queue",
+        available=True,
+        items=1,
+        current_index=0,
+        current_item=queue_item,
+        elapsed_time=17,
+        elapsed_time_last_updated=1234.5,
+        state=PlaybackState.PLAYING,
+    )
+    mass.player_queues._queue_data["q1"] = PlayerQueueData(
+        queue=queue,
+        items=[queue_item],
+    )
+    player.update_state(signal_event=False)
+    return player
+
+
+@pytest.mark.parametrize("branch", ["stream_metadata", "media_item", "fallback"])
+def test_all_active_queue_media_branches_are_concealed_and_revealed(branch: str) -> None:
+    """Every active-queue media branch projects neutral state until the lease clears."""
+    mass = _mass()
+    player = _owner_player(mass, _queue_item(branch))
+    original = player.state.current_media
+    assert original is not None
+    owner = object()
+
+    mass.player_queues.set_media_presentation("q1", owner, "Music Quiz")
+
+    concealed = player.state.current_media
+    assert concealed is not None
+    assert concealed.uri.startswith("media-presentation://")
+    assert concealed.title == "Music Quiz"
+    assert concealed.media_type == MediaType.UNKNOWN
+    assert concealed.artist is None
+    assert concealed.album is None
+    assert concealed.album_artist is None
+    assert concealed.image_url is None
+    assert concealed.palette is None
+    assert concealed.duration is None
+    assert concealed.source_id is None
+    assert concealed.queue_item_id is None
+    assert concealed.custom_data is None
+    assert concealed.elapsed_time is not None
+
+    assert mass.player_queues.clear_media_presentation("q1", owner) is True
+    revealed = player.state.current_media
+    assert revealed is not None
+    assert revealed.uri == original.uri
+    assert revealed.title == original.title
+    assert revealed.media_type == original.media_type
+    assert revealed.duration == original.duration
+    assert revealed.source_id == "q1"
+    assert revealed.queue_item_id == original.queue_item_id
+
+
+def test_sync_protocol_and_late_join_children_inherit_concealed_media() -> None:
+    """Related and newly joined players copy the queue owner's final neutral media."""
+    mass = _mass()
+    owner_player = _owner_player(mass, _queue_item("media_item"))
+    provider = cast("MockProvider", owner_player.provider)
+    sync_child = MockPlayer(provider, "sync-child", "Sync child")
+    protocol_child = MockPlayer(
+        provider,
+        "protocol-child",
+        "Protocol child",
+        player_type=PlayerType.PROTOCOL,
+    )
+    sync_child.initialized.set()
+    protocol_child.initialized.set()
+    protocol_child.set_protocol_parent_id("q1")
+    mass.players._players.update(
+        {
+            "sync-child": sync_child,
+            "protocol-child": protocol_child,
+        }
+    )
+    owner_player._attr_group_members = ["q1", "sync-child"]
+    owner_player.refresh_state(signal_event=False)
+    sync_child.refresh_state(signal_event=False)
+    protocol_child.refresh_state(signal_event=False)
+    presentation_owner = object()
+
+    mass.player_queues.set_media_presentation("q1", presentation_owner, "Music Quiz")
+    sync_child.refresh_state(signal_event=False)
+    protocol_child.refresh_state(signal_event=False)
+
+    assert sync_child.state.current_media == owner_player.state.current_media
+    assert protocol_child.state.current_media == owner_player.state.current_media
+    assert sync_child.state.current_media is not None
+    assert sync_child.state.current_media.title == "Music Quiz"
+
+    late_child = MockPlayer(provider, "late-child", "Late child")
+    late_child.initialized.set()
+    mass.players._players["late-child"] = late_child
+    owner_player._attr_group_members.append("late-child")
+    owner_player.refresh_state(signal_event=False)
+    late_child.refresh_state(signal_event=False)
+
+    assert late_child.state.current_media == owner_player.state.current_media
+    assert late_child.state.current_media is not None
+    assert late_child.state.current_media.source_id is None
+    assert late_child.state.current_media.queue_item_id is None
+
+
+def test_active_group_child_inherits_concealed_media() -> None:
+    """A member captured by an active group copies the group's neutral media."""
+    mass = _mass()
+    group = _owner_player(mass, _queue_item("fallback"), PlayerType.GROUP)
+    group._attr_powered = True
+    group._attr_group_members = ["member"]
+    member = MockPlayer(cast("MockProvider", group.provider), "member", "Member")
+    member.initialized.set()
+    mass.players._players["member"] = member
+    group.refresh_state(signal_event=False)
+    member.refresh_state(signal_event=False)
+
+    mass.player_queues.set_media_presentation("q1", object(), "Music Quiz")
+    member.refresh_state(signal_event=False)
+
+    assert member.state.current_media == group.state.current_media
+    assert member.state.current_media is not None
+    assert member.state.current_media.title == "Music Quiz"
+    assert member.state.current_media.duration is None

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -8,10 +8,12 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.auth import Scope
+from music_assistant_models.auth import Scope, User, UserRole
 from music_assistant_models.enums import ConfigEntryType, PlaybackState, QueueOption
-from music_assistant_models.errors import InvalidDataError
+from music_assistant_models.errors import InsufficientPermissions, InvalidDataError
 
+from music_assistant.constants import GUEST_ACCESS_RESTRICTED_PLAYER_ID
+from music_assistant.controllers.webserver.helpers.auth_middleware import set_current_user
 from music_assistant.providers.music_quiz import (
     MUSIC_QUIZ_GUEST_DISPLAY_NAME,
     MUSIC_QUIZ_GUEST_USER,
@@ -422,6 +424,73 @@ async def test_full_game_flow() -> None:
     assert _phase(plugin) == MusicQuizPhase.FINISHED
     assert game.players[player_ids["Bob"]].score == 1000
     cast("AsyncMock", plugin._stop_playback).assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_last_guest_ready_uses_trusted_queue_playback_controls() -> None:
+    """Guest-triggered round advancement uses raw queue controls under its request context."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",), round_count=2)
+    await plugin.reveal()
+
+    order: list[str] = []
+    queue_controller = MagicMock()
+    queue_controller.play_media = AsyncMock(
+        side_effect=lambda *_args, **_kwargs: order.append("play")
+    )
+    queue_controller.play_media_for_api = AsyncMock(side_effect=InsufficientPermissions("denied"))
+    queue_controller.stop = AsyncMock(side_effect=lambda *_args: order.append("stop"))
+    queue_controller.stop_for_api = AsyncMock(side_effect=InsufficientPermissions("denied"))
+    plugin.mass.player_queues = queue_controller
+    players = cast("MagicMock", plugin.mass.players)
+    players.get_player.return_value = MagicMock()
+
+    session = MagicMock()
+    session.player_id = "host_player"
+    session.queue_id = "host_player"
+    session.set_media_presentation.side_effect = lambda _title: order.append("conceal")
+
+    async def clear_playback() -> None:
+        order.append("clear")
+        await queue_controller.stop("host_player")
+
+    session.clear_playback = AsyncMock(side_effect=clear_playback)
+    plugin._playback_session = session
+    plugin._play_track = MusicQuizPlugin._play_track.__get__(plugin)  # type: ignore[method-assign]
+    plugin._stop_playback = MusicQuizPlugin._stop_playback.__get__(plugin)  # type: ignore[method-assign]
+    guest = User(
+        user_id="guest",
+        username=MUSIC_QUIZ_GUEST_USER,
+        role=UserRole.GUEST,
+        player_filter=[GUEST_ACCESS_RESTRICTED_PLAYER_ID],
+    )
+
+    set_current_user(guest)
+    try:
+        await plugin.ready(player_ids["Alice"])
+    finally:
+        set_current_user(None)
+
+    assert _phase(plugin) == MusicQuizPhase.ANSWERING
+    assert order[:2] == ["conceal", "play"]
+    queue_controller.play_media.assert_awaited_once_with(
+        "host_player",
+        "library://track/1",
+        option=QueueOption.REPLACE,
+    )
+    queue_controller.play_media_for_api.assert_not_awaited()
+
+    await plugin.reveal()
+    set_current_user(guest)
+    try:
+        await plugin.ready(player_ids["Alice"])
+    finally:
+        set_current_user(None)
+
+    assert _phase(plugin) == MusicQuizPhase.FINISHED
+    assert order[-2:] == ["clear", "stop"]
+    queue_controller.stop.assert_awaited_once_with("host_player")
+    queue_controller.stop_for_api.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.auth import Scope
-from music_assistant_models.enums import ConfigEntryType, PlaybackState
+from music_assistant_models.enums import ConfigEntryType, PlaybackState, QueueOption
 from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.providers.music_quiz import (
@@ -2220,6 +2220,162 @@ async def test_listen_in_joins_session_under_playback_lock() -> None:
     session.add_guest_listener.assert_awaited_once_with("web-1")
 
 
+@pytest.mark.parametrize(
+    ("quiz_type", "game_name"),
+    [
+        ("guess_the_song", "Song Quiz"),
+        ("hitster", "Timeline Quiz"),
+    ],
+)
+@pytest.mark.parametrize("mode", ["venue", "remote"])
+async def test_play_track_conceals_before_loading_for_every_quiz_mode(
+    quiz_type: str,
+    game_name: str,
+    mode: str,
+) -> None:
+    """Both quiz types and playback modes conceal media before loading audio."""
+    plugin = _create_plugin(mode=mode)
+    plugin._game = cast(
+        "MusicQuizGame",
+        SimpleNamespace(
+            config=SimpleNamespace(name=game_name),
+            quiz_type=quiz_type,
+        ),
+    )
+    session = MagicMock()
+    session.player_id = "quiz-player"
+    session.queue_id = "quiz-player"
+    session.clear_playback = AsyncMock()
+    session.close = AsyncMock()
+    plugin._playback_session = session
+    cast("MagicMock", plugin.mass).players.get_player.return_value = MagicMock()
+
+    async def _assert_concealed(*_args: Any, **_kwargs: Any) -> None:
+        session.set_media_presentation.assert_called_once_with(game_name)
+        assert plugin._playback_lock.locked()
+
+    play_media = AsyncMock(side_effect=_assert_concealed)
+    plugin.mass.player_queues.play_media = play_media  # type: ignore[method-assign]
+
+    await MusicQuizPlugin._play_track(plugin, "library://track/secret")
+
+    play_media.assert_awaited_once_with(
+        "quiz-player",
+        "library://track/secret",
+        option=QueueOption.REPLACE,
+    )
+
+
+@pytest.mark.parametrize("error", [RuntimeError("play failed"), asyncio.CancelledError()])
+async def test_failed_or_cancelled_play_cleans_up_while_concealed(
+    error: BaseException,
+) -> None:
+    """Failed playback clears and closes the session before propagating the failure."""
+    plugin = _create_plugin()
+    plugin._game = _fake_game()
+    session = MagicMock()
+    session.player_id = "quiz-player"
+    session.queue_id = "quiz-player"
+    session.clear_playback = AsyncMock()
+    session.close = AsyncMock()
+    plugin._playback_session = session
+    cast("MagicMock", plugin.mass).players.get_player.return_value = MagicMock()
+    play_media = AsyncMock(side_effect=error)
+    plugin.mass.player_queues.play_media = play_media  # type: ignore[method-assign]
+
+    with pytest.raises(
+        type(error), match="play failed" if isinstance(error, RuntimeError) else None
+    ):
+        await MusicQuizPlugin._play_track(plugin, "library://track/secret")
+
+    session.set_media_presentation.assert_called_once_with("Music Quiz")
+    session.clear_playback.assert_awaited_once()
+    session.close.assert_awaited_once()
+    assert plugin._playback_session is None
+
+
+@pytest.mark.parametrize("quiz_type", ["guess_the_song", "hitster"])
+async def test_reveal_publishes_scored_state_before_exposing_media(quiz_type: str) -> None:
+    """Reveal commits and broadcasts public answer state before clearing presentation."""
+    plugin = _create_plugin()
+    if quiz_type == "hitster":
+        with (
+            patch(
+                "music_assistant.providers.music_quiz.quiz_types.hitster."
+                "HitsterQuizType.initialize",
+                new=AsyncMock(),
+            ),
+            patch(
+                "music_assistant.providers.music_quiz.quiz_types.hitster."
+                "HitsterQuizType.prepare_round",
+                new=AsyncMock(
+                    side_effect=lambda round_index, previous: _make_hitster_round(
+                        round_index, previous
+                    )
+                ),
+            ),
+        ):
+            await _create_started_hitster_game(plugin)
+    else:
+        await _create_started_game(plugin, player_names=("Alice",))
+    game = plugin._game
+    assert game is not None
+    order: list[str] = []
+    session = MagicMock()
+
+    def _expose_media() -> bool:
+        order.append("media")
+        return True
+
+    session.clear_media_presentation.side_effect = _expose_media
+    plugin._playback_session = session
+
+    def _record_public_state(payload: dict[str, Any]) -> None:
+        assert game.phase == MusicQuizPhase.REVEAL
+        assert payload["state"]["phase"] == MusicQuizPhase.REVEAL.value
+        assert payload["state"]["players"][0]["score"] == next(iter(game.players.values())).score
+        order.append("state")
+
+    plugin.signal_provider_event = MagicMock(side_effect=_record_public_state)  # type: ignore[method-assign, misc]
+
+    plugin._do_reveal()
+
+    assert order == ["state", "media"]
+
+
+async def test_stop_playback_clears_session_under_lifecycle_lock() -> None:
+    """Quiz cleanup delegates to fail-safe queue clearing while holding the session lock."""
+    plugin = _create_plugin()
+    session = MagicMock()
+
+    async def _assert_locked() -> None:
+        assert plugin._playback_lock.locked()
+
+    session.clear_playback = AsyncMock(side_effect=_assert_locked)
+    plugin._playback_session = session
+
+    await MusicQuizPlugin._stop_playback(plugin)
+
+    session.clear_playback.assert_awaited_once()
+
+
+async def test_prefetch_never_publishes_player_or_queue_metadata() -> None:
+    """Preparing the next round remains memory-only."""
+    plugin = _create_plugin()
+    await plugin.create_game(source_uris=["library://playlist/1"])
+    signal = cast("MagicMock", plugin.signal_provider_event)
+    player_queues = cast("MagicMock", plugin.mass.player_queues)
+    signal.reset_mock()
+    player_queues.play_media.reset_mock()
+
+    task = plugin._next_round_task
+    assert task is not None
+    await task
+
+    signal.assert_not_called()
+    player_queues.play_media.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_unload_cleans_up() -> None:
     """Unload unregisters commands, closes the session and revokes guest access."""
@@ -2239,6 +2395,7 @@ async def test_unload_cleans_up() -> None:
         await plugin.unload(is_removed=True)
 
     unregister.assert_called_once()
+    cast("AsyncMock", plugin._stop_playback).assert_awaited_once()
     session.close.assert_awaited_once()
     assert plugin._game is None
     cast("MagicMock", plugin.mass.cancel_timer).assert_any_call(plugin._presence_timer_id)

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -2294,6 +2294,21 @@ async def test_failed_or_cancelled_play_cleans_up_while_concealed(
     assert plugin._playback_session is None
 
 
+async def test_failed_play_cleanup_closes_session_when_queue_clear_fails() -> None:
+    """Failed-play cleanup closes and drops the session even when queue clearing fails."""
+    plugin = _create_plugin()
+    session = MagicMock()
+    session.clear_playback = AsyncMock(side_effect=RuntimeError("clear failed"))
+    session.close = AsyncMock()
+    plugin._playback_session = session
+
+    with pytest.raises(RuntimeError, match="clear failed"):
+        await MusicQuizPlugin._cleanup_failed_play_locked(plugin, session)
+
+    session.close.assert_awaited_once()
+    assert plugin._playback_session is None
+
+
 @pytest.mark.parametrize("quiz_type", ["guess_the_song", "hitster"])
 async def test_reveal_publishes_scored_state_before_exposing_media(quiz_type: str) -> None:
     """Reveal commits and broadcasts public answer state before clearing presentation."""

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -2404,6 +2404,30 @@ async def test_unload_cleans_up() -> None:
 
 
 @pytest.mark.asyncio
+async def test_unload_tears_down_session_when_playback_cleanup_fails() -> None:
+    """Unload revokes access and closes the session before surfacing a stop failure."""
+    plugin = _create_plugin()
+    session = MagicMock()
+    session.close = AsyncMock()
+    plugin._playback_session = session
+    stop_playback = cast("AsyncMock", plugin._stop_playback)
+    stop_playback.side_effect = RuntimeError("stop failed")
+
+    with (
+        patch(
+            "music_assistant.helpers.guest_access.revoke_guest_access",
+            new=AsyncMock(return_value=(0, 0)),
+        ) as revoke,
+        pytest.raises(RuntimeError, match="stop failed"),
+    ):
+        await plugin.unload(is_removed=True)
+
+    session.close.assert_awaited_once()
+    assert plugin.__dict__["_playback_session"] is None
+    revoke.assert_awaited_once_with(plugin.mass, MUSIC_QUIZ_GUEST_USER)
+
+
+@pytest.mark.asyncio
 async def test_create_game_rejects_invalid_difficulty() -> None:
     """An unknown difficulty is rejected before a game is created."""
     plugin = _create_plugin()

--- a/tests/providers/sendspin/test_metadata_privacy.py
+++ b/tests/providers/sendspin/test_metadata_privacy.py
@@ -1,0 +1,135 @@
+"""Tests for Sendspin metadata sourced from concealed queue presentation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import MediaType, PlaybackState
+from music_assistant_models.player import PlayerMedia
+from music_assistant_models.player_queue import PlayerQueue
+
+from music_assistant.controllers.player_queues.controller import PlayerQueuesController
+from music_assistant.controllers.player_queues.state import PlayerQueueData
+from music_assistant.providers.sendspin.player import SendspinPlayer
+
+
+def _projected_media() -> tuple[MagicMock, PlayerMedia, PlayerMedia]:
+    """Build concealed and revealed media from a real queue presentation lease."""
+    mass = MagicMock()
+    mass.players.get_player.return_value = None
+    controller = PlayerQueuesController.__new__(PlayerQueuesController)
+    controller.mass = mass
+    controller._queue_data = {
+        "q1": PlayerQueueData(
+            queue=PlayerQueue(
+                queue_id="q1",
+                active=True,
+                display_name="Queue",
+                available=True,
+                items=1,
+            )
+        )
+    }
+    mass.player_queues = controller
+    source = PlayerMedia(
+        uri="provider://track/secret",
+        media_type=MediaType.TRACK,
+        title="Secret title",
+        artist="Secret artist",
+        album="Secret album",
+        album_artist="Secret album artist",
+        image_url="https://example.test/secret.jpg",
+        palette=MagicMock(),
+        duration=123,
+        source_id="q1",
+        queue_item_id="secret-id",
+        elapsed_time=17,
+        elapsed_time_last_updated=1234.5,
+    )
+    owner = object()
+    controller.set_media_presentation("q1", owner, "Music Quiz")
+    concealed = controller.apply_media_presentation("q1", source)
+    controller.clear_media_presentation("q1", owner)
+    revealed = controller.apply_media_presentation("q1", source)
+    return mass, concealed, revealed
+
+
+def _sendspin_player(mass: MagicMock, media: PlayerMedia) -> MagicMock:
+    """Build the Sendspin collaborators used by metadata publication."""
+    player = MagicMock()
+    player.available = True
+    player.state.current_media = media
+    player.state.playback_state = PlaybackState.PLAYING
+    player._metadata_role = MagicMock()
+    player._controller_role = MagicMock()
+    player._color_role = MagicMock()
+    player._send_album_artwork = AsyncMock()
+    player._send_artist_artwork = AsyncMock()
+    player._compute_track_progress_ms.return_value = 17_000
+    player._send_beat_schedule = AsyncMock()
+    player.mass = mass
+    return player
+
+
+async def test_concealed_sendspin_metadata_is_neutral_without_relookup() -> None:
+    """Direct Sendspin publication exposes only the neutral title before reveal."""
+    mass, concealed, _ = _projected_media()
+    player = _sendspin_player(mass, concealed)
+
+    await SendspinPlayer.send_current_media_metadata(player)
+
+    metadata = player._metadata_role.set_metadata.call_args.args[0]
+    assert metadata.title == "Music Quiz"
+    assert metadata.artist is None
+    assert metadata.album is None
+    assert metadata.album_artist is None
+    assert metadata.artwork_url is None
+    assert metadata.year is None
+    assert metadata.track is None
+    assert metadata.track_duration is None
+    assert "secret" not in repr(metadata).lower()
+    mass.music.get_library_item_by_prov_id.assert_not_called()
+    player._send_artist_artwork.assert_awaited_once_with(None)
+    player._send_color_palette.assert_called_once_with(player._color_role, None)
+    player._send_beat_schedule.assert_awaited_once()
+    queue, queue_item, *_ = player._send_beat_schedule.await_args.args
+    assert queue is None
+    assert queue_item is None
+
+
+async def test_missing_queue_item_clears_stale_artist_artwork() -> None:
+    """Concealed metadata clears artist artwork retained from the previous item."""
+    player = MagicMock()
+    player.last_sent_artist_artwork_url = "https://example.test/secret-artist.jpg"
+    player._artwork_role = MagicMock()
+    player._artwork_role.set_artist_artwork = AsyncMock()
+
+    await SendspinPlayer._send_artist_artwork(player, None)
+
+    assert player.last_sent_artist_artwork_url is None
+    player._artwork_role.set_artist_artwork.assert_awaited_once_with(None)
+
+
+async def test_reveal_and_late_listener_use_current_presentation_state() -> None:
+    """Metadata becomes real after reveal while a late pre-reveal role remains neutral."""
+    mass, concealed, revealed = _projected_media()
+    player = _sendspin_player(mass, concealed)
+    late_metadata_role = MagicMock()
+    player._metadata_role = late_metadata_role
+
+    await SendspinPlayer.send_current_media_metadata(player)
+
+    late_metadata = late_metadata_role.set_metadata.call_args.args[0]
+    assert late_metadata.title == "Music Quiz"
+    assert late_metadata.artist is None
+    assert late_metadata.track_duration is None
+
+    player.state.current_media = revealed
+    await SendspinPlayer.send_current_media_metadata(player)
+
+    public_metadata = late_metadata_role.set_metadata.call_args.args[0]
+    assert public_metadata.title == "Secret title"
+    assert public_metadata.artist == "Secret artist"
+    assert public_metadata.album == "Secret album"
+    assert public_metadata.artwork_url == "https://example.test/secret.jpg"
+    assert public_metadata.track_duration == 123_000

--- a/tests/test_sendspin_proxy.py
+++ b/tests/test_sendspin_proxy.py
@@ -1,12 +1,16 @@
 """Tests for the Sendspin WebSocket proxy handler."""
 
 import asyncio
+import json
+from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
-from aiohttp import ClientConnectorError, web
+from aiohttp import ClientConnectorError, WSMsgType, web
 from aiohttp.test_utils import make_mocked_request
+from music_assistant_models.auth import UserRole
 
 from music_assistant.controllers.webserver.sendspin_proxy import SendspinProxyHandler
 
@@ -143,7 +147,7 @@ class TestSendspinProxyMessages:
             patch.object(handler, "_forward_internal_to_client", new=raise_disconnect),
             patch.object(handler, "_forward_client_to_internal", new=wait_forever),
         ):
-            await handler._proxy_messages(MagicMock(), MagicMock())
+            await handler._proxy_messages(MagicMock(), MagicMock(), MagicMock(role=UserRole.USER))
 
     async def test_unexpected_forwarding_error_is_raised(
         self, handler: SendspinProxyHandler
@@ -161,7 +165,7 @@ class TestSendspinProxyMessages:
             patch.object(handler, "_forward_client_to_internal", new=wait_forever),
             pytest.raises(RuntimeError, match="boom"),
         ):
-            await handler._proxy_messages(MagicMock(), MagicMock())
+            await handler._proxy_messages(MagicMock(), MagicMock(), MagicMock(role=UserRole.USER))
 
     async def test_primary_error_is_not_masked_by_peer_cleanup_failure(
         self, handler: SendspinProxyHandler
@@ -182,7 +186,7 @@ class TestSendspinProxyMessages:
             patch.object(handler, "_forward_client_to_internal", new=raise_on_cancel),
             pytest.raises(RuntimeError, match="primary failure"),
         ):
-            await handler._proxy_messages(MagicMock(), MagicMock())
+            await handler._proxy_messages(MagicMock(), MagicMock(), MagicMock(role=UserRole.USER))
 
     @pytest.mark.parametrize(
         "exc",
@@ -206,4 +210,245 @@ class TestSendspinProxyMessages:
             patch.object(handler, "_forward_internal_to_client", new=raise_disconnect),
             patch.object(handler, "_forward_client_to_internal", new=wait_forever),
         ):
-            await handler._proxy_messages(MagicMock(), MagicMock())
+            await handler._proxy_messages(MagicMock(), MagicMock(), MagicMock(role=UserRole.USER))
+
+
+class _MessageStream:
+    """Async iterator over websocket-like messages."""
+
+    def __init__(self, *messages: SimpleNamespace) -> None:
+        self._messages = iter(messages)
+
+    def __aiter__(self) -> _MessageStream:
+        return self
+
+    async def __anext__(self) -> SimpleNamespace:
+        try:
+            return next(self._messages)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+def _hello(*roles: str, include_player_support: bool = True) -> str:
+    """Build a Sendspin client hello with the given roles."""
+    payload: dict[str, object] = {
+        "client_id": "web-player",
+        "name": "Web player",
+        "version": 1,
+        "supported_roles": list(roles),
+    }
+    if include_player_support:
+        payload["player@v1_support"] = {
+            "supported_formats": [],
+            "buffer_capacity": 1024,
+            "supported_commands": [],
+        }
+    return json.dumps({"type": "client/hello", "payload": payload}, indent=2)
+
+
+class TestSendspinGuestRoles:
+    """Tests for authenticated role restriction on client-to-server messages."""
+
+    async def test_guest_first_and_repeated_hello_are_player_only(
+        self, handler: SendspinProxyHandler
+    ) -> None:
+        """Every Guest hello is rewritten while non-hello and binary traffic passes through."""
+        first_hello = _hello("player@v1", "metadata@v1", "controller@v1")
+        second_hello = _hello("metadata@v1")
+        non_hello = '{"type":"client/state","payload":{"volume":50}}'
+        malformed = "{not-json"
+        binary = b"\x00audio"
+        client = _MessageStream(
+            SimpleNamespace(type=WSMsgType.TEXT, data=first_hello),
+            SimpleNamespace(type=WSMsgType.TEXT, data=non_hello),
+            SimpleNamespace(type=WSMsgType.TEXT, data=second_hello),
+            SimpleNamespace(type=WSMsgType.TEXT, data=malformed),
+            SimpleNamespace(type=WSMsgType.BINARY, data=binary),
+        )
+        internal = AsyncMock()
+
+        await handler._forward_client_to_internal(
+            cast("web.WebSocketResponse", client), internal, ("player@v1",)
+        )
+
+        forwarded = [call.args[0] for call in internal.send_str.await_args_list]
+        assert json.loads(forwarded[0])["payload"]["supported_roles"] == ["player@v1"]
+        assert forwarded[1] == non_hello
+        assert json.loads(forwarded[2])["payload"]["supported_roles"] == ["player@v1"]
+        assert forwarded[3] == malformed
+        internal.send_bytes.assert_awaited_once_with(binary)
+
+    @pytest.mark.parametrize("role", [UserRole.USER, UserRole.ADMIN, UserRole.SERVICE])
+    async def test_non_guest_hello_is_byte_identical(
+        self, handler: SendspinProxyHandler, role: UserRole
+    ) -> None:
+        """Regular, admin and service users retain exact client traffic."""
+        raw_hello = _hello("player@v1", "metadata@v1")
+        client = _MessageStream(SimpleNamespace(type=WSMsgType.TEXT, data=raw_hello))
+        internal = AsyncMock()
+
+        await handler._forward_client_to_internal(
+            cast("web.WebSocketResponse", client), internal, None
+        )
+
+        internal.send_str.assert_awaited_once_with(raw_hello)
+
+    @pytest.mark.parametrize(
+        "raw_message",
+        [
+            "{not-json",
+            "[]",
+            '{"type":"client/hello","payload":[]}',
+            '{"type":"client/state","payload":{"supported_roles":["metadata@v1"]}}',
+        ],
+    )
+    def test_malformed_or_non_hello_text_passes_through(
+        self, handler: SendspinProxyHandler, raw_message: str
+    ) -> None:
+        """Messages that are not structurally valid hellos remain parser-visible unchanged."""
+        assert handler._restrict_client_hello_roles(raw_message, ("player@v1",)) == raw_message
+
+    def test_rewrite_preserves_player_support_without_synthesizing_it(
+        self, handler: SendspinProxyHandler
+    ) -> None:
+        """Role rewriting preserves support data and leaves missing support for upstream rejection."""
+        supported = json.loads(
+            handler._restrict_client_hello_roles(
+                _hello("metadata@v1", include_player_support=True),
+                ("player@v1",),
+            )
+        )
+        missing = json.loads(
+            handler._restrict_client_hello_roles(
+                _hello("metadata@v1", include_player_support=False),
+                ("player@v1",),
+            )
+        )
+
+        assert supported["payload"]["supported_roles"] == ["player@v1"]
+        assert supported["payload"]["player@v1_support"]["buffer_capacity"] == 1024
+        assert missing["payload"]["supported_roles"] == ["player@v1"]
+        assert "player@v1_support" not in missing["payload"]
+
+    @pytest.mark.parametrize(
+        ("role", "allowed_roles"),
+        [
+            (UserRole.GUEST, ("player@v1",)),
+            (UserRole.USER, None),
+            (UserRole.ADMIN, None),
+            (UserRole.SERVICE, None),
+        ],
+    )
+    async def test_authenticated_role_selects_forwarding_policy(
+        self,
+        handler: SendspinProxyHandler,
+        role: UserRole,
+        allowed_roles: tuple[str, ...] | None,
+    ) -> None:
+        """The forwarding policy depends only on the authenticated user's role."""
+        user = MagicMock(role=role)
+        client = MagicMock()
+        internal = MagicMock()
+        with (
+            patch.object(
+                handler, "_forward_client_to_internal", new_callable=AsyncMock
+            ) as forward_client,
+            patch.object(handler, "_forward_internal_to_client", new_callable=AsyncMock),
+        ):
+            await handler._proxy_messages(client, internal, user)
+
+        forward_client.assert_awaited_once_with(client, internal, allowed_roles)
+
+    @pytest.mark.parametrize("ingress", [False, True], ids=["token", "ingress"])
+    async def test_guest_auth_paths_reach_proxy_with_authenticated_user(
+        self,
+        handler: SendspinProxyHandler,
+        ingress: bool,
+    ) -> None:
+        """Token and ingress Guest authentication both apply the same role policy."""
+        user = MagicMock(role=UserRole.GUEST, username="guest")
+        client_ws = AsyncMock(spec=web.WebSocketResponse)
+        client_ws.closed = True
+        internal_ws = AsyncMock()
+        internal_ws.closed = True
+        with (
+            patch("aiohttp.web.WebSocketResponse", return_value=client_ws),
+            patch(
+                "music_assistant.controllers.webserver.sendspin_proxy.is_request_from_ingress",
+                return_value=ingress,
+            ),
+            patch(
+                "music_assistant.controllers.webserver.sendspin_proxy.get_authenticated_user",
+                new=AsyncMock(return_value=user),
+            ),
+            patch.object(handler, "_authenticate", new=AsyncMock(return_value=user)),
+            patch.object(handler, "_proxy_messages", new_callable=AsyncMock) as proxy,
+        ):
+            handler.mass.http_session.ws_connect = AsyncMock(  # type: ignore[method-assign]
+                return_value=internal_ws
+            )
+            request = make_mocked_request("GET", "/sendspin")
+            await handler.handle_sendspin_proxy(request)
+
+        proxy.assert_awaited_once_with(client_ws, internal_ws, user)
+
+
+class TestSendspinProxyAuth:
+    """Tests for strict custom proxy authentication payloads."""
+
+    @pytest.mark.parametrize(
+        "auth_data",
+        [
+            [],
+            {"type": "auth", "token": ""},
+            {"type": "auth", "token": 123},
+            {"type": "auth", "token": "token", "client_id": ""},
+            {"type": "auth", "token": "token", "client_id": 123},
+            {"type": "auth", "token": "token", "client_id": None},
+        ],
+    )
+    async def test_invalid_auth_payload_types_are_rejected(
+        self,
+        handler: SendspinProxyHandler,
+        auth_data: object,
+    ) -> None:
+        """Auth payloads require a dict and non-empty string identifiers."""
+        wsock = AsyncMock()
+        wsock.receive.return_value = SimpleNamespace(
+            type=WSMsgType.TEXT,
+            data=json.dumps(auth_data),
+        )
+        handler.webserver.auth.authenticate_with_token = AsyncMock()  # type: ignore[method-assign]
+
+        assert await handler._authenticate(wsock) is None
+
+        wsock.close.assert_awaited_once()
+        handler.webserver.auth.authenticate_with_token.assert_not_awaited()
+
+    async def test_valid_auth_registers_non_empty_client_id(
+        self, handler: SendspinProxyHandler
+    ) -> None:
+        """A valid token and client id authenticate and register normally."""
+        user = MagicMock(user_id="guest-id", username="guest")
+        handler.webserver.auth.authenticate_with_token = AsyncMock(  # type: ignore[method-assign]
+            return_value=user
+        )
+        wsock = AsyncMock()
+        wsock.receive.return_value = SimpleNamespace(
+            type=WSMsgType.TEXT,
+            data=json.dumps(
+                {
+                    "type": "auth",
+                    "token": "token",
+                    "client_id": "web-player",
+                }
+            ),
+        )
+
+        assert await handler._authenticate(wsock) is user
+
+        handler.webserver.auth.authenticate_with_token.assert_awaited_once_with("token")
+        cast("MagicMock", handler.webserver.set_sendspin_player_for_user).assert_called_once_with(
+            "guest-id", "web-player"
+        )
+        wsock.send_str.assert_awaited_once_with('{"type": "auth_ok"}')


### PR DESCRIPTION
# What does this implement/fix?

Music Quiz track details could be exposed through player metadata before a round was revealed.

- Conceals answer metadata at the active queue while preserving audio playback.
- Reveals real metadata only after the score and public answer state are emitted.
- Makes guest Sendspin proxy connections receive-only and keeps normal shared playback unchanged.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) - `bugfix`
- [ ] New feature (non-breaking change which adds functionality) - `new-feature`
- [ ] Enhancement to an existing feature - `enhancement`
- [ ] New music/player/metadata/plugin provider - `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) - `breaking-change`
- [ ] Refactor (no behaviour change) - `refactor`
- [ ] Documentation only - `documentation`
- [ ] Maintenance / chore - `maintenance`
- [ ] CI / workflow change - `ci`
- [ ] Dependencies bump - `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.