### PR TITLE
Keep managed guests receive-only

### DIFF
--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -59,8 +59,8 @@ from music_assistant.models.core_controller import CoreController
 from .api_docs import generate_commands_json, generate_openapi_spec, generate_schemas_json
 from .auth import AuthenticationManager
 from .helpers.auth_middleware import (
+    check_command_permission,
     get_authenticated_user,
-    has_scope,
     is_request_from_ingress,
     resolve_command_impersonation,
     set_current_token,
@@ -73,6 +73,7 @@ from .sendspin_proxy import SendspinProxyHandler
 from .websocket_client import WebsocketClientHandler
 
 if TYPE_CHECKING:
+    from music_assistant_models.auth import User
     from music_assistant_models.config_entries import ConfigValueType, CoreConfig
 
     from music_assistant import MusicAssistant
@@ -445,6 +446,17 @@ class WebserverController(CoreController):
                 )
                 client._cancel()
 
+    def get_authenticated_user_for_webrtc_session(self, session_id: str) -> User | None:
+        """
+        Return the authenticated API user for a WebRTC session.
+
+        :param session_id: The WebRTC session ID.
+        """
+        for client in self.clients:
+            if client._webrtc_session_id == session_id and client._authenticated_user is not None:
+                return client._authenticated_user
+        return None
+
     def set_sendspin_player_for_user(self, user_id: str, player_id: str) -> None:
         """
         Set the sendspin player_id on websocket clients for a specific user.
@@ -643,10 +655,12 @@ class WebserverController(CoreController):
         auth_header = request.headers.get("Authorization", "")
         if auth_header.lower().startswith("bearer "):
             set_current_token(auth_header[7:])
-        if handler.required_scope and not has_scope(user, handler.required_scope):
+        try:
+            check_command_permission(user, handler)
+        except InsufficientPermissions as err:
             return web.Response(
                 status=403,
-                text=f"This command requires the {handler.required_scope} scope",
+                text=str(err),
             )
         return None
 

--- a/music_assistant/controllers/webserver/helpers/auth_middleware.py
+++ b/music_assistant/controllers/webserver/helpers/auth_middleware.py
@@ -12,7 +12,12 @@ from aiohttp import web
 from music_assistant_models.auth import AuthProviderType, Scope, User, UserRole
 from music_assistant_models.errors import InsufficientPermissions, InvalidDataError
 
-from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER, MASS_LOGGER_NAME, VERBOSE_LOG_LEVEL
+from music_assistant.constants import (
+    GUEST_ACCESS_RESTRICTED_PLAYER_ID,
+    HOMEASSISTANT_SYSTEM_USER,
+    MASS_LOGGER_NAME,
+    VERBOSE_LOG_LEVEL,
+)
 
 from .auth_providers import get_ha_user_details, get_ha_user_role
 
@@ -20,6 +25,7 @@ LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.auth")
 
 if TYPE_CHECKING:
     from music_assistant import MusicAssistant
+    from music_assistant.helpers.api import APICommandHandler
 
 # Context key for storing authenticated user in request
 USER_CONTEXT_KEY = "authenticated_user"
@@ -54,6 +60,8 @@ ROLE_SCOPES: Final[Mapping[str, frozenset[Scope]]] = {
     # slightly elevated rights over a regular user
     UserRole.SERVICE: _USER_SCOPES | {Scope.CONFIG_PLAYERS_WRITE, Scope.USERS_IMPERSONATE},
 }
+_RECEIVE_ONLY_COMMAND_PREFIXES: Final = ("players/", "player_queues/")
+_RECEIVE_ONLY_CONTROL_SCOPES: Final = frozenset({Scope.PLAYERS_CONTROL, Scope.QUEUES_CONTROL})
 
 # ContextVar for tracking current user and token across async calls
 current_user: ContextVar[User | None] = ContextVar("current_user", default=None)
@@ -192,6 +200,26 @@ def has_scope(user: User, scope: Scope) -> bool:
     """
     role_scopes = ROLE_SCOPES.get(user.role, frozenset())
     return Scope.ALL in role_scopes or scope in role_scopes
+
+
+def check_command_permission(user: User, handler: APICommandHandler) -> None:
+    """
+    Validate that a user may invoke an external API command.
+
+    :param user: The authenticated user invoking the command.
+    :param handler: The API command handler being invoked.
+    :raises InsufficientPermissions: If the user lacks the required permission.
+    """
+    if handler.required_scope and not has_scope(user, handler.required_scope):
+        raise InsufficientPermissions(f"This command requires the {handler.required_scope} scope")
+    if (
+        handler.required_scope in _RECEIVE_ONLY_CONTROL_SCOPES
+        and handler.command.startswith(_RECEIVE_ONLY_COMMAND_PREFIXES)
+        and GUEST_ACCESS_RESTRICTED_PLAYER_ID in (user.player_filter or [])
+    ):
+        raise InsufficientPermissions(
+            "This managed guest account is receive-only and cannot control players or queues"
+        )
 
 
 async def resolve_impersonated_user(mass: MusicAssistant, user: str) -> User:

--- a/music_assistant/controllers/webserver/remote_access/__init__.py
+++ b/music_assistant/controllers/webserver/remote_access/__init__.py
@@ -198,6 +198,9 @@ class RemoteAccessManager:
             ice_servers_callback=self.get_ice_servers if ha_cloud_available else None,
             # Pass callback to set sendspin player on websocket client
             set_sendspin_player_callback=self.webserver.set_sendspin_player_for_webrtc_session,
+            get_authenticated_user_callback=(
+                self.webserver.get_authenticated_user_for_webrtc_session
+            ),
         )
 
         await self.gateway.start()

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -22,10 +22,15 @@ from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection, RTCSession
 from aiortc.sdp import candidate_from_sdp
 
 from music_assistant.constants import MASS_LOGGER_NAME, VERBOSE_LOG_LEVEL
+from music_assistant.helpers.sendspin import (
+    get_sendspin_role_restriction,
+    restrict_sendspin_client_hello_roles,
+)
 from music_assistant.helpers.webrtc_certificate import create_peer_connection_with_certificate
 
 if TYPE_CHECKING:
     from aiortc.rtcdtlstransport import RTCCertificate
+    from music_assistant_models.auth import User
 
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.remote_access")
 
@@ -51,6 +56,7 @@ class WebRTCSession:
     sendspin_ws: Any = None
     sendspin_queue: asyncio.Queue[str | bytes] = field(default_factory=asyncio.Queue)
     sendspin_player_id: str | None = None  # Extracted from first sendspin auth message
+    sendspin_allowed_roles: tuple[str, ...] | None = None
     sendspin_to_local_task: asyncio.Task[None] | None = None
     sendspin_from_local_task: asyncio.Task[None] | None = None
 
@@ -89,6 +95,7 @@ class WebRTCGateway:
         ice_servers: list[dict[str, Any]] | None = None,
         ice_servers_callback: Callable[[], Awaitable[list[dict[str, Any]]]] | None = None,
         set_sendspin_player_callback: Callable[[str, str], None] | None = None,
+        get_authenticated_user_callback: Callable[[str], User | None] | None = None,
     ) -> None:
         """
         Initialize the WebRTC Gateway.
@@ -102,6 +109,7 @@ class WebRTCGateway:
         :param ice_servers: List of ICE server configurations (used at registration time).
         :param ice_servers_callback: Optional callback to fetch fresh ICE servers for each session.
         :param set_sendspin_player_callback: Callback to set sendspin player for a session.
+        :param get_authenticated_user_callback: Callback to resolve a session's authenticated user.
         """
         self.http_session = http_session
         self.signaling_url = signaling_url
@@ -112,6 +120,7 @@ class WebRTCGateway:
         self.logger = LOGGER
         self._ice_servers_callback = ice_servers_callback
         self._set_sendspin_player_callback = set_sendspin_player_callback
+        self._get_authenticated_user_callback = get_authenticated_user_callback
 
         # Static ICE servers used at registration time (relayed to clients via signaling server)
         self.ice_servers = ice_servers or self.DEFAULT_ICE_SERVERS
@@ -741,6 +750,20 @@ class WebRTCGateway:
             return
 
         try:
+            user = (
+                self._get_authenticated_user_callback(session.session_id)
+                if self._get_authenticated_user_callback
+                else None
+            )
+            if user is None:
+                self.logger.warning(
+                    "Rejecting Sendspin channel without authenticated API session %s",
+                    session.session_id,
+                )
+                channel.close()
+                return
+            session.sendspin_allowed_roles = get_sendspin_role_restriction(user.role)
+
             loop = asyncio.get_event_loop()
 
             @channel.on("message")  # type: ignore[untyped-decorator]
@@ -781,6 +804,7 @@ class WebRTCGateway:
                 session.sendspin_from_local_task.cancel()
             if session.sendspin_ws and not session.sendspin_ws.closed:
                 await session.sendspin_ws.close()
+            channel.close()
 
     async def _forward_sendspin_to_local(self, session: WebRTCSession) -> None:
         """
@@ -803,6 +827,10 @@ class WebRTCGateway:
                     if isinstance(message, bytes):
                         await session.sendspin_ws.send_bytes(message)
                     else:
+                        if session.sendspin_allowed_roles is not None:
+                            message = restrict_sendspin_client_hello_roles(
+                                message, session.sendspin_allowed_roles
+                            )
                         await session.sendspin_ws.send_str(message)
         except asyncio.CancelledError:
             self.logger.debug(

--- a/music_assistant/controllers/webserver/sendspin_proxy.py
+++ b/music_assistant/controllers/webserver/sendspin_proxy.py
@@ -16,12 +16,15 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 from aiohttp import ClientConnectorError, WSMsgType, web
-from music_assistant_models.auth import UserRole
 
 from music_assistant.constants import MASS_LOGGER_NAME
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_authenticated_user,
     is_request_from_ingress,
+)
+from music_assistant.helpers.sendspin import (
+    get_sendspin_role_restriction,
+    restrict_sendspin_client_hello_roles,
 )
 from music_assistant.helpers.util import format_ip_for_url
 
@@ -204,7 +207,7 @@ class SendspinProxyHandler:
         :param internal_ws: The internal Sendspin server WebSocket connection.
         :param user: The user authenticated for this proxy connection.
         """
-        allowed_roles = ("player@v1",) if user.role == UserRole.GUEST else None
+        allowed_roles = get_sendspin_role_restriction(user.role)
         client_to_internal = asyncio.create_task(
             self._forward_client_to_internal(client_ws, internal_ws, allowed_roles)
         )
@@ -272,7 +275,7 @@ class SendspinProxyHandler:
             if msg.type == WSMsgType.TEXT:
                 raw_message = msg.data
                 if allowed_roles is not None:
-                    raw_message = self._restrict_client_hello_roles(raw_message, allowed_roles)
+                    raw_message = restrict_sendspin_client_hello_roles(raw_message, allowed_roles)
                 await internal_ws.send_str(raw_message)
             elif msg.type == WSMsgType.BINARY:
                 await internal_ws.send_bytes(msg.data)
@@ -301,25 +304,3 @@ class SendspinProxyHandler:
                 if msg.type == WSMsgType.ERROR:
                     self.logger.debug("Sendspin proxy internal transport error: %s", msg.data)
                 break
-
-    @staticmethod
-    def _restrict_client_hello_roles(raw_message: str, allowed_roles: tuple[str, ...]) -> str:
-        """
-        Restrict the roles advertised by a structurally valid Sendspin client hello.
-
-        :param raw_message: Raw text message received from the client.
-        :param allowed_roles: Exact roles the client may advertise.
-        :return: The rewritten hello or the original message when it is not a valid hello.
-        """
-        try:
-            message = json.loads(raw_message)
-        except json.JSONDecodeError:
-            return raw_message
-        if (
-            not isinstance(message, dict)
-            or message.get("type") != "client/hello"
-            or not isinstance((payload := message.get("payload")), dict)
-        ):
-            return raw_message
-        payload["supported_roles"] = list(allowed_roles)
-        return json.dumps(message, separators=(",", ":"))

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -39,7 +39,7 @@ from music_assistant.constants import (
 from music_assistant.helpers.api import APICommandHandler, parse_arguments
 
 from .helpers.auth_middleware import (
-    has_scope,
+    check_command_permission,
     is_request_from_ingress,
     resolve_command_impersonation,
     set_current_token,
@@ -231,16 +231,15 @@ class WebsocketClientHandler:
             set_current_token(self._current_token)
             set_sendspin_player_id(self._sendspin_player_id)
 
-            # Check scope if required
-            if handler.required_scope and not has_scope(
-                self._authenticated_user, handler.required_scope
-            ):
+            try:
+                check_command_permission(self._authenticated_user, handler)
+            except InsufficientPermissions as err:
                 await self._send_message(
                     ErrorResultMessage(
                         msg.message_id,
-                        InsufficientPermissions.error_code,
-                        f"This command requires the {handler.required_scope} scope",
-                        translation_key="insufficient_permissions",
+                        err.error_code,
+                        str(err),
+                        translation_key=err.translation_key,
                     )
                 )
                 return

--- a/music_assistant/helpers/sendspin.py
+++ b/music_assistant/helpers/sendspin.py
@@ -1,0 +1,42 @@
+"""Shared helpers for authenticating Sendspin client capabilities."""
+
+from __future__ import annotations
+
+import json
+from typing import Final
+
+from music_assistant_models.auth import UserRole
+
+GUEST_SENDSPIN_ROLES: Final = ("player@v1",)
+
+
+def get_sendspin_role_restriction(role: str) -> tuple[str, ...] | None:
+    """
+    Return the Sendspin roles an authenticated user may advertise.
+
+    :param role: The authenticated user's role.
+    :return: Exact allowed roles, or None when messages may pass through unchanged.
+    """
+    return GUEST_SENDSPIN_ROLES if role == UserRole.GUEST else None
+
+
+def restrict_sendspin_client_hello_roles(raw_message: str, allowed_roles: tuple[str, ...]) -> str:
+    """
+    Restrict the roles advertised by a structurally valid Sendspin client hello.
+
+    :param raw_message: Raw text message received from the client.
+    :param allowed_roles: Exact roles the client may advertise.
+    :return: The rewritten hello or the original message when it is not a valid hello.
+    """
+    try:
+        message = json.loads(raw_message)
+    except json.JSONDecodeError:
+        return raw_message
+    if (
+        not isinstance(message, dict)
+        or message.get("type") != "client/hello"
+        or not isinstance((payload := message.get("payload")), dict)
+    ):
+        return raw_message
+    payload["supported_roles"] = list(allowed_roles)
+    return json.dumps(message, separators=(",", ":"))

--- a/tests/controllers/webserver/test_api_command_authorization.py
+++ b/tests/controllers/webserver/test_api_command_authorization.py
@@ -1,0 +1,285 @@
+"""Tests for external API command authorization."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from music_assistant_models.auth import Scope, User, UserRole
+from music_assistant_models.errors import InsufficientPermissions
+
+from music_assistant.constants import GUEST_ACCESS_RESTRICTED_PLAYER_ID
+from music_assistant.controllers.webserver.controller import WebserverController
+from music_assistant.controllers.webserver.helpers.auth_middleware import (
+    check_command_permission,
+)
+from music_assistant.helpers.api import APICommandHandler
+
+if TYPE_CHECKING:
+    from music_assistant import MusicAssistant
+
+
+async def _noop_command() -> None:
+    """Provide a no-op API command target."""
+
+
+def _handler(command: str, scope: Scope | None) -> APICommandHandler:
+    """Create an API command handler for authorization tests."""
+    return APICommandHandler.parse(command, _noop_command, required_scope=scope)
+
+
+def _user(
+    role: UserRole = UserRole.GUEST,
+    player_filter: list[str] | None = None,
+) -> User:
+    """Create an authenticated user for authorization tests."""
+    if player_filter is None:
+        return User(
+            user_id=f"{role.value}_id",
+            username=f"{role.value}_user",
+            role=role,
+        )
+    return User(
+        user_id=f"{role.value}_id",
+        username=f"{role.value}_user",
+        role=role,
+        player_filter=player_filter,
+    )
+
+
+@pytest.mark.parametrize("command", ["players/cmd/test", "player_queues/test"])
+@pytest.mark.parametrize("scope", [Scope.PLAYERS_CONTROL, Scope.QUEUES_CONTROL])
+def test_managed_guest_is_denied_every_core_control_prefix_and_scope(
+    command: str,
+    scope: Scope,
+) -> None:
+    """The receive-only boundary covers both core prefixes and control scopes."""
+    with pytest.raises(InsufficientPermissions, match="receive-only"):
+        check_command_permission(
+            _user(player_filter=[GUEST_ACCESS_RESTRICTED_PLAYER_ID]),
+            _handler(command, scope),
+        )
+
+
+@pytest.mark.parametrize(
+    ("command", "scope"),
+    [
+        ("players/all", Scope.PLAYERS_READ),
+        ("player_queues/all", Scope.QUEUES_READ),
+        ("music_quiz/listen_in", Scope.PLAYERS_CONTROL),
+        ("music_quiz/stop_listen_in", Scope.PLAYERS_CONTROL),
+        ("music_quiz/can_listen_in", Scope.PLAYERS_CONTROL),
+        ("music_quiz/submit_answer", None),
+        ("music_quiz/ready", None),
+    ],
+)
+def test_managed_guest_keeps_read_and_provider_command_access(
+    command: str,
+    scope: Scope | None,
+) -> None:
+    """Read commands and provider-owned controls remain available."""
+    check_command_permission(
+        _user(player_filter=[GUEST_ACCESS_RESTRICTED_PLAYER_ID]),
+        _handler(command, scope),
+    )
+
+
+@pytest.mark.parametrize(
+    "role",
+    [UserRole.GUEST, UserRole.USER, UserRole.ADMIN, UserRole.SERVICE],
+)
+def test_users_without_receive_only_sentinel_keep_control_access(role: UserRole) -> None:
+    """Built-in roles retain their existing core control permissions."""
+    check_command_permission(_user(role), _handler("players/cmd/play", Scope.PLAYERS_CONTROL))
+
+
+def test_party_guest_without_sentinel_keeps_control_access() -> None:
+    """Party-style guests without a managed filter retain existing behavior."""
+    check_command_permission(
+        _user(player_filter=[]),
+        _handler("player_queues/play", Scope.QUEUES_CONTROL),
+    )
+
+
+CORE_CONTROL_COMMANDS = (
+    ("players/cmd/play", Scope.PLAYERS_CONTROL, {"player_id": "host"}),
+    (
+        "players/cmd/set_members",
+        Scope.PLAYERS_CONTROL,
+        {"player_id": "host", "player_ids_to_add": ["guest_player"]},
+    ),
+    ("player_queues/clear", Scope.QUEUES_CONTROL, {"queue_id": "host"}),
+    (
+        "player_queues/shuffle",
+        Scope.QUEUES_CONTROL,
+        {"queue_id": "host", "shuffle_enabled": True},
+    ),
+    (
+        "player_queues/overlay",
+        Scope.QUEUES_CONTROL,
+        {"queue_id": "host", "characteristic": "volume", "value": 50},
+    ),
+)
+
+
+def _create_jsonrpc_controller(
+    handler: APICommandHandler,
+    target: AsyncMock,
+) -> WebserverController:
+    """Create a minimally wired JSON-RPC controller."""
+    controller = WebserverController.__new__(WebserverController)
+    controller.auth = MagicMock(has_users=True)
+    controller.logger = MagicMock()
+    controller.mass = MagicMock()
+    controller.mass.command_handlers = {handler.command: handler}
+    controller.mass.translations.ensure_locale_loaded = AsyncMock()
+    handler.target = target
+    return controller
+
+
+def _create_jsonrpc_request(command: str, args: dict[str, object] | None = None) -> MagicMock:
+    """Create a JSON-RPC request carrying one API command."""
+    request = MagicMock(spec=web.Request)
+    request.can_read_body = True
+    request.read = AsyncMock(
+        return_value=json.dumps(
+            {"message_id": "1", "command": command, "args": args or {}}
+        ).encode()
+    )
+    request.headers = {}
+    return request
+
+
+@pytest.mark.parametrize(("command", "scope", "args"), CORE_CONTROL_COMMANDS)
+async def test_jsonrpc_managed_guest_core_control_is_denied_before_target(
+    command: str,
+    scope: Scope,
+    args: dict[str, object],
+) -> None:
+    """JSON-RPC rejects receive-only controls before invoking their target."""
+    handler = _handler(command, scope)
+    target = AsyncMock()
+    controller = _create_jsonrpc_controller(handler, target)
+    request = _create_jsonrpc_request(command, args)
+
+    with patch(
+        "music_assistant.controllers.webserver.controller.get_authenticated_user",
+        new=AsyncMock(return_value=_user(player_filter=[GUEST_ACCESS_RESTRICTED_PLAYER_ID])),
+    ):
+        response = await controller._handle_jsonrpc_api_command(request)
+
+    assert response.status == 403
+    assert "receive-only" in (response.text or "")
+    target.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("command", "scope"),
+    [
+        ("music_quiz/listen_in", Scope.PLAYERS_CONTROL),
+        ("music_quiz/ready", None),
+    ],
+)
+async def test_jsonrpc_managed_guest_provider_command_reaches_target(
+    command: str,
+    scope: Scope | None,
+) -> None:
+    """JSON-RPC continues to invoke provider-owned guest commands."""
+    handler = _handler(command, scope)
+    target = AsyncMock(return_value=None)
+    controller = _create_jsonrpc_controller(handler, target)
+    request = _create_jsonrpc_request(command)
+
+    with patch(
+        "music_assistant.controllers.webserver.controller.get_authenticated_user",
+        new=AsyncMock(return_value=_user(player_filter=[GUEST_ACCESS_RESTRICTED_PLAYER_ID])),
+    ):
+        response = await controller._handle_jsonrpc_api_command(request)
+
+    assert response.status == 200
+    target.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize(
+    ("prefix", "control_scope", "non_control_commands"),
+    [
+        (
+            "players/",
+            Scope.PLAYERS_CONTROL,
+            frozenset(
+                {
+                    "players/all",
+                    "players/get",
+                    "players/get_by_name",
+                    "players/player_controls",
+                    "players/player_control",
+                    "players/sleep_timer/get",
+                    "players/create_group_player",
+                    "players/remove_group_player",
+                    "players/add_currently_playing_to_favorites",
+                    "players/remove",
+                }
+            ),
+        ),
+        (
+            "player_queues/",
+            Scope.QUEUES_CONTROL,
+            frozenset(
+                {
+                    "player_queues/all",
+                    "player_queues/get",
+                    "player_queues/items",
+                    "player_queues/get_active_queue",
+                    "player_queues/save_as_playlist",
+                }
+            ),
+        ),
+    ],
+)
+async def test_registered_core_api_handlers_cannot_bypass_receive_only_boundary(
+    mass: MusicAssistant,
+    prefix: str,
+    control_scope: Scope,
+    non_control_commands: frozenset[str],
+) -> None:
+    """Every registered core command is explicitly classified as control or non-control."""
+    handlers = {
+        command: handler
+        for command, handler in mass.command_handlers.items()
+        if command.startswith(prefix)
+    }
+    assert non_control_commands <= handlers.keys()
+    if prefix == "player_queues/":
+        assert handlers["player_queues/dont_stop_the_music"].alias is True
+    managed_guest = _user(player_filter=[GUEST_ACCESS_RESTRICTED_PLAYER_ID])
+
+    for command, handler in handlers.items():
+        if command in non_control_commands:
+            assert handler.required_scope != control_scope
+            continue
+        assert handler.required_scope == control_scope, (
+            f"{command} must use {control_scope} or be explicitly classified as non-control"
+        )
+        with pytest.raises(InsufficientPermissions, match="receive-only"):
+            check_command_permission(managed_guest, handler)
+
+
+def test_webrtc_session_user_lookup_requires_authenticated_match() -> None:
+    """WebRTC session lookup never returns an unauthenticated connection."""
+    controller = WebserverController.__new__(WebserverController)
+    authenticated_user = _user(UserRole.USER)
+    unauthenticated_client = MagicMock(_webrtc_session_id="missing-user", _authenticated_user=None)
+    authenticated_client = MagicMock(
+        _webrtc_session_id="authenticated",
+        _authenticated_user=authenticated_user,
+    )
+    controller.clients = {unauthenticated_client, authenticated_client}
+
+    assert (
+        controller.get_authenticated_user_for_webrtc_session("authenticated") is authenticated_user
+    )
+    assert controller.get_authenticated_user_for_webrtc_session("missing-user") is None
+    assert controller.get_authenticated_user_for_webrtc_session("unknown") is None

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -1,12 +1,16 @@
 """Tests for remote access feature."""
 
+import asyncio
 import base64
+import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 from urllib.parse import urlparse
 
 import pytest
 from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection
 from aiortc.rtcdtlstransport import RTCCertificate
+from music_assistant_models.auth import User, UserRole
 
 from music_assistant.controllers.webserver.remote_access import RemoteAccessInfo
 from music_assistant.controllers.webserver.remote_access.gateway import (
@@ -18,6 +22,56 @@ from music_assistant.helpers.webrtc_certificate import (
     _remote_id_from_certificate,
     create_peer_connection_with_certificate,
 )
+
+
+class _DataChannel:
+    """Minimal RTCDataChannel test double."""
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.handlers: dict[str, object] = {}
+
+    def on(self, event: str) -> object:
+        """Register a channel event handler."""
+
+        def decorator(handler: object) -> object:
+            self.handlers[event] = handler
+            return handler
+
+        return decorator
+
+    def close(self) -> None:
+        """Close the test channel."""
+        self.closed = True
+
+
+def _remote_user(role: UserRole) -> User:
+    """Create an authenticated remote-access user."""
+    return User(user_id=role.value, username=role.value, role=role)
+
+
+async def _forward_sendspin_messages(
+    gateway: WebRTCGateway,
+    session: WebRTCSession,
+    messages: tuple[str | bytes, ...],
+) -> list[str | bytes]:
+    """Forward a finite set of Sendspin messages and return what reached the server."""
+    forwarded: list[str | bytes] = []
+    sendspin_ws = SimpleNamespace(closed=False)
+
+    async def forward(message: str | bytes) -> None:
+        forwarded.append(message)
+        if len(forwarded) == len(messages):
+            sendspin_ws.closed = True
+
+    sendspin_ws.send_str = AsyncMock(side_effect=forward)
+    sendspin_ws.send_bytes = AsyncMock(side_effect=forward)
+    session.sendspin_ws = sendspin_ws
+    for message in messages:
+        session.sendspin_queue.put_nowait(message)
+
+    await gateway._forward_sendspin_to_local(session)
+    return forwarded
 
 
 @pytest.fixture
@@ -435,3 +489,170 @@ async def test_http_proxy_request_cannot_change_host(
     assert parsed.port == 8095
     assert parsed.username is None
     assert "evil.com" not in (parsed.netloc or "")
+
+
+@pytest.mark.parametrize(
+    ("role", "allowed_roles"),
+    [
+        (UserRole.GUEST, ("player@v1",)),
+        (UserRole.USER, None),
+        (UserRole.ADMIN, None),
+        (UserRole.SERVICE, None),
+    ],
+)
+async def test_webrtc_sendspin_setup_uses_authenticated_session_role(
+    mock_certificate: Mock,
+    role: UserRole,
+    allowed_roles: tuple[str, ...] | None,
+) -> None:
+    """The WebRTC Sendspin policy comes from its authenticated API session."""
+    http_session = Mock()
+    sendspin_ws = SimpleNamespace(closed=True)
+    http_session.ws_connect = AsyncMock(return_value=sendspin_ws)
+    get_user = Mock(return_value=_remote_user(role))
+    gateway = WebRTCGateway(
+        http_session=http_session,
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+        get_authenticated_user_callback=get_user,
+    )
+    channel = _DataChannel()
+    session = WebRTCSession(
+        session_id="authenticated-session",
+        peer_connection=Mock(),
+        sendspin_channel=channel,
+    )
+
+    await gateway._setup_sendspin_channel(session)
+    tasks = [
+        task
+        for task in (session.sendspin_to_local_task, session.sendspin_from_local_task)
+        if task is not None
+    ]
+    await asyncio.gather(*tasks)
+
+    get_user.assert_called_once_with("authenticated-session")
+    assert session.sendspin_allowed_roles == allowed_roles
+    assert channel.closed is False
+
+
+@pytest.mark.parametrize("resolver_available", [False, True], ids=["missing", "unauthenticated"])
+async def test_webrtc_sendspin_missing_authenticated_session_fails_closed(
+    mock_certificate: Mock,
+    resolver_available: bool,
+) -> None:
+    """A Sendspin channel cannot connect without a matching authenticated API session."""
+    http_session = Mock()
+    http_session.ws_connect = AsyncMock()
+    get_user = Mock(return_value=None) if resolver_available else None
+    gateway = WebRTCGateway(
+        http_session=http_session,
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+        get_authenticated_user_callback=get_user,
+    )
+    channel = _DataChannel()
+    session = WebRTCSession(
+        session_id="unauthenticated-session",
+        peer_connection=Mock(),
+        sendspin_channel=channel,
+    )
+
+    await gateway._setup_sendspin_channel(session)
+
+    assert channel.closed is True
+    http_session.ws_connect.assert_not_awaited()
+    if get_user is not None:
+        get_user.assert_called_once_with("unauthenticated-session")
+
+
+async def test_webrtc_guest_sendspin_hello_is_always_player_only(
+    mock_certificate: Mock,
+) -> None:
+    """Guest first and repeated hellos are rewritten while other traffic stays unchanged."""
+    set_player = Mock()
+    gateway = WebRTCGateway(
+        http_session=Mock(),
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+        set_sendspin_player_callback=set_player,
+    )
+    session = WebRTCSession(
+        session_id="guest-session",
+        peer_connection=Mock(),
+        sendspin_allowed_roles=("player@v1",),
+    )
+    auth = '{"type":"auth","client_id":"remote-web-player"}'
+    first_hello = json.dumps(
+        {
+            "type": "client/hello",
+            "payload": {
+                "supported_roles": ["player@v1", "controller@v1", "metadata@v1"],
+                "player@v1_support": {"buffer_capacity": 1024},
+            },
+        },
+        indent=2,
+    )
+    repeated_hello = json.dumps(
+        {
+            "type": "client/hello",
+            "payload": {"supported_roles": ["metadata@v1"]},
+        },
+        indent=2,
+    )
+    non_hello = '{"type":"client/state","payload":{"volume":50}}'
+    malformed = "{not-json"
+    list_message = "[]"
+    binary = b"\x00audio"
+
+    forwarded = await _forward_sendspin_messages(
+        gateway,
+        session,
+        (
+            auth,
+            first_hello,
+            non_hello,
+            repeated_hello,
+            malformed,
+            list_message,
+            binary,
+        ),
+    )
+
+    assert forwarded[0] == auth
+    assert json.loads(forwarded[1])["payload"]["supported_roles"] == ["player@v1"]
+    assert json.loads(forwarded[1])["payload"]["player@v1_support"] == {"buffer_capacity": 1024}
+    assert forwarded[2] == non_hello
+    assert json.loads(forwarded[3])["payload"]["supported_roles"] == ["player@v1"]
+    assert forwarded[4:] == [malformed, list_message, binary]
+    assert session.sendspin_player_id == "remote-web-player"
+    set_player.assert_called_once_with("guest-session", "remote-web-player")
+
+
+@pytest.mark.parametrize("role", [UserRole.USER, UserRole.ADMIN, UserRole.SERVICE])
+async def test_webrtc_non_guest_sendspin_traffic_is_byte_identical(
+    mock_certificate: Mock,
+    role: UserRole,
+) -> None:
+    """Regular, admin and service WebRTC Sendspin traffic remains unchanged."""
+    gateway = WebRTCGateway(
+        http_session=Mock(),
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+    )
+    raw_hello = json.dumps(
+        {
+            "type": "client/hello",
+            "payload": {"supported_roles": ["player@v1", "metadata@v1"]},
+        },
+        indent=2,
+    )
+    session = WebRTCSession(
+        session_id=f"{role.value}-session",
+        peer_connection=Mock(),
+        sendspin_allowed_roles=None,
+    )
+
+    forwarded = await _forward_sendspin_messages(gateway, session, (raw_hello,))
+
+    assert forwarded == [raw_hello]

--- a/tests/test_sendspin_proxy.py
+++ b/tests/test_sendspin_proxy.py
@@ -13,6 +13,7 @@ from aiohttp.test_utils import make_mocked_request
 from music_assistant_models.auth import UserRole
 
 from music_assistant.controllers.webserver.sendspin_proxy import SendspinProxyHandler
+from music_assistant.helpers.sendspin import restrict_sendspin_client_hello_roles
 
 
 @pytest.fixture
@@ -306,20 +307,20 @@ class TestSendspinGuestRoles:
         self, handler: SendspinProxyHandler, raw_message: str
     ) -> None:
         """Messages that are not structurally valid hellos remain parser-visible unchanged."""
-        assert handler._restrict_client_hello_roles(raw_message, ("player@v1",)) == raw_message
+        assert restrict_sendspin_client_hello_roles(raw_message, ("player@v1",)) == raw_message
 
     def test_rewrite_preserves_player_support_without_synthesizing_it(
         self, handler: SendspinProxyHandler
     ) -> None:
         """Role rewriting preserves support data and leaves missing support for upstream rejection."""
         supported = json.loads(
-            handler._restrict_client_hello_roles(
+            restrict_sendspin_client_hello_roles(
                 _hello("metadata@v1", include_player_support=True),
                 ("player@v1",),
             )
         )
         missing = json.loads(
-            handler._restrict_client_hello_roles(
+            restrict_sendspin_client_hello_roles(
                 _hello("metadata@v1", include_player_support=False),
                 ("player@v1",),
             )

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -10,6 +10,7 @@ from music_assistant_models.api import CommandMessage, ErrorResultMessage
 from music_assistant_models.auth import Scope, User, UserRole
 from music_assistant_models.errors import InsufficientPermissions
 
+from music_assistant.constants import GUEST_ACCESS_RESTRICTED_PLAYER_ID
 from music_assistant.controllers.webserver.websocket_client import WebsocketClientHandler
 from music_assistant.helpers.api import APICommandHandler
 
@@ -18,7 +19,11 @@ async def _noop_command() -> None:
     """Test command target."""
 
 
-def _create_client(user_role: UserRole | None, handler: APICommandHandler) -> Any:
+def _create_client(
+    user_role: UserRole | None,
+    handler: APICommandHandler,
+    player_filter: list[str] | None = None,
+) -> Any:
     """Create a minimally wired websocket client handler for dispatch tests."""
     client: Any = WebsocketClientHandler.__new__(WebsocketClientHandler)
     client._logger = MagicMock()
@@ -26,9 +31,17 @@ def _create_client(user_role: UserRole | None, handler: APICommandHandler) -> An
     client.mass.command_handlers = {handler.command: handler}
     # close the coroutine passed to create_task to avoid "never awaited" warnings
     client.mass.create_task = MagicMock(side_effect=lambda coro, *_: coro.close())
-    client._authenticated_user = (
-        User(user_id="user_1", username="tester", role=user_role) if user_role else None
-    )
+    if user_role is None:
+        client._authenticated_user = None
+    elif player_filter is None:
+        client._authenticated_user = User(user_id="user_1", username="tester", role=user_role)
+    else:
+        client._authenticated_user = User(
+            user_id="user_1",
+            username="tester",
+            role=user_role,
+            player_filter=player_filter,
+        )
     client._current_token = "token" if user_role else None
     client._sendspin_player_id = None
     client._send_message = AsyncMock()
@@ -38,10 +51,11 @@ def _create_client(user_role: UserRole | None, handler: APICommandHandler) -> An
 def _command_handler(
     required_scope: Scope | None = None,
     authenticated: bool = True,
+    command: str = "test/protected",
 ) -> APICommandHandler:
     """Create an API command handler with the given auth requirements."""
     return APICommandHandler.parse(
-        "test/protected",
+        command,
         _noop_command,
         authenticated=authenticated,
         required_scope=required_scope,
@@ -115,3 +129,67 @@ async def test_scoped_command_rejects_unauthenticated_socket() -> None:
 
     assert _sent_error_code(client) is not None
     client.mass.create_task.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("command", "scope", "args"),
+    [
+        ("players/cmd/play", Scope.PLAYERS_CONTROL, {"player_id": "host"}),
+        (
+            "players/cmd/set_members",
+            Scope.PLAYERS_CONTROL,
+            {"player_id": "host", "player_ids_to_add": ["guest_player"]},
+        ),
+        ("player_queues/clear", Scope.QUEUES_CONTROL, {"queue_id": "host"}),
+        (
+            "player_queues/shuffle",
+            Scope.QUEUES_CONTROL,
+            {"queue_id": "host", "shuffle_enabled": True},
+        ),
+        (
+            "player_queues/overlay",
+            Scope.QUEUES_CONTROL,
+            {"queue_id": "host", "characteristic": "volume", "value": 50},
+        ),
+    ],
+)
+async def test_managed_guest_core_control_is_denied_before_dispatch(
+    command: str,
+    scope: Scope,
+    args: dict[str, Any],
+) -> None:
+    """Managed guests cannot schedule direct core player or queue controls."""
+    client = _create_client(
+        UserRole.GUEST,
+        _command_handler(required_scope=scope, command=command),
+        [GUEST_ACCESS_RESTRICTED_PLAYER_ID],
+    )
+
+    await client._handle_command(CommandMessage(message_id="1", command=command, args=args))
+
+    assert _sent_error_code(client) == PERMISSION_DENIED
+    client.mass.create_task.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("command", "scope"),
+    [
+        ("music_quiz/listen_in", Scope.PLAYERS_CONTROL),
+        ("music_quiz/ready", None),
+    ],
+)
+async def test_managed_guest_provider_commands_remain_dispatchable(
+    command: str,
+    scope: Scope | None,
+) -> None:
+    """Managed guests may still invoke provider-owned commands."""
+    client = _create_client(
+        UserRole.GUEST,
+        _command_handler(required_scope=scope, command=command),
+        [GUEST_ACCESS_RESTRICTED_PLAYER_ID],
+    )
+
+    await client._handle_command(CommandMessage(message_id="1", command=command))
+
+    assert _sent_error_code(client) is None
+    client.mass.create_task.assert_called_once()


### PR DESCRIPTION
# What does this implement/fix?

Managed plugin guests could invoke core player and queue controls directly and advertise controller roles over Remote Access Sendspin connections.

- Enforce receive-only access for managed guests across WebSocket and JSON-RPC commands.
- Apply one shared guest role policy to local and remote Sendspin connections.
- Fail closed when a remote Sendspin session has no authenticated API identity.
- Cover core command aliases, Party/provider exceptions, and remote gateway behavior with regression tests.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.