### PR TITLE
Let guests use the active experience

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -51,7 +51,7 @@ import time
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, cast
 
-from music_assistant_models.auth import Scope
+from music_assistant_models.auth import Scope, UserRole
 from music_assistant_models.config_entries import (
     ConfigEntry,
     ConfigValueOption,
@@ -667,12 +667,12 @@ class MusicQuizPlugin(PluginProvider):
     @staticmethod
     def _validate_guest_access() -> None:
         """
-        Validate the current user is an authenticated Music Quiz guest.
+        Validate the current user is an authenticated dedicated guest.
 
-        :raises InvalidDataError: If the user is not a Music Quiz guest.
+        :raises InvalidDataError: If the user is not a dedicated guest.
         """
         user = get_current_user()
-        if not user or user.username != MUSIC_QUIZ_GUEST_USER:
+        if not user or user.role != UserRole.GUEST:
             raise InvalidDataError(
                 "This action is only available to Music Quiz guests",
                 translation_key="music_quiz_guest_only",

--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from mashumaro import DataClassDictMixin
-from music_assistant_models.auth import Scope
+from music_assistant_models.auth import Scope, UserRole
 from music_assistant_models.config_entries import (
     ConfigEntry,
     ConfigValueOption,
@@ -862,12 +862,12 @@ class PartyPlugin(PluginProvider):
     @staticmethod
     def _validate_guest_access() -> None:
         """
-        Validate the current user is an authenticated party guest.
+        Validate the current user is an authenticated dedicated guest.
 
-        :raises InvalidDataError: If the user is not a party guest.
+        :raises InvalidDataError: If the user is not a dedicated guest.
         """
         user = get_current_user()
-        if not user or user.username != PARTY_GUEST_USER:
+        if not user or user.role != UserRole.GUEST:
             raise InvalidDataError("This endpoint is only available to party guests")
 
     @staticmethod

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.auth import Scope
+from music_assistant_models.auth import Scope, UserRole
 from music_assistant_models.enums import ConfigEntryType, PlaybackState
 from music_assistant_models.errors import InvalidDataError
 
@@ -194,7 +194,7 @@ def _fake_game() -> MusicQuizGame:
 
 def _guest_user() -> SimpleNamespace:
     """Return a fake authenticated Music Quiz guest user."""
-    return SimpleNamespace(username=MUSIC_QUIZ_GUEST_USER)
+    return SimpleNamespace(username=MUSIC_QUIZ_GUEST_USER, role=UserRole.GUEST)
 
 
 def _phase(plugin: MusicQuizPlugin) -> MusicQuizPhase:
@@ -320,35 +320,48 @@ async def test_api_command_scopes_lock_out_guests_from_host_commands() -> None:
         assert registered[command] == Scope.PLAYERS_CONTROL
 
 
+@pytest.mark.parametrize(
+    "username",
+    [MUSIC_QUIZ_GUEST_USER, "party_guest", "temporary_guest"],
+)
 @pytest.mark.asyncio
-async def test_guest_commands_reject_non_guest_users() -> None:
-    """Guest game commands are only available to the Music Quiz guest user."""
+async def test_guest_commands_accept_any_dedicated_guest(username: str) -> None:
+    """Any authenticated guest role can use the active Music Quiz experience."""
+    plugin = _create_plugin()
+    await plugin.create_game(source_uris=["library://playlist/1"])
+
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=SimpleNamespace(username=username, role=UserRole.GUEST),
+    ):
+        result = await plugin.join_game("Guest")
+
+    assert result["player_id"]
+
+
+@pytest.mark.parametrize(
+    "user",
+    [
+        None,
+        SimpleNamespace(username="user", role=UserRole.USER),
+        SimpleNamespace(username="admin", role=UserRole.ADMIN),
+        SimpleNamespace(username="service", role=UserRole.SERVICE),
+    ],
+)
+@pytest.mark.asyncio
+async def test_guest_commands_reject_non_guest_users(user: SimpleNamespace | None) -> None:
+    """Guest game commands reject unauthenticated and non-guest users."""
     plugin = _create_plugin()
     await plugin.create_game(source_uris=["library://playlist/1"])
 
     with (
         patch(
             "music_assistant.providers.music_quiz.get_current_user",
-            return_value=SimpleNamespace(username="admin"),
+            return_value=user,
         ),
         pytest.raises(InvalidDataError, match="guests"),
     ):
         await plugin.join_game("Mallory")
-
-    with (
-        patch("music_assistant.providers.music_quiz.get_current_user", return_value=None),
-        pytest.raises(InvalidDataError, match="guests"),
-    ):
-        await plugin.answer("some_player", "some_suggestion")
-
-    with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=SimpleNamespace(username="admin"),
-        ),
-        pytest.raises(InvalidDataError, match="guests"),
-    ):
-        await plugin.heartbeat("some_player")
 
 
 @pytest.mark.asyncio
@@ -2182,7 +2195,7 @@ async def test_listen_in_joins_session_under_playback_lock() -> None:
     plugin._playback_session = session
     with patch(
         "music_assistant.providers.music_quiz.get_current_user",
-        return_value=SimpleNamespace(username=MUSIC_QUIZ_GUEST_USER),
+        return_value=SimpleNamespace(username=MUSIC_QUIZ_GUEST_USER, role=UserRole.GUEST),
     ):
         await plugin.listen_in("web-1")
     session.add_guest_listener.assert_awaited_once_with("web-1")

--- a/tests/providers/party/test_party_plugin.py
+++ b/tests/providers/party/test_party_plugin.py
@@ -8,7 +8,7 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.auth import Scope
+from music_assistant_models.auth import Scope, UserRole
 from music_assistant_models.enums import MediaType, PlaybackState
 from music_assistant_models.errors import InvalidDataError
 
@@ -75,7 +75,7 @@ async def test_add_to_queue_rechecks_duplicates_during_priority_insert() -> None
     with (
         patch(
             "music_assistant.providers.party.get_current_user",
-            return_value=SimpleNamespace(username=PARTY_GUEST_USER),
+            return_value=SimpleNamespace(username=PARTY_GUEST_USER, role=UserRole.GUEST),
         ),
         patch("music_assistant.providers.party.build_queue_item", return_value=queue_item),
         pytest.raises(InvalidDataError, match="already in the queue"),
@@ -130,7 +130,7 @@ async def test_listen_in_without_session_raises() -> None:
     with (
         patch(
             "music_assistant.providers.party.get_current_user",
-            return_value=SimpleNamespace(username=PARTY_GUEST_USER),
+            return_value=SimpleNamespace(username=PARTY_GUEST_USER, role=UserRole.GUEST),
         ),
         pytest.raises(InvalidDataError, match="not available"),
     ):
@@ -152,7 +152,7 @@ async def test_listen_in_attaches_guest_player() -> None:
 
     with patch(
         "music_assistant.providers.party.get_current_user",
-        return_value=SimpleNamespace(username=PARTY_GUEST_USER),
+        return_value=SimpleNamespace(username=PARTY_GUEST_USER, role=UserRole.GUEST),
     ):
         result = await plugin.listen_in("web_player_1")
 
@@ -186,3 +186,31 @@ async def test_guest_readable_commands_use_guest_scope() -> None:
     }
     assert scopes["party/url"] == Scope.PROVIDERS_READ
     assert scopes["party/config"] == Scope.PROVIDERS_READ
+
+
+@pytest.mark.parametrize("username", [PARTY_GUEST_USER, "music_quiz_guest", "temporary_guest"])
+def test_guest_access_accepts_any_dedicated_guest(username: str) -> None:
+    """Any authenticated guest role can use the active Party experience."""
+    with patch(
+        "music_assistant.providers.party.get_current_user",
+        return_value=SimpleNamespace(username=username, role=UserRole.GUEST),
+    ):
+        PartyPlugin._validate_guest_access()
+
+
+@pytest.mark.parametrize(
+    "user",
+    [
+        None,
+        SimpleNamespace(username="user", role=UserRole.USER),
+        SimpleNamespace(username="admin", role=UserRole.ADMIN),
+        SimpleNamespace(username="service", role=UserRole.SERVICE),
+    ],
+)
+def test_guest_access_rejects_non_guests(user: SimpleNamespace | None) -> None:
+    """Party guest commands reject unauthenticated and non-guest users."""
+    with (
+        patch("music_assistant.providers.party.get_current_user", return_value=user),
+        pytest.raises(InvalidDataError, match="party guests"),
+    ):
+        PartyPlugin._validate_guest_access()


### PR DESCRIPTION
# What does this implement/fix?

Party and Music Quiz guest tokens were limited to their own provider, which prevented the shared guest frontend from using whichever experience is active.

- Authorize guest-only provider commands by the dedicated `GUEST` role.
- Cover both provider guest accounts, generic guest accounts, and denied non-guest roles.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.