### PR TITLE
Prevent interrupted streams from corrupting audio analysis

### DIFF
--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -11,7 +11,7 @@ import sys
 import time
 from collections.abc import AsyncGenerator, Iterable, Mapping
 from concurrent.futures import ThreadPoolExecutor
-from math import inf
+from math import isfinite
 from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.audio_analysis import AudioAnalysisCoverage
@@ -67,6 +67,10 @@ ANALYSIS_THREAD_NICE = 10
 # Rapid track skipping would otherwise spawn an analysis per abandoned track; the oldest is
 # evicted to keep the count bounded.
 REALTIME_ANALYSIS_MAX_SESSIONS = 2
+# Minimum fraction of the expected track duration that must have been received before an
+# ended stream is finalized. A source that ends far short of it (e.g. a stream that died
+# without raising an error) is discarded instead, so no truncated analysis is persisted.
+ANALYSIS_MIN_COMPLETENESS_RATIO = 0.9
 # Free the heavy analysis models after this long with no analysis activity; they are reloaded
 # on the next track. Long enough that gaps between tracks/sessions don't thrash the reload.
 MODEL_IDLE_UNLOAD_SECONDS = 300
@@ -97,17 +101,33 @@ def _get_row_value(row: Mapping[str, Any], key: str) -> Any:
         return None
 
 
-def _parse_row(row: Mapping[str, Any]) -> AudioAnalysisData | None:
-    """Parse a single audio_analysis row's analysis_data, logging and skipping on error."""
+def _parse_row(
+    row: Mapping[str, Any],
+    unparsable_ids: list[Any] | None = None,
+) -> AudioAnalysisData | None:
+    """
+    Parse a single audio_analysis row's analysis_data, logging and skipping on error.
+
+    :param row: The audio_analysis row to parse.
+    :param unparsable_ids: When given, the id of a row that fails to parse is appended.
+    """
     try:
         return AudioAnalysisData.from_dict(json_loads(row["analysis_data"]))
     except (IndexError, KeyError, TypeError, ValueError) as err:
+        row_id = _get_row_value(row, "id")
+        # the error itself may embed the full (huge) field value, so log only
+        # the error type plus the offending field name when available
+        error_detail = type(err).__name__
+        if field_name := getattr(err, "field_name", None):
+            error_detail = f"{error_detail} in field {field_name}"
         LOGGER.warning(
             "Skipping unparsable audio_analysis row (id=%s, domain=%s, error=%s)",
-            _get_row_value(row, "id"),
+            row_id,
             _get_row_value(row, "aa_provider_domain"),
-            type(err).__name__,
+            error_detail,
         )
+        if unparsable_ids is not None and row_id is not None:
+            unparsable_ids.append(row_id)
         return None
 
 
@@ -115,6 +135,7 @@ def _merged_from_rows(
     rows: Iterable[Mapping[str, Any]],
     available_aa_domains: set[str],
     priority: tuple[str, ...] | None = None,
+    unparsable_ids: list[Any] | None = None,
 ) -> AudioAnalysisData | None:
     """
     Fold audio_analysis rows into one merged result.
@@ -128,6 +149,8 @@ def _merged_from_rows(
     :param priority: When None, merge all available providers' rows with latest-write-wins
         (non-None fields). When a tuple of AA provider domains is given, only those domains
         are considered and the first-listed domain wins each per-field conflict.
+    :param unparsable_ids: When given, ids of rows whose analysis_data fails to parse
+        are appended.
     """
     merged = AudioAnalysisData()
     found = False
@@ -135,7 +158,7 @@ def _merged_from_rows(
         for row in rows:
             if row["aa_provider_domain"] not in available_aa_domains:
                 continue
-            if (row_data := _parse_row(row)) is None:
+            if (row_data := _parse_row(row, unparsable_ids)) is None:
                 continue
             merged.update(row_data)
             found = True
@@ -149,7 +172,7 @@ def _merged_from_rows(
         domain = row["aa_provider_domain"]
         if domain not in wanted_set or domain in by_domain:
             continue
-        if (row_data := _parse_row(row)) is None:
+        if (row_data := _parse_row(row, unparsable_ids)) is None:
             continue
         by_domain[domain] = row_data
     for domain in reversed(wanted):
@@ -157,6 +180,20 @@ def _merged_from_rows(
             merged.update(row_data)
             found = True
     return merged if found else None
+
+
+def _first_non_finite_field(analysis: AudioAnalysisData) -> str | None:
+    """Return the name of the first float field holding a non-finite value, if any."""
+    for fld in dataclasses.fields(analysis):
+        value = getattr(analysis, fld.name)
+        if isinstance(value, float):
+            if not isfinite(value):
+                return fld.name
+        elif isinstance(value, list) and any(
+            isinstance(item, float) and not isfinite(item) for item in value
+        ):
+            return fld.name
+    return None
 
 
 def _nice_analysis_worker() -> None:
@@ -354,7 +391,9 @@ class AudioAnalysisController:
 
         self._active_sessions[session_key] = provider_ids
         self._session_queues[session_key] = queue_id
-        worker = self.mass.create_task(self._buffer_reader_worker(session_key, audio_buffer))
+        worker = self.mass.create_task(
+            self._buffer_reader_worker(session_key, audio_buffer, streamdetails.duration)
+        )
         self._workers[session_key] = worker
 
         def _on_cancel() -> None:
@@ -381,7 +420,14 @@ class AudioAnalysisController:
         :param analysis: The analysis data to store.
         :param analysis_version: Version of the AA provider's algorithm.
         :param media_type: The media type of the item being analyzed.
+        :raises ValueError: When a float field of the analysis holds a non-finite value.
         """
+        # non-finite floats serialize to JSON null, which corrupts the stored row;
+        # refuse them here so a bad payload can never poison the database
+        if (field_name := _first_non_finite_field(analysis)) is not None:
+            raise ValueError(
+                f"audio analysis for {item_id} contains a non-finite value in {field_name}"
+            )
         provider = self.mass.get_provider(provider_instance_id_or_domain)
         if not isinstance(provider, MusicProvider):
             return
@@ -495,7 +541,8 @@ class AudioAnalysisController:
         """
         Get merged audio analysis data for a track.
 
-        Only rows from currently available AA providers are included.
+        Only rows from currently available AA providers are included. Rows that fail
+        to parse are deleted, so the track can be re-analyzed.
 
         :param item_id: Provider-native item ID from streamdetails.item_id.
         :param provider_instance_id_or_domain: Music provider instance ID or domain.
@@ -526,7 +573,21 @@ class AudioAnalysisController:
         available_aa_domains = {
             p.domain for p in self.mass.get_providers(ProviderType.AUDIO_ANALYSIS) if p.available
         }
-        return _merged_from_rows(rows, available_aa_domains, priority)
+        unparsable_ids: list[Any] = []
+        merged = _merged_from_rows(rows, available_aa_domains, priority, unparsable_ids)
+        # corrupt rows would otherwise block re-analysis forever (their stored
+        # analysis_version still gates new sessions), so drop them right away
+        for row_id in unparsable_ids:
+            await self.mass.music.database.delete(DB_TABLE_AUDIO_ANALYSIS, {"id": row_id})
+        if unparsable_ids:
+            self.logger.info(
+                "Deleted %d corrupt audio_analysis row(s) for %s/%s; "
+                "the item is eligible for re-analysis",
+                len(unparsable_ids),
+                prov_key,
+                item_id,
+            )
+        return merged
 
     async def get_track_audio_metadata(self, track: Track) -> AudioMetadata | None:
         """
@@ -595,11 +656,11 @@ class AudioAnalysisController:
         :param loudness_album: Optional album-level integrated loudness in LUFS.
         :param media_type: The media type of the item.
         """
-        if loudness in (None, inf, -inf) or loudness <= LOUDNESS_MEASUREMENT_MIN_LUFS:
+        if loudness is None or not isfinite(loudness) or loudness <= LOUDNESS_MEASUREMENT_MIN_LUFS:
             return
         if (
             loudness_album is None
-            or loudness_album in (inf, -inf)
+            or not isfinite(loudness_album)
             or loudness_album <= LOUDNESS_MEASUREMENT_MIN_LUFS
         ):
             loudness_album = None
@@ -1389,18 +1450,27 @@ class AudioAnalysisController:
             if not provider_ids:
                 self._active_sessions.pop(session_key, None)
 
-    async def _buffer_reader_worker(self, session_key: str, audio_buffer: AudioBuffer) -> None:
+    async def _buffer_reader_worker(
+        self,
+        session_key: str,
+        audio_buffer: AudioBuffer,
+        expected_duration: float | None,
+    ) -> None:
         """
         Read PCM straight from the shared playback buffer and distribute it to providers.
 
         Reads at its own pace from the buffer's retained window. On clean end-of-stream the
-        providers are finalized; if the reader falls a full window behind playback (the chunk
-        it needs has been evicted) or the buffer is torn down first, the session is dropped.
+        providers are finalized, unless the source ended far short of the expected duration.
+        If the reader falls a full window behind playback (the chunk it needs has been
+        evicted) or the buffer is torn down first, the session is dropped.
 
         :param session_key: Active-session key for this worker.
         :param audio_buffer: The shared playback buffer to read PCM from.
+        :param expected_duration: Expected track duration in seconds (None when unknown,
+            e.g. radio), used to discard sessions of streams that ended prematurely.
         """
-        cursor = audio_buffer.first_buffered_chunk
+        start_chunk = audio_buffer.first_buffered_chunk
+        cursor = start_chunk
         completed = False
         try:
             while session_key in self._active_sessions:
@@ -1427,6 +1497,21 @@ class AudioAnalysisController:
         finally:
             self._workers.pop(session_key, None)
             self._session_queues.pop(session_key, None)
+            # one chunk equals one second of audio
+            received_seconds = cursor - start_chunk
+            if (
+                completed
+                and expected_duration
+                and received_seconds < expected_duration * ANALYSIS_MIN_COMPLETENESS_RATIO
+            ):
+                self.logger.debug(
+                    "Analysis received only %ds of the expected %ds for %s; "
+                    "discarding incomplete session",
+                    received_seconds,
+                    expected_duration,
+                    session_key,
+                )
+                completed = False
             if completed:
                 self._finalize_providers(session_key)
             else:

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -288,8 +288,11 @@ class AudioBuffer:
             except asyncio.CancelledError:
                 status = "cancelled"
                 raise
-            except Exception:
+            except Exception as err:
                 status = "aborted with error"
+                # record the error before the EOF signal below, so readers that
+                # check for a producer error never observe the abort as a clean EOF
+                self._producer_error = err
                 raise
             finally:
                 # signal EOF even on error if we produced valid chunks,

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -363,6 +363,9 @@ class SmartFadesProvider(AudioAnalysisProvider):
         if len(pcm_22k) >= self._spectral_centroid.n_fft:
             pcm_tensor = torch.from_numpy(pcm_22k)
             centroid_frames = self._spectral_centroid(pcm_tensor.unsqueeze(0)).squeeze(0).numpy()
+            # digitally-silent frames divide 0/0 into NaN; treat them as 0 Hz like
+            # other negligible-energy frames so no non-finite value is ever stored
+            np.nan_to_num(centroid_frames, copy=False, nan=0.0, posinf=0.0, neginf=0.0)
             if len(centroid_frames) > 0:
                 data.centroid_chunks.append(centroid_frames.astype(np.float32))
 

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -20,6 +20,7 @@ from music_assistant_models.media_items import AudioFormat, ProviderMapping, Tra
 
 import music_assistant.controllers.streams.audio_analysis as audio_analysis_mod
 from music_assistant.constants import (
+    DB_TABLE_AUDIO_ANALYSIS,
     DEFAULT_BACKGROUND_SCAN_CONCURRENCY,
     _default_background_scan_concurrency,
 )
@@ -30,6 +31,7 @@ from music_assistant.controllers.streams.audio_analysis import (
     AudioAnalysisController,
     _merged_from_rows,
 )
+from music_assistant.controllers.streams.audio_buffer import AudioBufferEOF
 from music_assistant.helpers.json import json_dumps
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import (
@@ -725,6 +727,49 @@ async def test_close_drains_sessions_and_workers() -> None:
     p.cancel.assert_called_once_with("track://test/a")
 
 
+async def _run_buffer_reader_worker(
+    chunk_count: int, expected_duration: float | None
+) -> tuple[MagicMock, MagicMock]:
+    """Run the reader worker against a buffer yielding chunk_count 1s chunks, then EOF."""
+    controller = _make_controller()
+    session_key = "track://test/worker"
+    controller._active_sessions[session_key] = {"prov-1"}
+    controller._distribute_chunk = AsyncMock()  # type: ignore[method-assign]
+    controller._finalize_providers = MagicMock()  # type: ignore[method-assign]
+    controller._cancel_providers = MagicMock()  # type: ignore[method-assign]
+    audio_buffer = MagicMock()
+    audio_buffer.first_buffered_chunk = 0
+    audio_buffer.read_chunk_for_analysis = AsyncMock(
+        side_effect=[b"pcm"] * chunk_count + [AudioBufferEOF()]
+    )
+    await controller._buffer_reader_worker(session_key, audio_buffer, expected_duration)
+    return controller._finalize_providers, controller._cancel_providers
+
+
+@pytest.mark.asyncio
+async def test_buffer_reader_worker_finalizes_when_near_expected_duration() -> None:
+    """An EOF within the completeness tolerance finalizes the session."""
+    finalize, cancel = await _run_buffer_reader_worker(9, expected_duration=10)
+    finalize.assert_called_once_with("track://test/worker")
+    cancel.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_buffer_reader_worker_discards_incomplete_stream() -> None:
+    """A source that ends far short of the expected duration is cancelled, not finalized."""
+    finalize, cancel = await _run_buffer_reader_worker(8, expected_duration=10)
+    finalize.assert_not_called()
+    cancel.assert_called_once_with("track://test/worker")
+
+
+@pytest.mark.asyncio
+async def test_buffer_reader_worker_finalizes_when_duration_unknown() -> None:
+    """Without an expected duration (e.g. radio), any clean EOF finalizes the session."""
+    finalize, cancel = await _run_buffer_reader_worker(1, expected_duration=None)
+    finalize.assert_called_once_with("track://test/worker")
+    cancel.assert_not_called()
+
+
 def _stub_controller(
     count_result: int = 0,
     iter_rows: list[dict[str, Any]] | None = None,
@@ -734,6 +779,7 @@ def _stub_controller(
     c.logger = MagicMock()
     db = MagicMock()
     db.get_count_from_query = AsyncMock(return_value=count_result)
+    db.delete = AsyncMock()
     rows_to_yield = list(iter_rows or [])
 
     async def _iter_stub(*_args: Any, **_kwargs: Any) -> AsyncGenerator[Mapping[str, Any]]:
@@ -1340,6 +1386,48 @@ async def test_get_track_audio_metadata_skips_corrupt_sqlite_row(
     assert "id=1, domain=sonic_analysis" in warning.getMessage()
     assert corrupt_data not in warning.getMessage()
     assert warning.exc_info is None
+
+
+@pytest.mark.asyncio
+async def test_get_audio_analysis_deletes_unparsable_rows(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Corrupt rows are deleted, so their stored version no longer blocks re-analysis."""
+    rows: list[Mapping[str, Any]] = [
+        {
+            "id": 7,
+            "aa_provider_domain": SMART_FADES_ANALYSIS_DOMAIN,
+            "analysis_data": json_dumps({"spectral_centroid": [100.0, None]}),
+        },
+        _aa_row(SONIC_ANALYSIS_DOMAIN, 8, bpm=101.0),
+    ]
+    controller = _analysis_controller_with_rows(rows)
+    with caplog.at_level("WARNING", logger=audio_analysis_mod.LOGGER.name):
+        result = await controller.get_audio_analysis("track-1", "test-provider")
+
+    assert result is not None
+    assert result.bpm == 101.0
+    delete_mock = cast("AsyncMock", controller.mass.music.database.delete)
+    delete_mock.assert_awaited_once_with(DB_TABLE_AUDIO_ANALYSIS, {"id": 7})
+    warning = next(r for r in caplog.records if r.name == audio_analysis_mod.LOGGER.name)
+    assert "in field spectral_centroid" in warning.getMessage()
+
+
+@pytest.mark.asyncio
+async def test_set_audio_analysis_rejects_non_finite_values() -> None:
+    """A payload holding non-finite floats is refused before anything reaches the database."""
+    c, db = _stub_controller()
+    list_case = AudioAnalysisData(spectral_centroid=[100.0, float("nan"), 200.0])
+    with pytest.raises(ValueError, match="spectral_centroid"):
+        await c.set_audio_analysis(
+            "track-1", "test-provider", SMART_FADES_ANALYSIS_DOMAIN, list_case
+        )
+    scalar_case = AudioAnalysisData(bpm=float("inf"))
+    with pytest.raises(ValueError, match="bpm"):
+        await c.set_audio_analysis(
+            "track-1", "test-provider", SMART_FADES_ANALYSIS_DOMAIN, scalar_case
+        )
+    db.insert_or_replace.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/streams/test_audio_analysis_controller.py
+++ b/tests/controllers/streams/test_audio_analysis_controller.py
@@ -108,6 +108,8 @@ def mock_stream_details() -> MagicMock:
     sd.media_type = "track"
     sd.item_id = "test_123"
     sd.uri = "test_prov://track/test_123"
+    # unknown duration: the completeness guard only applies when a duration is known
+    sd.duration = None
     return sd
 
 

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -207,6 +207,24 @@ async def test_fill_error_propagation() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fill_error_surfaces_to_analysis_reader() -> None:
+    """An aborted source raises its error to the analysis reader instead of a clean EOF."""
+
+    async def _failing_source() -> AsyncGenerator[bytes]:
+        yield ONE_SECOND_CHUNK
+        msg = "test error"
+        raise RuntimeError(msg)
+
+    buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
+    buf.fill(_failing_source(), source_name="test")
+
+    # buffered chunks are still delivered before the error surfaces
+    assert await buf.read_chunk_for_analysis(0) == ONE_SECOND_CHUNK
+    with pytest.raises(RuntimeError, match="test error"):
+        await buf.read_chunk_for_analysis(1)
+
+
+@pytest.mark.asyncio
 async def test_fill_error_no_data() -> None:
     """When the source errors without producing any data, the error propagates."""
 

--- a/tests/providers/smart_fades/test_provider.py
+++ b/tests/providers/smart_fades/test_provider.py
@@ -334,6 +334,24 @@ async def test_finalize_raises_when_not_enough_beats(provider: SmartFadesProvide
         await provider._finalize(session_id)
 
 
+async def test_digital_silence_yields_finite_spectral_centroid(
+    provider: SmartFadesProvider,
+) -> None:
+    """Digitally-silent audio yields 0 Hz centroid frames instead of non-finite values."""
+    sample_rate = 22050
+    tone = np.sin(2 * np.pi * 440 * np.arange(sample_rate, dtype=np.float32) / sample_rate)
+    pcm = np.concatenate([tone.astype(np.float32), np.zeros(sample_rate, dtype=np.float32)])
+    data = Mock()
+    data.energy_chunks = []
+    data.frequency_band_chunks = {}
+    data.centroid_chunks = []
+
+    provider._compute_energy_and_spectral_centroids(pcm, data)
+
+    assert data.centroid_chunks
+    assert np.isfinite(np.concatenate(data.centroid_chunks)).all()
+
+
 async def test_setup_raises_when_requirements_not_met(
     mass_mock: Mock, manifest_mock: Mock, config_mock: Mock
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

When a stream breaks off halfway (as happened at scale during the recent Spotify token issues), the audio analysis treated the interrupted stream as a completed track: results of partial audio were stored, and silent passages could even produce unusable values in the database. Those corrupt entries caused the repeated "Skipping unparsable audio_analysis row" warnings and permanently blocked re-analysis of the affected tracks.

- A stream that breaks off with an error no longer looks like a normal end-of-track to the analyzer; the analysis is discarded instead of stored.
- Analysis results are also discarded when a stream ends far short of the expected track duration.
- Silent audio passages no longer produce invalid (non-finite) values in the Smart Fades analysis.
- Analysis results are validated before they are stored, so invalid values can never reach the database.
- Existing corrupt entries are deleted when encountered, so affected tracks are automatically analyzed again.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
