### PR TITLE
Fix Hitster edge placement

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -520,7 +520,7 @@ class MusicQuizPlugin(PluginProvider):
     async def submit_answer(
         self,
         player_id: str,
-        submission: dict[str, object],
+        submission: dict[str, Any],
     ) -> dict[str, SerializableType]:
         """
         Submit a typed answer for the current round.

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -70,6 +70,7 @@ from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.music_quiz.answer_types import get_answer_type
 from music_assistant.providers.music_quiz.answer_types.base import (
     QuizAnswerSubmission,
+    QuizAnswerSubmissionPayload,
     QuizAnswerType,
 )
 from music_assistant.providers.music_quiz.answer_types.multiple_choice import (
@@ -520,7 +521,7 @@ class MusicQuizPlugin(PluginProvider):
     async def submit_answer(
         self,
         player_id: str,
-        submission: dict[str, Any],
+        submission: QuizAnswerSubmissionPayload,
     ) -> dict[str, SerializableType]:
         """
         Submit a typed answer for the current round.

--- a/music_assistant/providers/music_quiz/answer_types/base.py
+++ b/music_assistant/providers/music_quiz/answer_types/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Collection
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from typing import ClassVar
 
@@ -14,6 +14,9 @@ from music_assistant.providers.music_quiz.models import (
     MusicQuizPlayer,
     QuizRoundAnswerState,
 )
+
+QuizAnswerSubmissionValue = str | None
+QuizAnswerSubmissionPayload = dict[str, QuizAnswerSubmissionValue]
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,7 +32,7 @@ class QuizAnswerType(ABC):
     answer_type: ClassVar[MusicQuizAnswerType]
 
     @abstractmethod
-    def parse_submission(self, payload: dict[str, object]) -> QuizAnswerSubmission:
+    def parse_submission(self, payload: Mapping[str, object]) -> QuizAnswerSubmission:
         """
         Parse an answer submission received from the API.
 

--- a/music_assistant/providers/music_quiz/answer_types/base.py
+++ b/music_assistant/providers/music_quiz/answer_types/base.py
@@ -15,7 +15,7 @@ from music_assistant.providers.music_quiz.models import (
     QuizRoundAnswerState,
 )
 
-QuizAnswerSubmissionValue = str | None
+QuizAnswerSubmissionValue = object | None
 QuizAnswerSubmissionPayload = dict[str, QuizAnswerSubmissionValue]
 
 

--- a/music_assistant/providers/music_quiz/answer_types/multiple_choice.py
+++ b/music_assistant/providers/music_quiz/answer_types/multiple_choice.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from typing import ClassVar
 
@@ -42,7 +42,7 @@ class MultipleChoiceAnswerType(QuizAnswerType):
 
     answer_type = MusicQuizAnswerType.MULTIPLE_CHOICE
 
-    def parse_submission(self, payload: dict[str, object]) -> QuizAnswerSubmission:
+    def parse_submission(self, payload: Mapping[str, object]) -> QuizAnswerSubmission:
         """
         Parse a multiple-choice submission.
 

--- a/music_assistant/providers/music_quiz/answer_types/timeline.py
+++ b/music_assistant/providers/music_quiz/answer_types/timeline.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from typing import ClassVar
 
@@ -91,7 +91,7 @@ class TimelineAnswerType(QuizAnswerType):
 
     answer_type = MusicQuizAnswerType.TIMELINE
 
-    def parse_submission(self, payload: dict[str, object]) -> QuizAnswerSubmission:
+    def parse_submission(self, payload: Mapping[str, object]) -> QuizAnswerSubmission:
         """
         Parse a strict timeline submission.
 
@@ -490,7 +490,7 @@ class TimelineAnswerType(QuizAnswerType):
             )
         return {"answer": serialized_answer}
 
-    def _parse_placement(self, payload: dict[str, object]) -> TimelinePlacementSubmission:
+    def _parse_placement(self, payload: Mapping[str, object]) -> TimelinePlacementSubmission:
         """Parse a strict timeline placement submission."""
         expected_keys = {
             "answer_type",
@@ -510,7 +510,7 @@ class TimelineAnswerType(QuizAnswerType):
         )
         return TimelinePlacementSubmission(previous_entry_id, next_entry_id)
 
-    def _parse_bonus_text(self, payload: dict[str, object]) -> TimelineBonusTextSubmission:
+    def _parse_bonus_text(self, payload: Mapping[str, object]) -> TimelineBonusTextSubmission:
         """Parse a strict free-text timeline bonus submission."""
         expected_keys = {"answer_type", "action", "bonus_type", "value"}
         if payload.keys() != expected_keys:
@@ -530,7 +530,7 @@ class TimelineAnswerType(QuizAnswerType):
             )
         return TimelineBonusTextSubmission(bonus_type, value)
 
-    def _parse_bonus_choice(self, payload: dict[str, object]) -> TimelineBonusChoiceSubmission:
+    def _parse_bonus_choice(self, payload: Mapping[str, object]) -> TimelineBonusChoiceSubmission:
         """Parse a strict multiple-choice timeline bonus submission."""
         expected_keys = {"answer_type", "action", "bonus_type", "option_id"}
         if payload.keys() != expected_keys:

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -21,6 +21,7 @@ from music_assistant.providers.music_quiz import (
     get_config_entries,
 )
 from music_assistant.providers.music_quiz.answer_types import get_answer_type
+from music_assistant.providers.music_quiz.answer_types.base import QuizAnswerSubmissionPayload
 from music_assistant.providers.music_quiz.errors import (
     MusicQuizGameActiveError,
     MusicQuizInvalidAnswerError,
@@ -497,10 +498,28 @@ async def test_hitster_edge_placement_accepts_null_at_api_boundary(
                 },
             },
         )
+        invalid_arguments = parse_arguments(
+            handler.signature,
+            handler.type_hints,
+            {
+                "player_id": player_ids["Alice"],
+                "submission": {
+                    "answer_type": "timeline",
+                    "action": 1,
+                    "previous_entry_id": None,
+                    "next_entry_id": "anchor",
+                },
+            },
+        )
         with patch(
             "music_assistant.providers.music_quiz.get_current_user",
             return_value=_guest_user(),
         ):
+            with pytest.raises(MusicQuizInvalidAnswerError):
+                await cast(
+                    "Coroutine[Any, Any, Any]",
+                    handler.target(**invalid_arguments),
+                )
             await cast("Coroutine[Any, Any, Any]", handler.target(**arguments))
 
     game = plugin._game
@@ -1087,7 +1106,7 @@ async def test_hitster_late_joiner_starts_on_prefetched_next_round() -> None:
     ],
 )
 async def test_generic_submit_answer_rejects_invalid_payload(
-    submission: dict[str, object],
+    submission: QuizAnswerSubmissionPayload,
 ) -> None:
     """Malformed generic submissions fail without mutating round state."""
     plugin = _create_plugin()

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -505,8 +505,8 @@ async def test_hitster_edge_placement_accepts_null_at_api_boundary(
                 "player_id": player_ids["Alice"],
                 "submission": {
                     "answer_type": "timeline",
-                    "action": 1,
-                    "previous_entry_id": None,
+                    "action": "place",
+                    "previous_entry_id": 1,
                     "next_entry_id": "anchor",
                 },
             },

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Coroutine
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,6 +13,7 @@ from music_assistant_models.auth import Scope, UserRole
 from music_assistant_models.enums import ConfigEntryType, PlaybackState
 from music_assistant_models.errors import InvalidDataError
 
+from music_assistant.helpers.api import APICommandHandler, parse_arguments
 from music_assistant.providers.music_quiz import (
     MUSIC_QUIZ_GUEST_USER,
     PLAYER_RECONNECT_GRACE_SECONDS,
@@ -447,6 +449,65 @@ async def test_generic_submit_answer_uses_discriminated_payload() -> None:
     assert state["you"]["answer"]["correct"] is True
     assert state["you"]["answer"]["points"] == 1000
     assert game.players[player_ids["Alice"]].last_seen == 120.0
+
+
+@pytest.mark.parametrize(
+    ("previous_entry_id", "next_entry_id"),
+    [(None, "anchor"), ("anchor", None)],
+)
+@pytest.mark.asyncio
+async def test_hitster_edge_placement_accepts_null_at_api_boundary(
+    previous_entry_id: str | None,
+    next_entry_id: str | None,
+) -> None:
+    """Accept either null timeline boundary through the registered API handler."""
+    plugin = _create_plugin()
+    registered: dict[str, APICommandHandler] = {}
+
+    def _register(command: str, handler: Any, **kwargs: Any) -> Any:
+        registered[command] = APICommandHandler.parse(command, handler, **kwargs)
+        return MagicMock()
+
+    cast("MagicMock", plugin.mass).register_api_command.side_effect = _register
+    await plugin.loaded_in_mass()
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.prepare_round",
+            new=AsyncMock(
+                side_effect=lambda round_index, previous: _make_hitster_round(round_index, previous)
+            ),
+        ),
+    ):
+        player_ids = await _create_started_hitster_game(plugin)
+        handler = registered["music_quiz/submit_answer"]
+        arguments = parse_arguments(
+            handler.signature,
+            handler.type_hints,
+            {
+                "player_id": player_ids["Alice"],
+                "submission": {
+                    "answer_type": "timeline",
+                    "action": "place",
+                    "previous_entry_id": previous_entry_id,
+                    "next_entry_id": next_entry_id,
+                },
+            },
+        )
+        with patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ):
+            await cast("Coroutine[Any, Any, Any]", handler.target(**arguments))
+
+    game = plugin._game
+    assert game is not None
+    placement = _timeline_answer_state(game.rounds[0]).placements[player_ids["Alice"]]
+    assert placement.previous_entry_id == previous_entry_id
+    assert placement.next_entry_id == next_entry_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Hitster placements at either timeline edge failed before provider validation when one boundary was JSON `null`.

- Preserve raw answer values through API parsing, including null boundaries.
- Keep strict strategy validation on read-only payload mappings.
- Cover both valid edges and invalid nullable boundary types through the registered handler.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.