### PR TITLE
Add note about using server ID to validate servers

### DIFF
--- a/music_assistant/helpers/resources/api_docs.html
+++ b/music_assistant/helpers/resources/api_docs.html
@@ -683,6 +683,12 @@ api.subscribe(<span class="string">'player_updated'</span>, (event) => {
                     <li><strong>Home Assistant OAuth</strong> - OAuth flow for HA users (optional)</li>
                     <li><strong>Bearer Tokens</strong> - Token-based authentication for HTTP and WebSocket</li>
                 </ul>
+                <p>
+                  When using tokens to automatically authenticate users, clients should be careful to validate that the server
+                  ID for the server they are communicating with matches the ID observed when the user logged in explicitly. Otherwise,
+                  there is a risk of sending tokens and attempting to authenticate with a different server that has the same local address
+                  and port (`homeassistant.local:8095` for example) as their own.
+                </p>
 
                 <h3>HTTP Authentication Endpoints</h3>
                 <p>The following HTTP endpoints are available for authentication (no auth required):</p>

--- a/music_assistant/helpers/resources/api_docs.html
+++ b/music_assistant/helpers/resources/api_docs.html
@@ -687,7 +687,7 @@ api.subscribe(<span class="string">'player_updated'</span>, (event) => {
                   When using tokens to automatically authenticate users, clients should be careful to validate that the server
                   ID for the server they are communicating with matches the ID observed when the user logged in explicitly. Otherwise,
                   there is a risk of sending tokens and attempting to authenticate with a different server that has the same local address
-                  and port (`homeassistant.local:8095` for example) as their own.
+                  and port (<code>homeassistant.local:8095</code> for example).
                 </p>
 
                 <h3>HTTP Authentication Endpoints</h3>

--- a/music_assistant/helpers/resources/api_docs.html
+++ b/music_assistant/helpers/resources/api_docs.html
@@ -742,7 +742,18 @@ curl -X POST {BASE_URL}/api \
                     <code>auth</code> command as the first message:
                 </p>
                 <div class="code-block">
-<span class="comment"># Send auth command immediately after connection</span>
+<span class="comment"># Login with username and password...</span>
+{
+  <span class="string">"message_id"</span>: <span class="string">"auth-123"</span>,
+  <span class="string">"command"</span>: <span class="string">"auth"</span>,
+  <span class="string">"args"</span>: {
+    <span class="string">"username"</span>: <span class="string">"your_username"</span>
+    <span class="string">"password"</span>: <span class="string">"your_password"</span>
+    <span class="string">"device_name"</span>: <span class="string">"you_device_name"</span>
+  }
+}
+
+<span class="comment"># ...or use token from previous login</span>
 {
   <span class="string">"message_id"</span>: <span class="string">"auth-123"</span>,
   <span class="string">"command"</span>: <span class="string">"auth"</span>,

--- a/music_assistant/helpers/resources/api_docs.html
+++ b/music_assistant/helpers/resources/api_docs.html
@@ -755,7 +755,7 @@ curl -X POST {BASE_URL}/api \
   <span class="string">"args"</span>: {
     <span class="string">"username"</span>: <span class="string">"your_username"</span>
     <span class="string">"password"</span>: <span class="string">"your_password"</span>
-    <span class="string">"device_name"</span>: <span class="string">"you_device_name"</span>
+    <span class="string">"device_name"</span>: <span class="string">"your_device_name"</span>
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

This highlights how clients can prevent potentially problematic scenarios where they try to authenticate automatically against a new (to them) server with the same local address as their own.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
