### PR TITLE
Fix Home Assistant AI and TTS defaults

### DIFF
--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -53,7 +53,7 @@ from .constants import OFF_STATES, MediaPlayerEntityFeature
 
 if TYPE_CHECKING:
     from aiohttp import ClientSession
-    from hass_client.models import CompressedState, Device, EntityStateEvent
+    from hass_client.models import CompressedState, Device, EntityStateEvent, State
     from music_assistant_models.config_entries import ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
@@ -76,12 +76,7 @@ async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
     """Initialize provider(instance) with given configuration."""
-    supported_features: set[ProviderFeature] = set()
-    if config.get_value(CONF_TTS_ENTITY):
-        supported_features.add(ProviderFeature.TTS)
-    if config.get_value(CONF_AI_TASK_ENTITY):
-        supported_features.add(ProviderFeature.AI_QUERY)
-    return HomeAssistantProvider(mass, manifest, config, supported_features)
+    return HomeAssistantProvider(mass, manifest, config, set())
 
 
 async def get_config_entries(
@@ -240,12 +235,14 @@ async def _get_config_entries(hass: HomeAssistantClient) -> tuple[ConfigEntry, .
     all_power_entities: list[ConfigValueOption] = []
     all_mute_entities: list[ConfigValueOption] = []
     all_volume_entities: list[ConfigValueOption] = []
-    tts_entities: list[ConfigValueOption] = []
-    ai_task_entities: list[ConfigValueOption] = []
     if not hass.connected:
         return ()
-    for state in await hass.get_states():
+    states = await hass.get_states()
+    tts_entities, ai_task_entities = _get_feature_entity_options(states)
+    for state in states:
         entity_platform = state["entity_id"].split(".")[0]
+        if entity_platform in ("tts", "ai_task"):
+            continue
         if "friendly_name" not in state["attributes"]:
             name = state["entity_id"]
         else:
@@ -260,13 +257,6 @@ async def _get_config_entries(hass: HomeAssistantClient) -> tuple[ConfigEntry, .
             # number and input_number are very similar, both are suitable for volume control
             all_volume_entities.append(ConfigValueOption(state["entity_id"], title=name))
             continue
-        if entity_platform == "tts":
-            tts_entities.append(ConfigValueOption(state["entity_id"], title=name))
-            continue
-        if entity_platform == "ai_task":
-            ai_task_entities.append(ConfigValueOption(state["entity_id"], title=name))
-            continue
-
         # media player can be used as control, depending on features
         if entity_platform != "media_player":
             continue
@@ -286,8 +276,6 @@ async def _get_config_entries(hass: HomeAssistantClient) -> tuple[ConfigEntry, .
     all_power_entities.sort(key=lambda x: x.title or "")
     all_mute_entities.sort(key=lambda x: x.title or "")
     all_volume_entities.sort(key=lambda x: x.title or "")
-    tts_entities.sort(key=lambda x: x.title or "")
-    ai_task_entities.sort(key=lambda x: x.title or "")
     entries: list[ConfigEntry] = [
         ConfigEntry(
             key=CONF_POWER_CONTROLS,
@@ -342,6 +330,8 @@ class HomeAssistantProvider(PluginProvider):
     hass: HomeAssistantClient
     _listen_task: asyncio.Task[None] | None = None
     _player_controls: dict[str, PlayerControl] | None = None
+    _tts_entity_id: str | None = None
+    _ai_task_entity_id: str | None = None
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the plugin."""
@@ -357,6 +347,7 @@ class HomeAssistantProvider(PluginProvider):
         except BaseHassClientError as err:
             err_msg = str(err) or err.__class__.__name__
             raise SetupFailedError(err_msg) from err
+        await self._resolve_feature_entities()
         self._listen_task = self.mass.create_task(self._hass_listener())
 
     async def loaded_in_mass(self) -> None:
@@ -483,7 +474,8 @@ class HomeAssistantProvider(PluginProvider):
 
     async def ai_query(self, query: str) -> str:
         """Handle an AI query via Home Assistant's ai_task service."""
-        entity_id = self.config.get_value(CONF_AI_TASK_ENTITY)
+        if self._ai_task_entity_id is None:
+            raise UnsupportedFeaturedException("AI Task entity is not configured")
         result = await self.hass.send_command(
             "call_service",
             domain="ai_task",
@@ -491,7 +483,7 @@ class HomeAssistantProvider(PluginProvider):
             service_data={
                 "task_name": "music_assistant",
                 "instructions": query,
-                "entity_id": str(entity_id),
+                "entity_id": self._ai_task_entity_id,
             },
             return_response=True,
         )
@@ -504,10 +496,10 @@ class HomeAssistantProvider(PluginProvider):
 
     async def get_tts_message(self, message: str, language: str | None = None) -> StreamDetails:
         """Handle text-to-speech via Home Assistant's REST API."""
-        if (entity_id := self.config.get_value(CONF_TTS_ENTITY)) is None:
+        if self._tts_entity_id is None:
             raise UnsupportedFeaturedException("TTS entity is not configured")
         ha_url, headers, http_session = self._get_ha_http()
-        payload: dict[str, str] = {"engine_id": str(entity_id), "message": message}
+        payload: dict[str, str] = {"engine_id": self._tts_entity_id, "message": message}
         if language:
             payload["language"] = language
         async with http_session.post(
@@ -692,3 +684,48 @@ class HomeAssistantProvider(PluginProvider):
         ssl = bool(self.config.get_value(CONF_VERIFY_SSL))
         http_session = self.mass.http_session if ssl else self.mass.http_session_no_ssl
         return ha_url, headers, http_session
+
+    async def _resolve_feature_entities(self) -> None:
+        """Resolve configured or default Home Assistant feature entities."""
+        tts_entities, ai_task_entities = _get_feature_entity_options(await self.hass.get_states())
+        self._tts_entity_id = _select_feature_entity(
+            self.config.get_value(CONF_TTS_ENTITY), tts_entities
+        )
+        self._ai_task_entity_id = _select_feature_entity(
+            self.config.get_value(CONF_AI_TASK_ENTITY), ai_task_entities
+        )
+        self._supported_features.discard(ProviderFeature.TTS)
+        self._supported_features.discard(ProviderFeature.AI_QUERY)
+        if self._tts_entity_id:
+            self._supported_features.add(ProviderFeature.TTS)
+        if self._ai_task_entity_id:
+            self._supported_features.add(ProviderFeature.AI_QUERY)
+
+
+def _get_feature_entity_options(
+    states: list[State],
+) -> tuple[list[ConfigValueOption], list[ConfigValueOption]]:
+    """Return sorted TTS and AI Task entity options."""
+    feature_entities: dict[str, list[ConfigValueOption]] = {"tts": [], "ai_task": []}
+    for state in states:
+        entity_platform = state["entity_id"].split(".", 1)[0]
+        if entity_platform not in feature_entities:
+            continue
+        friendly_name = state["attributes"].get("friendly_name")
+        name = f"{friendly_name} ({state['entity_id']})" if friendly_name else state["entity_id"]
+        feature_entities[entity_platform].append(ConfigValueOption(state["entity_id"], title=name))
+    for entities in feature_entities.values():
+        entities.sort(key=lambda option: option.title or "")
+    return feature_entities["tts"], feature_entities["ai_task"]
+
+
+def _select_feature_entity(
+    configured_entity: ConfigValueType, options: list[ConfigValueOption]
+) -> str | None:
+    """Return the configured available entity or the first available entity."""
+    available_entity_ids = {str(option.value) for option in options}
+    if configured_entity:
+        if not isinstance(configured_entity, str):
+            return None
+        return configured_entity if configured_entity in available_entity_ids else None
+    return str(options[0].value) if options else None

--- a/tests/providers/hass/__init__.py
+++ b/tests/providers/hass/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Home Assistant provider."""

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -1,0 +1,175 @@
+"""Tests for the Home Assistant provider."""
+
+from __future__ import annotations
+
+from collections.abc import Coroutine
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from music_assistant_models.enums import ProviderFeature
+
+from music_assistant.constants import CONF_LOG_LEVEL
+from music_assistant.providers.hass import (
+    CONF_AI_TASK_ENTITY,
+    CONF_AUTH_TOKEN,
+    CONF_TTS_ENTITY,
+    CONF_URL,
+    CONF_VERIFY_SSL,
+    HomeAssistantProvider,
+    setup,
+)
+
+
+def _state(entity_id: str, friendly_name: str) -> dict[str, Any]:
+    """Return a Home Assistant entity state."""
+    return {
+        "entity_id": entity_id,
+        "state": "idle",
+        "attributes": {"friendly_name": friendly_name},
+    }
+
+
+def _config(**values: str) -> MagicMock:
+    """Return a provider config with the given persisted values."""
+    persisted_values = {
+        CONF_URL: "http://homeassistant.local:8123",
+        CONF_AUTH_TOKEN: "token",
+        CONF_VERIFY_SSL: True,
+        CONF_LOG_LEVEL: "GLOBAL",
+        **values,
+    }
+    config = MagicMock()
+    config.instance_id = "hass--test"
+    config.name = "Home Assistant"
+    config.get_value.side_effect = persisted_values.get
+    return config
+
+
+def _mass() -> MagicMock:
+    """Return the Music Assistant dependencies used during provider startup."""
+    mass = MagicMock()
+    mass.cache = MagicMock()
+    mass.http_session = MagicMock()
+    mass.http_session_no_ssl = MagicMock()
+
+    def close_listener(coro: Coroutine[Any, Any, None]) -> MagicMock:
+        coro.close()
+        return MagicMock()
+
+    mass.create_task.side_effect = close_listener
+    return mass
+
+
+async def _start_provider(
+    states: list[dict[str, Any]], **config_values: str
+) -> tuple[HomeAssistantProvider, MagicMock]:
+    """Start the provider with a connected mocked Home Assistant client."""
+    hass = MagicMock()
+    hass.connect = AsyncMock()
+    hass.get_states = AsyncMock(return_value=states)
+    hass.send_command = AsyncMock(return_value={"response": {"data": "answer"}})
+    manifest = MagicMock()
+    manifest.domain = "hass"
+    manifest.name = "Home Assistant"
+    with patch("music_assistant.providers.hass.HomeAssistantClient", return_value=hass):
+        provider = await setup(_mass(), manifest, _config(**config_values))
+        assert isinstance(provider, HomeAssistantProvider)
+        await provider.handle_async_init()
+    return provider, hass
+
+
+@pytest.mark.parametrize(
+    ("states", "expected_entity"),
+    [
+        ([_state("ai_task.default", "Default")], "ai_task.default"),
+        (
+            [
+                _state("ai_task.first", "First"),
+                _state("ai_task.selected", "Selected"),
+            ],
+            "ai_task.selected",
+        ),
+    ],
+)
+async def test_ai_query_uses_resolved_entity_after_startup(
+    states: list[dict[str, Any]], expected_entity: str
+) -> None:
+    """Advertise AI queries and use the default or explicitly selected entity."""
+    config_values = (
+        {CONF_AI_TASK_ENTITY: expected_entity} if expected_entity == "ai_task.selected" else {}
+    )
+
+    provider, hass = await _start_provider(states, **config_values)
+    result = await provider.ai_query("What is this song?")
+
+    assert ProviderFeature.AI_QUERY in provider.supported_features
+    assert result == "answer"
+    hass.send_command.assert_awaited_once_with(
+        "call_service",
+        domain="ai_task",
+        service="generate_data",
+        service_data={
+            "task_name": "music_assistant",
+            "instructions": "What is this song?",
+            "entity_id": expected_entity,
+        },
+        return_response=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "config_values",
+    [{}, {CONF_AI_TASK_ENTITY: "ai_task.missing"}],
+)
+async def test_ai_query_not_advertised_without_entity(config_values: dict[str, str]) -> None:
+    """Do not advertise AI queries when Home Assistant has no AI Task entity."""
+    provider, _ = await _start_provider([_state("sensor.example", "Example")], **config_values)
+
+    assert ProviderFeature.AI_QUERY not in provider.supported_features
+
+
+@pytest.mark.parametrize(
+    ("states", "expected_entity"),
+    [
+        ([_state("tts.default", "Default")], "tts.default"),
+        (
+            [
+                _state("tts.first", "First"),
+                _state("tts.selected", "Selected"),
+            ],
+            "tts.selected",
+        ),
+    ],
+)
+async def test_tts_uses_resolved_entity_after_startup(
+    states: list[dict[str, Any]], expected_entity: str
+) -> None:
+    """Advertise TTS and use the default or explicitly selected entity."""
+    config_values = {CONF_TTS_ENTITY: expected_entity} if expected_entity == "tts.selected" else {}
+    provider, _ = await _start_provider(states, **config_values)
+    response = AsyncMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = {"url": "http://homeassistant.local/tts.mp3"}
+    post = cast("MagicMock", provider.mass.http_session.post)
+    post.return_value.__aenter__.return_value = response
+
+    stream = await provider.get_tts_message("Hello")
+
+    assert ProviderFeature.TTS in provider.supported_features
+    assert stream.path == "http://homeassistant.local/tts.mp3"
+    post.assert_called_once()
+    request = post.call_args
+    assert request.args == ("http://homeassistant.local:8123/api/tts_get_url",)
+    assert request.kwargs["json"] == {"engine_id": expected_entity, "message": "Hello"}
+
+
+@pytest.mark.parametrize(
+    "config_values",
+    [{}, {CONF_TTS_ENTITY: "tts.missing"}],
+)
+async def test_tts_not_advertised_without_entity(config_values: dict[str, str]) -> None:
+    """Do not advertise TTS when Home Assistant has no TTS entity."""
+    provider, _ = await _start_provider([_state("sensor.example", "Example")], **config_values)
+
+    assert ProviderFeature.TTS not in provider.supported_features


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Fix Home Assistant AI Task and TTS defaults being lost after a restart or provider reload.

- Resolve omitted defaults after Home Assistant connects.
- Keep advertised features and the entities used for requests in sync.
- Preserve explicit entity selections and disable unavailable features.
- Add startup coverage for AI Task and TTS defaults.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project’s [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.