### PR TITLE
Fix Home Assistant startup deadlock

### DIFF
--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from contextlib import suppress
 from functools import partial
 from typing import TYPE_CHECKING, cast
 
@@ -347,8 +348,19 @@ class HomeAssistantProvider(PluginProvider):
         except BaseHassClientError as err:
             err_msg = str(err) or err.__class__.__name__
             raise SetupFailedError(err_msg) from err
-        await self._resolve_feature_entities()
         self._listen_task = self.mass.create_task(self._hass_listener())
+        try:
+            await self._resolve_feature_entities()
+        except asyncio.CancelledError:
+            await self._cleanup_failed_init()
+            raise
+        except BaseHassClientError as err:
+            await self._cleanup_failed_init()
+            err_msg = str(err) or err.__class__.__name__
+            raise SetupFailedError(err_msg) from err
+        except Exception:
+            await self._cleanup_failed_init()
+            raise
 
     async def loaded_in_mass(self) -> None:
         """Call after the provider has been loaded."""
@@ -364,9 +376,7 @@ class HomeAssistantProvider(PluginProvider):
         if self._player_controls:
             for entity_id in self._player_controls:
                 self.mass.players.remove_player_control(entity_id)
-        if self._listen_task and not self._listen_task.done():
-            self._listen_task.cancel()
-        await self.hass.disconnect()
+        await self._disconnect_hass()
 
     async def get_diagnostics(self) -> dict[str, SerializableType]:
         """Return diagnostics info for this provider to include in diagnostics reports."""
@@ -684,6 +694,23 @@ class HomeAssistantProvider(PluginProvider):
         ssl = bool(self.config.get_value(CONF_VERIFY_SSL))
         http_session = self.mass.http_session if ssl else self.mass.http_session_no_ssl
         return ha_url, headers, http_session
+
+    async def _disconnect_hass(self) -> None:
+        """Stop listening for Home Assistant events and disconnect the client."""
+        if listen_task := self._listen_task:
+            self._listen_task = None
+            if not listen_task.done():
+                listen_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await listen_task
+        await self.hass.disconnect()
+
+    async def _cleanup_failed_init(self) -> None:
+        """Clean up the Home Assistant connection after initialization fails."""
+        try:
+            await self._disconnect_hass()
+        except BaseHassClientError as err:
+            self.logger.warning("Failed to disconnect from Home Assistant: %s", err)
 
     async def _resolve_feature_entities(self) -> None:
         """Resolve configured or default Home Assistant feature entities."""

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -70,6 +70,7 @@ CONF_MUTE_CONTROLS = "mute_controls"
 CONF_VOLUME_CONTROLS = "volume_controls"
 CONF_TTS_ENTITY = "tts_entity"
 CONF_AI_TASK_ENTITY = "ai_task_entity"
+FEATURE_DISCOVERY_TIMEOUT = 30
 
 
 async def setup(
@@ -332,9 +333,14 @@ class HomeAssistantProvider(PluginProvider):
     _player_controls: dict[str, PlayerControl] | None = None
     _tts_entity_id: str | None = None
     _ai_task_entity_id: str | None = None
+    _startup_complete: bool = False
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the plugin."""
+        if self._listen_task and not self._listen_task.done():
+            msg = "Home Assistant listener is already running"
+            raise SetupFailedError(msg)
+        self._startup_complete = False
         self._player_controls = {}
         url = get_websocket_url(self.config.get_value(CONF_URL))
         token = self.config.get_value(CONF_AUTH_TOKEN)
@@ -350,7 +356,7 @@ class HomeAssistantProvider(PluginProvider):
             raise SetupFailedError(err_msg) from err
         self._listen_task = self.mass.create_task(self._hass_listener())
         try:
-            await self._resolve_feature_entities()
+            await self._resolve_startup_features()
         except asyncio.CancelledError:
             await self._cleanup_failed_init()
             raise
@@ -376,6 +382,7 @@ class HomeAssistantProvider(PluginProvider):
         if self._player_controls:
             for entity_id in self._player_controls:
                 self.mass.players.remove_player_control(entity_id)
+        self._startup_complete = False
         await self._disconnect_hass()
 
     async def get_diagnostics(self) -> dict[str, SerializableType]:
@@ -534,6 +541,8 @@ class HomeAssistantProvider(PluginProvider):
             await self.hass.start_listening()
         except BaseHassClientError as err:
             self.logger.warning("Connection to HA lost due to error: %s", err)
+        if not self._startup_complete:
+            return
         self.logger.info("Connection to HA lost. Connection will be automatically retried later.")
         # schedule a reload of the provider
         self.available = False
@@ -715,6 +724,39 @@ class HomeAssistantProvider(PluginProvider):
             await self._disconnect_hass()
         except Exception as err:
             self.logger.warning("Failed to disconnect from Home Assistant: %s", err)
+
+    async def _resolve_startup_features(self) -> None:
+        """Resolve Home Assistant features while the listener remains active."""
+        assert self._listen_task is not None
+        feature_task = asyncio.create_task(self._resolve_feature_entities())
+        try:
+            try:
+                async with asyncio.timeout(FEATURE_DISCOVERY_TIMEOUT):
+                    await asyncio.wait(
+                        {feature_task, self._listen_task},
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+            except TimeoutError as err:
+                msg = "Timed out while resolving Home Assistant feature entities"
+                raise SetupFailedError(msg) from err
+            if not feature_task.done():
+                msg = "Home Assistant listener stopped during startup"
+                raise SetupFailedError(msg)
+            if feature_task.cancelled():
+                if self._listen_task.done():
+                    msg = "Home Assistant listener stopped during startup"
+                else:
+                    msg = "Home Assistant feature resolution was cancelled"
+                raise SetupFailedError(msg)
+            await feature_task
+            if self._listen_task.done():
+                msg = "Home Assistant listener stopped during startup"
+                raise SetupFailedError(msg)
+            self._startup_complete = True
+        finally:
+            if not feature_task.done():
+                feature_task.cancel()
+                await asyncio.gather(feature_task, return_exceptions=True)
 
     async def _resolve_feature_entities(self) -> None:
         """Resolve configured or default Home Assistant feature entities."""

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from contextlib import suppress
 from functools import partial
 from typing import TYPE_CHECKING, cast
 
@@ -346,6 +345,7 @@ class HomeAssistantProvider(PluginProvider):
         try:
             await self.hass.connect()
         except BaseHassClientError as err:
+            await self._cleanup_failed_init()
             err_msg = str(err) or err.__class__.__name__
             raise SetupFailedError(err_msg) from err
         self._listen_task = self.mass.create_task(self._hass_listener())
@@ -701,15 +701,19 @@ class HomeAssistantProvider(PluginProvider):
             self._listen_task = None
             if not listen_task.done():
                 listen_task.cancel()
-            with suppress(asyncio.CancelledError):
+            try:
                 await listen_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as err:
+                self.logger.warning("Home Assistant listener stopped with error: %s", err)
         await self.hass.disconnect()
 
     async def _cleanup_failed_init(self) -> None:
         """Clean up the Home Assistant connection after initialization fails."""
         try:
             await self._disconnect_hass()
-        except BaseHassClientError as err:
+        except Exception as err:
             self.logger.warning("Failed to disconnect from Home Assistant: %s", err)
 
     async def _resolve_feature_entities(self) -> None:

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
-from collections.abc import Coroutine
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from hass_client.exceptions import BaseHassClientError
 from music_assistant_models.enums import ProviderFeature
+from music_assistant_models.errors import SetupFailedError
 
 from music_assistant.constants import CONF_LOG_LEVEL
 from music_assistant.providers.hass import (
@@ -52,31 +56,108 @@ def _mass() -> MagicMock:
     mass.cache = MagicMock()
     mass.http_session = MagicMock()
     mass.http_session_no_ssl = MagicMock()
-
-    def close_listener(coro: Coroutine[Any, Any, None]) -> MagicMock:
-        coro.close()
-        return MagicMock()
-
-    mass.create_task.side_effect = close_listener
+    mass.create_task.side_effect = asyncio.create_task
     return mass
 
 
+class _HomeAssistantClient:
+    """Provide lifecycle-aware Home Assistant behavior for provider tests."""
+
+    def __init__(
+        self,
+        states: list[dict[str, Any]],
+        get_states_error: Exception | None = None,
+    ) -> None:
+        self.connected = False
+        self.disconnected = False
+        self.listener_started = asyncio.Event()
+        self.listener_stopped = asyncio.Event()
+        self.calls: list[str] = []
+        self._states = states
+        self._get_states_error = get_states_error
+        self.send_command = AsyncMock(return_value={"response": {"data": "answer"}})
+
+    async def connect(self) -> None:
+        """Connect the client."""
+        self.calls.append("connect")
+        self.connected = True
+
+    async def start_listening(self) -> None:
+        """Listen until the provider stops the listener task."""
+        self.calls.append("start_listening")
+        self.listener_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            self.listener_stopped.set()
+
+    async def get_states(self) -> list[dict[str, Any]]:
+        """Return states after command responses can be received."""
+        await self.listener_started.wait()
+        self.calls.append("get_states")
+        if self._get_states_error:
+            raise self._get_states_error
+        return self._states
+
+    async def disconnect(self) -> None:
+        """Disconnect the client."""
+        self.calls.append("disconnect")
+        self.connected = False
+        self.disconnected = True
+
+
+@asynccontextmanager
 async def _start_provider(
     states: list[dict[str, Any]], **config_values: str
-) -> tuple[HomeAssistantProvider, MagicMock]:
+) -> AsyncIterator[tuple[HomeAssistantProvider, _HomeAssistantClient]]:
     """Start the provider with a connected mocked Home Assistant client."""
-    hass = MagicMock()
-    hass.connect = AsyncMock()
-    hass.get_states = AsyncMock(return_value=states)
-    hass.send_command = AsyncMock(return_value={"response": {"data": "answer"}})
+    hass = _HomeAssistantClient(states)
     manifest = MagicMock()
     manifest.domain = "hass"
     manifest.name = "Home Assistant"
     with patch("music_assistant.providers.hass.HomeAssistantClient", return_value=hass):
         provider = await setup(_mass(), manifest, _config(**config_values))
         assert isinstance(provider, HomeAssistantProvider)
-        await provider.handle_async_init()
-    return provider, hass
+        async with asyncio.timeout(1):
+            await provider.handle_async_init()
+    try:
+        yield provider, hass
+    finally:
+        await provider.unload()
+
+
+async def test_feature_resolution_starts_listener_first() -> None:
+    """Resolve startup features only after the Home Assistant listener starts."""
+    states = [
+        _state("ai_task.default", "Default AI"),
+        _state("tts.default", "Default TTS"),
+    ]
+
+    async with _start_provider(states) as (provider, hass):
+        assert hass.calls[:3] == ["connect", "start_listening", "get_states"]
+        assert ProviderFeature.AI_QUERY in provider.supported_features
+        assert ProviderFeature.TTS in provider.supported_features
+
+
+async def test_feature_resolution_failure_cleans_up_connection() -> None:
+    """Clean up the listener and connection when feature resolution fails."""
+    hass = _HomeAssistantClient([], BaseHassClientError("Unable to load Home Assistant states"))
+    manifest = MagicMock()
+    manifest.domain = "hass"
+    manifest.name = "Home Assistant"
+    with patch("music_assistant.providers.hass.HomeAssistantClient", return_value=hass):
+        provider = await setup(_mass(), manifest, _config())
+        assert isinstance(provider, HomeAssistantProvider)
+
+        with pytest.raises(SetupFailedError, match="Unable to load Home Assistant states"):
+            async with asyncio.timeout(1):
+                await provider.handle_async_init()
+
+    assert hass.listener_started.is_set()
+    assert hass.listener_stopped.is_set()
+    assert hass.disconnected
+    assert hass.calls == ["connect", "start_listening", "get_states", "disconnect"]
+    assert provider._listen_task is None
 
 
 @pytest.mark.parametrize(
@@ -100,22 +181,22 @@ async def test_ai_query_uses_resolved_entity_after_startup(
         {CONF_AI_TASK_ENTITY: expected_entity} if expected_entity == "ai_task.selected" else {}
     )
 
-    provider, hass = await _start_provider(states, **config_values)
-    result = await provider.ai_query("What is this song?")
+    async with _start_provider(states, **config_values) as (provider, hass):
+        result = await provider.ai_query("What is this song?")
 
-    assert ProviderFeature.AI_QUERY in provider.supported_features
-    assert result == "answer"
-    hass.send_command.assert_awaited_once_with(
-        "call_service",
-        domain="ai_task",
-        service="generate_data",
-        service_data={
-            "task_name": "music_assistant",
-            "instructions": "What is this song?",
-            "entity_id": expected_entity,
-        },
-        return_response=True,
-    )
+        assert ProviderFeature.AI_QUERY in provider.supported_features
+        assert result == "answer"
+        hass.send_command.assert_awaited_once_with(
+            "call_service",
+            domain="ai_task",
+            service="generate_data",
+            service_data={
+                "task_name": "music_assistant",
+                "instructions": "What is this song?",
+                "entity_id": expected_entity,
+            },
+            return_response=True,
+        )
 
 
 @pytest.mark.parametrize(
@@ -124,9 +205,11 @@ async def test_ai_query_uses_resolved_entity_after_startup(
 )
 async def test_ai_query_not_advertised_without_entity(config_values: dict[str, str]) -> None:
     """Do not advertise AI queries when Home Assistant has no AI Task entity."""
-    provider, _ = await _start_provider([_state("sensor.example", "Example")], **config_values)
-
-    assert ProviderFeature.AI_QUERY not in provider.supported_features
+    async with _start_provider([_state("sensor.example", "Example")], **config_values) as (
+        provider,
+        _,
+    ):
+        assert ProviderFeature.AI_QUERY not in provider.supported_features
 
 
 @pytest.mark.parametrize(
@@ -147,21 +230,21 @@ async def test_tts_uses_resolved_entity_after_startup(
 ) -> None:
     """Advertise TTS and use the default or explicitly selected entity."""
     config_values = {CONF_TTS_ENTITY: expected_entity} if expected_entity == "tts.selected" else {}
-    provider, _ = await _start_provider(states, **config_values)
-    response = AsyncMock()
-    response.raise_for_status = MagicMock()
-    response.json.return_value = {"url": "http://homeassistant.local/tts.mp3"}
-    post = cast("MagicMock", provider.mass.http_session.post)
-    post.return_value.__aenter__.return_value = response
+    async with _start_provider(states, **config_values) as (provider, _):
+        response = AsyncMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {"url": "http://homeassistant.local/tts.mp3"}
+        post = cast("MagicMock", provider.mass.http_session.post)
+        post.return_value.__aenter__.return_value = response
 
-    stream = await provider.get_tts_message("Hello")
+        stream = await provider.get_tts_message("Hello")
 
-    assert ProviderFeature.TTS in provider.supported_features
-    assert stream.path == "http://homeassistant.local/tts.mp3"
-    post.assert_called_once()
-    request = post.call_args
-    assert request.args == ("http://homeassistant.local:8123/api/tts_get_url",)
-    assert request.kwargs["json"] == {"engine_id": expected_entity, "message": "Hello"}
+        assert ProviderFeature.TTS in provider.supported_features
+        assert stream.path == "http://homeassistant.local/tts.mp3"
+        post.assert_called_once()
+        request = post.call_args
+        assert request.args == ("http://homeassistant.local:8123/api/tts_get_url",)
+        assert request.kwargs["json"] == {"engine_id": expected_entity, "message": "Hello"}
 
 
 @pytest.mark.parametrize(
@@ -170,6 +253,8 @@ async def test_tts_uses_resolved_entity_after_startup(
 )
 async def test_tts_not_advertised_without_entity(config_values: dict[str, str]) -> None:
     """Do not advertise TTS when Home Assistant has no TTS entity."""
-    provider, _ = await _start_provider([_state("sensor.example", "Example")], **config_values)
-
-    assert ProviderFeature.TTS not in provider.supported_features
+    async with _start_provider([_state("sensor.example", "Example")], **config_values) as (
+        provider,
+        _,
+    ):
+        assert ProviderFeature.TTS not in provider.supported_features

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -74,7 +74,10 @@ class _HomeAssistantClient:
         self.connected = False
         self.disconnected = False
         self.listener_started = asyncio.Event()
+        self.listener_cancelled = asyncio.Event()
         self.listener_stopped = asyncio.Event()
+        self.get_states_started = asyncio.Event()
+        self.get_states_cancelled = asyncio.Event()
         self.get_states_stopped = asyncio.Event()
         self.calls: list[str] = []
         self._states = states
@@ -101,6 +104,9 @@ class _HomeAssistantClient:
             if self._listener_error:
                 raise self._listener_error
             await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.listener_cancelled.set()
+            raise
         finally:
             if self._get_states_result and not self._get_states_result.done():
                 self._get_states_result.cancel()
@@ -110,12 +116,16 @@ class _HomeAssistantClient:
         """Return states after command responses can be received."""
         await self.listener_started.wait()
         self.calls.append("get_states")
+        self.get_states_started.set()
         try:
             if self._get_states_result:
                 await self._get_states_result
             if self._get_states_error:
                 raise self._get_states_error
             return self._states
+        except asyncio.CancelledError:
+            self.get_states_cancelled.set()
+            raise
         finally:
             self.get_states_stopped.set()
 
@@ -224,6 +234,64 @@ async def test_listener_exit_terminates_pending_feature_resolution() -> None:
     assert hass.listener_started.is_set()
     assert hass.listener_stopped.is_set()
     assert hass.get_states_stopped.is_set()
+    assert hass.disconnected
+    assert provider._listen_task is None
+    mass.call_later.assert_not_called()
+
+
+async def test_feature_resolution_timeout_cleans_up_connection() -> None:
+    """Clean up startup when Home Assistant feature resolution times out."""
+    hass = _HomeAssistantClient([], block_get_states=True)
+    mass = _mass()
+    manifest = MagicMock()
+    manifest.domain = "hass"
+    manifest.name = "Home Assistant"
+    with (
+        patch("music_assistant.providers.hass.HomeAssistantClient", return_value=hass),
+        patch("music_assistant.providers.hass.FEATURE_DISCOVERY_TIMEOUT", 0.1),
+    ):
+        provider = await setup(mass, manifest, _config())
+        assert isinstance(provider, HomeAssistantProvider)
+        init_task = asyncio.create_task(provider.handle_async_init())
+        async with asyncio.timeout(1):
+            await hass.get_states_started.wait()
+
+        with pytest.raises(
+            SetupFailedError, match="Timed out while resolving Home Assistant feature entities"
+        ):
+            await init_task
+
+    assert hass.get_states_stopped.is_set()
+    assert hass.get_states_cancelled.is_set()
+    assert hass.listener_stopped.is_set()
+    assert hass.listener_cancelled.is_set()
+    assert hass.disconnected
+    assert provider._listen_task is None
+    mass.call_later.assert_not_called()
+
+
+async def test_feature_resolution_cancellation_cleans_up_connection() -> None:
+    """Clean up startup when Home Assistant initialization is cancelled."""
+    hass = _HomeAssistantClient([], block_get_states=True)
+    mass = _mass()
+    manifest = MagicMock()
+    manifest.domain = "hass"
+    manifest.name = "Home Assistant"
+    with patch("music_assistant.providers.hass.HomeAssistantClient", return_value=hass):
+        provider = await setup(mass, manifest, _config())
+        assert isinstance(provider, HomeAssistantProvider)
+        init_task = asyncio.create_task(provider.handle_async_init())
+        async with asyncio.timeout(1):
+            await hass.get_states_started.wait()
+        init_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await init_task
+
+    assert hass.get_states_stopped.is_set()
+    assert hass.get_states_cancelled.is_set()
+    assert hass.listener_stopped.is_set()
+    assert hass.listener_cancelled.is_set()
     assert hass.disconnected
     assert provider._listen_task is None
     mass.call_later.assert_not_called()

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -69,16 +69,21 @@ class _HomeAssistantClient:
         get_states_error: Exception | None = None,
         listener_error: Exception | None = None,
         connect_error: Exception | None = None,
+        block_get_states: bool = False,
     ) -> None:
         self.connected = False
         self.disconnected = False
         self.listener_started = asyncio.Event()
         self.listener_stopped = asyncio.Event()
+        self.get_states_stopped = asyncio.Event()
         self.calls: list[str] = []
         self._states = states
         self._get_states_error = get_states_error
         self._listener_error = listener_error
         self._connect_error = connect_error
+        self._get_states_result = (
+            asyncio.get_running_loop().create_future() if block_get_states else None
+        )
         self.send_command = AsyncMock(return_value={"response": {"data": "answer"}})
 
     async def connect(self) -> None:
@@ -92,20 +97,27 @@ class _HomeAssistantClient:
         """Listen until the provider stops the listener task."""
         self.calls.append("start_listening")
         self.listener_started.set()
-        if self._listener_error:
-            raise self._listener_error
         try:
+            if self._listener_error:
+                raise self._listener_error
             await asyncio.Event().wait()
         finally:
+            if self._get_states_result and not self._get_states_result.done():
+                self._get_states_result.cancel()
             self.listener_stopped.set()
 
     async def get_states(self) -> list[dict[str, Any]]:
         """Return states after command responses can be received."""
         await self.listener_started.wait()
         self.calls.append("get_states")
-        if self._get_states_error:
-            raise self._get_states_error
-        return self._states
+        try:
+            if self._get_states_result:
+                await self._get_states_result
+            if self._get_states_error:
+                raise self._get_states_error
+            return self._states
+        finally:
+            self.get_states_stopped.set()
 
     async def disconnect(self) -> None:
         """Disconnect the client."""
@@ -188,6 +200,33 @@ async def test_listener_failure_does_not_mask_feature_resolution_failure() -> No
 
     assert hass.disconnected
     assert provider._listen_task is None
+
+
+async def test_listener_exit_terminates_pending_feature_resolution() -> None:
+    """Fail startup when the listener exits while feature resolution is pending."""
+    hass = _HomeAssistantClient(
+        [],
+        listener_error=BaseHassClientError("Listener failed"),
+        block_get_states=True,
+    )
+    mass = _mass()
+    manifest = MagicMock()
+    manifest.domain = "hass"
+    manifest.name = "Home Assistant"
+    with patch("music_assistant.providers.hass.HomeAssistantClient", return_value=hass):
+        provider = await setup(mass, manifest, _config())
+        assert isinstance(provider, HomeAssistantProvider)
+
+        with pytest.raises(SetupFailedError, match="listener stopped during startup"):
+            async with asyncio.timeout(1):
+                await provider.handle_async_init()
+
+    assert hass.listener_started.is_set()
+    assert hass.listener_stopped.is_set()
+    assert hass.get_states_stopped.is_set()
+    assert hass.disconnected
+    assert provider._listen_task is None
+    mass.call_later.assert_not_called()
 
 
 async def test_connection_failure_cleans_up_client() -> None:

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -67,6 +67,8 @@ class _HomeAssistantClient:
         self,
         states: list[dict[str, Any]],
         get_states_error: Exception | None = None,
+        listener_error: Exception | None = None,
+        connect_error: Exception | None = None,
     ) -> None:
         self.connected = False
         self.disconnected = False
@@ -75,17 +77,23 @@ class _HomeAssistantClient:
         self.calls: list[str] = []
         self._states = states
         self._get_states_error = get_states_error
+        self._listener_error = listener_error
+        self._connect_error = connect_error
         self.send_command = AsyncMock(return_value={"response": {"data": "answer"}})
 
     async def connect(self) -> None:
         """Connect the client."""
         self.calls.append("connect")
+        if self._connect_error:
+            raise self._connect_error
         self.connected = True
 
     async def start_listening(self) -> None:
         """Listen until the provider stops the listener task."""
         self.calls.append("start_listening")
         self.listener_started.set()
+        if self._listener_error:
+            raise self._listener_error
         try:
             await asyncio.Event().wait()
         finally:
@@ -157,6 +165,45 @@ async def test_feature_resolution_failure_cleans_up_connection() -> None:
     assert hass.listener_stopped.is_set()
     assert hass.disconnected
     assert hass.calls == ["connect", "start_listening", "get_states", "disconnect"]
+    assert provider._listen_task is None
+
+
+async def test_listener_failure_does_not_mask_feature_resolution_failure() -> None:
+    """Preserve the startup error when the listener also fails."""
+    hass = _HomeAssistantClient(
+        [],
+        BaseHassClientError("Unable to load Home Assistant states"),
+        RuntimeError("Listener failed"),
+    )
+    manifest = MagicMock()
+    manifest.domain = "hass"
+    manifest.name = "Home Assistant"
+    with patch("music_assistant.providers.hass.HomeAssistantClient", return_value=hass):
+        provider = await setup(_mass(), manifest, _config())
+        assert isinstance(provider, HomeAssistantProvider)
+
+        with pytest.raises(SetupFailedError, match="Unable to load Home Assistant states"):
+            async with asyncio.timeout(1):
+                await provider.handle_async_init()
+
+    assert hass.disconnected
+    assert provider._listen_task is None
+
+
+async def test_connection_failure_cleans_up_client() -> None:
+    """Clean up the client when connecting to Home Assistant fails."""
+    hass = _HomeAssistantClient([], connect_error=BaseHassClientError("Unable to connect"))
+    manifest = MagicMock()
+    manifest.domain = "hass"
+    manifest.name = "Home Assistant"
+    with patch("music_assistant.providers.hass.HomeAssistantClient", return_value=hass):
+        provider = await setup(_mass(), manifest, _config())
+        assert isinstance(provider, HomeAssistantProvider)
+
+        with pytest.raises(SetupFailedError, match="Unable to connect"):
+            await provider.handle_async_init()
+
+    assert hass.disconnected
     assert provider._listen_task is None
 
 


### PR DESCRIPTION
# What does this implement/fix?

Home Assistant could stall during startup because feature discovery waited for WebSocket responses before the listener was running.

- Start the listener before resolving AI Task and TTS entities.
- Clean up the listener and connection when startup fails.
- Cover the real command-response lifecycle in provider tests.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.