### PR TITLE
Rename quiz game to Music Timeline

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -3,7 +3,7 @@ Music Quiz Plugin Provider for Music Assistant.
 
 Provides the backend game engine for multiplayer music quiz games. Guests
 join with a QR code on their own device and play the selected quiz type:
-guess-the-song uses multiple-choice answers, while Hitster uses a shared
+guess-the-song uses multiple-choice answers, while Music Timeline uses a shared
 chronological timeline with optional artist and title bonuses. Trivia uses
 AI-worded multiple-choice questions grounded in selected library metadata.
 
@@ -345,8 +345,8 @@ class MusicQuizPlugin(PluginProvider):
         :param source_uris: Track, playlist, album, artist or genre URIs to draw rounds from.
         :param name: Optional game name.
         :param difficulty: Guess-the-song difficulty ("easy", "normal" or "hard").
-        :param artist_bonus_mode: Hitster artist bonus mode.
-        :param title_bonus_mode: Hitster title bonus mode.
+        :param artist_bonus_mode: Music Timeline artist bonus mode.
+        :param title_bonus_mode: Music Timeline title bonus mode.
         """
         quiz_type_class = get_quiz_type(quiz_type)
         get_answer_type(quiz_type_class.answer_type)

--- a/music_assistant/providers/music_quiz/quiz_types/__init__.py
+++ b/music_assistant/providers/music_quiz/quiz_types/__init__.py
@@ -9,7 +9,7 @@ from music_assistant_models.errors import InvalidDataError
 from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
 from music_assistant.providers.music_quiz.quiz_types.base import QuizType
 from music_assistant.providers.music_quiz.quiz_types.guess_the_song import GuessTheSongQuizType
-from music_assistant.providers.music_quiz.quiz_types.hitster import HitsterQuizType
+from music_assistant.providers.music_quiz.quiz_types.music_timeline import MusicTimelineQuizType
 from music_assistant.providers.music_quiz.quiz_types.trivia import TriviaQuizType
 
 if TYPE_CHECKING:
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 QUIZ_TYPES: dict[str, type[QuizType]] = {
     "guess_the_song": GuessTheSongQuizType,
-    "hitster": HitsterQuizType,
+    "music_timeline": MusicTimelineQuizType,
     "trivia": TriviaQuizType,
 }
 

--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -1,4 +1,4 @@
-"""Hitster quiz type: place the currently playing track on a shared timeline."""
+"""Music Timeline quiz type: place the currently playing track on a shared timeline."""
 
 from __future__ import annotations
 
@@ -56,7 +56,7 @@ MAX_AI_PROMPT_BYTES = 8192
 MAX_AI_RESPONSE_BYTES = 4096
 
 
-class HitsterQuizType(QuizType):
+class MusicTimelineQuizType(QuizType):
     """Quiz type where players place songs on a shared chronological timeline."""
 
     answer_type = MusicQuizAnswerType.TIMELINE
@@ -64,7 +64,7 @@ class HitsterQuizType(QuizType):
 
     def __init__(self, mass: MusicAssistant, config: MusicQuizConfig) -> None:
         """
-        Initialize the Hitster quiz type for a single game.
+        Initialize the Music Timeline quiz type for a single game.
 
         :param mass: MusicAssistant instance.
         :param config: Config of the game this quiz type generates rounds for.
@@ -75,7 +75,7 @@ class HitsterQuizType(QuizType):
     @classmethod
     def normalize_config(cls, config: MusicQuizConfig) -> MusicQuizConfig:
         """
-        Set fixed internal defaults for configuration not exposed by Hitster.
+        Set fixed internal defaults for configuration not exposed by Music Timeline.
 
         :param config: Raw typed game configuration.
         :return: Configuration to persist for this quiz type.
@@ -89,7 +89,7 @@ class HitsterQuizType(QuizType):
     @classmethod
     def validate_config(cls, config: MusicQuizConfig) -> None:
         """
-        Validate Hitster source and bonus-mode requirements.
+        Validate Music Timeline source and bonus-mode requirements.
 
         :param config: Configuration to validate.
         """
@@ -116,7 +116,7 @@ class HitsterQuizType(QuizType):
         required_track_count = self.config.round_count + 1
         if len(eligible_tracks) < required_track_count:
             raise InvalidDataError(
-                f"Hitster requires at least {required_track_count} unique tracks with release years",
+                f"Music Timeline requires at least {required_track_count} unique tracks with release years",
                 translation_key="music_quiz_not_enough_dated_tracks",
                 translation_owner=TRANSLATION_OWNER,
                 translation_args=[required_track_count],
@@ -126,7 +126,7 @@ class HitsterQuizType(QuizType):
         self, round_index: int, previous_rounds: list[MusicQuizRound]
     ) -> MusicQuizRound:
         """
-        Prepare a Hitster round against the timeline guaranteed at reveal.
+        Prepare a Music Timeline round against the timeline guaranteed at reveal.
 
         :param round_index: Index of the round to prepare.
         :param previous_rounds: Rounds already prepared in earlier iterations.
@@ -135,9 +135,11 @@ class HitsterQuizType(QuizType):
         """
         eligible_tracks = await self._get_eligible_tracks()
         if round_index < 0 or round_index >= self.config.round_count:
-            raise InvalidDataError("Hitster round index is outside the configured game")
+            raise InvalidDataError("Music Timeline round index is outside the configured game")
         if len(previous_rounds) != round_index:
-            raise InvalidDataError("Hitster round history does not match the requested round")
+            raise InvalidDataError(
+                "Music Timeline round history does not match the requested round"
+            )
 
         if round_index == 0:
             anchor_track = self._select_unused_track(eligible_tracks, set())
@@ -167,7 +169,7 @@ class HitsterQuizType(QuizType):
 
     def reject_track(self, track_uri: str) -> None:
         """
-        Remove a failed track from future Hitster rounds.
+        Remove a failed track from future Music Timeline rounds.
 
         :param track_uri: URI of the track that failed playback.
         """
@@ -229,7 +231,7 @@ class HitsterQuizType(QuizType):
         """Create a stable timeline entry from an eligible track."""
         release_year = self._release_year(track)
         if release_year is None or not track.uri or not track.artist_str:
-            raise InvalidDataError("Hitster track is missing required timeline metadata")
+            raise InvalidDataError("Music Timeline track is missing required timeline metadata")
         existing_ids = existing_ids or set()
         while (entry_id := secrets.token_hex(8)) in existing_ids:
             continue
@@ -273,7 +275,7 @@ class HitsterQuizType(QuizType):
                 continue
             correct_value = values[bonus_type]
             if not correct_value:
-                raise InvalidDataError("Hitster track is missing required bonus metadata")
+                raise InvalidDataError("Music Timeline track is missing required bonus metadata")
             if mode == TimelineBonusMode.FREE_TEXT:
                 definitions.append(TimelineFreeTextBonusDefinition(bonus_type=bonus_type))
                 continue
@@ -454,7 +456,7 @@ class HitsterQuizType(QuizType):
             ranked_ids = self._parse_ai_ranking(response, set(candidate_map))
         except Exception as err:
             LOGGER.debug(
-                "Hitster bonus ranking failed via %s (%s)",
+                "Music Timeline bonus ranking failed via %s (%s)",
                 provider.instance_id,
                 type(err).__name__,
             )
@@ -491,9 +493,9 @@ class HitsterQuizType(QuizType):
             'object with only this key: {"ranked_ids":["candidate_0", "..."]}. '
             "The array must be a complete permutation of every supplied candidate ID. Return "
             "no markdown, code fences, preamble, or explanation.\n"
-            "BEGIN_UNTRUSTED_HITSTER_CANDIDATES_JSON\n"
+            "BEGIN_UNTRUSTED_MUSIC_TIMELINE_CANDIDATES_JSON\n"
             f"{grounded_data}\n"
-            "END_UNTRUSTED_HITSTER_CANDIDATES_JSON"
+            "END_UNTRUSTED_MUSIC_TIMELINE_CANDIDATES_JSON"
         )
 
     def _parse_ai_ranking(self, response: object, candidate_ids: set[str]) -> list[str]:
@@ -627,21 +629,25 @@ class HitsterQuizType(QuizType):
         timeline: list[TimelineEntry] = []
         for previous_round in previous_rounds:
             if not isinstance(previous_round.answer_state, TimelineRoundState):
-                raise InvalidDataError("Hitster round history contains a different answer type")
+                raise InvalidDataError(
+                    "Music Timeline round history contains a different answer type"
+                )
             state = previous_round.answer_state
             expected_snapshot = sorted(
                 timeline or state.placement_snapshot,
                 key=lambda entry: (entry.release_year, entry.entry_id),
             )
             if state.placement_snapshot != expected_snapshot:
-                raise InvalidDataError("Hitster round history contains a stale timeline snapshot")
+                raise InvalidDataError(
+                    "Music Timeline round history contains a stale timeline snapshot"
+                )
             timeline = sorted(
                 [*state.placement_snapshot, state.candidate.entry],
                 key=lambda entry: (entry.release_year, entry.entry_id),
             )
         track_uris = [entry.track_uri for entry in timeline]
         if len(track_uris) != len(set(track_uris)):
-            raise InvalidDataError("Hitster round history contains duplicate tracks")
+            raise InvalidDataError("Music Timeline round history contains duplicate tracks")
         return timeline
 
     def _bonus_mode(self, bonus_type: TimelineBonusType) -> TimelineBonusMode:
@@ -693,7 +699,7 @@ class HitsterQuizType(QuizType):
 
     @classmethod
     def _track_is_eligible(cls, track: Track) -> bool:
-        """Return whether a track has all metadata required by Hitster."""
+        """Return whether a track has all metadata required by Music Timeline."""
         return bool(
             track.available
             and track.is_playable

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -1,4 +1,4 @@
-"""Tests for the Hitster Music Quiz type."""
+"""Tests for the Music Timeline Music Quiz type."""
 
 from __future__ import annotations
 
@@ -29,11 +29,11 @@ from music_assistant.providers.music_quiz.models import (
     TimelineMultipleChoiceBonusDefinition,
     TimelineRoundState,
 )
-from music_assistant.providers.music_quiz.quiz_types.hitster import (
+from music_assistant.providers.music_quiz.quiz_types.music_timeline import (
     AI_QUERY_TIMEOUT_SECONDS,
     DEFAULT_BONUS_OPTION_COUNT,
     TRACK_ENRICHMENT_CONCURRENCY,
-    HitsterQuizType,
+    MusicTimelineQuizType,
 )
 from music_assistant.providers.music_quiz.suggestions import SuggestionCandidate
 
@@ -109,7 +109,7 @@ def _ai_provider(
 
 
 def _mass() -> MagicMock:
-    """Return a mock MusicAssistant for Hitster tests."""
+    """Return a mock MusicAssistant for Music Timeline tests."""
     mass = MagicMock()
     mass.metadata.get_image_url_for_item = AsyncMock(
         side_effect=lambda track: f"https://img/{track.item_id}"
@@ -130,8 +130,8 @@ def _quiz(
     artist_mode: TimelineBonusMode = TimelineBonusMode.OFF,
     title_mode: TimelineBonusMode = TimelineBonusMode.OFF,
     use_ai: bool = False,
-) -> tuple[HitsterQuizType, MagicMock]:
-    """Return a Hitster type backed by a deterministic source pool."""
+) -> tuple[MusicTimelineQuizType, MagicMock]:
+    """Return a Music Timeline type backed by a deterministic source pool."""
     mass = _mass()
     config = MusicQuizConfig(
         round_count=round_count,
@@ -140,12 +140,12 @@ def _quiz(
         title_bonus_mode=title_mode,
         use_ai_distractors=use_ai,
     )
-    quiz = HitsterQuizType(mass, config)
+    quiz = MusicTimelineQuizType(mass, config)
     quiz._source_track_pool = {track.uri: track for track in tracks if track.uri}
     return quiz, mass
 
 
-def test_config_normalization_and_validation_are_hitster_specific() -> None:
+def test_config_normalization_and_validation_are_music_timeline_specific() -> None:
     """Use fixed option defaults without requiring guess-the-song settings."""
     config = MusicQuizConfig(
         round_count=2,
@@ -157,14 +157,14 @@ def test_config_normalization_and_validation_are_hitster_specific() -> None:
         title_bonus_mode=TimelineBonusMode.MULTIPLE_CHOICE,
     )
 
-    normalized = HitsterQuizType.normalize_config(config)
-    HitsterQuizType.validate_config(normalized)
+    normalized = MusicTimelineQuizType.normalize_config(config)
+    MusicTimelineQuizType.validate_config(normalized)
 
     assert normalized.suggestion_count == DEFAULT_BONUS_OPTION_COUNT
     assert normalized.difficulty == MusicQuizDifficulty.NORMAL.value
     assert normalized.use_ai_distractors is True
     with pytest.raises(InvalidDataError, match="bonus mode"):
-        HitsterQuizType.validate_config(
+        MusicTimelineQuizType.validate_config(
             MusicQuizConfig(
                 source_uris=["prov://playlist/1"],
                 artist_bonus_mode=cast("TimelineBonusMode", "invalid"),
@@ -368,17 +368,17 @@ def test_release_year_uses_earliest_valid_track_or_album_year() -> None:
         release_year=999,
     )
 
-    assert HitsterQuizType._release_year(track_first) == 1999
-    assert HitsterQuizType._release_year(album_first) == 2000
-    assert HitsterQuizType._release_year(album_only) == 2001
-    assert HitsterQuizType._release_year(track_only) == 2003
-    assert HitsterQuizType._release_year(future_album) == 2004
-    assert HitsterQuizType._release_year(too_old_track) == 2006
-    assert HitsterQuizType._release_year(invalid) is None
+    assert MusicTimelineQuizType._release_year(track_first) == 1999
+    assert MusicTimelineQuizType._release_year(album_first) == 2000
+    assert MusicTimelineQuizType._release_year(album_only) == 2001
+    assert MusicTimelineQuizType._release_year(track_only) == 2003
+    assert MusicTimelineQuizType._release_year(future_album) == 2004
+    assert MusicTimelineQuizType._release_year(too_old_track) == 2006
+    assert MusicTimelineQuizType._release_year(invalid) is None
 
 
-def test_reject_track_removes_it_from_hitster_caches() -> None:
-    """Exclude failed playback tracks from future Hitster selection."""
+def test_reject_track_removes_it_from_music_timeline_caches() -> None:
+    """Exclude failed playback tracks from future Music Timeline selection."""
     failed = _track("failed", "Unavailable", "Artist", album_year=2000)
     available = _track("available", "Playable", "Artist", album_year=2001)
     quiz, _ = _quiz([failed, available])
@@ -403,14 +403,14 @@ async def test_prepare_round_seeds_anchor_and_prefetches_guaranteed_future_snaps
     quiz._eligible_tracks = [anchor, first, second]
 
     with patch(
-        "music_assistant.providers.music_quiz.quiz_types.hitster.secrets.choice",
+        "music_assistant.providers.music_quiz.quiz_types.music_timeline.secrets.choice",
         side_effect=[anchor, first],
     ):
         first_round = await quiz.prepare_round(0, [])
     reconnected_quiz, _ = _quiz([anchor, first, second], round_count=2)
     reconnected_quiz._eligible_tracks = [anchor, first, second]
     with patch(
-        "music_assistant.providers.music_quiz.quiz_types.hitster.secrets.choice",
+        "music_assistant.providers.music_quiz.quiz_types.music_timeline.secrets.choice",
         return_value=second,
     ):
         second_round = await reconnected_quiz.prepare_round(1, [first_round])
@@ -458,7 +458,7 @@ async def test_prepare_round_builds_free_text_and_opaque_multiple_choice_bonuses
     quiz._eligible_tracks = tracks
 
     with patch(
-        "music_assistant.providers.music_quiz.quiz_types.hitster.secrets.choice",
+        "music_assistant.providers.music_quiz.quiz_types.music_timeline.secrets.choice",
         side_effect=tracks[:2],
     ):
         game_round = await quiz.prepare_round(0, [])
@@ -755,7 +755,7 @@ async def test_ai_ranking_timeout_falls_back_to_catalog_order() -> None:
     candidates = [SuggestionCandidate("Daft Punk"), SuggestionCandidate("Air")]
 
     with patch(
-        "music_assistant.providers.music_quiz.quiz_types.hitster.AI_QUERY_TIMEOUT_SECONDS",
+        "music_assistant.providers.music_quiz.quiz_types.music_timeline.AI_QUERY_TIMEOUT_SECONDS",
         AI_QUERY_TIMEOUT_SECONDS / 30_000,
     ):
         ranked = await quiz._rank_bonus_candidates(
@@ -785,7 +785,7 @@ async def test_candidate_persists_display_artist_contributors_and_sort_aliases()
     quiz._eligible_tracks = [anchor, current]
 
     with patch(
-        "music_assistant.providers.music_quiz.quiz_types.hitster.secrets.choice",
+        "music_assistant.providers.music_quiz.quiz_types.music_timeline.secrets.choice",
         side_effect=[anchor, current],
     ):
         game_round = await quiz.prepare_round(0, [])

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -109,12 +109,12 @@ def _make_round(round_index: int, suggestion_count: int = 4) -> MusicQuizRound:
     )
 
 
-def _make_hitster_round(
+def _make_music_timeline_round(
     round_index: int,
     previous_rounds: list[MusicQuizRound],
     bonus_definitions: list[TimelineBonusDefinition] | None = None,
 ) -> MusicQuizRound:
-    """Return a deterministic Hitster round with a prefetch-safe snapshot."""
+    """Return a deterministic Music Timeline round with a prefetch-safe snapshot."""
     if previous_rounds:
         previous_state = previous_rounds[-1].answer_state
         assert isinstance(previous_state, TimelineRoundState)
@@ -135,12 +135,12 @@ def _make_hitster_round(
             )
         ]
     current_entry = TimelineEntry(
-        entry_id=f"hitster-{round_index}",
+        entry_id=f"music_timeline-{round_index}",
         release_year=2000 + round_index,
         title=f"Secret Title {round_index}",
         artist=f"Secret Artist {round_index}",
-        track_uri=f"library://track/hitster-{round_index}",
-        image_url=f"https://img/hitster-{round_index}",
+        track_uri=f"library://track/music_timeline-{round_index}",
+        image_url=f"https://img/music_timeline-{round_index}",
     )
     return MusicQuizRound(
         round_index=round_index,
@@ -320,7 +320,7 @@ async def _create_started_game(
     return player_ids
 
 
-async def _create_started_hitster_game(
+async def _create_started_music_timeline_game(
     plugin: MusicQuizPlugin,
     player_names: tuple[str, ...] = ("Alice",),
     round_count: int = 1,
@@ -328,9 +328,9 @@ async def _create_started_hitster_game(
     artist_bonus_mode: str = TimelineBonusMode.OFF.value,
     title_bonus_mode: str = TimelineBonusMode.OFF.value,
 ) -> dict[str, str]:
-    """Create and start a Hitster game, returning name-to-player credentials."""
+    """Create and start a Music Timeline game, returning name-to-player credentials."""
     await plugin.create_game(
-        quiz_type="hitster",
+        quiz_type="music_timeline",
         round_count=round_count,
         source_uris=["library://playlist/1"],
         name="Timeline Quiz",
@@ -815,11 +815,11 @@ async def test_available_quiz_types_reflect_ai_plugin_availability() -> None:
     providers = cast("MagicMock", plugin.mass.get_providers_supporting_feature)
 
     providers.return_value = []
-    assert await plugin.available_quiz_types() == ["guess_the_song", "hitster"]
+    assert await plugin.available_quiz_types() == ["guess_the_song", "music_timeline"]
     providers.return_value = [MagicMock()]
-    assert await plugin.available_quiz_types() == ["guess_the_song", "hitster"]
+    assert await plugin.available_quiz_types() == ["guess_the_song", "music_timeline"]
     providers.return_value = [MagicMock(spec=PluginProvider)]
-    assert await plugin.available_quiz_types() == ["guess_the_song", "hitster", "trivia"]
+    assert await plugin.available_quiz_types() == ["guess_the_song", "music_timeline", "trivia"]
 
 
 @pytest.mark.parametrize(
@@ -827,7 +827,7 @@ async def test_available_quiz_types_reflect_ai_plugin_availability() -> None:
     [(None, "anchor"), ("anchor", None)],
 )
 @pytest.mark.asyncio
-async def test_hitster_edge_placement_accepts_null_at_api_boundary(
+async def test_music_timeline_edge_placement_accepts_null_at_api_boundary(
     previous_entry_id: str | None,
     next_entry_id: str | None,
 ) -> None:
@@ -843,17 +843,19 @@ async def test_hitster_edge_placement_accepts_null_at_api_boundary(
     await plugin.loaded_in_mass()
     with (
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.initialize",
             new=AsyncMock(),
         ),
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.prepare_round",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.prepare_round",
             new=AsyncMock(
-                side_effect=lambda round_index, previous: _make_hitster_round(round_index, previous)
+                side_effect=lambda round_index, previous: _make_music_timeline_round(
+                    round_index, previous
+                )
             ),
         ),
     ):
-        player_ids = await _create_started_hitster_game(plugin)
+        player_ids = await _create_started_music_timeline_game(plugin)
         handler = registered["music_quiz/submit_answer"]
         arguments = parse_arguments(
             handler.signature,
@@ -1215,23 +1217,25 @@ async def test_trivia_reset_delete_and_recreate_keep_lifecycle_non_audio() -> No
 
 
 @pytest.mark.asyncio
-async def test_hitster_create_uses_flat_config_and_derived_answer_type() -> None:
-    """Create Hitster from flattened fields without exposing GTS-only controls."""
+async def test_music_timeline_create_uses_flat_config_and_derived_answer_type() -> None:
+    """Create Music Timeline from flattened fields without exposing GTS-only controls."""
     plugin = _create_plugin(use_ai_distractors=True)
     with (
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.initialize",
             new=AsyncMock(),
         ),
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.prepare_round",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.prepare_round",
             new=AsyncMock(
-                side_effect=lambda round_index, previous: _make_hitster_round(round_index, previous)
+                side_effect=lambda round_index, previous: _make_music_timeline_round(
+                    round_index, previous
+                )
             ),
         ),
     ):
         created = await plugin.create_game(
-            quiz_type="hitster",
+            quiz_type="music_timeline",
             round_count=2,
             suggestion_count=9,
             source_uris=["library://playlist/1"],
@@ -1242,7 +1246,7 @@ async def test_hitster_create_uses_flat_config_and_derived_answer_type() -> None
 
     game = plugin._game
     assert game is not None
-    assert game.quiz_type == "hitster"
+    assert game.quiz_type == "music_timeline"
     assert game.answer_type == "timeline"
     assert game.config.suggestion_count == 4
     assert game.config.difficulty == "normal"
@@ -1253,23 +1257,27 @@ async def test_hitster_create_uses_flat_config_and_derived_answer_type() -> None
 
 
 @pytest.mark.asyncio
-async def test_hitster_placement_auto_reveals_without_bonuses_and_never_warms_lyrics() -> None:
-    """Complete on placement, preserve playback, and skip lyrics warm-up for Hitster."""
+async def test_music_timeline_placement_auto_reveals_without_bonuses_and_never_warms_lyrics() -> (
+    None
+):
+    """Complete on placement, preserve playback, and skip lyrics warm-up for Music Timeline."""
     plugin = _create_plugin()
     plugin._warm_up_lyrics = MagicMock()  # type: ignore[method-assign]
     with (
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.initialize",
             new=AsyncMock(),
         ),
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.prepare_round",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.prepare_round",
             new=AsyncMock(
-                side_effect=lambda round_index, previous: _make_hitster_round(round_index, previous)
+                side_effect=lambda round_index, previous: _make_music_timeline_round(
+                    round_index, previous
+                )
             ),
         ),
     ):
-        player_ids = await _create_started_hitster_game(plugin)
+        player_ids = await _create_started_music_timeline_game(plugin)
         _, deadline_callback, round_index = _round_timer_call(plugin, plugin._reveal_timer_id)
         signal = cast("MagicMock", plugin.signal_provider_event)
         hidden_state = signal.call_args[0][0]["state"]
@@ -1317,15 +1325,20 @@ async def test_hitster_placement_auto_reveals_without_bonuses_and_never_warms_ly
         assert game.rounds[0].auto_advance_at == 130.0
         assert state["current_round"]["auto_advance_at"] == 130.0
         assert game.players[player_ids["Alice"]].score == 1000
-        cast("AsyncMock", plugin._play_track).assert_awaited_with("library://track/hitster-0")
+        cast("AsyncMock", plugin._play_track).assert_awaited_with(
+            "library://track/music_timeline-0"
+        )
         plugin._warm_up_lyrics.assert_not_called()
         assert state["current_round"]["revealed_entry"]["release_year"] == 2000
         assert [entry["entry_id"] for entry in state["current_round"]["timeline"]] == [
             "anchor",
-            "hitster-0",
+            "music_timeline-0",
         ]
         assert (
-            sum(entry["entry_id"] == "hitster-0" for entry in state["current_round"]["timeline"])
+            sum(
+                entry["entry_id"] == "music_timeline-0"
+                for entry in state["current_round"]["timeline"]
+            )
             == 1
         )
         assert state["you"]["answer"]["previous_entry_id"] == "anchor"
@@ -1343,23 +1356,23 @@ async def test_hitster_placement_auto_reveals_without_bonuses_and_never_warms_ly
 
 
 @pytest.mark.asyncio
-async def test_hitster_ready_cancels_intermediate_auto_advance() -> None:
+async def test_music_timeline_ready_cancels_intermediate_auto_advance() -> None:
     """Advance once on Ready and ignore the stale reveal timer."""
     plugin = _create_plugin()
     prepare_round = AsyncMock(
-        side_effect=lambda round_index, previous: _make_hitster_round(round_index, previous)
+        side_effect=lambda round_index, previous: _make_music_timeline_round(round_index, previous)
     )
     with (
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.initialize",
             new=AsyncMock(),
         ),
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.prepare_round",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.prepare_round",
             new=prepare_round,
         ),
     ):
-        player_ids = await _create_started_hitster_game(plugin, round_count=2)
+        player_ids = await _create_started_music_timeline_game(plugin, round_count=2)
         with (
             patch(
                 "music_assistant.providers.music_quiz.get_current_user",
@@ -1404,7 +1417,9 @@ async def test_hitster_ready_cancels_intermediate_auto_advance() -> None:
         assert first_round.to_dict()["auto_advance_at"] is None
         assert state["current_round"]["round_index"] == 1
         cast("MagicMock", plugin.mass.cancel_timer).assert_any_call(plugin._advance_timer_id)
-        cast("AsyncMock", plugin._play_track).assert_awaited_once_with("library://track/hitster-1")
+        cast("AsyncMock", plugin._play_track).assert_awaited_once_with(
+            "library://track/music_timeline-1"
+        )
         assert prepare_round.await_count == 2
 
         await stale_callback(stale_round_index)
@@ -1417,7 +1432,7 @@ async def test_hitster_ready_cancels_intermediate_auto_advance() -> None:
 
 
 @pytest.mark.asyncio
-async def test_hitster_finish_skips_unanswered_bonus() -> None:
+async def test_music_timeline_finish_skips_unanswered_bonus() -> None:
     """Keep finish as a backward-compatible way to skip a bonus."""
     definitions: list[TimelineBonusDefinition] = [
         TimelineFreeTextBonusDefinition(
@@ -1436,19 +1451,19 @@ async def test_hitster_finish_skips_unanswered_bonus() -> None:
     plugin = _create_plugin()
     with (
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.initialize",
             new=AsyncMock(),
         ),
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.prepare_round",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.prepare_round",
             new=AsyncMock(
-                side_effect=lambda round_index, previous: _make_hitster_round(
+                side_effect=lambda round_index, previous: _make_music_timeline_round(
                     round_index, previous, definitions
                 )
             ),
         ),
     ):
-        player_ids = await _create_started_hitster_game(
+        player_ids = await _create_started_music_timeline_game(
             plugin,
             artist_bonus_mode="free_text",
             title_bonus_mode="multiple_choice",
@@ -1499,7 +1514,7 @@ async def test_hitster_finish_skips_unanswered_bonus() -> None:
 
 
 @pytest.mark.asyncio
-async def test_hitster_deadline_scores_unfinished_placement_and_bonus() -> None:
+async def test_music_timeline_deadline_scores_unfinished_placement_and_bonus() -> None:
     """Reveal and score submitted work at the deadline without a finish action."""
     definitions: list[TimelineBonusDefinition] = [
         TimelineFreeTextBonusDefinition(
@@ -1518,20 +1533,20 @@ async def test_hitster_deadline_scores_unfinished_placement_and_bonus() -> None:
     plugin = _create_plugin()
     with (
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.initialize",
             new=AsyncMock(),
         ),
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.prepare_round",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.prepare_round",
             new=AsyncMock(
-                side_effect=lambda round_index, previous: _make_hitster_round(
+                side_effect=lambda round_index, previous: _make_music_timeline_round(
                     round_index, previous, definitions
                 )
             ),
         ),
     ):
         with patch("music_assistant.providers.music_quiz.time.time", return_value=100.0):
-            player_ids = await _create_started_hitster_game(
+            player_ids = await _create_started_music_timeline_game(
                 plugin,
                 artist_bonus_mode="free_text",
                 title_bonus_mode="multiple_choice",
@@ -1580,23 +1595,25 @@ async def test_hitster_deadline_scores_unfinished_placement_and_bonus() -> None:
 
 
 @pytest.mark.asyncio
-async def test_hitster_manual_reveal_keeps_track_end_auto_advance() -> None:
-    """Keep the existing track-end schedule for a manual Hitster reveal."""
+async def test_music_timeline_manual_reveal_keeps_track_end_auto_advance() -> None:
+    """Keep the existing track-end schedule for a manual Music Timeline reveal."""
     plugin = _create_plugin()
     with (
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.initialize",
             new=AsyncMock(),
         ),
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.prepare_round",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.prepare_round",
             new=AsyncMock(
-                side_effect=lambda round_index, previous: _make_hitster_round(round_index, previous)
+                side_effect=lambda round_index, previous: _make_music_timeline_round(
+                    round_index, previous
+                )
             ),
         ),
         patch("music_assistant.providers.music_quiz.time.time", return_value=100.0),
     ):
-        await _create_started_hitster_game(plugin)
+        await _create_started_music_timeline_game(plugin)
 
     with patch("music_assistant.providers.music_quiz.time.time", return_value=110.0):
         state = await plugin.reveal()
@@ -1610,7 +1627,7 @@ async def test_hitster_manual_reveal_keeps_track_end_auto_advance() -> None:
 
 
 @pytest.mark.asyncio
-async def test_hitster_host_public_and_personalized_rounds_remain_flat() -> None:
+async def test_music_timeline_host_public_and_personalized_rounds_remain_flat() -> None:
     """Compose strategy fragments without leaking nested persisted answer state."""
     definitions: list[TimelineBonusDefinition] = [
         TimelineFreeTextBonusDefinition(
@@ -1620,19 +1637,19 @@ async def test_hitster_host_public_and_personalized_rounds_remain_flat() -> None
     plugin = _create_plugin()
     with (
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.initialize",
             new=AsyncMock(),
         ),
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.prepare_round",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.prepare_round",
             new=AsyncMock(
-                side_effect=lambda round_index, previous: _make_hitster_round(
+                side_effect=lambda round_index, previous: _make_music_timeline_round(
                     round_index, previous, definitions
                 )
             ),
         ),
     ):
-        player_ids = await _create_started_hitster_game(
+        player_ids = await _create_started_music_timeline_game(
             plugin,
             artist_bonus_mode="free_text",
         )
@@ -1702,8 +1719,8 @@ async def test_hitster_host_public_and_personalized_rounds_remain_flat() -> None
 
 
 @pytest.mark.asyncio
-async def test_hitster_reset_preserves_config_and_reinitializes_strategy() -> None:
-    """Reset Hitster to a fresh lobby while preserving its typed game config."""
+async def test_music_timeline_reset_preserves_config_and_reinitializes_strategy() -> None:
+    """Reset Music Timeline to a fresh lobby while preserving its typed game config."""
     plugin = _create_plugin()
     pending_task = MagicMock()
     pending_task.cancelled.return_value = False
@@ -1722,17 +1739,19 @@ async def test_hitster_reset_preserves_config_and_reinitializes_strategy() -> No
     initialize = AsyncMock(side_effect=_initialize)
     with (
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.initialize",
             new=initialize,
         ),
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.prepare_round",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.prepare_round",
             new=AsyncMock(
-                side_effect=lambda round_index, previous: _make_hitster_round(round_index, previous)
+                side_effect=lambda round_index, previous: _make_music_timeline_round(
+                    round_index, previous
+                )
             ),
         ),
     ):
-        await _create_started_hitster_game(plugin)
+        await _create_started_music_timeline_game(plugin)
         plugin._next_round_task = pending_task
         cast("MagicMock", plugin.mass.cancel_timer).reset_mock()
         cast("MagicMock", plugin.mass.cancel_task).reset_mock()
@@ -1751,7 +1770,7 @@ async def test_hitster_reset_preserves_config_and_reinitializes_strategy() -> No
     cast("AsyncMock", plugin._stop_playback).assert_awaited_once()
     assert game.rounds == []
     assert state["phase"] == "lobby"
-    assert state["quiz_type"] == "hitster"
+    assert state["quiz_type"] == "music_timeline"
     assert state["answer_type"] == "timeline"
     assert state["artist_bonus_mode"] == "off"
     assert state["title_bonus_mode"] == "off"
@@ -1762,7 +1781,7 @@ async def test_hitster_reset_preserves_config_and_reinitializes_strategy() -> No
     "initial_phase",
     [MusicQuizPhase.ANSWERING, MusicQuizPhase.REVEAL],
 )
-async def test_hitster_failed_reset_preserves_active_game(
+async def test_music_timeline_failed_reset_preserves_active_game(
     initial_phase: MusicQuizPhase,
 ) -> None:
     """Keep the current game and its background work intact when initialization fails."""
@@ -1775,17 +1794,19 @@ async def test_hitster_failed_reset_preserves_active_game(
     )
     with (
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.initialize",
             new=initialize,
         ),
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.prepare_round",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.prepare_round",
             new=AsyncMock(
-                side_effect=lambda round_index, previous: _make_hitster_round(round_index, previous)
+                side_effect=lambda round_index, previous: _make_music_timeline_round(
+                    round_index, previous
+                )
             ),
         ),
     ):
-        await _create_started_hitster_game(plugin, round_count=2)
+        await _create_started_music_timeline_game(plugin, round_count=2)
         game = plugin._game
         assert game is not None
         if initial_phase == MusicQuizPhase.REVEAL:
@@ -1831,22 +1852,24 @@ async def test_hitster_failed_reset_preserves_active_game(
 
 
 @pytest.mark.asyncio
-async def test_hitster_late_joiner_starts_on_prefetched_next_round() -> None:
+async def test_music_timeline_late_joiner_starts_on_prefetched_next_round() -> None:
     """Exclude a late joiner from the active round and include them in the next snapshot."""
     plugin = _create_plugin()
     with (
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.initialize",
             new=AsyncMock(),
         ),
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.prepare_round",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.prepare_round",
             new=AsyncMock(
-                side_effect=lambda round_index, previous: _make_hitster_round(round_index, previous)
+                side_effect=lambda round_index, previous: _make_music_timeline_round(
+                    round_index, previous
+                )
             ),
         ),
     ):
-        player_ids = await _create_started_hitster_game(plugin, round_count=2)
+        player_ids = await _create_started_music_timeline_game(plugin, round_count=2)
         with patch(
             "music_assistant.providers.music_quiz.get_current_user",
             return_value=_guest_user(),
@@ -1890,14 +1913,14 @@ async def test_hitster_late_joiner_starts_on_prefetched_next_round() -> None:
             second_state = _timeline_answer_state(game.rounds[1])
             assert [entry.entry_id for entry in second_state.placement_snapshot] == [
                 "anchor",
-                "hitster-0",
+                "music_timeline-0",
             ]
             await plugin.submit_answer(
                 player_ids["Alice"],
                 {
                     "answer_type": "timeline",
                     "action": "place",
-                    "previous_entry_id": "hitster-0",
+                    "previous_entry_id": "music_timeline-0",
                     "next_entry_id": None,
                 },
             )
@@ -1908,7 +1931,7 @@ async def test_hitster_late_joiner_starts_on_prefetched_next_round() -> None:
                     {
                         "answer_type": "timeline",
                         "action": "place",
-                        "previous_entry_id": "hitster-0",
+                        "previous_entry_id": "music_timeline-0",
                         "next_entry_id": None,
                     },
                 ),
@@ -3149,18 +3172,20 @@ async def test_create_game_cancels_previous_background_work_after_initialize() -
 
     with (
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.initialize",
             new=_initialize,
         ),
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.prepare_round",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.prepare_round",
             new=AsyncMock(
-                side_effect=lambda round_index, previous: _make_hitster_round(round_index, previous)
+                side_effect=lambda round_index, previous: _make_music_timeline_round(
+                    round_index, previous
+                )
             ),
         ),
     ):
         await plugin.create_game(
-            quiz_type="hitster",
+            quiz_type="music_timeline",
             source_uris=["library://playlist/2"],
         )
 
@@ -3229,13 +3254,13 @@ async def test_create_game_initialize_failure_preserves_existing_finished_game()
     initialize = AsyncMock(side_effect=InvalidDataError("Initialization failed"))
     with (
         patch(
-            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.initialize",
             new=initialize,
         ),
         pytest.raises(InvalidDataError, match="Initialization failed"),
     ):
         await plugin.create_game(
-            quiz_type="hitster",
+            quiz_type="music_timeline",
             source_uris=["library://playlist/2"],
         )
 

--- a/tests/providers/music_quiz/test_sources.py
+++ b/tests/providers/music_quiz/test_sources.py
@@ -28,7 +28,7 @@ from music_assistant.providers.music_quiz.quiz_types.base import (
     MAX_GENRE_TRACK_COUNT,
 )
 from music_assistant.providers.music_quiz.quiz_types.guess_the_song import GuessTheSongQuizType
-from music_assistant.providers.music_quiz.quiz_types.hitster import HitsterQuizType
+from music_assistant.providers.music_quiz.quiz_types.music_timeline import MusicTimelineQuizType
 
 SourceItem = Album | Artist | Genre | ItemMapping | Playlist | Track
 
@@ -426,14 +426,14 @@ async def test_guess_the_song_prepares_from_album_source() -> None:
 
 
 @pytest.mark.asyncio
-async def test_hitster_prepares_from_artist_source() -> None:
-    """Prepare Hitster unchanged from an expanded source collection."""
+async def test_music_timeline_prepares_from_artist_source() -> None:
+    """Prepare Music Timeline unchanged from an expanded source collection."""
     artist = _artist()
     tracks = [_track("one", year=1990), _track("two", year=2000)]
     artist_uri = _uri(artist)
     mass = _mass({artist_uri: artist})
     mass.music.artists.tracks.return_value = tracks
-    quiz = HitsterQuizType(
+    quiz = MusicTimelineQuizType(
         mass,
         MusicQuizConfig(round_count=1, source_uris=[artist_uri]),
     )

--- a/tests/providers/music_quiz/test_timeline.py
+++ b/tests/providers/music_quiz/test_timeline.py
@@ -109,7 +109,7 @@ def _game(
             artist_bonus_mode=artist_mode,
             title_bonus_mode=title_mode,
         ),
-        quiz_type="hitster",
+        quiz_type="music_timeline",
         answer_type=MusicQuizAnswerType.TIMELINE,
         phase=MusicQuizPhase.ANSWERING,
         players=players,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Rename the unreleased timeline quiz to Music Timeline before release to avoid using a commercial game trademark.

- Use `music_timeline` as the canonical quiz type and API identifier.
- Rename the provider implementation and tests without changing game behavior.
- Keep the reusable `timeline` answer type unchanged.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
