### PR TITLE
Add Music Quiz replay countdown

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -26,7 +26,9 @@ The public game state is guest-safe by construction. Common state contains:
 
 - always: ``phase`` (lobby/answering/reveal/finished), ``name``, ``quiz_type``,
   ``answer_type``, ``mode`` (venue/remote), ``round_count``, ``answer_duration``
-  and public player progress. Private player IDs never appear in broadcasts.
+  and public player progress. ``auto_start_at`` contains the authoritative replay
+  deadline while a lobby countdown is active. Private player IDs never appear in
+  broadcasts.
 - answering rounds expose common timing and question fields plus a strategy
   fragment. Multiple-choice exposes opaque ``suggestions``. Timeline exposes
   the revealed shared ``timeline`` and redacted ``bonus_definitions``; the
@@ -162,6 +164,7 @@ MAX_PLAYER_COUNT = 100
 MAX_PLAYER_NAME_LENGTH = 40
 PLAYER_RECONNECT_GRACE_SECONDS = 60.0
 MAX_PLAYBACK_ATTEMPTS = 5
+REPLAY_AUTO_START_SECONDS = 30
 
 # minimum time players get to see the reveal/scoreboard before the game
 # advances, even when the round track has (almost) finished playing
@@ -243,6 +246,7 @@ class MusicQuizPlugin(PluginProvider):
         self._quiz_type: QuizType | None = None
         self._answer_type: QuizAnswerType | None = None
         self._game_lock = asyncio.Lock()
+        self._game_generation = 0
         self._playback_session: SharedPlaybackSession | None = None
         self._playback_lock = asyncio.Lock()
         self._next_round_task: asyncio.Task[MusicQuizRound] | None = None
@@ -302,6 +306,7 @@ class MusicQuizPlugin(PluginProvider):
         async with self._game_lock:
             self._cancel_timers()
             self._cancel_next_round_task()
+            self._game_generation += 1
             # clear game state before tearing down the session so a guest listen-in
             # racing with unload cannot (re)create or join a session mid-teardown
             self._game = None
@@ -389,6 +394,7 @@ class MusicQuizPlugin(PluginProvider):
                     await self._close_playback_session_locked()
                 self._cancel_timers()
                 self._cancel_next_round_task()
+                self._game_generation += 1
                 self._game = game
                 self._quiz_type = quiz_strategy
                 self._answer_type = answer_strategy
@@ -412,10 +418,7 @@ class MusicQuizPlugin(PluginProvider):
     async def start_game(self) -> dict[str, Any]:
         """Start the first round of the current game."""
         async with self._game_lock:
-            game = self._require_game()
-            if game.phase != MusicQuizPhase.LOBBY:
-                raise MusicQuizWrongPhaseError("The game has already started")
-            await self._start_next_round()
+            await self._start_game_from_lobby()
             return await self._host_state()
 
     async def reveal(self) -> dict[str, Any]:
@@ -434,8 +437,12 @@ class MusicQuizPlugin(PluginProvider):
             await self._advance_from_reveal()
             return await self._host_state()
 
-    async def reset(self) -> dict[str, Any]:
-        """Reset the current game for a new run with the same settings and players."""
+    async def reset(self, auto_start: bool = False) -> dict[str, Any]:
+        """
+        Reset the current game for a new run with the same settings and players.
+
+        :param auto_start: Start a replay countdown when an active player remains.
+        """
         async with self._game_lock:
             game = self._require_game()
             quiz_strategy, answer_strategy = self._resolve_game_strategies(game)
@@ -445,11 +452,15 @@ class MusicQuizPlugin(PluginProvider):
             self._cancel_next_round_task()
             if quiz_strategy.uses_audio:
                 await self._stop_playback()
+            now = time.time()
             reset_game(game)
+            self._game_generation += 1
             self._quiz_type = quiz_strategy
             self._answer_type = answer_strategy
             self._prefetch_round(0)
-            self._schedule_presence_expiry()
+            self._schedule_presence_expiry(now)
+            if auto_start and _has_active_players(game, now):
+                self._schedule_replay_auto_start(game, now)
             self._signal_game_updated()
             return await self._host_state()
 
@@ -460,6 +471,7 @@ class MusicQuizPlugin(PluginProvider):
             uses_audio = self._quiz_type is None or self._quiz_type.uses_audio
             self._cancel_timers()
             self._cancel_next_round_task()
+            self._game_generation += 1
             # clear game state before tearing down the session so a guest listen-in
             # racing with delete cannot (re)create or join a session mid-teardown
             self._game = None
@@ -487,6 +499,7 @@ class MusicQuizPlugin(PluginProvider):
                 "mode": self._mode,
                 "player_count": len(game.players),
                 "round_count": game.config.round_count,
+                "auto_start_at": game.auto_start_at,
             }
 
     async def join_game(self, name: str) -> dict[str, Any]:
@@ -815,6 +828,19 @@ class MusicQuizPlugin(PluginProvider):
 
     # ---------- round/phase progression (call with self._game_lock held) ----------
 
+    async def _start_game_from_lobby(self, *, timer_owned: bool = False) -> None:
+        """Start the first round from the lobby."""
+        game = self._require_game()
+        if game.phase != MusicQuizPhase.LOBBY:
+            raise MusicQuizWrongPhaseError("The game has already started")
+        self._cancel_replay_auto_start(cancel_task=not timer_owned)
+        try:
+            await self._start_next_round()
+        except Exception:
+            if self._game is game and game.phase == MusicQuizPhase.LOBBY:
+                self._signal_game_updated()
+            raise
+
     async def _start_next_round(self) -> None:
         """Prepare the next round, start its playback (if any) and open the answering phase."""
         with _system_auth_context():
@@ -916,7 +942,7 @@ class MusicQuizPlugin(PluginProvider):
             expired_player_ids = [
                 player.player_id
                 for player in game.players.values()
-                if player.last_seen + PLAYER_RECONNECT_GRACE_SECONDS <= now
+                if not _is_player_active(player, now)
             ]
             if not expired_player_ids:
                 self._schedule_presence_expiry(now)
@@ -924,6 +950,13 @@ class MusicQuizPlugin(PluginProvider):
 
             for player_id in expired_player_ids:
                 remove_game_player(game, player_id, answer_type)
+
+            if (
+                game.phase == MusicQuizPhase.LOBBY
+                and game.auto_start_at is not None
+                and not _has_active_players(game, now)
+            ):
+                self._cancel_replay_auto_start(cancel_task=True)
 
             if game.players and game.phase == MusicQuizPhase.ANSWERING:
                 if all_active_players_complete(game, answer_type):
@@ -938,6 +971,41 @@ class MusicQuizPlugin(PluginProvider):
             else:
                 self._signal_game_updated()
             self._schedule_presence_expiry()
+
+    async def _on_replay_auto_start(
+        self,
+        game: MusicQuizGame,
+        generation: int,
+        auto_start_at: float,
+    ) -> None:
+        """
+        Start a replay whose authoritative countdown reached its deadline.
+
+        :param game: Game for which the countdown was scheduled.
+        :param generation: Lifecycle generation for which the countdown was scheduled.
+        :param auto_start_at: Authoritative deadline for this countdown.
+        """
+        with _system_auth_context():
+            async with self._game_lock:
+                if (
+                    self._game is not game
+                    or self._game_generation != generation
+                    or game.phase != MusicQuizPhase.LOBBY
+                    or game.auto_start_at != auto_start_at
+                ):
+                    return
+                if not _has_active_players(game, time.time()):
+                    self._cancel_replay_auto_start(cancel_task=False)
+                    self._signal_game_updated()
+                    return
+                try:
+                    await self._start_game_from_lobby(timer_owned=True)
+                except Exception as err:
+                    self.logger.error(
+                        "Could not automatically start Music Quiz replay: %s",
+                        err,
+                        exc_info=err,
+                    )
 
     async def _on_answer_deadline(self, round_index: int) -> None:
         """Reveal the round when the answering deadline passed."""
@@ -1155,6 +1223,37 @@ class MusicQuizPlugin(PluginProvider):
 
     # ---------- timers ----------
 
+    def _schedule_replay_auto_start(self, game: MusicQuizGame, now: float) -> None:
+        """
+        Schedule automatic replay startup for a lobby.
+
+        :param game: Lobby game to start.
+        :param now: Current server timestamp.
+        """
+        auto_start_at = now + REPLAY_AUTO_START_SECONDS
+        self.mass.call_later(
+            REPLAY_AUTO_START_SECONDS,
+            self._on_replay_auto_start,
+            game,
+            self._game_generation,
+            auto_start_at,
+            task_id=self._replay_auto_start_timer_id,
+        )
+        game.auto_start_at = auto_start_at
+
+    def _cancel_replay_auto_start(self, *, cancel_task: bool) -> None:
+        """
+        Cancel and clear automatic replay startup.
+
+        :param cancel_task: Also cancel a callback that already started.
+        """
+        had_countdown = self._game is not None and self._game.auto_start_at is not None
+        self.mass.cancel_timer(self._replay_auto_start_timer_id)
+        if cancel_task and had_countdown:
+            self.mass.cancel_task(self._replay_auto_start_timer_id)
+        if self._game is not None:
+            self._game.auto_start_at = None
+
     def _refresh_player_presence(
         self,
         player: MusicQuizPlayer,
@@ -1218,10 +1317,16 @@ class MusicQuizPlugin(PluginProvider):
         """Return the task_id of the player presence timer."""
         return f"music_quiz_presence_{self.instance_id}"
 
+    @property
+    def _replay_auto_start_timer_id(self) -> str:
+        """Return the task_id of the replay auto-start timer."""
+        return f"music_quiz_replay_{self.instance_id}"
+
     def _cancel_timers(self) -> None:
         """Cancel all scheduled game timers."""
         self.mass.cancel_timer(self._reveal_timer_id)
         self.mass.cancel_timer(self._advance_timer_id)
+        self._cancel_replay_auto_start(cancel_task=True)
         self._cancel_presence_expiry(cancel_task=True)
 
 
@@ -1272,6 +1377,26 @@ def _find_player(game: MusicQuizGame, player_id: str) -> MusicQuizPlayer | None:
         if secrets.compare_digest(player.player_id, player_id):
             return player
     return None
+
+
+def _is_player_active(player: MusicQuizPlayer, now: float) -> bool:
+    """
+    Return whether a player's reconnect grace period is active.
+
+    :param player: Player to inspect.
+    :param now: Current server timestamp.
+    """
+    return player.last_seen + PLAYER_RECONNECT_GRACE_SECONDS > now
+
+
+def _has_active_players(game: MusicQuizGame, now: float) -> bool:
+    """
+    Return whether the game has a player within the reconnect grace period.
+
+    :param game: Game to inspect.
+    :param now: Current server timestamp.
+    """
+    return any(_is_player_active(player, now) for player in game.players.values())
 
 
 def _answer_window(game: MusicQuizGame, game_round: MusicQuizRound) -> float:
@@ -1330,6 +1455,7 @@ def _public_state(game: MusicQuizGame, mode: str, answer_type: QuizAnswerType) -
         "mode": mode,
         "round_count": game.config.round_count,
         "answer_duration": game.config.answer_duration,
+        "auto_start_at": game.auto_start_at,
         **answer_type.serialize_game_config(game),
         "players": players,
         "current_round": _public_round(

--- a/music_assistant/providers/music_quiz/game.py
+++ b/music_assistant/providers/music_quiz/game.py
@@ -199,6 +199,7 @@ def reset_game(game: MusicQuizGame) -> None:
     :param game: Game to mutate.
     """
     game.phase = MusicQuizPhase.LOBBY
+    game.auto_start_at = None
     game.rounds.clear()
     game.current_round_index = None
     for player in game.players.values():

--- a/music_assistant/providers/music_quiz/models.py
+++ b/music_assistant/providers/music_quiz/models.py
@@ -371,6 +371,7 @@ class MusicQuizGame(DataClassDictMixin):
     answer_type: MusicQuizAnswerType
     phase: MusicQuizPhase = MusicQuizPhase.LOBBY
     created_at: float = 0
+    auto_start_at: float | None = None
     players: dict[str, MusicQuizPlayer] = field(default_factory=dict)
     rounds: list[MusicQuizRound] = field(default_factory=list)
     sources: list[MusicQuizSource] = field(default_factory=list)

--- a/tests/providers/music_quiz/test_game.py
+++ b/tests/providers/music_quiz/test_game.py
@@ -331,10 +331,12 @@ def test_reset_game_keeps_players_and_config_for_new_game() -> None:
     game.players["p1"].ready = True
     game.players["p2"].score = 500
     game.players["p2"].ready = True
+    game.auto_start_at = 30
 
     reset_game(game)
 
     assert game.phase == MusicQuizPhase.LOBBY
+    assert game.to_dict()["auto_start_at"] is None
     assert game.quiz_type == "guess_the_song"
     assert game.answer_type == MusicQuizAnswerType.MULTIPLE_CHOICE
     assert game.current_round_index is None

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -25,6 +25,7 @@ from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.music_quiz import (
     MUSIC_QUIZ_GUEST_USER,
     PLAYER_RECONNECT_GRACE_SECONDS,
+    REPLAY_AUTO_START_SECONDS,
     MusicQuizPlugin,
     get_config_entries,
 )
@@ -208,6 +209,7 @@ def _create_plugin(
     plugin._quiz_type = None
     plugin._answer_type = None
     plugin._game_lock = asyncio.Lock()
+    plugin._game_generation = 0
     plugin._playback_session = None
     plugin._playback_lock = asyncio.Lock()
     plugin._next_round_task = None
@@ -271,6 +273,22 @@ def _round_timer_call(plugin: MusicQuizPlugin, task_id: str) -> tuple[float, Any
                 cast("int", timer_call.args[2]),
             )
     raise AssertionError(f"No round timer was scheduled for {task_id}")
+
+
+def _replay_timer_call(
+    plugin: MusicQuizPlugin,
+) -> tuple[float, Any, MusicQuizGame, int, float]:
+    """Return the most recently scheduled replay auto-start timer."""
+    for timer_call in reversed(cast("MagicMock", plugin.mass.call_later).call_args_list):
+        if timer_call.kwargs.get("task_id") == plugin._replay_auto_start_timer_id:
+            return (
+                cast("float", timer_call.args[0]),
+                timer_call.args[1],
+                cast("MusicQuizGame", timer_call.args[2]),
+                cast("int", timer_call.args[3]),
+                cast("float", timer_call.args[4]),
+            )
+    raise AssertionError("No replay auto-start timer was scheduled")
 
 
 def _timeline_answer_state(game_round: MusicQuizRound) -> TimelineRoundState:
@@ -1924,6 +1942,7 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
         "round_count",
         "suggestion_count",
         "answer_duration",
+        "auto_start_at",
         "players",
         "current_round",
     }
@@ -2032,6 +2051,7 @@ async def test_game_info_exposes_game_identity_and_playback_mode() -> None:
         "mode": "remote",
         "player_count": 0,
         "round_count": 5,
+        "auto_start_at": None,
     }
 
 
@@ -2578,6 +2598,342 @@ async def test_reset_preserves_quiz_type_in_state_and_events() -> None:
     payload = cast("MagicMock", plugin.signal_provider_event).call_args[0][0]
     assert payload["state"]["quiz_type"] == "guess_the_song"
     assert payload["state"]["answer_type"] == "multiple_choice"
+
+
+@pytest.mark.asyncio
+async def test_replay_reset_schedules_and_serializes_authoritative_deadline() -> None:
+    """Expose one 30-second replay deadline in host, public and personal state."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",))
+    game = plugin._game
+    assert game is not None
+    game.players[player_ids["Alice"]].last_seen = 100.0
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=100.0):
+        host_state = await plugin.reset(auto_start=True)
+        with patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ):
+            personal_state = await plugin.get_player_state(player_ids["Alice"])
+        game_info = await plugin.get_game_info()
+
+    delay, _, scheduled_game, generation, deadline = _replay_timer_call(plugin)
+    public_state = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]["state"]
+    assert delay == REPLAY_AUTO_START_SECONDS
+    assert deadline == 100.0 + REPLAY_AUTO_START_SECONDS
+    assert scheduled_game is game
+    assert generation == plugin._game_generation
+    assert game.auto_start_at == deadline
+    assert host_state["auto_start_at"] == deadline
+    assert public_state["auto_start_at"] == deadline
+    assert personal_state["auto_start_at"] == deadline
+    assert game_info is not None
+    assert game_info["auto_start_at"] == deadline
+
+
+@pytest.mark.asyncio
+async def test_manual_or_inactive_replay_reset_does_not_schedule() -> None:
+    """Keep reset manual by default and ignore stale player dictionary entries."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",))
+    game = plugin._game
+    assert game is not None
+    player = game.players[player_ids["Alice"]]
+    player.last_seen = 100.0
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=100.0):
+        manual_state = await plugin.reset()
+    assert manual_state["auto_start_at"] is None
+    assert not any(
+        call.kwargs.get("task_id") == plugin._replay_auto_start_timer_id
+        for call in cast("MagicMock", plugin.mass.call_later).call_args_list
+    )
+
+    cast("MagicMock", plugin.mass.call_later).reset_mock()
+    player.last_seen = 40.0
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=100.0):
+        inactive_state = await plugin.reset(auto_start=True)
+
+    assert player.player_id in game.players
+    assert inactive_state["phase"] == "lobby"
+    assert inactive_state["auto_start_at"] is None
+    assert not any(
+        call.kwargs.get("task_id") == plugin._replay_auto_start_timer_id
+        for call in cast("MagicMock", plugin.mass.call_later).call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_manual_start_cancels_replay_countdown_and_starts_once() -> None:
+    """Let the host start immediately without a later timer duplicating the round."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",), round_count=1)
+    game = plugin._game
+    assert game is not None
+    game.players[player_ids["Alice"]].last_seen = 100.0
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=100.0):
+        await plugin.reset(auto_start=True)
+    _, callback, scheduled_game, generation, deadline = _replay_timer_call(plugin)
+    cast("AsyncMock", plugin._play_track).reset_mock()
+    cast("MagicMock", plugin.mass.cancel_timer).reset_mock()
+    cast("MagicMock", plugin.mass.cancel_task).reset_mock()
+
+    state = await plugin.start_game()
+
+    assert state["phase"] == "answering"
+    assert state["auto_start_at"] is None
+    assert game.auto_start_at is None
+    assert len(game.rounds) == 1
+    cast("AsyncMock", plugin._play_track).assert_awaited_once()
+    cast("MagicMock", plugin.mass.cancel_timer).assert_called_once_with(
+        plugin._replay_auto_start_timer_id
+    )
+    cast("MagicMock", plugin.mass.cancel_task).assert_called_once_with(
+        plugin._replay_auto_start_timer_id
+    )
+
+    await callback(scheduled_game, generation, deadline)
+
+    assert len(game.rounds) == 1
+    cast("AsyncMock", plugin._play_track).assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_replay_deadline_starts_once_in_system_context() -> None:
+    """Run timed preparation and playback without inheriting the host request."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",), round_count=1)
+    game = plugin._game
+    assert game is not None
+    game.players[player_ids["Alice"]].last_seen = 100.0
+    prepare_contexts: list[tuple[User | None, User | None]] = []
+    playback_contexts: list[tuple[User | None, User | None]] = []
+
+    async def _prepare_round(
+        round_index: int,
+        _previous_rounds: list[MusicQuizRound],
+    ) -> MusicQuizRound:
+        prepare_contexts.append((current_user.get(), impersonated_user.get()))
+        return _make_round(round_index)
+
+    async def _play_track(_track_uri: str) -> None:
+        playback_contexts.append((current_user.get(), impersonated_user.get()))
+
+    prepare_round = AsyncMock(side_effect=_prepare_round)
+    plugin._play_track = AsyncMock(side_effect=_play_track)  # type: ignore[method-assign]
+    requesting_user = cast("User", _guest_user())
+    requesting_impersonation = cast("User", _guest_user())
+    current_user_token = current_user.set(requesting_user)
+    impersonated_user_token = impersonated_user.set(requesting_impersonation)
+    try:
+        with (
+            patch(
+                "music_assistant.providers.music_quiz.quiz_types.guess_the_song."
+                "GuessTheSongQuizType.prepare_round",
+                new=prepare_round,
+            ),
+            patch("music_assistant.providers.music_quiz.time.time", return_value=100.0),
+        ):
+            await plugin.reset(auto_start=True)
+        _, callback, scheduled_game, generation, deadline = _replay_timer_call(plugin)
+
+        with patch("music_assistant.providers.music_quiz.time.time", return_value=130.0):
+            await callback(scheduled_game, generation, deadline)
+            await callback(scheduled_game, generation, deadline)
+
+        assert current_user.get() is requesting_user
+        assert impersonated_user.get() is requesting_impersonation
+    finally:
+        impersonated_user.reset(impersonated_user_token)
+        current_user.reset(current_user_token)
+
+    prepare_round.assert_awaited_once_with(0, [])
+    assert prepare_contexts == [(None, None)]
+    assert playback_contexts == [(None, None)]
+    assert game.phase == MusicQuizPhase.ANSWERING
+    assert len(game.rounds) == 1
+    assert game.auto_start_at is None
+
+
+@pytest.mark.asyncio
+async def test_all_players_expiring_cancels_replay_without_rescheduling_on_join() -> None:
+    """Cancel an empty replay lobby and require another explicit reset to rearm it."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",), round_count=1)
+    game = plugin._game
+    assert game is not None
+    game.players[player_ids["Alice"]].last_seen = 100.0
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=140.0):
+        await plugin.reset(auto_start=True)
+    _, replay_callback, scheduled_game, generation, deadline = _replay_timer_call(plugin)
+    presence_delay, presence_callback = _presence_timer_call(plugin)
+    assert presence_delay == 20.0
+    signal = cast("MagicMock", plugin.signal_provider_event)
+    signal.reset_mock()
+    cast("MagicMock", plugin.mass.cancel_timer).reset_mock()
+    cast("MagicMock", plugin.mass.cancel_task).reset_mock()
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=160.0):
+        await presence_callback()
+
+    assert game.players == {}
+    assert game.phase == MusicQuizPhase.LOBBY
+    assert game.auto_start_at is None
+    cast("MagicMock", plugin.mass.cancel_timer).assert_any_call(plugin._replay_auto_start_timer_id)
+    cast("MagicMock", plugin.mass.cancel_task).assert_called_once_with(
+        plugin._replay_auto_start_timer_id
+    )
+    cancelled_state = signal.call_args.args[0]["state"]
+    assert cancelled_state["auto_start_at"] is None
+    assert cancelled_state["players"] == []
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+        patch("music_assistant.providers.music_quiz.time.time", return_value=165.0),
+    ):
+        joined = await plugin.join_game("Bob")
+
+    assert joined["state"]["auto_start_at"] is None
+    assert (
+        sum(
+            call.kwargs.get("task_id") == plugin._replay_auto_start_timer_id
+            for call in cast("MagicMock", plugin.mass.call_later).call_args_list
+        )
+        == 1
+    )
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=170.0):
+        await replay_callback(scheduled_game, generation, deadline)
+    assert game.phase == MusicQuizPhase.LOBBY
+    assert game.rounds == []
+
+
+@pytest.mark.asyncio
+async def test_stale_replay_generation_cannot_reuse_identical_deadline() -> None:
+    """Reject an old reset callback even when a new reset chose the same epoch deadline."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",), round_count=1)
+    game = plugin._game
+    assert game is not None
+    game.players[player_ids["Alice"]].last_seen = 100.0
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=100.0):
+        await plugin.reset(auto_start=True)
+        old_timer = _replay_timer_call(plugin)
+        await plugin.reset(auto_start=True)
+        current_timer = _replay_timer_call(plugin)
+
+    assert old_timer[2] is current_timer[2] is game
+    assert old_timer[3] != current_timer[3]
+    assert old_timer[4] == current_timer[4]
+    cast("AsyncMock", plugin._play_track).reset_mock()
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=130.0):
+        await old_timer[1](*old_timer[2:])
+        assert _phase(plugin) == MusicQuizPhase.LOBBY
+        assert game.rounds == []
+        await current_timer[1](*current_timer[2:])
+
+    assert _phase(plugin) == MusicQuizPhase.ANSWERING
+    assert len(game.rounds) == 1
+    cast("AsyncMock", plugin._play_track).assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("lifecycle_action", ["reset", "delete", "unload", "replace"])
+async def test_stale_replay_callbacks_ignore_lifecycle_changes(lifecycle_action: str) -> None:
+    """Keep callbacks harmless after every lifecycle path that invalidates a game."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",), round_count=1)
+    game = plugin._game
+    assert game is not None
+    game.players[player_ids["Alice"]].last_seen = 100.0
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=100.0):
+        await plugin.reset(auto_start=True)
+    timer = _replay_timer_call(plugin)
+    cast("MagicMock", plugin.mass.cancel_task).reset_mock()
+
+    if lifecycle_action == "reset":
+        await plugin.reset()
+    elif lifecycle_action == "delete":
+        await plugin.delete_game()
+    elif lifecycle_action == "unload":
+        await plugin.unload()
+    else:
+        await plugin.create_game(source_uris=["library://playlist/replacement"])
+
+    cast("MagicMock", plugin.mass.cancel_task).assert_any_call(plugin._replay_auto_start_timer_id)
+    cast("AsyncMock", plugin._play_track).reset_mock()
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=130.0):
+        await timer[1](*timer[2:])
+
+    cast("AsyncMock", plugin._play_track).assert_not_awaited()
+    if plugin._game is not None:
+        assert plugin._game.phase == MusicQuizPhase.LOBBY
+        assert plugin._game.rounds == []
+        assert plugin._game.auto_start_at is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_stage", ["preparation", "playback"])
+async def test_failed_timed_start_remains_retryable(failure_stage: str) -> None:
+    """Clear a failed timed start and let the host retry the unchanged lobby."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin, player_names=("Alice",), round_count=1)
+    game = plugin._game
+    assert game is not None
+    game.players[player_ids["Alice"]].last_seen = 100.0
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=100.0):
+        await plugin.reset(auto_start=True)
+    timer = _replay_timer_call(plugin)
+    plugin._cancel_next_round_task()
+    quiz_type = plugin._quiz_type
+    assert quiz_type is not None
+    prepared_round = _make_round(0)
+    prepare_round = AsyncMock()
+    quiz_type.prepare_round = prepare_round  # type: ignore[method-assign]
+    if failure_stage == "preparation":
+        failure = InvalidDataError("Round preparation failed")
+        prepare_round.side_effect = failure
+    else:
+        failure = MusicQuizNoPlaybackTargetError("Playback unavailable")
+        prepare_round.return_value = prepared_round
+        cast("AsyncMock", plugin._play_track).side_effect = failure
+    signal = cast("MagicMock", plugin.signal_provider_event)
+    signal.reset_mock()
+    cast("MagicMock", plugin.logger.error).reset_mock()
+
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=130.0):
+        await timer[1](*timer[2:])
+
+    assert game.phase == MusicQuizPhase.LOBBY
+    assert game.rounds == []
+    assert game.auto_start_at is None
+    assert signal.call_args.args[0]["state"]["auto_start_at"] is None
+    cast("MagicMock", plugin.logger.error).assert_called_once_with(
+        "Could not automatically start Music Quiz replay: %s",
+        failure,
+        exc_info=failure,
+    )
+
+    recovered_round = _make_round(0)
+    prepare_round.side_effect = None
+    prepare_round.return_value = recovered_round
+    cast("AsyncMock", plugin._play_track).side_effect = None
+
+    state = await plugin.start_game()
+
+    assert state["phase"] == "answering"
+    assert game.rounds == [recovered_round]
+    assert game.auto_start_at is None
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -1343,6 +1343,80 @@ async def test_hitster_placement_auto_reveals_without_bonuses_and_never_warms_ly
 
 
 @pytest.mark.asyncio
+async def test_hitster_ready_cancels_intermediate_auto_advance() -> None:
+    """Advance once on Ready and ignore the stale reveal timer."""
+    plugin = _create_plugin()
+    prepare_round = AsyncMock(
+        side_effect=lambda round_index, previous: _make_hitster_round(round_index, previous)
+    )
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.hitster.HitsterQuizType.prepare_round",
+            new=prepare_round,
+        ),
+    ):
+        player_ids = await _create_started_hitster_game(plugin, round_count=2)
+        with (
+            patch(
+                "music_assistant.providers.music_quiz.get_current_user",
+                return_value=_guest_user(),
+            ),
+            patch("music_assistant.providers.music_quiz.time.time", return_value=100.0),
+        ):
+            await plugin.submit_answer(
+                player_ids["Alice"],
+                {
+                    "answer_type": "timeline",
+                    "action": "place",
+                    "previous_entry_id": "anchor",
+                    "next_entry_id": None,
+                },
+            )
+
+        game = plugin._game
+        assert game is not None
+        first_round = game.rounds[0]
+        advance_delay, stale_callback, stale_round_index = _round_timer_call(
+            plugin, plugin._advance_timer_id
+        )
+        assert _phase(plugin) == MusicQuizPhase.REVEAL
+        assert advance_delay == 30.0
+        assert first_round.auto_advance_at == 130.0
+        cast("AsyncMock", plugin._play_track).reset_mock()
+        cast("MagicMock", plugin.mass.cancel_timer).reset_mock()
+
+        with (
+            patch(
+                "music_assistant.providers.music_quiz.get_current_user",
+                return_value=_guest_user(),
+            ),
+            patch("music_assistant.providers.music_quiz.time.time", return_value=110.0),
+        ):
+            state = await plugin.ready(player_ids["Alice"])
+
+        assert _phase(plugin) == MusicQuizPhase.ANSWERING
+        assert game.current_round_index == 1
+        assert len(game.rounds) == 2
+        assert first_round.to_dict()["auto_advance_at"] is None
+        assert state["current_round"]["round_index"] == 1
+        cast("MagicMock", plugin.mass.cancel_timer).assert_any_call(plugin._advance_timer_id)
+        cast("AsyncMock", plugin._play_track).assert_awaited_once_with("library://track/hitster-1")
+        assert prepare_round.await_count == 2
+
+        await stale_callback(stale_round_index)
+
+    assert _phase(plugin) == MusicQuizPhase.ANSWERING
+    assert game.current_round_index == 1
+    assert len(game.rounds) == 2
+    cast("AsyncMock", plugin._play_track).assert_awaited_once()
+    assert prepare_round.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_hitster_finish_skips_unanswered_bonus() -> None:
     """Keep finish as a backward-compatible way to skip a bonus."""
     definitions: list[TimelineBonusDefinition] = [


### PR DESCRIPTION
# What does this implement/fix?

Adds an optional 30-second countdown when a host chooses Play again, so active players can continue without another manual start.

- Keeps the existing manual reset behavior by default.
- Shares one authoritative replay deadline with hosts and guests.
- Cancels safely on manual start, inactivity, and game lifecycle changes.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project AI Policy for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.