### PR TITLE
Speed up Music Timeline startup

### DIFF
--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -7,13 +7,13 @@ import logging
 import secrets
 from collections.abc import Sequence
 from dataclasses import replace
-from itertools import batched
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import Artist, ItemMapping, Track
 
+from music_assistant.helpers.compare import compare_artist
 from music_assistant.helpers.json import JSON_DECODE_EXCEPTIONS, json_dumps, json_loads
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
@@ -51,6 +51,7 @@ LOGGER = logging.getLogger(__name__)
 DEFAULT_BONUS_OPTION_COUNT = 4
 COMPLETED_REVEAL_AUTO_ADVANCE_SECONDS = 30.0
 TRACK_ENRICHMENT_CONCURRENCY = 10
+PLAYBACK_REPLACEMENT_RESERVE = 4
 BONUS_CANDIDATE_LIMIT = 24
 AI_QUERY_TIMEOUT_SECONDS = 30.0
 MAX_AI_PROMPT_BYTES = 8192
@@ -72,6 +73,8 @@ class MusicTimelineQuizType(QuizType):
         """
         super().__init__(mass, config)
         self._eligible_tracks: list[Track] | None = None
+        self._title_top_track_candidates: dict[tuple[str, str], list[SuggestionCandidate]] = {}
+        self._title_search_candidates: dict[tuple[str, str], list[SuggestionCandidate]] = {}
 
     @classmethod
     def normalize_config(cls, config: MusicQuizConfig) -> MusicQuizConfig:
@@ -180,18 +183,27 @@ class MusicTimelineQuizType(QuizType):
             self._eligible_tracks = [
                 track for track in self._eligible_tracks if track.uri != track_uri
             ]
+        for cache in (self._title_top_track_candidates, self._title_search_candidates):
+            for artist_key, candidates in cache.items():
+                cache[artist_key] = [
+                    candidate for candidate in candidates if candidate.uri != track_uri
+                ]
 
     async def _get_eligible_tracks(self) -> list[Track]:
         """Return unique source tracks with usable release metadata."""
         if self._eligible_tracks is not None:
             return self._eligible_tracks
         source_tracks = list((await self._get_source_track_pool()).values())
+        eligible_tracks: dict[str, Track] = {}
+        unresolved_tracks: list[Track] = []
+        for track in source_tracks:
+            if self._track_is_eligible(track):
+                assert track.uri is not None
+                eligible_tracks[track.uri] = track
+            elif track.available and track.is_playable:
+                unresolved_tracks.append(track)
 
         async def _resolve_track(track: Track) -> Track | None:
-            if not track.available or not track.is_playable:
-                return None
-            if self._track_is_eligible(track):
-                return track
             try:
                 enriched = await self.mass.music.tracks.get(track.item_id, track.provider)
             except Exception as err:
@@ -199,22 +211,24 @@ class MusicTimelineQuizType(QuizType):
                 return None
             return enriched if self._track_is_eligible(enriched) else None
 
-        resolved_tracks: list[Track | None] = []
-        for track_batch in batched(
-            source_tracks,
-            TRACK_ENRICHMENT_CONCURRENCY,
-            strict=False,
+        target_track_count = self.config.round_count + 1 + PLAYBACK_REPLACEMENT_RESERVE
+        unresolved_offset = 0
+        while len(eligible_tracks) < target_track_count and unresolved_offset < len(
+            unresolved_tracks
         ):
-            resolved_tracks.extend(
-                await asyncio.gather(*(_resolve_track(track) for track in track_batch))
+            batch_size = min(
+                TRACK_ENRICHMENT_CONCURRENCY,
+                target_track_count - len(eligible_tracks),
             )
-        self._eligible_tracks = list(
-            {
-                track.uri: track
-                for track in resolved_tracks
-                if track is not None and track.uri is not None
-            }.values()
-        )
+            track_batch = unresolved_tracks[unresolved_offset : unresolved_offset + batch_size]
+            unresolved_offset += len(track_batch)
+            resolved_tracks = await asyncio.gather(
+                *(_resolve_track(track) for track in track_batch)
+            )
+            for resolved_track in resolved_tracks:
+                if resolved_track is not None and resolved_track.uri is not None:
+                    eligible_tracks.setdefault(resolved_track.uri, resolved_track)
+        self._eligible_tracks = list(eligible_tracks.values())
         if not self._eligible_tracks:
             raise InvalidDataError(
                 "None of the configured tracks have usable release years",
@@ -392,45 +406,89 @@ class MusicTimelineQuizType(QuizType):
         if primary_artist is None:
             return []
         assert self._eligible_tracks is not None
-        candidates = [
-            self._bonus_candidate(candidate, TimelineBonusType.TITLE)
-            for candidate in self._eligible_tracks
-            if candidate.uri != track.uri and self._track_has_artist(candidate, primary_artist)
-        ]
+        candidates = self._filter_bonus_candidates(
+            track,
+            TimelineBonusType.TITLE,
+            [
+                self._bonus_candidate(candidate, TimelineBonusType.TITLE)
+                for candidate in self._eligible_tracks
+                if self._track_has_primary_artist(candidate, primary_artist)
+            ],
+        )
         if self._has_enough_bonus_candidates(track, TimelineBonusType.TITLE, candidates):
             return candidates
+        candidates = self._filter_bonus_candidates(
+            track,
+            TimelineBonusType.TITLE,
+            [
+                *candidates,
+                *(await self._get_top_track_title_candidates(primary_artist)),
+            ],
+        )
+        if self._has_enough_bonus_candidates(track, TimelineBonusType.TITLE, candidates):
+            return candidates
+        return self._filter_bonus_candidates(
+            track,
+            TimelineBonusType.TITLE,
+            [
+                *candidates,
+                *(await self._get_search_title_candidates(primary_artist)),
+            ],
+        )
+
+    async def _get_top_track_title_candidates(
+        self,
+        artist: Artist | ItemMapping,
+    ) -> list[SuggestionCandidate]:
+        """Return cached real title candidates from the artist's bounded top tracks."""
+        artist_key = (artist.provider, artist.item_id)
+        if artist_key in self._title_top_track_candidates:
+            return self._title_top_track_candidates[artist_key]
         try:
-            artist_tracks = await self.mass.music.artists.tracks(
-                item_id=primary_artist.item_id,
-                provider_instance_id_or_domain=primary_artist.provider,
+            top_tracks = await self.mass.music.artists.top_tracks(
+                item_id=artist.item_id,
+                provider_instance_id_or_domain=artist.provider,
             )
         except Exception as err:
-            LOGGER.debug("Could not fetch tracks for %s: %s", primary_artist.name, err)
-        else:
-            candidates.extend(
-                self._bonus_candidate(candidate, TimelineBonusType.TITLE)
-                for candidate in artist_tracks
-                if self._track_has_artist(candidate, primary_artist)
-            )
-        if self._has_enough_bonus_candidates(track, TimelineBonusType.TITLE, candidates):
-            return candidates
+            LOGGER.debug("Could not fetch top tracks for %s: %s", artist.name, err)
+            return []
+        candidates = self._title_candidates_for_artist(top_tracks, artist)
+        self._title_top_track_candidates[artist_key] = candidates
+        return candidates
+
+    async def _get_search_title_candidates(
+        self,
+        artist: Artist | ItemMapping,
+    ) -> list[SuggestionCandidate]:
+        """Return cached real title candidates from a bounded artist track search."""
+        artist_key = (artist.provider, artist.item_id)
+        if artist_key in self._title_search_candidates:
+            return self._title_search_candidates[artist_key]
         try:
             search_results = await self.mass.music.search(
-                search_query=primary_artist.name,
+                search_query=artist.name,
                 media_types=[MediaType.TRACK],
                 limit=BONUS_CANDIDATE_LIMIT,
                 library_only=False,
             )
         except Exception as err:
-            LOGGER.debug("Could not search for tracks by %s: %s", primary_artist.name, err)
-        else:
-            candidates.extend(
-                self._bonus_candidate(candidate, TimelineBonusType.TITLE)
-                for candidate in search_results.tracks
-                if isinstance(candidate, Track)
-                and self._track_has_artist(candidate, primary_artist)
-            )
+            LOGGER.debug("Could not search for tracks by %s: %s", artist.name, err)
+            return []
+        candidates = self._title_candidates_for_artist(search_results.tracks, artist)
+        self._title_search_candidates[artist_key] = candidates
         return candidates
+
+    def _title_candidates_for_artist(
+        self,
+        tracks: Sequence[Track | ItemMapping],
+        artist: Artist | ItemMapping,
+    ) -> list[SuggestionCandidate]:
+        """Convert real tracks by the requested primary artist to title candidates."""
+        return [
+            self._bonus_candidate(track, TimelineBonusType.TITLE)
+            for track in tracks
+            if isinstance(track, Track) and self._track_has_primary_artist(track, artist)
+        ]
 
     async def _rank_bonus_candidates(
         self,
@@ -614,14 +672,10 @@ class MusicTimelineQuizType(QuizType):
         return track.artists[0] if track.artists else None
 
     @staticmethod
-    def _track_has_artist(track: Track, artist: Artist | ItemMapping) -> bool:
-        """Return whether a track belongs to the given artist."""
-        normalized_name = normalize_answer_label(artist.name)
-        return any(
-            (track_artist.item_id == artist.item_id and track_artist.provider == artist.provider)
-            or normalize_answer_label(track_artist.name) == normalized_name
-            for track_artist in track.artists
-        )
+    def _track_has_primary_artist(track: Track, artist: Artist | ItemMapping) -> bool:
+        """Return whether a track has the requested primary artist."""
+        primary_artist = MusicTimelineQuizType._primary_artist(track)
+        return primary_artist is not None and bool(compare_artist(primary_artist, artist))
 
     def _timeline_from_previous_rounds(
         self,

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -31,7 +31,9 @@ from music_assistant.providers.music_quiz.models import (
 )
 from music_assistant.providers.music_quiz.quiz_types.music_timeline import (
     AI_QUERY_TIMEOUT_SECONDS,
+    BONUS_CANDIDATE_LIMIT,
     DEFAULT_BONUS_OPTION_COUNT,
+    PLAYBACK_REPLACEMENT_RESERVE,
     TRACK_ENRICHMENT_CONCURRENCY,
     MusicTimelineQuizType,
 )
@@ -117,6 +119,7 @@ def _mass() -> MagicMock:
     mass.music.tracks.get = AsyncMock()
     mass.music.tracks.similar_tracks = AsyncMock(return_value=[])
     mass.music.artists.similar_artists = AsyncMock(return_value=[])
+    mass.music.artists.top_tracks = AsyncMock(return_value=[])
     mass.music.artists.tracks = AsyncMock(return_value=[])
     mass.music.search = AsyncMock(return_value=SimpleNamespace(tracks=[]))
     mass.get_providers_supporting_feature = MagicMock(return_value=[])
@@ -247,6 +250,26 @@ async def test_initialize_excludes_unavailable_and_unplayable_dated_tracks() -> 
 
 
 @pytest.mark.asyncio
+async def test_large_eligible_pool_skips_enrichment_and_remains_available() -> None:
+    """Preserve every ready source track without requesting redundant details."""
+    tracks = [
+        _track(
+            f"track-{index}",
+            f"Track {index}",
+            f"Artist {index}",
+            album_year=1980 + index,
+        )
+        for index in range(40)
+    ]
+    quiz, mass = _quiz(tracks, round_count=5)
+
+    await quiz.initialize()
+
+    mass.music.tracks.get.assert_not_awaited()
+    assert quiz._eligible_tracks == tracks
+
+
+@pytest.mark.asyncio
 async def test_partial_playlist_tracks_are_enriched_through_track_api() -> None:
     """Fetch full track details when a playlist item lacks release metadata."""
     partial = _track("partial", "Teardrop", "Massive Attack")
@@ -260,6 +283,64 @@ async def test_partial_playlist_tracks_are_enriched_through_track_api() -> None:
     mass.music.tracks.get.assert_awaited_once_with(partial.item_id, partial.provider)
     assert quiz._eligible_tracks is not None
     assert {track.item_id for track in quiz._eligible_tracks} == {"partial", "other"}
+
+
+@pytest.mark.asyncio
+async def test_track_enrichment_stops_after_game_requirement_and_reserve() -> None:
+    """Stop requesting details once the complete game has replacement capacity."""
+    ready = [
+        _track("ready-one", "Ready One", "Artist One", album_year=1990),
+        _track("ready-two", "Ready Two", "Artist Two", album_year=1991),
+    ]
+    partial = [
+        _track(f"partial-{index}", f"Partial {index}", f"Artist {index}") for index in range(20)
+    ]
+    enriched = {
+        track.item_id: _track(
+            track.item_id,
+            track.name,
+            track.artist_str,
+            album_year=2000 + index,
+        )
+        for index, track in enumerate(partial)
+    }
+    round_count = 3
+    target_count = round_count + 1 + PLAYBACK_REPLACEMENT_RESERVE
+    expected_enrichments = target_count - len(ready)
+    quiz, mass = _quiz([*ready, *partial], round_count=round_count)
+    mass.music.tracks.get.side_effect = lambda item_id, _provider: enriched[item_id]
+
+    await quiz.initialize()
+
+    assert mass.music.tracks.get.await_count == expected_enrichments
+    assert [await_call.args[0] for await_call in mass.music.tracks.get.await_args_list] == [
+        track.item_id for track in partial[:expected_enrichments]
+    ]
+    assert quiz._eligible_tracks is not None
+    assert len(quiz._eligible_tracks) == target_count
+    assert quiz._eligible_tracks[: len(ready)] == ready
+
+
+@pytest.mark.asyncio
+async def test_insufficient_enrichment_exhausts_unresolved_tracks() -> None:
+    """Check every unresolved source track before reporting an insufficient pool."""
+    ready = [
+        _track("ready-one", "Ready One", "Artist One", album_year=1990),
+        _track("ready-two", "Ready Two", "Artist Two", album_year=1991),
+    ]
+    unresolved = [
+        _track(f"partial-{index}", f"Partial {index}", f"Artist {index}") for index in range(12)
+    ]
+    quiz, mass = _quiz([*ready, *unresolved], round_count=4)
+    mass.music.tracks.get.side_effect = lambda item_id, _provider: next(
+        track for track in unresolved if track.item_id == item_id
+    )
+
+    with pytest.raises(InvalidDataError) as insufficient:
+        await quiz.initialize()
+
+    assert insufficient.value.translation_key == "music_quiz_not_enough_dated_tracks"
+    assert mass.music.tracks.get.await_count == len(unresolved)
 
 
 @pytest.mark.asyncio
@@ -386,11 +467,24 @@ def test_reject_track_removes_it_from_music_timeline_caches() -> None:
     assert available.uri is not None
     quiz._source_track_pool = {failed.uri: failed, available.uri: available}
     quiz._eligible_tracks = [failed, available]
+    artist_key = ("prov", "artist")
+    failed_candidate = SuggestionCandidate(failed.name, uri=failed.uri)
+    available_candidate = SuggestionCandidate(available.name, uri=available.uri)
+    quiz._title_top_track_candidates[artist_key] = [
+        failed_candidate,
+        available_candidate,
+    ]
+    quiz._title_search_candidates[artist_key] = [
+        available_candidate,
+        failed_candidate,
+    ]
 
     quiz.reject_track(failed.uri)
 
     assert quiz._source_track_pool == {available.uri: available}
     assert quiz._eligible_tracks == [available]
+    assert quiz._title_top_track_candidates[artist_key] == [available_candidate]
+    assert quiz._title_search_candidates[artist_key] == [available_candidate]
 
 
 @pytest.mark.asyncio
@@ -475,7 +569,8 @@ async def test_prepare_round_builds_free_text_and_opaque_multiple_choice_bonuses
     assert sum(option.is_correct for option in title_definition.options) == 1
     assert len({option.option_id for option in title_definition.options}) == 4
     assert all("correct" not in option.option_id for option in title_definition.options)
-    mass.music.artists.tracks.assert_awaited_once()
+    mass.music.artists.top_tracks.assert_awaited_once()
+    mass.music.artists.tracks.assert_not_awaited()
     mass.music.search.assert_awaited_once()
 
 
@@ -597,22 +692,30 @@ async def test_title_bonus_prefers_same_artist_source_tracks_and_excludes_versio
         "Phantom",
         "Audio, Video, Disco",
     }
+    mass.music.artists.top_tracks.assert_not_awaited()
     mass.music.artists.tracks.assert_not_awaited()
     mass.music.search.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_title_bonus_uses_artist_catalog_before_unrelated_source_tracks() -> None:
-    """Fill sparse same-artist source titles from the artist controller first."""
+async def test_title_bonus_uses_filtered_top_tracks_before_unrelated_sources() -> None:
+    """Supplement source titles with real primary-artist top tracks only."""
     current = _track("current", "Genesis", "Justice", album_year=2007)
     source_same_artist = _track("source-same", "D.A.N.C.E.", "Justice", album_year=2007)
     unrelated = _track("unrelated", "Teardrop", "Massive Attack", album_year=1998)
+    secondary_artist = _track("secondary", "Waters of Nazareth", "Mr. Oizo")
+    secondary_artist.artists.append(_artist("justice", "Justice"))
     quiz, mass = _quiz(
         [current, source_same_artist, unrelated],
         title_mode=TimelineBonusMode.MULTIPLE_CHOICE,
     )
     quiz._eligible_tracks = [current, source_same_artist, unrelated]
-    mass.music.artists.tracks.return_value = [
+    mass.music.artists.top_tracks.return_value = [
+        current,
+        _track("close", "Genesis (Remix)", "Justice"),
+        _track("duplicate", "D.A.N.C.E.", "Justice"),
+        secondary_artist,
+        _artist("not-a-track", "Not a track"),
         _track("catalog-one", "Phantom", "Justice"),
         _track("catalog-two", "Audio, Video, Disco", "Justice"),
     ]
@@ -625,8 +728,85 @@ async def test_title_bonus_uses_artist_catalog_before_unrelated_source_tracks() 
         "Audio, Video, Disco",
     }
     assert "Teardrop" not in {option.label for option in options}
-    mass.music.artists.tracks.assert_awaited_once()
+    mass.music.artists.top_tracks.assert_awaited_once_with(
+        item_id=current.artists[0].item_id,
+        provider_instance_id_or_domain=current.artists[0].provider,
+    )
+    mass.music.artists.tracks.assert_not_awaited()
     mass.music.search.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_title_bonus_search_is_bounded_and_cached_per_artist() -> None:
+    """Reuse one top-track and bounded search result for repeated artist rounds."""
+    current = _track("current", "Genesis", "Justice", album_year=2007)
+    other = _track("other", "Stress", "Justice", album_year=2007)
+    other.artists = UniqueList([current.artists[0]])
+    unrelated = _track("unrelated", "Teardrop", "Massive Attack", album_year=1998)
+    quiz, mass = _quiz(
+        [current, other, unrelated],
+        title_mode=TimelineBonusMode.MULTIPLE_CHOICE,
+    )
+    quiz._eligible_tracks = [current, other, unrelated]
+    mass.music.artists.top_tracks.return_value = [
+        _track("top", "Phantom", "Justice"),
+    ]
+    mass.music.search.return_value = SimpleNamespace(
+        tracks=[
+            _track("wrong-artist", "Sexy Boy", "Air"),
+            _track("search-one", "Audio, Video, Disco", "Justice"),
+            _track("search-two", "Civilization", "Justice"),
+        ]
+    )
+
+    current_options = await quiz._create_bonus_options(current, TimelineBonusType.TITLE)
+    other_options = await quiz._create_bonus_options(other, TimelineBonusType.TITLE)
+
+    assert "Teardrop" not in {option.label for option in current_options}
+    assert "Teardrop" not in {option.label for option in other_options}
+    assert "Sexy Boy" not in {option.label for option in current_options}
+    assert "Sexy Boy" not in {option.label for option in other_options}
+    mass.music.artists.top_tracks.assert_awaited_once()
+    mass.music.search.assert_awaited_once_with(
+        search_query="Justice",
+        media_types=[MediaType.TRACK],
+        limit=BONUS_CANDIDATE_LIMIT,
+        library_only=False,
+    )
+    mass.music.artists.tracks.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_title_bonus_uses_unrelated_source_only_when_grounded_pool_is_sparse() -> None:
+    """Use unrelated source titles only after bounded same-artist sources run out."""
+    current = _track("current", "Genesis", "Justice", album_year=2007)
+    source_same_artist = _track("source-same", "D.A.N.C.E.", "Justice", album_year=2007)
+    unrelated = _track("unrelated", "Teardrop", "Massive Attack", album_year=1998)
+    unused_fallback = _track("other", "Glory Box", "Portishead", album_year=1994)
+    quiz, mass = _quiz(
+        [current, source_same_artist, unrelated, unused_fallback],
+        title_mode=TimelineBonusMode.MULTIPLE_CHOICE,
+    )
+    quiz._eligible_tracks = [
+        current,
+        source_same_artist,
+        unrelated,
+        unused_fallback,
+    ]
+    mass.music.artists.top_tracks.return_value = [
+        _track("top", "Phantom", "Justice"),
+    ]
+
+    options = await quiz._create_bonus_options(current, TimelineBonusType.TITLE)
+
+    assert {option.label for option in options if not option.is_correct} == {
+        "D.A.N.C.E.",
+        "Phantom",
+        "Teardrop",
+    }
+    mass.music.artists.top_tracks.assert_awaited_once()
+    mass.music.search.assert_awaited_once()
+    mass.music.artists.tracks.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Music Timeline could enumerate an artist's complete discography while building title choices, causing excessive provider requests and slow game startup.

- Uses source tracks first, then bounded artist top tracks and track search.
- Stops metadata enrichment once the full game plus a playback reserve is ready.
- Keeps grounded fallbacks and rejected-track caches consistent.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.