### PR TITLE
Reduce Spotify playlist loading requests

### DIFF
--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 from collections.abc import AsyncGenerator, Sequence
@@ -89,6 +90,8 @@ class SpotifyProvider(MusicProvider):
     _sp_user: dict[str, Any] | None = None
     _librespot_bin: str | None = None
     _audiobooks_supported = False
+    _playlist_pagination_snapshot: tuple[str, bool, dict[str, Any]] | None = None
+    _playlist_pagination_lock: asyncio.Lock
     # True if user has configured a custom client ID with valid authentication
     dev_session_active: bool = False
     throttler: ThrottlerManager
@@ -96,6 +99,8 @@ class SpotifyProvider(MusicProvider):
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
         self.cache_dir = os.path.join(self.mass.cache_path, self.instance_id)
+        self._playlist_pagination_snapshot = None
+        self._playlist_pagination_lock = asyncio.Lock()
         # Default throttler for global session (heavy rate limited)
         self.throttler = ThrottlerManager(rate_limit=1, period=2)
         self.streamer = LibrespotStreamer(self)
@@ -582,7 +587,7 @@ class SpotifyProvider(MusicProvider):
         page_size = 50
         offset = page * page_size
 
-        meta = await self._get_paginated_meta(uri, limit=1, offset=0, use_global_session=use_global)
+        meta = await self._get_playlist_pagination_meta(uri, page, use_global)
         cache_checksum = meta["etag"]
         total = meta["total"]
 
@@ -1175,6 +1180,39 @@ class SpotifyProvider(MusicProvider):
 
         return liked_songs
 
+    async def _get_playlist_pagination_meta(
+        self, endpoint: str, page: int, use_global_session: bool
+    ) -> dict[str, Any]:
+        """
+        Return pagination metadata for a Spotify playlist traversal.
+
+        :param endpoint: Spotify API endpoint for the playlist items.
+        :param page: Requested playlist page.
+        :param use_global_session: Whether the global Spotify session is required.
+        """
+        observed_snapshot = self._playlist_pagination_snapshot
+        async with self._playlist_pagination_lock:
+            snapshot = self._playlist_pagination_snapshot
+            # A concurrent page may have populated this snapshot while this call waited.
+            if (
+                snapshot
+                and snapshot[0] == endpoint
+                and snapshot[1] == use_global_session
+                and (page > 0 or snapshot is not observed_snapshot)
+            ):
+                return snapshot[2]
+
+            if page == 0:
+                self._playlist_pagination_snapshot = None
+            meta = await self._get_paginated_meta(
+                endpoint,
+                limit=1,
+                offset=0,
+                use_global_session=use_global_session,
+            )
+            self._playlist_pagination_snapshot = (endpoint, use_global_session, meta)
+            return meta
+
     async def _playlist_requires_global_token(self, prov_playlist_id: str) -> bool:
         """
         Check if a playlist requires global token (cached).
@@ -1317,7 +1355,6 @@ class SpotifyProvider(MusicProvider):
         )
         return result
 
-    @use_cache(120, allow_bypass=False)  # short cache: subsequent calls reuse cached data
     async def _get_paginated_meta(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
         """Get etag and total item count for a paginated api endpoint."""
         _res = await self._get_data(endpoint, **kwargs)

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import os
 import time
+from collections import OrderedDict
 from collections.abc import AsyncGenerator, Sequence
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, cast
 
@@ -75,9 +77,19 @@ from .parsers import (
 )
 from .streaming import LibrespotStreamer
 
+_PLAYLIST_PAGINATION_STATE_LIMIT = 32
+
 
 class NotModifiedError(Exception):
     """Exception raised when a resource has not been modified."""
+
+
+@dataclass(slots=True)
+class _PlaylistPaginationState:
+    """Hold the synchronization and metadata snapshot for one playlist endpoint."""
+
+    lock: asyncio.Lock
+    snapshot: dict[str, Any] | None = None
 
 
 class SpotifyProvider(MusicProvider):
@@ -90,8 +102,7 @@ class SpotifyProvider(MusicProvider):
     _sp_user: dict[str, Any] | None = None
     _librespot_bin: str | None = None
     _audiobooks_supported = False
-    _playlist_pagination_snapshot: tuple[str, bool, dict[str, Any]] | None = None
-    _playlist_pagination_lock: asyncio.Lock
+    _playlist_pagination_states: OrderedDict[tuple[str, bool], _PlaylistPaginationState]
     # True if user has configured a custom client ID with valid authentication
     dev_session_active: bool = False
     throttler: ThrottlerManager
@@ -99,8 +110,7 @@ class SpotifyProvider(MusicProvider):
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
         self.cache_dir = os.path.join(self.mass.cache_path, self.instance_id)
-        self._playlist_pagination_snapshot = None
-        self._playlist_pagination_lock = asyncio.Lock()
+        self._playlist_pagination_states = OrderedDict()
         # Default throttler for global session (heavy rate limited)
         self.throttler = ThrottlerManager(rate_limit=1, period=2)
         self.streamer = LibrespotStreamer(self)
@@ -1190,27 +1200,31 @@ class SpotifyProvider(MusicProvider):
         :param page: Requested playlist page.
         :param use_global_session: Whether the global Spotify session is required.
         """
-        observed_snapshot = self._playlist_pagination_snapshot
-        async with self._playlist_pagination_lock:
-            snapshot = self._playlist_pagination_snapshot
+        state_key = (endpoint, use_global_session)
+        if state := self._playlist_pagination_states.get(state_key):
+            self._playlist_pagination_states.move_to_end(state_key)
+        else:
+            state = _PlaylistPaginationState(lock=asyncio.Lock())
+            self._playlist_pagination_states[state_key] = state
+            while len(self._playlist_pagination_states) > _PLAYLIST_PAGINATION_STATE_LIMIT:
+                self._playlist_pagination_states.popitem(last=False)
+
+        observed_snapshot = state.snapshot
+        async with state.lock:
+            snapshot = state.snapshot
             # A concurrent page may have populated this snapshot while this call waited.
-            if (
-                snapshot
-                and snapshot[0] == endpoint
-                and snapshot[1] == use_global_session
-                and (page > 0 or snapshot is not observed_snapshot)
-            ):
-                return snapshot[2]
+            if snapshot and (page > 0 or snapshot is not observed_snapshot):
+                return snapshot
 
             if page == 0:
-                self._playlist_pagination_snapshot = None
+                state.snapshot = None
             meta = await self._get_paginated_meta(
                 endpoint,
                 limit=1,
                 offset=0,
                 use_global_session=use_global_session,
             )
-            self._playlist_pagination_snapshot = (endpoint, use_global_session, meta)
+            state.snapshot = meta
             return meta
 
     async def _playlist_requires_global_token(self, prov_playlist_id: str) -> bool:

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -1318,7 +1318,7 @@ class SpotifyProvider(MusicProvider):
         """Get all items from a paged list."""
         offset = 0
         # single request to fetch the etag (used as cache checksum) and total
-        meta = await self._get_paginated_meta(endpoint, limit=1, offset=0, **kwargs)
+        meta = await self._get_cached_paginated_meta(endpoint, limit=1, offset=0, **kwargs)
         cache_checksum = meta["etag"]
         total = meta["total"]
         while True:
@@ -1354,6 +1354,11 @@ class SpotifyProvider(MusicProvider):
             cache_key, result, provider=self.instance_id, checksum=cache_checksum
         )
         return result
+
+    @use_cache(120, allow_bypass=False)  # short cache: repeated traversals reuse metadata
+    async def _get_cached_paginated_meta(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        """Get cached pagination metadata for a paginated API endpoint."""
+        return await self._get_paginated_meta(endpoint, **kwargs)
 
     async def _get_paginated_meta(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
         """Get etag and total item count for a paginated api endpoint."""

--- a/tests/providers/spotify/test_playlist_tracks.py
+++ b/tests/providers/spotify/test_playlist_tracks.py
@@ -115,6 +115,56 @@ async def test_multipage_traversal_reuses_pagination_metadata() -> None:
     assert pages[3] == []
 
 
+async def test_second_full_traversal_reuses_etag_page_cache() -> None:
+    """A repeated full traversal refreshes metadata but reuses every unchanged page."""
+    harness = _make_provider()
+    harness.provider.__dict__.pop("_get_paginated_meta")
+    harness.provider.__dict__.pop("_get_data_with_caching")
+    page_cache: dict[tuple[str, str | None], dict[str, Any]] = {}
+
+    async def cache_get(
+        key: str, *, checksum: str | None = None, **_kwargs: Any
+    ) -> dict[str, Any] | None:
+        return page_cache.get((key, checksum))
+
+    async def cache_set(
+        key: str,
+        data: dict[str, Any],
+        *,
+        checksum: str | None = None,
+        **_kwargs: Any,
+    ) -> None:
+        page_cache[(key, checksum)] = data
+
+    async def get_data(_endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        if kwargs["limit"] == 1:
+            return {"etag": "stable-etag", "total": 120}
+        return _playlist_page(120, f"track-{kwargs['offset']}")
+
+    harness.provider.mass.cache.get = AsyncMock(side_effect=cache_get)  # type: ignore[method-assign]
+    harness.provider.mass.cache.set = AsyncMock(side_effect=cache_set)  # type: ignore[method-assign]
+    get_data_mock = AsyncMock(side_effect=get_data)
+    harness.provider._get_data = get_data_mock  # type: ignore[method-assign]
+    get_playlist_tracks: Any = SpotifyProvider.get_playlist_tracks.__wrapped__  # type: ignore[attr-defined]
+
+    traversals = [
+        [await get_playlist_tracks(harness.provider, PLAYLIST_ID, page=page) for page in range(4)]
+        for _ in range(2)
+    ]
+
+    metadata_calls = [args for args in get_data_mock.await_args_list if args.kwargs["limit"] == 1]
+    page_calls = [args for args in get_data_mock.await_args_list if args.kwargs["limit"] == 50]
+    assert len(metadata_calls) == 2
+    assert [args.kwargs["offset"] for args in page_calls] == [0, 50, 100]
+    assert harness.provider.mass.cache.get.await_count == 6
+    assert harness.provider.mass.cache.set.await_count == 3
+    assert [[page[0].position for page in traversal[:3]] for traversal in traversals] == [
+        [1, 51, 101],
+        [1, 51, 101],
+    ]
+    assert traversals[0][3] == traversals[1][3] == []
+
+
 async def test_concurrent_cold_pages_share_inflight_pagination_metadata() -> None:
     """Concurrent cache refreshes share one in-flight metadata request."""
     harness = _make_provider()

--- a/tests/providers/spotify/test_playlist_tracks.py
+++ b/tests/providers/spotify/test_playlist_tracks.py
@@ -1,0 +1,298 @@
+"""Tests for Spotify playlist track pagination."""
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any, NamedTuple
+from unittest.mock import AsyncMock, MagicMock, call
+
+from music_assistant.providers.spotify.provider import SpotifyProvider
+
+PLAYLIST_ID = "private-playlist"
+
+
+class SpotifyPlaylistHarness(NamedTuple):
+    """Container for a Spotify provider and its mocked API collaborators."""
+
+    provider: SpotifyProvider
+    get_playlist: AsyncMock
+    requires_global: AsyncMock
+    get_metadata: AsyncMock
+    get_page: AsyncMock
+
+
+def _make_provider(instance_id: str = "spotify--test") -> SpotifyPlaylistHarness:
+    """Return a Spotify provider with isolated playlist API mocks."""
+    provider = object.__new__(SpotifyProvider)
+    provider.config = MagicMock(instance_id=instance_id)
+    provider.manifest = MagicMock(domain="spotify")
+    provider.logger = MagicMock()
+    provider._sp_user = {"id": "test-user", "display_name": "Test User"}
+    provider._playlist_pagination_snapshot = None
+    provider._playlist_pagination_lock = asyncio.Lock()
+
+    mass = MagicMock()
+    mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
+    mass.cache.set = AsyncMock()
+
+    def close_task(coro: Coroutine[Any, Any, Any], **_: Any) -> None:
+        coro.close()
+
+    mass.create_task = MagicMock(side_effect=close_task)
+    provider.mass = mass
+
+    get_playlist = AsyncMock()
+    requires_global = AsyncMock(return_value=False)
+    get_metadata = AsyncMock()
+    get_page = AsyncMock()
+    provider.get_playlist = get_playlist  # type: ignore[method-assign]
+    provider._playlist_requires_global_token = requires_global  # type: ignore[method-assign]
+    provider._get_paginated_meta = get_metadata  # type: ignore[method-assign]
+    provider._get_data_with_caching = get_page  # type: ignore[method-assign]
+
+    return SpotifyPlaylistHarness(
+        provider,
+        get_playlist,
+        requires_global,
+        get_metadata,
+        get_page,
+    )
+
+
+def _spotify_track(track_id: str) -> dict[str, Any]:
+    """Return the minimum Spotify track payload accepted by the parser."""
+    return {
+        "id": track_id,
+        "name": track_id,
+        "duration_ms": 180000,
+        "external_urls": {"spotify": f"https://open.spotify.com/track/{track_id}"},
+        "is_local": False,
+        "is_playable": True,
+        "explicit": False,
+    }
+
+
+def _playlist_page(total: int, track_id: str) -> dict[str, Any]:
+    """Return a Spotify playlist page containing one playable track."""
+    return {"total": total, "items": [{"track": _spotify_track(track_id)}]}
+
+
+async def test_multipage_traversal_reuses_pagination_metadata() -> None:
+    """A cold sequential traversal requests metadata once and each valid page once."""
+    harness = _make_provider()
+    harness.get_metadata.return_value = {"etag": "snapshot-etag", "total": 120}
+
+    async def get_page(
+        _endpoint: str, _cache_checksum: str | None, **kwargs: Any
+    ) -> dict[str, Any]:
+        return _playlist_page(120, f"track-{kwargs['offset']}")
+
+    harness.get_page.side_effect = get_page
+
+    pages = [
+        await harness.provider.get_playlist_tracks(PLAYLIST_ID, page=page) for page in range(4)
+    ]
+
+    harness.get_metadata.assert_awaited_once_with(
+        f"playlists/{PLAYLIST_ID}/items",
+        limit=1,
+        offset=0,
+        use_global_session=False,
+    )
+    assert harness.get_page.await_args_list == [
+        call(
+            f"playlists/{PLAYLIST_ID}/items",
+            "snapshot-etag",
+            limit=50,
+            offset=offset,
+            use_global_session=False,
+        )
+        for offset in (0, 50, 100)
+    ]
+    assert [page[0].position for page in pages[:3]] == [1, 51, 101]
+    assert pages[3] == []
+
+
+async def test_concurrent_cold_pages_share_inflight_pagination_metadata() -> None:
+    """Concurrent cache refreshes share one in-flight metadata request."""
+    harness = _make_provider()
+    metadata_started = asyncio.Event()
+    release_metadata = asyncio.Event()
+
+    async def get_metadata(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        metadata_started.set()
+        await release_metadata.wait()
+        return {"etag": "shared-etag", "total": 100}
+
+    harness.get_metadata.side_effect = get_metadata
+    harness.get_page.side_effect = [
+        _playlist_page(100, "page-one-track"),
+        _playlist_page(100, "page-zero-track"),
+    ]
+
+    page_one_task = asyncio.create_task(harness.provider.get_playlist_tracks(PLAYLIST_ID, page=1))
+    await metadata_started.wait()
+    page_zero_task = asyncio.create_task(harness.provider.get_playlist_tracks(PLAYLIST_ID, page=0))
+    await asyncio.sleep(0)
+    release_metadata.set()
+    await asyncio.gather(page_one_task, page_zero_task)
+
+    harness.get_metadata.assert_awaited_once()
+    assert [args.args[1] for args in harness.get_page.await_args_list] == [
+        "shared-etag",
+        "shared-etag",
+    ]
+
+
+async def test_page_zero_refresh_replaces_pagination_snapshot() -> None:
+    """A new page-zero request replaces both the ETag and total for later pages."""
+    harness = _make_provider()
+    harness.get_metadata.side_effect = [
+        {"etag": "old-etag", "total": 120},
+        {"etag": "new-etag", "total": 50},
+    ]
+    harness.get_page.side_effect = [
+        _playlist_page(120, "old-track"),
+        _playlist_page(50, "new-track"),
+    ]
+
+    await harness.provider.get_playlist_tracks(PLAYLIST_ID, page=0)
+    await harness.provider.get_playlist_tracks(PLAYLIST_ID, page=0)
+    guarded_page = await harness.provider.get_playlist_tracks(PLAYLIST_ID, page=1)
+
+    assert harness.get_metadata.await_count == 2
+    assert [args.args[1] for args in harness.get_page.await_args_list] == [
+        "old-etag",
+        "new-etag",
+    ]
+    assert guarded_page == []
+    assert harness.get_page.await_count == 2
+
+
+async def test_cold_nonzero_page_fetches_pagination_metadata() -> None:
+    """A direct nonzero page request fetches metadata before requesting its page."""
+    harness = _make_provider()
+    harness.get_metadata.return_value = {"etag": "cold-etag", "total": 151}
+    harness.get_page.return_value = _playlist_page(151, "page-two-track")
+
+    tracks = await harness.provider.get_playlist_tracks(PLAYLIST_ID, page=2)
+
+    harness.get_metadata.assert_awaited_once()
+    harness.get_page.assert_awaited_once_with(
+        f"playlists/{PLAYLIST_ID}/items",
+        "cold-etag",
+        limit=50,
+        offset=100,
+        use_global_session=False,
+    )
+    assert tracks[0].position == 101
+
+
+async def test_playlist_identities_do_not_share_pagination_metadata() -> None:
+    """Private playlists and liked songs each use their own pagination snapshot."""
+    harness = _make_provider()
+    liked_songs_id = harness.provider._get_liked_songs_playlist_id()
+    harness.get_metadata.side_effect = [
+        {"etag": "private-a-etag", "total": 100},
+        {"etag": "private-b-etag", "total": 100},
+        {"etag": "liked-etag", "total": 100},
+    ]
+    harness.get_page.side_effect = [
+        _playlist_page(100, "private-a-track"),
+        _playlist_page(100, "private-b-track"),
+        _playlist_page(100, "liked-track"),
+    ]
+
+    await harness.provider.get_playlist_tracks("private-a", page=1)
+    await harness.provider.get_playlist_tracks("private-b", page=1)
+    await harness.provider.get_playlist_tracks(liked_songs_id, page=1)
+
+    assert harness.get_metadata.await_args_list == [
+        call(
+            "playlists/private-a/items",
+            limit=1,
+            offset=0,
+            use_global_session=False,
+        ),
+        call(
+            "playlists/private-b/items",
+            limit=1,
+            offset=0,
+            use_global_session=False,
+        ),
+        call("me/tracks", limit=1, offset=0, use_global_session=True),
+    ]
+    assert [args.args[1] for args in harness.get_page.await_args_list] == [
+        "private-a-etag",
+        "private-b-etag",
+        "liked-etag",
+    ]
+    assert harness.get_playlist.await_count == 2
+    assert harness.requires_global.await_count == 2
+
+
+async def test_session_paths_do_not_share_pagination_metadata() -> None:
+    """The same playlist refetches metadata when its required token path changes."""
+    harness = _make_provider()
+    harness.requires_global.side_effect = [False, True]
+    harness.get_metadata.side_effect = [
+        {"etag": "dev-etag", "total": 100},
+        {"etag": "global-etag", "total": 100},
+    ]
+    harness.get_page.side_effect = [
+        _playlist_page(100, "dev-track"),
+        _playlist_page(100, "global-track"),
+    ]
+
+    await harness.provider.get_playlist_tracks(PLAYLIST_ID, page=1)
+    await harness.provider.get_playlist_tracks(PLAYLIST_ID, page=1)
+
+    assert harness.get_metadata.await_args_list == [
+        call(
+            f"playlists/{PLAYLIST_ID}/items",
+            limit=1,
+            offset=0,
+            use_global_session=False,
+        ),
+        call(
+            f"playlists/{PLAYLIST_ID}/items",
+            limit=1,
+            offset=0,
+            use_global_session=True,
+        ),
+    ]
+    assert [
+        (args.args[1], args.kwargs["use_global_session"])
+        for args in harness.get_page.await_args_list
+    ] == [("dev-etag", False), ("global-etag", True)]
+
+
+async def test_provider_instances_do_not_share_pagination_metadata() -> None:
+    """Each Spotify provider instance maintains an independent pagination snapshot."""
+    first = _make_provider("spotify--first")
+    second = _make_provider("spotify--second")
+    first.get_metadata.return_value = {"etag": "first-etag", "total": 100}
+    second.get_metadata.return_value = {"etag": "second-etag", "total": 100}
+    first.get_page.return_value = _playlist_page(100, "first-track")
+    second.get_page.return_value = _playlist_page(100, "second-track")
+
+    await first.provider.get_playlist_tracks(PLAYLIST_ID, page=1)
+    await second.provider.get_playlist_tracks(PLAYLIST_ID, page=1)
+
+    first.get_metadata.assert_awaited_once()
+    second.get_metadata.assert_awaited_once()
+    assert first.get_page.await_args is not None
+    assert second.get_page.await_args is not None
+    assert first.get_page.await_args.args[1] == "first-etag"
+    assert second.get_page.await_args.args[1] == "second-etag"
+
+
+async def test_offset_guard_skips_invalid_playlist_page_request() -> None:
+    """Known totals prevent Spotify requests at or beyond the playlist end."""
+    harness = _make_provider()
+    harness.get_metadata.return_value = {"etag": "guard-etag", "total": 50}
+
+    tracks = await harness.provider.get_playlist_tracks(PLAYLIST_ID, page=1)
+
+    harness.get_metadata.assert_awaited_once()
+    harness.get_page.assert_not_awaited()
+    assert tracks == []

--- a/tests/providers/spotify/test_playlist_tracks.py
+++ b/tests/providers/spotify/test_playlist_tracks.py
@@ -1,11 +1,15 @@
 """Tests for Spotify playlist track pagination."""
 
 import asyncio
+from collections import OrderedDict
 from collections.abc import Coroutine
 from typing import Any, NamedTuple
 from unittest.mock import AsyncMock, MagicMock, call
 
-from music_assistant.providers.spotify.provider import SpotifyProvider
+from music_assistant.providers.spotify.provider import (
+    _PLAYLIST_PAGINATION_STATE_LIMIT,
+    SpotifyProvider,
+)
 
 PLAYLIST_ID = "private-playlist"
 
@@ -27,8 +31,7 @@ def _make_provider(instance_id: str = "spotify--test") -> SpotifyPlaylistHarness
     provider.manifest = MagicMock(domain="spotify")
     provider.logger = MagicMock()
     provider._sp_user = {"id": "test-user", "display_name": "Test User"}
-    provider._playlist_pagination_snapshot = None
-    provider._playlist_pagination_lock = asyncio.Lock()
+    provider._playlist_pagination_states = OrderedDict()
 
     mass = MagicMock()
     mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
@@ -140,6 +143,60 @@ async def test_concurrent_cold_pages_share_inflight_pagination_metadata() -> Non
     assert [args.args[1] for args in harness.get_page.await_args_list] == [
         "shared-etag",
         "shared-etag",
+    ]
+
+
+async def test_distinct_playlists_use_independent_pagination_states() -> None:
+    """Different playlists neither block nor replace each other's metadata."""
+    harness = _make_provider()
+    first_metadata_started = asyncio.Event()
+    release_first_metadata = asyncio.Event()
+
+    async def get_metadata(endpoint: str, **_kwargs: Any) -> dict[str, Any]:
+        if endpoint == "playlists/private-a/items":
+            first_metadata_started.set()
+            await release_first_metadata.wait()
+            return {"etag": "private-a-etag", "total": 100}
+        return {"etag": "private-b-etag", "total": 100}
+
+    async def get_page(_endpoint: str, cache_checksum: str | None, **kwargs: Any) -> dict[str, Any]:
+        return _playlist_page(100, f"{cache_checksum}-{kwargs['offset']}")
+
+    harness.get_metadata.side_effect = get_metadata
+    harness.get_page.side_effect = get_page
+
+    first_task = asyncio.create_task(harness.provider.get_playlist_tracks("private-a", page=0))
+    await first_metadata_started.wait()
+    try:
+        await asyncio.wait_for(
+            harness.provider.get_playlist_tracks("private-b", page=0),
+            timeout=1,
+        )
+    finally:
+        release_first_metadata.set()
+        await first_task
+    await harness.provider.get_playlist_tracks("private-a", page=1)
+    await harness.provider.get_playlist_tracks("private-b", page=1)
+
+    assert harness.get_metadata.await_args_list == [
+        call(
+            "playlists/private-a/items",
+            limit=1,
+            offset=0,
+            use_global_session=False,
+        ),
+        call(
+            "playlists/private-b/items",
+            limit=1,
+            offset=0,
+            use_global_session=False,
+        ),
+    ]
+    assert [args.args[1] for args in harness.get_page.await_args_list] == [
+        "private-b-etag",
+        "private-a-etag",
+        "private-a-etag",
+        "private-b-etag",
     ]
 
 
@@ -296,3 +353,14 @@ async def test_offset_guard_skips_invalid_playlist_page_request() -> None:
     harness.get_metadata.assert_awaited_once()
     harness.get_page.assert_not_awaited()
     assert tracks == []
+
+
+async def test_playlist_pagination_state_is_bounded() -> None:
+    """Pagination state retains only the most recently accessed playlists."""
+    harness = _make_provider()
+    harness.get_metadata.return_value = {"etag": "guard-etag", "total": 50}
+
+    for index in range(_PLAYLIST_PAGINATION_STATE_LIMIT + 1):
+        await harness.provider.get_playlist_tracks(f"playlist-{index}", page=1)
+
+    assert len(harness.provider._playlist_pagination_states) == _PLAYLIST_PAGINATION_STATE_LIMIT


### PR DESCRIPTION
# What does this implement/fix?

Spotify requested the same playlist metadata for every page of a large playlist, which could cause throttling and slow playlist loading.

- Reuse one ETag and total snapshot throughout each playlist traversal.
- Refresh the snapshot on page zero and isolate it by playlist, session path, and provider instance.
- Cover cold, concurrent, refreshed, and out-of-range page requests.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
