### PR TITLE
Fix silent audio overlays

### DIFF
--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -9,6 +9,7 @@ import time
 from collections import deque
 from collections.abc import AsyncGenerator
 from contextlib import suppress
+from copy import copy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final
 
@@ -439,7 +440,9 @@ async def get_ffmpeg_overlay_stream(
     )
     async with FFMpeg(
         audio_input=audio_input,
-        input_format=pcm_format,
+        # The overlay is input 0, so ffmpeg probes it before the PCM input and
+        # mutates input_format with its metadata. Keep that mutation local.
+        input_format=copy(pcm_format),
         output_format=pcm_format,
         extra_input_args=overlay_input_args,
         extra_output_args=["-filter_complex", filter_complex, "-map", "[mixed]"],

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -239,6 +239,30 @@ async def test_overlay_stream_mixes_loops_and_preserves_length(overlay_file: Pat
     assert any(output[2 * _BYTES_PER_SECOND :])
 
 
+async def test_overlay_stream_does_not_mutate_pcm_format(overlay_file: Path) -> None:
+    """Mixing an overlay leaves the caller's PCM format unchanged."""
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_F32LE,
+        sample_rate=48000,
+        bit_depth=32,
+        channels=2,
+    )
+    original_format = pcm_format.to_dict()
+
+    async def silence() -> AsyncGenerator[bytes]:
+        yield b"\x00" * pcm_format.pcm_sample_size
+
+    await _collect_chunks(
+        get_ffmpeg_overlay_stream(
+            audio_input=silence(),
+            overlay_input=str(overlay_file),
+            pcm_format=pcm_format,
+        )
+    )
+
+    assert pcm_format.to_dict() == original_format
+
+
 async def test_overlay_stream_applies_volume(overlay_file: Path) -> None:
     """Overlay volume 0% silences the overlay entirely (gain is applied)."""
     output = b"".join(


### PR DESCRIPTION
# What does this implement/fix?

Audio overlays could silence playback because the overlay sound's format replaced the queue stream format during setup.

- Keep overlay format detection isolated from the music stream.
- Add regression coverage for mixed audio formats.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
