### PR TITLE
Add reveal flow to Music Trivia

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1106,8 +1106,15 @@ class MusicQuizPlugin(PluginProvider):
             try:
                 await self._advance_from_reveal()
             except Exception as err:
-                # leave the game in reveal so the host can retry via next/reset
+                # leave the game in reveal so the host or players can retry manually
                 self.logger.error("Could not advance Music Quiz game: %s", err, exc_info=err)
+                if (
+                    self._game is game
+                    and self._game_generation == generation
+                    and self._is_current_round(round_index, MusicQuizPhase.REVEAL)
+                ):
+                    get_current_round(game).auto_advance_at = None
+                    self._signal_game_updated()
 
     def _is_current_round(self, round_index: int, phase: MusicQuizPhase) -> bool:
         """Return whether the game is still in the given round and phase."""

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -27,8 +27,9 @@ The public game state is guest-safe by construction. Common state contains:
 - always: ``phase`` (lobby/answering/reveal/finished), ``name``, ``quiz_type``,
   ``answer_type``, ``mode`` (venue/remote), ``round_count``, ``answer_duration``
   and public player progress. ``auto_start_at`` contains the authoritative replay
-  deadline while a lobby countdown is active. Private player IDs never appear in
-  broadcasts. Trivia additionally exposes its canonical ``language``.
+  deadline while a lobby countdown is active. Private player IDs never appear
+  in broadcasts. Trivia additionally exposes its canonical ``language`` and
+  ``play_reveal_audio`` setting.
 - answering rounds expose common timing and question fields plus a strategy
   fragment. Multiple-choice exposes opaque ``suggestions``. Timeline exposes
   the revealed shared ``timeline`` and redacted ``bonus_definitions``; the
@@ -53,7 +54,7 @@ import asyncio
 import secrets
 import time
 from collections.abc import Callable, Coroutine, Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import Scope, UserRole
@@ -251,6 +252,7 @@ class MusicQuizPlugin(PluginProvider):
         self._playback_session: SharedPlaybackSession | None = None
         self._playback_lock = asyncio.Lock()
         self._next_round_task: asyncio.Task[MusicQuizRound] | None = None
+        self._reveal_playback_task: asyncio.Task[None] | None = None
         self._unregister_handles: list[Callable[[], None]] = []
 
     async def loaded_in_mass(self) -> None:
@@ -305,8 +307,12 @@ class MusicQuizPlugin(PluginProvider):
             unregister()
         self._unregister_handles.clear()
         async with self._game_lock:
+            quiz_type = self._quiz_type
             self._cancel_timers()
             self._cancel_next_round_task()
+            await self._cancel_reveal_playback_task()
+            if quiz_type is None or quiz_type.uses_audio:
+                await self._stop_playback()
             self._game_generation += 1
             # clear game state before tearing down the session so a guest listen-in
             # racing with unload cannot (re)create or join a session mid-teardown
@@ -324,7 +330,7 @@ class MusicQuizPlugin(PluginProvider):
         """Return quiz types currently available for game creation."""
         return get_available_quiz_types(self.mass)
 
-    async def create_game(
+    async def create_game(  # noqa: PLR0913
         self,
         quiz_type: str = "guess_the_song",
         round_count: int = 5,
@@ -334,6 +340,7 @@ class MusicQuizPlugin(PluginProvider):
         name: str | None = None,
         difficulty: str = MusicQuizDifficulty.NORMAL.value,
         language: str = DEFAULT_TRIVIA_LANGUAGE,
+        play_reveal_audio: bool = True,
         artist_bonus_mode: str = TimelineBonusMode.OFF.value,
         title_bonus_mode: str = TimelineBonusMode.OFF.value,
     ) -> dict[str, Any]:
@@ -348,6 +355,7 @@ class MusicQuizPlugin(PluginProvider):
         :param name: Optional game name.
         :param difficulty: Guess-the-song difficulty ("easy", "normal" or "hard").
         :param language: Language tag for Trivia question content.
+        :param play_reveal_audio: Play Trivia's grounded track during each reveal.
         :param artist_bonus_mode: Music Timeline artist bonus mode.
         :param title_bonus_mode: Music Timeline title bonus mode.
         """
@@ -372,6 +380,7 @@ class MusicQuizPlugin(PluginProvider):
                 difficulty=difficulty,
                 use_ai_distractors=bool(self.config.get_value(CONF_USE_AI_DISTRACTORS)),
                 language=language,
+                play_reveal_audio=play_reveal_audio,
                 artist_bonus_mode=parsed_artist_bonus_mode,
                 title_bonus_mode=parsed_title_bonus_mode,
             )
@@ -393,6 +402,10 @@ class MusicQuizPlugin(PluginProvider):
             quiz_strategy, answer_strategy = self._resolve_game_strategies(game)
             with _system_auth_context():
                 await quiz_strategy.initialize()
+            previous_quiz_type = self._quiz_type
+            await self._cancel_reveal_playback_task()
+            if previous_quiz_type is not None and previous_quiz_type.uses_audio:
+                await self._stop_playback()
             async with self._playback_lock:
                 if not quiz_strategy.uses_audio:
                     await self._close_playback_session_locked()
@@ -454,6 +467,7 @@ class MusicQuizPlugin(PluginProvider):
                 await quiz_strategy.initialize()
             self._cancel_timers()
             self._cancel_next_round_task()
+            await self._cancel_reveal_playback_task()
             if quiz_strategy.uses_audio:
                 await self._stop_playback()
             now = time.time()
@@ -475,6 +489,7 @@ class MusicQuizPlugin(PluginProvider):
             uses_audio = self._quiz_type is None or self._quiz_type.uses_audio
             self._cancel_timers()
             self._cancel_next_round_task()
+            await self._cancel_reveal_playback_task()
             self._game_generation += 1
             # clear game state before tearing down the session so a guest listen-in
             # racing with delete cannot (re)create or join a session mid-teardown
@@ -852,12 +867,16 @@ class MusicQuizPlugin(PluginProvider):
             game, quiz_type, answer_type = self._require_game_strategies()
             round_index = len(game.rounds)
             next_round = await self._prepare_playable_round(round_index)
-            start_round(game, next_round, time.time(), answer_type)
+            started_at = time.time()
+            start_round(game, next_round, started_at, answer_type)
             answer_window = _answer_window(game, next_round)
             self.mass.call_later(
                 answer_window,
                 self._on_answer_deadline,
+                game,
+                self._game_generation,
                 round_index,
+                started_at + answer_window,
                 task_id=self._reveal_timer_id,
             )
             if next_round.track_uri and quiz_type.warm_up_lyrics:
@@ -868,15 +887,15 @@ class MusicQuizPlugin(PluginProvider):
     async def _prepare_playable_round(self, round_index: int) -> MusicQuizRound:
         """Return a prepared round after its audio starts successfully."""
         _, quiz_type, _ = self._require_game_strategies()
+        if not quiz_type.plays_track_before_answering:
+            return await self._get_prepared_round(round_index)
         rejected_uris: set[str] = set()
         last_error: AudioError | MediaNotFoundError | None = None
         for _attempt in range(MAX_PLAYBACK_ATTEMPTS):
             next_round = await self._get_prepared_round(round_index)
             track_uri = next_round.track_uri
             if track_uri is None:
-                if quiz_type.uses_audio:
-                    raise InvalidDataError("Prepared audio round is missing a track URI")
-                return next_round
+                raise InvalidDataError("Prepared audio round is missing a track URI")
             if track_uri in rejected_uris:
                 quiz_type.reject_track(track_uri)
                 continue
@@ -909,26 +928,45 @@ class MusicQuizPlugin(PluginProvider):
         current_round.auto_advance_at = None
         now = time.time()
         advance_delay = quiz_type.completed_reveal_auto_advance_delay if completed else None
+        if advance_delay is None:
+            advance_delay = quiz_type.reveal_auto_advance_delay
         if advance_delay is None and current_round.duration and current_round.started_at:
             remaining = current_round.started_at + current_round.duration - now
             advance_delay = max(remaining, MIN_REVEAL_SECONDS)
         if advance_delay is not None:
+            auto_advance_at = now + advance_delay
             self.mass.call_later(
                 advance_delay,
-                self._on_reveal_finished,
+                self._on_reveal_auto_advance,
+                game,
+                self._game_generation,
                 current_round.round_index,
+                auto_advance_at,
                 task_id=self._advance_timer_id,
             )
-            current_round.auto_advance_at = now + advance_delay
+            current_round.auto_advance_at = auto_advance_at
         self._signal_game_updated()
+        if quiz_type.plays_track_on_reveal:
+            if current_round.track_uri is None:
+                self.logger.warning("Prepared Music Quiz reveal round is missing a track URI")
+            else:
+                self._start_reveal_playback(
+                    game,
+                    self._game_generation,
+                    current_round.round_index,
+                    current_round.track_uri,
+                )
 
     async def _advance_from_reveal(self) -> None:
         """Advance a revealed game to the next round or finish it."""
-        game = self._require_game()
+        game, quiz_type, _ = self._require_game_strategies()
         get_current_round(game).auto_advance_at = None
         self.mass.cancel_timer(self._advance_timer_id)
+        if quiz_type.plays_track_on_reveal:
+            await self._cancel_reveal_playback_task()
+            await self._stop_playback()
         if len(game.rounds) >= game.config.round_count:
-            if self._quiz_type is None or self._quiz_type.uses_audio:
+            if quiz_type.uses_audio and not quiz_type.plays_track_on_reveal:
                 await self._stop_playback()
             finish_game(game)
             self._cancel_presence_expiry()
@@ -1012,17 +1050,58 @@ class MusicQuizPlugin(PluginProvider):
                         exc_info=err,
                     )
 
-    async def _on_answer_deadline(self, round_index: int) -> None:
-        """Reveal the round when the answering deadline passed."""
+    async def _on_answer_deadline(
+        self,
+        game: MusicQuizGame,
+        generation: int,
+        round_index: int,
+        answer_deadline: float,
+    ) -> None:
+        """
+        Reveal an answering round whose authoritative deadline was reached.
+
+        :param game: Game for which the deadline was scheduled.
+        :param generation: Lifecycle generation for which the deadline was scheduled.
+        :param round_index: Answering round index.
+        :param answer_deadline: Authoritative deadline for this answer window.
+        """
         async with self._game_lock:
-            if not self._is_current_round(round_index, MusicQuizPhase.ANSWERING):
+            if (
+                self._game is not game
+                or self._game_generation != generation
+                or not self._is_current_round(round_index, MusicQuizPhase.ANSWERING)
+            ):
+                return
+            current_round = get_current_round(game)
+            if (
+                current_round.started_at is None
+                or current_round.started_at + _answer_window(game, current_round) != answer_deadline
+            ):
                 return
             self._do_reveal()
 
-    async def _on_reveal_finished(self, round_index: int) -> None:
-        """Advance the game when the revealed track finished playing."""
+    async def _on_reveal_auto_advance(
+        self,
+        game: MusicQuizGame,
+        generation: int,
+        round_index: int,
+        auto_advance_at: float,
+    ) -> None:
+        """
+        Advance a reveal whose authoritative deadline was reached.
+
+        :param game: Game for which advancement was scheduled.
+        :param generation: Lifecycle generation for which advancement was scheduled.
+        :param round_index: Revealed round index.
+        :param auto_advance_at: Authoritative deadline for this reveal.
+        """
         async with self._game_lock:
-            if not self._is_current_round(round_index, MusicQuizPhase.REVEAL):
+            if (
+                self._game is not game
+                or self._game_generation != generation
+                or not self._is_current_round(round_index, MusicQuizPhase.REVEAL)
+                or get_current_round(game).auto_advance_at != auto_advance_at
+            ):
                 return
             try:
                 await self._advance_from_reveal()
@@ -1078,6 +1157,102 @@ class MusicQuizPlugin(PluginProvider):
             # already failed is not reported by asyncio as an unhandled exception
             self._next_round_task.add_done_callback(_consume_task_exception)
             self._next_round_task = None
+
+    def _start_reveal_playback(
+        self,
+        game: MusicQuizGame,
+        generation: int,
+        round_index: int,
+        track_uri: str,
+    ) -> None:
+        """
+        Start best-effort reveal playback for the current Trivia round.
+
+        :param game: Game owning the revealed round.
+        :param generation: Lifecycle generation owning the playback.
+        :param round_index: Revealed round index.
+        :param track_uri: Grounded track to play.
+        """
+        if self._reveal_playback_task is not None:
+            self._reveal_playback_task.cancel()
+            self._reveal_playback_task.add_done_callback(_consume_task_exception)
+            self._reveal_playback_task = None
+        playback = self._play_reveal_track(game, generation, round_index, track_uri)
+        try:
+            with _system_auth_context():
+                self._reveal_playback_task = self.mass.create_task(
+                    playback,
+                    eager_start=False,
+                )
+        except Exception as err:
+            playback.close()
+            self.logger.warning(
+                "Could not start Music Quiz reveal playback for %s: %s",
+                track_uri,
+                err,
+            )
+
+    async def _play_reveal_track(
+        self,
+        game: MusicQuizGame,
+        generation: int,
+        round_index: int,
+        track_uri: str,
+    ) -> None:
+        """
+        Play a track while its owning Trivia reveal remains current.
+
+        :param game: Game owning the revealed round.
+        :param generation: Lifecycle generation owning the playback.
+        :param round_index: Revealed round index.
+        :param track_uri: Grounded track to play.
+        """
+        with _system_auth_context():
+            if not self._is_reveal_playback_current(game, generation, round_index):
+                return
+            try:
+                await self._play_track(track_uri)
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:
+                self.logger.warning(
+                    "Could not play Music Quiz reveal track %s: %s",
+                    track_uri,
+                    err,
+                )
+                return
+            if not self._is_reveal_playback_current(game, generation, round_index):
+                await self._stop_playback()
+
+    async def _cancel_reveal_playback_task(self) -> None:
+        """Cancel and await the provider-owned reveal playback task, if any."""
+        task = self._reveal_playback_task
+        self._reveal_playback_task = None
+        if task is None:
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    def _is_reveal_playback_current(
+        self,
+        game: MusicQuizGame,
+        generation: int,
+        round_index: int,
+    ) -> bool:
+        """
+        Return whether reveal playback still belongs to the active round.
+
+        :param game: Game owning the playback.
+        :param generation: Lifecycle generation owning the playback.
+        :param round_index: Revealed round index.
+        """
+        return (
+            self._game is game
+            and self._game_generation == generation
+            and game.phase == MusicQuizPhase.REVEAL
+            and game.current_round_index == round_index
+        )
 
     def _warm_up_lyrics(self, track_uri: str) -> None:
         """Fetch/caches the track lyrics so they are ready when revealed."""
@@ -1173,7 +1348,8 @@ class MusicQuizPlugin(PluginProvider):
         if self._quiz_type is not None and not self._quiz_type.uses_audio:
             return None
         if self._quiz_type is None and isinstance(self._game, MusicQuizGame):
-            if not get_quiz_type(self._game.quiz_type).uses_audio:
+            quiz_type = get_quiz_type(self._game.quiz_type)(self.mass, self._game.config)
+            if not quiz_type.uses_audio:
                 return None
         # drop a stale session whose player no longer exists
         if self._playback_session is not None and (
@@ -1186,14 +1362,8 @@ class MusicQuizPlugin(PluginProvider):
             return self._playback_session
 
         if self.config.get_value(CONF_MODE) == SharedPlaybackMode.REMOTE.value:
-            game_name = self._game.config.name if self._game else None
             try:
-                self._playback_session = await SharedPlaybackSession.create_remote(
-                    self.mass,
-                    owner_instance_id=self.instance_id,
-                    display_name=game_name or "Music Quiz",
-                    session_id=self.instance_id,
-                )
+                self._playback_session = await self._create_remote_playback_session()
             except SetupFailedError as err:
                 self.logger.warning("Unable to create remote quiz session: %s", err)
         elif player_id := self._resolve_venue_player_id():
@@ -1204,6 +1374,33 @@ class MusicQuizPlugin(PluginProvider):
             except SetupFailedError as err:
                 self.logger.warning("Unable to create venue quiz session: %s", err)
         return self._playback_session
+
+    async def _create_remote_playback_session(self) -> SharedPlaybackSession:
+        """Create a remote session without abandoning a partially created virtual player."""
+        game_name = self._game.config.name if self._game else None
+        creation_task = self.mass.create_task(
+            SharedPlaybackSession.create_remote(
+                self.mass,
+                owner_instance_id=self.instance_id,
+                display_name=game_name or "Music Quiz",
+                session_id=self.instance_id,
+            ),
+            eager_start=False,
+        )
+        try:
+            return await asyncio.shield(creation_task)
+        except asyncio.CancelledError:
+            try:
+                while True:
+                    try:
+                        self._playback_session = await asyncio.shield(creation_task)
+                        break
+                    except asyncio.CancelledError:
+                        if creation_task.cancelled():
+                            raise
+            except SetupFailedError as err:
+                self.logger.warning("Unable to create remote quiz session: %s", err)
+            raise
 
     def _resolve_venue_player_id(self) -> str | None:
         """

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1376,31 +1376,14 @@ class MusicQuizPlugin(PluginProvider):
         return self._playback_session
 
     async def _create_remote_playback_session(self) -> SharedPlaybackSession:
-        """Create a remote session without abandoning a partially created virtual player."""
+        """Create the remote playback session for the active game."""
         game_name = self._game.config.name if self._game else None
-        creation_task = self.mass.create_task(
-            SharedPlaybackSession.create_remote(
-                self.mass,
-                owner_instance_id=self.instance_id,
-                display_name=game_name or "Music Quiz",
-                session_id=self.instance_id,
-            ),
-            eager_start=False,
+        return await SharedPlaybackSession.create_remote(
+            self.mass,
+            owner_instance_id=self.instance_id,
+            display_name=game_name or "Music Quiz",
+            session_id=self.instance_id,
         )
-        try:
-            return await asyncio.shield(creation_task)
-        except asyncio.CancelledError:
-            try:
-                while True:
-                    try:
-                        self._playback_session = await asyncio.shield(creation_task)
-                        break
-                    except asyncio.CancelledError:
-                        if creation_task.cancelled():
-                            raise
-            except SetupFailedError as err:
-                self.logger.warning("Unable to create remote quiz session: %s", err)
-            raise
 
     def _resolve_venue_player_id(self) -> str | None:
         """

--- a/music_assistant/providers/music_quiz/models.py
+++ b/music_assistant/providers/music_quiz/models.py
@@ -66,6 +66,7 @@ class MusicQuizConfig(DataClassDictMixin):
     use_ai_distractors: bool = False
     # trivia specific; other quiz types ignore this
     language: str = DEFAULT_TRIVIA_LANGUAGE
+    play_reveal_audio: bool = True
     # timeline specific; other answer types ignore these
     artist_bonus_mode: TimelineBonusMode = TimelineBonusMode.OFF
     title_bonus_mode: TimelineBonusMode = TimelineBonusMode.OFF
@@ -350,8 +351,8 @@ class MusicQuizRound(DataClassDictMixin):
     round_index: int
     answer_label: str
     answer_state: QuizRoundAnswerState
-    # a round plays a track (audio round) and/or poses a text question;
-    # non-audio quiz types leave track_uri unset
+    # a round may play its track while answering or after reveal, and/or pose
+    # a text question; fully text-only rounds leave track_uri unset
     track_uri: str | None = None
     question: str | None = None
     image_url: str | None = None

--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -68,8 +68,8 @@ class QuizType(ABC):
     """
 
     answer_type: ClassVar[MusicQuizAnswerType]
-    uses_audio: ClassVar[bool] = True
     warm_up_lyrics: ClassVar[bool] = False
+    reveal_auto_advance_delay: ClassVar[float | None] = None
     completed_reveal_auto_advance_delay: ClassVar[float | None] = None
 
     def __init__(self, mass: MusicAssistant, config: MusicQuizConfig) -> None:
@@ -82,6 +82,21 @@ class QuizType(ABC):
         self.mass = mass
         self.config = config
         self._source_track_pool: dict[str, Track] | None = None
+
+    @property
+    def uses_audio(self) -> bool:
+        """Return whether this quiz type uses a shared playback session."""
+        return self.plays_track_before_answering or self.plays_track_on_reveal
+
+    @property
+    def plays_track_before_answering(self) -> bool:
+        """Return whether a prepared track must start before answering opens."""
+        return True
+
+    @property
+    def plays_track_on_reveal(self) -> bool:
+        """Return whether a prepared track should start when its answer is revealed."""
+        return False
 
     @classmethod
     def is_available(cls, mass: MusicAssistant) -> bool:  # noqa: ARG003

--- a/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
+++ b/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
@@ -67,6 +67,7 @@ class GuessTheSongQuizType(QuizType):
         return replace(
             config,
             language=DEFAULT_TRIVIA_LANGUAGE,
+            play_reveal_audio=True,
             artist_bonus_mode=TimelineBonusMode.OFF,
             title_bonus_mode=TimelineBonusMode.OFF,
         )

--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -93,6 +93,7 @@ class MusicTimelineQuizType(QuizType):
             suggestion_count=DEFAULT_BONUS_OPTION_COUNT,
             difficulty=MusicQuizDifficulty.NORMAL.value,
             language=DEFAULT_TRIVIA_LANGUAGE,
+            play_reveal_audio=True,
         )
 
     @classmethod

--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -56,6 +56,7 @@ MAX_METADATA_VALUE_LENGTH = 500
 MAX_ANSWER_LENGTH = 200
 MAX_QUESTION_LENGTH = 300
 MAX_TRIVIA_LANGUAGE_TAG_LENGTH = 16
+TRIVIA_REVEAL_AUTO_ADVANCE_SECONDS = 15.0
 SYSTEM_RANDOM = random.SystemRandom()
 _LANGUAGE_TAG_PATTERN = re.compile(
     r"(?P<language>[A-Za-z]{2,3})"
@@ -106,7 +107,7 @@ class TriviaQuizType(QuizType):
     """Quiz type with AI-worded questions grounded in selected track metadata."""
 
     answer_type = MusicQuizAnswerType.MULTIPLE_CHOICE
-    uses_audio = False
+    reveal_auto_advance_delay = TRIVIA_REVEAL_AUTO_ADVANCE_SECONDS
 
     def __init__(self, mass: MusicAssistant, config: MusicQuizConfig) -> None:
         """
@@ -117,6 +118,16 @@ class TriviaQuizType(QuizType):
         """
         super().__init__(mass, config)
         self._eligible_tracks: dict[str, TriviaTrackFacts] | None = None
+
+    @property
+    def plays_track_before_answering(self) -> bool:
+        """Return whether Trivia starts a track while players answer."""
+        return False
+
+    @property
+    def plays_track_on_reveal(self) -> bool:
+        """Return whether Trivia plays its grounded track after revealing the answer."""
+        return self.config.play_reveal_audio
 
     @classmethod
     def is_available(cls, mass: MusicAssistant) -> bool:
@@ -185,7 +196,10 @@ class TriviaQuizType(QuizType):
 
         :param game: Game whose configuration should be serialized.
         """
-        return {"language": _normalize_trivia_language(game.config.language)}
+        return {
+            "language": _normalize_trivia_language(game.config.language),
+            "play_reveal_audio": game.config.play_reveal_audio,
+        }
 
     async def initialize(self) -> None:
         """Validate AI availability and enough grounded content for the complete game."""
@@ -208,7 +222,7 @@ class TriviaQuizType(QuizType):
         :param round_index: Index of the round to prepare.
         :param previous_rounds: Rounds already prepared in earlier iterations.
         :raises InvalidDataError: If round history, source metadata or AI output is unusable.
-        :return: The prepared non-audio Trivia round.
+        :return: The prepared Trivia round.
         """
         if round_index < 0 or round_index >= self.config.round_count:
             raise InvalidDataError("Trivia round index is outside the configured game")
@@ -248,6 +262,7 @@ class TriviaQuizType(QuizType):
             question=generation.question,
             answer_label=fact.correct_answer,
             answer_state=MultipleChoiceRoundState(suggestions=suggestions),
+            track_uri=track_facts.source_uri if self.plays_track_on_reveal else None,
         )
 
     async def _get_eligible_tracks(self) -> dict[str, TriviaTrackFacts]:
@@ -424,7 +439,6 @@ class TriviaQuizType(QuizType):
         for expected_index, previous_round in enumerate(previous_rounds):
             if (
                 previous_round.round_index != expected_index
-                or previous_round.track_uri is not None
                 or previous_round.duration is not None
                 or previous_round.image_url is not None
                 or not previous_round.question
@@ -448,6 +462,11 @@ class TriviaQuizType(QuizType):
             ):
                 raise InvalidDataError("Trivia round history contains invalid source metadata")
             source_uri = correct_suggestions[0].uri
+            expected_track_uri = source_uri if self.plays_track_on_reveal else None
+            if previous_round.track_uri != expected_track_uri:
+                raise InvalidDataError(
+                    "Trivia round history contains incompatible playback metadata"
+                )
             if source_uri in used_source_uris:
                 raise InvalidDataError("Trivia round history contains duplicate source tracks")
             used_source_uris.add(source_uri)

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -164,9 +164,10 @@ def _make_trivia_round(
     round_index: int,
     _previous_rounds: list[MusicQuizRound],
 ) -> MusicQuizRound:
-    """Return a deterministic non-audio Trivia round."""
+    """Return a deterministic Trivia round with protected reveal audio."""
     return MusicQuizRound(
         round_index=round_index,
+        track_uri=f"library://track/trivia-{round_index}",
         question=f"Trivia question {round_index}?",
         answer_label=f"Correct answer {round_index}",
         answer_state=MultipleChoiceRoundState(
@@ -187,6 +188,16 @@ def _make_trivia_round(
             ]
         ),
     )
+
+
+def _make_text_trivia_round(
+    round_index: int,
+    previous_rounds: list[MusicQuizRound],
+) -> MusicQuizRound:
+    """Return a deterministic text-only Trivia round."""
+    game_round = _make_trivia_round(round_index, previous_rounds)
+    game_round.track_uri = None
+    return game_round
 
 
 def _create_plugin(
@@ -213,6 +224,7 @@ def _create_plugin(
     plugin._playback_session = None
     plugin._playback_lock = asyncio.Lock()
     plugin._next_round_task = None
+    plugin._reveal_playback_task = None
     plugin._unregister_handles = []
 
     def _create_task(target: Any, *args: Any, **_kwargs: Any) -> asyncio.Task[Any]:
@@ -267,10 +279,21 @@ def _round_timer_call(plugin: MusicQuizPlugin, task_id: str) -> tuple[float, Any
     """Return the most recently scheduled timer for a game round."""
     for timer_call in reversed(cast("MagicMock", plugin.mass.call_later).call_args_list):
         if timer_call.kwargs.get("task_id") == task_id:
+            target = timer_call.args[1]
+            target_args = timer_call.args[2:]
+            round_index = cast("int", target_args[2])
+
+            async def _invoke(
+                _round_index: int,
+                _target: Any = target,
+                _target_args: tuple[Any, ...] = target_args,
+            ) -> None:
+                await _target(*_target_args)
+
             return (
                 cast("float", timer_call.args[0]),
-                timer_call.args[1],
-                cast("int", timer_call.args[2]),
+                _invoke,
+                round_index,
             )
     raise AssertionError(f"No round timer was scheduled for {task_id}")
 
@@ -336,6 +359,33 @@ async def _create_started_music_timeline_game(
         name="Timeline Quiz",
         artist_bonus_mode=artist_bonus_mode,
         title_bonus_mode=title_bonus_mode,
+    )
+    player_ids: dict[str, str] = {}
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        for player_name in player_names:
+            result = await plugin.join_game(player_name)
+            player_ids[player_name] = result["player_id"]
+    await plugin.start_game()
+    return player_ids
+
+
+async def _create_started_trivia_game(
+    plugin: MusicQuizPlugin,
+    player_names: tuple[str, ...] = ("Alice",),
+    round_count: int = 2,
+    *,
+    play_reveal_audio: bool = True,
+) -> dict[str, str]:
+    """Create and start a Trivia game, returning name-to-player credentials."""
+    await plugin.create_game(
+        quiz_type="trivia",
+        round_count=round_count,
+        source_uris=["library://playlist/1"],
+        name="Trivia Quiz",
+        play_reveal_audio=play_reveal_audio,
     )
     player_ids: dict[str, str] = {}
     with patch(
@@ -941,6 +991,7 @@ async def test_trivia_creation_initializes_with_ai_plugin() -> None:
     assert state["quiz_type"] == "trivia"
     assert state["answer_type"] == "multiple_choice"
     assert state["language"] == "en"
+    assert state["play_reveal_audio"] is True
     eligible_tracks.assert_awaited_once()
     assert plugin._next_round_task is not None
     plugin._cancel_next_round_task()
@@ -963,8 +1014,8 @@ async def test_trivia_creation_rejects_invalid_language() -> None:
 
 
 @pytest.mark.asyncio
-async def test_trivia_creation_closes_previous_audio_session() -> None:
-    """Detach existing audio listeners when replacing an audio lobby with Trivia."""
+async def test_trivia_creation_reuses_previous_audio_session() -> None:
+    """Keep existing audio listeners when replacing an audio lobby with audio Trivia."""
     plugin = _create_plugin()
     await plugin.create_game(source_uris=["library://playlist/1"])
     previous_game = plugin._game
@@ -987,8 +1038,9 @@ async def test_trivia_creation_closes_previous_audio_session() -> None:
 
     assert state["quiz_type"] == "trivia"
     assert plugin._game is not previous_game
-    assert vars(plugin)["_playback_session"] is None
-    playback_session.close.assert_awaited_once()
+    assert vars(plugin)["_playback_session"] is playback_session
+    cast("AsyncMock", plugin._stop_playback).assert_awaited_once()
+    playback_session.close.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1013,7 +1065,7 @@ async def test_trivia_replacement_blocks_concurrent_listen_in_recreation() -> No
         patch.object(
             TriviaQuizType,
             "prepare_round",
-            new=AsyncMock(side_effect=_make_trivia_round),
+            new=AsyncMock(side_effect=_make_text_trivia_round),
         ),
         patch(
             "music_assistant.providers.music_quiz.get_current_user",
@@ -1025,11 +1077,11 @@ async def test_trivia_replacement_blocks_concurrent_listen_in_recreation() -> No
                 quiz_type="trivia",
                 round_count=1,
                 source_uris=["library://playlist/1"],
+                play_reveal_audio=False,
             )
         )
         await close_started.wait()
         listen_task = asyncio.create_task(plugin.listen_in("web-player"))
-        await asyncio.sleep(0)
         assert not listen_task.done()
         allow_close.set()
         state = await create_task
@@ -1042,11 +1094,11 @@ async def test_trivia_replacement_blocks_concurrent_listen_in_recreation() -> No
 
 
 @pytest.mark.asyncio
-async def test_trivia_serialization_and_listen_in_remain_non_audio() -> None:
+async def test_disabled_trivia_serialization_and_listen_in_remain_non_audio() -> None:  # noqa: PLR0915
     """Expose flat redacted Trivia state without playback, lyrics, or listen-in."""
     plugin = _create_plugin(use_ai_distractors=True)
     plugin._warm_up_lyrics = MagicMock()  # type: ignore[method-assign]
-    prepare_round = AsyncMock(side_effect=_make_trivia_round)
+    prepare_round = AsyncMock(side_effect=_make_text_trivia_round)
     with (
         patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
         patch.object(TriviaQuizType, "prepare_round", new=prepare_round),
@@ -1064,6 +1116,7 @@ async def test_trivia_serialization_and_listen_in_remain_non_audio() -> None:
             name="Music Trivia",
             difficulty="hard",
             language="pt_BR",
+            play_reveal_audio=False,
             artist_bonus_mode="free_text",
             title_bonus_mode="multiple_choice",
         )
@@ -1074,8 +1127,11 @@ async def test_trivia_serialization_and_listen_in_remain_non_audio() -> None:
         assert game is not None
         assert game.config.difficulty == "hard"
         assert game.config.use_ai_distractors is False
-        assert game.config.artist_bonus_mode == "off"
-        assert game.config.title_bonus_mode == "off"
+        assert (
+            game.config.artist_bonus_mode,
+            game.config.title_bonus_mode,
+            game.config.play_reveal_audio,
+        ) == ("off", "off", False)
         assert _phase(plugin) == MusicQuizPhase.ANSWERING
         cast("AsyncMock", plugin._play_track).assert_not_awaited()
         plugin._warm_up_lyrics.assert_not_called()
@@ -1083,6 +1139,7 @@ async def test_trivia_serialization_and_listen_in_remain_non_audio() -> None:
         public_state = cast("MagicMock", plugin.signal_provider_event).call_args[0][0]["state"]
         assert public_state["quiz_type"] == "trivia"
         assert public_state["answer_type"] == "multiple_choice"
+        assert public_state["play_reveal_audio"] is False
         assert public_state["current_round"]["question"] == "Trivia question 0?"
         assert set(public_state["current_round"]) == {
             "round_index",
@@ -1116,11 +1173,23 @@ async def test_trivia_serialization_and_listen_in_remain_non_audio() -> None:
             game_info["language"],
             personal_state["language"],
         } == {"pt-BR"}
+        assert {
+            public_state["play_reveal_audio"],
+            host_state["play_reveal_audio"],
+            game_info["play_reveal_audio"],
+            personal_state["play_reveal_audio"],
+        } == {False}
         assert personal_state["current_round"] == public_state["current_round"]
         assert alice not in str(personal_state)
-        assert await plugin.can_listen_in("web-player") is False
-        with pytest.raises(MusicQuizNoPlaybackTargetError):
-            await plugin.listen_in("web-player")
+        with patch(
+            "music_assistant.providers.music_quiz.SharedPlaybackSession.create_venue",
+            new=AsyncMock(),
+        ) as create_venue:
+            assert await plugin.can_listen_in("web-player") is False
+            with pytest.raises(MusicQuizNoPlaybackTargetError):
+                await plugin.listen_in("web-player")
+        create_venue.assert_not_awaited()
+        assert plugin._playback_session is None
         await plugin.answer(alice, "correct_0")
         revealed = cast("MagicMock", plugin.signal_provider_event).call_args[0][0]["state"]
         assert revealed["current_round"]["answer_label"] == "Correct answer 0"
@@ -1136,10 +1205,510 @@ async def test_trivia_serialization_and_listen_in_remain_non_audio() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["venue", "remote"])
+async def test_enabled_trivia_uses_existing_playback_session_rules(mode: str) -> None:
+    """Offer Trivia listen-in through the configured playback mode when audio is enabled."""
+    plugin = _create_plugin(mode=mode)
+    session = MagicMock()
+    session.player_id = "quiz-player"
+    session.close = AsyncMock()
+    session.can_listen_in.return_value = True
+    factory_name = "create_remote" if mode == "remote" else "create_venue"
+    with (
+        patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
+        patch.object(
+            TriviaQuizType,
+            "prepare_round",
+            new=AsyncMock(side_effect=_make_trivia_round),
+        ),
+        patch(
+            f"music_assistant.providers.music_quiz.SharedPlaybackSession.{factory_name}",
+            new=AsyncMock(return_value=session),
+        ) as create_session,
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+    ):
+        await plugin.create_game(
+            quiz_type="trivia",
+            round_count=1,
+            source_uris=["library://playlist/1"],
+        )
+        assert await plugin.can_listen_in("web-player") is True
+
+    create_session.assert_awaited_once()
+    session.can_listen_in.assert_called_once_with("web-player")
+    assert plugin._playback_session is session
+
+
+@pytest.mark.asyncio
+async def test_cancelled_remote_reveal_adopts_created_session_before_advancing() -> None:
+    """Finish remote session creation safely when reveal startup is cancelled."""
+    plugin = _create_plugin(mode="remote")
+    session_creation_started = asyncio.Event()
+    allow_session_creation = asyncio.Event()
+    cancellation_started = asyncio.Event()
+    session = MagicMock()
+    session.player_id = "virtual-quiz-player"
+    session.queue_id = "virtual-quiz-player"
+    play_media = AsyncMock()
+    cast("MagicMock", plugin.mass.player_queues).play_media = play_media
+    cast("MagicMock", plugin.mass.players.get_player).return_value = SimpleNamespace(extra_data={})
+    plugin._play_track = MusicQuizPlugin._play_track.__get__(  # type: ignore[method-assign]
+        plugin, MusicQuizPlugin
+    )
+    cancel_reveal_playback = plugin._cancel_reveal_playback_task
+
+    async def _create_remote_session(*_args: Any, **_kwargs: Any) -> MagicMock:
+        session_creation_started.set()
+        await allow_session_creation.wait()
+        return session
+
+    async def _cancel_reveal_playback() -> None:
+        cancellation_started.set()
+        await cancel_reveal_playback()
+
+    plugin._cancel_reveal_playback_task = (  # type: ignore[method-assign]
+        _cancel_reveal_playback
+    )
+    with (
+        patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
+        patch.object(
+            TriviaQuizType,
+            "prepare_round",
+            new=AsyncMock(side_effect=_make_trivia_round),
+        ),
+        patch(
+            "music_assistant.providers.music_quiz.SharedPlaybackSession.create_remote",
+            new=AsyncMock(side_effect=_create_remote_session),
+        ),
+    ):
+        await _create_started_trivia_game(plugin, player_names=(), round_count=2)
+        await plugin.reveal()
+        playback_task = plugin._reveal_playback_task
+        assert playback_task is not None
+        await session_creation_started.wait()
+
+        cancellation_started.clear()
+        advance_task = asyncio.create_task(plugin.next_round())
+        await cancellation_started.wait()
+        assert playback_task.cancelling()
+        playback_task.cancel()
+        allow_session_creation.set()
+        await advance_task
+
+    assert playback_task.cancelled()
+    assert plugin._playback_session is session
+    play_media.assert_not_awaited()
+    cast("AsyncMock", plugin._stop_playback).assert_awaited_once()
+    assert _phase(plugin) == MusicQuizPhase.ANSWERING
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("trigger", ["all_complete", "deadline", "manual"])
+async def test_trivia_reveal_paths_schedule_one_fixed_deadline(  # noqa: PLR0915
+    trigger: str,
+) -> None:
+    """Give every Trivia reveal path the same authoritative 15-second deadline."""
+    plugin = _create_plugin()
+    prepare_round = AsyncMock(side_effect=_make_trivia_round)
+    playback_contexts: list[tuple[User | None, User | None]] = []
+
+    async def _play_reveal(track_uri: str) -> None:
+        playback_contexts.append((current_user.get(), impersonated_user.get()))
+        event = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]
+        assert event["state"]["phase"] == "reveal"
+        assert event["state"]["current_round"]["auto_advance_at"] == 215.0
+        assert track_uri == "library://track/trivia-0"
+
+    plugin._play_track = AsyncMock(side_effect=_play_reveal)  # type: ignore[method-assign]
+    with (
+        patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
+        patch.object(TriviaQuizType, "prepare_round", new=prepare_round),
+        patch("music_assistant.providers.music_quiz.time.time", return_value=100.0),
+    ):
+        player_ids = await _create_started_trivia_game(plugin, round_count=1)
+
+    game = plugin._game
+    assert game is not None
+    hidden_state = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]["state"]
+    assert hidden_state["phase"] == "answering"
+    assert "library://track/trivia-0" not in str(hidden_state)
+    plugin._play_track.assert_not_awaited()
+
+    requesting_user = cast("User", _guest_user())
+    requesting_impersonation = cast("User", _guest_user())
+    current_user_token = current_user.set(requesting_user)
+    impersonated_user_token = impersonated_user.set(requesting_impersonation)
+    try:
+        with (
+            patch(
+                "music_assistant.providers.music_quiz.get_current_user",
+                return_value=_guest_user(),
+            ),
+            patch("music_assistant.providers.music_quiz.time.time", return_value=200.0),
+        ):
+            if trigger == "all_complete":
+                state = await plugin.answer(player_ids["Alice"], "correct_0")
+            elif trigger == "deadline":
+                _, deadline_callback, round_index = _round_timer_call(
+                    plugin, plugin._reveal_timer_id
+                )
+                await deadline_callback(round_index)
+                state = await plugin.get_player_state(player_ids["Alice"])
+            else:
+                state = await plugin.reveal()
+        playback_task = plugin._reveal_playback_task
+        assert playback_task is not None
+        await playback_task
+    finally:
+        impersonated_user.reset(impersonated_user_token)
+        current_user.reset(current_user_token)
+
+    delay, _, _ = _round_timer_call(plugin, plugin._advance_timer_id)
+    public_state = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]["state"]
+    host_state = await plugin.get_game()
+    assert host_state is not None
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        personal_state = await plugin.get_player_state(player_ids["Alice"])
+
+    assert delay == 15.0
+    assert game.rounds[0].auto_advance_at == 215.0
+    assert {
+        state["current_round"]["auto_advance_at"],
+        public_state["current_round"]["auto_advance_at"],
+        host_state["current_round"]["auto_advance_at"],
+        personal_state["current_round"]["auto_advance_at"],
+    } == {215.0}
+    assert public_state["current_round"]["track_uri"] == "library://track/trivia-0"
+    assert playback_contexts == [(None, None)]
+    plugin._play_track.assert_awaited_once_with("library://track/trivia-0")
+    assert prepare_round.await_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("advance", ["ready", "next", "automatic"])
+async def test_trivia_early_and_automatic_advance_cancel_pending_audio(
+    advance: str,
+) -> None:
+    """Cancel reveal startup and stop playback before the next answer window opens."""
+    plugin = _create_plugin()
+    prepare_round = AsyncMock(side_effect=_make_trivia_round)
+    playback_started = asyncio.Event()
+    keep_playback_pending = asyncio.Event()
+
+    async def _play_reveal(_track_uri: str) -> None:
+        playback_started.set()
+        await keep_playback_pending.wait()
+
+    stop_phases: list[MusicQuizPhase] = []
+
+    async def _stop_reveal() -> None:
+        stop_phases.append(_phase(plugin))
+
+    plugin._play_track = AsyncMock(side_effect=_play_reveal)  # type: ignore[method-assign]
+    plugin._stop_playback = AsyncMock(side_effect=_stop_reveal)  # type: ignore[method-assign]
+    with (
+        patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
+        patch.object(TriviaQuizType, "prepare_round", new=prepare_round),
+    ):
+        player_ids = await _create_started_trivia_game(plugin, round_count=2)
+        await plugin.reveal()
+        playback_task = plugin._reveal_playback_task
+        assert playback_task is not None
+        await playback_started.wait()
+        _, stale_callback, stale_round_index = _round_timer_call(plugin, plugin._advance_timer_id)
+        cast("MagicMock", plugin.mass.cancel_timer).reset_mock()
+
+        if advance == "ready":
+            with patch(
+                "music_assistant.providers.music_quiz.get_current_user",
+                return_value=_guest_user(),
+            ):
+                await plugin.ready(player_ids["Alice"])
+        elif advance == "next":
+            await plugin.next_round()
+        else:
+            await stale_callback(stale_round_index)
+
+        game = plugin._game
+        assert game is not None
+        assert playback_task.cancelled()
+        assert plugin._reveal_playback_task is None
+        assert stop_phases == [MusicQuizPhase.REVEAL]
+        assert game.phase == MusicQuizPhase.ANSWERING
+        assert game.current_round_index == 1
+        assert game.rounds[0].auto_advance_at is None
+        cast("MagicMock", plugin.mass.cancel_timer).assert_any_call(plugin._advance_timer_id)
+        plugin._play_track.assert_awaited_once()
+        plugin._stop_playback.assert_awaited_once()
+        assert prepare_round.await_count == 2
+
+        await stale_callback(stale_round_index)
+
+    assert game.phase == MusicQuizPhase.ANSWERING
+    assert game.current_round_index == 1
+    assert len(game.rounds) == 2
+    plugin._play_track.assert_awaited_once()
+    plugin._stop_playback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("advance", ["ready", "next", "automatic"])
+async def test_final_trivia_reveal_finishes_once(advance: str) -> None:
+    """Finish final Trivia results once through Ready or the reveal deadline."""
+    plugin = _create_plugin()
+    playback_started = asyncio.Event()
+    keep_playback_pending = asyncio.Event()
+
+    async def _play_reveal(_track_uri: str) -> None:
+        playback_started.set()
+        await keep_playback_pending.wait()
+
+    plugin._play_track = AsyncMock(side_effect=_play_reveal)  # type: ignore[method-assign]
+    with (
+        patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
+        patch.object(
+            TriviaQuizType,
+            "prepare_round",
+            new=AsyncMock(side_effect=_make_trivia_round),
+        ),
+    ):
+        player_ids = await _create_started_trivia_game(plugin, round_count=1)
+        await plugin.reveal()
+        playback_task = plugin._reveal_playback_task
+        assert playback_task is not None
+        await playback_started.wait()
+        _, stale_callback, stale_round_index = _round_timer_call(plugin, plugin._advance_timer_id)
+
+        if advance == "ready":
+            with patch(
+                "music_assistant.providers.music_quiz.get_current_user",
+                return_value=_guest_user(),
+            ):
+                state = await plugin.ready(player_ids["Alice"])
+        elif advance == "next":
+            state = await plugin.next_round()
+        else:
+            await stale_callback(stale_round_index)
+            state = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]["state"]
+
+        game = plugin._game
+        assert game is not None
+        assert playback_task.cancelled()
+        assert game.phase == MusicQuizPhase.FINISHED
+        assert state["phase"] == "finished"
+        assert state["current_round"]["auto_advance_at"] is None
+        cast("AsyncMock", plugin._stop_playback).assert_awaited_once()
+
+        await stale_callback(stale_round_index)
+
+    assert game.phase == MusicQuizPhase.FINISHED
+    cast("AsyncMock", plugin._stop_playback).assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("lifecycle", ["reset", "delete", "unload", "replacement"])
+async def test_trivia_lifecycle_cancels_pending_reveal_playback(lifecycle: str) -> None:
+    """Cancel pending reveal startup and stop audio on every game teardown path."""
+    plugin = _create_plugin()
+    playback_started = asyncio.Event()
+    keep_playback_pending = asyncio.Event()
+
+    async def _play_reveal(_track_uri: str) -> None:
+        playback_started.set()
+        await keep_playback_pending.wait()
+
+    plugin._play_track = AsyncMock(side_effect=_play_reveal)  # type: ignore[method-assign]
+    with (
+        patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
+        patch.object(
+            TriviaQuizType,
+            "prepare_round",
+            new=AsyncMock(side_effect=_make_trivia_round),
+        ),
+    ):
+        await _create_started_trivia_game(plugin, player_names=(), round_count=1)
+        await plugin.reveal()
+        playback_task = plugin._reveal_playback_task
+        assert playback_task is not None
+        await playback_started.wait()
+        game = plugin._game
+        assert game is not None
+
+        if lifecycle == "reset":
+            await plugin.reset()
+        elif lifecycle == "delete":
+            await plugin.delete_game()
+        elif lifecycle == "unload":
+            await plugin.unload()
+        else:
+            game.phase = MusicQuizPhase.FINISHED
+            await plugin.create_game(source_uris=["library://playlist/2"])
+
+    assert playback_task.cancelled()
+    assert plugin._reveal_playback_task is None
+    cast("AsyncMock", plugin._stop_playback).assert_awaited_once()
+    if lifecycle == "reset":
+        assert plugin._game is game
+        assert game.phase == MusicQuizPhase.LOBBY
+    elif lifecycle in ("delete", "unload"):
+        assert plugin._game is None
+    else:
+        assert plugin._game is not game
+        assert _phase(plugin) == MusicQuizPhase.LOBBY
+    plugin._cancel_next_round_task()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stale_by", ["generation", "round", "phase"])
+async def test_stale_trivia_reveal_completion_stops_playback(stale_by: str) -> None:
+    """Stop audio when reveal startup completes outside its owning game state."""
+    plugin = _create_plugin()
+    playback_started = asyncio.Event()
+    release_playback = asyncio.Event()
+
+    async def _play_reveal(_track_uri: str) -> None:
+        playback_started.set()
+        await release_playback.wait()
+
+    plugin._play_track = AsyncMock(side_effect=_play_reveal)  # type: ignore[method-assign]
+    with (
+        patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
+        patch.object(
+            TriviaQuizType,
+            "prepare_round",
+            new=AsyncMock(side_effect=_make_trivia_round),
+        ),
+    ):
+        await _create_started_trivia_game(plugin, player_names=(), round_count=1)
+        await plugin.reveal()
+
+    playback_task = plugin._reveal_playback_task
+    game = plugin._game
+    assert playback_task is not None
+    assert game is not None
+    await playback_started.wait()
+    if stale_by == "generation":
+        plugin._game_generation += 1
+    elif stale_by == "round":
+        game.current_round_index = 1
+    else:
+        game.phase = MusicQuizPhase.ANSWERING
+    release_playback.set()
+    await playback_task
+
+    cast("AsyncMock", plugin._stop_playback).assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_trivia_reveal_playback_failure_keeps_game_authoritative() -> None:
+    """Keep reveal results and deadlines intact when optional playback cannot start."""
+    plugin = _create_plugin()
+    playback_error = MusicQuizNoPlaybackTargetError("No playback target")
+    plugin._play_track = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[playback_error, None]
+    )
+    with (
+        patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
+        patch.object(
+            TriviaQuizType,
+            "prepare_round",
+            new=AsyncMock(side_effect=_make_trivia_round),
+        ),
+    ):
+        await _create_started_trivia_game(plugin, player_names=(), round_count=2)
+        with patch("music_assistant.providers.music_quiz.time.time", return_value=100.0):
+            first_state = await plugin.reveal()
+        first_task = plugin._reveal_playback_task
+        assert first_task is not None
+        await first_task
+
+        game = plugin._game
+        assert game is not None
+        assert _phase(plugin) == MusicQuizPhase.REVEAL
+        assert first_state["current_round"]["question"] == "Trivia question 0?"
+        assert first_state["current_round"]["answer_label"] == "Correct answer 0"
+        assert first_state["current_round"]["auto_advance_at"] == 115.0
+        cast("MagicMock", plugin.logger.warning).assert_called_once_with(
+            "Could not play Music Quiz reveal track %s: %s",
+            "library://track/trivia-0",
+            playback_error,
+        )
+
+        await plugin.next_round()
+        assert _phase(plugin) == MusicQuizPhase.ANSWERING
+        assert game.current_round_index == 1
+        plugin._play_track.assert_awaited_once()
+
+        with patch("music_assistant.providers.music_quiz.time.time", return_value=200.0):
+            second_state = await plugin.reveal()
+        second_task = plugin._reveal_playback_task
+        assert second_task is not None
+        await second_task
+
+        assert _phase(plugin) == MusicQuizPhase.REVEAL
+        assert second_state["current_round"]["question"] == "Trivia question 1?"
+        assert second_state["current_round"]["auto_advance_at"] == 215.0
+        assert plugin._play_track.await_count == 2
+        _, finish_callback, round_index = _round_timer_call(plugin, plugin._advance_timer_id)
+        await finish_callback(round_index)
+
+    assert _phase(plugin) == MusicQuizPhase.FINISHED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timer_phase", ["answering", "reveal"])
+async def test_stale_trivia_timer_cannot_mutate_reset_generation(timer_phase: str) -> None:
+    """Ignore a fired round callback after reset reaches the same round and phase."""
+    plugin = _create_plugin()
+    prepare_round = AsyncMock(side_effect=_make_text_trivia_round)
+    with (
+        patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
+        patch.object(TriviaQuizType, "prepare_round", new=prepare_round),
+    ):
+        await _create_started_trivia_game(
+            plugin,
+            player_names=(),
+            round_count=2,
+            play_reveal_audio=False,
+        )
+        timer_id = plugin._reveal_timer_id
+        if timer_phase == "reveal":
+            with patch("music_assistant.providers.music_quiz.time.time", return_value=100.0):
+                await plugin.reveal()
+            timer_id = plugin._advance_timer_id
+        _, stale_callback, stale_round_index = _round_timer_call(plugin, timer_id)
+
+        await plugin.reset()
+        await plugin.start_game()
+        if timer_phase == "reveal":
+            with patch("music_assistant.providers.music_quiz.time.time", return_value=200.0):
+                await plugin.reveal()
+
+        game = plugin._game
+        assert game is not None
+        assert game.current_round_index == 0
+        expected_auto_advance = 215.0 if timer_phase == "reveal" else None
+        assert game.rounds[0].auto_advance_at == expected_auto_advance
+        await stale_callback(stale_round_index)
+
+    assert game.phase.value == timer_phase
+    assert game.current_round_index == 0
+    assert len(game.rounds) == 1
+    assert game.rounds[0].auto_advance_at == expected_auto_advance
+    assert prepare_round.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_trivia_reuses_full_multiplayer_flow_and_persisted_prefetch() -> None:
     """Reuse early reveal, eligibility, presence, scoring, deadlines and prefetch."""
     plugin = _create_plugin()
-    prepare_round = AsyncMock(side_effect=_make_trivia_round)
+    prepare_round = AsyncMock(side_effect=_make_text_trivia_round)
     with (
         patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
         patch.object(TriviaQuizType, "prepare_round", new=prepare_round),
@@ -1152,6 +1721,7 @@ async def test_trivia_reuses_full_multiplayer_flow_and_persisted_prefetch() -> N
             quiz_type="trivia",
             round_count=3,
             source_uris=["library://playlist/1"],
+            play_reveal_audio=False,
         )
         alice = (await plugin.join_game("Alice"))["player_id"]
         bob = (await plugin.join_game("Bob"))["player_id"]
@@ -1204,11 +1774,11 @@ async def test_trivia_reuses_full_multiplayer_flow_and_persisted_prefetch() -> N
 
 
 @pytest.mark.asyncio
-async def test_trivia_reset_delete_and_recreate_keep_lifecycle_non_audio() -> None:
+async def test_disabled_trivia_reset_delete_and_recreate_keep_lifecycle_non_audio() -> None:
     """Reset, delete and recreate Trivia transactionally without playback hooks."""
     plugin = _create_plugin()
     initialize = AsyncMock()
-    prepare_round = AsyncMock(side_effect=_make_trivia_round)
+    prepare_round = AsyncMock(side_effect=_make_text_trivia_round)
     with (
         patch.object(TriviaQuizType, "initialize", new=initialize),
         patch.object(TriviaQuizType, "prepare_round", new=prepare_round),
@@ -1218,6 +1788,7 @@ async def test_trivia_reset_delete_and_recreate_keep_lifecycle_non_audio() -> No
             round_count=1,
             source_uris=["library://playlist/1"],
             language="zh_hans_cn",
+            play_reveal_audio=False,
         )
         await plugin.start_game()
         game = plugin._game
@@ -1227,6 +1798,7 @@ async def test_trivia_reset_delete_and_recreate_keep_lifecycle_non_audio() -> No
         assert reset_state["quiz_type"] == "trivia"
         assert reset_state["answer_type"] == "multiple_choice"
         assert reset_state["language"] == "zh-Hans-CN"
+        assert reset_state["play_reveal_audio"] is False
         assert game.config.language == "zh-Hans-CN"
         assert game.rounds == []
         assert initialize.await_count == 2
@@ -1238,6 +1810,7 @@ async def test_trivia_reset_delete_and_recreate_keep_lifecycle_non_audio() -> No
             quiz_type="trivia",
             round_count=1,
             source_uris=["library://playlist/1"],
+            play_reveal_audio=False,
         )
         assert recreated["phase"] == "lobby"
         assert recreated["quiz_type"] == "trivia"
@@ -1269,22 +1842,30 @@ async def test_music_timeline_create_uses_flat_config_and_derived_answer_type() 
             source_uris=["library://playlist/1"],
             difficulty="not-used",
             language="nl",
+            play_reveal_audio=False,
             artist_bonus_mode="free_text",
             title_bonus_mode="multiple_choice",
         )
 
     game = plugin._game
+    quiz_type = plugin._quiz_type
     assert game is not None
+    assert quiz_type is not None
     assert game.quiz_type == "music_timeline"
     assert game.answer_type == "timeline"
     assert game.config.suggestion_count == 4
     assert game.config.difficulty == "normal"
     assert game.config.language == "en"
+    assert game.config.play_reveal_audio is True
+    assert quiz_type.uses_audio is True
+    assert quiz_type.plays_track_before_answering is True
+    assert quiz_type.plays_track_on_reveal is False
     assert game.config.use_ai_distractors is True
     assert created["artist_bonus_mode"] == "free_text"
     assert created["title_bonus_mode"] == "multiple_choice"
     assert "suggestion_count" not in created
     assert "language" not in created
+    assert "play_reveal_audio" not in created
 
 
 @pytest.mark.asyncio
@@ -2172,7 +2753,16 @@ async def test_game_info_exposes_game_identity_and_playback_mode() -> None:
         source_uris=["library://playlist/1"],
         name="Test Quiz",
         language="nl",
+        play_reveal_audio=False,
     )
+    game = plugin._game
+    quiz_type = plugin._quiz_type
+    assert game is not None
+    assert quiz_type is not None
+    assert game.config.play_reveal_audio is True
+    assert quiz_type.uses_audio is True
+    assert quiz_type.plays_track_before_answering is True
+    assert quiz_type.plays_track_on_reveal is False
 
     info = await plugin.get_game_info()
     assert info == {
@@ -3104,7 +3694,7 @@ async def test_answer_deadline_timer_reveals_round() -> None:
     game = plugin._game
     assert game is not None
 
-    delay, target, round_index = cast("MagicMock", plugin.mass.call_later).call_args[0]
+    delay, target, round_index = _round_timer_call(plugin, plugin._reveal_timer_id)
     assert delay == 30  # configured answer_duration capped by track duration
     await target(round_index)
     assert game.phase == MusicQuizPhase.REVEAL
@@ -3123,7 +3713,7 @@ async def test_reveal_schedules_track_end_advance() -> None:
     assert game is not None
 
     await plugin.reveal()
-    delay, target, round_index = cast("MagicMock", plugin.mass.call_later).call_args[0]
+    delay, target, round_index = _round_timer_call(plugin, plugin._advance_timer_id)
     assert delay > 0
     await target(round_index)
     assert game.phase == MusicQuizPhase.ANSWERING

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -38,6 +38,7 @@ from music_assistant.providers.music_quiz.errors import (
     MusicQuizNoPlaybackTargetError,
     MusicQuizUnknownPlayerError,
 )
+from music_assistant.providers.music_quiz.game import finish_game as finish_game_state
 from music_assistant.providers.music_quiz.models import (
     MultipleChoiceRoundState,
     MultipleChoiceSuggestion,
@@ -397,6 +398,32 @@ async def _create_started_trivia_game(
             player_ids[player_name] = result["player_id"]
     await plugin.start_game()
     return player_ids
+
+
+async def _assert_reveal_deadline_cleared(
+    plugin: MusicQuizPlugin,
+    player_id: str,
+) -> None:
+    """Assert every client state sees a retryable reveal without a deadline."""
+    game = plugin._game
+    assert game is not None
+    public_state = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]["state"]
+    host_state = await plugin.get_game()
+    assert host_state is not None
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        personal_state = await plugin.get_player_state(player_id)
+
+    assert game.phase == MusicQuizPhase.REVEAL
+    assert game.rounds[-1].auto_advance_at is None
+    assert {
+        public_state["current_round"]["auto_advance_at"],
+        host_state["current_round"]["auto_advance_at"],
+        host_state["rounds"][-1]["auto_advance_at"],
+        personal_state["current_round"]["auto_advance_at"],
+    } == {None}
 
 
 @pytest.fixture(autouse=True)
@@ -1511,6 +1538,143 @@ async def test_final_trivia_reveal_finishes_once(advance: str) -> None:
 
     assert game.phase == MusicQuizPhase.FINISHED
     cast("AsyncMock", plugin._stop_playback).assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_intermediate_trivia_auto_advance_failure_broadcasts_retryable_reveal() -> None:
+    """Clear the expired deadline and allow host Next after round preparation fails."""
+    plugin = _create_plugin()
+    fail_next_round = True
+
+    async def _prepare_round(
+        round_index: int,
+        previous_rounds: list[MusicQuizRound],
+    ) -> MusicQuizRound:
+        if round_index == 1 and fail_next_round:
+            raise InvalidDataError("round preparation failed")
+        return _make_trivia_round(round_index, previous_rounds)
+
+    prepare_round = AsyncMock(side_effect=_prepare_round)
+    with (
+        patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
+        patch.object(TriviaQuizType, "prepare_round", new=prepare_round),
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+    ):
+        player_ids = await _create_started_trivia_game(plugin, round_count=2)
+        await plugin.answer(player_ids["Alice"], "correct_0")
+        playback_task = plugin._reveal_playback_task
+        assert playback_task is not None
+        await playback_task
+
+        game = plugin._game
+        assert game is not None
+        revealed_answer_state = game.rounds[0].answer_state.to_dict()
+        revealed_ended_at = game.rounds[0].ended_at
+        revealed_score = game.players[player_ids["Alice"]].score
+        _, stale_callback, stale_round_index = _round_timer_call(plugin, plugin._advance_timer_id)
+        signal = cast("MagicMock", plugin.signal_provider_event)
+        signal.reset_mock()
+
+        await stale_callback(stale_round_index)
+
+        signal.assert_called_once()
+        await _assert_reveal_deadline_cleared(plugin, player_ids["Alice"])
+        assert game.current_round_index == 0
+        assert len(game.rounds) == 1
+        assert game.rounds[0].answer_state.to_dict() == revealed_answer_state
+        assert game.rounds[0].ended_at == revealed_ended_at
+        assert game.players[player_ids["Alice"]].score == revealed_score
+        assert (
+            sum(
+                call.kwargs.get("task_id") == plugin._advance_timer_id
+                for call in cast("MagicMock", plugin.mass.call_later).call_args_list
+            )
+            == 1
+        )
+
+        fail_next_round = False
+        state = await plugin.next_round()
+        assert state["phase"] == "answering"
+        assert game.current_round_index == 1
+        assert len(game.rounds) == 2
+        await stale_callback(stale_round_index)
+
+    assert game.phase == MusicQuizPhase.ANSWERING
+    assert game.current_round_index == 1
+    assert len(game.rounds) == 2
+
+
+@pytest.mark.asyncio
+async def test_final_trivia_auto_advance_failure_broadcasts_retryable_reveal() -> None:
+    """Clear the expired deadline and allow player Ready after finalization fails."""
+    plugin = _create_plugin()
+    finish_attempts = 0
+
+    def _finish_game(game: MusicQuizGame) -> None:
+        nonlocal finish_attempts
+        finish_attempts += 1
+        if finish_attempts == 1:
+            raise RuntimeError("finalization failed")
+        finish_game_state(game)
+
+    with (
+        patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
+        patch.object(
+            TriviaQuizType,
+            "prepare_round",
+            new=AsyncMock(side_effect=_make_trivia_round),
+        ),
+        patch("music_assistant.providers.music_quiz.finish_game", side_effect=_finish_game),
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+    ):
+        player_ids = await _create_started_trivia_game(plugin, round_count=1)
+        await plugin.answer(player_ids["Alice"], "correct_0")
+        playback_task = plugin._reveal_playback_task
+        assert playback_task is not None
+        await playback_task
+
+        game = plugin._game
+        assert game is not None
+        revealed_answer_state = game.rounds[0].answer_state.to_dict()
+        revealed_ended_at = game.rounds[0].ended_at
+        revealed_score = game.players[player_ids["Alice"]].score
+        _, stale_callback, stale_round_index = _round_timer_call(plugin, plugin._advance_timer_id)
+        signal = cast("MagicMock", plugin.signal_provider_event)
+        signal.reset_mock()
+
+        await stale_callback(stale_round_index)
+
+        signal.assert_called_once()
+        await _assert_reveal_deadline_cleared(plugin, player_ids["Alice"])
+        assert game.current_round_index == 0
+        assert len(game.rounds) == 1
+        assert game.rounds[0].answer_state.to_dict() == revealed_answer_state
+        assert game.rounds[0].ended_at == revealed_ended_at
+        assert game.players[player_ids["Alice"]].score == revealed_score
+        assert (
+            sum(
+                call.kwargs.get("task_id") == plugin._advance_timer_id
+                for call in cast("MagicMock", plugin.mass.call_later).call_args_list
+            )
+            == 1
+        )
+
+        state = await plugin.ready(player_ids["Alice"])
+        assert state["phase"] == "finished"
+        assert state["current_round"]["auto_advance_at"] is None
+        assert game.phase == MusicQuizPhase.FINISHED
+        assert game.players[player_ids["Alice"]].score == revealed_score
+        assert finish_attempts == 2
+        await stale_callback(stale_round_index)
+
+    assert game.phase == MusicQuizPhase.FINISHED
+    assert finish_attempts == 2
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -1249,7 +1249,7 @@ async def test_cancelled_remote_reveal_adopts_created_session_before_advancing()
     session_creation_started = asyncio.Event()
     allow_session_creation = asyncio.Event()
     cancellation_started = asyncio.Event()
-    session = MagicMock()
+    session = cast("Any", MagicMock())
     session.player_id = "virtual-quiz-player"
     session.queue_id = "virtual-quiz-player"
     play_media = AsyncMock()
@@ -1260,7 +1260,7 @@ async def test_cancelled_remote_reveal_adopts_created_session_before_advancing()
     )
     cancel_reveal_playback = plugin._cancel_reveal_playback_task
 
-    async def _create_remote_session(*_args: Any, **_kwargs: Any) -> MagicMock:
+    async def _create_remote_session(*_args: Any, **_kwargs: Any) -> Any:
         session_creation_started.set()
         await allow_session_creation.wait()
         return session
@@ -1294,11 +1294,13 @@ async def test_cancelled_remote_reveal_adopts_created_session_before_advancing()
         advance_task = asyncio.create_task(plugin.next_round())
         await cancellation_started.wait()
         assert playback_task.cancelling()
-        playback_task.cancel()
-        allow_session_creation.set()
         await advance_task
+        assert playback_task.cancelled()
+        assert _phase(plugin) == MusicQuizPhase.ANSWERING
+        assert plugin._playback_session is None
+        allow_session_creation.set()
+        assert await plugin._get_playback_session() is session
 
-    assert playback_task.cancelled()
     assert plugin._playback_session is session
     play_media.assert_not_awaited()
     cast("AsyncMock", plugin._stop_playback).assert_awaited_once()

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
+from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -148,6 +149,7 @@ def _quiz(
     suggestion_count: int = 4,
     difficulty: str = MusicQuizDifficulty.NORMAL.value,
     language: str = DEFAULT_TRIVIA_LANGUAGE,
+    play_reveal_audio: bool = True,
 ) -> tuple[TriviaQuizType, MagicMock]:
     """Return a Trivia strategy backed by a selected-track pool."""
     mass = _mass(providers if providers is not None else [_ai_provider()])
@@ -157,6 +159,7 @@ def _quiz(
         source_uris=["prov://playlist/source"],
         difficulty=difficulty,
         language=language,
+        play_reveal_audio=play_reveal_audio,
     )
     quiz = TriviaQuizType(mass, config)
     quiz._source_track_pool = {track.uri: track for track in tracks if track.uri}
@@ -208,7 +211,6 @@ def test_registry_identity_and_config_are_trivia_specific() -> None:
     """Register stable Trivia identity and normalize unrelated settings."""
     assert get_quiz_type("trivia") is TriviaQuizType
     assert TriviaQuizType.answer_type is MusicQuizAnswerType.MULTIPLE_CHOICE
-    assert TriviaQuizType.uses_audio is False
 
     config = MusicQuizConfig(
         round_count=2,
@@ -228,6 +230,14 @@ def test_registry_identity_and_config_are_trivia_specific() -> None:
     assert normalized.use_ai_distractors is False
     assert normalized.artist_bonus_mode is TimelineBonusMode.OFF
     assert normalized.title_bonus_mode is TimelineBonusMode.OFF
+    quiz_type = TriviaQuizType(_mass(), normalized)
+    assert quiz_type.uses_audio is True
+    assert quiz_type.plays_track_before_answering is False
+    assert quiz_type.plays_track_on_reveal is True
+
+    text_only = TriviaQuizType(_mass(), replace(normalized, play_reveal_audio=False))
+    assert text_only.uses_audio is False
+    assert text_only.plays_track_on_reveal is False
 
 
 @pytest.mark.parametrize(
@@ -531,8 +541,8 @@ async def test_prepare_round_persists_unique_sources_across_fresh_strategies() -
     assert isinstance(second_round.answer_state, MultipleChoiceRoundState)
     assert _correct_source_uri(first_round.answer_state) == first_track.uri
     assert _correct_source_uri(second_round.answer_state) == second_track.uri
-    assert first_round.track_uri is None
-    assert second_round.track_uri is None
+    assert first_round.track_uri == first_track.uri
+    assert second_round.track_uri == second_track.uri
     assert not hasattr(first_quiz, "_selected_tracks")
     assert not hasattr(fresh_quiz, "_selected_tracks")
 
@@ -581,15 +591,15 @@ async def test_prepare_round_rejects_incompatible_or_duplicate_history() -> None
         side_effect=lambda candidates: candidates[0],
     ):
         first_round = await quiz.prepare_round(0, [])
-    first_round.track_uri = tracks[0].uri
+    first_round.track_uri = None
 
     with pytest.raises(InvalidDataError, match="incompatible"):
         await quiz.prepare_round(1, [first_round])
 
 
 @pytest.mark.asyncio
-async def test_prepare_round_builds_trusted_opaque_non_audio_suggestions() -> None:
-    """Inject the server truth into exact opaque suggestions without audio data."""
+async def test_prepare_round_builds_trusted_opaque_reveal_suggestions() -> None:
+    """Inject the server truth into exact opaque suggestions with protected reveal audio."""
     source_track = _track(
         "one",
         "Teardrop",
@@ -609,7 +619,7 @@ async def test_prepare_round_builds_trusted_opaque_non_audio_suggestions() -> No
 
     assert game_round.question == "Welke artiest heeft het geselecteerde nummer Teardrop opgenomen?"
     assert game_round.answer_label == "Massive Attack"
-    assert game_round.track_uri is None
+    assert game_round.track_uri == source_track.uri
     assert game_round.duration is None
     assert game_round.image_url is None
     assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
@@ -627,6 +637,23 @@ async def test_prepare_round_builds_trusted_opaque_non_audio_suggestions() -> No
         "Air",
     }
     assert all(suggestion.uri is None for suggestion in suggestions if not suggestion.is_correct)
+
+
+@pytest.mark.asyncio
+async def test_prepare_round_omits_playback_track_when_reveal_audio_is_disabled() -> None:
+    """Keep disabled Trivia rounds text-only while retaining protected source identity."""
+    source_track = _track("one", "Teardrop", "Massive Attack")
+    quiz, _ = _quiz(
+        [source_track],
+        providers=[_ai_provider(_valid_response())],
+        play_reveal_audio=False,
+    )
+
+    game_round = await quiz.prepare_round(0, [])
+
+    assert game_round.track_uri is None
+    assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+    assert _correct_source_uri(game_round.answer_state) == source_track.uri
 
 
 def test_prompt_json_encodes_untrusted_metadata_without_source_identifiers() -> None:


### PR DESCRIPTION
## Summary

Music Trivia reveals now have a predictable countdown and can optionally play the question's source track after answers are shown.

- add a server-controlled 15-second reveal countdown with Ready and Next shortcuts
- add an enabled-by-default reveal audio setting with dynamic listen-in support
- stop and isolate reveal playback across round and game lifecycle changes