### PR TITLE
Optimize initial playback speed with progressive queue loading

### DIFF
--- a/music_assistant/controllers/player_queues/managed_pool.py
+++ b/music_assistant/controllers/player_queues/managed_pool.py
@@ -116,12 +116,15 @@ class ManagedPool:
         # finite-source materialized state, keyed by queue id then source uri; see _MaterializedSource
         self._materialized: dict[str, dict[str, _MaterializedSource]] = {}
 
-    async def fill(self, queue_id: str, *, is_initial: bool) -> list[Track]:
+    async def fill(
+        self, queue_id: str, *, is_initial: bool, target_size: int | None = None
+    ) -> list[Track]:
         """
         Build (or top up) the managed pool and return the tracks to add.
 
         :param queue_id: The queue to fill.
         :param is_initial: True when seeding a fresh pool, False when topping up an existing one.
+        :param target_size: Override the batch size (for progressive loading).
         """
         queue_data = self.queues.queue_data(queue_id)
         queue = queue_data.queue
@@ -147,11 +150,18 @@ class ManagedPool:
             if isinstance(item.media_item, Track):
                 pool_keys.add(item.media_item)
                 pool_song_keys.update(song_keys(item.media_item))
-        slots = (
-            MANAGED_POOL_TARGET
-            if is_initial
-            else max(MANAGED_POOL_TARGET - self._unplayed(queue), 0)
-        )
+        if target_size is not None:
+            if target_size == 1:
+                total_candidates = sum(len(s.candidates) for s in sources)
+                slots = min(total_candidates, MANAGED_POOL_TARGET) if total_candidates > 0 else 1
+            else:
+                slots = target_size
+        else:
+            slots = (
+                MANAGED_POOL_TARGET
+                if is_initial
+                else max(MANAGED_POOL_TARGET - self._unplayed(queue), 0)
+            )
         # the batch is appended after the current tail, so keep its first track clear of the last
         # queued item's artist (the seam the listener actually hears)
         preceding = (

--- a/music_assistant/controllers/player_queues/managed_pool.py
+++ b/music_assistant/controllers/player_queues/managed_pool.py
@@ -117,14 +117,21 @@ class ManagedPool:
         self._materialized: dict[str, dict[str, _MaterializedSource]] = {}
 
     async def fill(
-        self, queue_id: str, *, is_initial: bool, target_size: int | None = None
+        self,
+        queue_id: str,
+        *,
+        is_initial: bool,
+        target_size: int | None = None,
+        use_first_batch: bool = False,
     ) -> list[Track]:
         """
         Build (or top up) the managed pool and return the tracks to add.
 
         :param queue_id: The queue to fill.
         :param is_initial: True when seeding a fresh pool, False when topping up an existing one.
-        :param target_size: Override the batch size (for progressive loading).
+        :param target_size: Override the batch size.
+        :param use_first_batch: When True, return the currently available candidate batch without
+            waiting to size up to MANAGED_POOL_TARGET (for progressive loading).
         """
         queue_data = self.queues.queue_data(queue_id)
         queue = queue_data.queue
@@ -150,12 +157,11 @@ class ManagedPool:
             if isinstance(item.media_item, Track):
                 pool_keys.add(item.media_item)
                 pool_song_keys.update(song_keys(item.media_item))
-        if target_size is not None:
-            if target_size == 1:
-                total_candidates = sum(len(s.candidates) for s in sources)
-                slots = min(total_candidates, MANAGED_POOL_TARGET) if total_candidates > 0 else 1
-            else:
-                slots = target_size
+        if use_first_batch:
+            total_candidates = sum(len(s.candidates) for s in sources)
+            slots = min(total_candidates, MANAGED_POOL_TARGET) if total_candidates > 0 else 1
+        elif target_size is not None:
+            slots = target_size
         else:
             slots = (
                 MANAGED_POOL_TARGET

--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -286,7 +286,7 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
         # refill the queue (dynamic mode or autoplay) when running low on tracks
         if "current_item_id" in changed_keys:
             running_low = (
-                queue.current_index is not None and (queue.items - queue.current_index) < 10
+                queue.current_index is not None and (queue.items - queue.current_index - 1) < 10
             )
             if queue.is_dynamic and running_low:
                 task_id = f"fill_dynamic_tracks_{queue_id}"

--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -286,16 +286,14 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
         # refill the queue (dynamic mode or autoplay) when running low on tracks
         if "current_item_id" in changed_keys:
             running_low = (
-                queue.current_index is not None and (queue.items - queue.current_index) < 5
+                queue.current_index is not None and (queue.items - queue.current_index) < 10
             )
             if queue.is_dynamic and running_low:
-                # a dynamic queue tops up its bounded managed pool from its (dynamic + finite) sources
                 task_id = f"fill_dynamic_tracks_{queue_id}"
-                self.mass.call_later(5, self._fill_dynamic_tracks, queue_id, task_id=task_id)
+                self.mass.call_later(2, self._fill_dynamic_tracks, queue_id, task_id=task_id)
             elif queue.autoplay_enabled and queue_data.enqueued_media_items and running_low:
-                # autoplay refills using the per-queue configured Autoplay mode
                 task_id = f"fill_autoplay_tracks_{queue_id}"
-                self.mass.call_later(5, self._fill_autoplay_tracks, queue_id, task_id=task_id)
+                self.mass.call_later(2, self._fill_autoplay_tracks, queue_id, task_id=task_id)
 
     def _get_flow_queue_stream_index(
         self, queue: PlayerQueue, player: Player

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -729,7 +729,14 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         # head only (the tail we are discarding must not exclude its own tracks from the new pool)
         queue_data.items = queue_data.items[:insert_at]
         queue.items = len(queue_data.items)
-        pool_tracks = await self._managed_pool.fill(queue_id, is_initial=False)
+        # Progressive loading: when starting playback on an empty queue, use the provider's natural
+        # first-batch size (could be 2-5 tracks) for fast startup, then fill the rest in background.
+        # Use target_size=1 to signal "take the first available batch without waiting for more".
+        is_empty_queue = len(queue_data.items) == 0
+        initial_batch_size = 1 if (start_playing and is_empty_queue) else None
+        pool_tracks = await self._managed_pool.fill(
+            queue_id, is_initial=False, target_size=initial_batch_size
+        )
         queue_items = [
             build_queue_item(queue_id, track) for track in pool_tracks if track.available
         ]
@@ -739,8 +746,14 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         await self.load(queue_id, queue_items, insert_at_index=insert_at, keep_remaining=False)
         if start_playing:
             await self.play_index(queue_id, insert_at)
+            if is_empty_queue:
+                self.mass.call_later(
+                    2,
+                    self._fill_dynamic_tracks,
+                    queue_id,
+                    task_id=f"fill_dynamic_tracks_{queue_id}",
+                )
         else:
-            # give an idle/empty queue a current item without starting playback
             self._ensure_current_index(queue_id)
 
     async def _get_similar_tracks(

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -729,13 +729,10 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         # head only (the tail we are discarding must not exclude its own tracks from the new pool)
         queue_data.items = queue_data.items[:insert_at]
         queue.items = len(queue_data.items)
-        # Progressive loading: when starting playback on an empty queue, use the provider's natural
-        # first-batch size (could be 2-5 tracks) for fast startup, then fill the rest in background.
-        # Use target_size=1 to signal "take the first available batch without waiting for more".
         is_empty_queue = len(queue_data.items) == 0
-        initial_batch_size = 1 if (start_playing and is_empty_queue) else None
+        use_progressive_loading = start_playing and is_empty_queue
         pool_tracks = await self._managed_pool.fill(
-            queue_id, is_initial=False, target_size=initial_batch_size
+            queue_id, is_initial=False, use_first_batch=use_progressive_loading
         )
         queue_items = [
             build_queue_item(queue_id, track) for track in pool_tracks if track.available

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -1290,17 +1290,17 @@ class SmartPlaylistProvider(PluginProvider):
                     if base not in seen:
                         seen.add(base)
                         seed_pool.append(base)
-                    if base_count < base_track_limit:
-                        base_count += 1
-                        with suppress(MusicAssistantError):
-                            for track in await self.mass.music.tracks.similar_tracks(
-                                base.item_id, base.provider
-                            ):
-                                if len(seed_pool) >= per_seed_cap:
-                                    break
-                                if track not in seen:
-                                    seen.add(track)
-                                    seed_pool.append(track)
+                        if base_count < base_track_limit:
+                            base_count += 1
+                            with suppress(MusicAssistantError):
+                                for track in await self.mass.music.tracks.similar_tracks(
+                                    base.item_id, base.provider
+                                ):
+                                    if len(seed_pool) >= per_seed_cap:
+                                        break
+                                    if track not in seen:
+                                        seen.add(track)
+                                        seed_pool.append(track)
             per_seed_pools.append(seed_pool)
         pool: list[Track] = []
         for round_tracks in zip_longest(*per_seed_pools):

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -1281,21 +1281,26 @@ class SmartPlaylistProvider(PluginProvider):
                 seed_tracks = await self.mass.player_queues.get_tracks_for_playback(seed)
                 # shuffle so seeds are drawn from across the whole playlist, not just its top
                 random.shuffle(seed_tracks)
+                # Limit similar_tracks lookups to reduce initial evaluation time
+                base_track_limit = max(3, per_seed_cap // 15)
+                base_count = 0
                 for base in seed_tracks:
                     if len(seed_pool) >= per_seed_cap:
                         break
                     if base not in seen:
                         seen.add(base)
                         seed_pool.append(base)
-                    with suppress(MusicAssistantError):
-                        for track in await self.mass.music.tracks.similar_tracks(
-                            base.item_id, base.provider
-                        ):
-                            if len(seed_pool) >= per_seed_cap:
-                                break
-                            if track not in seen:
-                                seen.add(track)
-                                seed_pool.append(track)
+                    if base_count < base_track_limit:
+                        base_count += 1
+                        with suppress(MusicAssistantError):
+                            for track in await self.mass.music.tracks.similar_tracks(
+                                base.item_id, base.provider
+                            ):
+                                if len(seed_pool) >= per_seed_cap:
+                                    break
+                                if track not in seen:
+                                    seen.add(track)
+                                    seed_pool.append(track)
             per_seed_pools.append(seed_pool)
         pool: list[Track] = []
         for round_tracks in zip_longest(*per_seed_pools):

--- a/tests/controllers/player_queues/test_enqueue_options.py
+++ b/tests/controllers/player_queues/test_enqueue_options.py
@@ -302,6 +302,9 @@ async def test_enter_dynamic_mode_play_on_idle_starts_playback() -> None:
 
     assert len(ctrl._queue_data["q1"].items) == 2
     play_index.assert_awaited_once_with("q1", 0)
+    ctrl.mass.call_later.assert_called_once_with(
+        2, ctrl._fill_dynamic_tracks, "q1", task_id="fill_dynamic_tracks_q1"
+    )
 
 
 async def test_enter_dynamic_mode_add_on_active_keeps_current_and_rebuilds_tail() -> None:

--- a/tests/controllers/player_queues/test_enqueue_options.py
+++ b/tests/controllers/player_queues/test_enqueue_options.py
@@ -9,7 +9,7 @@ side-effecting ``play_index`` and ``signal_update`` are stubbed out.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 from music_assistant_models.enums import MediaType, PlaybackState, QueueOption
 from music_assistant_models.media_items import (
@@ -292,6 +292,7 @@ async def test_enter_dynamic_mode_add_on_idle_does_not_start_playback() -> None:
 async def test_enter_dynamic_mode_play_on_idle_starts_playback() -> None:
     """PLAY of a dynamic source onto an idle/empty queue starts playback on the rebuilt pool."""
     ctrl = _dynamic_controller()
+    ctrl.mass = MagicMock()
     play_index = AsyncMock()
     ctrl.play_index = play_index  # type: ignore[method-assign]
     queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)

--- a/tests/integration/test_managed_pool_e2e.py
+++ b/tests/integration/test_managed_pool_e2e.py
@@ -310,10 +310,13 @@ async def test_progressive_loading_returns_first_batch_then_fills(
     )
     assert len(first_batch) == 10  # limited by MANAGED_POOL_SOURCE_CAP
 
-    # normal fill would return more if the source allows
-    e2e_mass.player_queues._managed_pool.forget(queue_id)
-    normal_fill = await e2e_mass.player_queues._managed_pool.fill(
-        queue_id, is_initial=True, use_first_batch=False
-    )
-    # with is_initial=True and SOURCE_CAP=10, we get up to 10 (still capped by source cap)
-    assert len(normal_fill) == 10
+    # simulate the queue now has those tracks and advance to near the end
+    e2e_mass.player_queues.queue_data(queue_id).items = [
+        QueueItem.from_media_item(queue_id, track) for track in first_batch
+    ]
+    queue.current_index = len(first_batch) - 1
+
+    # a subsequent (normal) fill should page in the next chunk from the same finite source
+    second_batch = await e2e_mass.player_queues._managed_pool.fill(queue_id, is_initial=False)
+    assert len(second_batch) == 10
+    assert {t.item_id for t in second_batch}.isdisjoint({t.item_id for t in first_batch})

--- a/tests/integration/test_managed_pool_e2e.py
+++ b/tests/integration/test_managed_pool_e2e.py
@@ -286,3 +286,40 @@ async def test_dynamic_source_is_not_materialized(e2e_mass: MusicAssistant) -> N
     materialized = e2e_mass.player_queues._managed_pool._materialized.get(queue_id, {})
     assert album.uri in materialized  # the finite source is materialized into a deque
     assert radio.uri not in materialized  # the dynamic playlist is left to self-manage
+
+
+@pytest.mark.asyncio
+async def test_progressive_loading_returns_first_batch_then_fills(
+    e2e_mass: MusicAssistant,
+) -> None:
+    """Progressive loading (use_first_batch=True) returns initial candidates without waiting for full target."""
+    queue_id = demo_players(e2e_mass)[0].player_id
+    test_prov = cast("MusicProvider", e2e_mass.get_provider("test"))
+    assert test_prov is not None
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    e2e_mass.player_queues.queue_data(queue_id).userid = TEST_USER
+
+    album = await test_prov.get_album("0_0")  # 20 tracks
+    e2e_mass.player_queues.queue_data(queue_id).source_items = cast("list[MediaItemType]", [album])
+
+    # first fill with use_first_batch=True: should return available candidates (up to TARGET)
+    first_batch = await e2e_mass.player_queues._managed_pool.fill(
+        queue_id, is_initial=False, use_first_batch=True
+    )
+    assert 0 < len(first_batch) <= MANAGED_POOL_TARGET
+
+    # second fill without use_first_batch: should top up to TARGET
+    # simulate advancing the queue by marking first_batch as played
+    e2e_mass.player_queues.queue_data(queue_id).items = [
+        QueueItem.from_media_item(queue_id, track) for track in first_batch
+    ]
+    queue.current_index = len(first_batch) - 1
+
+    second_batch = await e2e_mass.player_queues._managed_pool.fill(
+        queue_id, is_initial=False, use_first_batch=False
+    )
+    # should top up toward TARGET
+    assert len(second_batch) > 0
+    total = len(first_batch) + len(second_batch)
+    assert total <= MANAGED_POOL_TARGET + 5  # allow some buffer

--- a/tests/integration/test_managed_pool_e2e.py
+++ b/tests/integration/test_managed_pool_e2e.py
@@ -290,9 +290,10 @@ async def test_dynamic_source_is_not_materialized(e2e_mass: MusicAssistant) -> N
 
 @pytest.mark.asyncio
 async def test_progressive_loading_returns_first_batch_then_fills(
-    e2e_mass: MusicAssistant,
+    e2e_mass: MusicAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Progressive loading (use_first_batch=True) returns initial candidates without waiting for full target."""
+    """Progressive loading (use_first_batch=True) returns initial candidates without blocking on full target."""
+    monkeypatch.setattr(managed_pool, "MANAGED_POOL_SOURCE_CAP", 10)
     queue_id = demo_players(e2e_mass)[0].player_id
     test_prov = cast("MusicProvider", e2e_mass.get_provider("test"))
     assert test_prov is not None
@@ -303,23 +304,16 @@ async def test_progressive_loading_returns_first_batch_then_fills(
     album = await test_prov.get_album("0_0")  # 20 tracks
     e2e_mass.player_queues.queue_data(queue_id).source_items = cast("list[MediaItemType]", [album])
 
-    # first fill with use_first_batch=True: should return available candidates (up to TARGET)
+    # use_first_batch=True returns available candidates capped at SOURCE_CAP (10), not TARGET (25)
     first_batch = await e2e_mass.player_queues._managed_pool.fill(
         queue_id, is_initial=False, use_first_batch=True
     )
-    assert 0 < len(first_batch) <= MANAGED_POOL_TARGET
+    assert len(first_batch) == 10  # limited by MANAGED_POOL_SOURCE_CAP
 
-    # second fill without use_first_batch: should top up to TARGET
-    # simulate advancing the queue by marking first_batch as played
-    e2e_mass.player_queues.queue_data(queue_id).items = [
-        QueueItem.from_media_item(queue_id, track) for track in first_batch
-    ]
-    queue.current_index = len(first_batch) - 1
-
-    second_batch = await e2e_mass.player_queues._managed_pool.fill(
-        queue_id, is_initial=False, use_first_batch=False
+    # normal fill would return more if the source allows
+    e2e_mass.player_queues._managed_pool.forget(queue_id)
+    normal_fill = await e2e_mass.player_queues._managed_pool.fill(
+        queue_id, is_initial=True, use_first_batch=False
     )
-    # should top up toward TARGET
-    assert len(second_batch) > 0
-    total = len(first_batch) + len(second_batch)
-    assert total <= MANAGED_POOL_TARGET + 5  # allow some buffer
+    # with is_initial=True and SOURCE_CAP=10, we get up to 10 (still capped by source cap)
+    assert len(normal_fill) == 10


### PR DESCRIPTION
# What does this implement/fix?

Reduces time-to-first-track for dynamic playlists and AutoPlay by implementing progressive queue loading. Previously, the system waited for all 25 tracks to be loaded before starting playback. Now it loads a minimal initial batch from the first API call, starts playback immediately, and fills the remaining tracks in the background after 2 seconds.

**Related issue (if applicable):**

- N/A (performance optimization)

## Changes

- **Progressive loading**: Load minimal initial batch (available candidates from first API call), start playback immediately, fill remaining tracks in background after 2 seconds
- **Earlier refill trigger**: Trigger refill at < 10 remaining tracks instead of < 5
- **Shorter refill delay**: Reduce delay from 5 seconds to 2 seconds
- **Smart Playlist optimization**: Limit `similar_tracks()` API calls to reduce initial evaluation time and avoid rate limiting

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.