### PR TITLE
Fix cancelled shared playback sessions

### DIFF
--- a/music_assistant/helpers/shared_playback.py
+++ b/music_assistant/helpers/shared_playback.py
@@ -20,7 +20,10 @@ to :meth:`SharedPlaybackSession.create_remote` yields the same player_id.
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from enum import StrEnum
+from functools import partial
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.enums import PlayerFeature
@@ -32,6 +35,11 @@ if TYPE_CHECKING:
     from music_assistant.providers.sendspin.provider import SendspinProvider
 
 SENDSPIN_DOMAIN = "sendspin"
+REMOTE_CREATION_CLEANUP_TIMEOUT = 15.0
+REMOTE_REMOVAL_CLEANUP_DELAYS = (0.0, 1.0, 5.0)
+REMOTE_REMOVAL_CLEANUP_TIMEOUT = 5.0
+
+LOGGER = logging.getLogger(__name__)
 
 
 class SharedPlaybackMode(StrEnum):
@@ -97,11 +105,38 @@ class SharedPlaybackSession:
         sendspin = cast("SendspinProvider | None", mass.get_provider(SENDSPIN_DOMAIN))
         if sendspin is None:
             raise SetupFailedError("The Sendspin provider is required for a remote session")
-        player_id = await sendspin.create_virtual_player(
+        creation = sendspin.create_virtual_player(
             owner_instance_id=owner_instance_id,
             display_name=display_name,
             player_id=session_id,
         )
+        try:
+            creation_task = mass.create_task(creation, eager_start=False)
+        except Exception:
+            creation.close()
+            raise
+        cleanup_required = asyncio.get_running_loop().create_future()
+        cleanup = cls._cleanup_cancelled_remote_creation(
+            mass,
+            sendspin,
+            creation_task,
+            cleanup_required,
+        )
+        try:
+            mass.create_task(cleanup, eager_start=False)
+        except Exception:
+            cleanup.close()
+            cls._cancel_and_observe_creation(mass, sendspin, creation_task)
+            raise
+        try:
+            player_id = await asyncio.shield(creation_task)
+        except asyncio.CancelledError:
+            cleanup_required.set_result(True)
+            raise
+        except Exception:
+            cleanup_required.set_result(False)
+            raise
+        cleanup_required.set_result(False)
         return cls(mass, SharedPlaybackMode.REMOTE, player_id)
 
     @property
@@ -184,6 +219,123 @@ class SharedPlaybackSession:
                 self._player_id, player_ids_to_remove=list(self._guest_listeners)
             )
         self._guest_listeners.clear()
+
+    @classmethod
+    async def _cleanup_cancelled_remote_creation(
+        cls,
+        mass: MusicAssistant,
+        sendspin: SendspinProvider,
+        creation_task: asyncio.Task[str],
+        cleanup_required: asyncio.Future[bool],
+    ) -> None:
+        """
+        Clean up a remote virtual player when its session creation is cancelled.
+
+        :param mass: MusicAssistant instance.
+        :param sendspin: Sendspin provider that owns the virtual player.
+        :param creation_task: In-flight virtual-player creation task.
+        :param cleanup_required: Signal indicating whether cleanup is needed.
+        """
+        if not await asyncio.shield(cleanup_required):
+            return
+        try:
+            done, _ = await asyncio.wait(
+                (creation_task,),
+                timeout=REMOTE_CREATION_CLEANUP_TIMEOUT,
+            )
+            if not done:
+                LOGGER.warning("Timed out waiting for cancelled remote session creation")
+                cls._cancel_and_observe_creation(mass, sendspin, creation_task)
+                return
+        except asyncio.CancelledError:
+            cls._cancel_and_observe_creation(mass, sendspin, creation_task)
+            raise
+
+        try:
+            player_id = creation_task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception as err:
+            LOGGER.debug("Cancelled remote session creation failed: %s", err)
+            return
+
+        await cls._cleanup_cancelled_remote_player(sendspin, player_id)
+
+    @staticmethod
+    async def _cleanup_cancelled_remote_player(
+        sendspin: SendspinProvider,
+        player_id: str,
+    ) -> None:
+        """
+        Remove a virtual player left by cancelled remote session creation.
+
+        :param sendspin: Sendspin provider that owns the virtual player.
+        :param player_id: Virtual player to remove.
+        """
+        last_error: Exception | None = None
+        for delay in REMOTE_REMOVAL_CLEANUP_DELAYS:
+            if delay:
+                await asyncio.sleep(delay)
+            try:
+                if not sendspin.is_virtual_player(player_id):
+                    return
+                async with asyncio.timeout(REMOTE_REMOVAL_CLEANUP_TIMEOUT):
+                    await sendspin.remove_virtual_player(player_id)
+                return
+            except Exception as err:
+                last_error = err
+        LOGGER.warning(
+            "Could not clean up cancelled remote session %s: %s",
+            player_id,
+            last_error,
+        )
+
+    @classmethod
+    def _cancel_and_observe_creation(
+        cls,
+        mass: MusicAssistant,
+        sendspin: SendspinProvider,
+        task: asyncio.Task[str],
+    ) -> None:
+        """Cancel virtual-player creation and observe its eventual result."""
+        task.cancel()
+        cls._observe_late_remote_creation(mass, sendspin, task)
+
+    @classmethod
+    def _observe_late_remote_creation(
+        cls,
+        mass: MusicAssistant,
+        sendspin: SendspinProvider,
+        task: asyncio.Task[str],
+    ) -> None:
+        """Observe creation after bounded cleanup stops waiting for it."""
+        task.add_done_callback(partial(cls._handle_late_remote_creation, mass, sendspin))
+
+    @classmethod
+    def _handle_late_remote_creation(
+        cls,
+        mass: MusicAssistant,
+        sendspin: SendspinProvider,
+        task: asyncio.Task[str],
+    ) -> None:
+        """Schedule cleanup when cancelled creation eventually returns a player."""
+        if task.cancelled():
+            return
+        try:
+            player_id = task.result()
+        except Exception as err:
+            LOGGER.debug("Cancelled remote session creation failed: %s", err)
+            return
+        cleanup = cls._cleanup_cancelled_remote_player(sendspin, player_id)
+        try:
+            mass.create_task(cleanup, eager_start=False)
+        except Exception as err:
+            cleanup.close()
+            LOGGER.warning(
+                "Could not schedule cancelled remote session cleanup for %s: %s",
+                player_id,
+                err,
+            )
 
     def _get_host_player(self) -> Player | None:
         """Return the (available) player hosting this session, if any."""

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -72,6 +72,8 @@ if TYPE_CHECKING:
 DEFAULT_SENDSPIN_CLIENT_PORT = 8928
 DEFAULT_SENDSPIN_CLIENT_PATH = "/sendspin"
 VIRTUAL_PLAYER_REGISTER_TIMEOUT = 10.0
+VIRTUAL_PLAYER_CLEANUP_DELAYS = (0.0, 0.5, 2.0)
+VIRTUAL_PLAYER_CLEANUP_TIMEOUT = 2.0
 
 
 def _manual_client_url(address: str) -> str:
@@ -336,13 +338,11 @@ class SendspinProvider(PlayerProvider):
         try:
             self._register_virtual_player_client(player_id, display_name)
             await self._wait_for_virtual_player(player_id)
+        except asyncio.CancelledError:
+            await self._cleanup_failed_virtual_player_creation(player_id)
+            raise
         except Exception as err:
-            self._virtual_players.pop(player_id, None)
-            # purge any partially registered player and its config
-            await self.mass.players.unregister(player_id, permanent=True)
-            if self.server_api.get_client(player_id) is not None:
-                await self.server_api.remove_client(player_id)
-            self.mass.players.delete_player_config(player_id)
+            await self._cleanup_failed_virtual_player_creation(player_id)
             if isinstance(err, SetupFailedError):
                 raise
             raise SetupFailedError(f"Failed to create virtual player {player_id}") from err
@@ -365,7 +365,6 @@ class SendspinProvider(PlayerProvider):
             and self._get_virtual_player_config_owner(player_id) is None
         ):
             raise ValueError(f"{player_id} is not a virtual player")
-        self._virtual_players.pop(player_id, None)
         # unregister the player first so the client removed event handler
         # can not race us with a non-permanent unregister
         await self.mass.players.unregister(player_id, permanent=True)
@@ -373,6 +372,7 @@ class SendspinProvider(PlayerProvider):
             await self.server_api.remove_client(player_id)
         # the config may linger when the player was never registered
         self.mass.players.delete_player_config(player_id)
+        self._virtual_players.pop(player_id, None)
         self.logger.info("Virtual player %s removed", player_id)
 
     def is_virtual_player(self, player_id: str) -> bool:
@@ -735,6 +735,28 @@ class SendspinProvider(PlayerProvider):
                 return
             await asyncio.sleep(0.1)
         raise SetupFailedError(f"Virtual player {player_id} was not registered in time")
+
+    async def _cleanup_failed_virtual_player_creation(self, player_id: str) -> None:
+        """
+        Remove a virtual player after its creation does not complete.
+
+        :param player_id: Virtual player to remove.
+        """
+        last_error: Exception | None = None
+        for delay in VIRTUAL_PLAYER_CLEANUP_DELAYS:
+            if delay:
+                await asyncio.sleep(delay)
+            try:
+                async with asyncio.timeout(VIRTUAL_PLAYER_CLEANUP_TIMEOUT):
+                    await self.remove_virtual_player(player_id)
+                return
+            except Exception as err:
+                last_error = err
+        self.logger.warning(
+            "Could not clean up failed virtual player creation %s: %s",
+            player_id,
+            last_error,
+        )
 
     def _on_virtual_player_stream_start(self, _request: ExternalStreamStartRequest) -> None:
         """Accept stream start requests for virtual players (nothing to connect)."""

--- a/tests/helpers/test_shared_playback.py
+++ b/tests/helpers/test_shared_playback.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Coroutine
 from typing import TYPE_CHECKING, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import PlayerFeature
@@ -22,6 +24,26 @@ def _create_mock_mass(venue_player: MagicMock | None) -> MagicMock:
     mass.players.get_player.return_value = venue_player
     mass.players.cmd_set_members = AsyncMock()
     return mass
+
+
+def _create_mock_remote_mass(
+    sendspin: MagicMock,
+) -> tuple[MagicMock, list[asyncio.Task[object]]]:
+    """Create a mock MusicAssistant that tracks created tasks."""
+    mass = MagicMock()
+    tasks: list[asyncio.Task[object]] = []
+
+    def _create_task(
+        target: Coroutine[object, object, object],
+        **_kwargs: object,
+    ) -> asyncio.Task[object]:
+        task = asyncio.create_task(target)
+        tasks.append(task)
+        return task
+
+    mass.get_provider.return_value = sendspin
+    mass.create_task.side_effect = _create_task
+    return mass, tasks
 
 
 def _create_venue_player(
@@ -207,6 +229,255 @@ async def test_create_remote_session_no_sendspin() -> None:
         await SharedPlaybackSession.create_remote(
             mass, owner_instance_id="some_plugin", display_name="Test Party"
         )
+
+
+async def test_cancelled_remote_creation_cleans_up_virtual_player() -> None:
+    """Cancel promptly and remove the virtual player after creation finishes."""
+    sendspin = MagicMock()
+    mass, tasks = _create_mock_remote_mass(sendspin)
+    creation_started = asyncio.Event()
+    allow_creation = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+
+    async def _create_virtual_player(**_kwargs: object) -> str:
+        creation_started.set()
+        await allow_creation.wait()
+        return "virtual-player"
+
+    async def _remove_virtual_player(_player_id: str, **_kwargs: object) -> None:
+        cleanup_finished.set()
+
+    sendspin.create_virtual_player = AsyncMock(side_effect=_create_virtual_player)
+    sendspin.is_virtual_player.return_value = True
+    sendspin.remove_virtual_player = AsyncMock(side_effect=_remove_virtual_player)
+
+    session_task = asyncio.create_task(
+        SharedPlaybackSession.create_remote(
+            mass,
+            owner_instance_id="plugin--test",
+            display_name="Test Party",
+            session_id="test",
+        )
+    )
+    await creation_started.wait()
+    session_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await session_task
+    assert not cleanup_finished.is_set()
+
+    allow_creation.set()
+    await cleanup_finished.wait()
+    await asyncio.gather(*tasks)
+
+    sendspin.remove_virtual_player.assert_awaited_once_with("virtual-player")
+    assert all(task.done() for task in tasks)
+
+
+async def test_cancelled_remote_creation_failure_is_observed() -> None:
+    """Observe a creation error after the caller has already been cancelled."""
+    sendspin = MagicMock()
+    mass, tasks = _create_mock_remote_mass(sendspin)
+    creation_started = asyncio.Event()
+    allow_creation = asyncio.Event()
+
+    async def _create_virtual_player(**_kwargs: object) -> str:
+        creation_started.set()
+        await allow_creation.wait()
+        raise RuntimeError("creation failed")
+
+    sendspin.create_virtual_player = AsyncMock(side_effect=_create_virtual_player)
+    sendspin.remove_virtual_player = AsyncMock()
+
+    with patch("music_assistant.helpers.shared_playback.LOGGER") as logger:
+        session_task = asyncio.create_task(
+            SharedPlaybackSession.create_remote(
+                mass,
+                owner_instance_id="plugin--test",
+                display_name="Test Party",
+            )
+        )
+        await creation_started.wait()
+        session_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await session_task
+
+        allow_creation.set()
+        await tasks[1]
+
+    logger.debug.assert_called_once()
+    sendspin.remove_virtual_player.assert_not_awaited()
+    assert all(task.done() for task in tasks)
+
+
+async def test_cancelled_remote_creation_timeout_cancels_task() -> None:
+    """Bound cleanup when virtual-player creation does not finish."""
+    sendspin = MagicMock()
+    mass, tasks = _create_mock_remote_mass(sendspin)
+    creation_started = asyncio.Event()
+    creation_cancelled = asyncio.Event()
+    never_finish = asyncio.Event()
+
+    async def _create_virtual_player(**_kwargs: object) -> str:
+        creation_started.set()
+        try:
+            await never_finish.wait()
+        finally:
+            creation_cancelled.set()
+        return "virtual-player"
+
+    sendspin.create_virtual_player = AsyncMock(side_effect=_create_virtual_player)
+
+    with patch(
+        "music_assistant.helpers.shared_playback.REMOTE_CREATION_CLEANUP_TIMEOUT",
+        0.01,
+    ):
+        session_task = asyncio.create_task(
+            SharedPlaybackSession.create_remote(
+                mass,
+                owner_instance_id="plugin--test",
+                display_name="Test Party",
+            )
+        )
+        await creation_started.wait()
+        session_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await session_task
+
+        await creation_cancelled.wait()
+        await tasks[1]
+
+    assert tasks[0].cancelled()
+    assert all(task.done() for task in tasks)
+
+
+async def test_cancelled_remote_creation_cleans_up_late_success() -> None:
+    """Remove a virtual player returned after bounded creation cleanup ends."""
+    sendspin = MagicMock()
+    mass, tasks = _create_mock_remote_mass(sendspin)
+    creation_started = asyncio.Event()
+    cancellation_received = asyncio.Event()
+    allow_late_success = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+    never_finish = asyncio.Event()
+
+    async def _create_virtual_player(**_kwargs: object) -> str:
+        creation_started.set()
+        try:
+            await never_finish.wait()
+        except asyncio.CancelledError:
+            cancellation_received.set()
+            await allow_late_success.wait()
+        return "virtual-player"
+
+    async def _remove_virtual_player(_player_id: str, **_kwargs: object) -> None:
+        cleanup_finished.set()
+
+    sendspin.create_virtual_player = AsyncMock(side_effect=_create_virtual_player)
+    sendspin.is_virtual_player.return_value = True
+    sendspin.remove_virtual_player = AsyncMock(side_effect=_remove_virtual_player)
+
+    with patch(
+        "music_assistant.helpers.shared_playback.REMOTE_CREATION_CLEANUP_TIMEOUT",
+        0.01,
+    ):
+        session_task = asyncio.create_task(
+            SharedPlaybackSession.create_remote(
+                mass,
+                owner_instance_id="plugin--test",
+                display_name="Test Party",
+            )
+        )
+        await creation_started.wait()
+        session_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await session_task
+
+        await cancellation_received.wait()
+        await tasks[1]
+        assert not cleanup_finished.is_set()
+        allow_late_success.set()
+        await cleanup_finished.wait()
+        await asyncio.gather(*tasks)
+
+    sendspin.remove_virtual_player.assert_awaited_once_with("virtual-player")
+    assert all(task.done() for task in tasks)
+
+
+async def test_cancelled_remote_creation_retries_cleanup() -> None:
+    """Retry cleanup when removing the created virtual player fails temporarily."""
+    sendspin = MagicMock()
+    mass = MagicMock()
+    sendspin.is_virtual_player.return_value = True
+    sendspin.remove_virtual_player = AsyncMock(
+        side_effect=[RuntimeError("temporary failure"), None]
+    )
+    cleanup_required = asyncio.get_running_loop().create_future()
+    cleanup_required.set_result(True)
+
+    async def _created_player() -> str:
+        return "virtual-player"
+
+    creation_task = asyncio.create_task(_created_player())
+    with patch(
+        "music_assistant.helpers.shared_playback.REMOTE_REMOVAL_CLEANUP_DELAYS",
+        (0.0, 0.0),
+    ):
+        await SharedPlaybackSession._cleanup_cancelled_remote_creation(
+            mass,
+            sendspin,
+            creation_task,
+            cleanup_required,
+        )
+
+    assert sendspin.remove_virtual_player.await_count == 2
+
+
+async def test_cancelled_remote_creation_bounds_hung_removal() -> None:
+    """Bound cleanup when virtual-player removal does not finish."""
+    sendspin = MagicMock()
+    mass = MagicMock()
+    removal_started = asyncio.Event()
+    removal_cancelled = asyncio.Event()
+    never_finish = asyncio.Event()
+
+    async def _remove_virtual_player(_player_id: str, **_kwargs: object) -> None:
+        removal_started.set()
+        try:
+            await never_finish.wait()
+        finally:
+            removal_cancelled.set()
+
+    sendspin.is_virtual_player.return_value = True
+    sendspin.remove_virtual_player = AsyncMock(side_effect=_remove_virtual_player)
+    cleanup_required = asyncio.get_running_loop().create_future()
+    cleanup_required.set_result(True)
+
+    async def _created_player() -> str:
+        return "virtual-player"
+
+    creation_task = asyncio.create_task(_created_player())
+    with (
+        patch(
+            "music_assistant.helpers.shared_playback.REMOTE_REMOVAL_CLEANUP_DELAYS",
+            (0.0,),
+        ),
+        patch(
+            "music_assistant.helpers.shared_playback.REMOTE_REMOVAL_CLEANUP_TIMEOUT",
+            0.01,
+        ),
+        patch("music_assistant.helpers.shared_playback.LOGGER") as logger,
+    ):
+        await SharedPlaybackSession._cleanup_cancelled_remote_creation(
+            mass,
+            sendspin,
+            creation_task,
+            cleanup_required,
+        )
+
+    assert removal_started.is_set()
+    assert removal_cancelled.is_set()
+    logger.warning.assert_called_once()
 
 
 async def test_remote_close_is_idempotent(mass: MusicAssistant) -> None:

--- a/tests/providers/sendspin/test_virtual_player.py
+++ b/tests/providers/sendspin/test_virtual_player.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import PlayerFeature, PlayerType
@@ -14,12 +15,12 @@ from music_assistant.providers.sendspin.constants import (
     CONF_VIRTUAL_PLAYER_OWNER,
     VIRTUAL_PLAYER_ID_PREFIX,
 )
+from music_assistant.providers.sendspin.provider import SendspinProvider
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from music_assistant.mass import MusicAssistant
-    from music_assistant.providers.sendspin.provider import SendspinProvider
 
 
 def _get_sendspin_provider(mass: MusicAssistant) -> SendspinProvider:
@@ -105,6 +106,70 @@ async def test_create_virtual_player_duplicate(mass: MusicAssistant) -> None:
         )
 
 
+async def test_create_virtual_player_cancellation_cleans_partial_player() -> None:
+    """Test cancellation rolls back a partially-created virtual player."""
+    sendspin = SendspinProvider.__new__(SendspinProvider)
+    sendspin.mass = MagicMock()
+    sendspin.server_api = MagicMock()
+    sendspin.logger = MagicMock()
+    sendspin._virtual_players = {}
+    owner = MagicMock(instance_id="owner--test")
+    sendspin.mass.get_provider.return_value = owner
+    client_registered = asyncio.Event()
+    creation_started = asyncio.Event()
+    never_finish = asyncio.Event()
+    client = MagicMock()
+
+    def _register_virtual_player_client(_player_id: str, _display_name: str) -> None:
+        client_registered.set()
+
+    async def _wait_for_virtual_player(_player_id: str) -> None:
+        creation_started.set()
+        await never_finish.wait()
+
+    sendspin.server_api.get_client.side_effect = lambda _player_id: (
+        client if client_registered.is_set() else None
+    )
+    sendspin.server_api.remove_client = AsyncMock()
+    sendspin.mass.players.unregister = AsyncMock()
+
+    with (
+        patch.object(
+            sendspin,
+            "_get_virtual_player_config_owner",
+            return_value=None,
+        ),
+        patch.object(
+            sendspin,
+            "_register_virtual_player_client",
+            side_effect=_register_virtual_player_client,
+        ),
+        patch.object(
+            sendspin,
+            "_wait_for_virtual_player",
+            new=AsyncMock(side_effect=_wait_for_virtual_player),
+        ),
+    ):
+        creation_task = asyncio.create_task(
+            sendspin.create_virtual_player(
+                owner_instance_id=owner.instance_id,
+                display_name="Test Session",
+                player_id="cancelled",
+            )
+        )
+        await creation_started.wait()
+        creation_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await creation_task
+
+    player_id = f"{VIRTUAL_PLAYER_ID_PREFIX}cancelled"
+    assert not sendspin.is_virtual_player(player_id)
+    sendspin.mass.players.unregister.assert_awaited_once_with(player_id, permanent=True)
+    sendspin.server_api.remove_client.assert_awaited_once_with(player_id)
+    sendspin.mass.players.delete_player_config.assert_called_once_with(player_id)
+
+
 async def test_create_virtual_player_owner_not_loaded(mass: MusicAssistant) -> None:
     """Test that creating a virtual player for an unknown owner raises."""
     sendspin = _get_sendspin_provider(mass)
@@ -147,6 +212,33 @@ async def test_remove_virtual_player(mass: MusicAssistant) -> None:
     assert mass.players.get_player(player_id) is None
     assert sendspin.server_api.get_client(player_id) is None
     assert mass.config.get(f"{CONF_PLAYERS}/{player_id}") is None
+
+
+async def test_remove_virtual_player_retries_after_partial_failure() -> None:
+    """Retain virtual-player ownership until removal completes successfully."""
+    sendspin = SendspinProvider.__new__(SendspinProvider)
+    sendspin.mass = MagicMock()
+    sendspin.server_api = MagicMock()
+    sendspin.logger = MagicMock()
+    player_id = f"{VIRTUAL_PLAYER_ID_PREFIX}retry"
+    sendspin._virtual_players = {player_id: "owner--test"}
+    sendspin.mass.players.unregister = AsyncMock()
+    sendspin.server_api.get_client.return_value = MagicMock()
+    sendspin.server_api.remove_client = AsyncMock(
+        side_effect=[RuntimeError("client removal failed"), None]
+    )
+
+    with pytest.raises(RuntimeError, match="client removal failed"):
+        await sendspin.remove_virtual_player(player_id)
+
+    assert sendspin.is_virtual_player(player_id)
+
+    await sendspin.remove_virtual_player(player_id)
+
+    assert not sendspin.is_virtual_player(player_id)
+    assert sendspin.mass.players.unregister.await_count == 2
+    assert sendspin.server_api.remove_client.await_count == 2
+    sendspin.mass.players.delete_player_config.assert_called_once_with(player_id)
 
 
 async def test_remove_virtual_player_rejects_regular_player(mass: MusicAssistant) -> None:


### PR DESCRIPTION
## Summary

Cancelled remote shared playback creation could leave a Sendspin virtual player or background task behind.

- return caller cancellation immediately while Mass tracks creation completion
- bound and retry cleanup for partial creation and removal failures
- keep Sendspin removal bookkeeping until teardown succeeds
- cover cancellation, timeout, retry, and idempotent paths