### PR TITLE
Fix album artists for Apple Music compilations

### DIFF
--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -189,47 +189,6 @@ def parse_album(
     return album
 
 
-def _parse_album_artists(
-    provider: AppleMusicProvider,
-    attributes: dict[str, Any],
-    relationships: dict[str, Any],
-) -> UniqueList[Artist | ItemMapping] | None:
-    """Parse the album artists from an album's attributes and relationships."""
-    album_artist_name = normalize_unicode(attributes.get("artistName"))
-    # Skip incomplete relationships that only produce ID-based artist mappings.
-    artist_objs = [
-        artist
-        for artist in relationships.get("artists", {}).get("data", [])
-        if _has_artist_details(artist)
-    ]
-    artists = UniqueList([parse_artist(provider, artist) for artist in artist_objs])
-    if album_artist_name and attributes.get("isCompilation"):
-        # A lone related artist can be a contributor rather than the album artist.
-        if len(artists) == 1 and artists[0].name != album_artist_name:
-            artists = UniqueList()
-    if artists:
-        return artists
-    if album_artist_name:
-        return UniqueList(
-            [
-                ItemMapping(
-                    media_type=MediaType.ARTIST,
-                    provider=provider.instance_id,
-                    item_id=album_artist_name,
-                    name=album_artist_name,
-                )
-            ]
-        )
-    return None
-
-
-def _has_artist_details(artist_obj: dict[str, Any]) -> bool:
-    """Check if an artist object holds enough details to parse it."""
-    if "attributes" in artist_obj:
-        return True
-    return bool(artist_obj.get("relationships", {}).get("catalog", {}).get("data"))
-
-
 def parse_track(
     provider: AppleMusicProvider,
     track_obj: dict[str, Any],
@@ -425,3 +384,48 @@ def parse_station_as_playlist(
             )
         )
     return playlist
+
+
+def _parse_album_artists(
+    provider: AppleMusicProvider,
+    attributes: dict[str, Any],
+    relationships: dict[str, Any],
+) -> UniqueList[Artist | ItemMapping] | None:
+    """Parse the album artists from an album's attributes and relationships."""
+    album_artist_name = normalize_unicode(attributes.get("artistName"))
+    # Skip relationships that cannot produce a named artist.
+    artist_objs = [
+        artist
+        for artist in relationships.get("artists", {}).get("data", [])
+        if _has_artist_details(artist)
+    ]
+    artists = UniqueList([parse_artist(provider, artist) for artist in artist_objs])
+    if album_artist_name and attributes.get("isCompilation"):
+        # A lone related artist can be a contributor rather than the album artist.
+        if len(artists) == 1 and artists[0].name != album_artist_name:
+            artists = UniqueList()
+    if artists:
+        return artists
+    if album_artist_name:
+        return UniqueList(
+            [
+                ItemMapping(
+                    media_type=MediaType.ARTIST,
+                    provider=provider.instance_id,
+                    item_id=album_artist_name,
+                    name=album_artist_name,
+                )
+            ]
+        )
+    return None
+
+
+def _has_artist_details(artist_obj: dict[str, Any]) -> bool:
+    """Check if an artist object holds enough details to parse it."""
+    relationships = artist_obj.get("relationships", {})
+    catalog_data = relationships.get("catalog", {}).get("data", [])
+    if artist_obj.get("type") == "library-artists" and catalog_data:
+        attributes = catalog_data[0].get("attributes", {})
+    else:
+        attributes = artist_obj.get("attributes", {})
+    return bool(normalize_unicode(attributes.get("name")))

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -196,8 +196,7 @@ def _parse_album_artists(
 ) -> UniqueList[Artist | ItemMapping] | None:
     """Parse the album artists from an album's attributes and relationships."""
     album_artist_name = normalize_unicode(attributes.get("artistName"))
-    # compilations may reference unresolvable placeholder artists that carry
-    # no details at all; those only yield a useless id-as-name mapping
+    # Skip incomplete relationships that only produce ID-based artist mappings.
     artist_objs = [
         artist
         for artist in relationships.get("artists", {}).get("data", [])
@@ -205,10 +204,7 @@ def _parse_album_artists(
     ]
     artists = UniqueList([parse_artist(provider, artist) for artist in artist_objs])
     if album_artist_name and attributes.get("isCompilation"):
-        # compilations may reference a single contributing artist instead of
-        # the album-level artist (e.g. 'Various Artists', localized), so only
-        # keep the related artists when they match the album-level artist;
-        # multiple related artists (DJ-mix compilations) are kept as-is
+        # A lone related artist can be a contributor rather than the album artist.
         if len(artists) == 1 and artists[0].name != album_artist_name:
             artists = UniqueList()
     if artists:

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -143,19 +143,9 @@ def parse_album(
             )
         },
     )
-    if artists := relationships.get("artists"):
-        album.artists = UniqueList([parse_artist(provider, artist) for artist in artists["data"]])
-    elif artist_name := normalize_unicode(attributes.get("artistName")):
-        album.artists = UniqueList(
-            [
-                ItemMapping(
-                    media_type=MediaType.ARTIST,
-                    provider=provider.instance_id,
-                    item_id=artist_name,
-                    name=artist_name,
-                )
-            ]
-        )
+    album_artists = _parse_album_artists(provider, attributes, relationships)
+    if album_artists:
+        album.artists = album_artists
     if release_date := attributes.get("releaseDate"):
         album.year = int(release_date.split("-")[0])
     if genres := attributes.get("genreNames"):
@@ -197,6 +187,51 @@ def parse_album(
         album.album_type = inferred_type
     album.favorite = is_favourite or False
     return album
+
+
+def _parse_album_artists(
+    provider: AppleMusicProvider,
+    attributes: dict[str, Any],
+    relationships: dict[str, Any],
+) -> UniqueList[Artist | ItemMapping] | None:
+    """Parse the album artists from an album's attributes and relationships."""
+    album_artist_name = normalize_unicode(attributes.get("artistName"))
+    # compilations may reference unresolvable placeholder artists that carry
+    # no details at all; those only yield a useless id-as-name mapping
+    artist_objs = [
+        artist
+        for artist in relationships.get("artists", {}).get("data", [])
+        if _has_artist_details(artist)
+    ]
+    artists = UniqueList([parse_artist(provider, artist) for artist in artist_objs])
+    if album_artist_name and attributes.get("isCompilation"):
+        # compilations may reference a single contributing artist instead of
+        # the album-level artist (e.g. 'Various Artists', localized), so only
+        # keep the related artists when they match the album-level artist;
+        # multiple related artists (DJ-mix compilations) are kept as-is
+        if len(artists) == 1 and artists[0].name != album_artist_name:
+            artists = UniqueList()
+    if artists:
+        return artists
+    if album_artist_name:
+        return UniqueList(
+            [
+                ItemMapping(
+                    media_type=MediaType.ARTIST,
+                    provider=provider.instance_id,
+                    item_id=album_artist_name,
+                    name=album_artist_name,
+                )
+            ]
+        )
+    return None
+
+
+def _has_artist_details(artist_obj: dict[str, Any]) -> bool:
+    """Check if an artist object holds enough details to parse it."""
+    if "attributes" in artist_obj:
+        return True
+    return bool(artist_obj.get("relationships", {}).get("catalog", {}).get("data"))
 
 
 def parse_track(

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -122,6 +122,42 @@ def test_parse_album_single_artist_compilation_keeps_rich_artist() -> None:
     assert result.artists[0].item_id == "artist0"
 
 
+def test_parse_album_compilation_keeps_catalog_artist_details() -> None:
+    """A compilation must keep complete catalog details for a library artist."""
+    provider = _create_provider_mock()
+    album_obj = _make_album_obj(
+        {"artistName": "Eminem", "isCompilation": True},
+        {
+            "artists": {
+                "data": [
+                    {
+                        "id": "l.artist0",
+                        "type": "library-artists",
+                        "relationships": {
+                            "catalog": {
+                                "data": [
+                                    {
+                                        "id": "artist0",
+                                        "type": "artists",
+                                        "attributes": {"name": "Eminem"},
+                                    }
+                                ]
+                            }
+                        },
+                    }
+                ]
+            }
+        },
+    )
+
+    result = parse_album(provider, album_obj)
+
+    assert isinstance(result, Album)
+    assert len(result.artists) == 1
+    assert result.artists[0].name == "Eminem"
+    assert result.artists[0].item_id == "artist0"
+
+
 def test_parse_album_dj_mix_compilation_keeps_multiple_artists() -> None:
     """A DJ-mix compilation with multiple related artists must keep them all."""
     provider = _create_provider_mock()
@@ -136,12 +172,26 @@ def test_parse_album_dj_mix_compilation_keeps_multiple_artists() -> None:
     assert [artist.name for artist in result.artists] == ["Pete Tong", "Boy George"]
 
 
-def test_parse_album_compilation_ignores_placeholder_artist_stub() -> None:
-    """An unresolvable artist stub (id only) must not become the album artist."""
+@pytest.mark.parametrize(
+    "artist_obj",
+    [
+        {"id": "80204262", "type": "artists"},
+        {"id": "80204262", "type": "artists", "attributes": {}},
+        {
+            "id": "l.artist.80204262",
+            "type": "library-artists",
+            "relationships": {"catalog": {"data": [{"id": "80204262", "type": "artists"}]}},
+        },
+    ],
+)
+def test_parse_album_compilation_ignores_placeholder_artist_stub(
+    artist_obj: dict[str, Any],
+) -> None:
+    """An unresolvable artist stub must not become the album artist."""
     provider = _create_provider_mock()
     album_obj = _make_album_obj(
         {"artistName": "Verschillende artiesten", "isCompilation": True},
-        {"artists": {"data": [{"id": "80204262", "type": "artists"}]}},
+        {"artists": {"data": [artist_obj]}},
     )
 
     result = parse_album(provider, album_obj)

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -56,6 +56,128 @@ def test_parse_album_keeps_album_without_catalog_url() -> None:
     assert mapping.url is None
 
 
+def _make_album_obj(attributes: dict[str, Any], relationships: dict[str, Any]) -> dict[str, Any]:
+    """Create a catalog album object for parse_album."""
+    return {
+        "id": "1234567890",
+        "type": "albums",
+        "attributes": {"name": "Test Album", **attributes},
+        "relationships": relationships,
+    }
+
+
+def _artists_relationship(*names: str) -> dict[str, Any]:
+    """Create an artists relationship payload with the given artist names."""
+    return {
+        "artists": {
+            "data": [
+                {"id": f"artist{idx}", "type": "artists", "attributes": {"name": name}}
+                for idx, name in enumerate(names)
+            ]
+        }
+    }
+
+
+def test_parse_album_compilation_uses_album_level_artist_name() -> None:
+    """Compilations must show the album-level artist, not a contributing artist."""
+    provider = _create_provider_mock()
+    album_obj = _make_album_obj(
+        {"artistName": "Various Artists", "isCompilation": True},
+        _artists_relationship("Paul McCartney"),
+    )
+
+    result = parse_album(provider, album_obj)
+
+    assert isinstance(result, Album)
+    assert [artist.name for artist in result.artists] == ["Various Artists"]
+
+
+def test_parse_album_compilation_without_artist_name_keeps_related_artists() -> None:
+    """A compilation without artistName must fall back to the related artists."""
+    provider = _create_provider_mock()
+    album_obj = _make_album_obj(
+        {"isCompilation": True},
+        _artists_relationship("Paul McCartney"),
+    )
+
+    result = parse_album(provider, album_obj)
+
+    assert isinstance(result, Album)
+    assert [artist.name for artist in result.artists] == ["Paul McCartney"]
+
+
+def test_parse_album_single_artist_compilation_keeps_rich_artist() -> None:
+    """A greatest-hits compilation by one artist must keep the full artist object."""
+    provider = _create_provider_mock()
+    album_obj = _make_album_obj(
+        {"artistName": "Eminem", "isCompilation": True},
+        _artists_relationship("Eminem"),
+    )
+
+    result = parse_album(provider, album_obj)
+
+    assert isinstance(result, Album)
+    assert len(result.artists) == 1
+    assert result.artists[0].name == "Eminem"
+    assert result.artists[0].item_id == "artist0"
+
+
+def test_parse_album_dj_mix_compilation_keeps_multiple_artists() -> None:
+    """A DJ-mix compilation with multiple related artists must keep them all."""
+    provider = _create_provider_mock()
+    album_obj = _make_album_obj(
+        {"artistName": "Pete Tong & Boy George", "isCompilation": True},
+        _artists_relationship("Pete Tong", "Boy George"),
+    )
+
+    result = parse_album(provider, album_obj)
+
+    assert isinstance(result, Album)
+    assert [artist.name for artist in result.artists] == ["Pete Tong", "Boy George"]
+
+
+def test_parse_album_compilation_ignores_placeholder_artist_stub() -> None:
+    """An unresolvable artist stub (id only) must not become the album artist."""
+    provider = _create_provider_mock()
+    album_obj = _make_album_obj(
+        {"artistName": "Verschillende artiesten", "isCompilation": True},
+        {"artists": {"data": [{"id": "80204262", "type": "artists"}]}},
+    )
+
+    result = parse_album(provider, album_obj)
+
+    assert isinstance(result, Album)
+    assert [artist.name for artist in result.artists] == ["Verschillende artiesten"]
+
+
+def test_parse_album_compilation_with_empty_artists_uses_artist_name() -> None:
+    """A compilation without any related artists must use the album-level artist."""
+    provider = _create_provider_mock()
+    album_obj = _make_album_obj(
+        {"artistName": "Various Artists", "isCompilation": True},
+        {"artists": {"data": []}},
+    )
+
+    result = parse_album(provider, album_obj)
+
+    assert isinstance(result, Album)
+    assert [artist.name for artist in result.artists] == ["Various Artists"]
+
+
+def test_parse_album_regular_album_keeps_related_artists() -> None:
+    """A regular album must keep the artists from the relationships."""
+    provider = _create_provider_mock()
+    album_obj = _make_album_obj(
+        {"artistName": "Paul McCartney"},
+        _artists_relationship("Paul McCartney"),
+    )
+
+    result = parse_album(provider, album_obj)
+
+    assert isinstance(result, Album)
+    assert [artist.name for artist in result.artists] == ["Paul McCartney"]
+
+
 def test_parse_track_falls_back_to_album_name_when_relationship_missing() -> None:
     """Track parsing should keep album info from albumName if no album relation is present."""
     provider = _create_provider_mock()


### PR DESCRIPTION
# What does this implement/fix?

Apple Music compilation albums could show a contributing artist, a raw artist ID, or no artist instead of the album-level artist. Apple sometimes returns incomplete or misleading artist relationships for compilations.

- Ignore artist relationship entries that do not contain usable artist details
- Fall back to the localized album-level `artistName` when compilation relationships are empty or point to a different single artist
- Preserve rich artist relationships for single-artist greatest-hits albums and multi-artist DJ mixes
- Add tests covering compilation, regular album, placeholder, single-artist, and multi-artist payloads

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5670

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
