### PR TITLE
Add similar music to Music Quiz

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -39,7 +39,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 35
+API_SCHEMA_VERSION: Final[int] = 36
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -25,11 +25,11 @@ contract (all payloads are JSON objects)::
 The public game state is guest-safe by construction. Common state contains:
 
 - always: ``phase`` (lobby/answering/reveal/finished), ``name``, ``quiz_type``,
-  ``answer_type``, ``mode`` (venue/remote), ``round_count``, ``answer_duration``
-  and public player progress. ``auto_start_at`` contains the authoritative replay
-  deadline while a lobby countdown is active. Private player IDs never appear
-  in broadcasts. Trivia additionally exposes its canonical ``language`` and
-  ``play_reveal_audio`` setting.
+  ``answer_type``, ``mode`` (venue/remote), ``round_count``, ``answer_duration``,
+  ``include_similar_music`` and public player progress. ``auto_start_at`` contains
+  the authoritative replay deadline while a lobby countdown is active. Private
+  player IDs never appear in broadcasts. Trivia additionally exposes its canonical
+  ``language`` and ``play_reveal_audio`` setting.
 - answering rounds expose common timing and question fields plus a strategy
   fragment. Multiple-choice exposes opaque ``suggestions``. Timeline exposes
   the revealed shared ``timeline`` and redacted ``bonus_definitions``; the
@@ -337,6 +337,7 @@ class MusicQuizPlugin(PluginProvider):
         suggestion_count: int = 4,
         answer_duration: int = 30,
         source_uris: list[str] | None = None,
+        include_similar_music: bool = False,
         name: str | None = None,
         difficulty: str = MusicQuizDifficulty.NORMAL.value,
         language: str = DEFAULT_TRIVIA_LANGUAGE,
@@ -352,6 +353,7 @@ class MusicQuizPlugin(PluginProvider):
         :param suggestion_count: Number of answer suggestions per round.
         :param answer_duration: Answering duration in seconds.
         :param source_uris: Track, playlist, album, artist or genre URIs to draw rounds from.
+        :param include_similar_music: Add bounded similar tracks to the selected source pool.
         :param name: Optional game name.
         :param difficulty: Guess-the-song difficulty ("easy", "normal" or "hard").
         :param language: Language tag for Trivia question content.
@@ -376,6 +378,7 @@ class MusicQuizPlugin(PluginProvider):
                 suggestion_count=suggestion_count,
                 answer_duration=answer_duration,
                 source_uris=source_uris or [],
+                include_similar_music=include_similar_music,
                 name=_clean_game_name(name),
                 difficulty=difficulty,
                 use_ai_distractors=bool(self.config.get_value(CONF_USE_AI_DISTRACTORS)),

--- a/music_assistant/providers/music_quiz/models.py
+++ b/music_assistant/providers/music_quiz/models.py
@@ -70,6 +70,7 @@ class MusicQuizConfig(DataClassDictMixin):
     # timeline specific; other answer types ignore these
     artist_bonus_mode: TimelineBonusMode = TimelineBonusMode.OFF
     title_bonus_mode: TimelineBonusMode = TimelineBonusMode.OFF
+    # shared across all quiz types
     include_similar_music: bool = False
 
 

--- a/music_assistant/providers/music_quiz/models.py
+++ b/music_assistant/providers/music_quiz/models.py
@@ -60,6 +60,7 @@ class MusicQuizConfig(DataClassDictMixin):
     suggestion_count: int = 4
     answer_duration: int = 30
     source_uris: list[str] = field(default_factory=list)
+    include_similar_music: bool = False
     name: str | None = None
     # difficulty is guess-the-song specific; AI distractors also apply to timeline bonuses
     difficulty: str = MusicQuizDifficulty.NORMAL.value
@@ -70,8 +71,6 @@ class MusicQuizConfig(DataClassDictMixin):
     # timeline specific; other answer types ignore these
     artist_bonus_mode: TimelineBonusMode = TimelineBonusMode.OFF
     title_bonus_mode: TimelineBonusMode = TimelineBonusMode.OFF
-    # shared across all quiz types
-    include_similar_music: bool = False
 
 
 @dataclass

--- a/music_assistant/providers/music_quiz/models.py
+++ b/music_assistant/providers/music_quiz/models.py
@@ -70,6 +70,7 @@ class MusicQuizConfig(DataClassDictMixin):
     # timeline specific; other answer types ignore these
     artist_bonus_mode: TimelineBonusMode = TimelineBonusMode.OFF
     title_bonus_mode: TimelineBonusMode = TimelineBonusMode.OFF
+    include_similar_music: bool = False
 
 
 @dataclass

--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, ClassVar, Final
+from typing import TYPE_CHECKING, ClassVar, Final, cast
 
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import InvalidDataError
@@ -18,6 +18,8 @@ from music_assistant_models.media_items import (
     Track,
 )
 
+from music_assistant.constants import DYNAMIC_PLAYLIST_SAMPLE_SIZE
+from music_assistant.controllers.music.constants import DYNAMIC_RADIO_DYNAMIC_TARGET
 from music_assistant.helpers.datetime import utc
 from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.uri import parse_uri
@@ -25,12 +27,15 @@ from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
 from music_assistant.providers.music_quiz.models import MusicQuizAnswerType
 
 if TYPE_CHECKING:
+    from music_assistant_models.media_items import MediaItemType
+
     from music_assistant.mass import MusicAssistant
     from music_assistant.providers.music_quiz.models import (
         MusicQuizConfig,
         MusicQuizGame,
         MusicQuizRound,
     )
+    from music_assistant.providers.radio_playlist import RadioPlaylistProvider
 
 LOGGER = logging.getLogger(__name__)
 
@@ -40,6 +45,7 @@ MAX_SOURCE_COUNT = 200
 GENRE_TRACK_PAGE_SIZE = 100
 MAX_GENRE_TRACK_COUNT = 500
 MAX_SUGGESTION_COUNT = 12
+PLAYBACK_REPLACEMENT_RESERVE = 4
 MIN_RELEASE_YEAR = 1000
 SUPPORTED_SOURCE_MEDIA_TYPES: Final = frozenset(
     {
@@ -178,14 +184,14 @@ class QuizType(ABC):
     @classmethod
     def serialize_game_config(
         cls,
-        game: MusicQuizGame,  # noqa: ARG003
+        game: MusicQuizGame,
     ) -> dict[str, SerializableType]:
         """
         Serialize quiz-specific game configuration.
 
         :param game: Game whose configuration should be serialized.
         """
-        return {}
+        return {"include_similar_music": game.config.include_similar_music}
 
     def reject_track(self, track_uri: str) -> None:
         """
@@ -201,6 +207,7 @@ class QuizType(ABC):
         if self._source_track_pool is not None:
             return self._source_track_pool
         pool: dict[str, Track] = {}
+        seeds: list[MediaItemType] = []
         for source_uri in self.config.source_uris:
             # skip individual unavailable sources so one bad source does not
             # abort a round that other sources can still populate
@@ -228,6 +235,7 @@ class QuizType(ABC):
                         media_item.media_type,
                     )
                     continue
+                seeds.append(media_item)
                 async for track in self._iter_source_tracks(media_item):
                     if track.uri:
                         pool[track.uri] = track
@@ -239,6 +247,8 @@ class QuizType(ABC):
                 translation_key="music_quiz_sources_unavailable",
                 translation_owner=TRANSLATION_OWNER,
             )
+        if self.config.include_similar_music:
+            await self._expand_source_track_pool(pool, seeds)
         self._source_track_pool = pool
         return pool
 
@@ -287,6 +297,63 @@ class QuizType(ABC):
         for track in tracks:
             if isinstance(track, Track):
                 yield track
+
+    async def _expand_source_track_pool(
+        self,
+        pool: dict[str, Track],
+        seeds: list[MediaItemType],
+    ) -> None:
+        """
+        Add playable similar tracks to a resolved Music Quiz source pool.
+
+        :param pool: Exact selected source tracks keyed by URI.
+        :param seeds: Resolved selected media items used to find similar music.
+        """
+        radio_provider = self.mass.get_provider("radio_playlist")
+        if radio_provider is None:
+            LOGGER.debug(
+                "Music Quiz similar-music expansion is unavailable without radio playlists"
+            )
+            return
+        target_size = min(
+            DYNAMIC_RADIO_DYNAMIC_TARGET,
+            max(
+                DYNAMIC_PLAYLIST_SAMPLE_SIZE,
+                self.config.round_count
+                + PLAYBACK_REPLACEMENT_RESERVE
+                + max(self.config.suggestion_count - 1, 0),
+            ),
+        )
+        preferred_provider_instances = sorted(
+            {
+                provider_instance
+                for seed in seeds
+                for provider_instance in (
+                    seed.provider,
+                    *(mapping.provider_instance for mapping in seed.provider_mappings),
+                )
+                if provider_instance != "library"
+            }
+        )
+        try:
+            similar_tracks = await cast("RadioPlaylistProvider", radio_provider).get_dynamic_tracks(
+                seeds,
+                include_base_tracks=False,
+                target_size=target_size,
+                preferred_provider_instances=preferred_provider_instances or None,
+            )
+        except Exception as err:
+            LOGGER.warning("Could not expand Music Quiz sources with similar music: %s", err)
+            return
+        if not similar_tracks:
+            LOGGER.debug("Radio playlists returned no similar tracks for Music Quiz")
+            return
+        initial_pool_size = len(pool)
+        for track in similar_tracks:
+            if isinstance(track, Track) and track.uri and track.available and track.is_playable:
+                pool.setdefault(track.uri, track)
+        if len(pool) == initial_pool_size:
+            LOGGER.debug("Radio playlists returned no new playable tracks for Music Quiz")
 
 
 def get_track_release_year(track: Track) -> int | None:

--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -38,7 +38,11 @@ from music_assistant.providers.music_quiz.models import (
     TimelineMultipleChoiceBonusDefinition,
     TimelineRoundState,
 )
-from music_assistant.providers.music_quiz.quiz_types.base import QuizType, get_track_release_year
+from music_assistant.providers.music_quiz.quiz_types.base import (
+    PLAYBACK_REPLACEMENT_RESERVE,
+    QuizType,
+    get_track_release_year,
+)
 from music_assistant.providers.music_quiz.suggestions import (
     SuggestionCandidate,
     answer_labels_are_too_close,
@@ -58,7 +62,6 @@ LOGGER = logging.getLogger(__name__)
 DEFAULT_BONUS_OPTION_COUNT = 4
 COMPLETED_REVEAL_AUTO_ADVANCE_SECONDS = 30.0
 TRACK_ENRICHMENT_CONCURRENCY = 10
-PLAYBACK_REPLACEMENT_RESERVE = 4
 BONUS_CANDIDATE_LIMIT = 24
 
 

--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -197,6 +197,7 @@ class TriviaQuizType(QuizType):
         :param game: Game whose configuration should be serialized.
         """
         return {
+            **super().serialize_game_config(game),
             "language": _normalize_trivia_language(game.config.language),
             "play_reveal_audio": game.config.play_reveal_audio,
         }

--- a/tests/providers/music_quiz/test_guess_the_song.py
+++ b/tests/providers/music_quiz/test_guess_the_song.py
@@ -23,6 +23,18 @@ from music_assistant.providers.music_quiz.suggestions import SuggestionCandidate
 CORRECT_LABEL = "Daft Punk - Around the World"
 
 
+def test_config_normalization_preserves_similar_music() -> None:
+    """Keep the shared source-expansion setting for Guess the Song."""
+    config = MusicQuizConfig(
+        source_uris=["prov://playlist/1"],
+        include_similar_music=True,
+    )
+
+    normalized = GuessTheSongQuizType.normalize_config(config)
+
+    assert normalized.include_similar_music is True
+
+
 def _track(item_id: str, name: str, artist: str, provider: str = "prov") -> Track:
     """Return a minimal Track with a single artist mapping."""
     return Track(

--- a/tests/providers/music_quiz/test_models.py
+++ b/tests/providers/music_quiz/test_models.py
@@ -15,6 +15,7 @@ from music_assistant.providers.music_quiz.models import (
     MultipleChoiceRoundState,
     MultipleChoiceSuggestion,
     MusicQuizAnswerType,
+    MusicQuizConfig,
     MusicQuizPlayer,
     MusicQuizRound,
     TimelineAnswerResult,
@@ -30,6 +31,16 @@ from music_assistant.providers.music_quiz.models import (
     TimelinePlacementResult,
     TimelineRoundState,
 )
+
+
+def test_config_defaults_and_round_trips_similar_music() -> None:
+    """Preserve default and explicit similar-music settings in persisted config."""
+    default_config = MusicQuizConfig.from_dict({})
+    enabled_config = MusicQuizConfig(include_similar_music=True)
+
+    assert default_config.include_similar_music is False
+    assert MusicQuizConfig().to_dict()["include_similar_music"] is False
+    assert MusicQuizConfig.from_dict(enabled_config.to_dict()) == enabled_config
 
 
 def test_round_answer_state_round_trips_with_discriminator() -> None:

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -31,10 +31,10 @@ from music_assistant.providers.music_quiz.models import (
     TimelineMultipleChoiceBonusDefinition,
     TimelineRoundState,
 )
+from music_assistant.providers.music_quiz.quiz_types.base import PLAYBACK_REPLACEMENT_RESERVE
 from music_assistant.providers.music_quiz.quiz_types.music_timeline import (
     BONUS_CANDIDATE_LIMIT,
     DEFAULT_BONUS_OPTION_COUNT,
-    PLAYBACK_REPLACEMENT_RESERVE,
     TRACK_ENRICHMENT_CONCURRENCY,
     MusicTimelineQuizType,
 )
@@ -173,6 +173,7 @@ def test_config_normalization_and_validation_are_music_timeline_specific() -> No
         round_count=2,
         suggestion_count=9,
         source_uris=["prov://playlist/1"],
+        include_similar_music=True,
         difficulty="not-used",
         use_ai_distractors=True,
         artist_bonus_mode=TimelineBonusMode.FREE_TEXT,
@@ -185,6 +186,7 @@ def test_config_normalization_and_validation_are_music_timeline_specific() -> No
     assert normalized.suggestion_count == DEFAULT_BONUS_OPTION_COUNT
     assert normalized.difficulty == MusicQuizDifficulty.NORMAL.value
     assert normalized.use_ai_distractors is True
+    assert normalized.include_similar_music is True
     with pytest.raises(InvalidDataError, match="bonus mode"):
         MusicTimelineQuizType.validate_config(
             MusicQuizConfig(

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Coroutine
+from collections.abc import AsyncGenerator, Coroutine
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,6 +12,7 @@ import pytest
 from music_assistant_models.auth import Scope, User, UserRole
 from music_assistant_models.enums import ConfigEntryType, MediaType, PlaybackState, QueueOption
 from music_assistant_models.errors import AudioError, InvalidDataError, MediaNotFoundError
+from music_assistant_models.media_items import Playlist, ProviderMapping, Track
 
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     current_user,
@@ -55,6 +56,7 @@ from music_assistant.providers.music_quiz.models import (
     TimelineMultipleChoiceBonusDefinition,
     TimelineRoundState,
 )
+from music_assistant.providers.music_quiz.quiz_types.guess_the_song import GuessTheSongQuizType
 from music_assistant.providers.music_quiz.quiz_types.trivia import TriviaQuizType
 
 INSTANCE_ID = "music_quiz--test"
@@ -1140,6 +1142,7 @@ async def test_disabled_trivia_serialization_and_listen_in_remain_non_audio() ->
             suggestion_count=4,
             answer_duration=20,
             source_uris=["library://playlist/1"],
+            include_similar_music=True,
             name="Music Trivia",
             difficulty="hard",
             language="pt_BR",
@@ -1206,6 +1209,12 @@ async def test_disabled_trivia_serialization_and_listen_in_remain_non_audio() ->
             game_info["play_reveal_audio"],
             personal_state["play_reveal_audio"],
         } == {False}
+        assert {
+            public_state["include_similar_music"],
+            host_state["include_similar_music"],
+            game_info["include_similar_music"],
+            personal_state["include_similar_music"],
+        } == {True}
         assert personal_state["current_round"] == public_state["current_round"]
         assert alice not in str(personal_state)
         with patch(
@@ -1953,6 +1962,7 @@ async def test_disabled_trivia_reset_delete_and_recreate_keep_lifecycle_non_audi
             quiz_type="trivia",
             round_count=1,
             source_uris=["library://playlist/1"],
+            include_similar_music=True,
             language="zh_hans_cn",
             play_reveal_audio=False,
         )
@@ -1965,6 +1975,7 @@ async def test_disabled_trivia_reset_delete_and_recreate_keep_lifecycle_non_audi
         assert reset_state["answer_type"] == "multiple_choice"
         assert reset_state["language"] == "zh-Hans-CN"
         assert reset_state["play_reveal_audio"] is False
+        assert reset_state["include_similar_music"] is True
         assert game.config.language == "zh-Hans-CN"
         assert game.rounds == []
         assert initialize.await_count == 2
@@ -2006,6 +2017,7 @@ async def test_music_timeline_create_uses_flat_config_and_derived_answer_type() 
             round_count=2,
             suggestion_count=9,
             source_uris=["library://playlist/1"],
+            include_similar_music=True,
             difficulty="not-used",
             language="nl",
             play_reveal_audio=False,
@@ -2023,12 +2035,14 @@ async def test_music_timeline_create_uses_flat_config_and_derived_answer_type() 
     assert game.config.difficulty == "normal"
     assert game.config.language == "en"
     assert game.config.play_reveal_audio is True
+    assert game.config.include_similar_music is True
     assert quiz_type.uses_audio is True
     assert quiz_type.plays_track_before_answering is True
     assert quiz_type.plays_track_on_reveal is False
     assert game.config.use_ai_distractors is True
     assert created["artist_bonus_mode"] == "free_text"
     assert created["title_bonus_mode"] == "multiple_choice"
+    assert created["include_similar_music"] is True
     assert "suggestion_count" not in created
     assert "language" not in created
     assert "play_reveal_audio" not in created
@@ -2817,6 +2831,7 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
         "round_count",
         "suggestion_count",
         "answer_duration",
+        "include_similar_music",
         "auto_start_at",
         "players",
         "current_round",
@@ -2824,7 +2839,7 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
     assert state["phase"] == "answering"
     assert state["quiz_type"] == "guess_the_song"
     assert state["answer_type"] == "multiple_choice"
-    assert state["mode"] == "venue"
+    assert (state["mode"], state["include_similar_music"]) == ("venue", False)
     public_player_keys = {
         "name",
         "score",
@@ -2939,6 +2954,7 @@ async def test_game_info_exposes_game_identity_and_playback_mode() -> None:
         "mode": "remote",
         "player_count": 0,
         "round_count": 5,
+        "include_similar_music": False,
         "auto_start_at": None,
     }
 
@@ -2975,6 +2991,7 @@ async def test_create_and_get_expose_persisted_quiz_type() -> None:
     created = await plugin.create_game(
         quiz_type="guess_the_song",
         source_uris=["library://playlist/1"],
+        include_similar_music=True,
         language="nl",
     )
     game = plugin._game
@@ -2982,13 +2999,16 @@ async def test_create_and_get_expose_persisted_quiz_type() -> None:
     assert game.quiz_type == "guess_the_song"
     assert game.answer_type == "multiple_choice"
     assert game.config.language == "en"
+    assert game.config.include_similar_music is True
     assert created["quiz_type"] == game.quiz_type
     assert created["answer_type"] == game.answer_type
+    assert created["include_similar_music"] is True
     assert "language" not in created
     host_state = await plugin.get_game()
     assert host_state is not None
     assert host_state["quiz_type"] == game.quiz_type
     assert host_state["answer_type"] == game.answer_type
+    assert host_state["include_similar_music"] is True
     assert "language" not in host_state
 
 
@@ -3939,6 +3959,122 @@ async def test_create_game_replaces_finished_game() -> None:
     assert result["phase"] == "lobby"
     assert plugin._game is not game
     cast("MagicMock", plugin.mass.cancel_task).assert_called_once_with(plugin._presence_timer_id)
+
+
+@pytest.mark.asyncio
+async def test_similar_music_pool_cache_follows_game_strategy_lifecycle() -> None:  # noqa: PLR0915
+    """Expand once per strategy while reset and replacement initialize fresh pools."""
+    plugin = _create_plugin()
+    source = Playlist(
+        item_id="source",
+        provider="provider",
+        name="Source",
+        provider_mappings=set(),
+    )
+    exact = Track(
+        item_id="exact",
+        provider="provider",
+        name="Exact",
+        provider_mappings={
+            ProviderMapping(
+                item_id="exact",
+                provider_domain="provider",
+                provider_instance="provider",
+            )
+        },
+    )
+    expanded = Track(
+        item_id="expanded",
+        provider="provider",
+        name="Expanded",
+        provider_mappings={
+            ProviderMapping(
+                item_id="expanded",
+                provider_domain="provider",
+                provider_instance="provider",
+            )
+        },
+    )
+    cast("AsyncMock", plugin.mass.music.get_item).return_value = source
+    assert source.uri is not None
+
+    async def _playlist_tracks(**_kwargs: object) -> AsyncGenerator[Track]:
+        yield exact
+
+    cast("MagicMock", plugin.mass.music.playlists.tracks).side_effect = _playlist_tracks
+    expansion_contexts: list[object | None] = []
+
+    async def _dynamic_tracks(
+        seeds: list[object],
+        *,
+        include_base_tracks: bool,
+        target_size: int,
+        preferred_provider_instances: list[str] | None,
+    ) -> list[Track]:
+        assert seeds == [source]
+        assert include_base_tracks is False
+        assert target_size == 25
+        assert preferred_provider_instances == ["provider"]
+        expansion_contexts.append(get_auth_current_user())
+        return [expanded]
+
+    radio_provider = MagicMock()
+    radio_provider.get_dynamic_tracks = AsyncMock(side_effect=_dynamic_tracks)
+    cast("MagicMock", plugin.mass.get_provider).return_value = radio_provider
+
+    async def _prepare_round(
+        strategy: GuessTheSongQuizType,
+        round_index: int,
+        _previous_rounds: list[MusicQuizRound],
+    ) -> MusicQuizRound:
+        await strategy._get_source_track_pool()
+        return _make_round(round_index)
+
+    requesting_user = cast("User", _guest_user())
+    requesting_impersonation = cast("User", _guest_user())
+    current_user_token = current_user.set(requesting_user)
+    impersonated_user_token = impersonated_user.set(requesting_impersonation)
+    try:
+        with patch.object(GuessTheSongQuizType, "prepare_round", new=_prepare_round):
+            first_state = await plugin.create_game(
+                source_uris=[source.uri],
+                include_similar_music=True,
+            )
+            assert plugin._next_round_task is not None
+            await plugin._next_round_task
+            first_strategy = plugin._quiz_type
+            assert first_strategy is not None
+            await first_strategy._get_source_track_pool()
+            assert radio_provider.get_dynamic_tracks.await_count == 1
+
+            reset_state = await plugin.reset()
+            assert plugin._next_round_task is not None
+            await plugin._next_round_task
+            reset_strategy = plugin._quiz_type
+            assert reset_strategy is not first_strategy
+            assert radio_provider.get_dynamic_tracks.await_count == 2
+
+            replacement_state = await plugin.create_game(
+                source_uris=[source.uri],
+                include_similar_music=True,
+            )
+            assert plugin._next_round_task is not None
+            await plugin._next_round_task
+            assert plugin._quiz_type is not reset_strategy
+            assert radio_provider.get_dynamic_tracks.await_count == 3
+            assert current_user.get() is requesting_user
+            assert impersonated_user.get() is requesting_impersonation
+    finally:
+        impersonated_user.reset(impersonated_user_token)
+        current_user.reset(current_user_token)
+
+    assert {
+        first_state["include_similar_music"],
+        reset_state["include_similar_music"],
+        replacement_state["include_similar_music"],
+    } == {True}
+    assert expansion_contexts == [None, None, None]
+    assert cast("MagicMock", plugin.mass.player_queues).mock_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_sources.py
+++ b/tests/providers/music_quiz/test_sources.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncGenerator, Mapping
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from music_assistant_models.enums import MediaType
@@ -22,18 +23,32 @@ from music_assistant_models.media_items import (
 from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.providers.music_quiz import MusicQuizPlugin
-from music_assistant.providers.music_quiz.models import MusicQuizConfig
+from music_assistant.providers.music_quiz.models import (
+    MultipleChoiceRoundState,
+    MusicQuizConfig,
+    TimelineRoundState,
+)
 from music_assistant.providers.music_quiz.quiz_types.base import (
     GENRE_TRACK_PAGE_SIZE,
     MAX_GENRE_TRACK_COUNT,
 )
 from music_assistant.providers.music_quiz.quiz_types.guess_the_song import GuessTheSongQuizType
 from music_assistant.providers.music_quiz.quiz_types.music_timeline import MusicTimelineQuizType
+from music_assistant.providers.music_quiz.quiz_types.trivia import (
+    TriviaGeneration,
+    TriviaQuizType,
+)
 
 SourceItem = Album | Artist | Genre | ItemMapping | Playlist | Track
 
 
-def _track(item_id: str, *, year: int | None = None) -> Track:
+def _track(
+    item_id: str,
+    *,
+    year: int | None = None,
+    available: bool = True,
+    is_playable: bool = True,
+) -> Track:
     """Return a minimal playable track."""
     provider = "provider"
     track = Track(
@@ -41,6 +56,7 @@ def _track(item_id: str, *, year: int | None = None) -> Track:
         provider=provider,
         name=f"Track {item_id}",
         duration=180,
+        is_playable=is_playable,
         artists=UniqueList(
             [
                 ItemMapping(
@@ -56,6 +72,7 @@ def _track(item_id: str, *, year: int | None = None) -> Track:
                 item_id=item_id,
                 provider_domain=provider,
                 provider_instance=provider,
+                available=available,
             )
         },
     )
@@ -140,17 +157,27 @@ def _mass(source_items: Mapping[str, object]) -> MagicMock:
     mass.music.tracks.get = AsyncMock()
     mass.metadata.get_image_url_for_item = AsyncMock(return_value=None)
     mass.get_providers_supporting_feature = MagicMock(return_value=[])
+    mass.get_provider = MagicMock(return_value=None)
+    mass.player_queues = MagicMock()
     return mass
 
 
-def _guess_quiz(mass: MagicMock, source_uris: list[str]) -> GuessTheSongQuizType:
+def _guess_quiz(
+    mass: MagicMock,
+    source_uris: list[str],
+    *,
+    round_count: int = 1,
+    suggestion_count: int = 2,
+    include_similar_music: bool = False,
+) -> GuessTheSongQuizType:
     """Return a Guess the Song quiz for source-resolution tests."""
     return GuessTheSongQuizType(
         mass,
         MusicQuizConfig(
-            round_count=1,
-            suggestion_count=2,
+            round_count=round_count,
+            suggestion_count=suggestion_count,
             source_uris=source_uris,
+            include_similar_music=include_similar_music,
         ),
     )
 
@@ -301,6 +328,260 @@ async def test_mixed_sources_deduplicate_and_skip_failure() -> None:
     )._get_source_track_pool()
 
     assert list(pool) == [direct_uri, extra_uri]
+
+
+@pytest.mark.asyncio
+async def test_default_source_pool_does_not_request_similar_music() -> None:
+    """Keep the complete exact playlist pool unchanged when expansion is disabled."""
+    source = _playlist()
+    tracks = [_track("one"), _track("two")]
+    source_uri = _uri(source)
+    mass = _mass({source_uri: source})
+    mass.music.playlists.tracks = MagicMock(return_value=_yield_tracks(tracks))
+    radio_provider = MagicMock()
+    radio_provider.get_dynamic_tracks = AsyncMock(return_value=[_track("similar")])
+    mass.get_provider.return_value = radio_provider
+
+    pool = await _guess_quiz(mass, [source_uri])._get_source_track_pool()
+
+    assert list(pool.values()) == tracks
+    mass.get_provider.assert_not_called()
+    radio_provider.get_dynamic_tracks.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("round_count", "suggestion_count", "expected_target"),
+    [(1, 2, 25), (100, 12, 50)],
+)
+@pytest.mark.asyncio
+async def test_similar_music_uses_resolved_seeds_and_bounded_target(
+    round_count: int,
+    suggestion_count: int,
+    expected_target: int,
+) -> None:
+    """Call radio once with selected media seeds and no playback-queue state."""
+    source = _playlist()
+    exact = _track("exact")
+    expanded = _track("expanded")
+    source_uri = _uri(source)
+    mass = _mass({source_uri: source})
+    mass.music.playlists.tracks = MagicMock(return_value=_yield_tracks([exact]))
+    radio_provider = MagicMock()
+    radio_provider.get_dynamic_tracks = AsyncMock(return_value=[expanded])
+    mass.get_provider.return_value = radio_provider
+    quiz = _guess_quiz(
+        mass,
+        [source_uri],
+        round_count=round_count,
+        suggestion_count=suggestion_count,
+        include_similar_music=True,
+    )
+
+    pool = await quiz._get_source_track_pool()
+    cached_pool = await quiz._get_source_track_pool()
+
+    assert cached_pool is pool
+    assert list(pool.values()) == [exact, expanded]
+    radio_provider.get_dynamic_tracks.assert_awaited_once_with(
+        [source],
+        include_base_tracks=False,
+        target_size=expected_target,
+        preferred_provider_instances=["provider"],
+    )
+    assert mass.player_queues.mock_calls == []
+
+
+@pytest.mark.asyncio
+async def test_similar_music_preserves_exact_tracks_and_filters_expansion() -> None:
+    """Retain exact tracks while deduplicating and filtering radio candidates."""
+    source = _playlist()
+    exact = _track("exact")
+    duplicate = _track("exact")
+    expanded = _track("expanded")
+    unavailable = _track("unavailable", available=False)
+    unplayable = _track("unplayable", is_playable=False)
+    source_uri = _uri(source)
+    mass = _mass({source_uri: source})
+    mass.music.playlists.tracks = MagicMock(return_value=_yield_tracks([exact]))
+    radio_provider = MagicMock()
+    radio_provider.get_dynamic_tracks = AsyncMock(
+        return_value=[duplicate, expanded, unavailable, unplayable]
+    )
+    mass.get_provider.return_value = radio_provider
+
+    pool = await _guess_quiz(
+        mass,
+        [source_uri],
+        include_similar_music=True,
+    )._get_source_track_pool()
+
+    assert list(pool.values()) == [exact, expanded]
+    assert pool[_uri(exact)] is exact
+
+
+@pytest.mark.parametrize("radio_mode", ["missing", "empty", "filtered", "error"])
+@pytest.mark.asyncio
+async def test_similar_music_failure_falls_back_to_exact_pool(
+    radio_mode: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Treat unavailable, empty, and failed radio expansion as optional."""
+    caplog.set_level(logging.DEBUG)
+    source = _playlist()
+    exact = _track("exact")
+    source_uri = _uri(source)
+    mass = _mass({source_uri: source})
+    mass.music.playlists.tracks = MagicMock(return_value=_yield_tracks([exact]))
+    if radio_mode != "missing":
+        radio_provider = MagicMock()
+        radio_provider.get_dynamic_tracks = AsyncMock(
+            return_value=(
+                [_track("unavailable", available=False)] if radio_mode == "filtered" else []
+            ),
+            side_effect=RuntimeError("radio failed") if radio_mode == "error" else None,
+        )
+        mass.get_provider.return_value = radio_provider
+
+    pool = await _guess_quiz(
+        mass,
+        [source_uri],
+        include_similar_music=True,
+    )._get_source_track_pool()
+
+    assert pool == {_uri(exact): exact}
+    assert any(
+        "similar" in record.message.lower() or "radio" in record.message.lower()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_guess_the_song_can_select_an_expanded_track() -> None:
+    """Apply normal distractor validation when an expanded track is selected."""
+    source = _playlist()
+    exact = _track("exact")
+    expanded = _track("expanded")
+    distractor = _track("distractor")
+    source_uri = _uri(source)
+    mass = _mass({source_uri: source})
+    mass.music.playlists.tracks = MagicMock(return_value=_yield_tracks([exact]))
+    mass.music.search.return_value = SimpleNamespace(tracks=[distractor])
+    radio_provider = MagicMock()
+    radio_provider.get_dynamic_tracks = AsyncMock(return_value=[expanded])
+    mass.get_provider.return_value = radio_provider
+    quiz = _guess_quiz(
+        mass,
+        [source_uri],
+        include_similar_music=True,
+    )
+
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types.guess_the_song.secrets.choice",
+        return_value=expanded,
+    ):
+        game_round = await quiz.prepare_round(0, [])
+
+    assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+    assert game_round.track_uri == expanded.uri
+    assert len(game_round.answer_state.suggestions) == 2
+    assert {suggestion.uri for suggestion in game_round.answer_state.suggestions} == {
+        expanded.uri,
+        distractor.uri,
+    }
+
+
+@pytest.mark.asyncio
+async def test_music_timeline_applies_date_rules_to_expanded_tracks() -> None:
+    """Select dated expansion while excluding expanded tracks without a usable year."""
+    source = _playlist()
+    exact = _track("exact", year=1990)
+    expanded = _track("expanded", year=2000)
+    undated = _track("undated")
+    source_uri = _uri(source)
+    mass = _mass({source_uri: source})
+    mass.music.playlists.tracks = MagicMock(return_value=_yield_tracks([exact]))
+    mass.music.tracks.get.return_value = undated
+    radio_provider = MagicMock()
+    radio_provider.get_dynamic_tracks = AsyncMock(return_value=[expanded, undated])
+    mass.get_provider.return_value = radio_provider
+    quiz = MusicTimelineQuizType(
+        mass,
+        MusicQuizConfig(
+            round_count=1,
+            source_uris=[source_uri],
+            include_similar_music=True,
+        ),
+    )
+
+    await quiz.initialize()
+    eligible_tracks = await quiz._get_eligible_tracks()
+    game_round = await quiz.prepare_round(0, [])
+
+    assert isinstance(game_round.answer_state, TimelineRoundState)
+    assert {track.uri for track in eligible_tracks} == {exact.uri, expanded.uri}
+    assert quiz._source_track_pool is not None
+    assert undated.uri in quiz._source_track_pool
+    assert {
+        game_round.answer_state.placement_snapshot[0].track_uri,
+        game_round.answer_state.candidate.entry.track_uri,
+    } == {exact.uri, expanded.uri}
+
+
+@pytest.mark.asyncio
+async def test_trivia_applies_grounding_rules_to_expanded_tracks() -> None:
+    """Select grounded expansion while excluding candidates without factual context."""
+    source = _playlist()
+    exact = _track("exact")
+    expanded = _track("expanded")
+    ungrounded = Track(
+        item_id="ungrounded",
+        provider="provider",
+        name="Ungrounded",
+        provider_mappings={
+            ProviderMapping(
+                item_id="ungrounded",
+                provider_domain="provider",
+                provider_instance="provider",
+            )
+        },
+    )
+    source_uri = _uri(source)
+    mass = _mass({source_uri: source})
+    mass.music.playlists.tracks = MagicMock(return_value=_yield_tracks([exact]))
+    radio_provider = MagicMock()
+    radio_provider.get_dynamic_tracks = AsyncMock(return_value=[expanded, ungrounded])
+    mass.get_provider.return_value = radio_provider
+    quiz = TriviaQuizType(
+        mass,
+        MusicQuizConfig(
+            round_count=1,
+            suggestion_count=2,
+            source_uris=[source_uri],
+            include_similar_music=True,
+        ),
+    )
+
+    eligible_tracks = await quiz._get_eligible_tracks()
+    generation = TriviaGeneration(
+        question="Which artist recorded this track?",
+        wrong_answers=("Different Artist",),
+    )
+    with (
+        patch.object(quiz, "_generate_question", new=AsyncMock(return_value=generation)),
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.trivia.SYSTEM_RANDOM.choice",
+            return_value=eligible_tracks[_uri(expanded)],
+        ),
+    ):
+        game_round = await quiz.prepare_round(0, [])
+
+    assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+    assert set(eligible_tracks) == {exact.uri, expanded.uri}
+    assert game_round.track_uri == expanded.uri
+    correct = next(
+        suggestion for suggestion in game_round.answer_state.suggestions if suggestion.is_correct
+    )
+    assert correct.uri == expanded.uri
 
 
 @pytest.mark.parametrize(

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -216,6 +216,7 @@ def test_registry_identity_and_config_are_trivia_specific() -> None:
         round_count=2,
         suggestion_count=6,
         source_uris=["prov://playlist/1"],
+        include_similar_music=True,
         difficulty=MusicQuizDifficulty.HARD.value,
         use_ai_distractors=True,
         artist_bonus_mode=TimelineBonusMode.FREE_TEXT,
@@ -228,6 +229,7 @@ def test_registry_identity_and_config_are_trivia_specific() -> None:
     assert normalized.suggestion_count == 6
     assert normalized.difficulty == MusicQuizDifficulty.HARD.value
     assert normalized.use_ai_distractors is False
+    assert normalized.include_similar_music is True
     assert normalized.artist_bonus_mode is TimelineBonusMode.OFF
     assert normalized.title_bonus_mode is TimelineBonusMode.OFF
     quiz_type = TriviaQuizType(_mass(), normalized)


### PR DESCRIPTION
# What does this implement/fix?

Adds an optional similar-music source expansion to all Music Quiz game types while keeping exact selected sources as the default.

- Expands each game pool once through the existing radio recommendations.
- Keeps all exact tracks and falls back cleanly when recommendations are unavailable.
- Applies the existing playback, timeline metadata, and trivia grounding rules to added tracks.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (Not applicable.)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (Not applicable.)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (Not applicable.)
