### PR TITLE
Unify and simplify deezer flow track fetching

### DIFF
--- a/music_assistant/providers/deezer/browse.py
+++ b/music_assistant/providers/deezer/browse.py
@@ -47,6 +47,8 @@ from .constants import (
     BROWSE_TOP_PLAYLISTS,
     BROWSE_YOUR_TOP_ALBUMS,
     BROWSE_YOUR_TOP_ARTISTS,
+    DEFAULT_FLOW_CONFIG_ID,
+    FLOW_BATCH_COUNT,
     FLOW_CONFIG_PREFIX,
     FLOW_PLAYLIST_ID,
     PERSONAL_SONGS_PLAYLIST_ID,
@@ -639,17 +641,11 @@ class DeezerBrowseManager:
         recs: GetRecommendationsMe | None,
     ) -> None:
         """Add Made For You section to recommendations."""
-        made_for_me_items: list[Playlist] = []
-        flow_me = await self.provider.gql_client.get_flow()
-        if flow_me and flow_me.flow:
-            cover = (
-                flow_me.flow.cover.urls[0]
-                if flow_me.flow.cover and flow_me.flow.cover.urls
-                else None
+        made_for_me_items: list[Playlist] = [
+            create_virtual_playlist(
+                self.provider, FLOW_PLAYLIST_ID, "Flow", image_url=await self._get_flow_cover()
             )
-            made_for_me_items.append(
-                create_virtual_playlist(self.provider, FLOW_PLAYLIST_ID, "Flow", image_url=cover)
-            )
+        ]
         made_for_me_items.extend(await self._get_smart_tracklist_playlists())
         if made_for_me_items:
             result.append(
@@ -874,7 +870,7 @@ class DeezerBrowseManager:
         if page > 0:
             return []
         if prov_playlist_id == FLOW_PLAYLIST_ID:
-            return await self._get_flow_tracks()
+            return await self._get_flow_config_tracks(DEFAULT_FLOW_CONFIG_ID)
         if prov_playlist_id == RECOMMENDED_TRACKS_PLAYLIST_ID:
             return await self._get_recommended_tracks()
         if prov_playlist_id == TOP_CHARTS_PLAYLIST_ID:
@@ -922,25 +918,6 @@ class DeezerBrowseManager:
                 )
         return playlists
 
-    async def _get_flow_tracks(self) -> list[Track]:
-        """Get a fresh batch of personalized Flow tracks."""
-        result = await self.provider.gql_client.get_flow_batch()
-        if result is None or result.flow is None:
-            return []
-        seen: set[str] = set()
-        tracks: list[Track] = []
-        for batch in (
-            result.flow.batch_1,
-            result.flow.batch_2,
-            result.flow.batch_3,
-            result.flow.batch_4,
-        ):
-            for ft in batch:
-                if ft.track is not None and ft.track.id not in seen:
-                    seen.add(ft.track.id)
-                    tracks.append(parse_track(self.provider, ft.track))
-        return filter_tracks(tracks)
-
     @use_cache(3600)
     async def _get_recommended_tracks(self) -> list[Track]:
         """Get cached recommended tracks (hot tracks)."""
@@ -972,15 +949,16 @@ class DeezerBrowseManager:
 
     async def _get_flow_config_tracks(self, config_id: str) -> list[Track]:
         """
-        Get a fresh batch of tracks for a mood/genre Flow config.
+        Get fresh batches of tracks for a Flow config, merged deduplicated.
 
-        :param config_id: The Flow config identifier (e.g. "happy", "chill", "genre-rock").
+        :param config_id: The Flow config identifier
+            (e.g. "default", "happy", "chill", "genre-rock").
         """
         seen: set[str] = set()
         tracks: list[Track] = []
-        for _ in range(4):
+        for _ in range(FLOW_BATCH_COUNT):
             result = await self.provider.gql_client.get_flow_config_tracks(flow_config_id=config_id)
-            if result is None:
+            if result is None or not result.tracks:
                 break
             for ft in result.tracks:
                 if ft.track is not None and ft.track.id not in seen:
@@ -1111,8 +1089,8 @@ class DeezerBrowseManager:
 
     @use_cache(3600)
     async def _get_flow_cover(self) -> str | None:
-        """Get the cover URL for the user's Flow."""
-        result = await self.provider.gql_client.get_flow()
-        if result and result.flow and result.flow.cover and result.flow.cover.urls:
-            return str(result.flow.cover.urls[0])
-        return None
+        """Get the cover URL for the user's default Flow."""
+        result = await self.provider.gql_client.get_flow_config_tracks(
+            flow_config_id=DEFAULT_FLOW_CONFIG_ID
+        )
+        return get_flow_config_image(result) if result else None

--- a/music_assistant/providers/deezer/constants.py
+++ b/music_assistant/providers/deezer/constants.py
@@ -4,6 +4,7 @@
 
 FLOW_PLAYLIST_ID = "flow"
 FLOW_CONFIG_PREFIX = "flow_config_"
+DEFAULT_FLOW_CONFIG_ID = "default"
 SMART_TRACKLIST_PREFIX = "smart_tracklist_"
 RECOMMENDED_TRACKS_PLAYLIST_ID = "recommended_tracks"
 TOP_CHARTS_PLAYLIST_ID = "top_charts"
@@ -22,6 +23,7 @@ PERSONAL_ALBUM_PREFIX = "personal_album_"
 
 FAVORITES_PAGE_SIZE = 50
 AUDIOBOOK_CHAPTERS_PAGE_SIZE = 200
+FLOW_BATCH_COUNT = 2
 
 # -- Browse folder names (used as path segments for routing) --
 


### PR DESCRIPTION
# What does this implement/fix?

It seems like Deezer reduced the complexity limits of their graphql api. The fetching of tracks for the personalized flow is directly affected by this, since it is calling 4 batches within a single api call. The mood and genre flows do not have the problem, since they are already calling the track batches sequentially.

Therefore the track fetching logic was unified towards the sequential approach. And the amount of fetched tracks was slightly reduced, since music assistant is now able to fetch additional tracks for dynamic playlists on-demand.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/5829

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
