### PR TITLE
Fix Guess the Song answer choices

### DIFF
--- a/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
+++ b/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
@@ -124,8 +124,9 @@ class GuessTheSongQuizType(QuizType):
             if previous_round.track_uri
         }
         track = await self._get_next_source_track(used_track_uris)
-        correct = _track_to_candidate(track)
+        correct = await self._get_correct_candidate(track)
         distractors = await self._gather_distractors(track, correct)
+        correct, distractors = _align_round_candidates(correct, distractors)
         try:
             suggestions = build_suggestions(
                 correct,
@@ -159,6 +160,28 @@ class GuessTheSongQuizType(QuizType):
                 translation_owner=TRANSLATION_OWNER,
             )
         return secrets.choice(available)
+
+    async def _get_correct_candidate(self, track: Track) -> SuggestionCandidate:
+        """Return the correct candidate with artist metadata when it can be resolved."""
+        candidate = _track_to_candidate(track)
+        if _candidate_artist_name(candidate):
+            return candidate
+        try:
+            full_track = await self.mass.music.tracks.get_provider_item(
+                track.item_id,
+                track.provider,
+            )
+        except Exception as err:
+            LOGGER.debug("Could not enrich Guess the Song track %s: %s", track.uri, err)
+            return candidate
+        artist_names = self._track_artist_names(full_track)
+        if not artist_names:
+            return candidate
+        return replace(
+            candidate,
+            label=build_answer_label(artist_names[0], track.name),
+            artist_names=artist_names,
+        )
 
     async def _gather_distractors(
         self, track: Track, correct: SuggestionCandidate
@@ -275,7 +298,12 @@ class GuessTheSongQuizType(QuizType):
         wrong_count = self.config.suggestion_count - 1
         expected_kinds = self._ai_distractor_kinds(wrong_count)
         real_count = wrong_count - len(expected_kinds)
-        if not expected_kinds or not track.artist_str or not similar or len(catalog) < real_count:
+        if (
+            not expected_kinds
+            or not _candidate_artist_name(correct)
+            or not similar
+            or len(catalog) < real_count
+        ):
             return None
         grounded = catalog[:AI_CONTEXT_CANDIDATE_LIMIT]
         candidate_map = {
@@ -302,7 +330,6 @@ class GuessTheSongQuizType(QuizType):
                 expected_kinds,
             )
             return self._compose_ai_distractors(
-                track,
                 correct,
                 candidate_map,
                 set(similar),
@@ -325,7 +352,7 @@ class GuessTheSongQuizType(QuizType):
         grounded_data = json_dumps(
             {
                 "source_track": {
-                    "artist": bounded_ai_context(track.artist_str),
+                    "artist": bounded_ai_context(_candidate_artist_name(correct)),
                     "title": bounded_ai_context(track.name),
                     "album": bounded_ai_context(track.album.name if track.album else None),
                     "correct_display_label": bounded_ai_context(correct.label),
@@ -366,7 +393,6 @@ class GuessTheSongQuizType(QuizType):
 
     def _compose_ai_distractors(
         self,
-        track: Track,
         correct: SuggestionCandidate,
         candidate_map: dict[str, SuggestionCandidate],
         similar: set[SuggestionCandidate],
@@ -381,13 +407,13 @@ class GuessTheSongQuizType(QuizType):
         ranked = [first_similar, *(candidate for candidate in ranked if candidate != first_similar)]
         synthetic = [
             self._synthetic_track_candidate(
-                track,
+                correct,
                 distractor.kind,
                 distractor.label,
                 {
                     normalize_answer_label(artist_name)
                     for artist_name in (
-                        *self._track_artist_names(track),
+                        *correct.artist_names,
                         *(
                             artist_name
                             for candidate in candidate_map.values()
@@ -424,7 +450,7 @@ class GuessTheSongQuizType(QuizType):
 
     @staticmethod
     def _synthetic_track_candidate(
-        track: Track,
+        correct: SuggestionCandidate,
         kind: str,
         label: str,
         known_artist_names: set[str],
@@ -440,15 +466,14 @@ class GuessTheSongQuizType(QuizType):
         ):
             raise ValueError("synthetic track labels must contain an artist and title")
         if kind == AI_KIND_SAME_ARTIST_TITLE:
-            if artist != track.artist_str:
+            if artist != _candidate_artist_name(correct):
                 raise ValueError("same-artist distractor changed the source artist")
         elif kind == AI_KIND_CONTEXT_TRACK:
             if normalize_answer_label(artist) in known_artist_names:
                 raise ValueError("context distractor reused a known artist")
         else:
             raise ValueError("unknown synthetic track kind")
-        candidate = SuggestionCandidate(label=label, title=title)
-        correct = _track_to_candidate(track)
+        candidate = SuggestionCandidate(label=label, title=title, artist_names=(artist,))
         if suggestion_candidates_are_too_close(candidate, correct):
             raise ValueError("synthetic track label is too close to the correct answer")
         return candidate
@@ -458,22 +483,61 @@ class GuessTheSongQuizType(QuizType):
         """Return display names and aliases associated with a track's artists."""
         return tuple(
             dict.fromkeys(
-                artist_name
+                artist_name.strip()
                 for artist_name in (
                     track.artist_str,
                     *(artist.name for artist in track.artists),
                     *(artist.sort_name for artist in track.artists),
                 )
-                if artist_name
+                if artist_name and artist_name.strip()
             )
         )
 
 
+def _align_round_candidates(
+    correct: SuggestionCandidate,
+    distractors: list[SuggestionCandidate],
+) -> tuple[SuggestionCandidate, list[SuggestionCandidate]]:
+    """Return candidates using one display shape for the entire round."""
+    assert correct.title is not None
+    correct_artist = _candidate_artist_name(correct)
+    aligned_correct = replace(
+        correct,
+        label=build_answer_label(correct_artist, correct.title),
+    )
+    aligned_distractors: list[SuggestionCandidate] = []
+    for candidate in distractors:
+        if candidate.title is None:
+            continue
+        candidate_artist = _candidate_artist_name(candidate)
+        if correct_artist and not candidate_artist:
+            continue
+        aligned_distractors.append(
+            replace(
+                candidate,
+                label=build_answer_label(
+                    candidate_artist if correct_artist else None,
+                    candidate.title,
+                ),
+            )
+        )
+    return (
+        aligned_correct,
+        filter_suggestion_candidates(aligned_correct, aligned_distractors),
+    )
+
+
+def _candidate_artist_name(candidate: SuggestionCandidate) -> str | None:
+    """Return the candidate's display artist when available."""
+    return next((name.strip() for name in candidate.artist_names if name.strip()), None)
+
+
 def _track_to_candidate(track: Track) -> SuggestionCandidate:
     """Convert a track to an answer suggestion candidate."""
+    artist_names = GuessTheSongQuizType._track_artist_names(track)
     return SuggestionCandidate(
-        label=build_answer_label(track.artist_str or None, track.name),
+        label=build_answer_label(artist_names[0] if artist_names else None, track.name),
         uri=track.uri,
         title=track.name,
-        artist_names=GuessTheSongQuizType._track_artist_names(track),
+        artist_names=artist_names,
     )

--- a/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
+++ b/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import logging
 import secrets
+from collections.abc import Iterable, Iterator
 from dataclasses import replace
+from itertools import chain
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import MediaType
@@ -44,6 +46,7 @@ if TYPE_CHECKING:
     from music_assistant.providers.music_quiz.models import MusicQuizConfig
 
 LOGGER = logging.getLogger(__name__)
+SYSTEM_RANDOM = secrets.SystemRandom()
 
 AI_CONTEXT_CANDIDATE_LIMIT = 24
 AI_KIND_SAME_ARTIST_TITLE = "same_artist_title"
@@ -126,7 +129,11 @@ class GuessTheSongQuizType(QuizType):
         track = await self._get_next_source_track(used_track_uris)
         correct = await self._get_correct_candidate(track)
         distractors = await self._gather_distractors(track, correct)
-        correct, distractors = _align_round_candidates(correct, distractors)
+        correct, distractors = _align_round_candidates(
+            correct,
+            distractors,
+            self.config.suggestion_count - 1,
+        )
         try:
             suggestions = build_suggestions(
                 correct,
@@ -185,13 +192,14 @@ class GuessTheSongQuizType(QuizType):
 
     async def _gather_distractors(
         self, track: Track, correct: SuggestionCandidate
-    ) -> list[SuggestionCandidate]:
+    ) -> Iterable[SuggestionCandidate]:
         """
         Collect distractor candidates ordered by preference for the game settings.
 
         :param track: The source track that is the correct answer this round.
         :param correct: The correct answer candidate.
         """
+        source_pool = self._iter_source_pool_distractors(track)
         if self.config.difficulty == MusicQuizDifficulty.HARD:
             similar = filter_suggestion_candidates(
                 correct,
@@ -202,17 +210,24 @@ class GuessTheSongQuizType(QuizType):
                 [*similar, *(await self._get_search_distractors(correct))],
             )
             if self.config.use_ai_distractors:
+                wrong_count = self.config.suggestion_count - 1
+                real_count = wrong_count - len(self._ai_distractor_kinds(wrong_count))
+                catalog = filter_suggestion_candidates(
+                    correct,
+                    chain(catalog, source_pool),
+                    limit=max(len(catalog), real_count),
+                )
                 mixed = await self._get_ai_distractors(track, correct, similar, catalog)
                 if mixed is not None:
-                    return filter_suggestion_candidates(correct, [*mixed, *catalog])
-            return catalog
-        candidates: list[SuggestionCandidate] = []
+                    return chain(
+                        filter_suggestion_candidates(correct, [*mixed, *catalog]),
+                        source_pool,
+                    )
+            return chain(catalog, source_pool)
+        search = await self._get_search_distractors(correct)
         if self.config.difficulty == MusicQuizDifficulty.EASY:
-            candidates.extend(await self._get_easy_distractors(track))
-        # the label search doubles as the normal-difficulty source and as the
-        # universal fallback, so a round never fails when preferred sources are sparse
-        candidates.extend(await self._get_search_distractors(correct))
-        return candidates
+            return chain(source_pool, search)
+        return chain(search, source_pool)
 
     async def _get_search_distractors(
         self, correct: SuggestionCandidate
@@ -279,13 +294,15 @@ class GuessTheSongQuizType(QuizType):
                 candidates.append(_track_to_candidate(top_tracks[0]))
         return candidates
 
-    async def _get_easy_distractors(self, track: Track) -> list[SuggestionCandidate]:
-        """Return obviously-different distractors sampled from the configured source pool."""
-        pool = await self._get_source_track_pool()
-        others = [item for uri, item in pool.items() if uri != track.uri]
-        sample_size = min(len(others), max(self.config.suggestion_count * 4, 12))
-        sampled = secrets.SystemRandom().sample(others, sample_size)
-        return [_track_to_candidate(item) for item in sampled]
+    def _iter_source_pool_distractors(
+        self,
+        track: Track,
+    ) -> Iterator[SuggestionCandidate]:
+        """Return randomized lazy candidates from the cached configured source pool."""
+        assert self._source_track_pool is not None
+        others = [item for uri, item in self._source_track_pool.items() if uri != track.uri]
+        SYSTEM_RANDOM.shuffle(others)
+        return (_track_to_candidate(item) for item in others)
 
     async def _get_ai_distractors(
         self,
@@ -496,7 +513,8 @@ class GuessTheSongQuizType(QuizType):
 
 def _align_round_candidates(
     correct: SuggestionCandidate,
-    distractors: list[SuggestionCandidate],
+    distractors: Iterable[SuggestionCandidate],
+    needed_count: int,
 ) -> tuple[SuggestionCandidate, list[SuggestionCandidate]]:
     """Return candidates using one display shape for the entire round."""
     assert correct.title is not None
@@ -505,25 +523,29 @@ def _align_round_candidates(
         correct,
         label=build_answer_label(correct_artist, correct.title),
     )
-    aligned_distractors: list[SuggestionCandidate] = []
-    for candidate in distractors:
-        if candidate.title is None:
-            continue
-        candidate_artist = _candidate_artist_name(candidate)
-        if correct_artist and not candidate_artist:
-            continue
-        aligned_distractors.append(
-            replace(
+
+    def _project_distractors() -> Iterator[SuggestionCandidate]:
+        for candidate in distractors:
+            if candidate.title is None:
+                continue
+            candidate_artist = _candidate_artist_name(candidate)
+            if correct_artist and not candidate_artist:
+                continue
+            yield replace(
                 candidate,
                 label=build_answer_label(
                     candidate_artist if correct_artist else None,
                     candidate.title,
                 ),
             )
-        )
+
     return (
         aligned_correct,
-        filter_suggestion_candidates(aligned_correct, aligned_distractors),
+        filter_suggestion_candidates(
+            aligned_correct,
+            _project_distractors(),
+            limit=needed_count,
+        ),
     )
 
 

--- a/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
+++ b/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
@@ -302,7 +302,8 @@ class GuessTheSongQuizType(QuizType):
         assert self._source_track_pool is not None
         others = [item for uri, item in self._source_track_pool.items() if uri != track.uri]
         SYSTEM_RANDOM.shuffle(others)
-        return (_track_to_candidate(item) for item in others)
+        for item in others:
+            yield _track_to_candidate(item)
 
     async def _get_ai_distractors(
         self,

--- a/tests/providers/music_quiz/test_guess_the_song.py
+++ b/tests/providers/music_quiz/test_guess_the_song.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import ItemMapping, ProviderMapping, Track
 from music_assistant_models.unique_list import UniqueList
 
@@ -17,7 +18,10 @@ from music_assistant.providers.music_quiz.models import (
     MultipleChoiceRoundState,
     MusicQuizConfig,
 )
-from music_assistant.providers.music_quiz.quiz_types.guess_the_song import GuessTheSongQuizType
+from music_assistant.providers.music_quiz.quiz_types.guess_the_song import (
+    GuessTheSongQuizType,
+    _track_to_candidate,
+)
 from music_assistant.providers.music_quiz.suggestions import SuggestionCandidate
 
 CORRECT_LABEL = "Daft Punk - Around the World"
@@ -35,7 +39,7 @@ def test_config_normalization_preserves_similar_music() -> None:
     assert normalized.include_similar_music is True
 
 
-def _track(item_id: str, name: str, artist: str, provider: str = "prov") -> Track:
+def _track(item_id: str, name: str, artist: str | None, provider: str = "prov") -> Track:
     """Return a minimal Track with a single artist mapping."""
     return Track(
         item_id=item_id,
@@ -50,6 +54,8 @@ def _track(item_id: str, name: str, artist: str, provider: str = "prov") -> Trac
                     name=artist,
                 )
             ]
+            if artist
+            else []
         ),
         provider_mappings={
             ProviderMapping(item_id=item_id, provider_domain=provider, provider_instance=provider)
@@ -74,7 +80,7 @@ def _pool(tracks: list[Track]) -> dict[str, Track]:
 def _correct() -> tuple[Track, SuggestionCandidate]:
     """Return the correct source track and its answer candidate."""
     track = _track("c1", "Around the World", "Daft Punk")
-    return track, SuggestionCandidate(CORRECT_LABEL, track.uri, title="Around the World")
+    return track, _track_to_candidate(track)
 
 
 def _quiz_type(
@@ -85,9 +91,11 @@ def _quiz_type(
     """Return a quiz type with a mock MusicAssistant and empty music lookups."""
     mass = MagicMock()
     mass.music.search = AsyncMock(return_value=SimpleNamespace(tracks=[]))
+    mass.music.tracks.get_provider_item = AsyncMock()
     mass.music.tracks.similar_tracks = AsyncMock(return_value=[])
     mass.music.artists.similar_artists = AsyncMock(return_value=[])
     mass.music.artists.top_tracks = AsyncMock(return_value=[])
+    mass.metadata.get_image_url_for_item = AsyncMock(return_value=None)
     mass.get_providers_supporting_feature = MagicMock(return_value=[])
     config = MusicQuizConfig(
         suggestion_count=suggestion_count,
@@ -314,6 +322,10 @@ async def test_hard_ai_distractors_mix_real_and_synthetic_context() -> None:
         ("Daft Punk - Neon Horizon", None),
         ("Lunar Circuit - Chrome Reverie", None),
     ]
+    assert [item.artist_names for item in result[1:3]] == [
+        ("Daft Punk",),
+        ("Lunar Circuit",),
+    ]
     provider.ai_query.assert_awaited_once()
     prompt = provider.ai_query.await_args.args[0]
     assert CORRECT_LABEL in prompt
@@ -362,11 +374,7 @@ async def test_hard_ai_context_preserves_non_english_grounding() -> None:
     """Pass non-English source/catalog data through the bounded untrusted context."""
     quiz_type, mass = _quiz_type("hard", use_ai=True)
     source = _track("source", "Zoutelande", "BLØF")
-    correct = SuggestionCandidate(
-        "BLØF - Zoutelande",
-        source.uri,
-        title="Zoutelande",
-    )
+    correct = _track_to_candidate(source)
     mass.music.tracks.similar_tracks.return_value = [
         _track("st1", "Het Is Een Nacht", "Guus Meeuwis"),
         _track("st2", "Rood", "Marco Borsato"),
@@ -455,11 +463,7 @@ async def test_context_track_cannot_reuse_an_individual_source_contributor() -> 
     quiz_type, mass = _quiz_type("hard", use_ai=True)
     correct_track, _ = _correct()
     correct_track.artists.append(_artist("pharrell", "Pharrell Williams"))
-    correct = SuggestionCandidate(
-        f"{correct_track.artist_str} - {correct_track.name}",
-        correct_track.uri,
-        title=correct_track.name,
-    )
+    correct = _track_to_candidate(correct_track)
     real_tracks = [
         _track("st1", "Digital Love", "Daft Punk"),
         _track("st2", "D.A.N.C.E.", "Justice"),
@@ -606,3 +610,229 @@ async def test_prepare_round_builds_suggestions_from_similar_tracks() -> None:
     assert len(suggestions) == 4
     assert sum(item.is_correct for item in suggestions) == 1
     assert [item.label for item in suggestions if item.is_correct] == [CORRECT_LABEL]
+    assert all(" - " in item.label for item in suggestions)
+    mass.music.tracks.get_provider_item.assert_not_awaited()
+
+
+@pytest.mark.parametrize("difficulty", ["easy", "normal"])
+@pytest.mark.asyncio
+async def test_artist_round_excludes_title_only_distractors(difficulty: str) -> None:
+    """Keep every option artist-title when the correct track has an artist."""
+    quiz_type, mass = _quiz_type(difficulty)
+    correct_track, _ = _correct()
+    missing_artist = _track("missing", "Hey There Delilah", None)
+    pool_distractor = _track("pool", "Digital Love", "Daft Punk")
+    quiz_type._source_track_pool = _pool([correct_track, missing_artist, pool_distractor])
+    mass.music.search.return_value = SimpleNamespace(
+        tracks=[
+            missing_artist,
+            _track("s1", "Genesis", "Justice"),
+            _track("s2", "Sexy Boy", "Air"),
+            _track("s3", "Lisztomania", "Phoenix"),
+        ]
+    )
+
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types.guess_the_song.secrets.choice",
+        return_value=correct_track,
+    ):
+        game_round = await quiz_type.prepare_round(0, [])
+
+    assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+    suggestions = game_round.answer_state.suggestions
+    assert len(suggestions) == 4
+    assert all(" - " in suggestion.label for suggestion in suggestions)
+    assert missing_artist.uri not in {suggestion.uri for suggestion in suggestions}
+    mass.music.tracks.get_provider_item.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_artist_round_projects_every_option_to_title_only() -> None:
+    """Prevent the screenshot-like title-only correct answer from standing out."""
+    quiz_type, mass = _quiz_type()
+    correct_track = _track("source", "Hey There Delilah", None)
+    quiz_type._source_track_pool = _pool([correct_track])
+    mass.music.tracks.get_provider_item.return_value = correct_track
+    mass.music.search.return_value = SimpleNamespace(
+        tracks=[
+            _track("s1", "Use Somebody", "Kings of Leon"),
+            _track("s2", "Apologize", "Timbaland"),
+            _track("s3", "Chasing Cars", "Snow Patrol"),
+        ]
+    )
+
+    with patch(
+        "music_assistant.providers.music_quiz.suggestions.secrets.token_hex",
+        side_effect=["id-a", "id-b", "id-c", "id-d"],
+    ):
+        game_round = await quiz_type.prepare_round(0, [])
+
+    assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+    suggestions = game_round.answer_state.suggestions
+    assert {suggestion.label for suggestion in suggestions} == {
+        "Hey There Delilah",
+        "Use Somebody",
+        "Apologize",
+        "Chasing Cars",
+    }
+    assert all(" - " not in suggestion.label for suggestion in suggestions)
+    assert {suggestion.suggestion_id for suggestion in suggestions} == {
+        "id-a",
+        "id-b",
+        "id-c",
+        "id-d",
+    }
+    correct = next(suggestion for suggestion in suggestions if suggestion.is_correct)
+    assert correct.uri == correct_track.uri
+    assert correct.label == game_round.answer_label == "Hey There Delilah"
+    mass.music.tracks.get_provider_item.assert_awaited_once_with(
+        correct_track.item_id,
+        correct_track.provider,
+    )
+
+
+@pytest.mark.asyncio
+async def test_selected_track_recovers_artist_with_one_full_item_lookup() -> None:
+    """Use recovered artist metadata without changing the selected source identity."""
+    quiz_type, mass = _quiz_type()
+    correct_track = _track("source", "Hey There Delilah", None)
+    full_track = _track("source", "Hey There Delilah", "Plain White T's")
+    quiz_type._source_track_pool = _pool([correct_track])
+    mass.music.tracks.get_provider_item.return_value = full_track
+    mass.music.search.return_value = SimpleNamespace(
+        tracks=[
+            _track("s1", "Use Somebody", "Kings of Leon"),
+            _track("s2", "Apologize", "Timbaland"),
+            _track("s3", "Chasing Cars", "Snow Patrol"),
+        ]
+    )
+
+    game_round = await quiz_type.prepare_round(0, [])
+
+    assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+    assert game_round.track_uri == correct_track.uri
+    assert game_round.answer_label == "Plain White T's - Hey There Delilah"
+    assert all(" - " in suggestion.label for suggestion in game_round.answer_state.suggestions)
+    correct = next(
+        suggestion for suggestion in game_round.answer_state.suggestions if suggestion.is_correct
+    )
+    assert correct.uri == correct_track.uri
+    mass.music.tracks.get_provider_item.assert_awaited_once_with(
+        correct_track.item_id,
+        correct_track.provider,
+    )
+
+
+@pytest.mark.asyncio
+async def test_selected_track_artist_lookup_error_falls_back_to_title_only() -> None:
+    """Keep a playable source when its optional artist lookup fails."""
+    quiz_type, mass = _quiz_type(suggestion_count=2)
+    correct_track = _track("source", "Hey There Delilah", None)
+    quiz_type._source_track_pool = _pool([correct_track])
+    mass.music.tracks.get_provider_item.side_effect = RuntimeError("unavailable")
+    mass.music.search.return_value = SimpleNamespace(
+        tracks=[_track("s1", "Use Somebody", "Kings of Leon")]
+    )
+
+    game_round = await quiz_type.prepare_round(0, [])
+
+    assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+    assert {suggestion.label for suggestion in game_round.answer_state.suggestions} == {
+        "Hey There Delilah",
+        "Use Somebody",
+    }
+    mass.music.tracks.get_provider_item.assert_awaited_once_with(
+        correct_track.item_id,
+        correct_track.provider,
+    )
+
+
+@pytest.mark.asyncio
+async def test_title_only_projection_refilters_duplicate_and_close_titles() -> None:
+    """Filter titles that collide only after artist labels are removed."""
+    quiz_type, mass = _quiz_type()
+    correct_track = _track("source", "Hey There Delilah", None)
+    quiz_type._source_track_pool = _pool([correct_track])
+    mass.music.tracks.get_provider_item.return_value = correct_track
+    mass.music.search.return_value = SimpleNamespace(
+        tracks=[
+            _track("s1", "Electric Feel", "Artist One"),
+            _track("s2", "Electric Feel", "Artist Two"),
+            _track("s3", "Electric Feel (Radio Edit)", "Artist Three"),
+            _track("s4", "Genesis", "Justice"),
+            _track("s5", "Lisztomania", "Phoenix"),
+        ]
+    )
+
+    game_round = await quiz_type.prepare_round(0, [])
+
+    assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+    assert {suggestion.label for suggestion in game_round.answer_state.suggestions} == {
+        "Hey There Delilah",
+        "Electric Feel",
+        "Genesis",
+        "Lisztomania",
+    }
+
+
+@pytest.mark.asyncio
+async def test_title_only_projection_reports_insufficient_candidates() -> None:
+    """Return the localized distractor error when projected titles all overlap."""
+    quiz_type, mass = _quiz_type(suggestion_count=3)
+    correct_track = _track("source", "Hey There Delilah", None)
+    quiz_type._source_track_pool = _pool([correct_track])
+    mass.music.tracks.get_provider_item.return_value = correct_track
+    mass.music.search.return_value = SimpleNamespace(
+        tracks=[
+            _track("s1", "Electric Feel", "Artist One"),
+            _track("s2", "Electric Feel", "Artist Two"),
+            _track("s3", "Electric Feel (Radio Edit)", "Artist Three"),
+        ]
+    )
+
+    with pytest.raises(InvalidDataError) as err:
+        await quiz_type.prepare_round(0, [])
+
+    assert err.value.translation_key == "music_quiz_not_enough_distractors"
+
+
+@pytest.mark.asyncio
+async def test_prepare_round_keeps_hard_ai_artist_title_shape() -> None:
+    """Retain artist-title formatting for real and synthetic hard-mode options."""
+    quiz_type, mass = _quiz_type("hard", use_ai=True)
+    correct_track = _track("c1", "Around the World", None)
+    quiz_type._source_track_pool = _pool([correct_track])
+    mass.music.tracks.get_provider_item.return_value = _track(
+        "c1",
+        "Around the World",
+        "Daft Punk",
+    )
+    mass.music.tracks.similar_tracks.return_value = [
+        _track("st1", "Digital Love", "Daft Punk"),
+        _track("st2", "D.A.N.C.E.", "Justice"),
+        _track("st3", "Sexy Boy", "Air"),
+    ]
+    provider = _ai_provider(
+        _ai_response(
+            ["candidate_2", "candidate_0", "candidate_1"],
+            [
+                ("same_artist_title", "Daft Punk - Neon Horizon"),
+                ("context_track", "Lunar Circuit - Chrome Reverie"),
+            ],
+        )
+    )
+    mass.get_providers_supporting_feature.return_value = [provider]
+
+    game_round = await quiz_type.prepare_round(0, [])
+
+    assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+    suggestions = game_round.answer_state.suggestions
+    assert len(suggestions) == 4
+    assert all(" - " in suggestion.label for suggestion in suggestions)
+    assert game_round.answer_label == CORRECT_LABEL
+    assert sum(suggestion.is_correct for suggestion in suggestions) == 1
+    provider.ai_query.assert_awaited_once()
+    mass.music.tracks.get_provider_item.assert_awaited_once_with(
+        correct_track.item_id,
+        correct_track.provider,
+    )

--- a/tests/providers/music_quiz/test_guess_the_song.py
+++ b/tests/providers/music_quiz/test_guess_the_song.py
@@ -299,7 +299,7 @@ async def test_easy_difficulty_uses_source_pool() -> None:
     with (
         patch(
             "music_assistant.providers.music_quiz.quiz_types.guess_the_song.SYSTEM_RANDOM.shuffle"
-        ),
+        ) as shuffle_pool,
         patch(
             "music_assistant.providers.music_quiz.quiz_types.guess_the_song._track_to_candidate",
             wraps=_track_to_candidate,
@@ -314,6 +314,7 @@ async def test_easy_difficulty_uses_source_pool() -> None:
         "Someone - Fallback",
     ]
     assert correct_track.uri not in {item.uri for item in result}
+    shuffle_pool.assert_called_once()
     assert convert_candidate.call_count == 4
     mass.music.search.assert_awaited_once()
     mass.music.tracks.similar_tracks.assert_not_awaited()
@@ -628,7 +629,10 @@ async def test_prepare_round_builds_suggestions_from_similar_tracks() -> None:
     ]
     mass.metadata.get_image_url_for_item = AsyncMock(return_value="http://img/1")
 
-    game_round = await quiz_type.prepare_round(0, [])
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types.guess_the_song.SYSTEM_RANDOM.shuffle"
+    ) as shuffle_pool:
+        game_round = await quiz_type.prepare_round(0, [])
 
     assert game_round.track_uri == correct_track.uri
     assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
@@ -637,6 +641,7 @@ async def test_prepare_round_builds_suggestions_from_similar_tracks() -> None:
     assert sum(item.is_correct for item in suggestions) == 1
     assert [item.label for item in suggestions if item.is_correct] == [CORRECT_LABEL]
     assert all(" - " in item.label for item in suggestions)
+    shuffle_pool.assert_not_called()
     mass.music.tracks.get_provider_item.assert_not_awaited()
 
 

--- a/tests/providers/music_quiz/test_guess_the_song.py
+++ b/tests/providers/music_quiz/test_guess_the_song.py
@@ -90,6 +90,7 @@ def _quiz_type(
 ) -> tuple[GuessTheSongQuizType, MagicMock]:
     """Return a quiz type with a mock MusicAssistant and empty music lookups."""
     mass = MagicMock()
+    mass.music.get_item = AsyncMock()
     mass.music.search = AsyncMock(return_value=SimpleNamespace(tracks=[]))
     mass.music.tracks.get_provider_item = AsyncMock()
     mass.music.tracks.similar_tracks = AsyncMock(return_value=[])
@@ -103,7 +104,9 @@ def _quiz_type(
         difficulty=difficulty,
         use_ai_distractors=use_ai,
     )
-    return GuessTheSongQuizType(mass, config), mass
+    quiz_type = GuessTheSongQuizType(mass, config)
+    quiz_type._source_track_pool = {}
+    return quiz_type, mass
 
 
 def _ai_provider(response: object = None, error: Exception | None = None) -> MagicMock:
@@ -143,17 +146,22 @@ def test_reject_track_removes_it_from_the_source_pool() -> None:
 
 
 @pytest.mark.asyncio
-async def test_normal_difficulty_uses_search_only() -> None:
-    """Normal difficulty draws distractors from a catalog search and nothing else."""
+async def test_normal_difficulty_prefers_search_before_source_pool() -> None:
+    """Normal difficulty keeps catalog results ahead of the source-pool fallback."""
     quiz_type, mass = _quiz_type("normal", use_ai=True)
     mass.music.search.return_value = SimpleNamespace(
         tracks=[_track("s1", "One More Time", "Daft Punk"), _track("s2", "Genesis", "Justice")]
     )
     correct_track, correct = _correct()
+    quiz_type._source_track_pool = _pool([correct_track, _track("pool", "Lisztomania", "Phoenix")])
 
-    result = await quiz_type._gather_distractors(correct_track, correct)
+    result = list(await quiz_type._gather_distractors(correct_track, correct))
 
-    assert [item.label for item in result] == ["Daft Punk - One More Time", "Justice - Genesis"]
+    assert [item.label for item in result] == [
+        "Daft Punk - One More Time",
+        "Justice - Genesis",
+        "Phoenix - Lisztomania",
+    ]
     mass.music.tracks.similar_tracks.assert_not_awaited()
     mass.get_providers_supporting_feature.assert_not_called()
 
@@ -169,8 +177,10 @@ async def test_hard_difficulty_prefers_similar_tracks() -> None:
     ]
     mass.music.search.return_value = SimpleNamespace(tracks=[_track("s1", "Fallback", "Someone")])
     correct_track, correct = _correct()
+    pool_fallback = _track("pool", "Lisztomania", "Phoenix")
+    quiz_type._source_track_pool = _pool([correct_track, pool_fallback])
 
-    result = await quiz_type._gather_distractors(correct_track, correct)
+    result = list(await quiz_type._gather_distractors(correct_track, correct))
 
     labels = [item.label for item in result]
     assert labels[:3] == [
@@ -178,7 +188,7 @@ async def test_hard_difficulty_prefers_similar_tracks() -> None:
         "Justice - D.A.N.C.E.",
         "Air - Sexy Boy",
     ]
-    assert "Someone - Fallback" in labels
+    assert labels[-2:] == ["Someone - Fallback", "Phoenix - Lisztomania"]
     mass.music.tracks.similar_tracks.assert_awaited_once()
 
 
@@ -200,7 +210,7 @@ async def test_hard_difficulty_enriches_with_similar_artists_when_tracks_sparse(
     mass.music.artists.top_tracks = AsyncMock(side_effect=_top_tracks)
     correct_track, correct = _correct()
 
-    result = await quiz_type._gather_distractors(correct_track, correct)
+    result = list(await quiz_type._gather_distractors(correct_track, correct))
 
     labels = {item.label for item in result}
     assert "Justice - Genesis" in labels
@@ -240,7 +250,7 @@ async def test_hard_filters_unusable_similar_tracks_before_artist_enrichment() -
     )
     mass.get_providers_supporting_feature.return_value = [provider]
 
-    result = await quiz_type._gather_distractors(correct_track, correct)
+    result = list(await quiz_type._gather_distractors(correct_track, correct))
 
     assert [item.label for item in result[:3]] == [
         "Justice - Genesis",
@@ -266,30 +276,46 @@ async def test_hard_difficulty_falls_back_to_search_on_error() -> None:
     )
     correct_track, correct = _correct()
 
-    result = await quiz_type._gather_distractors(correct_track, correct)
+    result = list(await quiz_type._gather_distractors(correct_track, correct))
 
     assert "Daft Punk - One More Time" in {item.label for item in result}
 
 
 @pytest.mark.asyncio
 async def test_easy_difficulty_uses_source_pool() -> None:
-    """Easy difficulty offers other tracks from the configured source pool."""
+    """Easy difficulty traverses the source pool once before search fallback."""
     quiz_type, mass = _quiz_type("easy", use_ai=True)
     correct_track, correct = _correct()
-    quiz_type._source_track_pool = _pool(
-        [
-            correct_track,
-            _track("p2", "Genesis", "Justice"),
-            _track("p3", "Sexy Boy", "Air"),
-            _track("p4", "1901", "Phoenix"),
-        ]
+    pool_tracks = [
+        _track("p2", "Genesis", "Justice"),
+        _track("p3", "Sexy Boy", "Air"),
+        _track("p4", "1901", "Phoenix"),
+    ]
+    quiz_type._source_track_pool = _pool([correct_track, *pool_tracks])
+    mass.music.search.return_value = SimpleNamespace(
+        tracks=[_track("search", "Fallback", "Someone")]
     )
 
-    result = await quiz_type._gather_distractors(correct_track, correct)
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.guess_the_song.SYSTEM_RANDOM.shuffle"
+        ),
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.guess_the_song._track_to_candidate",
+            wraps=_track_to_candidate,
+        ) as convert_candidate,
+    ):
+        result = list(await quiz_type._gather_distractors(correct_track, correct))
 
-    labels = {item.label for item in result}
-    assert {"Justice - Genesis", "Air - Sexy Boy", "Phoenix - 1901"} <= labels
+    assert [item.label for item in result] == [
+        "Justice - Genesis",
+        "Air - Sexy Boy",
+        "Phoenix - 1901",
+        "Someone - Fallback",
+    ]
     assert correct_track.uri not in {item.uri for item in result}
+    assert convert_candidate.call_count == 4
+    mass.music.search.assert_awaited_once()
     mass.music.tracks.similar_tracks.assert_not_awaited()
     mass.get_providers_supporting_feature.assert_not_called()
 
@@ -315,7 +341,7 @@ async def test_hard_ai_distractors_mix_real_and_synthetic_context() -> None:
     mass.get_providers_supporting_feature.return_value = [provider]
     correct_track, correct = _correct()
 
-    result = await quiz_type._gather_distractors(correct_track, correct)
+    result = list(await quiz_type._gather_distractors(correct_track, correct))
 
     assert [(item.label, item.uri) for item in result[:3]] == [
         ("Air - Sexy Boy", mass.music.tracks.similar_tracks.return_value[2].uri),
@@ -357,7 +383,7 @@ async def test_hard_ai_composition_scales_with_real_catalog_dominance() -> None:
     mass.get_providers_supporting_feature.return_value = [provider]
     correct_track, correct = _correct()
 
-    result = await quiz_type._gather_distractors(correct_track, correct)
+    result = list(await quiz_type._gather_distractors(correct_track, correct))
 
     selected = result[:5]
     assert sum(item.uri is not None for item in selected) == 3
@@ -391,7 +417,7 @@ async def test_hard_ai_context_preserves_non_english_grounding() -> None:
     )
     mass.get_providers_supporting_feature.return_value = [provider]
 
-    result = await quiz_type._gather_distractors(source, correct)
+    result = list(await quiz_type._gather_distractors(source, correct))
 
     assert {item.label for item in result[:3]} == {
         "Guus Meeuwis - Het Is Een Nacht",
@@ -446,7 +472,7 @@ async def test_invalid_hard_ai_semantics_fall_back_to_real_catalog(
     mass.get_providers_supporting_feature.return_value = [provider]
     correct_track, correct = _correct()
 
-    result = await quiz_type._gather_distractors(correct_track, correct)
+    result = list(await quiz_type._gather_distractors(correct_track, correct))
 
     assert [item.label for item in result[:3]] == [
         "Daft Punk - Digital Love",
@@ -484,7 +510,7 @@ async def test_context_track_cannot_reuse_an_individual_source_contributor() -> 
     )
     mass.get_providers_supporting_feature.return_value = [provider]
 
-    result = await quiz_type._gather_distractors(correct_track, correct)
+    result = list(await quiz_type._gather_distractors(correct_track, correct))
 
     assert [item.label for item in result[:3]] == [
         "Daft Punk - Digital Love",
@@ -520,7 +546,7 @@ async def test_invalid_primary_ai_response_does_not_try_another_provider() -> No
     mass.get_providers_supporting_feature.return_value = [later, invalid]
     correct_track, correct = _correct()
 
-    result = await quiz_type._gather_distractors(correct_track, correct)
+    result = list(await quiz_type._gather_distractors(correct_track, correct))
 
     assert [item.label for item in result[:3]] == [
         "Daft Punk - Digital Love",
@@ -555,7 +581,7 @@ async def test_hard_ai_timeout_falls_back_to_real_catalog() -> None:
         "music_assistant.providers.music_quiz.quiz_types.guess_the_song.AI_QUERY_TIMEOUT_SECONDS",
         0.001,
     ):
-        result = await quiz_type._gather_distractors(correct_track, correct)
+        result = list(await quiz_type._gather_distractors(correct_track, correct))
 
     assert [item.label for item in result[:3]] == [
         "Daft Punk - Digital Love",
@@ -579,7 +605,7 @@ async def test_hard_ai_provider_failure_falls_back_to_real_catalog() -> None:
     mass.get_providers_supporting_feature.return_value = [provider]
     correct_track, correct = _correct()
 
-    result = await quiz_type._gather_distractors(correct_track, correct)
+    result = list(await quiz_type._gather_distractors(correct_track, correct))
 
     assert [item.label for item in result[:3]] == [
         "Daft Punk - Digital Love",
@@ -748,23 +774,110 @@ async def test_selected_track_artist_lookup_error_falls_back_to_title_only() -> 
 
 
 @pytest.mark.asyncio
+async def test_normal_pool_fallback_scans_large_cached_pool_across_rounds() -> None:
+    """Fill collapsed search results lazily from one cached large source pool."""
+    quiz_type, mass = _quiz_type()
+    first_title = "Zij W\u0069l Mij"
+    first_correct = _track("first", first_title, "FLEMMING")
+    second_correct = _track("second", "Teardrop", "Massive Attack")
+    alternatives = [
+        _track("a1", "Genesis", "Justice"),
+        _track("a2", "Lisztomania", "Phoenix"),
+        _track("a3", "Chasing Cars", "Snow Patrol"),
+        _track("a4", "Midnight City", "M83"),
+    ]
+    source_pool = _pool(
+        [
+            first_correct,
+            second_correct,
+            *alternatives,
+            *[
+                _track(f"bulk-{index}", f"Bulk Song {index}", f"Bulk Artist {index}")
+                for index in range(1000)
+            ],
+        ]
+    )
+    quiz_type._source_track_pool = source_pool
+    mass.music.search.side_effect = [
+        SimpleNamespace(
+            tracks=[
+                first_correct,
+                _track("first-copy", first_title, "FLEMMING"),
+                _track("first-remix", f"{first_title} (Remix)", "FLEMMING"),
+            ]
+        ),
+        SimpleNamespace(
+            tracks=[
+                second_correct,
+                _track("second-copy", "Teardrop", "Massive Attack"),
+                _track("second-remix", "Teardrop (Remastered)", "Massive Attack"),
+            ]
+        ),
+    ]
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.guess_the_song.secrets.choice",
+            side_effect=[first_correct, second_correct],
+        ),
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.guess_the_song.SYSTEM_RANDOM.shuffle"
+        ),
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.guess_the_song._track_to_candidate",
+            wraps=_track_to_candidate,
+        ) as convert_candidate,
+    ):
+        first_round = await quiz_type.prepare_round(0, [])
+        second_round = await quiz_type.prepare_round(1, [first_round])
+
+    for game_round in (first_round, second_round):
+        assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+        assert len(game_round.answer_state.suggestions) == 4
+        assert all(" - " in item.label for item in game_round.answer_state.suggestions)
+    assert first_round.answer_label == f"FLEMMING - {first_title}"
+    assert second_round.answer_label == "Massive Attack - Teardrop"
+    assert convert_candidate.call_count == 14
+    assert mass.music.search.await_count == 2
+    assert all(item.kwargs["limit"] == 32 for item in mass.music.search.await_args_list)
+    mass.music.get_item.assert_not_awaited()
+    mass.music.tracks.get_provider_item.assert_not_awaited()
+    mass.music.tracks.similar_tracks.assert_not_awaited()
+    assert quiz_type._source_track_pool is source_pool
+
+
+@pytest.mark.asyncio
 async def test_title_only_projection_refilters_duplicate_and_close_titles() -> None:
-    """Filter titles that collide only after artist labels are removed."""
+    """Continue through pool collisions until enough projected titles survive."""
     quiz_type, mass = _quiz_type()
     correct_track = _track("source", "Hey There Delilah", None)
-    quiz_type._source_track_pool = _pool([correct_track])
-    mass.music.tracks.get_provider_item.return_value = correct_track
-    mass.music.search.return_value = SimpleNamespace(
-        tracks=[
+    quiz_type._source_track_pool = _pool(
+        [
+            correct_track,
             _track("s1", "Electric Feel", "Artist One"),
             _track("s2", "Electric Feel", "Artist Two"),
             _track("s3", "Electric Feel (Radio Edit)", "Artist Three"),
             _track("s4", "Genesis", "Justice"),
             _track("s5", "Lisztomania", "Phoenix"),
+            _track("unused", "Teardrop", "Massive Attack"),
         ]
     )
+    mass.music.tracks.get_provider_item.return_value = correct_track
 
-    game_round = await quiz_type.prepare_round(0, [])
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.guess_the_song.secrets.choice",
+            return_value=correct_track,
+        ),
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.guess_the_song.SYSTEM_RANDOM.shuffle"
+        ),
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.guess_the_song._track_to_candidate",
+            wraps=_track_to_candidate,
+        ) as convert_candidate,
+    ):
+        game_round = await quiz_type.prepare_round(0, [])
 
     assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
     assert {suggestion.label for suggestion in game_round.answer_state.suggestions} == {
@@ -773,6 +886,8 @@ async def test_title_only_projection_refilters_duplicate_and_close_titles() -> N
         "Genesis",
         "Lisztomania",
     }
+    assert convert_candidate.call_count == 6
+    mass.music.search.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -780,20 +895,89 @@ async def test_title_only_projection_reports_insufficient_candidates() -> None:
     """Return the localized distractor error when projected titles all overlap."""
     quiz_type, mass = _quiz_type(suggestion_count=3)
     correct_track = _track("source", "Hey There Delilah", None)
-    quiz_type._source_track_pool = _pool([correct_track])
-    mass.music.tracks.get_provider_item.return_value = correct_track
-    mass.music.search.return_value = SimpleNamespace(
-        tracks=[
+    quiz_type._source_track_pool = _pool(
+        [
+            correct_track,
             _track("s1", "Electric Feel", "Artist One"),
             _track("s2", "Electric Feel", "Artist Two"),
             _track("s3", "Electric Feel (Radio Edit)", "Artist Three"),
         ]
     )
+    mass.music.tracks.get_provider_item.return_value = correct_track
 
-    with pytest.raises(InvalidDataError) as err:
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.guess_the_song.secrets.choice",
+            return_value=correct_track,
+        ),
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.guess_the_song.SYSTEM_RANDOM.shuffle"
+        ),
+        pytest.raises(InvalidDataError) as err,
+    ):
         await quiz_type.prepare_round(0, [])
 
     assert err.value.translation_key == "music_quiz_not_enough_distractors"
+    mass.music.search.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_hard_ai_uses_pool_to_fill_real_candidate_slots() -> None:
+    """Keep the hard AI composition when preferred real candidates are sparse."""
+    quiz_type, mass = _quiz_type("hard", use_ai=True, suggestion_count=6)
+    correct_track, _ = _correct()
+    pool_tracks = [
+        _track("p1", "Genesis", "Justice"),
+        _track("p2", "Lisztomania", "Phoenix"),
+        _track("p3", "Chasing Cars", "Snow Patrol"),
+    ]
+    quiz_type._source_track_pool = _pool([correct_track, *pool_tracks])
+    similar = _track("similar", "Digital Love", "Daft Punk")
+    mass.music.tracks.similar_tracks.return_value = [similar]
+    mass.music.search.return_value = SimpleNamespace(
+        tracks=[
+            correct_track,
+            _track("copy", "Around the World", "Daft Punk"),
+            _track("remix", "Around the World (Remix)", "Daft Punk"),
+        ]
+    )
+    provider = _ai_provider(
+        _ai_response(
+            ["candidate_0", "candidate_1", "candidate_2"],
+            [
+                ("same_artist_title", "Daft Punk - Neon Horizon"),
+                ("context_track", "Lunar Circuit - Chrome Reverie"),
+            ],
+        )
+    )
+    mass.get_providers_supporting_feature.return_value = [provider]
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.guess_the_song.secrets.choice",
+            return_value=correct_track,
+        ),
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.guess_the_song.SYSTEM_RANDOM.shuffle"
+        ),
+    ):
+        game_round = await quiz_type.prepare_round(0, [])
+
+    assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+    suggestions = game_round.answer_state.suggestions
+    assert len(suggestions) == 6
+    assert sum(item.is_correct for item in suggestions) == 1
+    assert sum(item.uri is None for item in suggestions) == 2
+    assert len({item.uri for item in suggestions} & {item.uri for item in pool_tracks}) == 2
+    assert all(" - " in item.label for item in suggestions)
+    provider.ai_query.assert_awaited_once()
+    mass.music.tracks.similar_tracks.assert_awaited_once_with(
+        item_id=correct_track.item_id,
+        provider_instance_id_or_domain=correct_track.provider,
+        limit=24,
+    )
+    assert mass.music.search.await_args.kwargs["limit"] == 48
+    mass.music.get_item.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Fixes Guess the Song answer choices that could reveal the correct track or fail despite usable source tracks.

- Aligns every round to either artist-title or title-only answers.
- Resolves artist metadata for only the selected track and filters incompatible or overlapping choices.
- Uses the cached source pool when preferred distractors are sparse, without reloading or eagerly converting large playlists.
- Adds regressions for all difficulty, catalog, AI, cache, identity, and redaction paths.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] Music Quiz provider tests pass, with regressions added under `tests/`.
- [x] No shared model changes are required.
- [x] No UI changes are required.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] No documentation changes are required.