### PR TITLE
Choose Music Quiz playback for each game

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -39,7 +39,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 36
+API_SCHEMA_VERSION: Final[int] = 37
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -64,7 +64,7 @@ from music_assistant_models.config_entries import (
     ConfigValueType,
     ProviderConfig,
 )
-from music_assistant_models.enums import ConfigEntryType, PlayerFeature, PlayerType, QueueOption
+from music_assistant_models.enums import ConfigEntryType, PlayerType, QueueOption
 from music_assistant_models.errors import (
     AudioError,
     InvalidDataError,
@@ -430,10 +430,6 @@ class MusicQuizPlugin(PluginProvider):
                 if game_config.playback_mode == SharedPlaybackMode.VENUE
                 else playback_defaults.stored_venue_player_id
             )
-            await self._store_playback_preference(
-                game_config.playback_mode,
-                remembered_venue_player_id,
-            )
             previous_game = self._game
             previous_quiz_type = self._quiz_type
             await self._cancel_reveal_playback_task()
@@ -452,6 +448,10 @@ class MusicQuizPlugin(PluginProvider):
                 self._answer_type = answer_strategy
                 self._prefetch_round(0)
                 self._signal_game_updated()
+            await self._store_playback_preference(
+                game_config.playback_mode,
+                remembered_venue_player_id,
+            )
             return await self._host_state()
 
     async def get_game(self) -> dict[str, Any] | None:
@@ -1588,7 +1588,7 @@ class MusicQuizPlugin(PluginProvider):
             and not state.hide_in_ui
             and not state.needs_setup
             and state.type in (PlayerType.PLAYER, PlayerType.STEREO_PAIR, PlayerType.GROUP)
-            and PlayerFeature.PLAY_MEDIA in state.supported_features
+            and player.is_native_player
             and player.provider.domain != SENDSPIN_DOMAIN
         )
 
@@ -1629,21 +1629,26 @@ class MusicQuizPlugin(PluginProvider):
         venue_player_id: str | None,
     ) -> None:
         """
-        Persist a successful playback selection for this provider instance.
+        Best-effort persist a successful playback selection for this provider instance.
 
         :param playback_mode: Effective mode selected for the game.
         :param venue_player_id: Last successful venue player, if any.
         """
-        await self.mass.cache.set(
-            PLAYBACK_PREFERENCE_CACHE_KEY,
-            {
-                "playback_mode": playback_mode.value,
-                "venue_player_id": venue_player_id,
-            },
-            expiration=PLAYBACK_PREFERENCE_CACHE_EXPIRATION,
-            provider=self.instance_id,
-            persistent=True,
-        )
+        try:
+            await self.mass.cache.set(
+                PLAYBACK_PREFERENCE_CACHE_KEY,
+                {
+                    "playback_mode": playback_mode.value,
+                    "venue_player_id": venue_player_id,
+                },
+                expiration=PLAYBACK_PREFERENCE_CACHE_EXPIRATION,
+                provider=self.instance_id,
+                persistent=True,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            self.logger.warning("Could not persist Music Quiz playback preference: %s", err)
 
     async def _migrate_legacy_playback_preference(self) -> None:
         """Persist legacy provider playback values when no preference exists yet."""

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -7,10 +7,10 @@ guess-the-song uses multiple-choice answers, while Music Timeline uses a shared
 chronological timeline with optional artist and title bonuses. Trivia uses
 AI-worded multiple-choice questions grounded in selected library metadata.
 
-Playback is hosted by a SharedPlaybackSession in one of two modes
-(provider config):
+Playback is hosted by a SharedPlaybackSession in one of two modes selected for
+each game:
 
-- venue: a configured real player plays the rounds out loud; guests may
+- venue: a selected real player plays the rounds out loud; guests may
   optionally listen in on their own device when the player supports grouping.
 - remote: a hidden virtual player leads the rounds and every guest listens
   on their own device (silent-disco style).
@@ -55,16 +55,16 @@ import secrets
 import time
 from collections.abc import Callable, Coroutine, Iterator
 from contextlib import contextmanager, suppress
-from typing import TYPE_CHECKING, Any, cast
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from music_assistant_models.auth import Scope, UserRole
 from music_assistant_models.config_entries import (
     ConfigEntry,
-    ConfigValueOption,
     ConfigValueType,
     ProviderConfig,
 )
-from music_assistant_models.enums import ConfigEntryType, PlaybackState, QueueOption
+from music_assistant_models.enums import ConfigEntryType, PlayerFeature, PlayerType, QueueOption
 from music_assistant_models.errors import (
     AudioError,
     InvalidDataError,
@@ -81,7 +81,11 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
 )
 from music_assistant.helpers import guest_access
 from music_assistant.helpers.json import SerializableType
-from music_assistant.helpers.shared_playback import SharedPlaybackMode, SharedPlaybackSession
+from music_assistant.helpers.shared_playback import (
+    SENDSPIN_DOMAIN,
+    SharedPlaybackMode,
+    SharedPlaybackSession,
+)
 from music_assistant.helpers.uri import parse_uri
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.music_quiz.answer_types import get_answer_type
@@ -127,9 +131,12 @@ from music_assistant.providers.music_quiz.models import (
     MusicQuizDifficulty,
     MusicQuizGame,
     MusicQuizPhase,
+    MusicQuizPlaybackOptions,
+    MusicQuizPlaybackSummary,
     MusicQuizPlayer,
     MusicQuizRound,
     MusicQuizSource,
+    MusicQuizVenuePlayerOption,
     TimelineBonusMode,
 )
 from music_assistant.providers.music_quiz.quiz_types import (
@@ -147,6 +154,7 @@ if TYPE_CHECKING:
 
     from music_assistant.mass import MusicAssistant
     from music_assistant.models import ProviderInstanceType
+    from music_assistant.models.player import Player
 
 SUPPORTED_FEATURES: set[ProviderFeature] = set()
 
@@ -156,6 +164,9 @@ CONF_MODE = "mode"
 CONF_PLAYER = "player"
 CONF_PLAYER_AUTO = "__auto__"
 CONF_USE_AI_DISTRACTORS = "use_ai_distractors"
+
+PLAYBACK_PREFERENCE_CACHE_KEY = "playback_preference"
+PLAYBACK_PREFERENCE_CACHE_EXPIRATION = 86400 * 3650
 
 MUSIC_QUIZ_GUEST_USER = "music_quiz_guest"
 MUSIC_QUIZ_GUEST_DISPLAY_NAME = "Music Quiz Guest"
@@ -173,6 +184,21 @@ REPLAY_AUTO_START_SECONDS = 30
 MIN_REVEAL_SECONDS = 10.0
 
 
+class _PlaybackPreference(TypedDict):
+    """Persisted playback preference for this provider instance."""
+
+    playback_mode: str
+    venue_player_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _PlaybackDefaults:
+    """Resolved playback defaults and the venue preference they came from."""
+
+    options: MusicQuizPlaybackOptions
+    stored_venue_player_id: str | None
+
+
 async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
@@ -181,7 +207,7 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant,
+    mass: MusicAssistant,  # noqa: ARG001
     instance_id: str | None = None,  # noqa: ARG001
     action: str | None = None,  # noqa: ARG001
     values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
@@ -195,34 +221,6 @@ async def get_config_entries(
     :param values: The (intermediate) raw values for config entries sent with the action.
     """
     return (
-        ConfigEntry(
-            key=CONF_MODE,
-            type=ConfigEntryType.STRING,
-            required=True,
-            default_value=SharedPlaybackMode.VENUE.value,
-            options=[
-                ConfigValueOption(SharedPlaybackMode.VENUE.value),
-                ConfigValueOption(SharedPlaybackMode.REMOTE.value),
-            ],
-        ),
-        ConfigEntry(
-            key=CONF_PLAYER,
-            type=ConfigEntryType.STRING,
-            required=True,
-            default_value=CONF_PLAYER_AUTO,
-            depends_on=CONF_MODE,
-            depends_on_value=SharedPlaybackMode.VENUE.value,
-            options=[
-                ConfigValueOption(CONF_PLAYER_AUTO),
-                *[
-                    ConfigValueOption(player.player_id, title=player.display_name)
-                    for player in sorted(
-                        mass.players.all_players(False, False),
-                        key=lambda p: p.display_name.lower(),
-                    )
-                ],
-            ],
-        ),
         ConfigEntry(
             key=CONF_USE_AI_DISTRACTORS,
             type=ConfigEntryType.BOOLEAN,
@@ -257,8 +255,10 @@ class MusicQuizPlugin(PluginProvider):
 
     async def loaded_in_mass(self) -> None:
         """Call after the provider has been loaded."""
+        await self._migrate_legacy_playback_preference()
         host_commands: tuple[tuple[str, _ApiHandler], ...] = (
             ("music_quiz/available_quiz_types", self.available_quiz_types),
+            ("music_quiz/playback_options", self.playback_options),
             ("music_quiz/create", self.create_game),
             ("music_quiz/get", self.get_game),
             ("music_quiz/start", self.start_game),
@@ -330,6 +330,10 @@ class MusicQuizPlugin(PluginProvider):
         """Return quiz types currently available for game creation."""
         return get_available_quiz_types(self.mass)
 
+    async def playback_options(self) -> MusicQuizPlaybackOptions:
+        """Return the host's available and recommended playback options."""
+        return (await self._resolve_playback_defaults()).options
+
     async def create_game(  # noqa: PLR0913
         self,
         quiz_type: str = "guess_the_song",
@@ -344,6 +348,8 @@ class MusicQuizPlugin(PluginProvider):
         play_reveal_audio: bool = True,
         artist_bonus_mode: str = TimelineBonusMode.OFF.value,
         title_bonus_mode: str = TimelineBonusMode.OFF.value,
+        playback_mode: str | None = None,
+        venue_player_id: str | None = None,
     ) -> dict[str, Any]:
         """
         Create a new Music Quiz game, replacing a previous (finished) game.
@@ -360,6 +366,8 @@ class MusicQuizPlugin(PluginProvider):
         :param play_reveal_audio: Play Trivia's grounded track during each reveal.
         :param artist_bonus_mode: Music Timeline artist bonus mode.
         :param title_bonus_mode: Music Timeline title bonus mode.
+        :param playback_mode: Playback mode for this game ("venue" or "remote").
+        :param venue_player_id: Venue player selected for this game.
         """
         quiz_type_class = get_quiz_type(quiz_type)
         get_answer_type(quiz_type_class.answer_type)
@@ -372,6 +380,12 @@ class MusicQuizPlugin(PluginProvider):
                 translation_key="music_quiz_invalid_bonus_mode",
                 translation_owner=TRANSLATION_OWNER,
             ) from err
+        playback_defaults = await self._resolve_playback_defaults()
+        effective_mode, effective_player_id, effective_player_name = self._resolve_create_playback(
+            playback_mode,
+            venue_player_id,
+            playback_defaults.options,
+        )
         game_config = quiz_type_class.normalize_config(
             MusicQuizConfig(
                 round_count=round_count,
@@ -380,6 +394,9 @@ class MusicQuizPlugin(PluginProvider):
                 source_uris=source_uris or [],
                 include_similar_music=include_similar_music,
                 name=_clean_game_name(name),
+                playback_mode=effective_mode,
+                venue_player_id=effective_player_id,
+                venue_player_name=effective_player_name,
                 difficulty=difficulty,
                 use_ai_distractors=bool(self.config.get_value(CONF_USE_AI_DISTRACTORS)),
                 language=language,
@@ -405,12 +422,27 @@ class MusicQuizPlugin(PluginProvider):
             quiz_strategy, answer_strategy = self._resolve_game_strategies(game)
             with _system_auth_context():
                 await quiz_strategy.initialize()
+            selected_player = self._validate_playback_config(game_config)
+            if selected_player is not None:
+                game_config.venue_player_name = selected_player.display_name
+            remembered_venue_player_id = (
+                game_config.venue_player_id
+                if game_config.playback_mode == SharedPlaybackMode.VENUE
+                else playback_defaults.stored_venue_player_id
+            )
+            await self._store_playback_preference(
+                game_config.playback_mode,
+                remembered_venue_player_id,
+            )
+            previous_game = self._game
             previous_quiz_type = self._quiz_type
             await self._cancel_reveal_playback_task()
             if previous_quiz_type is not None and previous_quiz_type.uses_audio:
                 await self._stop_playback()
             async with self._playback_lock:
-                if not quiz_strategy.uses_audio:
+                if not quiz_strategy.uses_audio or (
+                    previous_game is not None and _playback_selection_changed(previous_game, game)
+                ):
                     await self._close_playback_session_locked()
                 self._cancel_timers()
                 self._cancel_next_round_task()
@@ -518,7 +550,7 @@ class MusicQuizPlugin(PluginProvider):
                 "quiz_type": game.quiz_type,
                 "answer_type": game.answer_type.value,
                 "phase": game.phase.value,
-                "mode": self._mode,
+                "mode": game.config.playback_mode.value,
                 "player_count": len(game.players),
                 "round_count": game.config.round_count,
                 "auto_start_at": game.auto_start_at,
@@ -558,7 +590,7 @@ class MusicQuizPlugin(PluginProvider):
             self._signal_game_updated()
             return {
                 "player_id": player.player_id,
-                "state": _player_state(game, player, self._mode, answer_type),
+                "state": _player_state(game, player, answer_type),
             }
 
     async def get_player_state(self, player_id: str) -> dict[str, Any]:
@@ -572,7 +604,7 @@ class MusicQuizPlugin(PluginProvider):
             game, _, answer_type = self._require_game_strategies()
             player = _get_player(game, player_id)
             self._refresh_player_presence(player)
-            return _player_state(game, player, self._mode, answer_type)
+            return _player_state(game, player, answer_type)
 
     async def heartbeat(self, player_id: str) -> bool:
         """
@@ -646,14 +678,14 @@ class MusicQuizPlugin(PluginProvider):
             # a repeat ready is a no-op: it cannot newly satisfy the all-ready
             # check, so return current state without re-broadcasting
             if game.phase != MusicQuizPhase.REVEAL or player.ready:
-                return _player_state(game, player, self._mode, answer_type)
+                return _player_state(game, player, answer_type)
             mark_player_ready(game, player.player_id)
             # advance early when every player is ready for the next round
             if are_active_players_ready(game):
                 await self._advance_from_reveal()
             else:
                 self._signal_game_updated()
-            return _player_state(game, player, self._mode, answer_type)
+            return _player_state(game, player, answer_type)
 
     async def listen_in(self, web_player_id: str) -> None:
         """
@@ -730,11 +762,6 @@ class MusicQuizPlugin(PluginProvider):
             raise InvalidDataError("Music Quiz game strategy identity mismatch")
         return game, self._quiz_type, self._answer_type
 
-    @property
-    def _mode(self) -> str:
-        """Return the configured playback mode (venue/remote)."""
-        return cast("str", self.config.get_value(CONF_MODE))
-
     @staticmethod
     def _validate_guest_access() -> None:
         """
@@ -772,17 +799,18 @@ class MusicQuizPlugin(PluginProvider):
             self._do_reveal(completed=True)
         else:
             self._signal_game_updated()
-        return _player_state(game, player, self._mode, answer_type)
+        return _player_state(game, player, answer_type)
 
     async def _host_state(self) -> dict[str, Any]:
         """Return the host-visible state of the current game."""
         game, _, answer_type = self._require_game_strategies()
         return {
-            **_public_state(game, self._mode, answer_type),
+            **_public_state(game, answer_type),
             "created_at": game.created_at,
             "sources": [source.to_dict() for source in game.sources],
             "join_url": await self._get_join_url(),
             "rounds": [_host_round(game_round, answer_type) for game_round in game.rounds],
+            "playback": _playback_summary(game),
         }
 
     async def _get_join_url(self) -> str:
@@ -801,7 +829,7 @@ class MusicQuizPlugin(PluginProvider):
             return
         game, _, answer_type = self._require_game_strategies()
         self.signal_provider_event(
-            {"event": "game_updated", "state": _public_state(game, self._mode, answer_type)}
+            {"event": "game_updated", "state": _public_state(game, answer_type)}
         )
 
     async def _resolve_sources(self, source_uris: list[str]) -> list[MusicQuizSource]:
@@ -1293,7 +1321,11 @@ class MusicQuizPlugin(PluginProvider):
                     "No playback target is available for the Music Quiz game"
                 )
             player = self.mass.players.get_player(session.player_id)
-            if player and player.extra_data.get(ATTR_ANNOUNCEMENT_IN_PROGRESS):
+            if player is None or not player.state.available:
+                raise MusicQuizNoPlaybackTargetError(
+                    "No playback target is available for the Music Quiz game"
+                )
+            if player.extra_data.get(ATTR_ANNOUNCEMENT_IN_PROGRESS):
                 raise MusicQuizNoPlaybackTargetError(
                     "The Music Quiz playback target is handling an announcement"
                 )
@@ -1333,7 +1365,7 @@ class MusicQuizPlugin(PluginProvider):
         In remote mode the session is backed by a hidden virtual player; the
         session is (re)created here when that player does not exist (e.g.
         after a Sendspin provider reload). In venue mode a session only exists
-        when a configured or auto-selected venue player is available.
+        while the player selected for the game remains eligible.
 
         :return: The session, or None when no session is available.
         """
@@ -1353,12 +1385,12 @@ class MusicQuizPlugin(PluginProvider):
         # a session only makes sense while a game is active; without one, never
         # (re)create it - this also stops a guest listen-in that races with game
         # teardown from leaking a fresh session / virtual player
-        if self._game is None:
+        if (game := self._game) is None:
             return None
         if self._quiz_type is not None and not self._quiz_type.uses_audio:
             return None
-        if self._quiz_type is None and isinstance(self._game, MusicQuizGame):
-            quiz_type = get_quiz_type(self._game.quiz_type)(self.mass, self._game.config)
+        if self._quiz_type is None:
+            quiz_type = get_quiz_type(game.quiz_type)(self.mass, game.config)
             if not quiz_type.uses_audio:
                 return None
         # drop a stale session whose player no longer exists
@@ -1368,15 +1400,30 @@ class MusicQuizPlugin(PluginProvider):
             await self._playback_session.close()
             self._playback_session = None
 
+        if (
+            self._playback_session is not None
+            and game.config.playback_mode == SharedPlaybackMode.VENUE
+            and (
+                self._playback_session.player_id != game.config.venue_player_id
+                or not self._is_eligible_venue_player_id(self._playback_session.player_id)
+            )
+        ):
+            await self._playback_session.close()
+            self._playback_session = None
+
         if self._playback_session is not None:
             return self._playback_session
 
-        if self.config.get_value(CONF_MODE) == SharedPlaybackMode.REMOTE.value:
+        if game.config.playback_mode == SharedPlaybackMode.REMOTE:
+            if not self._remote_playback_available():
+                return None
             try:
                 self._playback_session = await self._create_remote_playback_session()
             except SetupFailedError as err:
                 self.logger.warning("Unable to create remote quiz session: %s", err)
-        elif player_id := self._resolve_venue_player_id():
+        elif (player_id := game.config.venue_player_id) and self._is_eligible_venue_player_id(
+            player_id
+        ):
             try:
                 self._playback_session = await SharedPlaybackSession.create_venue(
                     self.mass, player_id
@@ -1395,26 +1442,236 @@ class MusicQuizPlugin(PluginProvider):
             session_id=self.instance_id,
         )
 
-    def _resolve_venue_player_id(self) -> str | None:
-        """
-        Resolve the venue player, honoring the "auto" fallback.
+    async def _resolve_playback_defaults(self) -> _PlaybackDefaults:
+        """Resolve current playback availability and the recommended defaults."""
+        preference = await self._load_playback_preference()
+        legacy_mode, legacy_player_id, _ = self._legacy_playback_preference()
+        eligible_players = self._eligible_venue_players()
+        venue_players: list[MusicQuizVenuePlayerOption] = [
+            {"player_id": player.player_id, "name": player.display_name}
+            for player in eligible_players
+        ]
+        eligible_player_ids = {player["player_id"] for player in venue_players}
+        stored_venue_player_id = (
+            preference["venue_player_id"] if preference is not None else legacy_player_id
+        )
+        default_venue_player_id = next(
+            (
+                player_id
+                for player_id in (
+                    preference["venue_player_id"] if preference is not None else None,
+                    legacy_player_id,
+                )
+                if player_id in eligible_player_ids
+            ),
+            venue_players[0]["player_id"] if venue_players else None,
+        )
+        venue_available = bool(venue_players)
+        remote_available = self._remote_playback_available()
+        preferred_mode = (
+            SharedPlaybackMode(preference["playback_mode"])
+            if preference is not None
+            else legacy_mode
+        )
+        if preferred_mode == SharedPlaybackMode.VENUE and venue_available:
+            default_mode = SharedPlaybackMode.VENUE
+        elif preferred_mode == SharedPlaybackMode.REMOTE and remote_available:
+            default_mode = SharedPlaybackMode.REMOTE
+        elif venue_available:
+            default_mode = SharedPlaybackMode.VENUE
+        elif remote_available:
+            default_mode = SharedPlaybackMode.REMOTE
+        else:
+            default_mode = preferred_mode
+        return _PlaybackDefaults(
+            options={
+                "default_playback_mode": default_mode.value,
+                "default_venue_player_id": default_venue_player_id,
+                "venue_available": venue_available,
+                "remote_available": remote_available,
+                "venue_players": venue_players,
+            },
+            stored_venue_player_id=stored_venue_player_id,
+        )
 
-        :return: The player_id to host venue playback, or None when no player is available.
+    def _resolve_create_playback(
+        self,
+        playback_mode: str | None,
+        venue_player_id: str | None,
+        options: MusicQuizPlaybackOptions,
+    ) -> tuple[SharedPlaybackMode, str | None, str | None]:
         """
-        player_id = cast("str | None", self.config.get_value(CONF_PLAYER))
-        if player_id and player_id != CONF_PLAYER_AUTO:
-            return player_id
-        # auto: prefer a player that is already playing, then paused, then any available
-        fallback: str | None = None
-        fallback_priority = -1
-        for player in self.mass.players.all_players(False, False):
-            if player.playback_state == PlaybackState.PLAYING:
-                return player.player_id
-            if player.playback_state == PlaybackState.PAUSED and fallback_priority < 1:
-                fallback, fallback_priority = player.player_id, 1
-            elif fallback_priority < 0:
-                fallback, fallback_priority = player.player_id, 0
-        return fallback
+        Resolve and validate playback requested for a new game.
+
+        :param playback_mode: Requested playback mode, or None for the recommended default.
+        :param venue_player_id: Requested venue player.
+        :param options: Current playback options.
+        :return: Effective mode, venue player ID and venue player name.
+        """
+        if playback_mode is None:
+            mode = SharedPlaybackMode(options["default_playback_mode"])
+        else:
+            try:
+                mode = SharedPlaybackMode(playback_mode)
+            except ValueError as err:
+                raise InvalidDataError(
+                    f"Unknown Music Quiz playback mode: {playback_mode}",
+                    translation_key="music_quiz_invalid_playback_mode",
+                    translation_owner=TRANSLATION_OWNER,
+                ) from err
+        if mode == SharedPlaybackMode.REMOTE:
+            if not options["remote_available"]:
+                raise MusicQuizNoPlaybackTargetError("Remote Music Quiz playback is not available")
+            return mode, None, None
+
+        selected_player_id = venue_player_id
+        if selected_player_id is None and playback_mode is None:
+            selected_player_id = options["default_venue_player_id"]
+        for player in options["venue_players"]:
+            if player["player_id"] == selected_player_id:
+                return mode, player["player_id"], player["name"]
+        raise MusicQuizNoPlaybackTargetError(
+            "The selected Music Quiz venue player is not available"
+        )
+
+    def _validate_playback_config(self, config: MusicQuizConfig) -> Player | None:
+        """
+        Validate a game's playback target immediately before publication.
+
+        :param config: Game configuration to validate.
+        :return: The selected venue player, or None for remote playback.
+        """
+        if config.playback_mode == SharedPlaybackMode.REMOTE:
+            if not self._remote_playback_available():
+                raise MusicQuizNoPlaybackTargetError("Remote Music Quiz playback is not available")
+            return None
+        if config.venue_player_id:
+            for player in self._eligible_venue_players():
+                if player.player_id == config.venue_player_id:
+                    return player
+        raise MusicQuizNoPlaybackTargetError(
+            "The selected Music Quiz venue player is not available"
+        )
+
+    def _eligible_venue_players(self) -> list[Player]:
+        """Return stable, visible and playable venue targets."""
+        eligible_players = [
+            player
+            for player in self.mass.players.all_players(False, False)
+            if self._is_eligible_venue_player(player)
+        ]
+        return sorted(
+            eligible_players,
+            key=lambda player: (player.display_name.casefold(), player.player_id),
+        )
+
+    def _is_eligible_venue_player_id(self, player_id: str) -> bool:
+        """
+        Return whether a player remains eligible for venue playback.
+
+        :param player_id: Player to validate.
+        """
+        player = self.mass.players.get_player(player_id)
+        return player is not None and self._is_eligible_venue_player(player)
+
+    @staticmethod
+    def _is_eligible_venue_player(player: Player) -> bool:
+        """
+        Return whether a player is a real venue playback target.
+
+        :param player: Player to inspect.
+        """
+        state = player.state
+        return (
+            state.available
+            and state.enabled
+            and not state.hide_in_ui
+            and not state.needs_setup
+            and state.type in (PlayerType.PLAYER, PlayerType.STEREO_PAIR, PlayerType.GROUP)
+            and PlayerFeature.PLAY_MEDIA in state.supported_features
+            and player.provider.domain != SENDSPIN_DOMAIN
+        )
+
+    def _remote_playback_available(self) -> bool:
+        """Return whether remote playback can create its Sendspin session."""
+        return self.mass.get_provider(SENDSPIN_DOMAIN) is not None
+
+    async def _load_playback_preference(self) -> _PlaybackPreference | None:
+        """Return the valid persisted playback preference for this provider instance."""
+        data = await self.mass.cache.get(
+            PLAYBACK_PREFERENCE_CACHE_KEY,
+            provider=self.instance_id,
+        )
+        if data is None:
+            return None
+        if not isinstance(data, dict):
+            self.logger.warning("Ignoring invalid Music Quiz playback preference")
+            return None
+        playback_mode = data.get("playback_mode")
+        venue_player_id = data.get("venue_player_id")
+        valid_venue_player_id = venue_player_id is None or (
+            isinstance(venue_player_id, str) and bool(venue_player_id)
+        )
+        if (
+            playback_mode not in {mode.value for mode in SharedPlaybackMode}
+            or not valid_venue_player_id
+        ):
+            self.logger.warning("Ignoring invalid Music Quiz playback preference")
+            return None
+        return {
+            "playback_mode": cast("str", playback_mode),
+            "venue_player_id": venue_player_id,
+        }
+
+    async def _store_playback_preference(
+        self,
+        playback_mode: SharedPlaybackMode,
+        venue_player_id: str | None,
+    ) -> None:
+        """
+        Persist a successful playback selection for this provider instance.
+
+        :param playback_mode: Effective mode selected for the game.
+        :param venue_player_id: Last successful venue player, if any.
+        """
+        await self.mass.cache.set(
+            PLAYBACK_PREFERENCE_CACHE_KEY,
+            {
+                "playback_mode": playback_mode.value,
+                "venue_player_id": venue_player_id,
+            },
+            expiration=PLAYBACK_PREFERENCE_CACHE_EXPIRATION,
+            provider=self.instance_id,
+            persistent=True,
+        )
+
+    async def _migrate_legacy_playback_preference(self) -> None:
+        """Persist legacy provider playback values when no preference exists yet."""
+        if await self._load_playback_preference() is not None:
+            return
+        playback_mode, venue_player_id, has_legacy_value = self._legacy_playback_preference()
+        if has_legacy_value:
+            await self._store_playback_preference(playback_mode, venue_player_id)
+
+    def _legacy_playback_preference(self) -> tuple[SharedPlaybackMode, str | None, bool]:
+        """Return compatible playback defaults from legacy provider settings."""
+        raw_mode = self.config.get_value(CONF_MODE)
+        raw_player_id = self.config.get_value(CONF_PLAYER)
+        if isinstance(raw_mode, str):
+            try:
+                playback_mode = SharedPlaybackMode(raw_mode)
+            except ValueError:
+                playback_mode = SharedPlaybackMode.VENUE
+        else:
+            playback_mode = SharedPlaybackMode.VENUE
+        venue_player_id = (
+            raw_player_id
+            if isinstance(raw_player_id, str)
+            and raw_player_id
+            and raw_player_id != CONF_PLAYER_AUTO
+            else None
+        )
+        return playback_mode, venue_player_id, raw_mode is not None or raw_player_id is not None
 
     # ---------- timers ----------
 
@@ -1525,6 +1782,24 @@ class MusicQuizPlugin(PluginProvider):
         self._cancel_presence_expiry(cancel_task=True)
 
 
+def _playback_selection_changed(previous: MusicQuizGame, current: MusicQuizGame) -> bool:
+    """Return whether two games require different playback sessions."""
+    return (
+        previous.config.playback_mode != current.config.playback_mode
+        or previous.config.venue_player_id != current.config.venue_player_id
+    )
+
+
+def _playback_summary(game: MusicQuizGame) -> MusicQuizPlaybackSummary:
+    """Return the host-only summary of a game's playback selection."""
+    is_venue = game.config.playback_mode == SharedPlaybackMode.VENUE
+    return {
+        "mode": game.config.playback_mode.value,
+        "venue_player_id": game.config.venue_player_id if is_venue else None,
+        "venue_player_name": game.config.venue_player_name if is_venue else None,
+    }
+
+
 def _clean_game_name(name: str | None) -> str | None:
     """Return a normalized optional game name."""
     if not name:
@@ -1621,7 +1896,7 @@ def _host_round(
     }
 
 
-def _public_state(game: MusicQuizGame, mode: str, answer_type: QuizAnswerType) -> dict[str, Any]:
+def _public_state(game: MusicQuizGame, answer_type: QuizAnswerType) -> dict[str, Any]:
     """Return the guest-safe public game state (see the module docstring)."""
     current_round = (
         game.rounds[game.current_round_index] if game.current_round_index is not None else None
@@ -1647,7 +1922,7 @@ def _public_state(game: MusicQuizGame, mode: str, answer_type: QuizAnswerType) -
         "name": game.config.name,
         "quiz_type": game.quiz_type,
         "answer_type": game.answer_type.value,
-        "mode": mode,
+        "mode": game.config.playback_mode.value,
         "round_count": game.config.round_count,
         "answer_duration": game.config.answer_duration,
         "auto_start_at": game.auto_start_at,
@@ -1693,7 +1968,6 @@ def _public_round(
 def _player_state(
     game: MusicQuizGame,
     player: MusicQuizPlayer,
-    mode: str,
     answer_type: QuizAnswerType,
 ) -> dict[str, Any]:
     """Return the personalized (still guest-safe) game state for a player."""
@@ -1713,4 +1987,4 @@ def _player_state(
             revealed=revealed,
         ),
     }
-    return {**_public_state(game, mode, answer_type), "you": you}
+    return {**_public_state(game, answer_type), "you": you}

--- a/music_assistant/providers/music_quiz/models.py
+++ b/music_assistant/providers/music_quiz/models.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Literal
+from typing import Literal, TypedDict
 
 from mashumaro import DataClassDictMixin, field_options
 from mashumaro.config import BaseConfig
 from mashumaro.types import Discriminator
+
+from music_assistant.helpers.shared_playback import SharedPlaybackMode
 
 DEFAULT_TRIVIA_LANGUAGE = "en"
 
@@ -52,6 +54,31 @@ class TimelineBonusType(StrEnum):
     TITLE = "title"
 
 
+class MusicQuizVenuePlayerOption(TypedDict):
+    """A venue player available for Music Quiz playback."""
+
+    player_id: str
+    name: str
+
+
+class MusicQuizPlaybackOptions(TypedDict):
+    """Host-visible options for configuring Music Quiz playback."""
+
+    default_playback_mode: str
+    default_venue_player_id: str | None
+    venue_available: bool
+    remote_available: bool
+    venue_players: list[MusicQuizVenuePlayerOption]
+
+
+class MusicQuizPlaybackSummary(TypedDict):
+    """Host-only summary of a game's playback selection."""
+
+    mode: str
+    venue_player_id: str | None
+    venue_player_name: str | None
+
+
 @dataclass
 class MusicQuizConfig(DataClassDictMixin):
     """Configuration for a Music Quiz game."""
@@ -62,6 +89,9 @@ class MusicQuizConfig(DataClassDictMixin):
     source_uris: list[str] = field(default_factory=list)
     include_similar_music: bool = False
     name: str | None = None
+    playback_mode: SharedPlaybackMode = SharedPlaybackMode.VENUE
+    venue_player_id: str | None = None
+    venue_player_name: str | None = None
     # difficulty is guess-the-song specific; AI distractors also apply to timeline bonuses
     difficulty: str = MusicQuizDifficulty.NORMAL.value
     use_ai_distractors: bool = False

--- a/music_assistant/providers/music_quiz/strings.json
+++ b/music_assistant/providers/music_quiz/strings.json
@@ -45,6 +45,7 @@
     "music_quiz_invalid_difficulty": "The selected difficulty is not valid.",
     "music_quiz_invalid_language": "The selected Trivia language is not valid.",
     "music_quiz_invalid_bonus_mode": "The selected timeline bonus mode is not valid.",
+    "music_quiz_invalid_playback_mode": "The selected playback mode is not valid.",
     "music_quiz_no_unused_source_tracks": "No unused source tracks are available.",
     "music_quiz_no_dated_tracks": "None of the selected tracks have a usable release year.",
     "music_quiz_not_enough_dated_tracks": "At least {0} unique tracks with release years are required for this game.",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1399,6 +1399,7 @@
   "provider.music_quiz.errors.music_quiz_invalid_bonus_mode": "The selected timeline bonus mode is not valid.",
   "provider.music_quiz.errors.music_quiz_invalid_difficulty": "The selected difficulty is not valid.",
   "provider.music_quiz.errors.music_quiz_invalid_language": "The selected Trivia language is not valid.",
+  "provider.music_quiz.errors.music_quiz_invalid_playback_mode": "The selected playback mode is not valid.",
   "provider.music_quiz.errors.music_quiz_name_required": "A player name is required.",
   "provider.music_quiz.errors.music_quiz_name_taken": "This player name is already taken.",
   "provider.music_quiz.errors.music_quiz_no_dated_tracks": "None of the selected tracks have a usable release year.",

--- a/tests/providers/music_quiz/test_models.py
+++ b/tests/providers/music_quiz/test_models.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 from mashumaro.exceptions import ExtraKeysError, InvalidFieldValue
 
+from music_assistant.helpers.shared_playback import SharedPlaybackMode
 from music_assistant.providers.music_quiz.models import (
     MultipleChoiceAnswer,
     MultipleChoiceRoundState,
@@ -41,6 +42,23 @@ def test_config_defaults_and_round_trips_similar_music() -> None:
     assert default_config.include_similar_music is False
     assert MusicQuizConfig().to_dict()["include_similar_music"] is False
     assert MusicQuizConfig.from_dict(enabled_config.to_dict()) == enabled_config
+
+
+def test_config_round_trips_game_playback_selection() -> None:
+    """Preserve the effective playback selection with persisted game settings."""
+    config = MusicQuizConfig(
+        playback_mode=SharedPlaybackMode.VENUE,
+        venue_player_id="living_room",
+        venue_player_name="Living Room",
+    )
+
+    serialized = config.to_dict()
+
+    assert serialized["playback_mode"] == "venue"
+    assert serialized["venue_player_id"] == "living_room"
+    assert serialized["venue_player_name"] == "Living Room"
+    assert MusicQuizConfig.from_dict(serialized) == config
+    assert MusicQuizConfig.from_dict({}).playback_mode == SharedPlaybackMode.VENUE
 
 
 def test_round_answer_state_round_trips_with_discriminator() -> None:

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -114,10 +114,17 @@ def _make_venue_player(
     playback_state: PlaybackState = PlaybackState.IDLE,
 ) -> SimpleNamespace:
     """Return a player-shaped venue target for tests."""
+    supported_features = features if features is not None else {PlayerFeature.PLAY_MEDIA}
+    is_native_player = (
+        PlayerFeature.PLAY_MEDIA in supported_features
+        and player_type != PlayerType.PROTOCOL
+        and provider_domain != "universal_player"
+    )
     return SimpleNamespace(
         player_id=player_id,
         display_name=name,
         playback_state=playback_state,
+        is_native_player=is_native_player,
         provider=SimpleNamespace(domain=provider_domain),
         state=SimpleNamespace(
             available=available,
@@ -125,7 +132,7 @@ def _make_venue_player(
             hide_in_ui=hidden,
             needs_setup=needs_setup,
             type=player_type,
-            supported_features=features if features is not None else {PlayerFeature.PLAY_MEDIA},
+            supported_features=supported_features,
         ),
         extra_data={},
     )
@@ -598,6 +605,7 @@ async def test_playback_options_filter_and_stably_rank_venue_players() -> None:
         _make_venue_player("display", "Display", player_type=PlayerType.DISPLAY),
         _make_venue_player("no-play", "No Playback", features=set()),
         _make_venue_player("browser", "Browser", provider_domain="sendspin"),
+        _make_venue_player("universal", "Universal", provider_domain="universal_player"),
     ]
     cast("MagicMock", plugin.mass.players.all_players).return_value = [
         playing_bathroom,
@@ -1001,6 +1009,83 @@ async def test_replacing_game_with_different_playback_closes_previous_session() 
     previous_session.close.assert_awaited_once()
     assert vars(plugin)["_playback_session"] is None
     assert state["playback"]["mode"] == "remote"
+
+
+@pytest.mark.asyncio
+async def test_failed_session_close_preserves_game_and_playback_preference() -> None:
+    """Do not remember a replacement game when its session transition fails."""
+    plugin = _create_plugin()
+    cache_values: dict[tuple[str, str], Any] = {}
+    _install_shared_preference_cache(plugin, cache_values)
+    await plugin.create_game(
+        source_uris=["library://playlist/1"],
+        playback_mode="venue",
+        venue_player_id="venue_player",
+    )
+    existing_game = plugin._game
+    assert existing_game is not None
+    existing_state = existing_game.to_dict()
+    existing_preference = cache_values[(INSTANCE_ID, PLAYBACK_PREFERENCE_CACHE_KEY)].copy()
+    cache_set = cast("AsyncMock", plugin.mass.cache.set)
+    cache_set.reset_mock()
+    previous_session = MagicMock()
+    previous_session.close = AsyncMock(side_effect=RuntimeError("Listener detach failed"))
+    plugin._playback_session = previous_session
+
+    with pytest.raises(RuntimeError, match="Listener detach failed"):
+        await plugin.create_game(
+            source_uris=["library://playlist/2"],
+            playback_mode="remote",
+        )
+
+    assert plugin._game is existing_game
+    assert existing_game.to_dict() == existing_state
+    assert cache_values[(INSTANCE_ID, PLAYBACK_PREFERENCE_CACHE_KEY)] == existing_preference
+    cache_set.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_preference_write_does_not_fail_game_creation() -> None:
+    """Publish a valid game when optional preference persistence is unavailable."""
+    plugin = _create_plugin()
+    cache_error = RuntimeError("Cache database unavailable")
+    cache_set = cast("AsyncMock", plugin.mass.cache.set)
+    cache_set.side_effect = cache_error
+
+    state = await plugin.create_game(
+        source_uris=["library://playlist/1"],
+        playback_mode="venue",
+        venue_player_id="venue_player",
+    )
+
+    game = plugin._game
+    assert game is not None
+    assert game.config.venue_player_id == "venue_player"
+    assert state["playback"]["venue_player_id"] == "venue_player"
+    cache_set.assert_awaited_once()
+    cast("MagicMock", plugin.logger.warning).assert_called_once_with(
+        "Could not persist Music Quiz playback preference: %s",
+        cache_error,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_preference_write_propagates_after_game_commit() -> None:
+    """Propagate cancellation instead of treating it as a cache failure."""
+    plugin = _create_plugin()
+    cache_set = cast("AsyncMock", plugin.mass.cache.set)
+    cache_set.side_effect = asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await plugin.create_game(
+            source_uris=["library://playlist/1"],
+            playback_mode="venue",
+            venue_player_id="venue_player",
+        )
+
+    assert plugin._game is not None
+    cast("MagicMock", plugin.signal_provider_event).assert_called()
+    cast("MagicMock", plugin.logger.warning).assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -10,7 +10,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.auth import Scope, User, UserRole
-from music_assistant_models.enums import ConfigEntryType, MediaType, PlaybackState, QueueOption
+from music_assistant_models.enums import (
+    ConfigEntryType,
+    MediaType,
+    PlaybackState,
+    PlayerFeature,
+    PlayerType,
+    QueueOption,
+)
 from music_assistant_models.errors import AudioError, InvalidDataError, MediaNotFoundError
 from music_assistant_models.media_items import Playlist, ProviderMapping, Track
 
@@ -22,9 +29,12 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_current_user as get_auth_current_user,
 )
 from music_assistant.helpers.api import APICommandHandler, parse_arguments
+from music_assistant.helpers.shared_playback import SharedPlaybackMode
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.music_quiz import (
     MUSIC_QUIZ_GUEST_USER,
+    PLAYBACK_PREFERENCE_CACHE_EXPIRATION,
+    PLAYBACK_PREFERENCE_CACHE_KEY,
     PLAYER_RECONNECT_GRACE_SECONDS,
     REPLAY_AUTO_START_SECONDS,
     MusicQuizPlugin,
@@ -43,6 +53,8 @@ from music_assistant.providers.music_quiz.game import finish_game as finish_game
 from music_assistant.providers.music_quiz.models import (
     MultipleChoiceRoundState,
     MultipleChoiceSuggestion,
+    MusicQuizAnswerType,
+    MusicQuizConfig,
     MusicQuizGame,
     MusicQuizPhase,
     MusicQuizRound,
@@ -63,6 +75,7 @@ INSTANCE_ID = "music_quiz--test"
 
 HOST_COMMANDS = (
     "music_quiz/available_quiz_types",
+    "music_quiz/playback_options",
     "music_quiz/create",
     "music_quiz/get",
     "music_quiz/start",
@@ -85,6 +98,37 @@ LISTEN_IN_COMMANDS = (
     "music_quiz/stop_listen_in",
     "music_quiz/can_listen_in",
 )
+
+
+def _make_venue_player(
+    player_id: str,
+    name: str,
+    *,
+    available: bool = True,
+    enabled: bool = True,
+    hidden: bool = False,
+    needs_setup: bool = False,
+    player_type: PlayerType = PlayerType.PLAYER,
+    features: set[PlayerFeature] | None = None,
+    provider_domain: str = "test_player",
+    playback_state: PlaybackState = PlaybackState.IDLE,
+) -> SimpleNamespace:
+    """Return a player-shaped venue target for tests."""
+    return SimpleNamespace(
+        player_id=player_id,
+        display_name=name,
+        playback_state=playback_state,
+        provider=SimpleNamespace(domain=provider_domain),
+        state=SimpleNamespace(
+            available=available,
+            enabled=enabled,
+            hide_in_ui=hidden,
+            needs_setup=needs_setup,
+            type=player_type,
+            supported_features=features if features is not None else {PlayerFeature.PLAY_MEDIA},
+        ),
+        extra_data={},
+    )
 
 
 def _make_round(round_index: int, suggestion_count: int = 4) -> MusicQuizRound:
@@ -204,7 +248,7 @@ def _make_text_trivia_round(
 
 
 def _create_plugin(
-    mode: str = "venue",
+    mode: str | None = "venue",
     player: str | None = "venue_player",
     use_ai_distractors: bool = False,
 ) -> MusicQuizPlugin:
@@ -214,11 +258,12 @@ def _create_plugin(
     plugin.logger = MagicMock()
     plugin.config = MagicMock()
     plugin.config.instance_id = INSTANCE_ID
-    plugin.config.get_value.side_effect = {
+    config_values = {
         "mode": mode,
         "player": player,
         "use_ai_distractors": use_ai_distractors,
-    }.__getitem__
+    }
+    plugin.config.get_value.side_effect = lambda key, default=None: config_values.get(key, default)
     plugin._game = None
     plugin._quiz_type = None
     plugin._answer_type = None
@@ -229,6 +274,23 @@ def _create_plugin(
     plugin._next_round_task = None
     plugin._reveal_playback_task = None
     plugin._unregister_handles = []
+    plugin.mass.cache.get = AsyncMock(return_value=None)
+    plugin.mass.cache.set = AsyncMock()
+    plugin.mass.get_provider.return_value = MagicMock()
+    plugin.mass.players.all_players.return_value = (
+        [_make_venue_player(player, "Venue Player")] if player and player != "__auto__" else []
+    )
+
+    def _get_player(player_id: str) -> SimpleNamespace | None:
+        players = cast("MagicMock", plugin.mass.players.all_players).return_value
+        if isinstance(players, list):
+            return next(
+                (player for player in players if player.player_id == player_id),
+                None,
+            )
+        return None
+
+    plugin.mass.players.get_player.side_effect = _get_player
 
     def _create_task(target: Any, *args: Any, **_kwargs: Any) -> asyncio.Task[Any]:
         if asyncio.iscoroutine(target):
@@ -247,9 +309,37 @@ def _create_plugin(
     return plugin
 
 
-def _fake_game() -> MusicQuizGame:
+def _install_shared_preference_cache(
+    plugin: MusicQuizPlugin,
+    values: dict[tuple[str, str], Any],
+) -> None:
+    """Attach a provider-scoped in-memory cache to a plugin."""
+
+    async def _get(key: str, *, provider: str, **_kwargs: Any) -> Any:
+        return values.get((provider, key))
+
+    async def _set(key: str, data: Any, *, provider: str, **_kwargs: Any) -> None:
+        values[(provider, key)] = data
+
+    cache = cast("Any", plugin.mass.cache)
+    cache.get = AsyncMock(side_effect=_get)
+    cache.set = AsyncMock(side_effect=_set)
+
+
+def _fake_game(
+    mode: SharedPlaybackMode = SharedPlaybackMode.VENUE,
+    venue_player_id: str | None = "venue_player",
+) -> MusicQuizGame:
     """Return a minimal active-game stub for playback-session tests."""
-    return cast("MusicQuizGame", SimpleNamespace(config=SimpleNamespace(name=None)))
+    return MusicQuizGame(
+        config=MusicQuizConfig(
+            playback_mode=mode,
+            venue_player_id=venue_player_id,
+            venue_player_name="Venue Player" if venue_player_id else None,
+        ),
+        quiz_type="guess_the_song",
+        answer_type=MusicQuizAnswerType.MULTIPLE_CHOICE,
+    )
 
 
 def _guest_user() -> SimpleNamespace:
@@ -460,6 +550,459 @@ async def test_api_command_scopes_lock_out_guests_from_host_commands() -> None:
         assert registered[command] == Scope.PLAYERS_CONTROL
 
 
+@pytest.mark.asyncio
+async def test_create_api_accepts_additive_playback_fields() -> None:
+    """Parse the explicit playback selection through the registered API contract."""
+    plugin = _create_plugin()
+    registered: dict[str, APICommandHandler] = {}
+
+    def _register(command: str, handler: Any, **kwargs: Any) -> Any:
+        registered[command] = APICommandHandler.parse(command, handler, **kwargs)
+        return MagicMock()
+
+    cast("MagicMock", plugin.mass.register_api_command).side_effect = _register
+    await plugin.loaded_in_mass()
+
+    handler = registered["music_quiz/create"]
+    arguments = parse_arguments(
+        handler.signature,
+        handler.type_hints,
+        {
+            "source_uris": ["library://playlist/1"],
+            "playback_mode": "venue",
+            "venue_player_id": "venue_player",
+        },
+    )
+
+    assert arguments["playback_mode"] == "venue"
+    assert arguments["venue_player_id"] == "venue_player"
+
+
+@pytest.mark.asyncio
+async def test_playback_options_filter_and_stably_rank_venue_players() -> None:
+    """Recommend a concrete playable target without using current playback activity."""
+    plugin = _create_plugin(player="__auto__")
+    alpha = _make_venue_player("alpha", "Alpha Room")
+    group = _make_venue_player("group", "House Group", player_type=PlayerType.GROUP)
+    playing_bathroom = _make_venue_player(
+        "bathroom",
+        "Z Bathroom",
+        playback_state=PlaybackState.PLAYING,
+    )
+    excluded = [
+        _make_venue_player("unavailable", "Unavailable", available=False),
+        _make_venue_player("disabled", "Disabled", enabled=False),
+        _make_venue_player("hidden", "Hidden", hidden=True),
+        _make_venue_player("needs-setup", "Needs Setup", needs_setup=True),
+        _make_venue_player("protocol", "Protocol", player_type=PlayerType.PROTOCOL),
+        _make_venue_player("display", "Display", player_type=PlayerType.DISPLAY),
+        _make_venue_player("no-play", "No Playback", features=set()),
+        _make_venue_player("browser", "Browser", provider_domain="sendspin"),
+    ]
+    cast("MagicMock", plugin.mass.players.all_players).return_value = [
+        playing_bathroom,
+        *excluded,
+        group,
+        alpha,
+    ]
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.SharedPlaybackSession.create_venue",
+            new=AsyncMock(),
+        ) as create_venue,
+        patch(
+            "music_assistant.providers.music_quiz.SharedPlaybackSession.create_remote",
+            new=AsyncMock(),
+        ) as create_remote,
+    ):
+        options = await plugin.playback_options()
+
+    assert options == {
+        "default_playback_mode": "venue",
+        "default_venue_player_id": "alpha",
+        "venue_available": True,
+        "remote_available": True,
+        "venue_players": [
+            {"player_id": "alpha", "name": "Alpha Room"},
+            {"player_id": "group", "name": "House Group"},
+            {"player_id": "bathroom", "name": "Z Bathroom"},
+        ],
+    }
+    create_venue.assert_not_awaited()
+    create_remote.assert_not_awaited()
+    assert cast("MagicMock", plugin.mass.player_queues).mock_calls == []
+
+
+@pytest.mark.asyncio
+async def test_playback_options_report_mode_availability() -> None:
+    """Expose unavailable modes while retaining a stable default value."""
+    plugin = _create_plugin(mode="remote", player=None)
+    cast("MagicMock", plugin.mass.players.all_players).return_value = []
+    cast("MagicMock", plugin.mass.get_provider).return_value = None
+
+    options = await plugin.playback_options()
+
+    assert options == {
+        "default_playback_mode": "remote",
+        "default_venue_player_id": None,
+        "venue_available": False,
+        "remote_available": False,
+        "venue_players": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_remembered_playback_survives_plugin_instances_and_remote_keeps_venue() -> None:
+    """Reuse provider-scoped choices and retain the venue target after a remote game."""
+    cache_values: dict[tuple[str, str], Any] = {}
+    speaker = _make_venue_player("living_room", "Living Room")
+    first_plugin = _create_plugin(mode="venue", player="__auto__")
+    cast("MagicMock", first_plugin.mass.players.all_players).return_value = [speaker]
+    _install_shared_preference_cache(first_plugin, cache_values)
+
+    await first_plugin.create_game(
+        source_uris=["library://playlist/1"],
+        playback_mode="venue",
+        venue_player_id="living_room",
+    )
+
+    second_plugin = _create_plugin(mode="venue", player=None)
+    cast("MagicMock", second_plugin.mass.players.all_players).return_value = [speaker]
+    _install_shared_preference_cache(second_plugin, cache_values)
+    options = await second_plugin.playback_options()
+    assert options["default_playback_mode"] == "venue"
+    assert options["default_venue_player_id"] == "living_room"
+
+    await second_plugin.create_game(
+        source_uris=["library://playlist/1"],
+        playback_mode="remote",
+        venue_player_id="ignored",
+    )
+
+    assert cache_values[(INSTANCE_ID, PLAYBACK_PREFERENCE_CACHE_KEY)] == {
+        "playback_mode": "remote",
+        "venue_player_id": "living_room",
+    }
+    third_plugin = _create_plugin(mode="venue", player=None)
+    cast("MagicMock", third_plugin.mass.players.all_players).return_value = [speaker]
+    _install_shared_preference_cache(third_plugin, cache_values)
+    remembered = await third_plugin.playback_options()
+    assert remembered["default_playback_mode"] == "remote"
+    assert remembered["default_venue_player_id"] == "living_room"
+
+
+@pytest.mark.parametrize(
+    ("mode", "player_id", "expected"),
+    [
+        (
+            "remote",
+            "legacy_player",
+            {"playback_mode": "remote", "venue_player_id": "legacy_player"},
+        ),
+        ("venue", "__auto__", {"playback_mode": "venue", "venue_player_id": None}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_loaded_provider_migrates_legacy_playback_settings(
+    mode: str,
+    player_id: str,
+    expected: dict[str, str | None],
+) -> None:
+    """Persist hidden legacy values before provider reconfiguration can discard them."""
+    plugin = _create_plugin(mode=mode, player=player_id)
+
+    await plugin.loaded_in_mass()
+
+    cast("AsyncMock", plugin.mass.cache.set).assert_awaited_once_with(
+        PLAYBACK_PREFERENCE_CACHE_KEY,
+        expected,
+        expiration=PLAYBACK_PREFERENCE_CACHE_EXPIRATION,
+        provider=INSTANCE_ID,
+        persistent=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_provider_does_not_seed_a_legacy_playback_preference() -> None:
+    """Leave first-use recommendation unclaimed when no legacy values exist."""
+    plugin = _create_plugin(mode=None, player=None)
+
+    await plugin.loaded_in_mass()
+
+    cast("AsyncMock", plugin.mass.cache.set).assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_explicit_venue_create_persists_game_authoritative_playback() -> None:
+    """Validate and persist the selected venue target in game and host state."""
+    plugin = _create_plugin(mode="remote", player=None)
+    speaker = _make_venue_player("living_room", "Living Room")
+    cast("MagicMock", plugin.mass.players.all_players).return_value = [speaker]
+
+    state = await plugin.create_game(
+        source_uris=["library://playlist/1"],
+        playback_mode="venue",
+        venue_player_id="living_room",
+    )
+
+    game = plugin._game
+    assert game is not None
+    assert game.config.playback_mode == SharedPlaybackMode.VENUE
+    assert game.config.venue_player_id == "living_room"
+    assert game.config.venue_player_name == "Living Room"
+    assert state["mode"] == "venue"
+    assert state["playback"] == {
+        "mode": "venue",
+        "venue_player_id": "living_room",
+        "venue_player_name": "Living Room",
+    }
+    public_state = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]["state"]
+    info = await plugin.get_game_info()
+    assert "living_room" not in str(public_state)
+    assert "Living Room" not in str(public_state)
+    assert info is not None
+    assert "playback" not in info
+    assert "living_room" not in str(info)
+    cast("AsyncMock", plugin.mass.cache.set).assert_awaited_once_with(
+        PLAYBACK_PREFERENCE_CACHE_KEY,
+        {"playback_mode": "venue", "venue_player_id": "living_room"},
+        expiration=PLAYBACK_PREFERENCE_CACHE_EXPIRATION,
+        provider=INSTANCE_ID,
+        persistent=True,
+    )
+    session = MagicMock()
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.SharedPlaybackSession.create_venue",
+            new=AsyncMock(return_value=session),
+        ) as create_venue,
+        patch(
+            "music_assistant.providers.music_quiz.SharedPlaybackSession.create_remote",
+            new=AsyncMock(),
+        ) as create_remote,
+    ):
+        assert await plugin._get_playback_session() is session
+    create_venue.assert_awaited_once_with(plugin.mass, "living_room")
+    create_remote.assert_not_awaited()
+
+
+@pytest.mark.parametrize("venue_player_id", [None, "unknown", "unavailable"])
+@pytest.mark.asyncio
+async def test_invalid_explicit_venue_create_preserves_existing_game(
+    venue_player_id: str | None,
+) -> None:
+    """Reject missing or ineligible venue targets without mutating game state."""
+    plugin = _create_plugin()
+    valid_player = _make_venue_player("valid", "Valid")
+    unavailable_player = _make_venue_player("unavailable", "Unavailable", available=False)
+    cast("MagicMock", plugin.mass.players.all_players).return_value = [
+        valid_player,
+        unavailable_player,
+    ]
+    await plugin.create_game(
+        source_uris=["library://playlist/1"],
+        playback_mode="venue",
+        venue_player_id="valid",
+    )
+    existing_game = plugin._game
+    assert existing_game is not None
+    existing_state = existing_game.to_dict()
+    cast("AsyncMock", plugin.mass.cache.set).reset_mock()
+
+    with pytest.raises(MusicQuizNoPlaybackTargetError):
+        await plugin.create_game(
+            source_uris=["library://playlist/2"],
+            playback_mode="venue",
+            venue_player_id=venue_player_id,
+        )
+
+    assert plugin._game is existing_game
+    assert existing_game.to_dict() == existing_state
+    cast("AsyncMock", plugin.mass.cache.set).assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_venue_player_is_revalidated_before_game_publication() -> None:
+    """Keep a finished game when the selected player vanishes during creation."""
+    plugin = _create_plugin()
+    speaker = _make_venue_player("speaker", "Speaker")
+    cast("MagicMock", plugin.mass.players.all_players).return_value = [speaker]
+    await plugin.create_game(
+        source_uris=["library://playlist/1"],
+        playback_mode="venue",
+        venue_player_id="speaker",
+    )
+    existing_game = plugin._game
+    assert existing_game is not None
+    existing_game.phase = MusicQuizPhase.FINISHED
+    existing_state = existing_game.to_dict()
+    cast("AsyncMock", plugin.mass.cache.set).reset_mock()
+    cast("MagicMock", plugin.mass.players.all_players).side_effect = [[speaker], []]
+
+    with pytest.raises(MusicQuizNoPlaybackTargetError):
+        await plugin.create_game(
+            source_uris=["library://playlist/2"],
+            playback_mode="venue",
+            venue_player_id="speaker",
+        )
+
+    assert plugin._game is existing_game
+    assert existing_game.to_dict() == existing_state
+    cast("AsyncMock", plugin.mass.cache.set).assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_explicit_remote_ignores_player_and_keeps_it_private() -> None:
+    """Use remote game state while preserving the prior venue preference."""
+    plugin = _create_plugin(mode="venue", player="legacy_player")
+    speaker = _make_venue_player("legacy_player", "Legacy Room")
+    cast("MagicMock", plugin.mass.players.all_players).return_value = [speaker]
+    cast("AsyncMock", plugin.mass.cache.get).return_value = {
+        "playback_mode": "venue",
+        "venue_player_id": "legacy_player",
+    }
+
+    state = await plugin.create_game(
+        source_uris=["library://playlist/1"],
+        playback_mode="remote",
+        venue_player_id="untrusted-player",
+    )
+
+    game = plugin._game
+    assert game is not None
+    assert game.config.playback_mode == SharedPlaybackMode.REMOTE
+    assert game.config.venue_player_id is None
+    assert game.config.venue_player_name is None
+    assert state["playback"] == {
+        "mode": "remote",
+        "venue_player_id": None,
+        "venue_player_name": None,
+    }
+    public_state = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]["state"]
+    info = await plugin.get_game_info()
+    assert public_state["mode"] == "remote"
+    assert info is not None
+    assert info["mode"] == "remote"
+    assert "legacy_player" not in str(public_state)
+    assert "legacy_player" not in str(info)
+    cast("AsyncMock", plugin.mass.cache.set).assert_awaited_once_with(
+        PLAYBACK_PREFERENCE_CACHE_KEY,
+        {"playback_mode": "remote", "venue_player_id": "legacy_player"},
+        expiration=PLAYBACK_PREFERENCE_CACHE_EXPIRATION,
+        provider=INSTANCE_ID,
+        persistent=True,
+    )
+    session = MagicMock()
+    session.can_listen_in.return_value = True
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.SharedPlaybackSession.create_remote",
+            new=AsyncMock(return_value=session),
+        ) as create_remote,
+        patch(
+            "music_assistant.providers.music_quiz.SharedPlaybackSession.create_venue",
+            new=AsyncMock(),
+        ) as create_venue,
+        patch(
+            "music_assistant.providers.music_quiz.get_current_user",
+            return_value=_guest_user(),
+        ),
+    ):
+        assert await plugin.can_listen_in("web-player") is True
+    create_remote.assert_awaited_once()
+    create_venue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_omitted_playback_fields_use_safe_concrete_recommendation() -> None:
+    """Keep old create payloads compatible without retaining the auto sentinel."""
+    plugin = _create_plugin(mode="venue", player="__auto__")
+    beta = _make_venue_player("beta", "Beta")
+    alpha = _make_venue_player("alpha", "Alpha")
+    cast("MagicMock", plugin.mass.players.all_players).return_value = [beta, alpha]
+
+    await plugin.create_game(source_uris=["library://playlist/1"])
+
+    game = plugin._game
+    assert game is not None
+    assert game.config.playback_mode == SharedPlaybackMode.VENUE
+    assert game.config.venue_player_id == "alpha"
+    assert game.config.venue_player_name == "Alpha"
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_unknown_or_unavailable_playback_mode() -> None:
+    """Return localized create errors for invalid and unavailable modes."""
+    plugin = _create_plugin()
+    with pytest.raises(InvalidDataError) as invalid_mode:
+        await plugin.create_game(
+            source_uris=["library://playlist/1"],
+            playback_mode="surround",
+        )
+    assert invalid_mode.value.translation_key == "music_quiz_invalid_playback_mode"
+    assert plugin._game is None
+
+    cast("MagicMock", plugin.mass.get_provider).return_value = None
+    with pytest.raises(MusicQuizNoPlaybackTargetError):
+        await plugin.create_game(
+            source_uris=["library://playlist/1"],
+            playback_mode="remote",
+            venue_player_id="ignored",
+        )
+    assert plugin._game is None
+    cast("AsyncMock", plugin.mass.cache.set).assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("mode", "venue_player_id"),
+    [("venue", "venue_player"), ("remote", None)],
+)
+@pytest.mark.asyncio
+async def test_reset_preserves_game_playback_selection(
+    mode: str,
+    venue_player_id: str | None,
+) -> None:
+    """Keep mode and venue target unchanged when replaying a game."""
+    plugin = _create_plugin()
+
+    created = await plugin.create_game(
+        source_uris=["library://playlist/1"],
+        playback_mode=mode,
+        venue_player_id=venue_player_id,
+    )
+    reset = await plugin.reset()
+
+    game = plugin._game
+    assert game is not None
+    assert game.config.playback_mode.value == mode
+    assert game.config.venue_player_id == venue_player_id
+    assert reset["playback"] == created["playback"]
+
+
+@pytest.mark.asyncio
+async def test_replacing_game_with_different_playback_closes_previous_session() -> None:
+    """Tear down listeners before publishing a game on a different playback target."""
+    plugin = _create_plugin()
+    await plugin.create_game(
+        source_uris=["library://playlist/1"],
+        playback_mode="venue",
+        venue_player_id="venue_player",
+    )
+    previous_session = MagicMock()
+    previous_session.close = AsyncMock()
+    plugin._playback_session = previous_session
+
+    state = await plugin.create_game(
+        source_uris=["library://playlist/2"],
+        playback_mode="remote",
+    )
+
+    previous_session.close.assert_awaited_once()
+    assert vars(plugin)["_playback_session"] is None
+    assert state["playback"]["mode"] == "remote"
+
+
 @pytest.mark.parametrize(
     "username",
     [MUSIC_QUIZ_GUEST_USER, "party_guest", "temporary_guest"],
@@ -591,8 +1134,10 @@ async def test_guest_ready_advances_and_prefetches_in_system_context() -> None:
         plugin._get_playback_session = AsyncMock(  # type: ignore[method-assign]
             return_value=SimpleNamespace(queue_id="quiz_queue", player_id="quiz_player")
         )
-        cast("MagicMock", plugin.mass.players.get_player).return_value = SimpleNamespace(
-            extra_data={}
+        get_player = cast("MagicMock", plugin.mass.players.get_player)
+        get_player.side_effect = None
+        get_player.return_value = SimpleNamespace(
+            state=SimpleNamespace(available=True), extra_data={}
         )
         play_media = AsyncMock(side_effect=_play_media)
         cast("MagicMock", plugin.mass.player_queues).play_media = play_media
@@ -796,7 +1341,9 @@ async def test_final_guest_ready_stops_playback_in_system_context(
     plugin._stop_playback = MusicQuizPlugin._stop_playback.__get__(  # type: ignore[method-assign]
         plugin, MusicQuizPlugin
     )
-    cast("MagicMock", plugin.mass.players.get_player).return_value = SimpleNamespace()
+    get_player = cast("MagicMock", plugin.mass.players.get_player)
+    get_player.side_effect = None
+    get_player.return_value = SimpleNamespace()
     stop = AsyncMock(side_effect=_stop)
     cast("MagicMock", plugin.mass.player_queues).stop = stop
     requesting_user = cast("User", _guest_user())
@@ -831,8 +1378,10 @@ async def test_play_track_rejects_busy_announcement_target() -> None:
     plugin._get_playback_session = AsyncMock(  # type: ignore[method-assign]
         return_value=SimpleNamespace(queue_id="quiz_queue", player_id="quiz_player")
     )
-    cast("MagicMock", plugin.mass.players.get_player).return_value = SimpleNamespace(
-        extra_data={"announcement_in_progress": True}
+    get_player = cast("MagicMock", plugin.mass.players.get_player)
+    get_player.side_effect = None
+    get_player.return_value = SimpleNamespace(
+        state=SimpleNamespace(available=True), extra_data={"announcement_in_progress": True}
     )
     play_media = AsyncMock()
     cast("MagicMock", plugin.mass.player_queues).play_media = play_media
@@ -1290,7 +1839,9 @@ async def test_cancelled_remote_reveal_adopts_created_session_before_advancing()
     session.queue_id = "virtual-quiz-player"
     play_media = AsyncMock()
     cast("MagicMock", plugin.mass.player_queues).play_media = play_media
-    cast("MagicMock", plugin.mass.players.get_player).return_value = SimpleNamespace(extra_data={})
+    get_player = cast("MagicMock", plugin.mass.players.get_player)
+    get_player.side_effect = None
+    get_player.return_value = SimpleNamespace(extra_data={})
     plugin._play_track = MusicQuizPlugin._play_track.__get__(  # type: ignore[method-assign]
         plugin, MusicQuizPlugin
     )
@@ -4292,7 +4843,8 @@ async def test_config_validation() -> None:
 async def test_playback_session_remote_mode() -> None:
     """Remote mode creates a virtual-player session keyed to the instance."""
     plugin = _create_plugin(mode="remote")
-    plugin._game = _fake_game()
+    plugin._game = _fake_game(SharedPlaybackMode.REMOTE, None)
+    cast("MagicMock", plugin.mass).players.get_player.side_effect = None
     cast("MagicMock", plugin.mass).players.get_player.return_value = None
     session = MagicMock()
     with patch(
@@ -4312,11 +4864,12 @@ async def test_playback_session_remote_mode() -> None:
 async def test_playback_session_recreated_when_player_vanished() -> None:
     """A session whose player disappeared (e.g. sendspin reload) is recreated."""
     plugin = _create_plugin(mode="remote")
-    plugin._game = _fake_game()
+    plugin._game = _fake_game(SharedPlaybackMode.REMOTE, None)
     stale_session = MagicMock()
     stale_session.player_id = "gone"
     stale_session.close = AsyncMock()
     plugin._playback_session = stale_session
+    cast("MagicMock", plugin.mass).players.get_player.side_effect = None
     cast("MagicMock", plugin.mass).players.get_player.return_value = None
     fresh_session = MagicMock()
     with patch(
@@ -4342,33 +4895,73 @@ async def test_playback_session_venue_mode() -> None:
 
 
 @pytest.mark.asyncio
-async def test_playback_session_venue_mode_auto_prefers_playing_player() -> None:
-    """Venue mode with the auto player picks a currently playing player."""
-    plugin = _create_plugin(mode="venue", player="__auto__")
-    plugin._game = _fake_game()
-    paused = SimpleNamespace(player_id="paused_player", playback_state=PlaybackState.PAUSED)
-    playing = SimpleNamespace(player_id="playing_player", playback_state=PlaybackState.PLAYING)
-    cast("MagicMock", plugin.mass).players.all_players.return_value = [paused, playing]
+async def test_playback_session_venue_mode_never_switches_to_active_player() -> None:
+    """A selected venue player never changes based on current playback activity."""
+    plugin = _create_plugin(mode="venue", player="selected_player")
+    plugin._game = _fake_game(venue_player_id="selected_player")
+    selected = _make_venue_player("selected_player", "Selected", playback_state=PlaybackState.IDLE)
+    playing = _make_venue_player(
+        "playing_player",
+        "Playing",
+        playback_state=PlaybackState.PLAYING,
+    )
+    cast("MagicMock", plugin.mass).players.all_players.return_value = [playing, selected]
     session = MagicMock()
     with patch(
         "music_assistant.providers.music_quiz.SharedPlaybackSession.create_venue",
         new=AsyncMock(return_value=session),
     ) as create_venue:
         assert await plugin._get_playback_session() is session
-    create_venue.assert_awaited_once_with(plugin.mass, "playing_player")
+    create_venue.assert_awaited_once_with(plugin.mass, "selected_player")
 
 
 @pytest.mark.asyncio
-async def test_playback_session_venue_mode_auto_without_players() -> None:
-    """Venue mode with the auto player yields no session when no player is available."""
-    plugin = _create_plugin(mode="venue", player="__auto__")
-    plugin._game = _fake_game()
+async def test_playback_session_venue_mode_missing_selected_player_has_no_fallback() -> None:
+    """A vanished selected player yields no session instead of changing rooms."""
+    plugin = _create_plugin(mode="venue", player="selected_player")
+    plugin._game = _fake_game(venue_player_id="selected_player")
     cast("MagicMock", plugin.mass).players.all_players.return_value = []
     with patch(
         "music_assistant.providers.music_quiz.SharedPlaybackSession.create_venue",
         new=AsyncMock(),
     ) as create_venue:
         assert await plugin._get_playback_session() is None
+    create_venue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_selected_venue_player_disappearing_keeps_game_recoverable() -> None:
+    """Fail round start without silently moving an existing game to another room."""
+    plugin = _create_plugin()
+    selected = _make_venue_player("selected", "Selected")
+    fallback = _make_venue_player("fallback", "Fallback")
+    cast("MagicMock", plugin.mass.players.all_players).return_value = [selected, fallback]
+    await plugin.create_game(
+        round_count=1,
+        source_uris=["library://playlist/1"],
+        playback_mode="venue",
+        venue_player_id="selected",
+    )
+    game = plugin._game
+    assert game is not None
+    cast("MagicMock", plugin.mass.players.all_players).return_value = [fallback]
+    plugin._play_track = MusicQuizPlugin._play_track.__get__(  # type: ignore[method-assign]
+        plugin,
+        MusicQuizPlugin,
+    )
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.SharedPlaybackSession.create_venue",
+            new=AsyncMock(),
+        ) as create_venue,
+        pytest.raises(MusicQuizNoPlaybackTargetError),
+    ):
+        await plugin.start_game()
+
+    assert game.phase == MusicQuizPhase.LOBBY
+    assert game.rounds == []
+    assert game.config.venue_player_id == "selected"
     create_venue.assert_not_awaited()
 
 
@@ -4389,8 +4982,13 @@ async def test_playback_session_requires_active_game() -> None:
 async def test_listen_in_joins_session_under_playback_lock() -> None:
     """listen_in joins the guest while holding the playback lock so teardown cannot race it."""
     plugin = _create_plugin(mode="remote")
-    plugin._game = _fake_game()
+    plugin._game = _fake_game(SharedPlaybackMode.REMOTE, None)
     session = MagicMock()
+    session.player_id = "remote-player"
+    session.close = AsyncMock()
+    get_player = cast("MagicMock", plugin.mass.players.get_player)
+    get_player.side_effect = None
+    get_player.return_value = MagicMock()
 
     async def _assert_locked(_web_player_id: str) -> None:
         assert plugin._playback_lock.locked()
@@ -4402,6 +5000,30 @@ async def test_listen_in_joins_session_under_playback_lock() -> None:
         return_value=SimpleNamespace(username=MUSIC_QUIZ_GUEST_USER, role=UserRole.GUEST),
     ):
         await plugin.listen_in("web-1")
+    session.add_guest_listener.assert_awaited_once_with("web-1")
+
+
+@pytest.mark.asyncio
+async def test_venue_listen_in_does_not_depend_on_guest_player_filter() -> None:
+    """Keep the selected venue target valid when guest topology is filtered."""
+    plugin = _create_plugin()
+    plugin._game = _fake_game(venue_player_id="venue-player")
+    cast("MagicMock", plugin.mass.players.all_players).return_value = []
+    selected = _make_venue_player("venue-player", "Venue")
+    get_player = cast("MagicMock", plugin.mass.players.get_player)
+    get_player.side_effect = None
+    get_player.return_value = selected
+    session = MagicMock()
+    session.player_id = "venue-player"
+    session.add_guest_listener = AsyncMock()
+    plugin._playback_session = session
+
+    with patch(
+        "music_assistant.providers.music_quiz.get_current_user",
+        return_value=_guest_user(),
+    ):
+        await plugin.listen_in("web-1")
+
     session.add_guest_listener.assert_awaited_once_with("web-1")
 
 
@@ -4441,14 +5063,14 @@ async def test_create_game_rejects_invalid_difficulty() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_config_entries_includes_ai_distractor_toggle() -> None:
-    """The provider exposes an off-by-default AI distractor toggle."""
+async def test_get_config_entries_only_exposes_provider_level_settings() -> None:
+    """Keep per-game playback choices out of provider configuration."""
     mass = MagicMock()
-    mass.players.all_players.return_value = []
 
     entries = await get_config_entries(mass)
 
-    ai_entry = next(entry for entry in entries if entry.key == "use_ai_distractors")
+    assert [entry.key for entry in entries] == ["use_ai_distractors"]
+    ai_entry = entries[0]
     assert ai_entry.type == ConfigEntryType.BOOLEAN
     assert ai_entry.default_value is False
     assert ai_entry.required is False


### PR DESCRIPTION
# What does this implement/fix?

Moves Music Quiz playback mode and venue speaker selection into each game's setup, preventing unrelated active players from being selected automatically.

- Adds host playback discovery and explicit game creation options.
- Validates and stores each game's selected playback target.
- Remembers successful choices while migrating hidden legacy settings.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
