### PR TITLE
Improve smart shuffle variety

### DIFF
--- a/music_assistant/controllers/player_queues/helpers.py
+++ b/music_assistant/controllers/player_queues/helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import random
 from collections.abc import Awaitable, Callable, Coroutine
 from typing import TYPE_CHECKING, Any, Concatenate, Protocol, TypedDict, TypeVar
 
@@ -165,6 +166,21 @@ def get_current_playback_speed(queue: PlayerQueue) -> float:
     if queue.current_item is None:
         return 1.0
     return float(queue.current_item.extra_attributes.get("playback_speed") or 1.0)
+
+
+def interleave_groups[ItemT](groups: list[list[ItemT]]) -> list[ItemT]:
+    """
+    Randomly interleave groups while preserving the item order within each group.
+
+    :param groups: The ordered item groups to spread across the result.
+    """
+    positioned: list[tuple[float, ItemT]] = []
+    for items in groups:
+        total = len(items)
+        for offset, item in enumerate(items):
+            positioned.append(((offset + random.random()) / total, item))
+    positioned.sort(key=lambda entry: entry[0])
+    return [item for _, item in positioned]
 
 
 # how many bounded passes to make separating directly-adjacent same-artist items

--- a/music_assistant/controllers/player_queues/managed_pool.py
+++ b/music_assistant/controllers/player_queues/managed_pool.py
@@ -18,10 +18,9 @@ source more than once weights it up) and gates every candidate against the share
 so a recently-heard track isn't pulled back in. A dynamic batch is offered least-recently-played
 first and de-prioritizes tracks whose artist is within the artist-recency window (a soft nudge, not
 a hard exclusion, so a single-artist station still plays); a finite source keeps its own
-(materialized) order so it plays through coherently. Once the batch is assembled it is passed
-through a seam-aware artist-spacing pass that best-effort keeps directly-adjacent tracks from
-sharing an artist, and the first added track is kept clear of the currently-queued tail's last
-artist.
+(materialized) order so it plays through coherently. The selected source groups are randomly
+interleaved across the batch before a seam-aware artist-spacing pass best-effort keeps
+directly-adjacent tracks from sharing an artist, including the currently-queued tail's last artist.
 """
 
 from __future__ import annotations
@@ -40,7 +39,7 @@ from music_assistant.controllers.player_queues.constants import (
     MANAGED_POOL_SOURCE_CAP,
     MANAGED_POOL_TARGET,
 )
-from music_assistant.controllers.player_queues.helpers import space_by_artist
+from music_assistant.controllers.player_queues.helpers import interleave_groups, space_by_artist
 from music_assistant.helpers.track_filter import track_filter
 
 if TYPE_CHECKING:
@@ -377,8 +376,9 @@ def allocate_refill(
     the recency snapshot (a within-window track is excluded entirely). A dynamic batch is ordered
     least-recently-played first and de-prioritizes recently-heard artists; a finite (TRACKS) source
     keeps its own materialized order. If gating leaves nothing, an ungated least-recently-played
-    fallback is returned so playback never stalls. The assembled batch is finally spaced so no two
-    adjacent tracks share an artist.
+    fallback is returned so playback never stalls. The selected source groups are randomly
+    interleaved while retaining each source's candidate order, then spaced so no two adjacent tracks
+    share an artist.
 
     :param sources: The queue's dynamic sources, each with its already-fetched candidate tracks.
     :param slots: How many tracks to add (0 or fewer returns nothing).
@@ -402,7 +402,7 @@ def allocate_refill(
     shares = [slots * (weight or 0) / total_weight for weight in weights]
     taken = [0.0] * len(sources)
     pointers = [0] * len(sources)
-    chosen: list[Track] = []
+    chosen_by_source: list[list[Track]] = [[] for _ in sources]
     chosen_set: set[Track] = set()
     chosen_song_keys: set[tuple[str, str]] = set()
     for _ in range(slots):
@@ -424,12 +424,16 @@ def allocate_refill(
         if best_index == -1:
             break
         track = eligible[best_index][pointers[best_index]]
-        chosen.append(track)
+        chosen_by_source[best_index].append(track)
         chosen_set.add(track)
         chosen_song_keys.update(song_keys(track))
         taken[best_index] += 1
         pointers[best_index] += 1
-    batch = chosen or _ungated_fallback(sources, slots, pool_keys, pool_song_keys, snapshot)
+    batch = (
+        interleave_groups(chosen_by_source)
+        if chosen_set
+        else _ungated_fallback(sources, slots, pool_keys, pool_song_keys, snapshot)
+    )
     return _space_tracks(batch, preceding_artists)
 
 

--- a/music_assistant/controllers/player_queues/smart_shuffle.py
+++ b/music_assistant/controllers/player_queues/smart_shuffle.py
@@ -10,9 +10,9 @@ shuffle in the controller.
 The algorithm works in two stages:
 - recency tiering: each item is fresh / artist-recently-played / song-recently-played, where a
   deliberately-duplicated song uses the short duplicate repeat-gap instead of the long song window;
-- within-tier interleave: each distinct song's copies are placed at evenly-spaced fractional
-  positions with a random phase so duplicates spread across the whole span without clustering, then
-  a bounded pass separates directly-adjacent same-artist items.
+- within-tier interleave: each distinct song's copies get independently randomized positions in
+  evenly-spaced strata, so duplicates stay spread without repeating the same sequence, then a
+  bounded pass separates directly-adjacent same-artist items.
 """
 
 from __future__ import annotations
@@ -36,7 +36,7 @@ from music_assistant.controllers.player_queues.constants import (
     SMART_SHUFFLE_DUPLICATE_GAP_DEFAULT,
     SMART_SHUFFLE_SONG_RECENCY_DEFAULT,
 )
-from music_assistant.controllers.player_queues.helpers import space_by_artist
+from music_assistant.controllers.player_queues.helpers import interleave_groups, space_by_artist
 
 if TYPE_CHECKING:
     from music_assistant_models.player_queue import PlayerQueue
@@ -155,18 +155,11 @@ def _tier(
 
 
 def _interleave(bucket: list[QueueItem]) -> list[QueueItem]:
-    """Spread each distinct song's copies evenly with a random phase so groups don't clump."""
+    """Spread each distinct song's copies with independently randomized repeat cycles."""
     groups: dict[tuple[str, str], list[QueueItem]] = defaultdict(list)
     for item in bucket:
         groups[_song_key(item)].append(item)
-    positioned: list[tuple[float, QueueItem]] = []
-    for copies in groups.values():
-        phase = random.random()
-        total = len(copies)
-        for offset, item in enumerate(copies):
-            positioned.append(((phase + offset / total) % 1.0, item))
-    positioned.sort(key=lambda entry: entry[0])
-    return [item for _, item in positioned]
+    return interleave_groups(list(groups.values()))
 
 
 def _space_artists(items: list[QueueItem], *, preceding: set[str] | None = None) -> list[QueueItem]:

--- a/tests/controllers/player_queues/test_managed_pool.py
+++ b/tests/controllers/player_queues/test_managed_pool.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import random
 from collections import Counter
+from itertools import groupby
 
 from music_assistant_models.enums import MediaType
 from music_assistant_models.media_items import ItemMapping, ProviderMapping, Track
@@ -183,6 +185,23 @@ def test_multiplicity_increases_share() -> None:
     assert counts["a"] == 2
 
 
+def test_weighted_sources_are_spread_across_batch() -> None:
+    """A higher-weight source is mixed through the batch instead of emitted as one block."""
+    sources = [
+        _source([f"a{i}" for i in range(20)]),
+        _source([f"b{i}" for i in range(20)], multiplicity=2),
+        _source([f"c{i}" for i in range(20)]),
+        _source([f"d{i}" for i in range(20)]),
+    ]
+    random.seed(0)
+    result = allocate_refill(
+        sources, slots=25, pool_keys=set(), snapshot=_snapshot(), windows=RecencyWindows()
+    )
+    source_ids = [track.item_id[0] for track in result]
+    longest_run = max(sum(1 for _ in run) for _, run in groupby(source_ids))
+    assert longest_run <= 2
+
+
 def test_size_multiplicity_weights_by_catalogue_size() -> None:
     """Under SIZE_MULTIPLICITY, the larger-catalogue source dominates the pool."""
     sources = [
@@ -327,21 +346,28 @@ def test_all_gated_falls_back_ungated() -> None:
     assert _ids(result) == ["c", "b"]
 
 
-def test_deterministic() -> None:
-    """Same inputs yield an identical allocation (the allocator uses no randomness)."""
+def test_randomized_order_is_reproducible_under_seed() -> None:
+    """A fixed seed reproduces the interleave while a different seed varies it."""
     sources = [
         _source([f"a{i}" for i in range(10)], multiplicity=2),
         _source([f"b{i}" for i in range(10)]),
     ]
     snapshot = _snapshot({"a3": NOW - 10, "b1": NOW - 20})
     windows = RecencyWindows(song_seconds=WEEK, duplicate_gap_seconds=GAP)
+    random.seed(123)
     first = _ids(
         allocate_refill(sources, slots=6, pool_keys=set(), snapshot=snapshot, windows=windows)
     )
+    random.seed(123)
     second = _ids(
         allocate_refill(sources, slots=6, pool_keys=set(), snapshot=snapshot, windows=windows)
     )
+    random.seed(124)
+    third = _ids(
+        allocate_refill(sources, slots=6, pool_keys=set(), snapshot=snapshot, windows=windows)
+    )
     assert first == second
+    assert first != third
 
 
 def test_gate_tracks_drops_recent() -> None:

--- a/tests/controllers/player_queues/test_smart_shuffle.py
+++ b/tests/controllers/player_queues/test_smart_shuffle.py
@@ -101,6 +101,25 @@ def test_duplicates_spread_not_bursted() -> None:
         assert all(positions[i + 1] - positions[i] >= 2 for i in range(len(positions) - 1))
 
 
+def test_duplicate_rounds_have_independent_order() -> None:
+    """Equally frequent songs do not repeat the same sequence on every pass."""
+    song_ids = ("a", "b", "c", "d", "e")
+    items = [
+        _item(song_id, artist=song_id, qiid=f"{song_id}-{copy}")
+        for song_id in song_ids
+        for copy in range(4)
+    ]
+    random.seed(0)
+    result = _arrange(items, _snapshot(), RecencyWindows())
+    sequence = [_song_id(item) for item in result]
+    rounds = [
+        tuple(sequence[offset : offset + len(song_ids)])
+        for offset in range(0, len(sequence), len(song_ids))
+    ]
+    assert all(set(round_) == set(song_ids) for round_ in rounds)
+    assert len(set(rounds)) > 1
+
+
 def test_recent_singletons_pushed_to_back() -> None:
     """Recently-played singletons sort behind fresh ones."""
     recent = [_item(f"r{i}", artist=f"R{i}") for i in range(6)]


### PR DESCRIPTION
# What does this implement/fix?

Smart shuffle could repeat weighted tracks in predictable blocks.

- Vary duplicate-track order between repeat cycles.
- Spread weighted dynamic sources throughout each refill.
- Keep existing recency limits and source weighting.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.