### PR TITLE
Improve Trivia question reliability

### DIFF
--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import random
 import re
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import TYPE_CHECKING
@@ -38,8 +39,8 @@ from music_assistant.providers.music_quiz.quiz_types.base import (
 )
 from music_assistant.providers.music_quiz.suggestions import (
     SuggestionCandidate,
-    answer_labels_are_too_close,
     build_suggestions,
+    filter_suggestion_candidates,
     normalize_answer_label,
 )
 
@@ -285,6 +286,8 @@ class TriviaQuizType(QuizType):
         prompt = self._build_prompt(fact)
         if len(prompt.encode("utf-8")) > MAX_AI_PROMPT_BYTES:
             raise self._generation_error()
+        grounded_tracks = list(self._eligible_tracks.values()) if self._eligible_tracks else []
+        SYSTEM_RANDOM.shuffle(grounded_tracks)
         for provider in self._require_ai_providers():
             for _attempt in range(AI_ATTEMPTS_PER_PROVIDER):
                 try:
@@ -298,7 +301,7 @@ class TriviaQuizType(QuizType):
                     )
                     continue
                 try:
-                    return self._parse_generation(response, fact)
+                    return self._parse_generation(response, fact, grounded_tracks)
                 except (TypeError, ValueError) as err:
                     LOGGER.debug(
                         "Trivia provider %s returned an invalid response: %s",
@@ -369,7 +372,12 @@ class TriviaQuizType(QuizType):
             "END_UNTRUSTED_MUSIC_METADATA_JSON"
         )
 
-    def _parse_generation(self, response: object, fact: TriviaFact) -> TriviaGeneration:
+    def _parse_generation(
+        self,
+        response: object,
+        fact: TriviaFact,
+        grounded_tracks: Sequence[TriviaTrackFacts] = (),
+    ) -> TriviaGeneration:
         """Parse and validate one strict AI Trivia response."""
         if not isinstance(response, str):
             raise TypeError("response must be a string")
@@ -410,13 +418,11 @@ class TriviaQuizType(QuizType):
                 raise ValueError("wrong answer exceeds the length limit")
             if "\n" in answer or "\r" in answer:
                 raise ValueError("wrong answers must be single-line strings")
-            if any(
-                answer_labels_are_too_close(answer, existing_answer)
-                for existing_answer in (fact.correct_answer, *parsed_answers)
-            ):
-                raise ValueError("wrong answers must be distinct from every answer")
             parsed_answers.append(answer)
-        return TriviaGeneration(question=question, wrong_answers=tuple(parsed_answers))
+        return TriviaGeneration(
+            question=question,
+            wrong_answers=self._repair_wrong_answers(parsed_answers, fact, grounded_tracks),
+        )
 
     def _select_fact(self, track: TriviaTrackFacts, round_index: int) -> TriviaFact:
         """Select a supported factual target deterministically for a round."""
@@ -424,18 +430,51 @@ class TriviaQuizType(QuizType):
         if not targets:
             raise InvalidDataError("Trivia track has no supported factual targets")
         target = targets[round_index % len(targets)]
+        correct_answer = self._target_value(track, target)
+        assert correct_answer is not None
+        return TriviaFact(target=target, correct_answer=correct_answer, track=track)
+
+    @classmethod
+    def _repair_wrong_answers(
+        cls,
+        wrong_answers: Sequence[str],
+        fact: TriviaFact,
+        grounded_tracks: Sequence[TriviaTrackFacts],
+    ) -> tuple[str, ...]:
+        """Return distinct wrong answers completed with same-target grounded facts."""
+
+        def iter_candidates() -> Iterator[SuggestionCandidate]:
+            for answer in wrong_answers:
+                yield SuggestionCandidate(label=answer)
+            for track in grounded_tracks:
+                if (value := cls._target_value(track, fact.target)) is not None:
+                    yield SuggestionCandidate(label=value)
+
+        expected_count = len(wrong_answers)
+        candidates = filter_suggestion_candidates(
+            SuggestionCandidate(label=fact.correct_answer),
+            iter_candidates(),
+            limit=expected_count,
+        )
+        if len(candidates) != expected_count:
+            raise ValueError("wrong answers could not be completed from grounded metadata")
+        return tuple(candidate.label for candidate in candidates)
+
+    @staticmethod
+    def _target_value(track: TriviaTrackFacts, target: TriviaTarget) -> str | None:
+        """Return the available value for one Trivia target."""
+        if target not in TriviaQuizType._available_targets(track):
+            return None
         if target == TriviaTarget.ARTIST:
             assert track.artist is not None
-            correct_answer = track.artist
-        elif target == TriviaTarget.TITLE:
-            correct_answer = track.title
-        elif target == TriviaTarget.ALBUM:
+            return track.artist
+        if target == TriviaTarget.TITLE:
+            return track.title
+        if target == TriviaTarget.ALBUM:
             assert track.album is not None
-            correct_answer = track.album
-        else:
-            assert track.release_year is not None
-            correct_answer = str(track.release_year)
-        return TriviaFact(target=target, correct_answer=correct_answer, track=track)
+            return track.album
+        assert track.release_year is not None
+        return str(track.release_year)
 
     def _used_source_uris(self, previous_rounds: list[MusicQuizRound]) -> set[str]:
         """Return source URIs persisted in validated Trivia round history."""

--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -10,9 +10,12 @@ from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
-from music_assistant_models.enums import ProviderFeature
+from music_assistant_models.enums import AlbumType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError
+from music_assistant_models.media_items import Album
 
+from music_assistant.constants import VARIOUS_ARTISTS_MBID, VARIOUS_ARTISTS_NAME
+from music_assistant.helpers.compare import compare_strings
 from music_assistant.helpers.json import (
     JSON_DECODE_EXCEPTIONS,
     SerializableType,
@@ -479,13 +482,18 @@ class TriviaQuizType(QuizType):
         if not track.uri or not (title := _bounded_metadata_value(track.name)):
             return None
         artist = _bounded_metadata_value(track.artist_str or None)
-        album = _bounded_metadata_value(track.album.name if track.album else None)
+        album = track.album
+        untrusted_compilation = isinstance(album, Album) and _is_untrusted_compilation_album(album)
         facts = TriviaTrackFacts(
             source_uri=track.uri,
             title=title,
             artist=artist,
-            album=album,
-            release_year=get_track_release_year(track),
+            album=(
+                None
+                if untrusted_compilation
+                else _bounded_metadata_value(album.name if album else None)
+            ),
+            release_year=None if untrusted_compilation else get_track_release_year(track),
         )
         return facts if TriviaQuizType._available_targets(facts) else None
 
@@ -527,6 +535,21 @@ def _bounded_metadata_value(value: str | None) -> str | None:
     if not value or not (cleaned := value.strip()):
         return None
     return cleaned if len(cleaned) <= MAX_METADATA_VALUE_LENGTH else None
+
+
+def _is_untrusted_compilation_album(album: Album) -> bool:
+    """
+    Return whether Trivia must omit release facts supplied with an album.
+
+    :param album: Full album metadata attached to a selected Trivia track.
+    """
+    if album.album_type == AlbumType.COMPILATION:
+        return True
+    return any(
+        artist.mbid == VARIOUS_ARTISTS_MBID
+        or compare_strings(artist.name, VARIOUS_ARTISTS_NAME, strict=False)
+        for artist in album.artists
+    )
 
 
 def _normalize_trivia_language(language: str) -> str:

--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import random
 import re
-from collections.abc import Iterator, Sequence
+from collections.abc import Collection, Iterator, Sequence
 from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import TYPE_CHECKING
@@ -286,8 +286,7 @@ class TriviaQuizType(QuizType):
         prompt = self._build_prompt(fact)
         if len(prompt.encode("utf-8")) > MAX_AI_PROMPT_BYTES:
             raise self._generation_error()
-        grounded_tracks = list(self._eligible_tracks.values()) if self._eligible_tracks else []
-        SYSTEM_RANDOM.shuffle(grounded_tracks)
+        grounded_tracks = self._eligible_tracks.values() if self._eligible_tracks else ()
         for provider in self._require_ai_providers():
             for _attempt in range(AI_ATTEMPTS_PER_PROVIDER):
                 try:
@@ -376,7 +375,7 @@ class TriviaQuizType(QuizType):
         self,
         response: object,
         fact: TriviaFact,
-        grounded_tracks: Sequence[TriviaTrackFacts] = (),
+        grounded_tracks: Collection[TriviaTrackFacts] = (),
     ) -> TriviaGeneration:
         """Parse and validate one strict AI Trivia response."""
         if not isinstance(response, str):
@@ -439,20 +438,38 @@ class TriviaQuizType(QuizType):
         cls,
         wrong_answers: Sequence[str],
         fact: TriviaFact,
-        grounded_tracks: Sequence[TriviaTrackFacts],
+        grounded_tracks: Collection[TriviaTrackFacts],
     ) -> tuple[str, ...]:
         """Return distinct wrong answers completed with same-target grounded facts."""
+        expected_count = len(wrong_answers)
+        correct = SuggestionCandidate(label=fact.correct_answer)
+        candidates = filter_suggestion_candidates(
+            correct,
+            (SuggestionCandidate(label=answer) for answer in wrong_answers),
+            limit=expected_count,
+        )
+        if len(candidates) == expected_count:
+            return tuple(candidate.label for candidate in candidates)
+
+        grounded_values: list[str] = []
+        seen_values: set[str] = set()
+        for track in grounded_tracks:
+            if (value := cls._target_value(track, fact.target)) is None:
+                continue
+            normalized_value = normalize_answer_label(value)
+            if not normalized_value or normalized_value in seen_values:
+                continue
+            seen_values.add(normalized_value)
+            grounded_values.append(value)
+        SYSTEM_RANDOM.shuffle(grounded_values)
 
         def iter_candidates() -> Iterator[SuggestionCandidate]:
-            for answer in wrong_answers:
-                yield SuggestionCandidate(label=answer)
-            for track in grounded_tracks:
-                if (value := cls._target_value(track, fact.target)) is not None:
-                    yield SuggestionCandidate(label=value)
+            yield from candidates
+            for value in grounded_values:
+                yield SuggestionCandidate(label=value)
 
-        expected_count = len(wrong_answers)
         candidates = filter_suggestion_candidates(
-            SuggestionCandidate(label=fact.correct_answer),
+            correct,
             iter_candidates(),
             limit=expected_count,
         )

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -245,6 +245,33 @@ def _all_facts() -> TriviaTrackFacts:
     )
 
 
+def _grounded_fallback_facts() -> tuple[TriviaTrackFacts, ...]:
+    """Return distinct bounded facts supporting every Trivia target."""
+    return (
+        TriviaTrackFacts(
+            source_uri="prov://track/genesis",
+            title="Genesis",
+            artist="Justice",
+            album="Cross",
+            release_year=2007,
+        ),
+        TriviaTrackFacts(
+            source_uri="prov://track/midnight-city",
+            title="Midnight City",
+            artist="M83",
+            album="Hurry Up, We're Dreaming",
+            release_year=2011,
+        ),
+        TriviaTrackFacts(
+            source_uri="prov://track/roads",
+            title="Roads",
+            artist="Portishead",
+            album="Dummy",
+            release_year=1994,
+        ),
+    )
+
+
 def _artist_fact() -> TriviaFact:
     """Return a server-selected artist fact for parser and prompt tests."""
     return TriviaFact(
@@ -990,6 +1017,279 @@ def test_strict_generation_parser_accepts_exact_valid_shape() -> None:
         question="Which artist recorded this selected track?",
         wrong_answers=("Portishead", "Radiohead", "Air"),
     )
+
+
+@pytest.mark.asyncio
+async def test_generation_repairs_duplicate_answers_from_cached_grounding() -> None:
+    """Keep valid AI answers and fill duplicate slots without another AI or source call."""
+    tracks = [
+        _track("correct", "Teardrop", "Massive Attack"),
+        _track("fallback-1", "Roads", "Portishead"),
+        _track("fallback-2", "All I Need", "Air"),
+        _track("fallback-3", "Hell Is Round the Corner", "Tricky"),
+    ]
+    provider = _ai_provider(
+        _valid_response(
+            wrong_answers=["Massive Attack", "Radiohead", "radio-head"],
+        )
+    )
+    quiz, mass = _quiz(tracks, providers=[provider])
+    mass.music.albums.get = AsyncMock()
+    mass.music.tracks.get = AsyncMock()
+    facts_by_uri = await quiz._get_eligible_tracks()
+    assert tracks[0].uri is not None
+    fact = TriviaFact(TriviaTarget.ARTIST, "Massive Attack", facts_by_uri[tracks[0].uri])
+
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types.trivia.SYSTEM_RANDOM.shuffle",
+        side_effect=lambda _tracks: None,
+    ) as shuffle:
+        result = await quiz._generate_question(fact)
+
+    assert result.wrong_answers == ("Radiohead", "Portishead", "Air")
+    provider.ai_query.assert_awaited_once()
+    shuffle.assert_called_once()
+    prompt = provider.ai_query.await_args.args[0]
+    assert "Portishead" not in prompt
+    assert "Air" not in prompt
+    assert "Tricky" not in prompt
+    mass.music.albums.get.assert_not_awaited()
+    mass.music.tracks.get.assert_not_awaited()
+    mass.music.search.assert_not_awaited()
+
+
+def test_generation_repair_skips_normalized_near_and_fallback_collisions() -> None:
+    """Continue scanning grounded facts after normalized and near-answer collisions."""
+    quiz, _ = _quiz([])
+    colliding_facts = tuple(
+        replace(
+            _all_facts(),
+            source_uri=f"prov://track/{index}",
+            artist=artist,
+        )
+        for index, artist in enumerate(
+            ["PORTISHEAD!", "Portishead Live at Roseland", "Radiohead", "Air"]
+        )
+    )
+    response = _valid_response(
+        wrong_answers=["massive-attack", "Portishead", "Portishead Live"],
+    )
+
+    result = quiz._parse_generation(response, _artist_fact(), colliding_facts)
+
+    assert result.wrong_answers == ("Portishead", "Radiohead", "Air")
+
+
+@pytest.mark.parametrize(
+    ("target", "correct_answer", "expected"),
+    [
+        (TriviaTarget.ARTIST, "Massive Attack", ("Justice", "M83", "Portishead")),
+        (TriviaTarget.TITLE, "Teardrop", ("Genesis", "Midnight City", "Roads")),
+        (
+            TriviaTarget.ALBUM,
+            "Mezzanine",
+            ("Cross", "Hurry Up, We're Dreaming", "Dummy"),
+        ),
+        (TriviaTarget.YEAR, "1998", ("2007", "2011", "1994")),
+    ],
+)
+def test_generation_repair_uses_only_same_target_grounding(
+    target: TriviaTarget,
+    correct_answer: str,
+    expected: tuple[str, ...],
+) -> None:
+    """Fill every Trivia target only from grounded values of that target."""
+    quiz, _ = _quiz([])
+    fact = TriviaFact(target, correct_answer, _all_facts())
+    response = _valid_response(
+        question="Which answer matches the selected metadata?",
+        wrong_answers=[correct_answer, correct_answer.upper(), correct_answer],
+    )
+
+    result = quiz._parse_generation(response, fact, _grounded_fallback_facts())
+
+    assert result.wrong_answers == expected
+
+
+@pytest.mark.parametrize(
+    ("target", "correct_answer", "excluded_value", "expected"),
+    [
+        (
+            TriviaTarget.ALBUM,
+            "Mezzanine",
+            "Party Hits 13",
+            ("Cross", "Hurry Up, We're Dreaming", "Dummy"),
+        ),
+        (TriviaTarget.YEAR, "1998", "2012", ("2007", "2011", "1994")),
+    ],
+)
+def test_generation_repair_excludes_compilation_release_facts(
+    target: TriviaTarget,
+    correct_answer: str,
+    excluded_value: str,
+    expected: tuple[str, ...],
+) -> None:
+    """Keep compilation-suppressed album and year values out of grounded fallback."""
+    compilation = _track(
+        "compilation-fallback",
+        "Everlasting Love",
+        "Sandra",
+        release_year=2012,
+    )
+    compilation.album = _full_album(
+        "party-hits-13",
+        "Party Hits 13",
+        album_type=AlbumType.COMPILATION,
+        year=2012,
+    )
+    compilation_facts = TriviaQuizType._track_facts(compilation)
+    assert compilation_facts is not None
+    response = _valid_response(
+        question="Which answer matches the selected metadata?",
+        wrong_answers=[correct_answer, correct_answer, correct_answer],
+    )
+    quiz, _ = _quiz([])
+
+    result = quiz._parse_generation(
+        response,
+        TriviaFact(target, correct_answer, _all_facts()),
+        (compilation_facts, *_grounded_fallback_facts()),
+    )
+
+    assert result.wrong_answers == expected
+    assert excluded_value not in result.wrong_answers
+
+
+@pytest.mark.asyncio
+async def test_generation_retries_when_grounded_repair_is_insufficient() -> None:
+    """Retry after a valid response cannot be completed from grounded metadata."""
+    insufficient = _valid_response(
+        wrong_answers=["Massive Attack", "massive-attack", "MASSIVE ATTACK"],
+    )
+    provider = _ai_provider()
+    provider.ai_query.side_effect = [insufficient, _valid_response()]
+    quiz, _ = _quiz([], providers=[provider])
+    quiz._eligible_tracks = {
+        _all_facts().source_uri: _all_facts(),
+        "prov://track/one-fallback": replace(
+            _all_facts(),
+            source_uri="prov://track/one-fallback",
+            artist="Justice",
+        ),
+    }
+
+    result = await quiz._generate_question(_artist_fact())
+
+    assert result.wrong_answers == ("Portishead", "Radiohead", "Air")
+    assert provider.ai_query.await_count == AI_ATTEMPTS_PER_PROVIDER
+
+
+@pytest.mark.asyncio
+async def test_generation_fails_when_all_grounded_repairs_are_insufficient() -> None:
+    """Keep the localized failure after every semantic repair exhausts its grounding."""
+    insufficient = _valid_response(
+        wrong_answers=["Massive Attack", "massive-attack", "MASSIVE ATTACK"],
+    )
+    provider = _ai_provider(insufficient)
+    quiz, _ = _quiz([], providers=[provider])
+    quiz._eligible_tracks = {
+        "prov://track/one-fallback": replace(
+            _all_facts(),
+            source_uri="prov://track/one-fallback",
+            artist="Justice",
+        )
+    }
+
+    with pytest.raises(InvalidDataError) as error:
+        await quiz._generate_question(_artist_fact())
+
+    assert error.value.translation_key == "music_quiz_trivia_generation_failed"
+    assert provider.ai_query.await_count == AI_ATTEMPTS_PER_PROVIDER
+
+
+@pytest.mark.parametrize(
+    "wrong_answers",
+    [
+        "Portishead",
+        ["Portishead", "Radiohead"],
+        ["Portishead", "Radiohead", "Air", "Tricky"],
+        ["Portishead", 42, "Air"],
+        ["Portishead", " ", "Air"],
+        ["Portishead\nLive", "Radiohead", "Air"],
+        ["x" * (MAX_ANSWER_LENGTH + 1), "Radiohead", "Air"],
+    ],
+)
+def test_generation_does_not_repair_malformed_wrong_answer_lists(
+    wrong_answers: object,
+) -> None:
+    """Reject malformed answer lists even when grounded fallback is sufficient."""
+    quiz, _ = _quiz([])
+    response = json_dumps(
+        {
+            "question": "Which artist recorded this selected track?",
+            "wrong_answers": wrong_answers,
+        }
+    )
+
+    with pytest.raises((TypeError, ValueError)):
+        quiz._parse_generation(response, _artist_fact(), _grounded_fallback_facts())
+
+
+@pytest.mark.asyncio
+async def test_next_round_repairs_duplicate_answers_without_extra_source_calls() -> None:
+    """Prepare the next Trivia round from cached grounding without an AI retry."""
+    tracks = [
+        _track("1", "Teardrop", "Massive Attack"),
+        _track("2", "Genesis", "Justice"),
+        _track("3", "Midnight City", "M83"),
+        _track("4", "Roads", "Portishead"),
+    ]
+    provider = _ai_provider()
+    provider.ai_query.side_effect = [
+        _valid_response(
+            "Who performs the selected track?",
+            ["Portishead", "Radiohead", "Air"],
+        ),
+        _valid_response(
+            "Which title was recorded by Justice?",
+            ["Genesis", "Teardrop", "teardrop!"],
+        ),
+    ]
+    quiz, mass = _quiz(tracks, providers=[provider], round_count=2)
+    mass.music.albums.get = AsyncMock()
+    mass.music.tracks.get = AsyncMock()
+
+    with (
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.trivia.SYSTEM_RANDOM.choice",
+            side_effect=lambda candidates: candidates[0],
+        ),
+        patch(
+            "music_assistant.providers.music_quiz.quiz_types.trivia.SYSTEM_RANDOM.shuffle",
+            side_effect=lambda _tracks: None,
+        ),
+    ):
+        first_round = await quiz.prepare_round(0, [])
+        second_round = await quiz.prepare_round(1, [first_round])
+
+    assert provider.ai_query.await_count == 2
+    assert second_round.answer_label == "Genesis"
+    assert isinstance(second_round.answer_state, MultipleChoiceRoundState)
+    assert {suggestion.label for suggestion in second_round.answer_state.suggestions} == {
+        "Genesis",
+        "Teardrop",
+        "Midnight City",
+        "Roads",
+    }
+    assert _correct_source_uri(second_round.answer_state) == tracks[1].uri
+    assert all(
+        suggestion.uri is None
+        for suggestion in second_round.answer_state.suggestions
+        if not suggestion.is_correct
+    )
+    mass.music.albums.get.assert_not_awaited()
+    mass.music.tracks.get.assert_not_awaited()
+    mass.music.search.assert_not_awaited()
 
 
 @pytest.mark.parametrize(

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -10,9 +10,10 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import AlbumType, ExternalID, MediaType
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import (
+    Album,
     Artist,
     ItemMapping,
     Playlist,
@@ -21,6 +22,7 @@ from music_assistant_models.media_items import (
 )
 from music_assistant_models.unique_list import UniqueList
 
+from music_assistant.constants import VARIOUS_ARTISTS_MBID, VARIOUS_ARTISTS_NAME
 from music_assistant.helpers.json import json_dumps, json_loads
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
@@ -104,6 +106,50 @@ def _track(
     return track
 
 
+def _full_album(
+    item_id: str,
+    name: str,
+    *,
+    album_type: AlbumType = AlbumType.ALBUM,
+    artists: Sequence[Artist | ItemMapping] = (),
+    year: int | None = None,
+    provider: str = "prov",
+) -> Album:
+    """Return a full album with configurable compilation evidence."""
+    return Album(
+        item_id=item_id,
+        provider=provider,
+        name=name,
+        album_type=album_type,
+        artists=UniqueList(artists),
+        year=year,
+        provider_mappings={
+            ProviderMapping(
+                item_id=item_id,
+                provider_domain=provider,
+                provider_instance=provider,
+            )
+        },
+    )
+
+
+def _album_artist(
+    item_id: str,
+    name: str,
+    *,
+    mbid: str | None = None,
+    provider: str = "prov",
+) -> Artist:
+    """Return a full album artist with optional MusicBrainz identity."""
+    return Artist(
+        item_id=item_id,
+        provider=provider,
+        name=name,
+        external_ids={(ExternalID.MB_ARTIST, mbid)} if mbid else set(),
+        provider_mappings=set(),
+    )
+
+
 def _playlist(item_id: str = "playlist", provider: str = "prov") -> Playlist:
     """Return a minimal playlist source."""
     return Playlist(
@@ -177,6 +223,15 @@ def _valid_response(
             "wrong_answers": wrong_answers or ["Portishead", "Radiohead", "Air"],
         }
     )
+
+
+def _prompt_payload(prompt: str) -> dict[str, Any]:
+    """Return the decoded grounded data block from a Trivia prompt."""
+    _, encoded_payload = prompt.split("BEGIN_UNTRUSTED_MUSIC_METADATA_JSON\n", 1)
+    encoded_block = encoded_payload.rsplit("\nEND_UNTRUSTED_MUSIC_METADATA_JSON", 1)[0]
+    payload = json_loads(encoded_block)
+    assert isinstance(payload, dict)
+    return payload
 
 
 def _all_facts() -> TriviaTrackFacts:
@@ -496,6 +551,188 @@ def test_track_facts_use_earliest_valid_release_year_without_defaults() -> None:
     assert TriviaQuizType._track_facts(too_old_track).release_year == 2000  # type: ignore[union-attr]
     assert TriviaQuizType._track_facts(invalid).release_year is None  # type: ignore[union-attr]
     assert TriviaQuizType._track_facts(missing).release_year is None  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_compilation_album_omits_album_and_year_from_grounding() -> None:
+    """Exclude every release fact supplied with a typed compilation album."""
+    track = _track(
+        "everlasting-love",
+        "Everlasting Love",
+        "Sandra",
+        release_year=2012,
+    )
+    track.album = _full_album(
+        "party-hits-13",
+        "Party Hits 13",
+        album_type=AlbumType.COMPILATION,
+        artists=[_album_artist("album-artist", "Compilation Curator")],
+        year=2012,
+    )
+    quiz, mass = _quiz([track])
+    mass.music.albums.get = AsyncMock()
+    mass.music.tracks.get = AsyncMock()
+
+    eligible_tracks = await quiz._get_eligible_tracks()
+
+    assert track.uri is not None
+    facts = eligible_tracks[track.uri]
+    assert facts.album is None
+    assert facts.release_year is None
+    assert quiz._available_targets(facts) == (TriviaTarget.ARTIST, TriviaTarget.TITLE)
+    fact = quiz._select_fact(facts, 0)
+    assert fact.correct_answer == "Sandra"
+    assert _prompt_payload(quiz._build_prompt(fact))["track_metadata"] == {
+        "title": "Everlasting Love",
+        "artist": "Sandra",
+    }
+    mass.music.albums.get.assert_not_awaited()
+    mass.music.tracks.get.assert_not_awaited()
+    mass.music.search.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "album_artists",
+    [
+        [_album_artist("va-name", "VARIOUS-ARTISTS")],
+        [
+            _album_artist(
+                "va-mbid",
+                "Artistes divers",
+                mbid=VARIOUS_ARTISTS_MBID,
+            )
+        ],
+        [
+            _album_artist("primary", "Primary Artist"),
+            _album_artist("va-multiple", VARIOUS_ARTISTS_NAME),
+        ],
+    ],
+    ids=["normalized-name", "canonical-mbid", "multiple-artists"],
+)
+def test_various_artists_album_omits_album_and_year(
+    album_artists: list[Artist],
+) -> None:
+    """Treat any canonical Various Artists album credit as compilation evidence."""
+    track = _track("compilation", "Selected Track", "Track Artist", release_year=2012)
+    track.album = _full_album(
+        "album",
+        "Compilation Album",
+        artists=album_artists,
+        year=2012,
+    )
+
+    facts = TriviaQuizType._track_facts(track)
+
+    assert facts is not None
+    assert facts.album is None
+    assert facts.release_year is None
+    assert TriviaQuizType._available_targets(facts) == (
+        TriviaTarget.ARTIST,
+        TriviaTarget.TITLE,
+    )
+
+
+def test_normal_full_album_retains_release_grounding() -> None:
+    """Keep album and earliest release year facts for a normal full album."""
+    track = _track("normal", "Teardrop", "Massive Attack", release_year=2001)
+    track.album = _full_album(
+        "mezzanine",
+        "Mezzanine",
+        album_type=AlbumType.ALBUM,
+        year=1998,
+    )
+    quiz, _ = _quiz([])
+
+    facts = quiz._track_facts(track)
+
+    assert facts is not None
+    assert facts.album == "Mezzanine"
+    assert facts.release_year == 1998
+    assert quiz._available_targets(facts) == tuple(TriviaTarget)
+    fact = quiz._select_fact(facts, 2)
+    assert fact.correct_answer == "Mezzanine"
+    assert _prompt_payload(quiz._build_prompt(fact))["track_metadata"] == {
+        "title": "Teardrop",
+        "artist": "Massive Attack",
+        "album": "Mezzanine",
+        "release_year": 1998,
+    }
+
+
+def test_album_mapping_retains_release_grounding_without_compilation_evidence() -> None:
+    """Keep existing release facts when only an album mapping is available."""
+    track = _track(
+        "mapping",
+        "Mapped Track",
+        "Mapped Artist",
+        album=VARIOUS_ARTISTS_NAME,
+        album_year=2000,
+        release_year=2004,
+    )
+
+    facts = TriviaQuizType._track_facts(track)
+
+    assert facts is not None
+    assert facts.album == VARIOUS_ARTISTS_NAME
+    assert facts.release_year == 2000
+    assert TriviaQuizType._available_targets(facts) == tuple(TriviaTarget)
+
+
+@pytest.mark.asyncio
+async def test_compilation_rounds_only_generate_artist_and_title_targets() -> None:
+    """Generate valid rounds without selecting compilation album or year targets."""
+    first_track = _track("one", "First Song", "Artist One", release_year=2012)
+    first_track.album = _full_album(
+        "first-album",
+        "First Compilation",
+        album_type=AlbumType.COMPILATION,
+        year=2012,
+    )
+    second_track = _track("two", "Second Song", "Artist Two", release_year=2013)
+    second_track.album = _full_album(
+        "second-album",
+        "Second Compilation",
+        artists=[_album_artist("va", VARIOUS_ARTISTS_NAME)],
+        year=2013,
+    )
+    provider = _ai_provider()
+    provider.ai_query.side_effect = [
+        _valid_response(
+            "Who performs the selected song?",
+            ["Portishead", "Radiohead", "Air"],
+        ),
+        _valid_response(
+            "Which title was recorded by Artist Two?",
+            ["Teardrop", "Genesis", "Midnight City"],
+        ),
+    ]
+    quiz, _ = _quiz(
+        [first_track, second_track],
+        providers=[provider],
+        round_count=2,
+    )
+
+    facts_by_uri = await quiz._get_eligible_tracks()
+    for facts in facts_by_uri.values():
+        assert {quiz._select_fact(facts, round_index).target for round_index in range(8)} == {
+            TriviaTarget.ARTIST,
+            TriviaTarget.TITLE,
+        }
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types.trivia.SYSTEM_RANDOM.choice",
+        side_effect=lambda tracks: tracks[0],
+    ):
+        first_round = await quiz.prepare_round(0, [])
+        second_round = await quiz.prepare_round(1, [first_round])
+
+    assert first_round.answer_label == "Artist One"
+    assert second_round.answer_label == "Second Song"
+    prompt_payloads = [_prompt_payload(call.args[0]) for call in provider.ai_query.await_args_list]
+    assert [payload["question_target"] for payload in prompt_payloads] == [
+        TriviaTarget.ARTIST,
+        TriviaTarget.TITLE,
+    ]
+    assert all(set(payload["track_metadata"]) == {"title", "artist"} for payload in prompt_payloads)
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -1058,6 +1058,41 @@ async def test_generation_repairs_duplicate_answers_from_cached_grounding() -> N
     mass.music.search.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_generation_defers_grounded_work_until_repair_is_needed() -> None:
+    """Avoid fallback iteration and shuffling until valid AI answers leave empty slots."""
+    provider = _ai_provider()
+    provider.ai_query.side_effect = [
+        _valid_response(),
+        _valid_response(
+            wrong_answers=["Massive Attack", "massive-attack", "MASSIVE ATTACK"],
+        ),
+    ]
+    quiz, _ = _quiz([], providers=[provider])
+    grounded_tracks = MagicMock()
+    grounded_tracks.__iter__.return_value = iter(_grounded_fallback_facts())
+    eligible_tracks = MagicMock()
+    eligible_tracks.values.return_value = grounded_tracks
+    quiz._eligible_tracks = eligible_tracks
+
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types.trivia.SYSTEM_RANDOM.shuffle",
+        side_effect=lambda _values: None,
+    ) as shuffle:
+        valid_result = await quiz._generate_question(_artist_fact())
+        grounded_tracks.__iter__.assert_not_called()
+        shuffle.assert_not_called()
+
+        repaired_result = await quiz._generate_question(_artist_fact())
+
+    assert valid_result.wrong_answers == ("Portishead", "Radiohead", "Air")
+    assert repaired_result.wrong_answers == ("Justice", "M83", "Portishead")
+    assert provider.ai_query.await_count == 2
+    assert eligible_tracks.values.call_count == 2
+    grounded_tracks.__iter__.assert_called_once()
+    shuffle.assert_called_once()
+
+
 def test_generation_repair_skips_normalized_near_and_fallback_collisions() -> None:
     """Continue scanning grounded facts after normalized and near-answer collisions."""
     quiz, _ = _quiz([])
@@ -1077,7 +1112,8 @@ def test_generation_repair_skips_normalized_near_and_fallback_collisions() -> No
 
     result = quiz._parse_generation(response, _artist_fact(), colliding_facts)
 
-    assert result.wrong_answers == ("Portishead", "Radiohead", "Air")
+    assert result.wrong_answers[0] == "Portishead"
+    assert set(result.wrong_answers) == {"Portishead", "Radiohead", "Air"}
 
 
 @pytest.mark.parametrize(
@@ -1108,7 +1144,8 @@ def test_generation_repair_uses_only_same_target_grounding(
 
     result = quiz._parse_generation(response, fact, _grounded_fallback_facts())
 
-    assert result.wrong_answers == expected
+    assert set(result.wrong_answers) == set(expected)
+    assert all(isinstance(answer, str) for answer in result.wrong_answers)
 
 
 @pytest.mark.parametrize(
@@ -1156,7 +1193,7 @@ def test_generation_repair_excludes_compilation_release_facts(
         (compilation_facts, *_grounded_fallback_facts()),
     )
 
-    assert result.wrong_answers == expected
+    assert set(result.wrong_answers) == set(expected)
     assert excluded_value not in result.wrong_answers
 
 


### PR DESCRIPTION
# What does this implement/fix?

Music Trivia could use compilation release details as original-track facts or fail round preparation when AI distractors repeated the answer or each other.

- Omit album and year grounding for typed compilations and canonical Various Artists releases.
- Keep valid AI distractors and fill duplicate slots from cached, same-target track facts without extra provider calls.
- Preserve strict malformed-response retries and cover next-round preparation and compilation interactions.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.