### PR TITLE
Keep Music Quiz listen-in active between songs

### DIFF
--- a/music_assistant/helpers/shared_playback.py
+++ b/music_assistant/helpers/shared_playback.py
@@ -27,7 +27,11 @@ from functools import partial
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.enums import PlayerFeature
-from music_assistant_models.errors import SetupFailedError, UnsupportedFeaturedException
+from music_assistant_models.errors import (
+    MusicAssistantError,
+    SetupFailedError,
+    UnsupportedFeaturedException,
+)
 
 if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
@@ -186,6 +190,42 @@ class SharedPlaybackSession:
             )
         await self.mass.players.cmd_set_members(self._player_id, player_ids_to_add=[web_player_id])
         self._guest_listeners.add(web_player_id)
+
+    async def restore_guest_listeners(self) -> None:
+        """
+        Restore tracked guest listeners missing from the host player's group.
+
+        Missing or temporarily incompatible guest players remain tracked so a
+        later playback transition can restore them after they reconnect.
+        """
+        host_player = self._get_host_player()
+        if host_player is None or not self._guest_listeners:
+            return
+        group_members = set(host_player.state.group_members)
+        for web_player_id in sorted(self._guest_listeners):
+            if web_player_id in group_members:
+                continue
+            guest_player = self.mass.players.get_player(web_player_id)
+            if (
+                guest_player is None
+                or not guest_player.state.available
+                or not self.can_listen_in(web_player_id)
+            ):
+                continue
+            try:
+                await self.mass.players.cmd_set_members(
+                    self._player_id,
+                    player_ids_to_add=[web_player_id],
+                )
+            except MusicAssistantError as err:
+                LOGGER.warning(
+                    "Could not restore guest listener %s to shared playback session %s: %s",
+                    web_player_id,
+                    self._player_id,
+                    err,
+                )
+                continue
+            group_members.add(web_player_id)
 
     async def remove_guest_listener(self, web_player_id: str) -> None:
         """

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1329,6 +1329,12 @@ class MusicQuizPlugin(PluginProvider):
                 raise MusicQuizNoPlaybackTargetError(
                     "The Music Quiz playback target is handling an announcement"
                 )
+            async with self._playback_lock:
+                if self._playback_session is not session:
+                    raise MusicQuizNoPlaybackTargetError(
+                        "No playback target is available for the Music Quiz game"
+                    )
+                await session.restore_guest_listeners()
             await self.mass.player_queues.play_media(
                 session.queue_id, track_uri, option=QueueOption.REPLACE
             )

--- a/tests/helpers/test_shared_playback.py
+++ b/tests/helpers/test_shared_playback.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Coroutine
+from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -59,6 +59,17 @@ def _create_venue_player(
     player.state.can_group_with = can_group_with or set()
     player.state.group_members = group_members or []
     return player
+
+
+async def _wait_for(condition: Callable[[], bool], timeout: float = 5.0) -> None:
+    """Wait until the given condition returns true."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if condition():
+            return
+        await asyncio.sleep(0.05)
+    raise TimeoutError("Condition not met within timeout")
 
 
 # ==================== VENUE mode ====================
@@ -128,6 +139,75 @@ async def test_venue_add_and_remove_guest_listener() -> None:
     )
 
 
+async def test_venue_restores_remembered_listener_only_when_missing() -> None:
+    """Restore a tracked listener after its actual group membership disappears."""
+    venue_player = _create_venue_player(can_group_with={"web_player_1"})
+    guest_player = MagicMock()
+    mass = _create_mock_mass(venue_player)
+    mass.players.get_player.side_effect = lambda player_id: (
+        venue_player if player_id == "venue_player" else guest_player
+    )
+    session = await SharedPlaybackSession.create_venue(mass, "venue_player")
+    await session.add_guest_listener("web_player_1")
+    venue_player.state.group_members = ["venue_player", "web_player_1"]
+    mass.players.cmd_set_members.reset_mock()
+
+    await session.restore_guest_listeners()
+    mass.players.cmd_set_members.assert_not_awaited()
+
+    venue_player.state.group_members = ["venue_player"]
+    await session.restore_guest_listeners()
+
+    mass.players.cmd_set_members.assert_awaited_once_with(
+        "venue_player", player_ids_to_add=["web_player_1"]
+    )
+    assert session._guest_listeners == {"web_player_1"}
+
+
+async def test_venue_restore_skips_disappeared_listener() -> None:
+    """Keep a missing listener remembered without blocking playback restoration."""
+    venue_player = _create_venue_player(can_group_with={"web_player_1"})
+    guest_player = MagicMock()
+    mass = _create_mock_mass(venue_player)
+    players = {
+        "venue_player": venue_player,
+        "web_player_1": guest_player,
+    }
+    mass.players.get_player.side_effect = players.get
+    session = await SharedPlaybackSession.create_venue(mass, "venue_player")
+    await session.add_guest_listener("web_player_1")
+    mass.players.cmd_set_members.reset_mock()
+    players.pop("web_player_1")
+
+    await session.restore_guest_listeners()
+
+    mass.players.cmd_set_members.assert_not_awaited()
+    assert session._guest_listeners == {"web_player_1"}
+
+
+async def test_venue_restore_failure_does_not_block_playback() -> None:
+    """Keep listener restoration best-effort when grouping temporarily fails."""
+    venue_player = _create_venue_player(can_group_with={"web_player_1"})
+    guest_player = MagicMock()
+    mass = _create_mock_mass(venue_player)
+    mass.players.get_player.side_effect = lambda player_id: (
+        venue_player if player_id == "venue_player" else guest_player
+    )
+    session = await SharedPlaybackSession.create_venue(mass, "venue_player")
+    await session.add_guest_listener("web_player_1")
+    mass.players.cmd_set_members.reset_mock()
+    mass.players.cmd_set_members.side_effect = UnsupportedFeaturedException(
+        "Grouping temporarily unavailable"
+    )
+
+    await session.restore_guest_listeners()
+
+    mass.players.cmd_set_members.assert_awaited_once_with(
+        "venue_player", player_ids_to_add=["web_player_1"]
+    )
+    assert session._guest_listeners == {"web_player_1"}
+
+
 async def test_venue_add_guest_listener_unsupported() -> None:
     """Attaching an incompatible web player raises."""
     venue_player = _create_venue_player(can_group_with=set())
@@ -194,6 +274,52 @@ async def test_create_remote_session(mass: MusicAssistant) -> None:
     assert mass.players.get_player(session.player_id) is None
     # with the virtual host player gone, listen-in is no longer possible
     assert session.can_listen_in(guest_player_id) is False
+
+
+async def test_remote_session_restores_listener_before_next_track(
+    mass: MusicAssistant,
+) -> None:
+    """Restore real Sendspin membership after stop before the next queue track."""
+    sendspin = cast("SendspinProvider | None", mass.get_provider("sendspin"))
+    assert sendspin is not None
+    await mass.config.save_provider_config("test", {})
+    assert mass.get_provider("test") is not None
+    session = await SharedPlaybackSession.create_remote(
+        mass,
+        owner_instance_id=sendspin.instance_id,
+        display_name="Test Party",
+    )
+    guest_player_id = await sendspin.create_virtual_player(
+        owner_instance_id=sendspin.instance_id,
+        display_name="Guest",
+    )
+    host_player = mass.players.get_player(session.player_id)
+    assert host_player is not None
+    host_player.update_state(signal_event=False)
+
+    try:
+        await session.add_guest_listener(guest_player_id)
+        await _wait_for(lambda: guest_player_id in host_player.state.group_members)
+        await mass.player_queues.play_media(session.queue_id, "test://track/0_0_0")
+        await mass.player_queues.stop(session.queue_id)
+        await mass.players.cmd_set_members(
+            session.player_id,
+            player_ids_to_remove=[guest_player_id],
+        )
+        await _wait_for(lambda: guest_player_id not in host_player.state.group_members)
+
+        await session.restore_guest_listeners()
+        await _wait_for(lambda: guest_player_id in host_player.state.group_members)
+        await mass.player_queues.play_media(session.queue_id, "test://track/0_0_1")
+
+        queue = mass.player_queues.get(session.queue_id)
+        assert queue is not None
+        assert queue.current_item is not None
+        assert queue.current_item.uri == "test://track/0_0_1"
+        assert session._guest_listeners == {guest_player_id}
+    finally:
+        await session.close()
+        await sendspin.remove_virtual_player(guest_player_id)
 
 
 async def test_create_remote_session_deterministic_id(mass: MusicAssistant) -> None:

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -29,7 +29,7 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_current_user as get_auth_current_user,
 )
 from music_assistant.helpers.api import APICommandHandler, parse_arguments
-from music_assistant.helpers.shared_playback import SharedPlaybackMode
+from music_assistant.helpers.shared_playback import SharedPlaybackMode, SharedPlaybackSession
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.music_quiz import (
     MUSIC_QUIZ_GUEST_USER,
@@ -314,6 +314,79 @@ def _create_plugin(
     plugin._stop_playback = AsyncMock()  # type: ignore[method-assign]
     plugin._get_join_url = AsyncMock(return_value="http://ma/join")  # type: ignore[method-assign]
     return plugin
+
+
+def _mock_playback_session(player_id: str, queue_id: str) -> SharedPlaybackSession:
+    """Create a shared playback session mock with stable player and queue IDs."""
+    session = MagicMock(spec=SharedPlaybackSession)
+    session.player_id = player_id
+    session.queue_id = queue_id
+    return cast("SharedPlaybackSession", session)
+
+
+def _configure_venue_listener_playback(
+    plugin: MusicQuizPlugin,
+) -> tuple[AsyncMock, list[str]]:
+    """Configure deterministic venue grouping and queue playback for a plugin test."""
+    venue_player = _make_venue_player(
+        "venue_player",
+        "Venue Player",
+        features={PlayerFeature.PLAY_MEDIA, PlayerFeature.SET_MEMBERS},
+    )
+    venue_player.state.can_group_with = {"web_player"}
+    venue_player.state.group_members = []
+    guest_player = SimpleNamespace(
+        player_id="web_player",
+        state=SimpleNamespace(available=True),
+    )
+    cast("MagicMock", plugin.mass.players.all_players).return_value = [venue_player]
+    cast("MagicMock", plugin.mass.players.get_player).side_effect = {
+        "venue_player": venue_player,
+        "web_player": guest_player,
+    }.get
+
+    async def _set_members(
+        _player_id: str,
+        *,
+        player_ids_to_add: list[str] | None = None,
+        player_ids_to_remove: list[str] | None = None,
+    ) -> None:
+        for player_id in player_ids_to_remove or []:
+            if player_id in venue_player.state.group_members:
+                venue_player.state.group_members.remove(player_id)
+        for player_id in player_ids_to_add or []:
+            if player_id not in venue_player.state.group_members:
+                venue_player.state.group_members.append(player_id)
+
+    set_members = AsyncMock(side_effect=_set_members)
+    cast("MagicMock", plugin.mass.players).cmd_set_members = set_members
+    played_tracks: list[str] = []
+
+    async def _play_media(
+        queue_id: str,
+        track_uri: str,
+        *,
+        option: QueueOption,
+    ) -> None:
+        assert queue_id == "venue_player"
+        assert option == QueueOption.REPLACE
+        assert "web_player" in venue_player.state.group_members
+        played_tracks.append(track_uri)
+
+    async def _stop(_queue_id: str) -> None:
+        venue_player.state.group_members.clear()
+
+    cast("MagicMock", plugin.mass.player_queues).play_media = AsyncMock(side_effect=_play_media)
+    cast("MagicMock", plugin.mass.player_queues).stop = AsyncMock(side_effect=_stop)
+    plugin._play_track = MusicQuizPlugin._play_track.__get__(  # type: ignore[method-assign]
+        plugin,
+        MusicQuizPlugin,
+    )
+    plugin._stop_playback = MusicQuizPlugin._stop_playback.__get__(  # type: ignore[method-assign]
+        plugin,
+        MusicQuizPlugin,
+    )
+    return set_members, played_tracks
 
 
 def _install_shared_preference_cache(
@@ -1216,8 +1289,10 @@ async def test_guest_ready_advances_and_prefetches_in_system_context() -> None:
         plugin._play_track = MusicQuizPlugin._play_track.__get__(  # type: ignore[method-assign]
             plugin, MusicQuizPlugin
         )
+        playback_session = _mock_playback_session("quiz_player", "quiz_queue")
+        plugin._playback_session = playback_session
         plugin._get_playback_session = AsyncMock(  # type: ignore[method-assign]
-            return_value=SimpleNamespace(queue_id="quiz_queue", player_id="quiz_player")
+            return_value=playback_session
         )
         get_player = cast("MagicMock", plugin.mass.players.get_player)
         get_player.side_effect = None
@@ -1475,6 +1550,75 @@ async def test_play_track_rejects_busy_announcement_target() -> None:
         await MusicQuizPlugin._play_track(plugin, "spotify://track/test")
 
     play_media.assert_not_awaited()
+
+
+@pytest.mark.parametrize("quiz_type", ["guess_the_song", "trivia"])
+@pytest.mark.asyncio
+async def test_venue_listener_is_restored_before_each_audio_track(quiz_type: str) -> None:
+    """Restore remembered venue listeners across Guess and Trivia playback transitions."""
+    plugin = _create_plugin()
+    set_members, played_tracks = _configure_venue_listener_playback(plugin)
+
+    async def _prepare_round(
+        round_index: int,
+        previous_rounds: list[MusicQuizRound],
+    ) -> MusicQuizRound:
+        if quiz_type == "trivia":
+            return _make_trivia_round(round_index, previous_rounds)
+        return _make_round(round_index)
+
+    initialize = AsyncMock()
+    with (
+        patch.object(TriviaQuizType, "initialize", new=initialize),
+        patch.object(
+            TriviaQuizType if quiz_type == "trivia" else GuessTheSongQuizType,
+            "prepare_round",
+            new=AsyncMock(side_effect=_prepare_round),
+        ),
+    ):
+        await plugin.create_game(
+            quiz_type=quiz_type,
+            round_count=2,
+            source_uris=["library://playlist/1"],
+            playback_mode="venue",
+            venue_player_id="venue_player",
+        )
+        session = await SharedPlaybackSession.create_venue(plugin.mass, "venue_player")
+        plugin._playback_session = session
+        await session.add_guest_listener("web_player")
+        set_members.reset_mock()
+        await plugin.start_game()
+
+        if quiz_type == "trivia":
+            assert played_tracks == []
+            await plugin.reveal()
+            first_reveal = plugin._reveal_playback_task
+            assert first_reveal is not None
+            await first_reveal
+            await plugin.next_round()
+            await plugin.reveal()
+            second_reveal = plugin._reveal_playback_task
+            assert second_reveal is not None
+            await second_reveal
+            expected_tracks = [
+                "library://track/trivia-0",
+                "library://track/trivia-1",
+            ]
+        else:
+            await plugin._stop_playback()
+            await plugin.reveal()
+            await plugin.next_round()
+            expected_tracks = [
+                "library://track/0",
+                "library://track/1",
+            ]
+
+    assert played_tracks == expected_tracks
+    set_members.assert_awaited_once_with(
+        "venue_player",
+        player_ids_to_add=["web_player"],
+    )
+    assert session._guest_listeners == {"web_player"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Music Quiz could remember that a guest was listening in after the player dropped the guest's actual group membership, leaving later songs silent on that device.

- Restore remembered listeners before each Quiz track.
- Keep stale or temporarily unavailable listeners from blocking venue playback.
- Cover venue and remote sessions plus Guess the Song and Trivia transitions.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.