### PR TITLE
Improved SoundCloud artworks for playlists

### DIFF
--- a/music_assistant/providers/soundcloud/__init__.py
+++ b/music_assistant/providers/soundcloud/__init__.py
@@ -231,7 +231,7 @@ class SoundcloudMusicProvider(MusicProvider):
     async def recommendations(self) -> list[RecommendationFolder]:
         """Get available recommendations."""
         # Part 1, the mixed selections
-        recommendations = await self._soundcloud.get_mixed_selection(20)
+        recommendations = await self._soundcloud.get_mixed_selection(40)
         folders = []
         for collection in recommendations.get("collection", []):
             folder = RecommendationFolder(
@@ -251,7 +251,7 @@ class SoundcloudMusicProvider(MusicProvider):
                     continue
             folders.append(folder)
         # Part 2, the subscribed feed
-        feed = await self._soundcloud.get_subscribe_feed(20)
+        feed = await self._soundcloud.get_subscribe_feed(40)
         if feed and "collection" in feed:
             folder = RecommendationFolder(
                 name="SoundCloud Feed",
@@ -538,17 +538,24 @@ class SoundcloudMusicProvider(MusicProvider):
         playlist.is_editable = False
         if playlist_obj.get("description"):
             playlist.metadata.description = playlist_obj["description"]
-        if playlist_obj.get("artwork_url"):
+        artwork_url = playlist_obj.get("artwork_url") or playlist_obj.get("calculated_artwork_url")
+        if artwork_url:
             playlist.metadata.images = UniqueList(
                 [
                     MediaItemImage(
                         type=ImageType.THUMB,
-                        path=self._transform_artwork_url(playlist_obj["artwork_url"]),
+                        path=self._transform_artwork_url(artwork_url),
                         provider=self.instance_id,
                         remotely_accessible=True,
                     )
                 ]
             )
+        if not artwork_url:
+            # fall back to the artwork of the first track that has one
+            for track_obj in playlist_obj.get("tracks", []):
+                if track_obj.get("artwork_url"):
+                    artwork_url = track_obj["artwork_url"]
+                    break
         if playlist_obj.get("genre"):
             playlist.metadata.genres = {playlist_obj["genre"]}
         if playlist_obj.get("tag_list"):


### PR DESCRIPTION
# What does this implement/fix?

Improved SoundCloud artworks for playlists. Sometimes playlists weren't getting an Artwork, turns out SC adds it in different fields depending on the kind of playlist.
Also extended the number of items from the SC feed, 20 is pretty limited when you actively follow many artists.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
