### PR TITLE
Speed up Apple Music radio startup

### DIFF
--- a/music_assistant/providers/apple_music/recommendations.py
+++ b/music_assistant/providers/apple_music/recommendations.py
@@ -49,31 +49,32 @@ class AppleMusicRecommendationManager:
 
     @use_cache(3600 * 24, allow_expired_cache=True)
     async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
-        """Retrieve a dynamic list of tracks based on the provided item."""
-        # Apple Music only provides ~2 tracks per call, cap at 6 to avoid flooding the API.
-        limit = min(limit, 6)
+        """
+        Retrieve tracks similar to the provided track.
+
+        :param prov_track_id: The Apple Music track ID.
+        :param limit: Maximum number of tracks to return.
+        """
+        if limit <= 0:
+            return []
         endpoint = f"me/stations/next-tracks/ra.{prov_track_id}"
-        found_tracks: list[Track] = []
-        while len(found_tracks) < limit:
-            try:
-                response = await self.api.post_data(endpoint, include="artists")
-            except ClientResponseError as err:
-                if err.status == 500:
-                    self.logger.debug(
-                        "Similar tracks unavailable for %s (%s)", prov_track_id, endpoint
-                    )
-                    break
-                raise
-            if not response or not response.get("data"):
-                break
-            track_ids = [track["id"] for track in response["data"] if track and track["id"]]
-            rating_response = await self.api.get_ratings(track_ids, MediaType.TRACK)
-            for track in response["data"]:
-                if track and track["id"]:
-                    found_tracks.append(
-                        parse_track(self.provider, track, rating_response.get(track["id"]))
-                    )
-        return found_tracks
+        try:
+            response = await self.api.post_data(endpoint, include="artists")
+        except ClientResponseError as err:
+            if err.status == 500:
+                self.logger.debug("Similar tracks unavailable for %s (%s)", prov_track_id, endpoint)
+                return []
+            raise
+        if not response:
+            return []
+        tracks = [track for track in response.get("data", []) if track and track.get("id")][:limit]
+        if not tracks:
+            return []
+        track_ids = [track["id"] for track in tracks]
+        rating_response = await self.api.get_ratings(track_ids, MediaType.TRACK)
+        return [
+            parse_track(self.provider, track, rating_response.get(track["id"])) for track in tracks
+        ]
 
     @use_cache(3600 * 24)
     async def get_similar_artists(self, prov_artist_id: str, limit: int = 25) -> list[Artist]:

--- a/music_assistant/providers/radio_playlist/__init__.py
+++ b/music_assistant/providers/radio_playlist/__init__.py
@@ -168,17 +168,17 @@ class RadioPlaylistProvider(PluginProvider):
                     )
                 except MusicAssistantError:
                     continue
-                if similar:
+                eligible_tracks = {
+                    track
+                    for track in similar
+                    if track not in base_tracks
+                    and track not in dynamic_tracks
+                    and track.duration <= RADIO_TRACK_MAX_DURATION_SECS
+                    and (active_filter is None or active_filter.allows(track))
+                }
+                if eligible_tracks:
+                    dynamic_tracks.update(eligible_tracks)
                     break
-            else:
-                # A base track without a similar-tracks-capable provider should not abort generation.
-                continue
-            for track in similar:
-                if track in base_tracks or track.duration > RADIO_TRACK_MAX_DURATION_SECS:
-                    continue
-                if active_filter is not None and not active_filter.allows(track):
-                    continue
-                dynamic_tracks.add(track)
             if len(dynamic_tracks) >= DYNAMIC_RADIO_DYNAMIC_TARGET:
                 break
 

--- a/music_assistant/providers/radio_playlist/__init__.py
+++ b/music_assistant/providers/radio_playlist/__init__.py
@@ -157,10 +157,8 @@ class RadioPlaylistProvider(PluginProvider):
         if active_filter is not None:
             base_tracks = [t for t in base_tracks if active_filter.allows(t)] or base_tracks
         dynamic_tracks: set[Track] = set()
-        for allow_lookup in (False, True):
-            if len(dynamic_tracks) >= DYNAMIC_RADIO_DYNAMIC_TARGET:
-                break
-            for base_track in base_tracks:
+        for base_track in base_tracks:
+            for allow_lookup in (False, True):
                 try:
                     similar = await self.mass.music.tracks.similar_tracks(
                         base_track.item_id,
@@ -169,17 +167,20 @@ class RadioPlaylistProvider(PluginProvider):
                         preferred_provider_instances=preferred_provider_instances,
                     )
                 except MusicAssistantError:
-                    # best-effort: a base track without a similar-tracks-capable provider
-                    # shouldn't abort generation (base tracks can still carry the playlist)
                     continue
-                for track in similar:
-                    if track in base_tracks or track.duration > RADIO_TRACK_MAX_DURATION_SECS:
-                        continue
-                    if active_filter is not None and not active_filter.allows(track):
-                        continue
-                    dynamic_tracks.add(track)
-                if len(dynamic_tracks) >= DYNAMIC_RADIO_DYNAMIC_TARGET:
+                if similar:
                     break
+            else:
+                # A base track without a similar-tracks-capable provider should not abort generation.
+                continue
+            for track in similar:
+                if track in base_tracks or track.duration > RADIO_TRACK_MAX_DURATION_SECS:
+                    continue
+                if active_filter is not None and not active_filter.allows(track):
+                    continue
+                dynamic_tracks.add(track)
+            if len(dynamic_tracks) >= DYNAMIC_RADIO_DYNAMIC_TARGET:
+                break
 
         result: list[Track] = []
         dynamic_tracks_list = list(dynamic_tracks)

--- a/tests/providers/apple_music/test_similar_artists.py
+++ b/tests/providers/apple_music/test_similar_artists.py
@@ -6,6 +6,7 @@ import pytest
 from aiohttp.client_exceptions import ClientResponseError
 from aiohttp.client_reqrep import RequestInfo
 from multidict import CIMultiDict, CIMultiDictProxy
+from music_assistant_models.enums import MediaType
 from music_assistant_models.media_items import Artist
 from yarl import URL
 
@@ -36,6 +37,20 @@ def _make_api_response(artist_objects: list[dict[str, object]]) -> dict[str, obj
                 },
             }
         ]
+    }
+
+
+def _make_track_obj(track_id: str) -> dict[str, object]:
+    return {
+        "id": track_id,
+        "type": "songs",
+        "attributes": {
+            "name": f"Track {track_id}",
+            "artistName": "Artist",
+            "durationInMillis": 180000,
+            "playParams": {"id": track_id},
+        },
+        "relationships": {},
     }
 
 
@@ -148,31 +163,16 @@ async def test_get_similar_tracks_returns_tracks(
     manager: AppleMusicRecommendationManager,
     mock_api: MagicMock,
 ) -> None:
-    """get_similar_tracks parses station tracks returned by Apple API."""
-    mock_api.post_data.side_effect = [
-        {
-            "data": [
-                {
-                    "id": "track1",
-                    "type": "songs",
-                    "attributes": {
-                        "name": "Track 1",
-                        "artistName": "Artist 1",
-                        "durationInMillis": 180000,
-                        "playParams": {"id": "track1"},
-                    },
-                    "relationships": {},
-                }
-            ]
-        },
-        {"data": []},
-    ]
-    mock_api.get_ratings.return_value = {"track1": True}
+    """get_similar_tracks returns one limited response from the Apple API."""
+    track_ids = [str(index) for index in range(1, 9)]
+    mock_api.post_data.return_value = {"data": [_make_track_obj(item_id) for item_id in track_ids]}
+    mock_api.get_ratings.return_value = dict.fromkeys(track_ids, False)
 
-    result = await manager.get_similar_tracks("123", limit=2)
+    result = await manager.get_similar_tracks("123", limit=7)
 
-    assert len(result) == 1
-    assert result[0].name == "Track 1"
+    mock_api.post_data.assert_awaited_once_with("me/stations/next-tracks/ra.123", include="artists")
+    mock_api.get_ratings.assert_awaited_once_with(track_ids[:7], MediaType.TRACK)
+    assert [track.item_id for track in result] == track_ids[:7]
 
 
 @pytest.mark.asyncio

--- a/tests/providers/radio_playlist/test_radio_playlist.py
+++ b/tests/providers/radio_playlist/test_radio_playlist.py
@@ -115,21 +115,26 @@ async def test_multiple_seeds_dedup_base_tracks() -> None:
     shared = _track("shared")
     prov = _make_provider(
         {"a": [shared, _track("a-only")], "b": [shared, _track("b-only")]},
-        [_track("sim1"), _track("sim2")],
+        [],
     )
+    similar_tracks = cast("Any", prov.mass.music.tracks.similar_tracks)
+    similar_tracks.side_effect = lambda item_id, _provider, **_kwargs: [
+        _track(f"similar-{item_id}")
+    ]
 
     await prov.get_dynamic_tracks([seed_a, seed_b], target_size=5)
     # Three unique base tracks remain after deduplication, each with a successful direct lookup.
-    assert cast("Any", prov.mass.music.tracks.similar_tracks).call_count == 3
+    assert similar_tracks.call_count == 3
 
 
 @pytest.mark.asyncio
-async def test_cross_provider_lookup_only_retries_empty_results() -> None:
-    """A cross-provider lookup is only used when the direct lookup has no result."""
+async def test_cross_provider_lookup_only_retries_without_usable_results() -> None:
+    """A cross-provider lookup is only used when the direct lookup has no usable result."""
     seed = _seed(MediaType.ALBUM, "seed")
     direct_base = _track("direct")
     fallback_base = _track("fallback")
-    prov = _make_provider({"seed": [direct_base, fallback_base]}, [])
+    filtered_base = _track("filtered")
+    prov = _make_provider({"seed": [direct_base, fallback_base, filtered_base]}, [])
     similar_tracks = cast("Any", prov.mass.music.tracks.similar_tracks)
 
     def get_similar(
@@ -137,6 +142,12 @@ async def test_cross_provider_lookup_only_retries_empty_results() -> None:
     ) -> list[MagicMock]:
         if item_id == "direct":
             return [_track("direct-result")]
+        if item_id == "filtered":
+            return (
+                [_track("filtered-fallback")]
+                if allow_lookup
+                else [_track("too-long", RADIO_TRACK_MAX_DURATION_SECS + 1)]
+            )
         if allow_lookup:
             return [_track("fallback-result")]
         return []
@@ -152,7 +163,13 @@ async def test_cross_provider_lookup_only_retries_empty_results() -> None:
     assert ("direct", True) not in lookups
     assert ("fallback", False) in lookups
     assert ("fallback", True) in lookups
-    assert {track.item_id for track in result} == {"direct-result", "fallback-result"}
+    assert ("filtered", False) in lookups
+    assert ("filtered", True) in lookups
+    assert {track.item_id for track in result} == {
+        "direct-result",
+        "fallback-result",
+        "filtered-fallback",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/providers/radio_playlist/test_radio_playlist.py
+++ b/tests/providers/radio_playlist/test_radio_playlist.py
@@ -119,10 +119,40 @@ async def test_multiple_seeds_dedup_base_tracks() -> None:
     )
 
     await prov.get_dynamic_tracks([seed_a, seed_b], target_size=5)
-    # 3 unique base tracks after dedup. similar_tracks fires once per base per allow_lookup pass;
-    # with only 2 similar mocks per call we never hit the dynamic-target threshold, so both
-    # passes run -> 3 * 2 = 6 calls. Without dedup it would be 4 * 2 = 8.
-    assert cast("Any", prov.mass.music.tracks.similar_tracks).call_count <= 6
+    # Three unique base tracks remain after deduplication, each with a successful direct lookup.
+    assert cast("Any", prov.mass.music.tracks.similar_tracks).call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_cross_provider_lookup_only_retries_empty_results() -> None:
+    """A cross-provider lookup is only used when the direct lookup has no result."""
+    seed = _seed(MediaType.ALBUM, "seed")
+    direct_base = _track("direct")
+    fallback_base = _track("fallback")
+    prov = _make_provider({"seed": [direct_base, fallback_base]}, [])
+    similar_tracks = cast("Any", prov.mass.music.tracks.similar_tracks)
+
+    def get_similar(
+        item_id: str, _provider: str, *, allow_lookup: bool, **_kwargs: Any
+    ) -> list[MagicMock]:
+        if item_id == "direct":
+            return [_track("direct-result")]
+        if allow_lookup:
+            return [_track("fallback-result")]
+        return []
+
+    similar_tracks.side_effect = get_similar
+
+    result = await prov.get_dynamic_tracks([seed], target_size=5)
+
+    lookups = [
+        (call.args[0], call.kwargs["allow_lookup"]) for call in similar_tracks.await_args_list
+    ]
+    assert ("direct", False) in lookups
+    assert ("direct", True) not in lookups
+    assert ("fallback", False) in lookups
+    assert ("fallback", True) in lookups
+    assert {track.item_id for track in result} == {"direct-result", "fallback-result"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Apple Music radio could make repeated similar-track requests before playback starts, causing unnecessary delays.

- Use the tracks returned by a single Apple Music request
- Only try another provider when the direct lookup returns no tracks
- Add regression coverage for request limits and fallback behavior

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.