### PR TITLE
Fix YouTube Music podcast shows being parsed as albums

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -718,8 +718,6 @@ class YoutubeMusicProvider(MusicProvider):
                         folder.items.append(self._parse_playlist(recommended_item))
                     elif recommended_item.get("browseId"):
                         if podcast := self._parse_browse_podcast(recommended_item):
-                            # Podcast shows carry an MPSP-prefixed browseId and
-                            # must not be treated as albums
                             folder.items.append(podcast)
                         else:
                             # Probably an album
@@ -1067,13 +1065,12 @@ class YoutubeMusicProvider(MusicProvider):
         return podcast
 
     def _parse_browse_podcast(self, item_obj: dict[str, Any]) -> Podcast | None:
-        """Parse a browse/search item into a MA Podcast, or None if it is not a podcast."""
+        """Parse a podcast from a browse or search item."""
         browse_id: str = item_obj.get("browseId") or ""
         if not browse_id.startswith("MPSP"):
             return None
         podcast_obj = dict(item_obj)
-        # get_podcast accepts the id both with and without the MPSP prefix, but
-        # library podcasts use the unprefixed form, so strip it for a stable item id
+        # Match the unprefixed IDs used by library podcasts.
         podcast_obj["podcastId"] = item_obj.get("podcastId") or browse_id.removeprefix("MPSP")
         return self._parse_podcast(podcast_obj)
 

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -254,6 +254,8 @@ class YoutubeMusicProvider(MusicProvider):
                 ytm_filter = "songs"
             if media_types[0] == MediaType.PLAYLIST:
                 ytm_filter = "playlists"
+            if media_types[0] == MediaType.PODCAST:
+                ytm_filter = "podcasts"
             if media_types[0] == MediaType.RADIO:
                 # bit of an edge case but still good to handle
                 return parsed_results
@@ -265,6 +267,7 @@ class YoutubeMusicProvider(MusicProvider):
         albums: list[Album | ItemMapping] = []
         playlists: list[Playlist | ItemMapping] = []
         tracks: list[Track | ItemMapping] = []
+        podcasts: list[Podcast | ItemMapping] = []
         for result in results:
             try:
                 if result["resultType"] == "artist" and MediaType.ARTIST in media_types:
@@ -273,6 +276,9 @@ class YoutubeMusicProvider(MusicProvider):
                     albums.append(self._parse_album(result))
                 elif result["resultType"] == "playlist" and MediaType.PLAYLIST in media_types:
                     playlists.append(self._parse_playlist(result))
+                elif result["resultType"] == "podcast" and MediaType.PODCAST in media_types:
+                    if podcast := self._parse_browse_podcast(result):
+                        podcasts.append(podcast)
                 elif (
                     result["resultType"] in ("song", "video")
                     and MediaType.TRACK in media_types
@@ -285,6 +291,7 @@ class YoutubeMusicProvider(MusicProvider):
         parsed_results.albums = albums
         parsed_results.playlists = playlists
         parsed_results.tracks = tracks
+        parsed_results.podcasts = podcasts
         return parsed_results
 
     async def get_library_artists(self) -> AsyncGenerator[Artist]:
@@ -710,8 +717,13 @@ class YoutubeMusicProvider(MusicProvider):
                         del recommended_item["playlistId"]
                         folder.items.append(self._parse_playlist(recommended_item))
                     elif recommended_item.get("browseId"):
-                        # Probably an album
-                        folder.items.append(self._parse_album(recommended_item))
+                        if podcast := self._parse_browse_podcast(recommended_item):
+                            # Podcast shows carry an MPSP-prefixed browseId and
+                            # must not be treated as albums
+                            folder.items.append(podcast)
+                        else:
+                            # Probably an album
+                            folder.items.append(self._parse_album(recommended_item))
                     elif recommended_item.get("subscribers"):
                         # Probably artist
                         folder.items.append(self._parse_album(recommended_item))
@@ -1048,11 +1060,22 @@ class YoutubeMusicProvider(MusicProvider):
         )
         if description := podcast_obj.get("description"):
             podcast.metadata.description = description
-        if author := podcast_obj.get("author"):
+        if author := podcast_obj.get("author") or podcast_obj.get("channel"):
             podcast.publisher = author["name"]
         if thumbnails := podcast_obj.get("thumbnails"):
             podcast.metadata.images = self._parse_thumbnails(thumbnails)
         return podcast
+
+    def _parse_browse_podcast(self, item_obj: dict[str, Any]) -> Podcast | None:
+        """Parse a browse/search item into a MA Podcast, or None if it is not a podcast."""
+        browse_id: str = item_obj.get("browseId") or ""
+        if not browse_id.startswith("MPSP"):
+            return None
+        podcast_obj = dict(item_obj)
+        # get_podcast accepts the id both with and without the MPSP prefix, but
+        # library podcasts use the unprefixed form, so strip it for a stable item id
+        podcast_obj["podcastId"] = item_obj.get("podcastId") or browse_id.removeprefix("MPSP")
+        return self._parse_podcast(podcast_obj)
 
     def _parse_podcast_episode(
         self, episode_obj: dict[str, Any], podcast: Podcast

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -19,7 +19,7 @@ from ytmusicapi.exceptions import YTMusicError
 from music_assistant.providers.ytmusic.constants import YTMRecommendationIcons
 
 # subset of ytmusicapi's accepted search filters that we use
-YTMSearchFilter = Literal["artists", "albums", "songs", "playlists"]
+YTMSearchFilter = Literal["artists", "albums", "songs", "playlists", "podcasts"]
 
 
 async def get_artist(

--- a/tests/providers/ytmusic/test_podcast_parsing.py
+++ b/tests/providers/ytmusic/test_podcast_parsing.py
@@ -1,0 +1,65 @@
+"""Tests for parsing YTM podcasts from browse/search results."""
+
+from unittest.mock import MagicMock
+
+from music_assistant_models.media_items import Podcast
+
+from music_assistant.providers.ytmusic import YoutubeMusicProvider
+
+
+def _make_provider() -> MagicMock:
+    """Create a mock YoutubeMusicProvider with the fields used by the parsers."""
+    prov = MagicMock()
+    prov.instance_id = "ytmusic_test"
+    prov.domain = "ytmusic"
+    prov._parse_thumbnails = MagicMock(return_value=[])
+    prov._parse_podcast = lambda obj: YoutubeMusicProvider._parse_podcast(prov, obj)
+    return prov
+
+
+def test_browse_podcast_with_mpsp_browse_id_is_parsed() -> None:
+    """A home/search item with an MPSP browseId must parse into a Podcast."""
+    prov = _make_provider()
+    item = {
+        "title": "Couple Of",
+        "browseId": "MPSPPLtest123",
+        "podcastId": None,
+        "channel": {"id": "UC123", "name": "Some Channel"},
+    }
+
+    podcast = YoutubeMusicProvider._parse_browse_podcast(prov, item)
+
+    assert isinstance(podcast, Podcast)
+    assert podcast.item_id == "PLtest123"
+    assert podcast.name == "Couple Of"
+    assert podcast.publisher == "Some Channel"
+
+
+def test_browse_podcast_prefers_explicit_podcast_id() -> None:
+    """The item's podcastId must be preferred over the derived browseId."""
+    prov = _make_provider()
+    item = {
+        "title": "Couple Of",
+        "browseId": "MPSPPLtest123",
+        "podcastId": "PLexplicit456",
+    }
+
+    podcast = YoutubeMusicProvider._parse_browse_podcast(prov, item)
+
+    assert isinstance(podcast, Podcast)
+    assert podcast.item_id == "PLexplicit456"
+
+
+def test_browse_album_is_not_parsed_as_podcast() -> None:
+    """An album item (MPRE browseId) must not be parsed as a podcast."""
+    prov = _make_provider()
+    item = {"title": "Some Album", "browseId": "MPREb_test123"}
+
+    assert YoutubeMusicProvider._parse_browse_podcast(prov, item) is None
+
+
+def test_browse_item_without_browse_id_is_not_parsed_as_podcast() -> None:
+    """An item without browseId must not be parsed as a podcast."""
+    prov = _make_provider()
+
+    assert YoutubeMusicProvider._parse_browse_podcast(prov, {"title": "X"}) is None


### PR DESCRIPTION
# What does this implement/fix?

YouTube Music podcast shows in the home feed were treated as albums because any item with a `browseId` was routed through the album parser. Podcast browse IDs start with `MPSP`, so playback and browsing failed with an invalid album browse ID error.

- Detect `MPSP` browse IDs and parse those items as podcasts
- Add podcast search support
- Use channel details as a publisher fallback
- Keep podcast IDs stable between library, browse, and search results
- Add tests covering podcast and non-podcast browse items

Verified with a real YouTube Music account: podcasts load and can be browsed again.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5666

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
