### PR TITLE
Fix Plex Connect selecting the wrong track in long queues

### DIFF
--- a/music_assistant/providers/plex_connect/queue_commands.py
+++ b/music_assistant/providers/plex_connect/queue_commands.py
@@ -151,6 +151,27 @@ class QueueCommandsMixin:
         playqueue.__dict__["items"] = all_items
         return playqueue
 
+    def _selected_item_index(self, playqueue: PlayQueue) -> int:
+        """
+        Return the index of the selected item within the fetched play queue items.
+
+        playQueueSelectedItemOffset is the offset from the start of the *full* queue,
+        while the fetched items list may start mid-queue (the Plex server windows the
+        response around the selected item). Locate the selected item by its
+        playQueueItemID instead, falling back to the raw offset when the ID is absent
+        (e.g. track-radio queues).
+
+        :param playqueue: The (non-empty) Plex play queue to inspect.
+        :return: Index of the selected item in ``playqueue.items``.
+        """
+        selected_id = getattr(playqueue, "playQueueSelectedItemID", None)
+        if selected_id is not None:
+            for index, item in enumerate(playqueue.items):
+                if getattr(item, "playQueueItemID", None) == selected_id:
+                    return index
+        selected_offset = getattr(playqueue, "playQueueSelectedItemOffset", 0) or 0
+        return selected_offset if selected_offset < len(playqueue.items) else 0
+
     def _source_key_from_play_queue_uri(self, source_uri: str) -> str | None:
         """
         Extract a Plex library key from a playQueueSourceURI string.
@@ -282,9 +303,8 @@ class QueueCommandsMixin:
             playqueue = await self._fetch_full_play_queue(queue_id)
 
             if playqueue is not None and playqueue.items:
-                # playQueueSelectedItemOffset may be None on track-radio queues.
-                selected_offset = getattr(playqueue, "playQueueSelectedItemOffset", 0) or 0
-                LOGGER.info(f"PlayQueue selected item offset: {selected_offset}")
+                selected_offset = self._selected_item_index(playqueue)
+                LOGGER.info(f"PlayQueue selected item index: {selected_offset}")
 
                 # When Plex reports a shuffled queue, load the original source into MA
                 # unshuffled and let MA apply its own shuffle, then propagate back to Plex.
@@ -296,11 +316,7 @@ class QueueCommandsMixin:
 
                 self.play_queue_item_ids = {}
 
-                first_item = (
-                    playqueue.items[selected_offset]
-                    if selected_offset < len(playqueue.items)
-                    else playqueue.items[0]
-                )
+                first_item = playqueue.items[selected_offset]
                 first_track_key, first_play_queue_item_id = plex_item_fields(first_item)
 
                 if not first_track_key:

--- a/music_assistant/providers/plex_connect/queue_commands.py
+++ b/music_assistant/providers/plex_connect/queue_commands.py
@@ -152,18 +152,7 @@ class QueueCommandsMixin:
         return playqueue
 
     def _selected_item_index(self, playqueue: PlayQueue) -> int:
-        """
-        Return the index of the selected item within the fetched play queue items.
-
-        playQueueSelectedItemOffset is the offset from the start of the *full* queue,
-        while the fetched items list may start mid-queue (the Plex server windows the
-        response around the selected item). Locate the selected item by its
-        playQueueItemID instead, falling back to the raw offset when the ID is absent
-        (e.g. track-radio queues).
-
-        :param playqueue: The (non-empty) Plex play queue to inspect.
-        :return: Index of the selected item in ``playqueue.items``.
-        """
+        """Return the selected item's index within the fetched queue window."""
         selected_id = getattr(playqueue, "playQueueSelectedItemID", None)
         if selected_id is not None:
             for index, item in enumerate(playqueue.items):

--- a/music_assistant/providers/plex_connect/queue_commands.py
+++ b/music_assistant/providers/plex_connect/queue_commands.py
@@ -159,7 +159,7 @@ class QueueCommandsMixin:
                 if getattr(item, "playQueueItemID", None) == selected_id:
                     return index
         selected_offset = getattr(playqueue, "playQueueSelectedItemOffset", 0) or 0
-        return selected_offset if selected_offset < len(playqueue.items) else 0
+        return selected_offset if 0 <= selected_offset < len(playqueue.items) else 0
 
     def _source_key_from_play_queue_uri(self, source_uri: str) -> str | None:
         """

--- a/tests/providers/plex_connect/test_selected_item_index.py
+++ b/tests/providers/plex_connect/test_selected_item_index.py
@@ -35,7 +35,7 @@ def _make_playqueue(
     items = [SimpleNamespace(playQueueItemID=1000 + n) for n in range(first_track, last_track + 1)]
     return SimpleNamespace(
         items=items,
-        playQueueSelectedItemID=1000 + selected_track if selected_track else None,
+        playQueueSelectedItemID=1000 + selected_track if selected_track is not None else None,
         playQueueSelectedItemOffset=selected_offset,
     )
 
@@ -68,6 +68,13 @@ def test_selected_index_out_of_range_offset() -> None:
     """An offset beyond the fetched items must not raise; default to first item."""
     handler = _QueueHandler()
     playqueue = _make_playqueue(1, 10, selected_track=None, selected_offset=42)
+    assert handler._selected_item_index(playqueue) == 0
+
+
+def test_selected_index_negative_offset() -> None:
+    """A negative offset must not index from the end of the list; default to first item."""
+    handler = _QueueHandler()
+    playqueue = _make_playqueue(1, 10, selected_track=None, selected_offset=-1)
     assert handler._selected_item_index(playqueue) == 0
 
 

--- a/tests/providers/plex_connect/test_selected_item_index.py
+++ b/tests/providers/plex_connect/test_selected_item_index.py
@@ -1,0 +1,78 @@
+"""Tests for locating the selected item in a windowed Plex play queue."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from music_assistant.providers.plex_connect.queue_commands import QueueCommandsMixin
+
+
+class _QueueHandler(QueueCommandsMixin):
+    """QueueCommandsMixin with the host-class attributes mocked."""
+
+    def __init__(self) -> None:
+        self.provider = Mock()
+        self._ma_player_id = "player1"
+        self._updating_from_plex = False
+        self.play_queue_id = None
+        self.play_queue_item_ids: dict[int, int] = {}
+
+
+def _make_playqueue(
+    first_track: int,
+    last_track: int,
+    selected_track: int | None,
+    selected_offset: int | None,
+) -> SimpleNamespace:
+    """
+    Build a fake windowed PlayQueue.
+
+    Track number N gets playQueueItemID 1000+N; the items list covers
+    first_track..last_track while selected_offset is the absolute (full-queue)
+    offset as reported by the Plex server.
+    """
+    items = [SimpleNamespace(playQueueItemID=1000 + n) for n in range(first_track, last_track + 1)]
+    return SimpleNamespace(
+        items=items,
+        playQueueSelectedItemID=1000 + selected_track if selected_track else None,
+        playQueueSelectedItemOffset=selected_offset,
+    )
+
+
+def test_selected_index_windowed_queue() -> None:
+    """The absolute offset must not be used as index into a mid-queue window."""
+    handler = _QueueHandler()
+    # Track 94 selected in a 200-track album; server window starts at track 44.
+    # Absolute offset 93 would land on track 137 (the reported 2x-51 bug).
+    playqueue = _make_playqueue(44, 200, selected_track=94, selected_offset=93)
+    index = handler._selected_item_index(playqueue)
+    assert playqueue.items[index].playQueueItemID == 1000 + 94
+
+
+def test_selected_index_full_queue() -> None:
+    """When the window covers the full queue, ID match equals the offset."""
+    handler = _QueueHandler()
+    playqueue = _make_playqueue(1, 100, selected_track=52, selected_offset=51)
+    assert handler._selected_item_index(playqueue) == 51
+
+
+def test_selected_index_falls_back_to_offset() -> None:
+    """Without a selected item ID (track radio), fall back to the raw offset."""
+    handler = _QueueHandler()
+    playqueue = _make_playqueue(1, 10, selected_track=None, selected_offset=3)
+    assert handler._selected_item_index(playqueue) == 3
+
+
+def test_selected_index_out_of_range_offset() -> None:
+    """An offset beyond the fetched items must not raise; default to first item."""
+    handler = _QueueHandler()
+    playqueue = _make_playqueue(1, 10, selected_track=None, selected_offset=42)
+    assert handler._selected_item_index(playqueue) == 0
+
+
+def test_selected_index_none_offset() -> None:
+    """A missing offset (None) defaults to the first item."""
+    handler = _QueueHandler()
+    playqueue = _make_playqueue(1, 10, selected_track=None, selected_offset=None)
+    assert handler._selected_item_index(playqueue) == 0


### PR DESCRIPTION
# What does this implement/fix?

Plex Connect played the wrong track when selecting tracks beyond roughly number 51. Plex reports the selected offset relative to the full queue, while the returned items can be a window starting partway through that queue. Applying the absolute offset to the window selected a later track.

- Locate the selected queue item by `playQueueSelectedItemID`
- Fall back safely to the reported offset for queues without a selected item ID
- Add tests for full, windowed, missing-ID, and out-of-range queue responses

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/4924

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
