### PR TITLE
Jellyfin replaygain tags

### DIFF
--- a/music_assistant/providers/jellyfin/__init__.py
+++ b/music_assistant/providers/jellyfin/__init__.py
@@ -180,7 +180,7 @@ class JellyfinProvider(MusicProvider):
         )
         tracks = []
         for item in resultset["Items"]:
-            tracks.append(parse_track(self.logger, self.instance_id, self._client, item))
+            tracks.append(parse_track(self.mass, self.logger, self.instance_id, self._client, item))
         return tracks
 
     async def _search_album(self, search_query: str, limit: int) -> list[Album]:
@@ -307,7 +307,7 @@ class JellyfinProvider(MusicProvider):
                         "Invalid track %s: Does not have any media streams", track[ITEM_KEY_NAME]
                     )
                     continue
-                yield parse_track(self.logger, self.instance_id, self._client, track)
+                yield parse_track(self.mass, self.logger, self.instance_id, self._client, track)
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve all library playlists from the provider."""
@@ -343,7 +343,9 @@ class JellyfinProvider(MusicProvider):
             .request()
         )
         return [
-            parse_track(self.logger, self.instance_id, self._client, jellyfin_album_track)
+            parse_track(
+                self.mass, self.logger, self.instance_id, self._client, jellyfin_album_track
+            )
             for jellyfin_album_track in jellyfin_album_tracks["Items"]
         ]
 
@@ -379,7 +381,7 @@ class JellyfinProvider(MusicProvider):
             track = await self._client.get_track(prov_track_id)
         except NotFound:
             raise MediaNotFoundError(f"Item {prov_track_id} not found")
-        return parse_track(self.logger, self.instance_id, self._client, track)
+        return parse_track(self.mass, self.logger, self.instance_id, self._client, track)
 
     @use_cache(60 * 15)  # Cache for 15 minutes
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
@@ -406,7 +408,7 @@ class JellyfinProvider(MusicProvider):
             pos = (page * 100) + index
             try:
                 if track := parse_track(
-                    self.logger, self.instance_id, self._client, jellyfin_track
+                    self.mass, self.logger, self.instance_id, self._client, jellyfin_track
                 ):
                     track.position = pos
                     result.append(track)
@@ -462,7 +464,7 @@ class JellyfinProvider(MusicProvider):
             prov_track_id, limit=limit, fields=TRACK_FIELDS
         )
         return [
-            parse_track(self.logger, self.instance_id, self._client, track)
+            parse_track(self.mass, self.logger, self.instance_id, self._client, track)
             for track in resp["Items"]
         ]
 

--- a/music_assistant/providers/jellyfin/__init__.py
+++ b/music_assistant/providers/jellyfin/__init__.py
@@ -302,7 +302,7 @@ class JellyfinProvider(MusicProvider):
                 .stream(100)
             )
             async for track in stream:
-                if not len(track[ITEM_KEY_MEDIA_STREAMS]):
+                if not len(track.get(ITEM_KEY_MEDIA_STREAMS, [])):
                     self.logger.warning(
                         "Invalid track %s: Does not have any media streams", track[ITEM_KEY_NAME]
                     )

--- a/music_assistant/providers/jellyfin/const.py
+++ b/music_assistant/providers/jellyfin/const.py
@@ -40,6 +40,8 @@ ITEM_KEY_CAN_DOWNLOAD: Final = "CanDownload"
 ITEM_KEY_PARENT_INDEX_NUM: Final = "ParentIndexNumber"
 ITEM_KEY_RUNTIME_TICKS: Final = "RunTimeTicks"
 ITEM_KEY_USER_DATA: Final = "UserData"
+ITEM_KEY_TRACK_NORMALIZATION_GAIN: Final = "NormalizationGain"
+ITEM_KEY_ALBUM_NORMALIZATION_GAIN: Final = "AlbumNormalizationGain"
 
 USER_DATA_KEY_IS_FAVORITE: Final = "IsFavorite"
 
@@ -56,6 +58,7 @@ ALBUM_FIELDS: Final = [
     ItemFields.Overview,
     ItemFields.ProviderIds,
     ItemFields.SortName,
+    ItemFields.NormalizationGain,
 ]
 TRACK_FIELDS: Final = [
     ItemFields.ProviderIds,
@@ -63,6 +66,8 @@ TRACK_FIELDS: Final = [
     ItemFields.SortName,
     ItemFields.MediaSources,
     ItemFields.MediaStreams,
+    ItemFields.NormalizationGain,
+    ItemFields.AlbumNormalizationGain,
 ]
 
 USER_APP_NAME: Final = "Music Assistant"

--- a/music_assistant/providers/jellyfin/parsers.py
+++ b/music_assistant/providers/jellyfin/parsers.py
@@ -23,6 +23,7 @@ from music_assistant_models.media_items import (
 
 from music_assistant.constants import UNKNOWN_ARTIST
 from music_assistant.helpers.util import parse_title_and_version
+from music_assistant.mass import MusicAssistant
 
 from .const import (
     DOMAIN,
@@ -30,6 +31,7 @@ from .const import (
     ITEM_KEY_ALBUM_ARTIST,
     ITEM_KEY_ALBUM_ARTISTS,
     ITEM_KEY_ALBUM_ID,
+    ITEM_KEY_ALBUM_NORMALIZATION_GAIN,
     ITEM_KEY_ARTIST_ITEMS,
     ITEM_KEY_CAN_DOWNLOAD,
     ITEM_KEY_CONTAINER,
@@ -52,6 +54,7 @@ from .const import (
     ITEM_KEY_PROVIDER_IDS,
     ITEM_KEY_RUNTIME_TICKS,
     ITEM_KEY_SORT_NAME,
+    ITEM_KEY_TRACK_NORMALIZATION_GAIN,
     ITEM_KEY_USER_DATA,
     MEDIA_IMAGE_TYPES,
     USER_DATA_KEY_IS_FAVORITE,
@@ -205,7 +208,11 @@ def audio_format(track: JellyTrack) -> AudioFormat:
 
 
 def parse_track(
-    logger: Logger, instance_id: str, client: Connection, jellyfin_track: JellyTrack
+    mass: MusicAssistant,
+    logger: Logger,
+    instance_id: str,
+    client: Connection,
+    jellyfin_track: JellyTrack,
 ) -> Track:
     """Parse a Jellyfin Track response to a Track model object."""
     available = jellyfin_track[ITEM_KEY_CAN_DOWNLOAD]
@@ -274,6 +281,25 @@ def parse_track(
             )
     user_data = jellyfin_track.get(ITEM_KEY_USER_DATA, {})
     track.favorite = user_data.get(USER_DATA_KEY_IS_FAVORITE, False)
+
+    # handle optional loudness measurement tag(s) assuming -18 dB reference according to ReplayGain 2.0
+    track_gain = jellyfin_track.get(ITEM_KEY_TRACK_NORMALIZATION_GAIN)
+    if track_gain is not None:
+        track_loudness = -18.0 - track_gain
+
+        album_gain = jellyfin_track.get(ITEM_KEY_ALBUM_NORMALIZATION_GAIN)
+
+        album_loudness = -18.0 - album_gain if album_gain is not None else None
+
+        mass.create_task(
+            mass.streams.audio_analysis.set_track_loudness(
+                track.item_id,
+                instance_id,
+                track_loudness,
+                album_loudness,
+            )
+        )
+
     return track
 
 

--- a/tests/providers/jellyfin/test_parsers.py
+++ b/tests/providers/jellyfin/test_parsers.py
@@ -13,6 +13,7 @@ from aiojellyfin.session import SessionConfiguration
 from mashumaro.codecs.json import JSONDecoder
 from music_assistant_models.enums import ContentType
 
+from music_assistant.mass import MusicAssistant
 from music_assistant.providers.jellyfin.const import (
     ITEM_KEY_CONTAINER,
     ITEM_KEY_MEDIA_CHANNELS,
@@ -84,12 +85,12 @@ async def test_parse_albums(
 
 @pytest.mark.parametrize("example", TRACK_FIXTURES, ids=lambda val: str(val.stem))
 async def test_parse_tracks(
-    example: pathlib.Path, connection: Connection, snapshot: SnapshotAssertion
+    mass: MusicAssistant, example: pathlib.Path, connection: Connection, snapshot: SnapshotAssertion
 ) -> None:
     """Test we can parse tracks."""
     async with aiofiles.open(example) as fp:
         raw_data = ARTIST_DECODER.decode(await fp.read())
-    parsed = parse_track(_LOGGER, "xx-instance-id-xx", connection, raw_data).to_dict()
+    parsed = parse_track(mass, _LOGGER, "xx-instance-id-xx", connection, raw_data).to_dict()
     # sort external Ids to ensure they are always in the same order for snapshot testing
     parsed["external_ids"]
     assert snapshot == parsed


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Adds support for volume normalization for the Jellyfin provider, for both track and album gain together with the ereference loudness. Requires the below 2 issues to be merged in their respective repos to work completely but should still not break things if the new fields aren't provided by the server and aiojellyfin:
- jellyfin/jellyfin#17315
- Jc2k/aiojellyfin#10

I'm not sure if I should update any Jellyfin tests. Can someone guide me here what to do, if anything? The tests seem to be failing due to Jc2k/aiojellyfin#10 not being merged yet.
For the documentation item in the checklist, the [jeellyfin page](https://github.com/music-assistant/music-assistant.io/blob/main/src/content/docs/music-providers/jellyfin.md) doesn't tmention normalization support so I wasn't sure if it's appropriate to add it.

**Related issue (if applicable):**
None

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
