### PR TITLE
Fix AirPlay Receiver losing audio after quick reconnects

### DIFF
--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -197,6 +197,10 @@ class AirPlayReceiverProvider(PluginProvider):
         # stream request — used to reject stale on_source_unselected callbacks
         # after a same-queue reconnect supersedes the previous request.
         self._active_session_id: str | None = None
+        # _pending_stop_task: the fire-and-forget cmd_stop issued on session
+        # stop. A quickly following play must await it, otherwise the late
+        # stop lands after play_media and kills the freshly started stream.
+        self._pending_stop_task: asyncio.Task[None] | None = None
         self._on_unload_callbacks: list[Callable[..., None]] = []
         self._runner_error_count = 0
         self._metadata_reader: MetadataReader | None = None
@@ -687,11 +691,7 @@ class AirPlayReceiverProvider(PluginProvider):
                 if target_player_id:
                     self.logger.info("Starting AirPlay playback on player %s", target_player_id)
                     self._active_player_id = target_player_id
-                    self.mass.create_task(
-                        self.mass.player_queues.play_media(
-                            target_player_id, str(self._audio_source.uri)
-                        )
-                    )
+                    self.mass.create_task(self._start_playback(target_player_id))
                 else:
                     self.logger.warning(
                         "AirPlay playback started but no player available. "
@@ -708,9 +708,26 @@ class AirPlayReceiverProvider(PluginProvider):
             # Write silence to the pipe so ffmpeg can produce a chunk and notice the
             # stream has stopped; the stop command below closes the generator path.
             self.mass.create_task(self._write_silence_to_unblock_stream())
-            # Stop the player that was using this source
+            # Stop the player that was using this source. Keep a handle on the
+            # task so a quickly following play can await it before starting.
             if current_player_id:
-                self.mass.create_task(self.mass.players.cmd_stop(current_player_id))
+                self._pending_stop_task = self.mass.create_task(
+                    self.mass.players.cmd_stop(current_player_id)
+                )
+
+    async def _start_playback(self, target_player_id: str) -> None:
+        """
+        Start playback of the AirPlay source on the target player.
+
+        Awaits any in-flight stop from a preceding session teardown first, so a
+        quick stop→play bounce (e.g. an AirPlay reconnect) cannot have the late
+        stop kill the freshly started stream.
+        """
+        if self._pending_stop_task and not self._pending_stop_task.done():
+            with suppress(Exception):
+                await self._pending_stop_task
+        self._pending_stop_task = None
+        await self.mass.player_queues.play_media(target_player_id, str(self._audio_source.uri))
 
     def _handle_volume_change(self, volume: int) -> None:
         """

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -33,6 +33,7 @@ from music_assistant_models.enums import (
 from music_assistant_models.errors import (
     AudioError,
     MediaNotFoundError,
+    PlayerCommandFailed,
     UnsupportedFeaturedException,
 )
 from music_assistant_models.media_items import (
@@ -197,9 +198,6 @@ class AirPlayReceiverProvider(PluginProvider):
         # stream request — used to reject stale on_source_unselected callbacks
         # after a same-queue reconnect supersedes the previous request.
         self._active_session_id: str | None = None
-        # _pending_stop_task: the fire-and-forget cmd_stop issued on session
-        # stop. A quickly following play must await it, otherwise the late
-        # stop lands after play_media and kills the freshly started stream.
         self._pending_stop_task: asyncio.Task[None] | None = None
         self._on_unload_callbacks: list[Callable[..., None]] = []
         self._runner_error_count = 0
@@ -708,24 +706,19 @@ class AirPlayReceiverProvider(PluginProvider):
             # Write silence to the pipe so ffmpeg can produce a chunk and notice the
             # stream has stopped; the stop command below closes the generator path.
             self.mass.create_task(self._write_silence_to_unblock_stream())
-            # Stop the player that was using this source. Keep a handle on the
-            # task so a quickly following play can await it before starting.
+            # Track the stop so a new session cannot overtake it.
             if current_player_id:
                 self._pending_stop_task = self.mass.create_task(
                     self.mass.players.cmd_stop(current_player_id)
                 )
 
     async def _start_playback(self, target_player_id: str) -> None:
-        """
-        Start playback of the AirPlay source on the target player.
-
-        Awaits any in-flight stop from a preceding session teardown first, so a
-        quick stop→play bounce (e.g. an AirPlay reconnect) cannot have the late
-        stop kill the freshly started stream.
-        """
+        """Start playback after any pending stop completes."""
         if self._pending_stop_task and not self._pending_stop_task.done():
-            with suppress(Exception):
+            try:
                 await self._pending_stop_task
+            except PlayerCommandFailed as err:
+                self.logger.warning("Failed to stop previous AirPlay playback: %s", err)
         self._pending_stop_task = None
         await self.mass.player_queues.play_media(target_player_id, str(self._audio_source.uri))
 

--- a/tests/providers/airplay_receiver/__init__.py
+++ b/tests/providers/airplay_receiver/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for AirPlay Receiver provider."""

--- a/tests/providers/airplay_receiver/test_stop_play_race.py
+++ b/tests/providers/airplay_receiver/test_stop_play_race.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from music_assistant_models.errors import PlayerCommandFailed
 
 from music_assistant.providers.airplay_receiver import AirPlayReceiverProvider
 
@@ -66,7 +67,6 @@ async def test_play_waits_for_inflight_stop(provider: MagicMock) -> None:
     _handle(provider, "stopped")
     _handle(provider, "playing")
 
-    # play must not start while the stop is still in flight
     for _ in range(5):
         await asyncio.sleep(0)
     assert events == []
@@ -90,7 +90,7 @@ async def test_play_without_pending_stop_starts_immediately(provider: MagicMock)
 
 async def test_play_proceeds_when_stop_fails(provider: MagicMock) -> None:
     """A failing stop must not block the new playback from starting."""
-    provider.mass.players.cmd_stop = AsyncMock(side_effect=RuntimeError("boom"))
+    provider.mass.players.cmd_stop = AsyncMock(side_effect=PlayerCommandFailed("boom"))
     provider.mass.player_queues.play_media = AsyncMock()
 
     _handle(provider, "stopped")

--- a/tests/providers/airplay_receiver/test_stop_play_race.py
+++ b/tests/providers/airplay_receiver/test_stop_play_race.py
@@ -1,0 +1,100 @@
+"""Tests for the stop→play race in AirPlay Receiver session handling."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from music_assistant.providers.airplay_receiver import AirPlayReceiverProvider
+
+
+@pytest.fixture
+def provider() -> MagicMock:
+    """Create a mock provider with the real play-state handling bound to it."""
+    mock = MagicMock()
+    mock.logger = MagicMock()
+    mock._first_volume_event_received = False
+    mock._in_use_by_queue = "queue1"
+    mock._active_player_id = "player1"
+    mock._active_session_id = "session1"
+    mock._pending_stop_task = None
+    mock._get_target_player_id.return_value = "player1"
+    mock._audio_source.uri = "airplay://source"
+    mock._write_silence_to_unblock_stream = AsyncMock()
+
+    def _clear_active_player() -> None:
+        mock._active_player_id = None
+        mock._in_use_by_queue = None
+        mock._active_session_id = None
+
+    mock._clear_active_player.side_effect = _clear_active_player
+
+    def _create_task(coro: Any) -> asyncio.Task[Any]:
+        return asyncio.get_event_loop().create_task(coro)
+
+    mock.mass.create_task.side_effect = _create_task
+
+    def _start_playback(player_id: str) -> Any:
+        return AirPlayReceiverProvider._start_playback(mock, player_id)
+
+    mock._start_playback.side_effect = _start_playback
+    return mock
+
+
+def _handle(mock: MagicMock, play_state: str) -> None:
+    AirPlayReceiverProvider._handle_play_state_change(mock, play_state)
+
+
+async def test_play_waits_for_inflight_stop(provider: MagicMock) -> None:
+    """A quick stop→play bounce must not let the late stop kill the new stream."""
+    events: list[str] = []
+    stop_release = asyncio.Event()
+
+    async def slow_stop(_player_id: str) -> None:
+        await stop_release.wait()
+        events.append("stop_done")
+
+    async def play_media(_player_id: str, _media: str) -> None:
+        events.append("play")
+
+    provider.mass.players.cmd_stop = slow_stop
+    provider.mass.player_queues.play_media = play_media
+
+    _handle(provider, "stopped")
+    _handle(provider, "playing")
+
+    # play must not start while the stop is still in flight
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert events == []
+
+    stop_release.set()
+    await asyncio.sleep(0.01)
+    assert events == ["stop_done", "play"]
+    assert provider._pending_stop_task is None
+
+
+async def test_play_without_pending_stop_starts_immediately(provider: MagicMock) -> None:
+    """A plain session start plays right away."""
+    provider._in_use_by_queue = None
+    provider.mass.player_queues.play_media = AsyncMock()
+
+    _handle(provider, "playing")
+    await asyncio.sleep(0.01)
+
+    provider.mass.player_queues.play_media.assert_awaited_once_with("player1", "airplay://source")
+
+
+async def test_play_proceeds_when_stop_fails(provider: MagicMock) -> None:
+    """A failing stop must not block the new playback from starting."""
+    provider.mass.players.cmd_stop = AsyncMock(side_effect=RuntimeError("boom"))
+    provider.mass.player_queues.play_media = AsyncMock()
+
+    _handle(provider, "stopped")
+    _handle(provider, "playing")
+    await asyncio.sleep(0.01)
+
+    provider.mass.player_queues.play_media.assert_awaited_once_with("player1", "airplay://source")


### PR DESCRIPTION
# What does this implement/fix?

AirPlay Receiver could report that playback started while producing no audio after a quick session reconnect. Session teardown stopped the target player in a background task, so the delayed stop could complete after the next session had already started playback and kill the new stream.

- Keep track of the pending stop task
- Wait for that stop before starting playback for the next AirPlay session
- Continue playback after a failed stop while logging the failure
- Add tests for quick reconnects, normal starts, and failed stops

This was reproduced with an asynchronous simulation. Live hardware verification requires reporter testing because the bundled `shairport-sync` cannot run in the available macOS test environment.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5771

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
