### PR TITLE
Fix AirPlay Receiver losing startup metadata events

### DIFF
--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -586,10 +586,7 @@ class AirPlayReceiverProvider(PluginProvider):
                 args, stderr=True, name=f"shairport-sync[{self.name}]"
             )
 
-            # Start the metadata reader before launching shairport-sync: the
-            # sessioncontrol hooks open the FIFO for writing, which blocks while
-            # nothing is reading, so a client connecting right at startup would
-            # stall the hook and delay/lose the MA_PLAY_BEGIN event.
+            # Open the FIFO before shairport-sync can invoke session-control hooks.
             self._metadata_reader = MetadataReader(
                 self.metadata_pipe.path, self.logger, self._on_metadata_update
             )

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -585,6 +585,16 @@ class AirPlayReceiverProvider(PluginProvider):
             self._shairport_proc = shairport = AsyncProcess(
                 args, stderr=True, name=f"shairport-sync[{self.name}]"
             )
+
+            # Start the metadata reader before launching shairport-sync: the
+            # sessioncontrol hooks open the FIFO for writing, which blocks while
+            # nothing is reading, so a client connecting right at startup would
+            # stall the hook and delay/lose the MA_PLAY_BEGIN event.
+            self._metadata_reader = MetadataReader(
+                self.metadata_pipe.path, self.logger, self._on_metadata_update
+            )
+            await self._metadata_reader.start()
+
             await shairport.start()
 
             # Check if process started successfully
@@ -594,12 +604,6 @@ class AirPlayReceiverProvider(PluginProvider):
                     "shairport-sync exited immediately with code %s", shairport.returncode
                 )
                 return
-
-            # Start metadata reader
-            self._metadata_reader = MetadataReader(
-                self.metadata_pipe.path, self.logger, self._on_metadata_update
-            )
-            await self._metadata_reader.start()
 
             # Keep reading logging from stderr until exit
             self.logger.debug("Starting to read shairport-sync stderr")

--- a/music_assistant/providers/airplay_receiver/metadata.py
+++ b/music_assistant/providers/airplay_receiver/metadata.py
@@ -49,7 +49,11 @@ class MetadataReader:
         """Start reading metadata from the pipe."""
         self._stop = False
         # Open the FIFO up front so hook writers never block on a missing reader.
-        self._fd = await self._open_pipe()
+        try:
+            self._fd = await self._open_pipe()
+        except OSError as err:
+            # _run() retries the open; raising here would take down the whole daemon.
+            self.logger.error("Unable to open metadata pipe %s: %s", self.metadata_pipe, err)
         self._reader_task = asyncio.create_task(self._run())
 
     async def stop(self) -> None:
@@ -59,7 +63,7 @@ class MetadataReader:
             self._reader_task.cancel()
             with suppress(asyncio.CancelledError):
                 await self._reader_task
-        # start() opens the pipe, so the fd can outlive a read loop that never ran.
+        # The fd stays open for the reader's whole lifetime, so stop() owns closing it.
         if self._fd is not None:
             with suppress(OSError):
                 os.close(self._fd)
@@ -72,70 +76,66 @@ class MetadataReader:
         A dead reader would silently drop all sessioncontrol markers and leave
         hook writers blocked on the FIFO, so unexpected errors must not be fatal.
         """
+        backoff = 1
         while not self._stop:
             try:
                 await self._read_metadata()
             except Exception as err:
-                self.logger.error("Metadata reader failed, restarting: %s", err)
+                # Only the first failure of a streak is worth an error, retries are noise.
+                log = self.logger.error if backoff == 1 else self.logger.debug
+                log("Metadata reader failed, retrying in %ss: %s", backoff, err)
             if not self._stop:
-                await asyncio.sleep(1)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30)
 
     async def _open_pipe(self) -> int:
         """Open the metadata pipe in non-blocking mode and return its file descriptor."""
-        return await asyncio.to_thread(os.open, self.metadata_pipe, os.O_RDONLY | os.O_NONBLOCK)
+        # O_RDWR keeps a writer attached so the read end never reaches EOF: epoll reports a
+        # writerless FIFO readable forever, which spins the event loop at 100% CPU.
+        return await asyncio.to_thread(os.open, self.metadata_pipe, os.O_RDWR | os.O_NONBLOCK)
 
     async def _read_metadata(self) -> None:
         """Read metadata from the pipe using async file descriptor."""
         loop = asyncio.get_running_loop()
+        # start() already opened the pipe; only open here when start() could not.
+        if self._fd is None:
+            self._fd = await self._open_pipe()
+        fd = self._fd
+
+        # Create an asyncio.Event to signal when data is available
+        data_available = asyncio.Event()
+
+        def on_readable() -> None:
+            """Set data available flag when file descriptor is readable."""
+            data_available.set()
+
+        # Register the file descriptor with the event loop
+        loop.add_reader(fd, on_readable)
+
         try:
-            # start() already opened the pipe; only reopen when a restart closed the fd.
-            if self._fd is None:
-                self._fd = await self._open_pipe()
-            fd = self._fd
+            while not self._stop:
+                # Wait for data to be available
+                await data_available.wait()
+                data_available.clear()
 
-            # Create an asyncio.Event to signal when data is available
-            data_available = asyncio.Event()
-
-            def on_readable() -> None:
-                """Set data available flag when file descriptor is readable."""
-                data_available.set()
-
-            # Register the file descriptor with the event loop
-            loop.add_reader(fd, on_readable)
-
-            try:
-                while not self._stop:
-                    # Wait for data to be available
-                    await data_available.wait()
-                    data_available.clear()
-
-                    # Read available data from the pipe
-                    try:
-                        chunk = os.read(fd, 4096)
-                        if chunk:
-                            # Decode as text and add to buffer
-                            self._buffer += chunk.decode("utf-8", errors="ignore")
-                            # Process all complete metadata items in the buffer
-                            self._process_buffer()
-                        else:
-                            # Avoid a busy loop while the FIFO has no writers.
-                            await asyncio.sleep(0.1)
-                    except BlockingIOError:
-                        # No data available right now, wait for next notification
-                        continue
-                    except OSError as err:
-                        self.logger.debug("Error reading from pipe: %s", err)
-                        await asyncio.sleep(0.1)
-
-            finally:
-                # Remove the reader callback
-                loop.remove_reader(fd)
+                # Read available data from the pipe
+                try:
+                    chunk = os.read(fd, 4096)
+                    # Decode as text and add to buffer
+                    self._buffer += chunk.decode("utf-8", errors="ignore")
+                    # Process all complete metadata items in the buffer
+                    self._process_buffer()
+                except BlockingIOError:
+                    # No data available right now, wait for next notification
+                    continue
+                except OSError as err:
+                    self.logger.debug("Error reading from pipe: %s", err)
+                    await asyncio.sleep(0.1)
 
         finally:
-            if self._fd is not None:
-                with suppress(OSError):
-                    os.close(self._fd)
-                self._fd = None
+            # Remove the reader callback, but keep the fd open so hook writers
+            # never find the FIFO readerless while _run() restarts the loop.
+            loop.remove_reader(fd)
 
     def _process_buffer(self) -> None:
         """Process all complete metadata items in the buffer (XML format or plain text markers)."""

--- a/music_assistant/providers/airplay_receiver/metadata.py
+++ b/music_assistant/providers/airplay_receiver/metadata.py
@@ -93,10 +93,7 @@ class MetadataReader:
                             # Process all complete metadata items in the buffer
                             self._process_buffer()
                         else:
-                            # EOF: all writers closed (e.g. a sessioncontrol hook
-                            # finished its echo). The fd stays readable, so back
-                            # off briefly to avoid busy-spinning the event loop
-                            # until a new writer opens the pipe.
+                            # Avoid a busy loop while the FIFO has no writers.
                             await asyncio.sleep(0.1)
                     except BlockingIOError:
                         # No data available right now, wait for next notification

--- a/music_assistant/providers/airplay_receiver/metadata.py
+++ b/music_assistant/providers/airplay_receiver/metadata.py
@@ -48,7 +48,7 @@ class MetadataReader:
     async def start(self) -> None:
         """Start reading metadata from the pipe."""
         self._stop = False
-        self._reader_task = asyncio.create_task(self._read_metadata())
+        self._reader_task = asyncio.create_task(self._run())
 
     async def stop(self) -> None:
         """Stop reading metadata."""
@@ -57,6 +57,21 @@ class MetadataReader:
             self._reader_task.cancel()
             with suppress(asyncio.CancelledError):
                 await self._reader_task
+
+    async def _run(self) -> None:
+        """
+        Keep the pipe reader alive until stopped.
+
+        A dead reader would silently drop all sessioncontrol markers and leave
+        hook writers blocked on the FIFO, so unexpected errors must not be fatal.
+        """
+        while not self._stop:
+            try:
+                await self._read_metadata()
+            except Exception as err:
+                self.logger.error("Metadata reader failed, restarting: %s", err)
+            if not self._stop:
+                await asyncio.sleep(1)
 
     async def _read_metadata(self) -> None:
         """Read metadata from the pipe using async file descriptor."""
@@ -106,8 +121,6 @@ class MetadataReader:
                 # Remove the reader callback
                 loop.remove_reader(self._fd)
 
-        except Exception as err:
-            self.logger.error("Error reading metadata pipe: %s", err)
         finally:
             if self._fd is not None:
                 with suppress(OSError):

--- a/music_assistant/providers/airplay_receiver/metadata.py
+++ b/music_assistant/providers/airplay_receiver/metadata.py
@@ -92,6 +92,12 @@ class MetadataReader:
                             self._buffer += chunk.decode("utf-8", errors="ignore")
                             # Process all complete metadata items in the buffer
                             self._process_buffer()
+                        else:
+                            # EOF: all writers closed (e.g. a sessioncontrol hook
+                            # finished its echo). The fd stays readable, so back
+                            # off briefly to avoid busy-spinning the event loop
+                            # until a new writer opens the pipe.
+                            await asyncio.sleep(0.1)
                     except BlockingIOError:
                         # No data available right now, wait for next notification
                         continue

--- a/music_assistant/providers/airplay_receiver/metadata.py
+++ b/music_assistant/providers/airplay_receiver/metadata.py
@@ -48,6 +48,8 @@ class MetadataReader:
     async def start(self) -> None:
         """Start reading metadata from the pipe."""
         self._stop = False
+        # Open the FIFO up front so hook writers never block on a missing reader.
+        self._fd = await self._open_pipe()
         self._reader_task = asyncio.create_task(self._run())
 
     async def stop(self) -> None:
@@ -57,6 +59,11 @@ class MetadataReader:
             self._reader_task.cancel()
             with suppress(asyncio.CancelledError):
                 await self._reader_task
+        # start() opens the pipe, so the fd can outlive a read loop that never ran.
+        if self._fd is not None:
+            with suppress(OSError):
+                os.close(self._fd)
+            self._fd = None
 
     async def _run(self) -> None:
         """
@@ -73,15 +80,18 @@ class MetadataReader:
             if not self._stop:
                 await asyncio.sleep(1)
 
+    async def _open_pipe(self) -> int:
+        """Open the metadata pipe in non-blocking mode and return its file descriptor."""
+        return await asyncio.to_thread(os.open, self.metadata_pipe, os.O_RDONLY | os.O_NONBLOCK)
+
     async def _read_metadata(self) -> None:
         """Read metadata from the pipe using async file descriptor."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         try:
-            # Open the metadata pipe in non-blocking mode
-            # Use O_RDONLY | O_NONBLOCK to avoid blocking on open
-            self._fd = await loop.run_in_executor(
-                None, os.open, self.metadata_pipe, os.O_RDONLY | os.O_NONBLOCK
-            )
+            # start() already opened the pipe; only reopen when a restart closed the fd.
+            if self._fd is None:
+                self._fd = await self._open_pipe()
+            fd = self._fd
 
             # Create an asyncio.Event to signal when data is available
             data_available = asyncio.Event()
@@ -91,7 +101,7 @@ class MetadataReader:
                 data_available.set()
 
             # Register the file descriptor with the event loop
-            loop.add_reader(self._fd, on_readable)
+            loop.add_reader(fd, on_readable)
 
             try:
                 while not self._stop:
@@ -101,7 +111,7 @@ class MetadataReader:
 
                     # Read available data from the pipe
                     try:
-                        chunk = os.read(self._fd, 4096)
+                        chunk = os.read(fd, 4096)
                         if chunk:
                             # Decode as text and add to buffer
                             self._buffer += chunk.decode("utf-8", errors="ignore")
@@ -119,7 +129,7 @@ class MetadataReader:
 
             finally:
                 # Remove the reader callback
-                loop.remove_reader(self._fd)
+                loop.remove_reader(fd)
 
         finally:
             if self._fd is not None:

--- a/tests/providers/airplay_receiver/__init__.py
+++ b/tests/providers/airplay_receiver/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for AirPlay Receiver provider."""

--- a/tests/providers/airplay_receiver/test_metadata_reader.py
+++ b/tests/providers/airplay_receiver/test_metadata_reader.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import pathlib
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -22,29 +23,10 @@ def pipe_path(tmp_path: pathlib.Path) -> str:
     return path
 
 
-async def _write_marker(pipe_path: str, marker: str) -> None:
-    """Write a marker using a short-lived FIFO writer."""
-
-    def _write() -> None:
-        fd = os.open(pipe_path, os.O_WRONLY)
-        try:
-            os.write(fd, f"{marker}\n".encode())
-        finally:
-            os.close(fd)
-
-    await asyncio.get_event_loop().run_in_executor(None, _write)
-
-
-async def _wait_for(condition: Callable[[], bool], timeout: float = 2.0) -> None:
-    async with asyncio.timeout(timeout):
-        while not condition():
-            await asyncio.sleep(0.01)
-
-
-async def _write_marker_when_reader_present(
-    pipe_path: str, marker: str, timeout: float = 5.0
-) -> None:
-    """Write a marker without blocking forever when the FIFO has no reader."""
+async def _write_marker(pipe_path: str, marker: str, timeout: float = 5.0) -> None:
+    """Write a marker using a short-lived FIFO writer, like a sessioncontrol hook does."""
+    # O_NONBLOCK so a regression leaving the FIFO readerless fails the test instead of
+    # hanging it: opening for write raises ENXIO while no reader is attached.
     async with asyncio.timeout(timeout):
         while True:
             try:
@@ -56,6 +38,12 @@ async def _write_marker_when_reader_present(
         os.write(fd, f"{marker}\n".encode())
     finally:
         os.close(fd)
+
+
+async def _wait_for(condition: Callable[[], bool], timeout: float = 2.0) -> None:
+    async with asyncio.timeout(timeout):
+        while not condition():
+            await asyncio.sleep(0.01)
 
 
 async def test_pipe_is_open_when_start_returns(pipe_path: str) -> None:
@@ -84,7 +72,7 @@ async def test_hook_marker_delivered(pipe_path: str) -> None:
 
 
 async def test_markers_after_writer_close(pipe_path: str) -> None:
-    """Accept markers from writers that connect after EOF."""
+    """Accept markers from hook writers that connect after an earlier writer closed."""
     updates: list[dict[str, Any]] = []
     reader = MetadataReader(pipe_path, logging.getLogger("test"), updates.append)
     await reader.start()
@@ -98,36 +86,28 @@ async def test_markers_after_writer_close(pipe_path: str) -> None:
         await reader.stop()
 
 
-async def test_reader_backs_off_on_eof(pipe_path: str, monkeypatch: pytest.MonkeyPatch) -> None:
-    """After all writers closed, the reader backs off instead of spinning the loop."""
+async def test_reader_stays_idle_after_writer_close(pipe_path: str) -> None:
+    """A FIFO with no writers left must not keep the event loop busy."""
     updates: list[dict[str, Any]] = []
     reader = MetadataReader(pipe_path, logging.getLogger("test"), updates.append)
-    real_read = os.read
-    read_counts: list[int] = []
-
-    def counting_read(fd: int, size: int) -> bytes:
-        if fd == reader._fd:
-            read_counts.append(fd)
-        return real_read(fd, size)
-
-    monkeypatch.setattr(os, "read", counting_read)
     await reader.start()
     try:
         await _write_marker(pipe_path, "MA_PLAY_BEGIN")
-        # The marker arriving proves the reader consumed it and the writer is gone,
-        # so every read from here on hits EOF.
+        # The marker arriving proves the reader consumed it and the hook writer is gone.
         await _wait_for(lambda: bool(updates))
-        read_counts.clear()
+        cpu_before = time.process_time()
         await asyncio.sleep(0.5)
-        assert len(read_counts) < 20
+        # Only epoll reports a writerless FIFO readable forever, so this guard is
+        # meaningful on Linux and passes trivially on macOS/kqueue.
+        assert time.process_time() - cpu_before < 0.1
     finally:
         await reader.stop()
 
 
-async def test_reader_restarts_after_unexpected_error(
+async def test_reader_keeps_pipe_attached_across_restart(
     pipe_path: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """After an unexpected error kills a read, the reader reopens the pipe and keeps working."""
+    """An unexpected read error restarts the loop without ever detaching from the FIFO."""
     updates: list[dict[str, Any]] = []
     reader = MetadataReader(pipe_path, logging.getLogger("test"), updates.append)
     real_read = os.read
@@ -145,8 +125,10 @@ async def test_reader_restarts_after_unexpected_error(
     try:
         await _write_marker(pipe_path, "MA_PLAY_BEGIN")
         await _wait_for(lambda: not fail_once)
-        await _write_marker_when_reader_present(pipe_path, "MA_PLAY_BEGIN")
-        await _wait_for(lambda: bool(updates), timeout=5.0)
-        assert updates[-1] == {"play_state": "playing"}
+        # Well inside the restart backoff: a hook writer must still find a reader here.
+        await asyncio.sleep(0.2)
+        os.close(os.open(pipe_path, os.O_WRONLY | os.O_NONBLOCK))
+        await _write_marker(pipe_path, "MA_PLAY_END")
+        await _wait_for(lambda: updates[-1:] == [{"play_state": "stopped"}], timeout=5.0)
     finally:
         await reader.stop()

--- a/tests/providers/airplay_receiver/test_metadata_reader.py
+++ b/tests/providers/airplay_receiver/test_metadata_reader.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import pathlib
+from collections.abc import Callable
 from typing import Any
 
 import pytest
@@ -13,7 +15,7 @@ from music_assistant.providers.airplay_receiver.metadata import MetadataReader
 
 
 @pytest.fixture
-def pipe_path(tmp_path: Any) -> str:
+def pipe_path(tmp_path: pathlib.Path) -> str:
     """Create a metadata FIFO like the provider does."""
     path = str(tmp_path / "metadata_pipe")
     os.mkfifo(path)
@@ -33,7 +35,7 @@ async def _write_marker(pipe_path: str, marker: str) -> None:
     await asyncio.get_event_loop().run_in_executor(None, _write)
 
 
-async def _wait_for(condition: Any, timeout: float = 2.0) -> None:
+async def _wait_for(condition: Callable[[], bool], timeout: float = 2.0) -> None:
     async with asyncio.timeout(timeout):
         while not condition():
             await asyncio.sleep(0.01)
@@ -56,6 +58,18 @@ async def _write_marker_when_reader_present(
         os.close(fd)
 
 
+async def test_pipe_is_open_when_start_returns(pipe_path: str) -> None:
+    """start() attaches to the FIFO so hook writers never block on a missing reader."""
+    reader = MetadataReader(pipe_path, logging.getLogger("test"), None)
+    await reader.start()
+    try:
+        # Opening for write fails with ENXIO while no reader is attached.
+        fd = os.open(pipe_path, os.O_WRONLY | os.O_NONBLOCK)
+        os.close(fd)
+    finally:
+        await reader.stop()
+
+
 async def test_hook_marker_delivered(pipe_path: str) -> None:
     """A sessioncontrol hook marker is delivered as a play_state update."""
     updates: list[dict[str, Any]] = []
@@ -63,7 +77,7 @@ async def test_hook_marker_delivered(pipe_path: str) -> None:
     await reader.start()
     try:
         await _write_marker(pipe_path, "MA_PLAY_BEGIN")
-        await _wait_for(lambda: updates)
+        await _wait_for(lambda: bool(updates))
         assert updates == [{"play_state": "playing"}]
     finally:
         await reader.stop()
@@ -86,7 +100,8 @@ async def test_markers_after_writer_close(pipe_path: str) -> None:
 
 async def test_reader_backs_off_on_eof(pipe_path: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """After all writers closed, the reader backs off instead of spinning the loop."""
-    reader = MetadataReader(pipe_path, logging.getLogger("test"), None)
+    updates: list[dict[str, Any]] = []
+    reader = MetadataReader(pipe_path, logging.getLogger("test"), updates.append)
     real_read = os.read
     read_counts: list[int] = []
 
@@ -99,7 +114,9 @@ async def test_reader_backs_off_on_eof(pipe_path: str, monkeypatch: pytest.Monke
     await reader.start()
     try:
         await _write_marker(pipe_path, "MA_PLAY_BEGIN")
-        await asyncio.sleep(0.1)  # Wait for the reader to reach EOF.
+        # The marker arriving proves the reader consumed it and the writer is gone,
+        # so every read from here on hits EOF.
+        await _wait_for(lambda: bool(updates))
         read_counts.clear()
         await asyncio.sleep(0.5)
         assert len(read_counts) < 20
@@ -129,7 +146,7 @@ async def test_reader_restarts_after_unexpected_error(
         await _write_marker(pipe_path, "MA_PLAY_BEGIN")
         await _wait_for(lambda: not fail_once)
         await _write_marker_when_reader_present(pipe_path, "MA_PLAY_BEGIN")
-        await _wait_for(lambda: updates, timeout=5.0)
+        await _wait_for(lambda: bool(updates), timeout=5.0)
         assert updates[-1] == {"play_state": "playing"}
     finally:
         await reader.stop()

--- a/tests/providers/airplay_receiver/test_metadata_reader.py
+++ b/tests/providers/airplay_receiver/test_metadata_reader.py
@@ -1,0 +1,97 @@
+"""Tests for the shairport-sync metadata pipe reader."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import pytest
+
+from music_assistant.providers.airplay_receiver.metadata import MetadataReader
+
+
+@pytest.fixture
+def pipe_path(tmp_path: Any) -> str:
+    """Create a metadata FIFO like the provider does."""
+    path = str(tmp_path / "metadata_pipe")
+    os.mkfifo(path)
+    return path
+
+
+async def _write_marker(pipe_path: str, marker: str) -> None:
+    """Write a sessioncontrol hook marker the way the shell hook does (open/write/close)."""
+
+    def _write() -> None:
+        fd = os.open(pipe_path, os.O_WRONLY)
+        try:
+            os.write(fd, f"{marker}\n".encode())
+        finally:
+            os.close(fd)
+
+    await asyncio.get_event_loop().run_in_executor(None, _write)
+
+
+async def _wait_for(condition: Any, timeout: float = 2.0) -> None:
+    async with asyncio.timeout(timeout):
+        while not condition():
+            await asyncio.sleep(0.01)
+
+
+async def test_hook_marker_delivered(pipe_path: str) -> None:
+    """A sessioncontrol hook marker is delivered as a play_state update."""
+    updates: list[dict[str, Any]] = []
+    reader = MetadataReader(pipe_path, logging.getLogger("test"), updates.append)
+    await reader.start()
+    try:
+        await _write_marker(pipe_path, "MA_PLAY_BEGIN")
+        await _wait_for(lambda: updates)
+        assert updates == [{"play_state": "playing"}]
+    finally:
+        await reader.stop()
+
+
+async def test_markers_after_writer_close(pipe_path: str) -> None:
+    """
+    Markers from later writers still arrive after a previous writer closed the pipe.
+
+    Each sessioncontrol hook is a short-lived shell that opens, writes and closes
+    the FIFO, so the reader repeatedly sees EOF between events.
+    """
+    updates: list[dict[str, Any]] = []
+    reader = MetadataReader(pipe_path, logging.getLogger("test"), updates.append)
+    await reader.start()
+    try:
+        await _write_marker(pipe_path, "MA_PLAY_BEGIN")
+        await _wait_for(lambda: len(updates) == 1)
+        # writer closed -> EOF; a new hook invocation must still get through
+        await _write_marker(pipe_path, "MA_PLAY_END")
+        await _wait_for(lambda: len(updates) == 2)
+        assert updates == [{"play_state": "playing"}, {"play_state": "stopped"}]
+    finally:
+        await reader.stop()
+
+
+async def test_reader_backs_off_on_eof(pipe_path: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """After all writers closed, the reader backs off instead of spinning the loop."""
+    reader = MetadataReader(pipe_path, logging.getLogger("test"), None)
+    real_read = os.read
+    read_counts: list[int] = []
+
+    def counting_read(fd: int, size: int) -> bytes:
+        if fd == reader._fd:
+            read_counts.append(fd)
+        return real_read(fd, size)
+
+    monkeypatch.setattr(os, "read", counting_read)
+    await reader.start()
+    try:
+        await _write_marker(pipe_path, "MA_PLAY_BEGIN")
+        await asyncio.sleep(0.1)  # let the reader consume the marker and hit EOF
+        read_counts.clear()
+        await asyncio.sleep(0.5)  # pipe is at EOF (no writers) the whole time
+        # with the 0.1s backoff we expect ~5 reads; a busy spin does thousands
+        assert len(read_counts) < 20
+    finally:
+        await reader.stop()

--- a/tests/providers/airplay_receiver/test_metadata_reader.py
+++ b/tests/providers/airplay_receiver/test_metadata_reader.py
@@ -39,6 +39,23 @@ async def _wait_for(condition: Any, timeout: float = 2.0) -> None:
             await asyncio.sleep(0.01)
 
 
+async def _write_marker_when_reader_present(
+    pipe_path: str, marker: str, timeout: float = 5.0
+) -> None:
+    """Write a marker without blocking forever when the FIFO has no reader."""
+    async with asyncio.timeout(timeout):
+        while True:
+            try:
+                fd = os.open(pipe_path, os.O_WRONLY | os.O_NONBLOCK)
+                break
+            except OSError:
+                await asyncio.sleep(0.05)
+    try:
+        os.write(fd, f"{marker}\n".encode())
+    finally:
+        os.close(fd)
+
+
 async def test_hook_marker_delivered(pipe_path: str) -> None:
     """A sessioncontrol hook marker is delivered as a play_state update."""
     updates: list[dict[str, Any]] = []
@@ -86,5 +103,33 @@ async def test_reader_backs_off_on_eof(pipe_path: str, monkeypatch: pytest.Monke
         read_counts.clear()
         await asyncio.sleep(0.5)
         assert len(read_counts) < 20
+    finally:
+        await reader.stop()
+
+
+async def test_reader_restarts_after_unexpected_error(
+    pipe_path: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After an unexpected error kills a read, the reader reopens the pipe and keeps working."""
+    updates: list[dict[str, Any]] = []
+    reader = MetadataReader(pipe_path, logging.getLogger("test"), updates.append)
+    real_read = os.read
+    fail_once = True
+
+    def flaky_read(fd: int, size: int) -> bytes:
+        nonlocal fail_once
+        if fd == reader._fd and fail_once:
+            fail_once = False
+            raise ValueError("unexpected error")
+        return real_read(fd, size)
+
+    monkeypatch.setattr(os, "read", flaky_read)
+    await reader.start()
+    try:
+        await _write_marker(pipe_path, "MA_PLAY_BEGIN")
+        await _wait_for(lambda: not fail_once)
+        await _write_marker_when_reader_present(pipe_path, "MA_PLAY_BEGIN")
+        await _wait_for(lambda: updates, timeout=5.0)
+        assert updates[-1] == {"play_state": "playing"}
     finally:
         await reader.stop()

--- a/tests/providers/airplay_receiver/test_metadata_reader.py
+++ b/tests/providers/airplay_receiver/test_metadata_reader.py
@@ -21,7 +21,7 @@ def pipe_path(tmp_path: Any) -> str:
 
 
 async def _write_marker(pipe_path: str, marker: str) -> None:
-    """Write a sessioncontrol hook marker the way the shell hook does (open/write/close)."""
+    """Write a marker using a short-lived FIFO writer."""
 
     def _write() -> None:
         fd = os.open(pipe_path, os.O_WRONLY)
@@ -53,19 +53,13 @@ async def test_hook_marker_delivered(pipe_path: str) -> None:
 
 
 async def test_markers_after_writer_close(pipe_path: str) -> None:
-    """
-    Markers from later writers still arrive after a previous writer closed the pipe.
-
-    Each sessioncontrol hook is a short-lived shell that opens, writes and closes
-    the FIFO, so the reader repeatedly sees EOF between events.
-    """
+    """Accept markers from writers that connect after EOF."""
     updates: list[dict[str, Any]] = []
     reader = MetadataReader(pipe_path, logging.getLogger("test"), updates.append)
     await reader.start()
     try:
         await _write_marker(pipe_path, "MA_PLAY_BEGIN")
         await _wait_for(lambda: len(updates) == 1)
-        # writer closed -> EOF; a new hook invocation must still get through
         await _write_marker(pipe_path, "MA_PLAY_END")
         await _wait_for(lambda: len(updates) == 2)
         assert updates == [{"play_state": "playing"}, {"play_state": "stopped"}]
@@ -88,10 +82,9 @@ async def test_reader_backs_off_on_eof(pipe_path: str, monkeypatch: pytest.Monke
     await reader.start()
     try:
         await _write_marker(pipe_path, "MA_PLAY_BEGIN")
-        await asyncio.sleep(0.1)  # let the reader consume the marker and hit EOF
+        await asyncio.sleep(0.1)  # Wait for the reader to reach EOF.
         read_counts.clear()
-        await asyncio.sleep(0.5)  # pipe is at EOF (no writers) the whole time
-        # with the 0.1s backoff we expect ~5 reads; a busy spin does thousands
+        await asyncio.sleep(0.5)
         assert len(read_counts) < 20
     finally:
         await reader.stop()


### PR DESCRIPTION
# What does this implement/fix?

AirPlay Receiver could start playing and then pause or seek back to the beginning after a few seconds. `shairport-sync` was launched before MA opened its metadata FIFO, so a client connecting during startup could block the session-control hook and delay or lose its playback-start event.

- Start the metadata reader before launching `shairport-sync`
- Back off briefly when the FIFO reaches EOF instead of busy-spinning the event loop
- Add real-FIFO tests for session markers, reconnecting writers, and EOF handling

The FIFO behavior was reproduced locally. 

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5772

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
