### PR TITLE
Prepare Music Quiz before starting

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -420,8 +420,7 @@ class MusicQuizPlugin(PluginProvider):
                 created_at=time.time(),
             )
             quiz_strategy, answer_strategy = self._resolve_game_strategies(game)
-            with _system_auth_context():
-                await quiz_strategy.initialize()
+            initial_round_task = await self._prepare_initial_round(quiz_strategy)
             selected_player = self._validate_playback_config(game_config)
             if selected_player is not None:
                 game_config.venue_player_name = selected_player.display_name
@@ -446,7 +445,7 @@ class MusicQuizPlugin(PluginProvider):
                 self._game = game
                 self._quiz_type = quiz_strategy
                 self._answer_type = answer_strategy
-                self._prefetch_round(0)
+                self._next_round_task = initial_round_task
                 self._signal_game_updated()
             await self._store_playback_preference(
                 game_config.playback_mode,
@@ -498,8 +497,7 @@ class MusicQuizPlugin(PluginProvider):
         async with self._game_lock:
             game = self._require_game()
             quiz_strategy, answer_strategy = self._resolve_game_strategies(game)
-            with _system_auth_context():
-                await quiz_strategy.initialize()
+            initial_round_task = await self._prepare_initial_round(quiz_strategy)
             self._cancel_timers()
             self._cancel_next_round_task()
             await self._cancel_reveal_playback_task()
@@ -510,7 +508,7 @@ class MusicQuizPlugin(PluginProvider):
             self._game_generation += 1
             self._quiz_type = quiz_strategy
             self._answer_type = answer_strategy
-            self._prefetch_round(0)
+            self._next_round_task = initial_round_task
             self._schedule_presence_expiry(now)
             if auto_start and _has_active_players(game, now):
                 self._schedule_replay_auto_start(game, now)
@@ -1156,6 +1154,17 @@ class MusicQuizPlugin(PluginProvider):
         )
 
     # ---------- round preparation ----------
+
+    async def _prepare_initial_round(
+        self,
+        quiz_type: QuizType,
+    ) -> asyncio.Task[MusicQuizRound]:
+        """Initialize a quiz type and complete its first round before opening the lobby."""
+        with _system_auth_context():
+            await quiz_type.initialize()
+            task = self.mass.create_task(quiz_type.prepare_round(0, []))
+            await task
+        return task
 
     def _prefetch_round(self, round_index: int) -> None:
         """Prepare an upcoming round in the background."""

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -1247,6 +1247,66 @@ async def test_full_game_flow() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_prepares_first_round_and_start_reuses_it() -> None:
+    """Complete Guess the Song preparation during create and reuse it when starting."""
+    plugin = _create_plugin()
+    prepared_round = _make_round(0)
+    prepare_round = AsyncMock(return_value=prepared_round)
+
+    with patch.object(GuessTheSongQuizType, "prepare_round", new=prepare_round):
+        state = await plugin.create_game(
+            round_count=1,
+            source_uris=["library://playlist/1"],
+        )
+
+        game = plugin._game
+        assert game is not None
+        assert state["phase"] == "lobby"
+        assert game.rounds == []
+        assert plugin._next_round_task is not None
+        assert plugin._next_round_task.done()
+        prepare_round.assert_awaited_once_with(0, [])
+        cast("AsyncMock", plugin._play_track).assert_not_awaited()
+
+        await plugin.start_game()
+
+    prepare_round.assert_awaited_once_with(0, [])
+    assert game.rounds == [prepared_round]
+    cast("AsyncMock", plugin._play_track).assert_awaited_once_with(prepared_round.track_uri)
+
+
+@pytest.mark.asyncio
+async def test_reset_prepares_replay_round_and_start_reuses_it() -> None:
+    """Prepare a fresh Guess the Song round before returning to the replay lobby."""
+    plugin = _create_plugin()
+    initial_round = _make_round(0)
+    replay_round = _make_round(0)
+    replay_round.track_uri = "library://track/replay"
+    prepare_round = AsyncMock(side_effect=[initial_round, replay_round])
+
+    with patch.object(GuessTheSongQuizType, "prepare_round", new=prepare_round):
+        await plugin.create_game(
+            round_count=1,
+            source_uris=["library://playlist/1"],
+        )
+        await plugin.start_game()
+        state = await plugin.reset()
+
+        game = plugin._game
+        assert game is not None
+        assert state["phase"] == "lobby"
+        assert game.rounds == []
+        assert plugin._next_round_task is not None
+        assert plugin._next_round_task.done()
+        assert prepare_round.await_count == 2
+
+        await plugin.start_game()
+
+    assert prepare_round.await_count == 2
+    assert game.rounds == [replay_round]
+
+
+@pytest.mark.asyncio
 async def test_guest_ready_advances_and_prefetches_in_system_context() -> None:
     """Keep provider playback and background preparation independent of the guest."""
     prepared_contexts: list[tuple[int, object | None]] = []
@@ -2650,13 +2710,14 @@ async def test_stale_trivia_timer_cannot_mutate_reset_generation(timer_phase: st
         assert game.current_round_index == 0
         expected_auto_advance = 215.0 if timer_phase == "reveal" else None
         assert game.rounds[0].auto_advance_at == expected_auto_advance
+        prepare_call_count = prepare_round.await_count
         await stale_callback(stale_round_index)
 
     assert game.phase.value == timer_phase
     assert game.current_round_index == 0
     assert len(game.rounds) == 1
     assert game.rounds[0].auto_advance_at == expected_auto_advance
-    assert prepare_round.await_count == 2
+    assert prepare_round.await_count == prepare_call_count
 
 
 @pytest.mark.asyncio
@@ -4984,6 +5045,41 @@ async def test_create_game_initialize_failure_preserves_existing_finished_game()
     assert plugin._answer_type is answer_strategy
     assert plugin._next_round_task is pending_task
     pending_task.cancel.assert_not_called()
+    cast("MagicMock", plugin.mass.cancel_timer).assert_not_called()
+    cast("MagicMock", plugin.mass.cancel_task).assert_not_called()
+    cast("MagicMock", plugin.mass.call_later).assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_game_round_preparation_failure_preserves_existing_lobby() -> None:
+    """Keep an existing lobby when replacement round preparation fails."""
+    plugin = _create_plugin()
+    await plugin.create_game(source_uris=["library://playlist/1"])
+    game = plugin._game
+    assert game is not None
+    game_state = game.to_dict()
+    quiz_strategy = plugin._quiz_type
+    answer_strategy = plugin._answer_type
+    pending_task = plugin._next_round_task
+    assert pending_task is not None
+    cast("MagicMock", plugin.mass.cancel_timer).reset_mock()
+    cast("MagicMock", plugin.mass.cancel_task).reset_mock()
+    cast("MagicMock", plugin.mass.call_later).reset_mock()
+
+    prepare_round = AsyncMock(side_effect=InvalidDataError("Round preparation failed"))
+    with (
+        patch.object(GuessTheSongQuizType, "prepare_round", new=prepare_round),
+        pytest.raises(InvalidDataError, match="Round preparation failed"),
+    ):
+        await plugin.create_game(source_uris=["library://playlist/2"])
+
+    prepare_round.assert_awaited_once_with(0, [])
+    assert plugin._game is game
+    assert game.to_dict() == game_state
+    assert plugin._quiz_type is quiz_strategy
+    assert plugin._answer_type is answer_strategy
+    assert plugin._next_round_task is pending_task
+    assert pending_task.cancelled() is False
     cast("MagicMock", plugin.mass.cancel_timer).assert_not_called()
     cast("MagicMock", plugin.mass.cancel_task).assert_not_called()
     cast("MagicMock", plugin.mass.call_later).assert_not_called()


### PR DESCRIPTION
# What does this implement/fix?

Guess the Song could leave its first round loading until Start, unlike the other Music Quiz modes.

- Complete initial-round preparation before Create and Reset return
- Reuse the prepared round when Start opens the game
- Preserve the current game if replacement preparation fails

**Related issue (if applicable):**

- Related frontend PR: https://github.com/music-assistant/frontend/pull/2122

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.