### PR TITLE
Bump pillow to 12.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "music-assistant-frontend==2.17.220",
   "mutagen==1.47.0",
   "orjson==3.11.6",
-  "pillow==12.2.0",
+  "pillow==12.3.0",
   "podcastparser==0.6.11",
   "propcache>=0.2.1",
   "python-slugify==8.0.4",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -56,7 +56,7 @@ niconico.py-ma==2.1.0.post2
 nnAudio==0.3.3
 numpy==2.3.5
 orjson==3.11.6
-pillow==12.2.0
+pillow==12.3.0
 pkce==1.0.3
 plexapi==4.18.2
 podcastparser==0.6.11


### PR DESCRIPTION
# What does this implement/fix?

Bumps `pillow` from 12.2.0 to 12.3.0 (latest release).

- `pyproject.toml`: `pillow==12.2.0` → `12.3.0`
- `requirements_all.txt`: regenerated via `scripts/gen_requirements_all.py`

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [x] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes. <!-- CI will run this; hook tools not installed in local worktree -->
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
