### PR TITLE
Return library tracks when browsing filesystem

### DIFF
--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -402,6 +402,23 @@ class LocalFileSystemProvider(MusicProvider):
                         name=item.filename,
                     )
                 )
+        if self.media_content_type == "music":
+            track_indexes = [
+                index
+                for index, item in enumerate(items)
+                if isinstance(item, ItemMapping) and item.media_type == MediaType.TRACK
+            ]
+            library_tracks = await asyncio.gather(
+                *(
+                    self.mass.music.tracks.get_library_item_by_prov_id(
+                        items[index].item_id, self.instance_id
+                    )
+                    for index in track_indexes
+                )
+            )
+            for index, library_track in zip(track_indexes, library_tracks, strict=True):
+                if library_track:
+                    items[index] = library_track
         return items
 
     async def sync_library(self, media_type: MediaType) -> None:

--- a/tests/providers/filesystem/test_sound_effects.py
+++ b/tests/providers/filesystem/test_sound_effects.py
@@ -147,3 +147,55 @@ async def test_browse_maps_files_to_sound_effects() -> None:
     assert len(result) == 1
     assert result[0].media_type == MediaType.SOUND_EFFECT
     assert result[0].item_id == "rain.mp3"
+    provider.mass.music.tracks.get_library_item_by_prov_id.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_browse_returns_library_track_for_cataloged_file() -> None:
+    """Browse returns the canonical library track for a cataloged music file."""
+    provider = _create_provider()
+    provider.media_content_type = "music"
+    audio_file = MagicMock()
+    audio_file.is_dir = False
+    audio_file.filename = "track.flac"
+    audio_file.ext = "flac"
+    audio_file.relative_path = "album/track.flac"
+    audio_file.absolute_path = "/media/album/track.flac"
+    library_track = MagicMock()
+    library_track.item_id = "42"
+    library_track.provider = "library"
+    provider._scandir = AsyncMock(return_value=[audio_file])  # type: ignore[method-assign]
+    provider.mass.music.tracks.get_library_item_by_prov_id = AsyncMock(  # type: ignore[method-assign]
+        return_value=library_track
+    )
+
+    result = await provider.browse("filesystem_local--test://album")
+
+    assert result == [library_track]
+    provider.mass.music.tracks.get_library_item_by_prov_id.assert_awaited_once_with(
+        "album/track.flac", "filesystem_local--test"
+    )
+
+
+@pytest.mark.asyncio
+async def test_browse_returns_provider_mapping_for_uncataloged_file() -> None:
+    """Browse retains the filesystem mapping when a music file is not cataloged."""
+    provider = _create_provider()
+    provider.media_content_type = "music"
+    audio_file = MagicMock()
+    audio_file.is_dir = False
+    audio_file.filename = "track.flac"
+    audio_file.ext = "flac"
+    audio_file.relative_path = "album/track.flac"
+    audio_file.absolute_path = "/media/album/track.flac"
+    provider._scandir = AsyncMock(return_value=[audio_file])  # type: ignore[method-assign]
+    provider.mass.music.tracks.get_library_item_by_prov_id = AsyncMock(  # type: ignore[method-assign]
+        return_value=None
+    )
+
+    result = await provider.browse("filesystem_local--test://album")
+
+    assert len(result) == 1
+    assert result[0].media_type == MediaType.TRACK
+    assert result[0].item_id == "album/track.flac"
+    assert result[0].provider == "filesystem_local--test"


### PR DESCRIPTION
# What does this implement/fix?

Use the library track data to display local filesystem tracks when browsing instead of plain filenames with no album art.

I often use Browse specifically for my local filesystem provider albums, but the existing display doesn't use the "enriched" data from the library database, so there is no album art, the tracks themselves are the raw filenames vs. the prettified title tracks, we don't display track length, etc. All other browse-capable providers (that I know of) use the library track data to do all of that. This brings the filesystem provider into line with them. Currently scoped to just 'music' media, as dealing with audiobooks and podcasts is a bit trickier and will be handled in a follow-up PR if/when I figure out how to do it cleanly.

<img width="1159" height="825" alt="before" src="https://github.com/user-attachments/assets/f1d042d2-e922-41a9-8c9e-b892a2dca8c9" />
<img width="1154" height="791" alt="after" src="https://github.com/user-attachments/assets/c1ecf6b3-38f8-4b6d-aa3a-d67c1972f6bb" />

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
