### PR TITLE
Decrypt stored Google Drive client secret when re-authorizing

### DIFF
--- a/music_assistant/providers/filesystem_google_drive/__init__.py
+++ b/music_assistant/providers/filesystem_google_drive/__init__.py
@@ -69,9 +69,12 @@ async def get_config_entries(
         client_id = str(values.get(CONF_CLIENT_ID) or "")
         client_secret = str(values.get(CONF_CLIENT_SECRET) or "")
         # the frontend masks a previously stored secret; fetch the real value
+        # (stored encrypted, so decrypt before use)
         if client_secret == SECURE_STRING_SUBSTITUTE and instance_id:
-            client_secret = str(
-                mass.config.get_raw_provider_config_value(instance_id, CONF_CLIENT_SECRET) or ""
+            client_secret = mass.config.decrypt_string(
+                str(
+                    mass.config.get_raw_provider_config_value(instance_id, CONF_CLIENT_SECRET) or ""
+                )
             )
         if not client_id or not client_secret:
             raise LoginFailed("Enter the Google OAuth Client ID and Client Secret first")


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Same bug as found in the OneDrive PR review (the code was copied from here): when re-authorizing an existing Google Drive instance without re-typing the client secret, the stored secret was fetched via `get_raw_provider_config_value`, which returns it as persisted, i.e. still encrypted, and that encrypted string was sent to Google. Now passed through `mass.config.decrypt_string(...)` first, which leaves plain or empty values untouched, so initial setup is unaffected.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
