### PR TITLE
Fix legacy Smart Fades centroid corruption

### DIFF
--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -9,7 +9,7 @@ DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
 
-DB_SCHEMA_VERSION: Final[int] = 52
+DB_SCHEMA_VERSION: Final[int] = 53
 
 # tracks longer that this will not be included in radio mode
 RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60

--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -802,6 +802,67 @@ async def migrate_database(  # noqa: PLR0915
             )
             await database.execute(f"ALTER TABLE {table} DROP COLUMN external_ids")
 
+    if prev_version <= 52:
+        audio_analysis_table_exists = await database.get_rows_from_query(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = :table_name",
+            {"table_name": DB_TABLE_AUDIO_ANALYSIS},
+            limit=1,
+        )
+        if audio_analysis_table_exists:
+            result = await database.execute(
+                f"""WITH RECURSIVE
+                null_centroids AS (
+                    SELECT
+                        aa.id,
+                        '$.spectral_centroid[' || centroid.key || ']' AS path,
+                        row_number() OVER (
+                            PARTITION BY aa.id
+                            ORDER BY CAST(centroid.key AS INTEGER)
+                        ) AS sequence
+                    FROM {DB_TABLE_AUDIO_ANALYSIS} AS aa,
+                        json_each(aa.analysis_data, '$.spectral_centroid') AS centroid
+                    WHERE aa.aa_provider_domain = :aa_provider_domain
+                        AND json_valid(aa.analysis_data)
+                        AND aa.analysis_data LIKE '%null%'
+                        AND json_type(aa.analysis_data, '$.spectral_centroid') = 'array'
+                        AND centroid.type = 'null'
+                ),
+                repaired(id, analysis_data, sequence) AS (
+                    SELECT aa.id, aa.analysis_data, 0
+                    FROM {DB_TABLE_AUDIO_ANALYSIS} AS aa
+                    WHERE aa.id IN (SELECT id FROM null_centroids)
+
+                    UNION ALL
+
+                    SELECT
+                        repaired.id,
+                        json_set(repaired.analysis_data, null_centroids.path, 0.0),
+                        null_centroids.sequence
+                    FROM repaired
+                    JOIN null_centroids
+                        ON null_centroids.id = repaired.id
+                        AND null_centroids.sequence = repaired.sequence + 1
+                )
+                UPDATE {DB_TABLE_AUDIO_ANALYSIS} AS aa
+                SET analysis_data = (
+                    SELECT repaired.analysis_data
+                    FROM repaired
+                    WHERE repaired.id = aa.id
+                    ORDER BY repaired.sequence DESC
+                    LIMIT 1
+                )
+                WHERE aa.id IN (SELECT id FROM null_centroids)
+                RETURNING id""",
+                {"aa_provider_domain": "smart_fades"},
+            )
+            repaired_rows = await result.fetchall()
+            if repaired_rows:
+                logger.info(
+                    "Repaired null spectral centroid values in %d Smart Fades "
+                    "audio analysis row(s)",
+                    len(repaired_rows),
+                )
+
     # NOTE: this genre restore runs after the <= 50 step on purpose: it inserts genres
     # with the current code/schema, so the external_ids column must be gone first.
     if prev_version <= 47:


### PR DESCRIPTION
# What does this implement/fix?

Repairs legacy Smart Fades audio-analysis rows where non-finite spectral centroid values were serialized as `null`. These rows currently fail model deserialization and repeatedly produce warning storms during Sonic Similarity index rebuilds.

- Bump the music database schema to 53.
- Atomically replace null centroid array elements with `0.0`, matching the current Smart Fades normalization.
- Preserve existing valid centroid values and leave unrelated analysis rows untouched.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
