### PR TITLE
Fix radio station image passed as raw provider path in stream metadata

### DIFF
--- a/music_assistant/controllers/metadata/radio.py
+++ b/music_assistant/controllers/metadata/radio.py
@@ -221,7 +221,7 @@ class RadioArtworkMixin:
         ):
             if queue.current_item and queue.current_item.media_item:
                 if station_image := queue.current_item.media_item.image:
-                    return station_image.path
+                    return self.get_image_url(station_image)
         return None
 
     @staticmethod


### PR DESCRIPTION


# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Was doing some testing of the ORF provider and saw some unusual errors in the log related to images

`get_radio_stream_station_image` returned `MediaItemImage.path` verbatim, so providers with local (not remotely accessible) station icons leaked their provider-internal path (e.g. `radiothek://station/noe.png`) into `stream_metadata.image_url`. The palette extraction then fed that string to ffmpeg (logging "Protocol not found" errors) and players received an artwork URL they cannot fetch.

Resolve the image through `get_image_url` instead, which passes plain http URLs through unchanged and builds an imageproxy URL for provider-local images.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
