### PR TITLE
Fix ORF Radiothek provider staying unloaded when startup coincides with network unavailable

### DIFF
--- a/music_assistant/providers/orf_radiothek/__init__.py
+++ b/music_assistant/providers/orf_radiothek/__init__.py
@@ -216,8 +216,6 @@ class RadiothekProvider(MusicProvider):
         try:
             await self._get_bundle(force=True)
         except (ClientError, TimeoutError, ValueError, InvalidDataError) as err:
-            # the core only retries failed loads for MusicAssistantError subclasses
-            # (network may not be up yet when MA starts at boot)
             raise ProviderUnavailableError(f"Unable to fetch ORF station bundle: {err}") from err
 
     # ----------------------------

--- a/music_assistant/providers/orf_radiothek/__init__.py
+++ b/music_assistant/providers/orf_radiothek/__init__.py
@@ -38,7 +38,12 @@ from music_assistant_models.enums import (
     ProviderFeature,
     StreamType,
 )
-from music_assistant_models.errors import MediaNotFoundError, UnplayableMediaError
+from music_assistant_models.errors import (
+    InvalidDataError,
+    MediaNotFoundError,
+    ProviderUnavailableError,
+    UnplayableMediaError,
+)
 from music_assistant_models.media_items import (
     AudioFormat,
     BrowseFolder,
@@ -208,7 +213,12 @@ class RadiothekProvider(MusicProvider):
         if self.catchup_proto not in ("progressive", "hls"):
             self.catchup_proto = "progressive"
 
-        await self._get_bundle(force=True)
+        try:
+            await self._get_bundle(force=True)
+        except (ClientError, TimeoutError, ValueError, InvalidDataError) as err:
+            # the core only retries failed loads for MusicAssistantError subclasses
+            # (network may not be up yet when MA starts at boot)
+            raise ProviderUnavailableError(f"Unable to fetch ORF station bundle: {err}") from err
 
     # ----------------------------
     # HTTP / caching helpers
@@ -223,7 +233,7 @@ class RadiothekProvider(MusicProvider):
             resp.raise_for_status()
             data = await resp.json()
             if not isinstance(data, dict):
-                raise TypeError("Expected JSON object")
+                raise InvalidDataError("Expected JSON object")
             return data
 
     async def _get_bundle(self, force: bool = False) -> dict[str, Any]:
@@ -232,7 +242,7 @@ class RadiothekProvider(MusicProvider):
         try:
             self._bundle = await self._http_get_json(API_BUNDLE)
             return self._bundle
-        except (ClientError, TimeoutError, ValueError) as err:
+        except (ClientError, TimeoutError, ValueError, InvalidDataError) as err:
             self.logger.warning("Failed to fetch bundle.json: %s", err)
             if self._bundle is not None:
                 return self._bundle


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Reported by the provider's original dev: the provider needed a manual reload after every server start on HAOS. The initial bundle.json fetch in handle_async_init raised a raw TimeoutError/ClientError when the network was not yet up at boot. The core only schedules the automatic 120s load retry for MusicAssistantError subclasses, so the raw error meant no retry was scheduled and the provider stayed unloaded for the session (visible in the logs as the load error without the "(will be retried later)" suffix).

Fetch errors during init are now translated to ProviderUnavailableError so the core retries the load until the network is up. A malformed bundle response now raises InvalidDataError instead of a bare TypeError for the same reason.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5836

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
