### PR TITLE
Offer fake mute control for players with protocol-provided volume

### DIFF
--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -735,7 +735,9 @@ class PlayerConfigMixin:
             ConfigValueOption(PLAYER_CONTROL_NONE),
         ]
         mute_options.append(ConfigValueOption(PLAYER_CONTROL_NONE))
-        if player.supports_feature(PlayerFeature.VOLUME_SET):
+        # fake mute drives the volume control, so offer it when the player has any
+        # usable volume path (native or via a linked protocol player)
+        if player.supports_feature(PlayerFeature.VOLUME_SET) or auto_option in volume_options:
             mute_options.append(ConfigValueOption(PLAYER_CONTROL_FAKE))
 
         # return final config entries for all options

--- a/tests/controllers/config/test_player_control_entries.py
+++ b/tests/controllers/config/test_player_control_entries.py
@@ -6,7 +6,11 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
-from music_assistant_models.constants import PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_NONE
+from music_assistant_models.constants import (
+    PLAYER_CONTROL_FAKE,
+    PLAYER_CONTROL_NATIVE,
+    PLAYER_CONTROL_NONE,
+)
 from music_assistant_models.enums import PlayerFeature, PlayerType
 
 from music_assistant.constants import (
@@ -37,11 +41,21 @@ def _make_player(features: set[PlayerFeature]) -> MagicMock:
     return player
 
 
-def _entries_by_key(mass: MusicAssistant, features: set[PlayerFeature]) -> dict[str, ConfigEntry]:
+def _entries_by_key(
+    mass: MusicAssistant,
+    features: set[PlayerFeature],
+    protocol_player: MagicMock | None = None,
+) -> dict[str, ConfigEntry]:
     """Build the player-control config entries for a player with the given features."""
+    player = _make_player(features)
+    if protocol_player is not None:
+        player.linked_output_protocols = [
+            MagicMock(output_protocol_id="protocol_player_1", protocol_domain="squeezelite")
+        ]
     mass.players = MagicMock()
     mass.players.player_controls.return_value = []
-    entries = mass.config._create_player_control_config_entries(_make_player(features))
+    mass.players.get_player.return_value = protocol_player
+    entries = mass.config._create_player_control_config_entries(player)
     return {entry.key: entry for entry in entries}
 
 
@@ -77,3 +91,32 @@ async def test_default_is_never_a_disabled_option(
     assert default_option.disabled is False
     # with no native support the safe fallback is the always-present "none" control
     assert entry.default_value == PLAYER_CONTROL_NONE
+
+
+async def test_fake_mute_offered_when_volume_provided_by_protocol_player(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """
+    Fake mute is offered when the volume path comes from a linked protocol player.
+
+    Regression test: players whose volume is provided by a linked protocol player
+    (e.g. squeezelite wrapped by the universal player) don't report VOLUME_SET
+    natively, yet fake mute works fine for them as it drives the configured
+    volume control.
+    """
+    protocol_player = MagicMock()
+    protocol_player.available = True
+    protocol_player.supports_feature.side_effect = lambda feature: (
+        feature == PlayerFeature.VOLUME_SET
+    )
+    entry = _entries_by_key(mass_minimal, set(), protocol_player)[CONF_MUTE_CONTROL]
+    fake = next(option for option in entry.options if option.value == PLAYER_CONTROL_FAKE)
+    assert fake.disabled is False
+
+
+async def test_fake_mute_not_offered_without_any_volume_path(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """Fake mute stays hidden when neither the player nor a protocol player provides volume."""
+    entry = _entries_by_key(mass_minimal, {PlayerFeature.VOLUME_MUTE})[CONF_MUTE_CONTROL]
+    assert all(option.value != PLAYER_CONTROL_FAKE for option in entry.options)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Fixes the report that squeezelite players no longer have a fake mute option. Under player settings the mute control only offered "None", even though the documentation says fake mute is available for squeezelite devices.

The cause appears to be the fake mute option is only shown when a player natively supports volume. Since the protocol player rework, squeezelite devices are wrapped by the universal player, and the wrapper does not have native volume itself. Its volume comes from the linked squeezelite protocol player. The settings builder only looked at the native capability, so the option quietly disappeared for these players. It still worked for players like sync groups that report volume natively, which matches what the reporter observed.

Fake mute itself works fine for these players. It simply sets the volume to zero and restores the previous level on unmute, using whatever volume control is configured, including protocol volume. Only the option list was wrong.

The fix offers the fake mute option when the player has any usable volume path, native or via a linked protocol player. As a side effect this also makes mute on a sync group of squeezelite players work again, because group mute forwards to the members, which previously had no mute control to forward to.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5832

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
