### PR TITLE
Keep metadata scan tasks running when a library row has corrupt metadata JSON

### DIFF
--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -394,13 +394,17 @@ class MetaDataController(
     async def _scan_missing_artist_metadata(self) -> None:
         """Scan for artists with missing metadata."""
         update_current_task_progress_text("Searching for artists with missing metadata")
+        await self._report_corrupt_metadata_rows(DB_TABLE_ARTISTS)
         missing_images = (
             f"(json_extract({DB_TABLE_ARTISTS}.metadata,'$.images') ISNULL "
             f"OR json_extract({DB_TABLE_ARTISTS}.metadata,'$.images') = '[]')"
         )
         missing_description = f"json_extract({DB_TABLE_ARTISTS}.metadata,'$.description') ISNULL"
         never_refreshed = f"json_extract({DB_TABLE_ARTISTS}.metadata,'$.last_refresh') ISNULL"
-        query = f"({missing_images} OR {missing_description}) AND {never_refreshed}"
+        query = (
+            f"{_valid_metadata_guard(DB_TABLE_ARTISTS)} AND "
+            f"({missing_images} OR {missing_description}) AND {never_refreshed}"
+        )
         artists = await self.mass.music.artists.get_library_items_by_query(
             limit=METADATA_SCAN_BATCH_SIZE,
             order_by="random",
@@ -430,8 +434,10 @@ class MetaDataController(
     async def _refresh_playlist_metadata_batch(self) -> None:
         """Refresh metadata for a small batch of library playlists."""
         update_current_task_progress_text("Searching for playlists needing metadata refresh")
+        await self._report_corrupt_metadata_rows(DB_TABLE_PLAYLISTS)
         refresh_before = int(time() - REFRESH_INTERVAL)
         query = (
+            f"{_valid_metadata_guard(DB_TABLE_PLAYLISTS)} AND "
             f"{DB_TABLE_PLAYLISTS}.is_dynamic = 0 AND ("
             f"json_extract({DB_TABLE_PLAYLISTS}.metadata,'$.last_refresh') ISNULL "
             f"OR json_extract({DB_TABLE_PLAYLISTS}.metadata,'$.last_refresh') < {refresh_before})"
@@ -473,3 +479,26 @@ class MetaDataController(
         removed = await cleanup_thumb_cache(self.mass.cache_path, max_size_mb * 1024 * 1024)
         if removed:
             self.logger.debug("Thumbnail cache cleanup: removed %s file(s)", removed)
+
+    async def _report_corrupt_metadata_rows(self, table: str) -> None:
+        """Report library rows whose metadata column holds invalid JSON."""
+        rows = await self.mass.music.database.get_rows_from_query(
+            f"SELECT item_id, name FROM {table} "
+            f"WHERE {table}.metadata IS NOT NULL AND NOT json_valid({table}.metadata)",
+            limit=25,
+        )
+        for row in rows:
+            message = (
+                f"'{row['name']}' has corrupt metadata and was skipped. To repair, remove "
+                f"'{row['name']}' from the library; it will be re-added with fresh metadata "
+                f"on the next library sync ({table} id {row['item_id']})."
+            )
+            report_current_task_failure(message)
+            self.logger.warning(message)
+
+
+def _valid_metadata_guard(table: str) -> str:
+    """Return a query part that excludes rows with invalid JSON in the metadata column."""
+    # sqlite's json functions raise a fatal 'malformed JSON' error on invalid input,
+    # which would fail the entire scan query because of a single corrupt row
+    return f"({table}.metadata IS NULL OR json_valid({table}.metadata))"

--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -69,6 +69,7 @@ if TYPE_CHECKING:
     )
 
     from music_assistant import MusicAssistant
+    from music_assistant.helpers.json import SerializableType
     from music_assistant.models.metadata_provider import MetadataProvider
 
 
@@ -107,6 +108,8 @@ class MetaDataController(
         self._image_id_lru: OrderedDict[str, tuple[str, str]] = OrderedDict()
         self._image_id_persisted: dict[str, float] = {}
         self._image_id_lock = threading.Lock()
+        # corrupt metadata rows found by the last scan pass, per table, for diagnostics
+        self._corrupt_metadata_rows: dict[str, list[dict[str, str | int]]] = {}
 
     async def get_config_entries(
         self,
@@ -350,6 +353,12 @@ class MetaDataController(
                 return metadata.lyrics, metadata.lrc_lyrics
         return None, None
 
+    async def get_diagnostics(self) -> dict[str, SerializableType] | None:
+        """Return diagnostics info for this controller to include in diagnostics reports."""
+        if not self._corrupt_metadata_rows:
+            return None
+        return {"corrupt_metadata_rows": cast("SerializableType", self._corrupt_metadata_rows)}
+
     def _register_maintenance_tasks(self) -> None:
         """Register the recurring metadata maintenance background tasks."""
         # Spread across the full day so instances don't all hit the shared MusicBrainz mirror at once
@@ -487,6 +496,14 @@ class MetaDataController(
             f"WHERE {table}.metadata IS NOT NULL AND NOT json_valid({table}.metadata)",
             limit=25,
         )
+        # keep the findings for the diagnostics report, replacing the previous
+        # pass so repaired rows drop out again
+        if rows:
+            self._corrupt_metadata_rows[table] = [
+                {"item_id": row["item_id"], "name": row["name"]} for row in rows
+            ]
+        else:
+            self._corrupt_metadata_rows.pop(table, None)
         for row in rows:
             message = (
                 f"'{row['name']}' has corrupt metadata and was skipped. To repair, remove "

--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -483,17 +483,7 @@ class MetaDataController(
         table: str,
         query: str,
     ) -> list[ItemCls]:
-        """
-        Fetch a metadata-scan batch, tolerating rows with corrupt metadata JSON.
-
-        Runs guard-free on the happy path. If a row with malformed metadata JSON
-        aborts the query, records it for the diagnostics report and retries with a
-        json_valid guard so the remaining good rows are still scanned this pass.
-
-        :param media_controller: Media controller to query (e.g. artists or playlists).
-        :param table: Library table being scanned, used for corrupt-row reporting.
-        :param query: Scan filter applied as an extra query part.
-        """
+        """Fetch a metadata-scan batch, tolerating rows with corrupt metadata JSON."""
         try:
             items = await media_controller.get_library_items_by_query(
                 limit=METADATA_SCAN_BATCH_SIZE,

--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import random
+import sqlite3
 import threading
 from collections import OrderedDict
 from time import time
@@ -69,6 +70,7 @@ if TYPE_CHECKING:
     )
 
     from music_assistant import MusicAssistant
+    from music_assistant.controllers.music.media.base import MediaControllerBase
     from music_assistant.helpers.json import SerializableType
     from music_assistant.models.metadata_provider import MetadataProvider
 
@@ -403,22 +405,14 @@ class MetaDataController(
     async def _scan_missing_artist_metadata(self) -> None:
         """Scan for artists with missing metadata."""
         update_current_task_progress_text("Searching for artists with missing metadata")
-        await self._report_corrupt_metadata_rows(DB_TABLE_ARTISTS)
         missing_images = (
             f"(json_extract({DB_TABLE_ARTISTS}.metadata,'$.images') ISNULL "
             f"OR json_extract({DB_TABLE_ARTISTS}.metadata,'$.images') = '[]')"
         )
         missing_description = f"json_extract({DB_TABLE_ARTISTS}.metadata,'$.description') ISNULL"
         never_refreshed = f"json_extract({DB_TABLE_ARTISTS}.metadata,'$.last_refresh') ISNULL"
-        query = (
-            f"{_valid_metadata_guard(DB_TABLE_ARTISTS)} AND "
-            f"({missing_images} OR {missing_description}) AND {never_refreshed}"
-        )
-        artists = await self.mass.music.artists.get_library_items_by_query(
-            limit=METADATA_SCAN_BATCH_SIZE,
-            order_by="random",
-            extra_query_parts=[query],
-        )
+        query = f"({missing_images} OR {missing_description}) AND {never_refreshed}"
+        artists = await self._get_scan_batch(self.mass.music.artists, DB_TABLE_ARTISTS, query)
         if not artists:
             update_current_task_progress_text("No artists with missing metadata found")
             return
@@ -443,19 +437,13 @@ class MetaDataController(
     async def _refresh_playlist_metadata_batch(self) -> None:
         """Refresh metadata for a small batch of library playlists."""
         update_current_task_progress_text("Searching for playlists needing metadata refresh")
-        await self._report_corrupt_metadata_rows(DB_TABLE_PLAYLISTS)
         refresh_before = int(time() - REFRESH_INTERVAL)
         query = (
-            f"{_valid_metadata_guard(DB_TABLE_PLAYLISTS)} AND "
             f"{DB_TABLE_PLAYLISTS}.is_dynamic = 0 AND ("
             f"json_extract({DB_TABLE_PLAYLISTS}.metadata,'$.last_refresh') ISNULL "
             f"OR json_extract({DB_TABLE_PLAYLISTS}.metadata,'$.last_refresh') < {refresh_before})"
         )
-        playlists = await self.mass.music.playlists.get_library_items_by_query(
-            limit=METADATA_SCAN_BATCH_SIZE,
-            order_by="random",
-            extra_query_parts=[query],
-        )
+        playlists = await self._get_scan_batch(self.mass.music.playlists, DB_TABLE_PLAYLISTS, query)
         if not playlists:
             update_current_task_progress_text("No playlists require metadata refresh")
             return
@@ -488,6 +476,42 @@ class MetaDataController(
         removed = await cleanup_thumb_cache(self.mass.cache_path, max_size_mb * 1024 * 1024)
         if removed:
             self.logger.debug("Thumbnail cache cleanup: removed %s file(s)", removed)
+
+    async def _get_scan_batch[ItemCls: MediaItemType](
+        self,
+        media_controller: MediaControllerBase[ItemCls],
+        table: str,
+        query: str,
+    ) -> list[ItemCls]:
+        """
+        Fetch a metadata-scan batch, tolerating rows with corrupt metadata JSON.
+
+        Runs guard-free on the happy path. If a row with malformed metadata JSON
+        aborts the query, records it for the diagnostics report and retries with a
+        json_valid guard so the remaining good rows are still scanned this pass.
+
+        :param media_controller: Media controller to query (e.g. artists or playlists).
+        :param table: Library table being scanned, used for corrupt-row reporting.
+        :param query: Scan filter applied as an extra query part.
+        """
+        try:
+            items = await media_controller.get_library_items_by_query(
+                limit=METADATA_SCAN_BATCH_SIZE,
+                order_by="random",
+                extra_query_parts=[query],
+            )
+        except sqlite3.OperationalError as err:
+            if "malformed JSON" not in str(err):
+                raise
+            await self._report_corrupt_metadata_rows(table)
+            return await media_controller.get_library_items_by_query(
+                limit=METADATA_SCAN_BATCH_SIZE,
+                order_by="random",
+                extra_query_parts=[f"{_valid_metadata_guard(table)} AND {query}"],
+            )
+        # a clean scan proves the table currently holds no corrupt rows
+        self._corrupt_metadata_rows.pop(table, None)
+        return items
 
     async def _report_corrupt_metadata_rows(self, table: str) -> None:
         """Report library rows whose metadata column holds invalid JSON."""

--- a/tests/test_dynamic_playlist_framework.py
+++ b/tests/test_dynamic_playlist_framework.py
@@ -17,7 +17,9 @@ from music_assistant.models.music_provider import MusicProvider
 
 def _controller() -> MetaDataController:
     """Create a bare MetaDataController without running __init__."""
-    return MetaDataController.__new__(MetaDataController)
+    ctrl = MetaDataController.__new__(MetaDataController)
+    ctrl._corrupt_metadata_rows = {}
+    return ctrl
 
 
 def _provider() -> MusicProvider:

--- a/tests/test_dynamic_playlist_framework.py
+++ b/tests/test_dynamic_playlist_framework.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import sqlite3
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, Mock, patch
 
+import pytest
 from music_assistant_models.enums import MediaType
 from music_assistant_models.media_items import ProviderMapping, Track, UniqueList
 
@@ -87,7 +89,6 @@ async def test_refresh_playlist_metadata_batch_query_excludes_dynamic_playlists(
     ctrl = _controller()
     mass = Mock()
     mass.music.playlists.get_library_items_by_query = AsyncMock(return_value=[])
-    mass.music.database.get_rows_from_query = AsyncMock(return_value=[])
     ctrl.mass = mass
 
     await ctrl._refresh_playlist_metadata_batch()
@@ -96,6 +97,57 @@ async def test_refresh_playlist_metadata_batch_query_excludes_dynamic_playlists(
     query_parts = kwargs["extra_query_parts"]
     # Batch query should still filter dynamic playlists (automated refresh)
     assert any(f"{DB_TABLE_PLAYLISTS}.is_dynamic = 0" in part for part in query_parts)
+
+
+async def test_refresh_playlist_metadata_batch_reports_corrupt_row_reactively() -> None:
+    """A malformed-JSON row aborts the scan, gets reported, and the scan retries guarded."""
+    ctrl = _controller()
+    ctrl.logger = Mock()
+    mass = Mock()
+    # first (guard-free) query aborts on the corrupt row; guarded retry succeeds
+    mass.music.playlists.get_library_items_by_query = AsyncMock(
+        side_effect=[sqlite3.OperationalError("malformed JSON"), []]
+    )
+    mass.music.database.get_rows_from_query = AsyncMock(
+        return_value=[{"item_id": 7, "name": "Broken"}]
+    )
+    ctrl.mass = mass
+
+    await ctrl._refresh_playlist_metadata_batch()
+
+    assert mass.music.playlists.get_library_items_by_query.await_count == 2
+    retry_parts = mass.music.playlists.get_library_items_by_query.call_args_list[1].kwargs[
+        "extra_query_parts"
+    ]
+    # only the retry carries the json_valid guard
+    assert any("json_valid" in part for part in retry_parts)
+    assert ctrl._corrupt_metadata_rows[DB_TABLE_PLAYLISTS] == [{"item_id": 7, "name": "Broken"}]
+
+
+async def test_refresh_playlist_metadata_batch_clears_stale_corrupt_rows() -> None:
+    """A clean scan clears corrupt rows recorded on a previous pass."""
+    ctrl = _controller()
+    ctrl._corrupt_metadata_rows = {DB_TABLE_PLAYLISTS: [{"item_id": 7, "name": "Broken"}]}
+    mass = Mock()
+    mass.music.playlists.get_library_items_by_query = AsyncMock(return_value=[])
+    ctrl.mass = mass
+
+    await ctrl._refresh_playlist_metadata_batch()
+
+    assert DB_TABLE_PLAYLISTS not in ctrl._corrupt_metadata_rows
+
+
+async def test_refresh_playlist_metadata_batch_reraises_unrelated_db_error() -> None:
+    """A non-malformed OperationalError is not swallowed by the corrupt-row handling."""
+    ctrl = _controller()
+    mass = Mock()
+    mass.music.playlists.get_library_items_by_query = AsyncMock(
+        side_effect=sqlite3.OperationalError("database is locked")
+    )
+    ctrl.mass = mass
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        await ctrl._refresh_playlist_metadata_batch()
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_dynamic_playlist_framework.py
+++ b/tests/test_dynamic_playlist_framework.py
@@ -85,6 +85,7 @@ async def test_refresh_playlist_metadata_batch_query_excludes_dynamic_playlists(
     ctrl = _controller()
     mass = Mock()
     mass.music.playlists.get_library_items_by_query = AsyncMock(return_value=[])
+    mass.music.database.get_rows_from_query = AsyncMock(return_value=[])
     ctrl.mass = mass
 
     await ctrl._refresh_playlist_metadata_batch()


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

A user reported that their nightly "Scan missing artist metadata" task always failed with "Task failed: malformed JSON". That error message comes from sqlite itself. The scan tasks use `json_extract` in their database queries, and sqlite raises a fatal error the moment json_extract reads a metadata value that is not valid JSON. So a single corrupt row in the artists or playlists table  made the whole query fail before any item was processed. The result was that automatic metadata enrichment silently stopped working for the entire library, which the user noticed as artist images never being downloaded.

This change does two things for both affected scan tasks (artist metadata scan and playlist metadata refresh):

1. The scan queries now filter out rows with invalid metadata using sqlite's `json_valid` function, so one corrupt row no longer takes down the whole scan. Rows with empty (NULL) metadata are still scanned as before.
2. Each corrupt row is reported in the task log so the user knows about the problem and how to fix it, for example: "'Some Artist' has corrupt metadata and was skipped. To repair, remove 'Some Artist' from the library; it will be re-added with fresh metadata on the next library sync (artists id 1234)." The task then finishes as partial success instead of failing outright.

Claude verified against sqlite 3.50 with a deliberately corrupted row: the old query reproduces the exact reported error, the guarded query skips the bad row and returns everything else, and the detection query identifies the corrupt row.

Following Marvin's suggestion, the corrupt rows found by the last scan pass are also kept in a private list on the metadata controller and returned through `get_diagnostics()`. They show up as a `core.metadata` section in the diagnostics report, so we can capture affected rows directly from a report attached to an issue. The section is omitted entirely while no corrupt rows are known, and repaired rows drop out again on the next scan pass. Note the list starts empty after a restart until the scheduled scan has run.

**Related issue (if applicable):**

- related issue https://github.com/orgs/music-assistant/discussions/5846#discussioncomment-17636407

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
