### PR TITLE
Preload lyrics in Music Quiz

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -893,7 +893,7 @@ class MusicQuizPlugin(PluginProvider):
     async def _start_next_round(self) -> None:
         """Prepare the next round, start its playback (if any) and open the answering phase."""
         with _system_auth_context():
-            game, quiz_type, answer_type = self._require_game_strategies()
+            game, _, answer_type = self._require_game_strategies()
             round_index = len(game.rounds)
             next_round = await self._prepare_playable_round(round_index)
             started_at = time.time()
@@ -908,8 +908,6 @@ class MusicQuizPlugin(PluginProvider):
                 started_at + answer_window,
                 task_id=self._reveal_timer_id,
             )
-            if next_round.track_uri and quiz_type.warm_up_lyrics:
-                self._warm_up_lyrics(next_round.track_uri)
             self._prefetch_round(round_index + 1)
             self._signal_game_updated()
 
@@ -1162,9 +1160,21 @@ class MusicQuizPlugin(PluginProvider):
         """Initialize a quiz type and complete its first round before opening the lobby."""
         with _system_auth_context():
             await quiz_type.initialize()
-            task = self.mass.create_task(quiz_type.prepare_round(0, []))
+            task = self.mass.create_task(self._prepare_round(quiz_type, 0, []))
             await task
         return task
+
+    async def _prepare_round(
+        self,
+        quiz_type: QuizType,
+        round_index: int,
+        previous_rounds: list[MusicQuizRound],
+    ) -> MusicQuizRound:
+        """Prepare a round and its required assets."""
+        game_round = await quiz_type.prepare_round(round_index, previous_rounds)
+        if game_round.track_uri and quiz_type.prefetch_lyrics:
+            await self._fetch_lyrics(game_round.track_uri)
+        return game_round
 
     def _prefetch_round(self, round_index: int) -> None:
         """Prepare an upcoming round in the background."""
@@ -1174,7 +1184,7 @@ class MusicQuizPlugin(PluginProvider):
         game, quiz_type, _ = self._require_game_strategies()
         with _system_auth_context():
             self._next_round_task = self.mass.create_task(
-                quiz_type.prepare_round(round_index, list(game.rounds))
+                self._prepare_round(quiz_type, round_index, list(game.rounds))
             )
 
     async def _get_prepared_round(self, round_index: int) -> MusicQuizRound:
@@ -1188,13 +1198,15 @@ class MusicQuizPlugin(PluginProvider):
                 if prepared.round_index == round_index:
                     return prepared
             except asyncio.CancelledError:
-                pass
+                current_task = asyncio.current_task()
+                if current_task is None or current_task.cancelling():
+                    raise
             except Exception as err:
                 self.logger.warning(
                     "Prefetched Music Quiz round failed, preparing a fresh one: %s", err
                 )
         with _system_auth_context():
-            return await quiz_type.prepare_round(round_index, list(game.rounds))
+            return await self._prepare_round(quiz_type, round_index, list(game.rounds))
 
     def _cancel_next_round_task(self) -> None:
         """Cancel a pending round prefetch task."""
@@ -1301,23 +1313,14 @@ class MusicQuizPlugin(PluginProvider):
             and game.current_round_index == round_index
         )
 
-    def _warm_up_lyrics(self, track_uri: str) -> None:
-        """Fetch/caches the track lyrics so they are ready when revealed."""
-        with _system_auth_context():
-            self.mass.create_task(
-                self._fetch_lyrics(track_uri),
-                task_id=f"music_quiz_lyrics_{self.instance_id}",
-                abort_existing=True,
-            )
-
     async def _fetch_lyrics(self, track_uri: str) -> None:
-        """Best-effort lyrics warm-up for the given track."""
+        """Fetch lyrics for a prepared round."""
         try:
             track = await self.mass.music.get_item_by_uri(track_uri)
             if isinstance(track, Track):
                 await self.mass.metadata.get_track_lyrics(track)
         except Exception as err:
-            self.logger.debug("Lyrics warm-up failed for %s: %s", track_uri, err)
+            self.logger.debug("Lyrics prefetch failed for %s: %s", track_uri, err)
 
     # ---------- playback ----------
 

--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -74,7 +74,7 @@ class QuizType(ABC):
     """
 
     answer_type: ClassVar[MusicQuizAnswerType]
-    warm_up_lyrics: ClassVar[bool] = False
+    prefetch_lyrics: ClassVar[bool] = False
     reveal_auto_advance_delay: ClassVar[float | None] = None
     completed_reveal_auto_advance_delay: ClassVar[float | None] = None
 

--- a/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
+++ b/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
@@ -57,7 +57,7 @@ class GuessTheSongQuizType(QuizType):
     """Quiz type where players guess the currently playing track."""
 
     answer_type = MusicQuizAnswerType.MULTIPLE_CHOICE
-    warm_up_lyrics = True
+    prefetch_lyrics = True
 
     @classmethod
     def normalize_config(cls, config: MusicQuizConfig) -> MusicQuizConfig:

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import AsyncGenerator, Coroutine
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from music_assistant_models.auth import Scope, User, UserRole
@@ -1682,14 +1682,91 @@ async def test_venue_listener_is_restored_before_each_audio_track(quiz_type: str
 
 
 @pytest.mark.asyncio
-async def test_guess_the_song_warms_lyrics_through_quiz_capability() -> None:
-    """Keep lyrics warm-up enabled for guess-the-song rounds."""
+async def test_guess_the_song_prefetches_lyrics_with_prepared_rounds() -> None:
+    """Wait for first-round lyrics and prefetch next-round lyrics during playback."""
     plugin = _create_plugin()
-    plugin._warm_up_lyrics = MagicMock()  # type: ignore[method-assign]
+    first_lyrics_started = asyncio.Event()
+    continue_first_lyrics = asyncio.Event()
+    next_lyrics_started = asyncio.Event()
+    continue_next_lyrics = asyncio.Event()
 
-    await _create_started_game(plugin, player_names=())
+    async def _fetch_lyrics(track_uri: str) -> None:
+        if track_uri == "library://track/0":
+            first_lyrics_started.set()
+            await continue_first_lyrics.wait()
+            return
+        assert track_uri == "library://track/1"
+        next_lyrics_started.set()
+        await continue_next_lyrics.wait()
 
-    plugin._warm_up_lyrics.assert_called_once_with("library://track/0")
+    fetch_lyrics = AsyncMock(side_effect=_fetch_lyrics)
+    plugin._fetch_lyrics = fetch_lyrics  # type: ignore[method-assign]
+    create_task = asyncio.create_task(
+        plugin.create_game(
+            round_count=2,
+            source_uris=["library://playlist/1"],
+            name="Test Quiz",
+        )
+    )
+    await first_lyrics_started.wait()
+    assert not create_task.done()
+
+    continue_first_lyrics.set()
+    await create_task
+    fetch_lyrics.assert_awaited_once_with("library://track/0")
+
+    await plugin.start_game()
+    await next_lyrics_started.wait()
+    next_round_task = plugin._next_round_task
+    assert next_round_task is not None
+    assert not next_round_task.done()
+    assert _phase(plugin) == MusicQuizPhase.ANSWERING
+    cast("AsyncMock", plugin._play_track).assert_awaited_once_with("library://track/0")
+
+    continue_next_lyrics.set()
+    await next_round_task
+    assert fetch_lyrics.await_args_list == [
+        call("library://track/0"),
+        call("library://track/1"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancelling_next_round_during_lyrics_prefetch_preserves_reveal() -> None:
+    """Propagate cancellation without preparing or starting another round."""
+    plugin = _create_plugin()
+    next_lyrics_started = asyncio.Event()
+    next_lyrics_attempts = 0
+
+    async def _fetch_lyrics(track_uri: str) -> None:
+        nonlocal next_lyrics_attempts
+        if track_uri == "library://track/0":
+            return
+        assert track_uri == "library://track/1"
+        next_lyrics_attempts += 1
+        if next_lyrics_attempts == 1:
+            next_lyrics_started.set()
+            await asyncio.Future()
+
+    plugin._fetch_lyrics = AsyncMock(side_effect=_fetch_lyrics)  # type: ignore[method-assign]
+    await _create_started_game(plugin, player_names=(), round_count=2)
+    await next_lyrics_started.wait()
+    await plugin.reveal()
+
+    next_round_task = asyncio.create_task(plugin.next_round())
+    await asyncio.sleep(0)
+    assert not next_round_task.done()
+    next_round_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await next_round_task
+
+    game = plugin._game
+    assert game is not None
+    assert game.phase == MusicQuizPhase.REVEAL
+    assert len(game.rounds) == 1
+    assert next_lyrics_attempts == 1
+    cast("AsyncMock", plugin._play_track).assert_awaited_once_with("library://track/0")
 
 
 @pytest.mark.asyncio
@@ -1964,7 +2041,8 @@ async def test_trivia_replacement_blocks_concurrent_listen_in_recreation() -> No
 async def test_disabled_trivia_serialization_and_listen_in_remain_non_audio() -> None:  # noqa: PLR0915
     """Expose flat redacted Trivia state without playback, lyrics, or listen-in."""
     plugin = _create_plugin(use_ai_distractors=True)
-    plugin._warm_up_lyrics = MagicMock()  # type: ignore[method-assign]
+    fetch_lyrics = AsyncMock()
+    plugin._fetch_lyrics = fetch_lyrics  # type: ignore[method-assign]
     prepare_round = AsyncMock(side_effect=_make_text_trivia_round)
     with (
         patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
@@ -2002,7 +2080,7 @@ async def test_disabled_trivia_serialization_and_listen_in_remain_non_audio() ->
         ) == ("off", "off", False)
         assert _phase(plugin) == MusicQuizPhase.ANSWERING
         cast("AsyncMock", plugin._play_track).assert_not_awaited()
-        plugin._warm_up_lyrics.assert_not_called()
+        fetch_lyrics.assert_not_awaited()
 
         public_state = cast("MagicMock", plugin.signal_provider_event).call_args[0][0]["state"]
         assert public_state["quiz_type"] == "trivia"
@@ -2890,12 +2968,13 @@ async def test_music_timeline_create_uses_flat_config_and_derived_answer_type() 
 
 
 @pytest.mark.asyncio
-async def test_music_timeline_placement_auto_reveals_without_bonuses_and_never_warms_lyrics() -> (
+async def test_music_timeline_placement_auto_reveals_without_bonuses_and_never_prefetches_lyrics() -> (
     None
 ):
-    """Complete on placement, preserve playback, and skip lyrics warm-up for Music Timeline."""
+    """Complete on placement, preserve playback, and skip lyrics prefetch for Music Timeline."""
     plugin = _create_plugin()
-    plugin._warm_up_lyrics = MagicMock()  # type: ignore[method-assign]
+    fetch_lyrics = AsyncMock()
+    plugin._fetch_lyrics = fetch_lyrics  # type: ignore[method-assign]
     with (
         patch(
             "music_assistant.providers.music_quiz.quiz_types.music_timeline.MusicTimelineQuizType.initialize",
@@ -2961,7 +3040,7 @@ async def test_music_timeline_placement_auto_reveals_without_bonuses_and_never_w
         cast("AsyncMock", plugin._play_track).assert_awaited_with(
             "library://track/music_timeline-0"
         )
-        plugin._warm_up_lyrics.assert_not_called()
+        fetch_lyrics.assert_not_awaited()
         assert state["current_round"]["revealed_entry"]["release_year"] == 2000
         assert [entry["entry_id"] for entry in state["current_round"]["timeline"]] == [
             "anchor",


### PR DESCRIPTION
# What does this implement/fix?

Preloads lyrics while each Guess the Song round is prepared, so they are ready when the song is revealed.

- Loads the first track and lyrics during game setup.
- Prepares the next track and lyrics while the current track is playing.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
