### PR TITLE
Allow any authenticated user on party and music quiz guest routes

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -58,7 +58,7 @@ from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
-from music_assistant_models.auth import Scope, UserRole
+from music_assistant_models.auth import Scope
 from music_assistant_models.config_entries import (
     ConfigEntry,
     ConfigValueType,
@@ -76,7 +76,6 @@ from music_assistant_models.media_items import Track
 from music_assistant.constants import ATTR_ANNOUNCEMENT_IN_PROGRESS
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     current_user,
-    get_current_user,
     impersonated_user,
 )
 from music_assistant.helpers import guest_access
@@ -563,7 +562,6 @@ class MusicQuizPlugin(PluginProvider):
         :return: The player's private player_id (their credential for further
             game commands) and their personalized game state.
         """
-        self._validate_guest_access()
         async with self._game_lock:
             game, _, answer_type = self._require_game_strategies()
             player_name = name.strip()[:MAX_PLAYER_NAME_LENGTH]
@@ -597,7 +595,6 @@ class MusicQuizPlugin(PluginProvider):
 
         :param player_id: The player's private player_id.
         """
-        self._validate_guest_access()
         async with self._game_lock:
             game, _, answer_type = self._require_game_strategies()
             player = _get_player(game, player_id)
@@ -611,7 +608,6 @@ class MusicQuizPlugin(PluginProvider):
         :param player_id: The player's private player_id.
         :return: True when the player still exists, otherwise False.
         """
-        self._validate_guest_access()
         async with self._game_lock:
             if self._game is None or (player := _find_player(self._game, player_id)) is None:
                 return False
@@ -629,7 +625,6 @@ class MusicQuizPlugin(PluginProvider):
         :param player_id: The player's private player_id.
         :param submission: Discriminated answer submission.
         """
-        self._validate_guest_access()
         async with self._game_lock:
             game, _, answer_type = self._require_game_strategies()
             submission_type = submission.get("answer_type")
@@ -651,7 +646,6 @@ class MusicQuizPlugin(PluginProvider):
         :param player_id: The player's private player_id.
         :param suggestion_id: Selected suggestion ID.
         """
-        self._validate_guest_access()
         async with self._game_lock:
             game, _, answer_type = self._require_game_strategies()
             if game.answer_type != MusicQuizAnswerType.MULTIPLE_CHOICE:
@@ -668,7 +662,6 @@ class MusicQuizPlugin(PluginProvider):
 
         :param player_id: The player's private player_id.
         """
-        self._validate_guest_access()
         async with self._game_lock:
             game, _, answer_type = self._require_game_strategies()
             player = _get_player(game, player_id)
@@ -691,7 +684,6 @@ class MusicQuizPlugin(PluginProvider):
 
         :param web_player_id: The player_id of the guest's web player.
         """
-        self._validate_guest_access()
         # hold the playback lock across resolving and joining the session so a
         # guest can never be attached to a session that is being torn down
         async with self._playback_lock:
@@ -707,7 +699,6 @@ class MusicQuizPlugin(PluginProvider):
 
         :param web_player_id: The player_id of the guest's web player.
         """
-        self._validate_guest_access()
         async with self._playback_lock:
             if self._playback_session is not None:
                 await self._playback_session.remove_guest_listener(web_player_id)
@@ -718,7 +709,6 @@ class MusicQuizPlugin(PluginProvider):
 
         :param web_player_id: The player_id of the guest's web player.
         """
-        self._validate_guest_access()
         async with self._playback_lock:
             session = await self._get_or_create_session_locked()
             return session is not None and session.can_listen_in(web_player_id)
@@ -759,21 +749,6 @@ class MusicQuizPlugin(PluginProvider):
         ):
             raise InvalidDataError("Music Quiz game strategy identity mismatch")
         return game, self._quiz_type, self._answer_type
-
-    @staticmethod
-    def _validate_guest_access() -> None:
-        """
-        Validate the current user is an authenticated dedicated guest.
-
-        :raises InvalidDataError: If the user is not a dedicated guest.
-        """
-        user = get_current_user()
-        if not user or user.role != UserRole.GUEST:
-            raise InvalidDataError(
-                "This action is only available to Music Quiz guests",
-                translation_key="music_quiz_guest_only",
-                translation_owner=TRANSLATION_OWNER,
-            )
 
     def _submit_player_answer(
         self,

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -270,8 +270,7 @@ class MusicQuizPlugin(PluginProvider):
             self._unregister_handles.append(
                 self.mass.register_api_command(command, handler, required_scope=Scope.USERS_INVITE)
             )
-        # guest game commands: any authenticated user passes the API layer,
-        # the handlers themselves validate the caller is the quiz guest user
+        # Participant game commands are available to any authenticated user.
         guest_commands: tuple[tuple[str, _ApiHandler], ...] = (
             ("music_quiz/info", self.get_game_info),
             ("music_quiz/join", self.join_game),

--- a/music_assistant/providers/music_quiz/strings.json
+++ b/music_assistant/providers/music_quiz/strings.json
@@ -53,7 +53,6 @@
     "music_quiz_trivia_insufficient_metadata": "At least {0} unique selected tracks with usable music metadata are required for Trivia.",
     "music_quiz_trivia_generation_failed": "Music Assistant could not generate a valid Trivia question. Please try again.",
     "music_quiz_not_enough_distractors": "Not enough distinct tracks are available to build answer options.",
-    "music_quiz_guest_only": "This action is only available to Music Quiz guests.",
     "music_quiz_unknown_quiz_type": "This quiz type is not available.",
     "music_quiz_unknown_player": "This Music Quiz player is not in the game.",
     "music_quiz_unknown_suggestion": "This answer option is not available.",

--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -453,17 +453,19 @@ class PartyPlugin(PluginProvider):
         )
         self._unregister_handles.append(
             self.mass.register_api_command(
-                "party/listen_in", self.listen_in, required_scope=Scope.QUEUES_CONTROL
+                "party/listen_in", self.listen_in, required_scope=Scope.PLAYERS_CONTROL
             )
         )
         self._unregister_handles.append(
             self.mass.register_api_command(
-                "party/stop_listen_in", self.stop_listen_in, required_scope=Scope.QUEUES_CONTROL
+                "party/stop_listen_in",
+                self.stop_listen_in,
+                required_scope=Scope.PLAYERS_CONTROL,
             )
         )
         self._unregister_handles.append(
             self.mass.register_api_command(
-                "party/can_listen_in", self.can_listen_in, required_scope=Scope.QUEUES_CONTROL
+                "party/can_listen_in", self.can_listen_in, required_scope=Scope.PLAYERS_CONTROL
             )
         )
 

--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from mashumaro import DataClassDictMixin
-from music_assistant_models.auth import Scope, UserRole
+from music_assistant_models.auth import Scope
 from music_assistant_models.config_entries import (
     ConfigEntry,
     ConfigValueOption,
@@ -24,7 +24,6 @@ from music_assistant_models.enums import ConfigEntryType, MediaType, PlaybackSta
 from music_assistant_models.errors import InvalidDataError, SetupFailedError
 
 from music_assistant.controllers.player_queues.helpers import build_queue_item
-from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers import guest_access
 from music_assistant.helpers.shared_playback import SharedPlaybackMode, SharedPlaybackSession
 from music_assistant.models.plugin import PluginProvider
@@ -616,8 +615,6 @@ class PartyPlugin(PluginProvider):
         :param boost: If True, insert at the front of the guest section (play next).
         :returns: Result dict with success status and queue position info.
         """
-        self._validate_guest_access()
-
         # Check if guest access is enabled
         if not self.config.get_value(CONF_ENABLE_GUEST_ACCESS):
             raise InvalidDataError("Party guest access is disabled")
@@ -701,7 +698,6 @@ class PartyPlugin(PluginProvider):
         :param queue_item_id: The queue_item_id of the item to boost.
         :returns: Result dict with success status.
         """
-        self._validate_guest_access()
         if not self.config.get_value(CONF_ENABLE_GUEST_ACCESS):
             raise InvalidDataError("Party guest access is disabled")
         if not self.config.get_value(CONF_ENABLE_BOOST):
@@ -860,17 +856,6 @@ class PartyPlugin(PluginProvider):
             )
 
     @staticmethod
-    def _validate_guest_access() -> None:
-        """
-        Validate the current user is an authenticated dedicated guest.
-
-        :raises InvalidDataError: If the user is not a dedicated guest.
-        """
-        user = get_current_user()
-        if not user or user.role != UserRole.GUEST:
-            raise InvalidDataError("This endpoint is only available to party guests")
-
-    @staticmethod
     def _queue_contains_uri(queue_items: list[QueueItem], uri: str) -> bool:
         """Return whether the queue already contains the given item URI."""
         return any(queue_item.uri == uri for queue_item in queue_items)
@@ -909,8 +894,6 @@ class PartyPlugin(PluginProvider):
 
         :returns: Result dict with success status.
         """
-        self._validate_guest_access()
-
         # Check if guest access and skip are enabled
         if not self.config.get_value(CONF_ENABLE_GUEST_ACCESS):
             raise InvalidDataError("Party guest access is disabled")
@@ -946,7 +929,6 @@ class PartyPlugin(PluginProvider):
         :param web_player_id: The player_id of the guest's web player.
         :returns: Result dict with success status and the party queue ID.
         """
-        self._validate_guest_access()
         if not self.config.get_value(CONF_ENABLE_GUEST_ACCESS):
             raise InvalidDataError("Party guest access is disabled")
 
@@ -972,8 +954,6 @@ class PartyPlugin(PluginProvider):
         :param web_player_id: The player_id of the guest's web player.
         :returns: Result dict with success status.
         """
-        self._validate_guest_access()
-
         async with self._session_lock:
             if self._session is not None:
                 await self._session.remove_guest_listener(web_player_id)
@@ -987,7 +967,6 @@ class PartyPlugin(PluginProvider):
 
         :param web_player_id: The player_id of the guest's web player.
         """
-        self._validate_guest_access()
         if not self.config.get_value(CONF_ENABLE_GUEST_ACCESS):
             return False
 

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1437,7 +1437,6 @@
   "provider.music_quiz.errors.music_quiz_answer_duration_min": "The answer duration must be at least 1 second.",
   "provider.music_quiz.errors.music_quiz_game_active": "A Music Quiz game is already in progress.",
   "provider.music_quiz.errors.music_quiz_game_full": "The Music Quiz game is full.",
-  "provider.music_quiz.errors.music_quiz_guest_only": "This action is only available to Music Quiz guests.",
   "provider.music_quiz.errors.music_quiz_invalid_answer": "This answer is not valid for the current game.",
   "provider.music_quiz.errors.music_quiz_invalid_bonus_mode": "The selected timeline bonus mode is not valid.",
   "provider.music_quiz.errors.music_quiz_invalid_difficulty": "The selected difficulty is not valid.",

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -505,13 +505,9 @@ async def _create_started_game(
         name="Test Quiz",
     )
     player_ids: dict[str, str] = {}
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        for player_name in player_names:
-            result = await plugin.join_game(player_name)
-            player_ids[player_name] = result["player_id"]
+    for player_name in player_names:
+        result = await plugin.join_game(player_name)
+        player_ids[player_name] = result["player_id"]
     await plugin.start_game()
     return player_ids
 
@@ -534,13 +530,9 @@ async def _create_started_music_timeline_game(
         title_bonus_mode=title_bonus_mode,
     )
     player_ids: dict[str, str] = {}
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        for player_name in player_names:
-            result = await plugin.join_game(player_name)
-            player_ids[player_name] = result["player_id"]
+    for player_name in player_names:
+        result = await plugin.join_game(player_name)
+        player_ids[player_name] = result["player_id"]
     await plugin.start_game()
     return player_ids
 
@@ -561,13 +553,9 @@ async def _create_started_trivia_game(
         play_reveal_audio=play_reveal_audio,
     )
     player_ids: dict[str, str] = {}
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        for player_name in player_names:
-            result = await plugin.join_game(player_name)
-            player_ids[player_name] = result["player_id"]
+    for player_name in player_names:
+        result = await plugin.join_game(player_name)
+        player_ids[player_name] = result["player_id"]
     await plugin.start_game()
     return player_ids
 
@@ -582,11 +570,7 @@ async def _assert_reveal_deadline_cleared(
     public_state = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]["state"]
     host_state = await plugin.get_game()
     assert host_state is not None
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        personal_state = await plugin.get_player_state(player_id)
+    personal_state = await plugin.get_player_state(player_id)
 
     assert game.phase == MusicQuizPhase.REVEAL
     assert game.rounds[-1].auto_advance_at is None
@@ -985,10 +969,6 @@ async def test_explicit_remote_ignores_player_and_keeps_it_private() -> None:
             "music_assistant.providers.music_quiz.SharedPlaybackSession.create_venue",
             new=AsyncMock(),
         ) as create_venue,
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
     ):
         assert await plugin.can_listen_in("web-player") is True
     create_remote.assert_awaited_once()
@@ -1161,48 +1141,14 @@ async def test_cancelled_preference_write_propagates_after_game_commit() -> None
     cast("MagicMock", plugin.logger.warning).assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "username",
-    [MUSIC_QUIZ_GUEST_USER, "party_guest", "temporary_guest"],
-)
 @pytest.mark.asyncio
-async def test_guest_commands_accept_any_dedicated_guest(username: str) -> None:
-    """Any authenticated guest role can use the active Music Quiz experience."""
+async def test_game_commands_do_not_require_guest_role() -> None:
+    """Game commands work without a dedicated guest role, so the host can play too."""
     plugin = _create_plugin()
     await plugin.create_game(source_uris=["library://playlist/1"])
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=SimpleNamespace(username=username, role=UserRole.GUEST),
-    ):
-        result = await plugin.join_game("Guest")
-
+    result = await plugin.join_game("Host")
     assert result["player_id"]
-
-
-@pytest.mark.parametrize(
-    "user",
-    [
-        None,
-        SimpleNamespace(username="user", role=UserRole.USER),
-        SimpleNamespace(username="admin", role=UserRole.ADMIN),
-        SimpleNamespace(username="service", role=UserRole.SERVICE),
-    ],
-)
-@pytest.mark.asyncio
-async def test_guest_commands_reject_non_guest_users(user: SimpleNamespace | None) -> None:
-    """Guest game commands reject unauthenticated and non-guest users."""
-    plugin = _create_plugin()
-    await plugin.create_game(source_uris=["library://playlist/1"])
-
-    with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=user,
-        ),
-        pytest.raises(InvalidDataError, match="guests"),
-    ):
-        await plugin.join_game("Mallory")
 
 
 @pytest.mark.asyncio
@@ -1216,28 +1162,24 @@ async def test_full_game_flow() -> None:
     assert game.current_round_index == 0
     cast("AsyncMock", plugin._play_track).assert_awaited_with("library://track/0")
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        # the round auto-reveals when all active players answered
-        await plugin.answer(player_ids["Alice"], "correct_0")
-        assert _phase(plugin) == MusicQuizPhase.ANSWERING
-        await plugin.answer(player_ids["Bob"], "wrong_0_1")
-        assert _phase(plugin) == MusicQuizPhase.REVEAL
-        assert game.players[player_ids["Alice"]].score == 1000
-        assert game.players[player_ids["Bob"]].score == 0
+    # the round auto-reveals when all active players answered
+    await plugin.answer(player_ids["Alice"], "correct_0")
+    assert _phase(plugin) == MusicQuizPhase.ANSWERING
+    await plugin.answer(player_ids["Bob"], "wrong_0_1")
+    assert _phase(plugin) == MusicQuizPhase.REVEAL
+    assert game.players[player_ids["Alice"]].score == 1000
+    assert game.players[player_ids["Bob"]].score == 0
 
-        # all players ready advances to the next round
-        await plugin.ready(player_ids["Alice"])
-        assert _phase(plugin) == MusicQuizPhase.REVEAL
-        await plugin.ready(player_ids["Bob"])
-        assert _phase(plugin) == MusicQuizPhase.ANSWERING
-        assert game.current_round_index == 1
+    # all players ready advances to the next round
+    await plugin.ready(player_ids["Alice"])
+    assert _phase(plugin) == MusicQuizPhase.REVEAL
+    await plugin.ready(player_ids["Bob"])
+    assert _phase(plugin) == MusicQuizPhase.ANSWERING
+    assert game.current_round_index == 1
 
-        # final round: reveal via host command, then next finishes the game
-        await plugin.answer(player_ids["Alice"], "wrong_1_1")
-        await plugin.answer(player_ids["Bob"], "correct_1")
+    # final round: reveal via host command, then next finishes the game
+    await plugin.answer(player_ids["Alice"], "wrong_1_1")
+    await plugin.answer(player_ids["Bob"], "correct_1")
 
     assert _phase(plugin) == MusicQuizPhase.REVEAL
     await plugin.next_round()
@@ -1702,10 +1644,6 @@ async def test_generic_submit_answer_uses_discriminated_payload() -> None:
     game.players[player_ids["Alice"]].last_seen = 100.0
 
     with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
         patch("music_assistant.providers.music_quiz.time.time", return_value=120.0),
     ):
         state = cast(
@@ -1800,16 +1738,12 @@ async def test_music_timeline_edge_placement_accepts_null_at_api_boundary(
                 },
             },
         )
-        with patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ):
-            with pytest.raises(MusicQuizInvalidAnswerError):
-                await cast(
-                    "Coroutine[Any, Any, Any]",
-                    handler.target(**invalid_arguments),
-                )
-            await cast("Coroutine[Any, Any, Any]", handler.target(**arguments))
+        with pytest.raises(MusicQuizInvalidAnswerError):
+            await cast(
+                "Coroutine[Any, Any, Any]",
+                handler.target(**invalid_arguments),
+            )
+        await cast("Coroutine[Any, Any, Any]", handler.target(**arguments))
 
     game = plugin._game
     assert game is not None
@@ -1934,10 +1868,6 @@ async def test_trivia_replacement_blocks_concurrent_listen_in_recreation() -> No
             "prepare_round",
             new=AsyncMock(side_effect=_make_text_trivia_round),
         ),
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
     ):
         create_task = asyncio.create_task(
             plugin.create_game(
@@ -1969,10 +1899,6 @@ async def test_disabled_trivia_serialization_and_listen_in_remain_non_audio() ->
     with (
         patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
         patch.object(TriviaQuizType, "prepare_round", new=prepare_round),
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
     ):
         await plugin.create_game(
             quiz_type="trivia",
@@ -2099,10 +2025,6 @@ async def test_enabled_trivia_uses_existing_playback_session_rules(mode: str) ->
             f"music_assistant.providers.music_quiz.SharedPlaybackSession.{factory_name}",
             new=AsyncMock(return_value=session),
         ) as create_session,
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
     ):
         await plugin.create_game(
             quiz_type="trivia",
@@ -2221,10 +2143,6 @@ async def test_trivia_reveal_paths_schedule_one_fixed_deadline(  # noqa: PLR0915
     impersonated_user_token = impersonated_user.set(requesting_impersonation)
     try:
         with (
-            patch(
-                "music_assistant.providers.music_quiz.get_current_user",
-                return_value=_guest_user(),
-            ),
             patch("music_assistant.providers.music_quiz.time.time", return_value=200.0),
         ):
             if trigger == "all_complete":
@@ -2248,11 +2166,7 @@ async def test_trivia_reveal_paths_schedule_one_fixed_deadline(  # noqa: PLR0915
     public_state = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]["state"]
     host_state = await plugin.get_game()
     assert host_state is not None
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        personal_state = await plugin.get_player_state(player_ids["Alice"])
+    personal_state = await plugin.get_player_state(player_ids["Alice"])
 
     assert delay == 15.0
     assert game.rounds[0].auto_advance_at == 215.0
@@ -2303,11 +2217,7 @@ async def test_trivia_early_and_automatic_advance_cancel_pending_audio(
         cast("MagicMock", plugin.mass.cancel_timer).reset_mock()
 
         if advance == "ready":
-            with patch(
-                "music_assistant.providers.music_quiz.get_current_user",
-                return_value=_guest_user(),
-            ):
-                await plugin.ready(player_ids["Alice"])
+            await plugin.ready(player_ids["Alice"])
         elif advance == "next":
             await plugin.next_round()
         else:
@@ -2364,11 +2274,7 @@ async def test_final_trivia_reveal_finishes_once(advance: str) -> None:
         _, stale_callback, stale_round_index = _round_timer_call(plugin, plugin._advance_timer_id)
 
         if advance == "ready":
-            with patch(
-                "music_assistant.providers.music_quiz.get_current_user",
-                return_value=_guest_user(),
-            ):
-                state = await plugin.ready(player_ids["Alice"])
+            state = await plugin.ready(player_ids["Alice"])
         elif advance == "next":
             state = await plugin.next_round()
         else:
@@ -2407,10 +2313,6 @@ async def test_intermediate_trivia_auto_advance_failure_broadcasts_retryable_rev
     with (
         patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
         patch.object(TriviaQuizType, "prepare_round", new=prepare_round),
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
     ):
         player_ids = await _create_started_trivia_game(plugin, round_count=2)
         await plugin.answer(player_ids["Alice"], "correct_0")
@@ -2477,10 +2379,6 @@ async def test_final_trivia_auto_advance_failure_broadcasts_retryable_reveal() -
             new=AsyncMock(side_effect=_make_trivia_round),
         ),
         patch("music_assistant.providers.music_quiz.finish_game", side_effect=_finish_game),
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
     ):
         player_ids = await _create_started_trivia_game(plugin, round_count=1)
         await plugin.answer(player_ids["Alice"], "correct_0")
@@ -2728,10 +2626,6 @@ async def test_trivia_reuses_full_multiplayer_flow_and_persisted_prefetch() -> N
     with (
         patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
         patch.object(TriviaQuizType, "prepare_round", new=prepare_round),
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
     ):
         await plugin.create_game(
             quiz_type="trivia",
@@ -2930,10 +2824,6 @@ async def test_music_timeline_placement_auto_reveals_without_bonuses_and_never_w
         assert player_ids["Alice"] not in str(hidden_state)
 
         with (
-            patch(
-                "music_assistant.providers.music_quiz.get_current_user",
-                return_value=_guest_user(),
-            ),
             patch("music_assistant.providers.music_quiz.time.time", return_value=100.0),
         ):
             state = cast(
@@ -2978,11 +2868,7 @@ async def test_music_timeline_placement_auto_reveals_without_bonuses_and_never_w
         assert state["you"]["answer"]["correct"] is True
         assert state["you"]["answer"]["points"] == 1000
         cast("MagicMock", plugin.mass.cancel_timer).reset_mock()
-        with patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ):
-            finished = await plugin.ready(player_ids["Alice"])
+        finished = await plugin.ready(player_ids["Alice"])
         assert _phase(plugin) == MusicQuizPhase.FINISHED
         assert finished["current_round"]["auto_advance_at"] is None
         cast("MagicMock", plugin.mass.cancel_timer).assert_any_call(plugin._advance_timer_id)
@@ -3007,10 +2893,6 @@ async def test_music_timeline_ready_cancels_intermediate_auto_advance() -> None:
     ):
         player_ids = await _create_started_music_timeline_game(plugin, round_count=2)
         with (
-            patch(
-                "music_assistant.providers.music_quiz.get_current_user",
-                return_value=_guest_user(),
-            ),
             patch("music_assistant.providers.music_quiz.time.time", return_value=100.0),
         ):
             await plugin.submit_answer(
@@ -3036,10 +2918,6 @@ async def test_music_timeline_ready_cancels_intermediate_auto_advance() -> None:
         cast("MagicMock", plugin.mass.cancel_timer).reset_mock()
 
         with (
-            patch(
-                "music_assistant.providers.music_quiz.get_current_user",
-                return_value=_guest_user(),
-            ),
             patch("music_assistant.providers.music_quiz.time.time", return_value=110.0),
         ):
             state = await plugin.ready(player_ids["Alice"])
@@ -3101,40 +2979,36 @@ async def test_music_timeline_finish_skips_unanswered_bonus() -> None:
             artist_bonus_mode="free_text",
             title_bonus_mode="multiple_choice",
         )
-        with patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ):
-            placed = cast(
-                "dict[str, Any]",
-                await plugin.submit_answer(
-                    player_ids["Alice"],
-                    {
-                        "answer_type": "timeline",
-                        "action": "place",
-                        "previous_entry_id": "anchor",
-                        "next_entry_id": None,
-                    },
-                ),
-            )
-            assert placed["phase"] == "answering"
-            assert placed["you"]["answer"]["finished"] is False
+        placed = cast(
+            "dict[str, Any]",
             await plugin.submit_answer(
                 player_ids["Alice"],
                 {
                     "answer_type": "timeline",
-                    "action": "bonus_text",
-                    "bonus_type": "artist",
-                    "value": "secret artist 0",
+                    "action": "place",
+                    "previous_entry_id": "anchor",
+                    "next_entry_id": None,
                 },
-            )
-            revealed = cast(
-                "dict[str, Any]",
-                await plugin.submit_answer(
-                    player_ids["Alice"],
-                    {"answer_type": "timeline", "action": "finish"},
-                ),
-            )
+            ),
+        )
+        assert placed["phase"] == "answering"
+        assert placed["you"]["answer"]["finished"] is False
+        await plugin.submit_answer(
+            player_ids["Alice"],
+            {
+                "answer_type": "timeline",
+                "action": "bonus_text",
+                "bonus_type": "artist",
+                "value": "secret artist 0",
+            },
+        )
+        revealed = cast(
+            "dict[str, Any]",
+            await plugin.submit_answer(
+                player_ids["Alice"],
+                {"answer_type": "timeline", "action": "finish"},
+            ),
+        )
 
     game = plugin._game
     assert game is not None
@@ -3185,10 +3059,6 @@ async def test_music_timeline_deadline_scores_unfinished_placement_and_bonus() -
                 title_bonus_mode="multiple_choice",
             )
         with (
-            patch(
-                "music_assistant.providers.music_quiz.get_current_user",
-                return_value=_guest_user(),
-            ),
             patch("music_assistant.providers.music_quiz.time.time", return_value=101.0),
         ):
             await plugin.submit_answer(
@@ -3311,25 +3181,21 @@ async def test_music_timeline_host_public_and_personalized_rounds_remain_flat() 
             assert player_id not in str(event_state)
             assert player_id not in str(host_state["players"])
 
-        with patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ):
-            personal = cast(
-                "dict[str, Any]",
-                await plugin.submit_answer(
-                    player_ids["Alice"],
-                    {
-                        "answer_type": "timeline",
-                        "action": "place",
-                        "previous_entry_id": "anchor",
-                        "next_entry_id": None,
-                    },
-                ),
-            )
-            reconnected = await plugin.get_player_state(player_ids["Alice"])
-            with pytest.raises(MusicQuizInvalidAnswerError, match="multiple_choice"):
-                await plugin.answer(player_ids["Alice"], "not-supported")
+        personal = cast(
+            "dict[str, Any]",
+            await plugin.submit_answer(
+                player_ids["Alice"],
+                {
+                    "answer_type": "timeline",
+                    "action": "place",
+                    "previous_entry_id": "anchor",
+                    "next_entry_id": None,
+                },
+            ),
+        )
+        reconnected = await plugin.get_player_state(player_ids["Alice"])
+        with pytest.raises(MusicQuizInvalidAnswerError, match="multiple_choice"):
+            await plugin.answer(player_ids["Alice"], "not-supported")
         assert set(personal["players"][0]) == public_player_keys
         assert set(personal["you"]) == {
             "name",
@@ -3503,73 +3369,67 @@ async def test_music_timeline_late_joiner_starts_on_prefetched_next_round() -> N
         ),
     ):
         player_ids = await _create_started_music_timeline_game(plugin, round_count=2)
-        with patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ):
-            joined = await plugin.join_game("Late")
-            player_ids["Late"] = joined["player_id"]
-            assert joined["state"]["you"]["active_from_round"] == 1
-            public_state = cast("MagicMock", plugin.signal_provider_event).call_args[0][0]["state"]
-            late_player = next(
-                player for player in public_state["players"] if player["name"] == "Late"
-            )
-            assert late_player == {
-                "name": "Late",
-                "score": 0,
-                "ready": False,
-                "active_from_round": 1,
-                "answered": False,
-                "placed": False,
-                "artist_bonus_answered": False,
-                "title_bonus_answered": False,
-            }
-            for player_id in player_ids.values():
-                assert player_id not in str(public_state)
+        joined = await plugin.join_game("Late")
+        player_ids["Late"] = joined["player_id"]
+        assert joined["state"]["you"]["active_from_round"] == 1
+        public_state = cast("MagicMock", plugin.signal_provider_event).call_args[0][0]["state"]
+        late_player = next(player for player in public_state["players"] if player["name"] == "Late")
+        assert late_player == {
+            "name": "Late",
+            "score": 0,
+            "ready": False,
+            "active_from_round": 1,
+            "answered": False,
+            "placed": False,
+            "artist_bonus_answered": False,
+            "title_bonus_answered": False,
+        }
+        for player_id in player_ids.values():
+            assert player_id not in str(public_state)
+        await plugin.submit_answer(
+            player_ids["Alice"],
+            {
+                "answer_type": "timeline",
+                "action": "place",
+                "previous_entry_id": "anchor",
+                "next_entry_id": None,
+            },
+        )
+        game = plugin._game
+        assert game is not None
+        assert _phase(plugin) == MusicQuizPhase.REVEAL
+        await plugin.ready(player_ids["Alice"])
+        assert _phase(plugin) == MusicQuizPhase.REVEAL
+        await plugin.ready(player_ids["Late"])
+        assert _phase(plugin) == MusicQuizPhase.ANSWERING
+        assert game.current_round_index == 1
+        second_state = _timeline_answer_state(game.rounds[1])
+        assert [entry.entry_id for entry in second_state.placement_snapshot] == [
+            "anchor",
+            "music_timeline-0",
+        ]
+        await plugin.submit_answer(
+            player_ids["Alice"],
+            {
+                "answer_type": "timeline",
+                "action": "place",
+                "previous_entry_id": "music_timeline-0",
+                "next_entry_id": None,
+            },
+        )
+        late_state = cast(
+            "dict[str, Any]",
             await plugin.submit_answer(
-                player_ids["Alice"],
-                {
-                    "answer_type": "timeline",
-                    "action": "place",
-                    "previous_entry_id": "anchor",
-                    "next_entry_id": None,
-                },
-            )
-            game = plugin._game
-            assert game is not None
-            assert _phase(plugin) == MusicQuizPhase.REVEAL
-            await plugin.ready(player_ids["Alice"])
-            assert _phase(plugin) == MusicQuizPhase.REVEAL
-            await plugin.ready(player_ids["Late"])
-            assert _phase(plugin) == MusicQuizPhase.ANSWERING
-            assert game.current_round_index == 1
-            second_state = _timeline_answer_state(game.rounds[1])
-            assert [entry.entry_id for entry in second_state.placement_snapshot] == [
-                "anchor",
-                "music_timeline-0",
-            ]
-            await plugin.submit_answer(
-                player_ids["Alice"],
+                player_ids["Late"],
                 {
                     "answer_type": "timeline",
                     "action": "place",
                     "previous_entry_id": "music_timeline-0",
                     "next_entry_id": None,
                 },
-            )
-            late_state = cast(
-                "dict[str, Any]",
-                await plugin.submit_answer(
-                    player_ids["Late"],
-                    {
-                        "answer_type": "timeline",
-                        "action": "place",
-                        "previous_entry_id": "music_timeline-0",
-                        "next_entry_id": None,
-                    },
-                ),
-            )
-            assert late_state["you"]["answer"]["correct"] is True
+            ),
+        )
+        assert late_state["you"]["answer"]["correct"] is True
 
 
 @pytest.mark.asyncio
@@ -3594,10 +3454,6 @@ async def test_generic_submit_answer_rejects_invalid_payload(
     player_ids = await _create_started_game(plugin, player_names=("Alice",))
 
     with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
         pytest.raises(MusicQuizInvalidAnswerError),
     ):
         await plugin.submit_answer(player_ids["Alice"], submission)
@@ -3616,10 +3472,6 @@ async def test_generic_submit_answer_rejects_game_type_mismatch() -> None:
     mismatched_type = SimpleNamespace(answer_type="other")
 
     with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
         patch(
             "music_assistant.providers.music_quiz.get_answer_type",
             side_effect=lambda answer_type: (
@@ -3644,10 +3496,6 @@ async def test_answer_with_unknown_player_is_rejected() -> None:
     await _create_started_game(plugin)
 
     with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
         pytest.raises(MusicQuizUnknownPlayerError),
     ):
         await plugin.answer("not-a-real-player", "correct_0")
@@ -3712,11 +3560,7 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
     assert "is_correct" not in serialized
     assert "track_uri" not in serialized
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        personal_state = await plugin.answer(player_ids["Alice"], "correct_0")
+    personal_state = await plugin.answer(player_ids["Alice"], "correct_0")
 
     own_answer = personal_state["you"]["answer"]
     assert set(personal_state) == {*state, "you"}
@@ -3922,15 +3766,11 @@ async def test_join_and_player_state_expose_persisted_quiz_type() -> None:
     plugin = _create_plugin()
     await plugin.create_game(source_uris=["library://playlist/1"])
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        joined = await plugin.join_game("Alice")
-        assert joined["state"]["quiz_type"] == "guess_the_song"
-        assert joined["state"]["answer_type"] == "multiple_choice"
-        assert "language" not in joined["state"]
-        state = await plugin.get_player_state(joined["player_id"])
+    joined = await plugin.join_game("Alice")
+    assert joined["state"]["quiz_type"] == "guess_the_song"
+    assert joined["state"]["answer_type"] == "multiple_choice"
+    assert "language" not in joined["state"]
+    state = await plugin.get_player_state(joined["player_id"])
 
     assert state["quiz_type"] == "guess_the_song"
     assert state["answer_type"] == "multiple_choice"
@@ -3944,10 +3784,6 @@ async def test_presence_expiry_honors_reconnect_grace_boundary() -> None:
     await plugin.create_game(source_uris=["library://playlist/1"])
 
     with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
         patch("music_assistant.providers.music_quiz.time.time", return_value=100.0),
     ):
         joined = await plugin.join_game("Alice")
@@ -3975,10 +3811,6 @@ async def test_presence_expiry_honors_reconnect_grace_boundary() -> None:
 
     assert player_id not in game.players
     with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
         patch("music_assistant.providers.music_quiz.time.time", return_value=161.0),
     ):
         assert await plugin.heartbeat(player_id) is False
@@ -3994,10 +3826,6 @@ async def test_heartbeat_reschedules_player_expiry() -> None:
     await plugin.create_game(source_uris=["library://playlist/1"])
 
     with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
         patch("music_assistant.providers.music_quiz.time.time", return_value=100.0),
     ):
         joined = await plugin.join_game("Alice")
@@ -4008,10 +3836,6 @@ async def test_heartbeat_reschedules_player_expiry() -> None:
     cast("MagicMock", plugin.mass.call_later).reset_mock()
 
     with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
         patch("music_assistant.providers.music_quiz.time.time", return_value=130.0),
     ):
         assert await plugin.heartbeat(player_id) is True
@@ -4036,16 +3860,12 @@ async def test_heartbeat_returns_false_for_missing_game_or_player() -> None:
     """Expected reconnect misses return false instead of raising an API error."""
     plugin = _create_plugin()
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        assert await plugin.heartbeat("missing") is False
-        await plugin.create_game(source_uris=["library://playlist/1"])
-        assert await plugin.heartbeat("missing") is False
-        joined = await plugin.join_game("Alice")
-        await plugin.delete_game()
-        assert await plugin.heartbeat(joined["player_id"]) is False
+    assert await plugin.heartbeat("missing") is False
+    await plugin.create_game(source_uris=["library://playlist/1"])
+    assert await plugin.heartbeat("missing") is False
+    joined = await plugin.join_game("Alice")
+    await plugin.delete_game()
+    assert await plugin.heartbeat(joined["player_id"]) is False
 
 
 @pytest.mark.asyncio
@@ -4055,10 +3875,6 @@ async def test_player_state_fetch_refreshes_presence() -> None:
     await plugin.create_game(source_uris=["library://playlist/1"])
 
     with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
         patch("music_assistant.providers.music_quiz.time.time", return_value=100.0),
     ):
         joined = await plugin.join_game("Alice")
@@ -4069,10 +3885,6 @@ async def test_player_state_fetch_refreshes_presence() -> None:
     cast("MagicMock", plugin.mass.call_later).reset_mock()
 
     with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
         patch("music_assistant.providers.music_quiz.time.time", return_value=125.0),
     ):
         state = await plugin.get_player_state(player_id)
@@ -4093,10 +3905,6 @@ async def test_answer_and_ready_refresh_presence() -> None:
     alice = game.players[player_ids["Alice"]]
 
     with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
         patch("music_assistant.providers.music_quiz.time.time", return_value=120.0),
     ):
         await plugin.answer(alice.player_id, "correct_0")
@@ -4104,20 +3912,12 @@ async def test_answer_and_ready_refresh_presence() -> None:
 
     await plugin.reveal()
     with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
         patch("music_assistant.providers.music_quiz.time.time", return_value=130.0),
     ):
         await plugin.ready(alice.player_id)
     assert alice.last_seen == 130.0
 
     with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
         patch("music_assistant.providers.music_quiz.time.time", return_value=140.0),
     ):
         await plugin.ready(alice.player_id)
@@ -4130,15 +3930,11 @@ async def test_expiry_removes_player_answer_state_from_every_round() -> None:
     plugin = _create_plugin()
     player_ids = await _create_started_game(plugin)
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        await plugin.answer(player_ids["Alice"], "correct_0")
-        await plugin.answer(player_ids["Bob"], "wrong_0_1")
-        await plugin.ready(player_ids["Alice"])
-        await plugin.ready(player_ids["Bob"])
-        await plugin.answer(player_ids["Alice"], "correct_1")
+    await plugin.answer(player_ids["Alice"], "correct_0")
+    await plugin.answer(player_ids["Bob"], "wrong_0_1")
+    await plugin.ready(player_ids["Alice"])
+    await plugin.ready(player_ids["Bob"])
+    await plugin.answer(player_ids["Alice"], "correct_1")
 
     game = plugin._game
     assert game is not None
@@ -4157,11 +3953,7 @@ async def test_expiry_removes_player_answer_state_from_every_round() -> None:
     )
     assert game.phase == MusicQuizPhase.ANSWERING
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        await plugin.answer(player_ids["Bob"], "correct_1")
+    await plugin.answer(player_ids["Bob"], "correct_1")
     assert game.players[player_ids["Bob"]].score == 1000
 
 
@@ -4171,11 +3963,7 @@ async def test_expiry_unblocks_answer_completion_and_keeps_events_private() -> N
     plugin = _create_plugin()
     player_ids = await _create_started_game(plugin)
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        await plugin.answer(player_ids["Alice"], "correct_0")
+    await plugin.answer(player_ids["Alice"], "correct_0")
 
     game = plugin._game
     assert game is not None
@@ -4203,11 +3991,7 @@ async def test_expiry_reveals_when_only_late_joiners_remain() -> None:
     plugin = _create_plugin()
     player_ids = await _create_started_game(plugin, player_names=("Alice",))
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        late_join = await plugin.join_game("Late")
+    late_join = await plugin.join_game("Late")
 
     game = plugin._game
     assert game is not None
@@ -4230,11 +4014,7 @@ async def test_expiry_unblocks_reveal_readiness() -> None:
     player_ids = await _create_started_game(plugin)
     await plugin.reveal()
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        await plugin.ready(player_ids["Alice"])
+    await plugin.ready(player_ids["Alice"])
 
     game = plugin._game
     assert game is not None
@@ -4256,11 +4036,7 @@ async def test_expiry_propagates_reveal_advance_failure() -> None:
     player_ids = await _create_started_game(plugin)
     await plugin.reveal()
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        await plugin.ready(player_ids["Alice"])
+    await plugin.ready(player_ids["Alice"])
 
     game = plugin._game
     assert game is not None
@@ -4320,11 +4096,7 @@ async def test_finished_game_stops_presence_expiry() -> None:
     game = plugin._game
     assert game is not None
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        await plugin.answer(player_ids["Alice"], "correct_0")
+    await plugin.answer(player_ids["Alice"], "correct_0")
     await plugin.next_round()
 
     assert game.phase == MusicQuizPhase.FINISHED
@@ -4366,11 +4138,7 @@ async def test_replay_reset_schedules_and_serializes_authoritative_deadline() ->
 
     with patch("music_assistant.providers.music_quiz.time.time", return_value=100.0):
         host_state = await plugin.reset(auto_start=True)
-        with patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ):
-            personal_state = await plugin.get_player_state(player_ids["Alice"])
+        personal_state = await plugin.get_player_state(player_ids["Alice"])
         game_info = await plugin.get_game_info()
 
     delay, _, scheduled_game, generation, deadline = _replay_timer_call(plugin)
@@ -4546,10 +4314,6 @@ async def test_all_players_expiring_cancels_replay_without_rescheduling_on_join(
     assert cancelled_state["players"] == []
 
     with (
-        patch(
-            "music_assistant.providers.music_quiz.get_current_user",
-            return_value=_guest_user(),
-        ),
         patch("music_assistant.providers.music_quiz.time.time", return_value=165.0),
     ):
         joined = await plugin.join_game("Bob")
@@ -4755,12 +4519,8 @@ async def test_join_during_round_activates_player_next_round() -> None:
     game = plugin._game
     assert game is not None
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        result = await plugin.join_game("Late")
-        assert result["state"]["you"]["active_from_round"] == 1
+    result = await plugin.join_game("Late")
+    assert result["state"]["you"]["active_from_round"] == 1
     public_state = cast("MagicMock", plugin.signal_provider_event).call_args[0][0]["state"]
     late_player = next(player for player in public_state["players"] if player["name"] == "Late")
     assert late_player == {
@@ -5320,11 +5080,7 @@ async def test_listen_in_joins_session_under_playback_lock() -> None:
 
     session.add_guest_listener = AsyncMock(side_effect=_assert_locked)
     plugin._playback_session = session
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=SimpleNamespace(username=MUSIC_QUIZ_GUEST_USER, role=UserRole.GUEST),
-    ):
-        await plugin.listen_in("web-1")
+    await plugin.listen_in("web-1")
     session.add_guest_listener.assert_awaited_once_with("web-1")
 
 
@@ -5343,11 +5099,7 @@ async def test_venue_listen_in_does_not_depend_on_guest_player_filter() -> None:
     session.add_guest_listener = AsyncMock()
     plugin._playback_session = session
 
-    with patch(
-        "music_assistant.providers.music_quiz.get_current_user",
-        return_value=_guest_user(),
-    ):
-        await plugin.listen_in("web-1")
+    await plugin.listen_in("web-1")
 
     session.add_guest_listener.assert_awaited_once_with("web-1")
 

--- a/tests/providers/party/test_party_plugin.py
+++ b/tests/providers/party/test_party_plugin.py
@@ -172,3 +172,6 @@ async def test_guest_readable_commands_use_guest_scope() -> None:
     }
     assert scopes["party/url"] == Scope.PROVIDERS_READ
     assert scopes["party/config"] == Scope.PROVIDERS_READ
+    assert scopes["party/listen_in"] == Scope.PLAYERS_CONTROL
+    assert scopes["party/stop_listen_in"] == Scope.PLAYERS_CONTROL
+    assert scopes["party/can_listen_in"] == Scope.PLAYERS_CONTROL

--- a/tests/providers/party/test_party_plugin.py
+++ b/tests/providers/party/test_party_plugin.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.auth import Scope, UserRole
+from music_assistant_models.auth import Scope
 from music_assistant_models.enums import MediaType, PlaybackState
 from music_assistant_models.errors import InvalidDataError
 
@@ -19,7 +18,6 @@ from music_assistant.providers.party import (
     CONF_ENABLE_GUEST_ACCESS,
     CONF_PARTY_MODE,
     CONF_PREVENT_DUPLICATE_TRACKS,
-    PARTY_GUEST_USER,
     PartyPlugin,
 )
 
@@ -73,10 +71,6 @@ async def test_add_to_queue_rechecks_duplicates_during_priority_insert() -> None
     queue_item.extra_attributes = {}
 
     with (
-        patch(
-            "music_assistant.providers.party.get_current_user",
-            return_value=SimpleNamespace(username=PARTY_GUEST_USER, role=UserRole.GUEST),
-        ),
         patch("music_assistant.providers.party.build_queue_item", return_value=queue_item),
         pytest.raises(InvalidDataError, match="already in the queue"),
     ):
@@ -128,10 +122,6 @@ async def test_listen_in_without_session_raises() -> None:
     plugin._get_or_create_session_locked = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     with (
-        patch(
-            "music_assistant.providers.party.get_current_user",
-            return_value=SimpleNamespace(username=PARTY_GUEST_USER, role=UserRole.GUEST),
-        ),
         pytest.raises(InvalidDataError, match="not available"),
     ):
         await plugin.listen_in("web_player_1")
@@ -150,11 +140,7 @@ async def test_listen_in_attaches_guest_player() -> None:
     session.add_guest_listener = AsyncMock(side_effect=_assert_locked)
     plugin._get_or_create_session_locked = AsyncMock(return_value=session)  # type: ignore[method-assign]
 
-    with patch(
-        "music_assistant.providers.party.get_current_user",
-        return_value=SimpleNamespace(username=PARTY_GUEST_USER, role=UserRole.GUEST),
-    ):
-        result = await plugin.listen_in("web_player_1")
+    result = await plugin.listen_in("web_player_1")
 
     assert result == {"success": True, "queue_id": "sendspin_virtual_party"}
     session.add_guest_listener.assert_awaited_once_with("web_player_1")
@@ -186,31 +172,3 @@ async def test_guest_readable_commands_use_guest_scope() -> None:
     }
     assert scopes["party/url"] == Scope.PROVIDERS_READ
     assert scopes["party/config"] == Scope.PROVIDERS_READ
-
-
-@pytest.mark.parametrize("username", [PARTY_GUEST_USER, "music_quiz_guest", "temporary_guest"])
-def test_guest_access_accepts_any_dedicated_guest(username: str) -> None:
-    """Any authenticated guest role can use the active Party experience."""
-    with patch(
-        "music_assistant.providers.party.get_current_user",
-        return_value=SimpleNamespace(username=username, role=UserRole.GUEST),
-    ):
-        PartyPlugin._validate_guest_access()
-
-
-@pytest.mark.parametrize(
-    "user",
-    [
-        None,
-        SimpleNamespace(username="user", role=UserRole.USER),
-        SimpleNamespace(username="admin", role=UserRole.ADMIN),
-        SimpleNamespace(username="service", role=UserRole.SERVICE),
-    ],
-)
-def test_guest_access_rejects_non_guests(user: SimpleNamespace | None) -> None:
-    """Party guest commands reject unauthenticated and non-guest users."""
-    with (
-        patch("music_assistant.providers.party.get_current_user", return_value=user),
-        pytest.raises(InvalidDataError, match="party guests"),
-    ):
-        PartyPlugin._validate_guest_access()


### PR DESCRIPTION
# What does this implement/fix?

The party and music_quiz guest API commands (song requests, quiz join/answer/ready, and listen-in) were restricted to dedicated GUEST-role accounts via _validate_guest_access. Feedback is that the host should be able to join the party or quiz experience with their own account instead of opening the guest link next to their session.

All these commands are registered with authentication required, so dropping the guest-role restriction simply means any authenticated user (guest, user, admin) can use them; per-command scopes and the guest-access config checks are unchanged. Remove the now-dead validator, its translation string, and the test patches that existed to satisfy it.

**Related issue (if applicable):**

- [The frontend PR that inspired this though it's not technically linked](https://github.com/music-assistant/frontend/pull/2140)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
