### PR TITLE
Fix Music Quiz speaker selection for groups

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1579,6 +1579,7 @@ class MusicQuizPlugin(PluginProvider):
             and state.enabled
             and not state.hide_in_ui
             and not state.needs_setup
+            and state.synced_to is None
             and state.type in (PlayerType.PLAYER, PlayerType.STEREO_PAIR, PlayerType.GROUP)
             and player.is_native_player
             and player.provider.domain != SENDSPIN_DOMAIN

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1580,6 +1580,7 @@ class MusicQuizPlugin(PluginProvider):
             and not state.hide_in_ui
             and not state.needs_setup
             and state.synced_to is None
+            and state.active_group is None
             and state.type in (PlayerType.PLAYER, PlayerType.STEREO_PAIR, PlayerType.GROUP)
             and player.is_native_player
             and player.provider.domain != SENDSPIN_DOMAIN

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -131,6 +131,8 @@ def _make_venue_player(
             enabled=enabled,
             hide_in_ui=hidden,
             needs_setup=needs_setup,
+            synced_to=None,
+            group_members=[],
             type=player_type,
             supported_features=supported_features,
         ),
@@ -653,10 +655,14 @@ async def test_playback_options_filter_and_stably_rank_venue_players() -> None:
         "Z Bathroom",
         playback_state=PlaybackState.PLAYING,
     )
+    playing_bathroom.state.group_members = ["bathroom", "bedroom"]
+    synced_child = _make_venue_player("bedroom", "Synced Child")
+    synced_child.state.synced_to = "bathroom"
     excluded = [
         _make_venue_player("unavailable", "Unavailable", available=False),
         _make_venue_player("disabled", "Disabled", enabled=False),
         _make_venue_player("hidden", "Hidden", hidden=True),
+        synced_child,
         _make_venue_player("needs-setup", "Needs Setup", needs_setup=True),
         _make_venue_player("protocol", "Protocol", player_type=PlayerType.PROTOCOL),
         _make_venue_player("display", "Display", player_type=PlayerType.DISPLAY),
@@ -852,7 +858,7 @@ async def test_explicit_venue_create_persists_game_authoritative_playback() -> N
     create_remote.assert_not_awaited()
 
 
-@pytest.mark.parametrize("venue_player_id", [None, "unknown", "unavailable"])
+@pytest.mark.parametrize("venue_player_id", [None, "unknown", "unavailable", "synced"])
 @pytest.mark.asyncio
 async def test_invalid_explicit_venue_create_preserves_existing_game(
     venue_player_id: str | None,
@@ -860,10 +866,14 @@ async def test_invalid_explicit_venue_create_preserves_existing_game(
     """Reject missing or ineligible venue targets without mutating game state."""
     plugin = _create_plugin()
     valid_player = _make_venue_player("valid", "Valid")
+    valid_player.state.group_members = ["valid", "synced"]
     unavailable_player = _make_venue_player("unavailable", "Unavailable", available=False)
+    synced_player = _make_venue_player("synced", "Synced")
+    synced_player.state.synced_to = "valid"
     cast("MagicMock", plugin.mass.players.all_players).return_value = [
         valid_player,
         unavailable_player,
+        synced_player,
     ]
     await plugin.create_game(
         source_uris=["library://playlist/1"],

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -132,6 +132,7 @@ def _make_venue_player(
             hide_in_ui=hidden,
             needs_setup=needs_setup,
             synced_to=None,
+            active_group=None,
             group_members=[],
             type=player_type,
             supported_features=supported_features,
@@ -658,11 +659,15 @@ async def test_playback_options_filter_and_stably_rank_venue_players() -> None:
     playing_bathroom.state.group_members = ["bathroom", "bedroom"]
     synced_child = _make_venue_player("bedroom", "Synced Child")
     synced_child.state.synced_to = "bathroom"
+    active_group_member = _make_venue_player("group-member", "Active Group Member")
+    active_group_member.state.active_group = "group"
+    group.state.group_members = ["group-member"]
     excluded = [
         _make_venue_player("unavailable", "Unavailable", available=False),
         _make_venue_player("disabled", "Disabled", enabled=False),
         _make_venue_player("hidden", "Hidden", hidden=True),
         synced_child,
+        active_group_member,
         _make_venue_player("needs-setup", "Needs Setup", needs_setup=True),
         _make_venue_player("protocol", "Protocol", player_type=PlayerType.PROTOCOL),
         _make_venue_player("display", "Display", player_type=PlayerType.DISPLAY),
@@ -858,7 +863,9 @@ async def test_explicit_venue_create_persists_game_authoritative_playback() -> N
     create_remote.assert_not_awaited()
 
 
-@pytest.mark.parametrize("venue_player_id", [None, "unknown", "unavailable", "synced"])
+@pytest.mark.parametrize(
+    "venue_player_id", [None, "unknown", "unavailable", "synced", "group-member"]
+)
 @pytest.mark.asyncio
 async def test_invalid_explicit_venue_create_preserves_existing_game(
     venue_player_id: str | None,
@@ -870,10 +877,13 @@ async def test_invalid_explicit_venue_create_preserves_existing_game(
     unavailable_player = _make_venue_player("unavailable", "Unavailable", available=False)
     synced_player = _make_venue_player("synced", "Synced")
     synced_player.state.synced_to = "valid"
+    active_group_member = _make_venue_player("group-member", "Active Group Member")
+    active_group_member.state.active_group = "group"
     cast("MagicMock", plugin.mass.players.all_players).return_value = [
         valid_player,
         unavailable_player,
         synced_player,
+        active_group_member,
     ]
     await plugin.create_game(
         source_uris=["library://playlist/1"],


### PR DESCRIPTION
# What does this implement/fix?

Music Quiz no longer offers speakers that are already synced to another speaker, preventing grouped setups from being disrupted.

- Keep standalone speakers, group players, and group leaders selectable.
- Reject synced child speakers in both the picker and game creation.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.