### PR TITLE
Fix Sonos S1 enqueue failing with UPnP error 701

### DIFF
--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -207,7 +207,7 @@ class SonosPlayer(Player):
             # Sonos really does not like FLAC streams without duration
             stream_url = stream_url.replace(".flac", ".mp3")
 
-        didl_metadata = create_didl_metadata(media)
+        didl_metadata = create_didl_metadata(media, stream_url)
         is_announcement = media.media_type == MediaType.ANNOUNCEMENT
         force_radio = False if is_announcement else not media.duration
 
@@ -231,8 +231,8 @@ class SonosPlayer(Player):
                 translation_args=[self.display_name],
             )
 
-        didl_metadata = create_didl_metadata(media)
         stream_url = await self.provider.mass.streams.resolve_stream_url(self.player_id, media)
+        didl_metadata = create_didl_metadata(media, stream_url)
 
         def add_to_queue() -> None:
             self.soco.avTransport.SetNextAVTransportURI(

--- a/tests/providers/sonos_s1/__init__.py
+++ b/tests/providers/sonos_s1/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Sonos S1 provider."""

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -1,0 +1,62 @@
+"""Unit tests for the Sonos S1 player."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import MediaType
+
+from music_assistant.models.player import PlayerMedia
+from music_assistant.providers.sonos_s1.player import SonosPlayer
+
+STREAM_URL = "http://192.168.1.2:8097/single/sessionabc/queue1/item1/player1.flac"
+
+
+@pytest.fixture
+def sonos_player() -> SonosPlayer:
+    """Create a SonosPlayer with a mocked soco device and provider."""
+    soco = MagicMock()
+    soco.uid = "RINCON_000E58AAAAAA01400"
+    soco.household_id = "Sonos_household"
+    soco.player_name = "Test Sonos"
+    soco.ip_address = "127.0.0.1"
+    soco.speaker_info = {"model_name": "Sonos Play:1"}
+    provider = MagicMock()
+    provider.mass.streams.resolve_stream_url = AsyncMock(return_value=STREAM_URL)
+    return SonosPlayer(provider=provider, soco=soco)
+
+
+def _make_media() -> PlayerMedia:
+    """Return PlayerMedia as built by the queue controller, with an MA media uri."""
+    return PlayerMedia(
+        uri="library://track/123",
+        media_type=MediaType.TRACK,
+        title="Test Track",
+        artist="Test Artist",
+        album="Test Album",
+        duration=180,
+        source_id="queue1",
+        queue_item_id="item1",
+    )
+
+
+async def test_enqueue_next_media_builds_didl_from_stream_url(
+    sonos_player: SonosPlayer,
+) -> None:
+    """The enqueue metadata res element must contain the stream url, not the MA media uri."""
+    await sonos_player.enqueue_next_media(_make_media())
+    call_args = sonos_player.soco.avTransport.SetNextAVTransportURI.call_args
+    args = dict(call_args.args[0])
+    assert args["NextURI"] == STREAM_URL
+    assert STREAM_URL in args["NextURIMetaData"]
+    assert "library://track/123" not in args["NextURIMetaData"]
+
+
+async def test_play_media_builds_didl_from_stream_url(sonos_player: SonosPlayer) -> None:
+    """The play metadata res element must contain the stream url, not the MA media uri."""
+    await sonos_player.play_media(_make_media())
+    call_args = sonos_player.soco.play_uri.call_args
+    assert call_args.args[0] == STREAM_URL
+    assert STREAM_URL in call_args.kwargs["meta"]
+    assert "library://track/123" not in call_args.kwargs["meta"]


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Fixes the linked regression where a Sonos S1 player plays the first track but rejects every enqueue of the next track with UPnP Error 701.

I believe the cause is a leftover from the stream URL refactor. `PlayerMedia.uri` used to hold the resolved HTTP stream URL but nowadays it holds the MA media uri such as `library://track/123`, and players resolve the stream URL themselves. The `create_didl_metadata` helper gained a url parameter for this reason and the dlna and wiim providers were updated to pass it, but the two call sites in the Sonos S1 provider appear to have been missed. The speaker therefore received a `NextURI` pointing at the stream server while the metadata res element referenced the unresolvable MA media uri, and S1 firmware rejects that mismatch on `SetNextAVTransportURI`.

The fix passes the resolved stream URL to `create_didl_metadata` in both call sites, matching the dlna and wiim providers. A regression test covers both and fails against the previous code.

I could not verify this on real S1 hardware, but the difference between the provider fixes made the omission obvious, and it lines up exactly with the reported regression window.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5852

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
