### PR TITLE
Allow adding players to a dynamic sync group when all members are offline

### DIFF
--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -215,19 +215,20 @@ class SyncGroupPlayer(Player):
         member_ids = self._attr_group_members if self._attr_group_members else []
         # current members bypass the allow-list filter (filter constrains joiners only)
         current_members = set(member_ids)
-        if member_ids:
-            can_group_with: set[str] = set()
-            for member_id in member_ids:
-                member_player = self.mass.players.get_player(member_id)
-                if member_player and member_player.state.available:
-                    can_group_with.add(member_player.player_id)
-                    can_group_with.update(member_player.state.can_group_with)
+        can_group_with: set[str] = set()
+        for member_id in member_ids:
+            member_player = self.mass.players.get_player(member_id)
+            if member_player and member_player.state.available:
+                can_group_with.add(member_player.player_id)
+                can_group_with.update(member_player.state.can_group_with)
+        if can_group_with:
             return {
                 pid
                 for pid in can_group_with
                 if pid in current_members or self._is_member_allowed(pid)
             }
-        # Empty dynamic groups can potentially group with any compatible players
+        # Without any available member to derive compatibility from (empty group or
+        # all members offline), offer any compatible player.
         # Actual compatibility is validated when adding members
         can_group_with = set()
         for player in self.mass.players.all_players(return_unavailable=False):

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -861,6 +861,50 @@ class TestPresetMembersInDynamicGroup:
         # an unrelated player is rejected
         assert sgp._is_member_allowed("outsider") is False
 
+    @pytest.mark.asyncio
+    async def test_can_group_with_falls_back_when_all_members_offline(self) -> None:
+        """
+        An offline preset member must not block adding other players.
+
+        Regression: with only offline members in the list, can_group_with
+        returned an empty set instead of offering compatible players, so
+        nothing could be added to the group until the member came back.
+        """
+        mass = _make_mock_mass()
+        sgp = self._make_dynamic_group_with_preset(mass, ["offline_member"])
+        await sgp.on_config_updated()
+
+        offline_member = _make_mock_player("offline_member", available=False)
+        candidate = _make_mock_player("candidate")
+        candidate.type = PlayerType.PLAYER
+        candidate.state.can_group_with = {"other"}
+        candidate.state.active_group = None
+        mass.players.get_player = _player_lookup(
+            {"offline_member": offline_member, "candidate": candidate}
+        )
+        mass.players.all_players = MagicMock(return_value=[candidate])
+
+        assert "candidate" in sgp.can_group_with
+
+    @pytest.mark.asyncio
+    async def test_can_group_with_aggregates_from_available_members(self) -> None:
+        """With at least one available member, candidates come from the members only."""
+        mass = _make_mock_mass()
+        sgp = self._make_dynamic_group_with_preset(mass, ["offline_member", "online_member"])
+        await sgp.on_config_updated()
+
+        offline_member = _make_mock_player("offline_member", available=False)
+        online_member = _make_mock_player("online_member")
+        online_member.state.can_group_with = {"online_member", "friend"}
+        mass.players.get_player = _player_lookup(
+            {"offline_member": offline_member, "online_member": online_member}
+        )
+
+        result = sgp.can_group_with
+
+        assert {"online_member", "friend"} <= result
+        mass.players.all_players.assert_not_called()
+
 
 class TestGetConfigEntriesMemberPicker:
     """Test the member options offered in the group settings dropdown."""


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Fixes the linked report where a dynamic sync group with a standing member that is currently unavailable refuses to accept any other players.

In dynamic mode the group derives its groupable candidates from the members that are currently available. When every listed member was offline this produced an empty set, and the fallback that offers any compatible player only triggered for a group with no members at all. The controller then rejected every join attempt against that empty set, so the group was unusable until a preset member came back online. This appears to be an unintended side effect of the protocol linking rework, since before that rework the code fell through to offering all compatible players whenever no member was available.

The fix runs the member aggregation first and falls back to offering any compatible player whenever it produces nothing, which can only happen when no member is available. Regression tests cover both the offline fallback and the normal case where an available member supplies the candidates, and the fallback test fails against the previous code.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5810

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
