### PR TITLE
Vary songs when replaying Music Quiz

### DIFF
--- a/music_assistant/controllers/music/recency.py
+++ b/music_assistant/controllers/music/recency.py
@@ -113,13 +113,18 @@ class RecencyEngine:
         self.mass = mass
 
     async def snapshot(
-        self, windows: RecencyWindows, *, userid: str | None = None
+        self,
+        windows: RecencyWindows,
+        *,
+        userid: str | None = None,
+        include_partially_played: bool = False,
     ) -> RecencySnapshot:
         """
         Build a recency snapshot from a single batched, user-scoped playlog query.
 
         :param windows: The lookback windows to read.
         :param userid: The user whose play history to read; falls back to the current user.
+        :param include_partially_played: Include tracks that were stopped before completion.
         """
         now = int(time.time())
         snapshot = RecencySnapshot(now=now)
@@ -137,9 +142,10 @@ class RecencyEngine:
             params["artist_cutoff"] = now - windows.artist_seconds
         if not clauses:
             return snapshot
-        # only fully-played items count as "recently heard" (artist credit rows are always
-        # written fully_played=1, so artist recency is unaffected)
-        where = f"fully_played = 1 AND ({' OR '.join(clauses)})"
+        where = f"({' OR '.join(clauses)})"
+        if not include_partially_played:
+            # Artist credit rows are always fully played, so this only affects track recency.
+            where = f"fully_played = 1 AND {where}"
         if not userid and (user := get_current_user()):
             userid = user.user_id
         if userid:

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -53,7 +53,7 @@ from __future__ import annotations
 import asyncio
 import secrets
 import time
-from collections.abc import Callable, Coroutine, Iterator
+from collections.abc import Callable, Coroutine, Iterable, Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypedDict, cast
@@ -428,7 +428,10 @@ class MusicQuizPlugin(PluginProvider):
                 sources=await self._resolve_sources(game_config.source_uris),
                 created_at=time.time(),
             )
-            quiz_strategy, answer_strategy = self._resolve_game_strategies(game)
+            quiz_strategy, answer_strategy = self._resolve_game_strategies(
+                game,
+                recent_track_uris=self._recent_track_uris_for_game(self._game),
+            )
             initial_round_task = await self._prepare_initial_round(quiz_strategy)
             selected_player = self._validate_playback_config(game_config)
             if selected_player is not None:
@@ -505,7 +508,10 @@ class MusicQuizPlugin(PluginProvider):
         """
         async with self._game_lock:
             game = self._require_game()
-            quiz_strategy, answer_strategy = self._resolve_game_strategies(game)
+            quiz_strategy, answer_strategy = self._resolve_game_strategies(
+                game,
+                recent_track_uris=self._recent_track_uris_for_game(game),
+            )
             initial_round_task = await self._prepare_initial_round(quiz_strategy)
             self._cancel_timers()
             self._cancel_next_round_task()
@@ -731,17 +737,35 @@ class MusicQuizPlugin(PluginProvider):
             raise MusicQuizNoGameError("There is no active Music Quiz game")
         return self._game
 
-    def _resolve_game_strategies(self, game: MusicQuizGame) -> tuple[QuizType, QuizAnswerType]:
+    def _resolve_game_strategies(
+        self,
+        game: MusicQuizGame,
+        *,
+        recent_track_uris: Iterable[str] = (),
+    ) -> tuple[QuizType, QuizAnswerType]:
         """
         Resolve the strategies declared by game state.
 
         :param game: Game whose strategy identities should be resolved.
+        :param recent_track_uris: Earlier game tracks to deprioritize.
         """
         quiz_type_class = get_quiz_type(game.quiz_type)
         answer_type_class = get_answer_type(game.answer_type)
         if quiz_type_class.answer_type != game.answer_type:
             raise InvalidDataError("Quiz type answer type does not match the game")
-        return quiz_type_class(self.mass, game.config), answer_type_class()
+        quiz_type = quiz_type_class(self.mass, game.config)
+        quiz_type.add_recent_track_uris(recent_track_uris)
+        return quiz_type, answer_type_class()
+
+    def _recent_track_uris_for_game(self, game: MusicQuizGame | None) -> set[str]:
+        """Return source tracks represented by an earlier game."""
+        if game is None:
+            return set()
+        quiz_type_class = get_quiz_type(game.quiz_type)
+        quiz_type = self._quiz_type
+        if quiz_type is None or type(quiz_type) is not quiz_type_class:
+            quiz_type = quiz_type_class(self.mass, game.config)
+        return quiz_type.get_recent_track_uris(game.rounds)
 
     def _require_game_strategies(
         self,

--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterable
 from typing import TYPE_CHECKING, ClassVar, Final, cast
 
 from music_assistant_models.enums import MediaType
@@ -20,6 +20,7 @@ from music_assistant_models.media_items import (
 
 from music_assistant.constants import DYNAMIC_PLAYLIST_SAMPLE_SIZE
 from music_assistant.controllers.music.constants import DYNAMIC_RADIO_DYNAMIC_TARGET
+from music_assistant.controllers.music.recency import RecencyWindows
 from music_assistant.helpers.datetime import utc
 from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.uri import parse_uri
@@ -29,6 +30,7 @@ from music_assistant.providers.music_quiz.models import MusicQuizAnswerType
 if TYPE_CHECKING:
     from music_assistant_models.media_items import MediaItemType
 
+    from music_assistant.controllers.music.recency import RecencySnapshot
     from music_assistant.mass import MusicAssistant
     from music_assistant.providers.music_quiz.models import (
         MusicQuizConfig,
@@ -46,6 +48,7 @@ GENRE_TRACK_PAGE_SIZE = 100
 MAX_GENRE_TRACK_COUNT = 500
 MAX_SUGGESTION_COUNT = 12
 PLAYBACK_REPLACEMENT_RESERVE = 4
+QUIZ_TRACK_RECENCY_SECONDS = 24 * 60 * 60
 MIN_RELEASE_YEAR = 1000
 SUPPORTED_SOURCE_MEDIA_TYPES: Final = frozenset(
     {
@@ -88,6 +91,8 @@ class QuizType(ABC):
         self.mass = mass
         self.config = config
         self._source_track_pool: dict[str, Track] | None = None
+        self._recency_snapshot: RecencySnapshot | None = None
+        self._recent_track_uris: set[str] = set()
 
     @property
     def uses_audio(self) -> bool:
@@ -166,7 +171,26 @@ class QuizType(ABC):
 
     async def initialize(self) -> None:
         """Prepare game-level content required before the game is created."""
-        return
+        self._recency_snapshot = await self.mass.music.recency.snapshot(
+            RecencyWindows(song_seconds=QUIZ_TRACK_RECENCY_SECONDS),
+            include_partially_played=True,
+        )
+
+    def add_recent_track_uris(self, track_uris: Iterable[str]) -> None:
+        """
+        Treat tracks selected by an earlier game as recently played.
+
+        :param track_uris: Track URIs to deprioritize during selection.
+        """
+        self._recent_track_uris.update(track_uris)
+
+    def get_recent_track_uris(self, rounds: list[MusicQuizRound]) -> set[str]:
+        """
+        Return the source tracks represented by completed game rounds.
+
+        :param rounds: Rounds from an earlier game.
+        """
+        return {game_round.track_uri for game_round in rounds if game_round.track_uri}
 
     @abstractmethod
     async def prepare_round(
@@ -354,6 +378,27 @@ class QuizType(ABC):
                 pool.setdefault(track.uri, track)
         if len(pool) == initial_pool_size:
             LOGGER.debug("Radio playlists returned no new playable tracks for Music Quiz")
+
+    def _recency_candidates(
+        self,
+        tracks: list[Track],
+        *,
+        prefer_recent: bool = False,
+    ) -> list[Track]:
+        """Return the preferred recency tier, falling back to the complete candidate pool."""
+        tracks_with_recency = [(track, self._track_is_recent(track)) for track in tracks]
+        preferred = [
+            track for track, is_recent in tracks_with_recency if is_recent is prefer_recent
+        ]
+        return preferred or tracks
+
+    def _track_is_recent(self, track: Track) -> bool:
+        """Return whether a track was selected or heard recently."""
+        if track.uri and track.uri in self._recent_track_uris:
+            return True
+        return self._recency_snapshot is not None and self._recency_snapshot.track_recent(
+            track, QUIZ_TRACK_RECENCY_SECONDS
+        )
 
 
 def get_track_release_year(track: Track) -> int | None:

--- a/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
+++ b/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
@@ -166,7 +166,7 @@ class GuessTheSongQuizType(QuizType):
                 translation_key="music_quiz_no_unused_source_tracks",
                 translation_owner=TRANSLATION_OWNER,
             )
-        return secrets.choice(available)
+        return secrets.choice(self._recency_candidates(available))
 
     async def _get_correct_candidate(self, track: Track) -> SuggestionCandidate:
         """Return the correct candidate with artist metadata when it can be resolved."""

--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -134,6 +134,7 @@ class MusicTimelineQuizType(QuizType):
                 translation_owner=TRANSLATION_OWNER,
                 translation_args=[required_track_count],
             )
+        await super().initialize()
 
     async def prepare_round(
         self, round_index: int, previous_rounds: list[MusicQuizRound]
@@ -155,7 +156,11 @@ class MusicTimelineQuizType(QuizType):
             )
 
         if round_index == 0:
-            anchor_track = self._select_unused_track(eligible_tracks, set())
+            anchor_track = self._select_unused_track(
+                eligible_tracks,
+                set(),
+                prefer_recent=True,
+            )
             placement_snapshot = [await self._create_entry(anchor_track, is_anchor=True)]
         else:
             placement_snapshot = self._timeline_from_previous_rounds(previous_rounds)
@@ -179,6 +184,14 @@ class MusicTimelineQuizType(QuizType):
             image_url=candidate.entry.image_url,
             duration=current_track.duration,
         )
+
+    def get_recent_track_uris(self, rounds: list[MusicQuizRound]) -> set[str]:
+        """
+        Return every track shown on an earlier game's timeline.
+
+        :param rounds: Music Timeline rounds from an earlier game.
+        """
+        return {entry.track_uri for entry in self._timeline_from_previous_rounds(rounds)}
 
     def reject_track(self, track_uri: str) -> None:
         """
@@ -772,10 +785,12 @@ class MusicTimelineQuizType(QuizType):
             else self.config.title_bonus_mode
         )
 
-    @staticmethod
     def _select_unused_track(
+        self,
         tracks: list[Track],
         used_track_uris: set[str],
+        *,
+        prefer_recent: bool = False,
     ) -> Track:
         """Return one random track that is absent from persisted round history."""
         available_tracks = [
@@ -787,7 +802,9 @@ class MusicTimelineQuizType(QuizType):
                 translation_key="music_quiz_no_unused_source_tracks",
                 translation_owner=TRANSLATION_OWNER,
             )
-        return secrets.choice(available_tracks)
+        return secrets.choice(
+            self._recency_candidates(available_tracks, prefer_recent=prefer_recent)
+        )
 
     @staticmethod
     def _artist_answers(track: Track) -> list[str]:

--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -206,6 +206,14 @@ class TriviaQuizType(QuizType):
             "play_reveal_audio": game.config.play_reveal_audio,
         }
 
+    def get_recent_track_uris(self, rounds: list[MusicQuizRound]) -> set[str]:
+        """
+        Return the grounded source tracks represented by earlier Trivia rounds.
+
+        :param rounds: Trivia rounds from an earlier game.
+        """
+        return self._used_source_uris(rounds)
+
     async def initialize(self) -> None:
         """Validate AI availability and enough grounded content for the complete game."""
         self._require_ai_providers()
@@ -217,6 +225,7 @@ class TriviaQuizType(QuizType):
                 translation_owner=TRANSLATION_OWNER,
                 translation_args=[self.config.round_count],
             )
+        await super().initialize()
 
     async def prepare_round(
         self, round_index: int, previous_rounds: list[MusicQuizRound]
@@ -236,8 +245,11 @@ class TriviaQuizType(QuizType):
 
         used_source_uris = self._used_source_uris(previous_rounds)
         facts_by_uri = await self._get_eligible_tracks()
+        source_pool = await self._get_source_track_pool()
         available_tracks = [
-            facts for uri, facts in sorted(facts_by_uri.items()) if uri not in used_source_uris
+            facts
+            for uri, facts in sorted(facts_by_uri.items())
+            if uri not in used_source_uris and uri in source_pool
         ]
         if not available_tracks:
             raise InvalidDataError(
@@ -247,7 +259,13 @@ class TriviaQuizType(QuizType):
                 translation_args=[self.config.round_count],
             )
 
-        track_facts = SYSTEM_RANDOM.choice(available_tracks)
+        preferred_tracks = self._recency_candidates(
+            [source_pool[facts.source_uri] for facts in available_tracks]
+        )
+        preferred_uris = {track.uri for track in preferred_tracks if track.uri}
+        track_facts = SYSTEM_RANDOM.choice(
+            [facts for facts in available_tracks if facts.source_uri in preferred_uris]
+        )
         fact = self._select_fact(track_facts, round_index)
         generation = await self._generate_question(fact)
         correct = SuggestionCandidate(

--- a/tests/controllers/music/test_recency.py
+++ b/tests/controllers/music/test_recency.py
@@ -24,6 +24,7 @@ async def _add_playlog_row(
     timestamp: int,
     userid: str = "user-a",
     artist_names: list[str] | None = None,
+    fully_played: bool = True,
 ) -> None:
     """Insert a single row into the playlog."""
     await mass.music.database.insert(
@@ -37,8 +38,8 @@ async def _add_playlog_row(
             if artist_names
             else None,
             "timestamp": timestamp,
-            "fully_played": True,
-            "seconds_played": 180,
+            "fully_played": fully_played,
+            "seconds_played": 180 if fully_played else 30,
             "userid": userid,
             "user_initiated": True,
         },
@@ -105,6 +106,32 @@ async def test_snapshot_builds_song_and_artist_maps(mass: MusicAssistant) -> Non
 
     assert ("library", "t1") in snapshot.song_ts
     assert "the beatles" in snapshot.artist_ts
+
+
+async def test_snapshot_can_include_partially_played_tracks(mass: MusicAssistant) -> None:
+    """Include interrupted tracks only when the caller opts in."""
+    now = int(time.time())
+    await _add_playlog_row(
+        mass,
+        item_id="partial",
+        provider="library",
+        media_type=MediaType.TRACK,
+        name="Partial",
+        timestamp=now - 60,
+        fully_played=False,
+    )
+
+    default_snapshot = await mass.music.recency.snapshot(
+        RecencyWindows(song_seconds=3600), userid="user-a"
+    )
+    inclusive_snapshot = await mass.music.recency.snapshot(
+        RecencyWindows(song_seconds=3600),
+        userid="user-a",
+        include_partially_played=True,
+    )
+
+    assert ("library", "partial") not in default_snapshot.song_ts
+    assert ("library", "partial") in inclusive_snapshot.song_ts
 
 
 async def test_snapshot_is_user_scoped(mass: MusicAssistant) -> None:

--- a/tests/providers/music_quiz/test_guess_the_song.py
+++ b/tests/providers/music_quiz/test_guess_the_song.py
@@ -13,11 +13,13 @@ from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import ItemMapping, ProviderMapping, Track
 from music_assistant_models.unique_list import UniqueList
 
+from music_assistant.controllers.music.recency import RecencySnapshot, RecencyWindows
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.music_quiz.models import (
     MultipleChoiceRoundState,
     MusicQuizConfig,
 )
+from music_assistant.providers.music_quiz.quiz_types.base import QUIZ_TRACK_RECENCY_SECONDS
 from music_assistant.providers.music_quiz.quiz_types.guess_the_song import (
     GuessTheSongQuizType,
     _track_to_candidate,
@@ -96,6 +98,7 @@ def _quiz_type(
     mass.music.tracks.similar_tracks = AsyncMock(return_value=[])
     mass.music.artists.similar_artists = AsyncMock(return_value=[])
     mass.music.artists.top_tracks = AsyncMock(return_value=[])
+    mass.music.recency.snapshot = AsyncMock(return_value=RecencySnapshot(now=0))
     mass.metadata.get_image_url_for_item = AsyncMock(return_value=None)
     mass.get_providers_supporting_feature = MagicMock(return_value=[])
     config = MusicQuizConfig(
@@ -143,6 +146,49 @@ def test_reject_track_removes_it_from_the_source_pool() -> None:
     quiz_type.reject_track(failed.uri)
 
     assert quiz_type._source_track_pool == _pool([available])
+
+
+@pytest.mark.asyncio
+async def test_initialize_reads_partial_play_recency() -> None:
+    """Load interrupted playback history for quiz track selection."""
+    quiz_type, mass = _quiz_type()
+    snapshot = RecencySnapshot(now=100)
+    mass.music.recency.snapshot.return_value = snapshot
+
+    await quiz_type.initialize()
+
+    assert quiz_type._recency_snapshot is snapshot
+    mass.music.recency.snapshot.assert_awaited_once_with(
+        RecencyWindows(song_seconds=QUIZ_TRACK_RECENCY_SECONDS),
+        include_partially_played=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_source_selection_prefers_tracks_not_played_recently() -> None:
+    """Choose a fresh source track while retaining recent tracks as fallback candidates."""
+    quiz_type, _ = _quiz_type()
+    recent = _track("recent", "Teardrop", "Massive Attack")
+    fresh = _track("fresh", "Genesis", "Justice")
+    quiz_type._source_track_pool = _pool([recent, fresh])
+    quiz_type._recency_snapshot = RecencySnapshot(
+        now=100,
+        song_ts={(recent.provider, recent.item_id): 100},
+    )
+
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types.guess_the_song.secrets.choice",
+        side_effect=lambda candidates: candidates[0],
+    ) as choose:
+        selected = await quiz_type._get_next_source_track(set())
+        assert quiz_type._recency_snapshot is not None
+        quiz_type._recency_snapshot.song_ts[(fresh.provider, fresh.item_id)] = 100
+        fallback = await quiz_type._get_next_source_track(set())
+
+    assert selected is fresh
+    assert fallback is recent
+    assert choose.call_args_list[0].args[0] == [fresh]
+    assert choose.call_args_list[1].args[0] == [recent, fresh]
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -20,6 +20,7 @@ from music_assistant_models.media_items import (
 )
 from music_assistant_models.unique_list import UniqueList
 
+from music_assistant.controllers.music.recency import RecencySnapshot
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.music_quiz.ai_distractors import AI_QUERY_TIMEOUT_SECONDS
 from music_assistant.providers.music_quiz.models import (
@@ -141,6 +142,7 @@ def _mass() -> MagicMock:
     mass.music.artists.top_tracks = AsyncMock(return_value=[])
     mass.music.artists.tracks = AsyncMock(return_value=[])
     mass.music.search = AsyncMock(return_value=SimpleNamespace(tracks=[]))
+    mass.music.recency.snapshot = AsyncMock(return_value=RecencySnapshot(now=0))
     mass.get_providers_supporting_feature = MagicMock(return_value=[])
     return mass
 
@@ -553,6 +555,29 @@ async def test_prepare_round_seeds_anchor_and_prefetches_guaranteed_future_snaps
         )
         == 3
     )
+
+
+@pytest.mark.asyncio
+async def test_prepare_round_reserves_fresh_track_for_scored_timeline_round() -> None:
+    """Use a recent track as the anchor so a fresh track remains for players to place."""
+    recent_anchor = _track("recent-anchor", "Teardrop", "Massive Attack", album_year=1998)
+    recent_other = _track("recent-other", "Genesis", "Justice", album_year=2007)
+    fresh = _track("fresh", "Lisztomania", "Phoenix", album_year=2009)
+    quiz, _ = _quiz([recent_anchor, recent_other, fresh])
+    quiz._eligible_tracks = [recent_anchor, recent_other, fresh]
+    assert recent_anchor.uri is not None
+    assert recent_other.uri is not None
+    quiz.add_recent_track_uris([recent_anchor.uri, recent_other.uri])
+
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types.music_timeline.secrets.choice",
+        side_effect=lambda candidates: candidates[0],
+    ):
+        game_round = await quiz.prepare_round(0, [])
+
+    assert isinstance(game_round.answer_state, TimelineRoundState)
+    assert game_round.answer_state.placement_snapshot[0].track_uri == recent_anchor.uri
+    assert game_round.track_uri == fresh.uri
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -22,6 +22,7 @@ from music_assistant_models.enums import (
 from music_assistant_models.errors import AudioError, InvalidDataError, MediaNotFoundError
 from music_assistant_models.media_items import Playlist, ProviderMapping, Track
 
+from music_assistant.controllers.music.recency import RecencySnapshot
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     current_user,
     impersonated_user,
@@ -313,6 +314,7 @@ def _create_plugin(
     source_item.name = "Test Playlist"
     source_item.media_type = MediaType.PLAYLIST
     plugin.mass.music.get_item = AsyncMock(return_value=source_item)
+    plugin.mass.music.recency.snapshot = AsyncMock(return_value=RecencySnapshot(now=0))
     plugin.signal_provider_event = MagicMock()  # type: ignore[method-assign, misc]
     plugin._play_track = AsyncMock()  # type: ignore[method-assign]
     plugin._stop_playback = AsyncMock()  # type: ignore[method-assign]
@@ -1262,6 +1264,8 @@ async def test_reset_prepares_replay_round_and_start_reuses_it() -> None:
         assert plugin._next_round_task is not None
         assert plugin._next_round_task.done()
         assert prepare_round.await_count == 2
+        assert isinstance(plugin._quiz_type, GuessTheSongQuizType)
+        assert initial_round.track_uri in plugin._quiz_type._recent_track_uris
 
         await plugin.start_game()
 
@@ -2813,6 +2817,8 @@ async def test_disabled_trivia_reset_delete_and_recreate_keep_lifecycle_non_audi
         assert game.config.language == "zh-Hans-CN"
         assert game.rounds == []
         assert initialize.await_count == 2
+        assert isinstance(plugin._quiz_type, TriviaQuizType)
+        assert plugin._quiz_type._recent_track_uris == {"library://track/trivia-0"}
         await plugin.delete_game()
         assert plugin._game is None
         cast("AsyncMock", plugin._stop_playback).assert_not_awaited()
@@ -3360,6 +3366,11 @@ async def test_music_timeline_reset_preserves_config_and_reinitializes_strategy(
     game = plugin._game
     assert game is not None
     assert initialize.await_count == 2
+    assert plugin._quiz_type is not None
+    assert plugin._quiz_type._recent_track_uris == {
+        "library://track/anchor",
+        "library://track/music_timeline-0",
+    }
     pending_task.cancel.assert_called_once()
     cancel_timer = cast("MagicMock", plugin.mass.cancel_timer)
     cancel_timer.assert_any_call(plugin._reveal_timer_id)

--- a/tests/providers/music_quiz/test_sources.py
+++ b/tests/providers/music_quiz/test_sources.py
@@ -22,6 +22,7 @@ from music_assistant_models.media_items import (
 )
 from music_assistant_models.unique_list import UniqueList
 
+from music_assistant.controllers.music.recency import RecencySnapshot
 from music_assistant.providers.music_quiz import MusicQuizPlugin
 from music_assistant.providers.music_quiz.models import (
     MultipleChoiceRoundState,
@@ -155,6 +156,7 @@ def _mass(source_items: Mapping[str, object]) -> MagicMock:
     mass.music.genres.tracks = AsyncMock(return_value=[])
     mass.music.search = AsyncMock(return_value=SimpleNamespace(tracks=[]))
     mass.music.tracks.get = AsyncMock()
+    mass.music.recency.snapshot = AsyncMock(return_value=RecencySnapshot(now=0))
     mass.metadata.get_image_url_for_item = AsyncMock(return_value=None)
     mass.get_providers_supporting_feature = MagicMock(return_value=[])
     mass.get_provider = MagicMock(return_value=None)

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -23,6 +23,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.constants import VARIOUS_ARTISTS_MBID, VARIOUS_ARTISTS_NAME
+from music_assistant.controllers.music.recency import RecencySnapshot
 from music_assistant.helpers.json import json_dumps, json_loads
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
@@ -184,6 +185,7 @@ def _mass(providers: Sequence[object] | None = None) -> MagicMock:
     mass = MagicMock()
     mass.get_providers_supporting_feature.return_value = list(providers or [])
     mass.music.search = AsyncMock()
+    mass.music.recency.snapshot = AsyncMock(return_value=RecencySnapshot(now=0))
     return mass
 
 
@@ -836,6 +838,30 @@ async def test_prepare_round_randomly_selects_from_unused_tracks() -> None:
     assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
     assert _correct_source_uri(game_round.answer_state) == tracks[1].uri
     assert len(choose.call_args.args[0]) == 2
+
+
+@pytest.mark.asyncio
+async def test_prepare_round_prefers_track_not_used_by_previous_game() -> None:
+    """Deprioritize a previous game's track when another grounded track is available."""
+    recent = _track("recent", "Teardrop", "Massive Attack")
+    fresh = _track("fresh", "Genesis", "Justice")
+    provider = _ai_provider(
+        _valid_response(
+            "Who performs the selected track Genesis?",
+            ["Daft Punk", "Air", "Phoenix"],
+        )
+    )
+    quiz, _ = _quiz([recent, fresh], providers=[provider])
+    assert recent.uri is not None
+    quiz.add_recent_track_uris([recent.uri])
+
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types.trivia.SYSTEM_RANDOM.choice",
+        side_effect=lambda candidates: candidates[0],
+    ):
+        game_round = await quiz.prepare_round(0, [])
+
+    assert game_round.track_uri == fresh.uri
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Music Quiz could select the same songs again when replaying a game with the same sources.

- Prefer songs that were not heard or used recently.
- Include interrupted playback and the previous game's song history.
- Fall back to the full source list when needed for smaller playlists.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.