### PR TITLE
Fix OOM in Smart Fades centroid repair migration

### DIFF
--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -811,57 +811,41 @@ async def migrate_database(  # noqa: PLR0915
         if audio_analysis_table_exists:
             # SQLite does not guarantee WHERE-term evaluation order, so a bare
             # json_valid() term cannot reliably shield json_each()/json_type()
-            # from raising on malformed rows - guard their input directly instead
+            # from raising on malformed rows - guard their input directly instead.
+            # The json() wrapper is required: the JSON subtype does not reliably
+            # survive the scalar-subquery boundary, so without it the rebuilt
+            # array would be stored as an escaped string on some SQLite versions.
             result = await database.execute(
-                f"""WITH RECURSIVE
-                null_centroids AS (
-                    SELECT
-                        aa.id,
-                        '$.spectral_centroid[' || centroid.key || ']' AS path,
-                        row_number() OVER (
-                            PARTITION BY aa.id
-                            ORDER BY CAST(centroid.key AS INTEGER)
-                        ) AS sequence
-                    FROM {DB_TABLE_AUDIO_ANALYSIS} AS aa,
-                        json_each(
+                f"""UPDATE {DB_TABLE_AUDIO_ANALYSIS} AS aa
+                SET analysis_data = json_replace(
+                    aa.analysis_data,
+                    '$.spectral_centroid',
+                    json((
+                        SELECT json_group_array(
+                            CASE WHEN centroid.type = 'null'
+                                THEN 0.0 ELSE centroid.value END
+                        )
+                        FROM json_each(
+                            aa.analysis_data, '$.spectral_centroid'
+                        ) AS centroid
+                    ))
+                )
+                WHERE aa.aa_provider_domain = :aa_provider_domain
+                    AND aa.analysis_data LIKE '%null%'
+                    AND json_type(
+                        CASE WHEN json_valid(aa.analysis_data)
+                            THEN aa.analysis_data END,
+                        '$.spectral_centroid'
+                    ) = 'array'
+                    AND EXISTS (
+                        SELECT 1
+                        FROM json_each(
                             CASE WHEN json_valid(aa.analysis_data)
                                 THEN aa.analysis_data END,
                             '$.spectral_centroid'
                         ) AS centroid
-                    WHERE aa.aa_provider_domain = :aa_provider_domain
-                        AND aa.analysis_data LIKE '%null%'
-                        AND json_type(
-                            CASE WHEN json_valid(aa.analysis_data)
-                                THEN aa.analysis_data END,
-                            '$.spectral_centroid'
-                        ) = 'array'
-                        AND centroid.type = 'null'
-                ),
-                repaired(id, analysis_data, sequence) AS (
-                    SELECT aa.id, aa.analysis_data, 0
-                    FROM {DB_TABLE_AUDIO_ANALYSIS} AS aa
-                    WHERE aa.id IN (SELECT id FROM null_centroids)
-
-                    UNION ALL
-
-                    SELECT
-                        repaired.id,
-                        json_set(repaired.analysis_data, null_centroids.path, 0.0),
-                        null_centroids.sequence
-                    FROM repaired
-                    JOIN null_centroids
-                        ON null_centroids.id = repaired.id
-                        AND null_centroids.sequence = repaired.sequence + 1
-                )
-                UPDATE {DB_TABLE_AUDIO_ANALYSIS} AS aa
-                SET analysis_data = (
-                    SELECT repaired.analysis_data
-                    FROM repaired
-                    WHERE repaired.id = aa.id
-                    ORDER BY repaired.sequence DESC
-                    LIMIT 1
-                )
-                WHERE aa.id IN (SELECT id FROM null_centroids)""",
+                        WHERE centroid.type = 'null'
+                    )""",
                 {"aa_provider_domain": "smart_fades"},
             )
             if result.rowcount:

--- a/tests/controllers/music/test_music_migrations.py
+++ b/tests/controllers/music/test_music_migrations.py
@@ -297,6 +297,10 @@ async def test_migration_repairs_null_smart_fades_centroids(
         3: ("other_domain", '{"spectral_centroid": [null], "bpm": 100}'),
         # a corrupt payload must not abort the migration
         4: ("smart_fades", '{"spectral_centroid": [null'),
+        # a non-array centroid value must not be touched
+        5: ("smart_fades", '{"spectral_centroid": null, "bpm": 90}'),
+        # "null" appearing only inside a string value must not trigger a rewrite
+        6: ("smart_fades", '{"spectral_centroid": [3.5], "key": "nullish"}'),
     }
     for row_id, (domain, analysis_data) in rows.items():
         await database.execute(
@@ -321,7 +325,7 @@ async def test_migration_repairs_null_smart_fades_centroids(
     }
     assert json.loads(repaired[1]) == {"spectral_centroid": [1.5, 0.0, 2.5, 0.0], "bpm": 120}
     # untouched rows must not be rewritten at all, hence the exact-string compare
-    for untouched_id in (2, 3, 4):
+    for untouched_id in (2, 3, 4, 5, 6):
         assert repaired[untouched_id] == rows[untouched_id][1]
 
 


### PR DESCRIPTION
# What does this implement/fix?

The schema-53 centroid repair (#4798) used a recursive CTE that materializes every affected analysis blob in memory (the connection runs with `temp_store=memory`) and re-evaluates the CTE per updated row. On large libraries this OOMs and blocks startup.

- Replace the recursive CTE with a single-pass `json_group_array` rebuild of the centroid array (measured ~200x faster, constant memory).
- No schema bump needed: affected installs never completed the 52→53 migration, so they re-enter the existing block.
- Extend the migration test with non-array and false-positive-`null` edge cases.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.