### PR TITLE
Prefer AirPlay 2 for known JBL models in automatic protocol selection

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -94,8 +94,14 @@ BROKEN_AIRPLAY_MODELS = (
 AIRPLAY_2_DEFAULT_MODELS = (
     # Models that are known to work better with AirPlay 2 protocol instead of RAOP
     # These use the translated/friendly model names from get_model_info()
+    # Both fields support fnmatch-style wildcards and match case-insensitively.
     ("Ubiquiti Inc.", "*"),
     ("LG Electronics", "*"),
+    # JBL models that advertise RAOP but reject the RAOP session.
+    # The model name comes from the am mDNS property on these devices.
+    ("*", "JBL BAR 1300"),
+    ("*", "JBL BAR 300"),
+    ("*", "JBL CHARGE 5*"),
 )
 
 BROKEN_AIRPLAY_WARN = ConfigEntry(

--- a/music_assistant/providers/airplay/helpers.py
+++ b/music_assistant/providers/airplay/helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 import logging
 import os
 import platform
@@ -142,7 +143,9 @@ def is_broken_airplay_model(manufacturer: str, model: str) -> bool:
 def is_airplay2_preferred_model(manufacturer: str, model: str) -> bool:
     """Check if a model is known to work better with AirPlay 2 protocol."""
     for ap2_manufacturer, ap2_model in AIRPLAY_2_DEFAULT_MODELS:
-        if ap2_manufacturer in (manufacturer, "*") and ap2_model in (model, "*"):
+        if fnmatch.fnmatchcase(manufacturer.lower(), ap2_manufacturer.lower()) and (
+            fnmatch.fnmatchcase(model.lower(), ap2_model.lower())
+        ):
             return True
     return False
 

--- a/tests/providers/airplay/test_helpers.py
+++ b/tests/providers/airplay/test_helpers.py
@@ -1,0 +1,27 @@
+"""Unit tests for AirPlay provider helpers."""
+
+import pytest
+
+from music_assistant.providers.airplay.helpers import is_airplay2_preferred_model
+
+
+@pytest.mark.parametrize(
+    ("manufacturer", "model", "expected"),
+    [
+        # existing exact entries keep working
+        ("Ubiquiti Inc.", "UPL-AMP", True),
+        ("LG Electronics", "Some Soundbar", True),
+        # known JBL models, matched case-insensitively on the am-derived model name
+        ("AirPlay", "JBL BAR 1300", True),
+        ("AirPlay", "JBL BAR 300", True),
+        ("AirPlay", "JBL Charge 5 Wi-Fi", True),
+        ("AirPlay", "jbl bar 1300", True),
+        # no match for unrelated or unlisted devices
+        ("Sonos", "One", False),
+        ("AirPlay", "Unknown", False),
+        ("AirPlay", "JBL Flip 6", False),
+    ],
+)
+def test_is_airplay2_preferred_model(manufacturer: str, model: str, expected: bool) -> None:
+    """Matching is case-insensitive and supports fnmatch-style wildcards."""
+    assert is_airplay2_preferred_model(manufacturer, model) is expected

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -194,6 +194,33 @@ async def test_airplay_protocol_option_enabled_when_advertised(
     assert options[StreamingProtocol.AIRPLAY2.value].disabled is False
 
 
+@pytest.mark.parametrize(
+    ("manufacturer", "model", "expected"),
+    [
+        # AirPlay 2 preferred models get AirPlay 2, even when RAOP is advertised
+        ("AirPlay", "JBL BAR 1300", StreamingProtocol.AIRPLAY2),
+        ("AirPlay", "JBL Charge 5 Wi-Fi", StreamingProtocol.AIRPLAY2),
+        # other devices advertising both protocols default to RAOP
+        ("Test Manufacturer", "Test Model", StreamingProtocol.RAOP),
+    ],
+)
+def test_auto_protocol_selection(
+    manufacturer: str, model: str, expected: StreamingProtocol
+) -> None:
+    """Automatic protocol selection prefers AirPlay 2 for known AP2-preferred models."""
+    player = AirPlayPlayer(
+        provider=MagicMock(),
+        player_id="test_player",
+        display_name="Test Player",
+        address="127.0.0.1",
+        manufacturer=manufacturer,
+        model=model,
+        raop_discovery_info=MagicMock(),
+        airplay_discovery_info=MagicMock(),
+    )
+    assert player._get_protocol_for_config_value(0) == expected
+
+
 # --- Volume and Mute tests ---
 
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

These JBL models advertise a RAOP service but reject the RAOP session, while AirPlay 2 works reliably. Add them to AIRPLAY_2_DEFAULT_MODELS and make the matching case-insensitive with fnmatch-style wildcards, as these devices expose their model name via the am mDNS property.

Automatic selection prefers AirPlay 2 only when the device advertises it, and RAOP can still be forced via the per-player protocol setting.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5831

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
