### PR TITLE
Normalise synced (LRC) lyrics before storing or serving them

### DIFF
--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -32,6 +32,7 @@ from music_assistant.controllers.tasks.context import (
 )
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.images import cleanup_thumb_cache
+from music_assistant.helpers.lyrics import normalize_lrc_lyrics
 from music_assistant.helpers.throttle_retry import Throttler
 from music_assistant.helpers.util import try_parse_int
 from music_assistant.models.core_controller import CoreController
@@ -313,6 +314,15 @@ class MetaDataController(
 
         Returns a tuple of (lyrics, lrc_lyrics) if found.
         """
+        lyrics, lrc_lyrics = await self._get_track_lyrics(track)
+        # on-demand lookups are not stored in the library db, so normalize on the way out
+        return lyrics, normalize_lrc_lyrics(lrc_lyrics)
+
+    async def _get_track_lyrics(
+        self,
+        track: Track,
+    ) -> tuple[str | None, str | None]:
+        """Look up (lyrics, lrc_lyrics) for the given track."""
         if track.metadata and track.metadata.lyrics:
             return track.metadata.lyrics, track.metadata.lrc_lyrics
 

--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -9,7 +9,7 @@ DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
 
-DB_SCHEMA_VERSION: Final[int] = 53
+DB_SCHEMA_VERSION: Final[int] = 54
 
 # tracks longer that this will not be included in radio mode
 RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -48,6 +48,7 @@ from music_assistant.helpers.compare import (
 )
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.json import json_loads, serialize_to_json
+from music_assistant.helpers.lyrics import normalize_lrc_lyrics
 from music_assistant.models.music_provider import MusicProvider
 
 from .base import MediaControllerBase, TrackSyncDetails
@@ -681,6 +682,8 @@ class TracksController(MediaControllerBase[Track]):
         if not item.artists:
             msg = "Track is missing artist(s)"
             raise InvalidDataError(msg)
+        # normalize synced lyrics so clients only need a minimal single-timestamp LRC parser
+        item.metadata.lrc_lyrics = normalize_lrc_lyrics(item.metadata.lrc_lyrics)
         db_id = await self.mass.music.database.insert(
             self.db_table,
             {
@@ -719,6 +722,7 @@ class TracksController(MediaControllerBase[Track]):
         db_id = int(item_id)  # ensure integer
         cur_item = await self.get_library_item(db_id)
         metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
+        metadata.lrc_lyrics = normalize_lrc_lyrics(metadata.lrc_lyrics)
         cur_item.external_ids.update(update.external_ids)
         name = update.name if overwrite else cur_item.name
         sort_name = update.sort_name if overwrite else cur_item.sort_name or update.sort_name

--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -41,6 +41,7 @@ from music_assistant.controllers.music.constants import DB_SCHEMA_VERSION
 from music_assistant.controllers.music.media.genres import GenreController
 from music_assistant.helpers.compare import create_safe_string
 from music_assistant.helpers.json import json_dumps, json_loads, serialize_to_json
+from music_assistant.helpers.lyrics import normalize_lrc_lyrics
 
 if TYPE_CHECKING:
     import logging
@@ -854,6 +855,42 @@ async def migrate_database(  # noqa: PLR0915
                     "audio analysis row(s)",
                     result.rowcount,
                 )
+
+    if prev_version <= 53:
+        # normalize stored synced lyrics: strip LRC ID tags and expand multi-timestamp
+        # (repeating) lines into one line per timestamp
+        tracks_columns = {
+            x["name"]
+            for x in await database.get_rows_from_query(
+                f"PRAGMA table_info({DB_TABLE_TRACKS})", limit=0
+            )
+        }
+        repaired_lyrics_rows = 0
+        if "metadata" in tracks_columns:
+            # guard against (test) databases with stand-in tables
+            async for db_row in database.iter_items(DB_TABLE_TRACKS):
+                if not db_row["metadata"] or '"lrc_lyrics"' not in db_row["metadata"]:
+                    continue
+                try:
+                    metadata = json_loads(db_row["metadata"])
+                except ValueError:
+                    # corrupt metadata rows are handled elsewhere (diagnostics), skip here
+                    continue
+                lrc_lyrics = metadata.get("lrc_lyrics")
+                if not isinstance(lrc_lyrics, str):
+                    continue
+                normalized = normalize_lrc_lyrics(lrc_lyrics)
+                if normalized == lrc_lyrics:
+                    continue
+                metadata["lrc_lyrics"] = normalized
+                await database.update(
+                    DB_TABLE_TRACKS,
+                    {"item_id": db_row["item_id"]},
+                    {"metadata": serialize_to_json(metadata)},
+                )
+                repaired_lyrics_rows += 1
+        if repaired_lyrics_rows:
+            logger.info("Normalized synced lyrics of %d track(s)", repaired_lyrics_rows)
 
     # NOTE: this genre restore runs after the <= 50 step on purpose: it inserts genres
     # with the current code/schema, so the external_ids column must be gone first.

--- a/music_assistant/helpers/lyrics.py
+++ b/music_assistant/helpers/lyrics.py
@@ -1,0 +1,67 @@
+"""Helpers for processing lyrics."""
+
+from __future__ import annotations
+
+import re
+
+# LRC ID tags such as [ar:Artist] or [ti:Title] have a key that never starts with a digit,
+# which distinguishes them from the [mm:ss.xx] timestamp tags on actual lyric lines.
+# Also matches colon-less comment lines like [#some comment].
+_LRC_ID_TAG_RE = re.compile(r"^\[(?:[a-zA-Z#][a-zA-Z0-9_]*:[^\]]*|#[^\]]*)\]\s*$")
+
+# a single [mm:ss.xx] timestamp tag (the fraction separator may be . or :)
+_LRC_TIMESTAMP_RE = re.compile(r"\[(\d{1,3}):(\d{1,2}(?:[.:]\d{1,3})?)\]")
+
+# one or more (optionally whitespace separated) timestamp tags at the start of a lyric line
+_LRC_TIMESTAMP_BLOCK_RE = re.compile(r"^((?:\[\d{1,3}:\d{1,2}(?:[.:]\d{1,3})?\]\s*)+)(.*)$")
+
+# enhanced LRC word timing tags such as <00:22.00>, which would render as literal text
+# TODO: consider supporting word level timing in the future instead of stripping it
+_LRC_WORD_TIMING_RE = re.compile(r"<\d{1,3}:\d{1,2}(?:[.:]\d{1,3})?>\s?")
+
+
+def normalize_lrc_lyrics(lrc_lyrics: str | None) -> str | None:
+    """
+    Normalize LRC formatted lyrics into simple, chronologically sorted LRC.
+
+    Strips ID/metadata tag lines (e.g. [ar:...], [ti:...]) and word timing tags,
+    and expands lines with multiple timestamps (repeating lyrics such as a chorus)
+    into one line per timestamp, so clients only need a minimal LRC parser.
+
+    :param lrc_lyrics: The LRC formatted lyrics to normalize, may be None.
+    """
+    if not lrc_lyrics:
+        return lrc_lyrics
+    entries: list[tuple[float, str]] = []
+    # untimed lines inherit the previous timestamp so the (stable) sort keeps them in place
+    last_time = 0.0
+    for line in lrc_lyrics.splitlines():
+        if _LRC_ID_TAG_RE.match(line.strip()):
+            continue
+        for time, lyric_line in _expand_line(_LRC_WORD_TIMING_RE.sub("", line)):
+            last_time = time if time is not None else last_time
+            entries.append((last_time, lyric_line))
+    entries.sort(key=lambda entry: entry[0])
+    return "\n".join(entry[1] for entry in entries).strip("\n") or None
+
+
+def _expand_line(line: str) -> list[tuple[float | None, str]]:
+    """Expand a lyric line into (time, line) entries, one per leading timestamp."""
+    block_match = _LRC_TIMESTAMP_BLOCK_RE.match(line)
+    if not block_match:
+        return [(None, line)]
+    timestamps = list(_LRC_TIMESTAMP_RE.finditer(block_match.group(1)))
+    if len(timestamps) == 1:
+        return [(_timestamp_to_seconds(timestamps[0]), line)]
+    text = block_match.group(2)
+    return [
+        (_timestamp_to_seconds(ts), f"{ts.group(0)}{text}")
+        for ts in sorted(timestamps, key=_timestamp_to_seconds)
+    ]
+
+
+def _timestamp_to_seconds(timestamp: re.Match[str]) -> float:
+    """Return the time in seconds represented by a matched timestamp tag."""
+    minutes = int(timestamp.group(1))
+    seconds = float(timestamp.group(2).replace(":", "."))
+    return minutes * 60 + seconds

--- a/tests/helpers/test_lyrics.py
+++ b/tests/helpers/test_lyrics.py
@@ -1,0 +1,94 @@
+"""Tests for the lyrics helpers."""
+
+from music_assistant.helpers.lyrics import normalize_lrc_lyrics
+
+LRC_WITH_ID_TAGS = """[ar:Chubby Checker oppure  Beatles, The]
+[al:Hits Of The 60's - Vol. 2 - Oldies]
+[ti:Let's Twist Again]
+[au:Written by Kal Mann / Dave Appell, 1961]
+[length: 2:23]
+[offset:+500]
+[by:lrc-author]
+[re:some editor]
+[ve:1.0]
+[#some comment]
+
+[00:12.00]Naku Penda Piya-Naku Taka Piya-Mpenziwe
+[00:15.30]Some more lyrics ...
+"""
+
+LRC_CLEAN = """[00:12.00]Naku Penda Piya-Naku Taka Piya-Mpenziwe
+[00:15.30]Some more lyrics ..."""
+
+
+def test_normalize_strips_id_tags() -> None:
+    """Test that LRC ID tag lines are stripped from LRC lyrics."""
+    assert normalize_lrc_lyrics(LRC_WITH_ID_TAGS) == LRC_CLEAN
+
+
+def test_normalize_no_changes_needed() -> None:
+    """Test that already normalized LRC lyrics are returned unmodified."""
+    assert normalize_lrc_lyrics(LRC_CLEAN) == LRC_CLEAN
+
+
+def test_normalize_preserves_untimed_and_blank_lines() -> None:
+    """Test that untimed lines and blank lines between timed lines are preserved."""
+    lrc = "[00:01.00]First line\n\n[00:05.00]Second line\nuntimed line"
+    assert normalize_lrc_lyrics(lrc) == lrc
+
+
+def test_normalize_empty_input() -> None:
+    """Test that None and empty strings pass through unmodified."""
+    assert normalize_lrc_lyrics(None) is None
+    assert normalize_lrc_lyrics("") == ""
+
+
+def test_normalize_only_id_tags() -> None:
+    """Test that lyrics consisting of only ID tags result in None."""
+    assert normalize_lrc_lyrics("[ar:Some Artist]\n[ti:Some Title]") is None
+
+
+def test_normalize_expands_repeated_lines() -> None:
+    """Test that lines with multiple timestamps are expanded into one line per timestamp."""
+    lrc = "[00:21.10][00:45.10]Repeating lyrics (e.g. chorus)"
+    assert normalize_lrc_lyrics(lrc) == (
+        "[00:21.10]Repeating lyrics (e.g. chorus)\n[00:45.10]Repeating lyrics (e.g. chorus)"
+    )
+
+
+def test_normalize_expands_and_sorts_within_line() -> None:
+    """Test that expanded repeating lines sort chronologically with surrounding lines."""
+    lrc = "[01:45][00:21.10] [00:33:99]Chorus\n[01:00]Second line"
+    assert normalize_lrc_lyrics(lrc) == (
+        "[00:21.10]Chorus\n[00:33:99]Chorus\n[01:00]Second line\n[01:45]Chorus"
+    )
+
+
+def test_normalize_strips_word_timing_tags() -> None:
+    """Test that (unsupported) enhanced LRC word timing tags are stripped."""
+    lrc = "[00:12.00]<00:12.10>Lyrics <00:12.50>with <00:13.00>word timing"
+    assert normalize_lrc_lyrics(lrc) == "[00:12.00]Lyrics with word timing"
+
+
+def test_normalize_full_file_with_repeats() -> None:
+    """Test a full LRC file with ID tags, repeated lines and enhanced word timing tags."""
+    lrc = (
+        "[ti:Some Title]\n"
+        "[offset:-200]\n"
+        "\n"
+        "[00:12.00]First verse line\n"
+        "[00:21.10][01:45.00]The chorus <00:22.00>with <00:23.00>word timing\n"
+        "[00:30.00]Second verse line"
+    )
+    assert normalize_lrc_lyrics(lrc) == (
+        "[00:12.00]First verse line\n"
+        "[00:21.10]The chorus with word timing\n"
+        "[00:30.00]Second verse line\n"
+        "[01:45.00]The chorus with word timing"
+    )
+
+
+def test_normalize_single_timestamp_line_untouched() -> None:
+    """Test that a single-timestamp line keeps its original formatting."""
+    lrc = "[00:01.00]  spaced text  "
+    assert normalize_lrc_lyrics(lrc) == lrc


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Satisfies: https://github.com/orgs/music-assistant/discussions/5863

LRC lyrics can contain ID tags such as `[ar:Artist]` and `[ti:Title]` at the top, and these would show up as text in the lyrics view. Lines with multiple timestamps such as `[00:21.10][00:45.10]Chorus` were not supported, and the second timestamp was displayed as literal text.

This PR adds a `normalize_lrc_lyrics` helper that strips ID tag lines, strips word timing tags (we do not support word level timing yet, so they would render as literal text), expands multi timestamp lines into one line per timestamp and sorts the result chronologically.

Normalisation is applied where track metadata is written to the library database, which covers all music and metadata providers in one place. It is also applied in the `get_track_lyrics` API for on demand lookups that are never stored. A migration (schema 54) normalises lyrics already in the database.

Clients need no changes because they now always receive plain single timestamp LRC that any minimal parser can handle.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [X] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
