### PR TITLE
Smart Fades: verbose logging for candidate-selection tuning

### DIFF
--- a/music_assistant/controllers/streams/smart_fades/planner/assembly.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/assembly.py
@@ -584,6 +584,20 @@ class EmergencyHandoffFactory:
                 target = max(target, ctx.audio_end - plan0.crossfade_duration)
             target = min(target, ctx.audio_end)
             anchor = _nearest_protective_anchor(ctx, target, prefer_earliest=vocal_would_be_cut)
+            reasons = [
+                reason
+                for reason, fired in (
+                    ("vocal_would_be_cut", vocal_would_be_cut),
+                    ("overtrims_short_fade", overtrims_short_fade),
+                )
+                if fired
+            ]
+            self._logger.debug(
+                "extending emergency handoff anchor (%s): old_anchor=%.2f new_anchor=%.2f",
+                ",".join(reasons),
+                plan0.fade_out_window,
+                anchor,
+            )
             spec = replace(base_spec, anchor_s=anchor)
             rebuilt = self._factory.build(spec)
             assert rebuilt is not None  # the 1-bar rung always yields a candidate
@@ -594,12 +608,24 @@ class EmergencyHandoffFactory:
         duration = max(MIN_HANDOFF_SECONDS, min(MAX_HANDOFF_SECONDS, incoming_onset - 0.1))
         handoff = self._as_handoff(candidate.plan, duration)
         metrics = self._factory.score(spec, handoff)
+        shrunk_to_min = False
         if (
             metrics.collision_seconds >= COLLISION_SECONDS_LIMIT
             or metrics.weighted_collision_seconds >= WEIGHTED_COLLISION_LIMIT
         ) and duration > MIN_HANDOFF_SECONDS:
             handoff = self._as_handoff(candidate.plan, MIN_HANDOFF_SECONDS)
             metrics = self._factory.score(spec, handoff)
+            shrunk_to_min = True
+        self._logger.debug(
+            "emergency handoff: duration=%.2f anchor=%.2f collision=%.2f weighted_collision=%.2f%s",
+            handoff.crossfade_duration,
+            handoff.fade_out_window,
+            metrics.collision_seconds,
+            metrics.weighted_collision_seconds,
+            " (shrunk to MIN_HANDOFF_SECONDS: auditioned window still collided)"
+            if shrunk_to_min
+            else "",
+        )
         return replace(handoff, metrics=metrics)
 
     @staticmethod

--- a/music_assistant/controllers/streams/smart_fades/planner/assembly.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/assembly.py
@@ -622,7 +622,7 @@ class EmergencyHandoffFactory:
             handoff.fade_out_window,
             metrics.collision_seconds,
             metrics.weighted_collision_seconds,
-            " (shrunk to MIN_HANDOFF_SECONDS: auditioned window still collided)"
+            " (onset-sized window collided; shrunk to the minimum duration)"
             if shrunk_to_min
             else "",
         )

--- a/music_assistant/controllers/streams/smart_fades/planner/candidates.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/candidates.py
@@ -360,6 +360,14 @@ class CandidateFactory:
             spec.entry_s if spec.entry_s is not None else self._choose_fadein_entry(tail, bars)
         )
         if bars > 1 and fadein_start_pos is None:
+            self._logger.log(
+                VERBOSE_LOG_LEVEL,
+                "dropping spec source=%s tier=%s bars=%d anchor=%s: no beat-aligned incoming entry",
+                spec.source,
+                tier,
+                bars,
+                spec.anchor_s,
+            )
             return None
         crossfade_duration = self._calculate_crossfade_duration(tail, bars)
 
@@ -368,6 +376,15 @@ class CandidateFactory:
             tail, crossfade_duration, fadein_start_pos, tempo_plan
         )
         if bars > 1 and fadein_start_pos is not None and fadein_trim_start is None:
+            self._logger.log(
+                VERBOSE_LOG_LEVEL,
+                "dropping spec source=%s tier=%s bars=%d anchor=%s: "
+                "no legal timing lock for the pinned entry",
+                spec.source,
+                tier,
+                bars,
+                spec.anchor_s,
+            )
             return None
         # Rolling-intro alignment: on a full blend with no pinned entry, deepen B's
         # trim so its groove entry lands at the overlap END (B's intro runs under A,
@@ -379,6 +396,15 @@ class CandidateFactory:
             feasible, aligned = self._align_rolling_intro(crossfade_duration, fadein_trim_start)
             if not feasible:
                 if bars > 1:
+                    self._logger.log(
+                        VERBOSE_LOG_LEVEL,
+                        "dropping spec source=%s tier=%s bars=%d anchor=%s: "
+                        "rolling intro: no legal cut clears the sung run",
+                        spec.source,
+                        tier,
+                        bars,
+                        spec.anchor_s,
+                    )
                     return None
             else:
                 fadein_trim_start = aligned

--- a/music_assistant/controllers/streams/smart_fades/planner/context.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/context.py
@@ -257,12 +257,34 @@ def build_transition_context(
         fade_out_analysis.duration or 0.0,
     )
 
-    # Additional verbose logging to debug rare failures
+    if vocal_out_scoring is not None and vocal_in_scoring is not None:
+        vocal_coverage = "both"
+    elif vocal_out_scoring is not None:
+        vocal_coverage = "out"
+    elif vocal_in_scoring is not None:
+        vocal_coverage = "in"
+    else:
+        vocal_coverage = "none"
     logger.log(
         VERBOSE_LOG_LEVEL,
-        "SmartCrossFade context: fade_out: %s, fade_in: %s",
-        fade_out_analysis,
-        fade_in_analysis,
+        "transition context: tier=%s bpm=%.1f->%.1f (diff=%.1f%%) cross_meter=%s buffer=%.1fs "
+        "offset=%.1fs audio_end=%.1fs anchor=%.2f mix_out=%.2f kick=%s fade_onset=%s coda=%s "
+        "natural_entry=%.2f vocals=%s",
+        tier,
+        outgoing.bpm,
+        incoming.bpm,
+        bpm_diff_percent,
+        cross_meter,
+        buffer_duration,
+        buffer_offset,
+        audio_end,
+        tier_anchor,
+        mix_out_anchor,
+        kick_anchor,
+        fade_onset,
+        coda_zone,
+        natural_entry,
+        vocal_coverage,
     )
 
     return TransitionContext(

--- a/music_assistant/controllers/streams/smart_fades/planner/planner.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/planner.py
@@ -85,14 +85,14 @@ class SmartCrossFadePlanner(TransitionPlanner):
         factory = CandidateFactory(ctx, self.logger)
         specs = [spec for generator in default_generators() for spec in generator.generate(ctx)]
         candidates = [candidate for spec in specs if (candidate := factory.build(spec)) is not None]
-        source_counts = Counter(spec.source for spec in specs)
-        self.logger.log(
-            VERBOSE_LOG_LEVEL,
-            "generated %d specs (%s), %d built",
-            len(specs),
-            dict(source_counts),
-            len(candidates),
-        )
+        if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+            self.logger.log(
+                VERBOSE_LOG_LEVEL,
+                "generated %d specs (%s), %d built",
+                len(specs),
+                dict(Counter(spec.source for spec in specs)),
+                len(candidates),
+            )
         if not candidates:
             raise SmartFadeNotApplicable("no feasible transition candidate")
         winner = CandidateSelector(default_policies(), self.logger).select(candidates, ctx)

--- a/music_assistant/controllers/streams/smart_fades/planner/planner.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/planner.py
@@ -12,9 +12,11 @@ strategies slot in as sibling ``TransitionPlanner`` subclasses.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections import Counter
 from dataclasses import replace
 from typing import TYPE_CHECKING
 
+from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.controllers.streams.smart_fades.models import SmartFadeNotApplicable
 
 from .assembly import EmergencyHandoffFactory, PlanAssembler
@@ -83,11 +85,20 @@ class SmartCrossFadePlanner(TransitionPlanner):
         factory = CandidateFactory(ctx, self.logger)
         specs = [spec for generator in default_generators() for spec in generator.generate(ctx)]
         candidates = [candidate for spec in specs if (candidate := factory.build(spec)) is not None]
+        source_counts = Counter(spec.source for spec in specs)
+        self.logger.log(
+            VERBOSE_LOG_LEVEL,
+            "generated %d specs (%s), %d built",
+            len(specs),
+            dict(source_counts),
+            len(candidates),
+        )
         if not candidates:
             raise SmartFadeNotApplicable("no feasible transition candidate")
         winner = CandidateSelector(default_policies(), self.logger).select(candidates, ctx)
         if winner is None:
             # every candidate breached a hard rejection: ship the click-free handoff
+            self.logger.debug("shipping click-free emergency handoff")
             plan = EmergencyHandoffFactory(ctx, factory, self.logger).build()
         else:
             plan = PlanAssembler(ctx, self.logger).finalize(winner.candidate)

--- a/music_assistant/controllers/streams/smart_fades/planner/selection.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/selection.py
@@ -65,21 +65,22 @@ class CandidateSelector:
             )
             return None
         winner = min(survivors, key=lambda entry: entry.total_penalty)
-        ranked = sorted(survivors, key=lambda entry: entry.total_penalty)
-        runner_up = ranked[1] if len(ranked) > 1 else None
-        self._logger.log(
-            VERBOSE_LOG_LEVEL,
-            "selection: scored=%d survivors=%d winner source=%s tier=%s bars=%d total=%.2f "
-            "runner_up=%s runner_up_total=%s",
-            len(scored),
-            len(survivors),
-            winner.candidate.spec.source,
-            winner.candidate.spec.tier,
-            winner.candidate.spec.bars,
-            winner.total_penalty,
-            runner_up.candidate.spec.source if runner_up is not None else None,
-            runner_up.total_penalty if runner_up is not None else None,
-        )
+        if self._logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+            ranked = sorted(survivors, key=lambda entry: entry.total_penalty)
+            runner_up = ranked[1] if len(ranked) > 1 else None
+            self._logger.log(
+                VERBOSE_LOG_LEVEL,
+                "selection: scored=%d survivors=%d winner source=%s tier=%s bars=%d total=%.2f "
+                "runner_up=%s runner_up_total=%s",
+                len(scored),
+                len(survivors),
+                winner.candidate.spec.source,
+                winner.candidate.spec.tier,
+                winner.candidate.spec.bars,
+                winner.total_penalty,
+                runner_up.candidate.spec.source if runner_up is not None else None,
+                runner_up.total_penalty if runner_up is not None else None,
+            )
         return winner
 
     def _score(self, candidate: Candidate, ctx: TransitionContext) -> ScoredCandidate:
@@ -87,33 +88,35 @@ class CandidateSelector:
         verdicts = tuple(policy.evaluate(candidate, ctx) for policy in self._policies)
         total_penalty = sum(verdict.penalty for verdict in verdicts)
         rejected = any(verdict.rejected for verdict in verdicts)
-        # per-policy breakdown so a tuning pass can see which penalty (or
-        # rejection) each policy contributed, not just the aggregate total
-        breakdown_entries = []
-        for policy, verdict in zip(self._policies, verdicts, strict=True):
-            name = type(policy).__name__.removesuffix("Policy")
-            value = f"REJECTED({verdict.reason})" if verdict.rejected else f"{verdict.penalty:.2f}"
-            breakdown_entries.append(f"{name}={value}")
-        breakdown = " ".join(breakdown_entries)
-        plan, metrics = candidate.plan, candidate.metrics
-        self._logger.log(
-            VERBOSE_LOG_LEVEL,
-            "candidate source=%s tier=%s bars=%d duration=%.2f anchor=%.2f entry=%s total=%.2f "
-            "rejected=%s trim=%.2f collision=%.2f weighted_collision=%.2f on_downbeat=%s %s",
-            candidate.spec.source,
-            candidate.spec.tier,
-            candidate.spec.bars,
-            plan.crossfade_duration,
-            plan.fade_out_window,
-            plan.fadein_trim_start,
-            total_penalty,
-            rejected,
-            metrics.audible_outgoing_trim,
-            metrics.collision_seconds,
-            metrics.weighted_collision_seconds,
-            metrics.anchor_on_downbeat,
-            breakdown,
-        )
+        if self._logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+            # per-policy breakdown so a tuning pass can see which penalty (or
+            # rejection) each policy contributed, not just the aggregate total
+            breakdown_entries = []
+            for policy, verdict in zip(self._policies, verdicts, strict=True):
+                name = type(policy).__name__.removesuffix("Policy")
+                value = (
+                    f"REJECTED({verdict.reason})" if verdict.rejected else f"{verdict.penalty:.2f}"
+                )
+                breakdown_entries.append(f"{name}={value}")
+            plan, metrics = candidate.plan, candidate.metrics
+            self._logger.log(
+                VERBOSE_LOG_LEVEL,
+                "candidate source=%s tier=%s bars=%d duration=%.2f anchor=%.2f entry=%s total=%.2f "
+                "rejected=%s trim=%.2f collision=%.2f weighted_collision=%.2f on_downbeat=%s %s",
+                candidate.spec.source,
+                candidate.spec.tier,
+                candidate.spec.bars,
+                plan.crossfade_duration,
+                plan.fade_out_window,
+                plan.fadein_trim_start,
+                total_penalty,
+                rejected,
+                metrics.audible_outgoing_trim,
+                metrics.collision_seconds,
+                metrics.weighted_collision_seconds,
+                metrics.anchor_on_downbeat,
+                " ".join(breakdown_entries),
+            )
         return ScoredCandidate(
             candidate=candidate,
             total_penalty=total_penalty,

--- a/music_assistant/controllers/streams/smart_fades/planner/selection.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/selection.py
@@ -11,6 +11,7 @@ log always shows the complete scoreboard, not just whichever rule fired first.
 from __future__ import annotations
 
 import logging
+from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -53,24 +54,65 @@ class CandidateSelector:
         scored = [self._score(candidate, ctx) for candidate in candidates]
         survivors = [entry for entry in scored if not entry.rejected]
         if not survivors:
+            histogram = Counter(
+                verdict.reason for entry in scored for verdict in entry.verdicts if verdict.rejected
+            )
+            reasons = ", ".join(f"{reason} x{count}" for reason, count in histogram.most_common())
+            self._logger.debug(
+                "all %d candidates rejected (%s); emergency handoff will be used",
+                len(scored),
+                reasons,
+            )
             return None
-        return min(survivors, key=lambda entry: entry.total_penalty)
+        winner = min(survivors, key=lambda entry: entry.total_penalty)
+        ranked = sorted(survivors, key=lambda entry: entry.total_penalty)
+        runner_up = ranked[1] if len(ranked) > 1 else None
+        self._logger.log(
+            VERBOSE_LOG_LEVEL,
+            "selection: scored=%d survivors=%d winner source=%s tier=%s bars=%d total=%.2f "
+            "runner_up=%s runner_up_total=%s",
+            len(scored),
+            len(survivors),
+            winner.candidate.spec.source,
+            winner.candidate.spec.tier,
+            winner.candidate.spec.bars,
+            winner.total_penalty,
+            runner_up.candidate.spec.source if runner_up is not None else None,
+            runner_up.total_penalty if runner_up is not None else None,
+        )
+        return winner
 
     def _score(self, candidate: Candidate, ctx: TransitionContext) -> ScoredCandidate:
         """Evaluate every policy on one candidate and log its full scoreboard entry."""
         verdicts = tuple(policy.evaluate(candidate, ctx) for policy in self._policies)
         total_penalty = sum(verdict.penalty for verdict in verdicts)
         rejected = any(verdict.rejected for verdict in verdicts)
-        reasons = [verdict.reason for verdict in verdicts if verdict.reason]
+        # per-policy breakdown so a tuning pass can see which penalty (or
+        # rejection) each policy contributed, not just the aggregate total
+        breakdown_entries = []
+        for policy, verdict in zip(self._policies, verdicts, strict=True):
+            name = type(policy).__name__.removesuffix("Policy")
+            value = f"REJECTED({verdict.reason})" if verdict.rejected else f"{verdict.penalty:.2f}"
+            breakdown_entries.append(f"{name}={value}")
+        breakdown = " ".join(breakdown_entries)
+        plan, metrics = candidate.plan, candidate.metrics
         self._logger.log(
             VERBOSE_LOG_LEVEL,
-            "candidate source=%s bars=%d anchor=%s total=%.2f rejected=%s reasons=%s",
+            "candidate source=%s tier=%s bars=%d duration=%.2f anchor=%.2f entry=%s total=%.2f "
+            "rejected=%s trim=%.2f collision=%.2f weighted_collision=%.2f on_downbeat=%s %s",
             candidate.spec.source,
+            candidate.spec.tier,
             candidate.spec.bars,
-            candidate.spec.anchor_s,
+            plan.crossfade_duration,
+            plan.fade_out_window,
+            plan.fadein_trim_start,
             total_penalty,
             rejected,
-            reasons,
+            metrics.audible_outgoing_trim,
+            metrics.collision_seconds,
+            metrics.weighted_collision_seconds,
+            metrics.anchor_on_downbeat,
+            breakdown,
         )
         return ScoredCandidate(
             candidate=candidate,

--- a/music_assistant/controllers/streams/smart_fades/planner/selection.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/selection.py
@@ -101,8 +101,9 @@ class CandidateSelector:
             plan, metrics = candidate.plan, candidate.metrics
             self._logger.log(
                 VERBOSE_LOG_LEVEL,
-                "candidate source=%s tier=%s bars=%d duration=%.2f anchor=%.2f entry=%s total=%.2f "
-                "rejected=%s trim=%.2f collision=%.2f weighted_collision=%.2f on_downbeat=%s %s",
+                "candidate source=%s tier=%s bars=%d duration=%.2f anchor=%.2f fadein_trim=%s "
+                "total=%.2f rejected=%s trim=%.2f collision=%.2f weighted_collision=%.2f "
+                "on_downbeat=%s %s",
                 candidate.spec.source,
                 candidate.spec.tier,
                 candidate.spec.bars,


### PR DESCRIPTION
# What does this implement/fix?

Tuning the smart-fades penalty parameters (e.g. to keep emergency handoffs rare) requires seeing *why* the planner picked a candidate, but the verbose log only showed aggregate penalties and dumped the full analysis objects (all beat/RMS/vocal arrays), clogging the log.

- Remove the full `AudioAnalysisData` dump; replace it with one compact context summary line (tier, bpm diff, anchors, fade onset, coda, vocal coverage).
- Scoreboard line now includes a per-policy penalty breakdown plus the plan facts driving it (duration, anchor, entry, trim, collision seconds, on-downbeat).
- Log the selection outcome: scored/survivor counts, winner and runner-up with totals, so the tuning margin is visible.
- Log every spec dropped as infeasible with the check that killed it.
- Emergency handoffs log at DEBUG: rejection-reason histogram, anchor extension, and the final handoff shape — so their frequency is visible without verbose logging.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
