### PR TITLE
Fix smart fades cutting off the outgoing track when vocal analysis data is stale

### DIFF
--- a/music_assistant/controllers/streams/smart_fades/planner/assembly.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/assembly.py
@@ -39,7 +39,7 @@ from music_assistant.controllers.streams.smart_fades.vocal import (
     WEIGHTED_COLLISION_LIMIT,
 )
 
-from .candidates import CandidateSpec, _nearest_protective_anchor
+from .candidates import CandidateSpec, _nearest_protective_anchor, _outgoing_vocal_end
 
 if TYPE_CHECKING:
     import logging
@@ -570,8 +570,7 @@ class EmergencyHandoffFactory:
         # RMS-audible boundary) far enough to cover any outgoing vocal the
         # handoff would cut short, AND to keep a short fade's audible trim
         # within its own overlap length
-        out_mask = ctx.vocal_out_placement
-        last_vocal_end = min(out_mask.last_end(), ctx.audio_end) if out_mask is not None else 0.0
+        last_vocal_end = _outgoing_vocal_end(ctx)
         plan0 = candidate.plan
         vocal_would_be_cut = last_vocal_end > plan0.fade_out_window + 1e-9
         overtrims_short_fade = (

--- a/music_assistant/controllers/streams/smart_fades/planner/candidates.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/candidates.py
@@ -246,7 +246,7 @@ class ProtectiveAnchorGenerator(CandidateGenerator):
         """Emit every ladder rung at the nearest anchor that doesn't truncate A's last phrase."""
         if ctx.vocal_out_placement is None or not ctx.vocal_out_placement.windows:
             return
-        target = min(ctx.vocal_out_placement.last_end(), ctx.audio_end)
+        target = _outgoing_vocal_end(ctx)
         anchor = _nearest_protective_anchor(ctx, target)
         ladder = bars_ladder(ctx, ctx.tier)
         ideal = ladder[0]
@@ -311,6 +311,30 @@ class VocalOnsetEntryGenerator(CandidateGenerator):
                 source=self.name,
                 ideal_bars=ideal,
             )
+
+
+class RescueAnchorGenerator(CandidateGenerator):
+    """Emits a modest, late-anchored rung as a last resort before the emergency handoff."""
+
+    name = "rescue-anchor"
+
+    def generate(self, ctx: TransitionContext) -> Iterable[CandidateSpec]:
+        """Emit 1-2 bar rungs anchored as late as the tail allows, never past A's own vocal end."""
+        full_ladder = bars_ladder(ctx, ctx.tier)
+        bar_seconds = ctx.outgoing.beats_per_bar * 60.0 / ctx.outgoing.bpm
+        last_vocal_end = _outgoing_vocal_end(ctx)
+        for bars in [rung for rung in full_ladder if rung <= 2]:
+            target = min(ctx.audio_end, max(ctx.audio_end - bars * bar_seconds, last_vocal_end))
+            anchor = _nearest_protective_anchor(ctx, target, prefer_earliest=False)
+            for entry in [None, *_entry_options(ctx, bars)]:
+                yield CandidateSpec(
+                    tier=ctx.tier,
+                    bars=bars,
+                    anchor_s=anchor,
+                    entry_s=entry,
+                    source=self.name,
+                    ideal_bars=full_ladder[0],
+                )
 
 
 def default_generators() -> tuple[CandidateGenerator, ...]:
@@ -797,26 +821,27 @@ class CandidateFactory:
         ctx = self._ctx
         audible_outgoing_trim = max(0.0, ctx.audio_end - plan.fade_out_window)
         anchor_on_downbeat = self._is_on_downbeat(plan.fade_out_window)
-        if ctx.vocal_out_scoring is None or ctx.vocal_in_scoring is None:
-            # deliberate extension over the old planner (which never scored the
-            # energy-only path): policies need real trim/downbeat facts on every
-            # candidate; only the vocal-dependent fields keep their defaults
-            return PlanMetrics(
-                strategy=spec.strategy,
-                audible_outgoing_trim=audible_outgoing_trim,
-                anchor_on_downbeat=anchor_on_downbeat,
+        # deliberate extension over the old planner (which never scored the
+        # energy-only path): policies need real trim/downbeat facts on every
+        # candidate; each vocal-dependent field needs only its own deck's mask
+        outgoing_vocal_fade_seconds = 0.0
+        collision_seconds = weighted_collision = 0.0
+        if ctx.vocal_out_scoring is not None:
+            outgoing_windows = self._rendered_outgoing_windows(plan)
+            in_fade = [
+                (max(0.0, left), min(plan.crossfade_duration, right))
+                for left, right in outgoing_windows
+                if right > 0.0 and left < plan.crossfade_duration
+            ]
+            outgoing_vocal_fade_seconds = sum(
+                right - left for left, right in merge_windows(in_fade)
             )
-        outgoing_windows = self._rendered_outgoing_windows(plan)
-        incoming_windows = self._rendered_incoming_windows(plan)
-        collision_seconds, weighted_collision = collision_metrics(
-            outgoing_windows, incoming_windows, plan.crossfade_duration
-        )
-        in_fade = [
-            (max(0.0, left), min(plan.crossfade_duration, right))
-            for left, right in outgoing_windows
-            if right > 0.0 and left < plan.crossfade_duration
-        ]
-        outgoing_vocal_fade_seconds = sum(right - left for left, right in merge_windows(in_fade))
+            if ctx.vocal_in_scoring is not None:
+                collision_seconds, weighted_collision = collision_metrics(
+                    outgoing_windows,
+                    self._rendered_incoming_windows(plan),
+                    plan.crossfade_duration,
+                )
         return PlanMetrics(
             strategy=spec.strategy,
             audible_outgoing_trim=audible_outgoing_trim,
@@ -949,6 +974,14 @@ def _entry_options(ctx: TransitionContext, bars: int) -> list[float]:
     if ctx.natural_entry not in options:
         options.append(ctx.natural_entry)
     return options
+
+
+def _outgoing_vocal_end(ctx: TransitionContext) -> float:
+    """Return the last outgoing vocal end within the audible tail, or 0.0 without vocal data."""
+    mask = ctx.vocal_out_placement
+    if mask is None or not mask.windows:
+        return 0.0
+    return min(mask.last_end(), ctx.audio_end)
 
 
 def _nearest_protective_anchor(

--- a/music_assistant/controllers/streams/smart_fades/planner/context.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/context.py
@@ -465,45 +465,56 @@ def _build_vocal_masks(
     buffer_offset: float,
     audio_end: float,
 ) -> tuple[VocalMask | None, VocalMask | None, VocalMask | None, VocalMask | None]:
-    """Validate and build both decks' FireRed vocal-activity masks, if the contract holds."""
+    """
+    Build each deck's placement and scoring vocal masks, per deck.
+
+    :param fade_out_analysis: Analysis row for the outgoing track.
+    :param fade_in_analysis: Analysis row for the incoming track.
+    :param outgoing: The outgoing deck, for its BPM.
+    :param incoming: The incoming deck, for its BPM.
+    :param buffer_offset: Media time where the outgoing buffer starts.
+    :param audio_end: Buffer-local RMS-audible boundary.
+
+    Returns ``(out_placement, in_placement, out_scoring, in_scoring)``; a deck
+    without a validated FireRed timeline yields ``None`` for its two masks.
+    """
     out_timeline = parse_vocal_probabilities(fade_out_analysis)
     in_timeline = parse_vocal_probabilities(fade_in_analysis)
-    if out_timeline is None or in_timeline is None:
-        return None, None, None, None
     duration = fade_out_analysis.duration or buffer_offset
     config = DEFAULT_VOCAL_CONFIG
     # the scoring variant differs only in padding: padded edges are silence,
     # so they place cuts and anchors but never count as collision
     scoring_config = replace(config, left_padding=0.0, right_padding=0.0)
-    vocal_out_placement = _build_outgoing_mask(
-        out_timeline, duration, config, outgoing, buffer_offset, audio_end
+    return (
+        _build_outgoing_mask(out_timeline, duration, config, outgoing, buffer_offset, audio_end),
+        _build_incoming_mask(in_timeline, config, incoming),
+        _build_outgoing_mask(
+            out_timeline, duration, scoring_config, outgoing, buffer_offset, audio_end
+        ),
+        _build_incoming_mask(in_timeline, scoring_config, incoming),
     )
-    vocal_out_scoring = _build_outgoing_mask(
-        out_timeline, duration, scoring_config, outgoing, buffer_offset, audio_end
-    )
-    vocal_in_placement = _build_incoming_mask(in_timeline, config, incoming)
-    vocal_in_scoring = _build_incoming_mask(in_timeline, scoring_config, incoming)
-    return vocal_out_placement, vocal_in_placement, vocal_out_scoring, vocal_in_scoring
 
 
 def _build_outgoing_mask(
-    timeline: VocalTimeline,
+    timeline: VocalTimeline | None,
     duration: float,
     config: VocalHysteresisConfig,
     outgoing: Deck,
     buffer_offset: float,
     audio_end: float,
-) -> VocalMask:
+) -> VocalMask | None:
     """
     Build the outgoing deck's buffer-local vocal mask for one config.
 
-    :param timeline: The outgoing deck's validated FireRed timeline.
+    :param timeline: The outgoing deck's validated FireRed timeline, or ``None``.
     :param duration: The outgoing track's media duration in seconds.
     :param config: Hysteresis/padding thresholds for the mask.
     :param outgoing: The outgoing deck, for its BPM.
     :param buffer_offset: Media time where the buffer starts.
     :param audio_end: Buffer-local RMS-audible boundary.
     """
+    if timeline is None:
+        return None
     media_time_mask = build_vocal_windows(
         timeline.probabilities,
         timeline.frame_duration,
@@ -524,15 +535,17 @@ def _build_outgoing_mask(
 
 
 def _build_incoming_mask(
-    timeline: VocalTimeline, config: VocalHysteresisConfig, incoming: Deck
-) -> VocalMask:
+    timeline: VocalTimeline | None, config: VocalHysteresisConfig, incoming: Deck
+) -> VocalMask | None:
     """
     Build the incoming deck's head vocal mask for one config.
 
-    :param timeline: The incoming deck's validated FireRed timeline.
+    :param timeline: The incoming deck's validated FireRed timeline, or ``None``.
     :param config: Hysteresis/padding thresholds for the mask.
     :param incoming: The incoming deck, for its BPM.
     """
+    if timeline is None:
+        return None
     return build_vocal_windows(
         timeline.probabilities,
         timeline.frame_duration,

--- a/music_assistant/controllers/streams/smart_fades/planner/planner.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/planner.py
@@ -5,7 +5,8 @@ Smart Fades - the candidate/policy transition planner.
 build the immutable ``TransitionContext``, let the generators propose
 candidate specs, build each into a timed candidate, score them all with the
 rejection/penalty policies, finalize the winner's EQ - or, when every
-candidate is rejected, ship the click-free emergency handoff. Alternative
+candidate is rejected, try a modest late-anchored rescue rung before falling
+back to the click-free emergency handoff as a last resort. Alternative
 strategies slot in as sibling ``TransitionPlanner`` subclasses.
 """
 
@@ -20,7 +21,7 @@ from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.controllers.streams.smart_fades.models import SmartFadeNotApplicable
 
 from .assembly import EmergencyHandoffFactory, PlanAssembler
-from .candidates import CandidateFactory, default_generators
+from .candidates import CandidateFactory, RescueAnchorGenerator, default_generators
 from .context import build_transition_context
 from .policies import default_policies
 from .selection import CandidateSelector
@@ -71,9 +72,9 @@ class SmartCrossFadePlanner(TransitionPlanner):
         """
         Build a smart-crossfade ``TransitionPlan`` from the two tracks' analysis.
 
-        Vocal-aware policies engage only when both tracks carry a validated
-        FireRed vocal-activity timeline; otherwise the same pipeline yields
-        the energy-only plan, with default (energy-only) metrics.
+        Vocal-aware protections engage per deck: each track with a validated
+        FireRed vocal-activity timeline gets its vocals protected, while a
+        track without one is planned on energy facts alone.
 
         :param fade_out_analysis: Analysis data for the outgoing track.
         :param fade_in_analysis: Analysis data for the incoming track.
@@ -95,9 +96,20 @@ class SmartCrossFadePlanner(TransitionPlanner):
             )
         if not candidates:
             raise SmartFadeNotApplicable("no feasible transition candidate")
-        winner = CandidateSelector(default_policies(), self.logger).select(candidates, ctx)
+        selector = CandidateSelector(default_policies(), self.logger)
+        winner = selector.select(candidates, ctx)
         if winner is None:
-            # every candidate breached a hard rejection: ship the click-free handoff
+            # every phrased candidate breached a hard rejection: try a modest,
+            # late-anchored rescue rung before falling back to the handoff
+            rescue_candidates = [
+                candidate
+                for spec in RescueAnchorGenerator().generate(ctx)
+                if (candidate := factory.build(spec)) is not None
+            ]
+            winner = selector.select(rescue_candidates, ctx) if rescue_candidates else None
+            if winner is not None:
+                self.logger.debug("shipping a rescue candidate instead of the emergency handoff")
+        if winner is None:
             self.logger.debug("shipping click-free emergency handoff")
             plan = EmergencyHandoffFactory(ctx, factory, self.logger).build()
         else:

--- a/music_assistant/controllers/streams/smart_fades/planner/policies.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/policies.py
@@ -118,13 +118,9 @@ class AudibleTrimPolicy(Policy):
         """Judge one candidate against the shared per-transition context."""
         plan = candidate.plan
         trim = candidate.metrics.audible_outgoing_trim
-        # the hard rule is vocal-protection-scoped, like the old planner's:
-        # an energy-only kick anchor legitimately trims a long audible outro
-        if (
-            ctx.vocal_out_scoring is not None
-            and plan.crossfade_duration <= self.short_fade_seconds
-            and trim > plan.crossfade_duration
-        ):
+        # missing vocal data must never disable this guard: a stale
+        # pre-vocal-analysis row would otherwise ship a huge, unprotected cut
+        if plan.crossfade_duration <= self.short_fade_seconds and trim > plan.crossfade_duration:
             return Verdict.reject("audible trim exceeds a short fade's own duration")
         return Verdict.ok(trim * self.trim_penalty_per_second)
 

--- a/music_assistant/models/audio_analysis_provider.py
+++ b/music_assistant/models/audio_analysis_provider.py
@@ -421,6 +421,26 @@ class AudioAnalysisProvider(Provider):
         # shield: a cancelled awaiter leaves the thread and its slot held until the work finishes.
         return await asyncio.shield(future)
 
+    async def _run_offloaded_timed(
+        self, func: Callable[..., _T], /, *args: Any, **kwargs: Any
+    ) -> tuple[_T, float]:
+        """
+        Run a blocking analysis function offloaded, returning its result and execution seconds.
+
+        Same slot semantics as ``_run_offloaded``; the returned seconds cover only the
+        callable's own execution, never the time spent queued for a slot.
+
+        :param func: The blocking callable to run off the event loop.
+        :param args: Positional arguments passed to func.
+        :param kwargs: Keyword arguments passed to func.
+        """
+
+        def _timed() -> tuple[_T, float]:
+            start = time.perf_counter()
+            return func(*args, **kwargs), time.perf_counter() - start
+
+        return await self._run_offloaded(_timed)
+
     async def _record_failure(
         self,
         session: AnalysisSessionData,

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -525,15 +525,16 @@ class SmartFadesProvider(AudioAnalysisProvider):
             model = self._firered_model
             if model is None:
                 raise RuntimeError("FireRed AED model is not loaded")
-            start = time.perf_counter()
+            compute_seconds = 0.0
             chunks = []
             for chunk, core_offset, core_length in split_firered_features(features):
-                chunk_probabilities = await self._run_offloaded(
-                    infer_firered_chunk,
+                chunk_probabilities, elapsed = await self._run_offloaded(
+                    self._timed_infer_firered_chunk,
                     model,
                     chunk,
                     self._device,
                 )
+                compute_seconds += elapsed
                 chunks.append(chunk_probabilities[core_offset : core_offset + core_length])
             frame_probabilities = (
                 np.concatenate(chunks) if chunks else np.empty((0, 3), dtype=np.float32)
@@ -549,8 +550,8 @@ class SmartFadesProvider(AudioAnalysisProvider):
             ) from err
         self.logger.log(
             VERBOSE_LOG_LEVEL,
-            "FireRed vocal inference: %.1fms over %d frames",
-            (time.perf_counter() - start) * 1000,
+            "FireRed vocal inference: %.1fms compute over %d frames",
+            compute_seconds * 1000,
             len(features),
         )
         return probabilities
@@ -631,6 +632,15 @@ class SmartFadesProvider(AudioAnalysisProvider):
         )
 
         return beats, downbeats, beats_per_bar
+
+    @staticmethod
+    def _timed_infer_firered_chunk(
+        model: Any, chunk: np.ndarray, device: str
+    ) -> tuple[np.ndarray, float]:
+        """Run one FireRed chunk inference, returning its probabilities and its own compute time."""
+        start = time.perf_counter()
+        probabilities = infer_firered_chunk(model, chunk, device)
+        return probabilities, time.perf_counter() - start
 
     def _clear_session_data(self, data: SmartFadesData) -> None:
         """Release all state retained for an analysis session."""

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -528,8 +528,8 @@ class SmartFadesProvider(AudioAnalysisProvider):
             compute_seconds = 0.0
             chunks = []
             for chunk, core_offset, core_length in split_firered_features(features):
-                chunk_probabilities, elapsed = await self._run_offloaded(
-                    self._timed_infer_firered_chunk,
+                chunk_probabilities, elapsed = await self._run_offloaded_timed(
+                    infer_firered_chunk,
                     model,
                     chunk,
                     self._device,
@@ -632,15 +632,6 @@ class SmartFadesProvider(AudioAnalysisProvider):
         )
 
         return beats, downbeats, beats_per_bar
-
-    @staticmethod
-    def _timed_infer_firered_chunk(
-        model: Any, chunk: np.ndarray, device: str
-    ) -> tuple[np.ndarray, float]:
-        """Run one FireRed chunk inference, returning its probabilities and its own compute time."""
-        start = time.perf_counter()
-        probabilities = infer_firered_chunk(model, chunk, device)
-        return probabilities, time.perf_counter() - start
 
     def _clear_session_data(self, data: SmartFadesData) -> None:
         """Release all state retained for an analysis session."""

--- a/tests/controllers/streams/smart_fades/test_context.py
+++ b/tests/controllers/streams/smart_fades/test_context.py
@@ -54,8 +54,64 @@ def _context(
     return build_transition_context(fade_out, fade_in, buffer, LOGGER)
 
 
+def _vocal_probabilities(duration: float, active_windows: list[tuple[float, float]]) -> list[float]:
+    """Build a probability timeline that is quiet except inside ``active_windows``."""
+    n_frames = 1800
+    frame_duration = duration / n_frames
+    probabilities = [0.05] * n_frames
+    for start, end in active_windows:
+        start_index = max(0, int(start / frame_duration))
+        end_index = min(n_frames, int(end / frame_duration) + 1)
+        for i in range(start_index, end_index):
+            probabilities[i] = 0.9
+    return probabilities
+
+
+def _with_vocal_activity(
+    analysis: AudioAnalysisData, active_windows: list[tuple[float, float]]
+) -> AudioAnalysisData:
+    """Attach a valid vocal_activity list, active only inside ``active_windows``."""
+    assert analysis.duration is not None
+    analysis.extra_data = {
+        "vocal_activity": _vocal_probabilities(analysis.duration, active_windows)
+    }
+    return analysis
+
+
 def test_context_energy_only_when_vocal_data_missing() -> None:
     """Analyses without a stored vocal-activity timeline disable all vocal-aware masks."""
+    context = _context(_analysis(120.0), _analysis(120.0))
+
+    assert context.vocal_out_placement is None
+    assert context.vocal_in_placement is None
+    assert context.vocal_out_scoring is None
+    assert context.vocal_in_scoring is None
+
+
+def test_context_builds_outgoing_masks_when_only_outgoing_timeline_is_valid() -> None:
+    """A validated outgoing-only timeline builds the outgoing masks, leaving incoming ones None."""
+    out = _with_vocal_activity(_analysis(120.0), [(220.0, 226.0)])
+    context = _context(out, _analysis(120.0))
+
+    assert context.vocal_out_placement is not None
+    assert context.vocal_out_scoring is not None
+    assert context.vocal_in_placement is None
+    assert context.vocal_in_scoring is None
+
+
+def test_context_builds_incoming_masks_when_only_incoming_timeline_is_valid() -> None:
+    """A validated incoming-only timeline builds the incoming masks, leaving outgoing ones None."""
+    inc = _with_vocal_activity(_analysis(120.0), [(10.0, 16.0)])
+    context = _context(_analysis(120.0), inc)
+
+    assert context.vocal_in_placement is not None
+    assert context.vocal_in_scoring is not None
+    assert context.vocal_out_placement is None
+    assert context.vocal_out_scoring is None
+
+
+def test_context_all_masks_none_when_both_timelines_missing() -> None:
+    """Neither side carrying a timeline still yields all four masks as None (unchanged)."""
     context = _context(_analysis(120.0), _analysis(120.0))
 
     assert context.vocal_out_placement is None
@@ -128,4 +184,10 @@ def test_context_tier_folds_kick_anchor_like_the_old_planner() -> None:
     # ...but the tier keys on the kick-folded window: only 6 downbeats fit
     # before the kick anchor, so the tail is not blendable
     assert context.tier is TransitionTier.QUICK_FADE
-    assert context.tier is SmartCrossFadePlanner(LOGGER).plan(out, inc, 45.0).tier
+    # the early anchor's rungs overtrim the audible tail and get rejected; the
+    # rescue pass re-anchors near the audible end, re-deriving the tier there
+    plan = SmartCrossFadePlanner(LOGGER).plan(out, inc, 45.0)
+    assert plan.tier is TransitionTier.FULL_BLEND
+    assert plan.fade_out_window == pytest.approx(43.0, abs=1.0)
+    assert plan.metrics.audible_outgoing_trim <= plan.crossfade_duration
+    assert plan.metrics.anchor_on_downbeat

--- a/tests/controllers/streams/smart_fades/test_generators.py
+++ b/tests/controllers/streams/smart_fades/test_generators.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any
 
 import numpy as np
+import pytest
 
 from music_assistant.controllers.streams.smart_fades.bands import build_band_profile
 from music_assistant.controllers.streams.smart_fades.models import Deck, TransitionTier
@@ -15,6 +16,7 @@ from music_assistant.controllers.streams.smart_fades.planner.candidates import (
     CodaAnchorGenerator,
     EnergyLadderGenerator,
     ProtectiveAnchorGenerator,
+    RescueAnchorGenerator,
     VocalOnsetEntryGenerator,
     _entry_options,
     default_generators,
@@ -468,6 +470,53 @@ class TestVocalOnsetEntryGenerator:
         """An onset-aligned entry landing inside a vocal window is not a legal cut."""
         ctx = _base_ctx(vocal_in_placement=VocalMask(windows=[(20.0, 25.0), (2.0, 5.0)]))
         assert list(VocalOnsetEntryGenerator().generate(ctx)) == []
+
+
+class TestRescueAnchorGenerator:
+    """The last-resort rescue rung: a modest (<=2-bar) late-anchored candidate."""
+
+    def test_emits_only_rungs_of_two_bars_or_fewer(self) -> None:
+        """The rescue ladder never proposes more than a 2-bar overlap."""
+        ctx = _base_ctx(
+            protective_downbeats=(20.0, 30.0, 39.0, 41.0),
+            audio_end=45.0,
+            vocal_out_placement=VocalMask(windows=[(0.0, 10.0)]),
+        )
+        specs = list(RescueAnchorGenerator().generate(ctx))
+
+        assert {s.bars for s in specs} == {2, 1}
+        assert all(s.source == "rescue-anchor" for s in specs)
+
+    def test_anchor_lands_near_audio_end_minus_bars_times_bar_seconds(self) -> None:
+        """Each rung's anchor snaps to the protective downbeat nearest its own late target."""
+        ctx = _base_ctx(
+            protective_downbeats=(20.0, 30.0, 39.0, 41.0),
+            audio_end=45.0,
+            vocal_out_placement=VocalMask(windows=[(0.0, 10.0)]),
+        )
+        specs = list(RescueAnchorGenerator().generate(ctx))
+
+        bar_seconds = 2.0
+        anchors_by_bars = {s.bars: s.anchor_s for s in specs}
+        assert anchors_by_bars[2] == pytest.approx(45.0 - 2 * bar_seconds)
+        assert anchors_by_bars[1] == pytest.approx(45.0 - 1 * bar_seconds)
+
+    def test_anchor_never_falls_below_the_outgoing_vocal_end(self) -> None:
+        """A late outgoing vocal floors every rung's target, so it is never truncated."""
+        ctx = _base_ctx(
+            protective_downbeats=(20.0, 30.0, 39.0, 41.0, 44.0),
+            audio_end=45.0,
+            vocal_out_placement=VocalMask(windows=[(0.0, 43.5)]),
+        )
+        specs = list(RescueAnchorGenerator().generate(ctx))
+
+        for spec in specs:
+            assert spec.anchor_s is not None
+            assert spec.anchor_s >= 43.5 - 1e-9
+
+    def test_not_part_of_default_generators(self) -> None:
+        """The rescue generator is a planner-only fallback, never part of the default set."""
+        assert RescueAnchorGenerator not in [type(g) for g in default_generators()]
 
 
 class TestDefaultGenerators:

--- a/tests/controllers/streams/smart_fades/test_planner.py
+++ b/tests/controllers/streams/smart_fades/test_planner.py
@@ -17,6 +17,7 @@ from music_assistant.controllers.streams.smart_fades.models import (
     ShelfSchedule,
     SmartFadeNotApplicable,
     TransitionPlan,
+    TransitionStrategy,
     TransitionTier,
 )
 from music_assistant.controllers.streams.smart_fades.planner import SmartCrossFadePlanner, assembly
@@ -403,6 +404,68 @@ class TestCandidateBuildGuards:
         plan = SmartCrossFadePlanner(LOGGER).plan(out, inc, 45.0)
 
         assert plan.crossfade_duration > 0.0
+
+
+def _vocal_probabilities(duration: float, active_windows: list[tuple[float, float]]) -> list[float]:
+    """Build a probability timeline that is quiet except inside ``active_windows``."""
+    n_frames = 1800
+    frame_duration = duration / n_frames
+    probabilities = [0.05] * n_frames
+    for start, end in active_windows:
+        start_index = max(0, int(start / frame_duration))
+        end_index = min(n_frames, int(end / frame_duration) + 1)
+        for i in range(start_index, end_index):
+            probabilities[i] = 0.9
+    return probabilities
+
+
+def _with_vocal_activity(
+    analysis: AudioAnalysisData, active_windows: list[tuple[float, float]]
+) -> AudioAnalysisData:
+    """Attach a valid vocal_activity list, active only inside ``active_windows``."""
+    assert analysis.duration is not None
+    analysis.extra_data = {
+        "vocal_activity": _vocal_probabilities(analysis.duration, active_windows)
+    }
+    return analysis
+
+
+class TestRescuePassBeforeEmergencyHandoff:
+    """When every regular candidate is rejected, a rescue rung ships before the handoff."""
+
+    def test_rescue_candidate_ships_instead_of_the_handoff_when_one_is_policy_clean(self) -> None:
+        """
+        An early energy mix-out overtrims every regular rung; a late rescue anchor survives.
+
+        The outro mixes out (audible but below the mix-out floor) far before the
+        RMS-audible boundary, so every regular ladder rung's audible trim busts
+        its own (short-fade) duration and gets hard-rejected. A late-anchored
+        1-2 bar rescue rung, anchored close to the audible boundary itself,
+        trims almost nothing and should ship instead of the emergency handoff.
+        """
+        bins = np.full(1800, 0.5, dtype=np.float32)
+        t = np.linspace(0, 240.0, 1800)
+        bins[t >= 208.0] = 0.2  # mixed out (audible, not silent) far before audio_end
+        out = _analysis(120.0, duration=240.0, rms_energy=bins)
+        inc = _analysis(120.0, duration=240.0)
+
+        ctx = build_transition_context(out, inc, 45.0, LOGGER)
+        plan = SmartCrossFadePlanner(LOGGER).plan(out, inc, 45.0)
+
+        assert plan.metrics.strategy is not TransitionStrategy.SHORT_VOCAL_HANDOFF
+        assert plan.crossfade_duration <= 4.0 + 1e-6
+        assert plan.fade_out_window > ctx.default_anchor
+        assert plan.metrics.audible_outgoing_trim < 1.0
+
+    def test_emergency_handoff_still_ships_when_the_rescue_pass_also_fails(self) -> None:
+        """Wall-to-wall vocal collision on both decks rejects the rescue rung too: handoff ships."""
+        out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(200.0, 239.9)])
+        inc = _with_vocal_activity(_analysis(120.0, duration=240.0), [(0.0, 40.0)])
+
+        plan = SmartCrossFadePlanner(LOGGER).plan(out, inc, 45.0)
+
+        assert plan.metrics.strategy is TransitionStrategy.SHORT_VOCAL_HANDOFF
+        assert 0.4 <= plan.crossfade_duration <= 1.0
 
 
 def _bands_pair(f_low_out: float, f_low_in: float) -> tuple[AudioAnalysisData, AudioAnalysisData]:

--- a/tests/controllers/streams/smart_fades/test_policies.py
+++ b/tests/controllers/streams/smart_fades/test_policies.py
@@ -231,6 +231,13 @@ class TestAudibleTrimPolicy:
 
         assert self.policy.evaluate(candidate, ctx).rejected is True
 
+    def test_rejects_even_when_vocal_data_is_missing(self) -> None:
+        """Missing vocal data must never disable the guard: a stale pre-vocal row still rejects."""
+        candidate = _candidate(duration=SHORT_FADE_SECONDS, trim=SHORT_FADE_SECONDS + 0.5)
+        ctx = _ctx(vocal_out_scoring=None)
+
+        assert self.policy.evaluate(candidate, ctx).rejected is True
+
     def test_no_rejection_when_trim_equals_short_fade_duration(self) -> None:
         """A short fade whose trim exactly equals its duration does not reject (strict >)."""
         candidate = _candidate(duration=SHORT_FADE_SECONDS, trim=SHORT_FADE_SECONDS)

--- a/tests/controllers/streams/smart_fades/test_vocal_aware.py
+++ b/tests/controllers/streams/smart_fades/test_vocal_aware.py
@@ -516,9 +516,28 @@ class TestMissingOrInvalidVocalDataFallsBackToEnergyOnly:
         plan = _plan(out, _analysis(120.0, duration=240.0))
         assert plan == baseline
 
-    def test_one_sided_valid_data_still_falls_back_to_energy_only(self) -> None:
-        """Valid data on only one side is not enough; both sides must validate."""
+    def test_one_sided_valid_data_engages_that_sides_protection(self) -> None:
+        """Valid data on one side engages that side's protections independently."""
         baseline = _plan(_analysis(120.0, duration=240.0), _analysis(120.0, duration=240.0))
         out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(238.0, 239.0)])
         plan = _plan(out, _analysis(120.0, duration=240.0))
-        assert plan == baseline
+        # this vocal rides the fade rather than forcing a re-anchor, so the
+        # geometry matches the energy-only baseline while the outgoing vocal
+        # is now measured; cross-deck collision needs both sides and stays 0
+        assert plan.fade_out_window == baseline.fade_out_window
+        assert plan.crossfade_duration == baseline.crossfade_duration
+        assert plan.metrics.outgoing_vocal_fade_seconds > 0.0
+        assert plan.metrics.collision_seconds == 0.0
+
+
+def test_outgoing_vocal_metrics_survive_a_missing_incoming_timeline() -> None:
+    """Outgoing-only vocal data still yields outgoing vocal metrics; collision stays neutral."""
+    out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(228.0, 230.05)])
+    inc = _analysis(120.0, duration=240.0)
+    ctx = build_transition_context(out, inc, 45.0, LOGGER)
+    candidate = CandidateFactory(ctx, LOGGER).build(
+        CandidateSpec(tier=ctx.tier, bars=8, anchor_s=None, entry_s=None)
+    )
+    assert candidate is not None
+    assert candidate.metrics.outgoing_vocal_fade_seconds > 0.0
+    assert candidate.metrics.collision_seconds == 0.0

--- a/tests/models/test_audio_analysis_provider.py
+++ b/tests/models/test_audio_analysis_provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import sqlite3
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, cast
@@ -196,6 +197,20 @@ async def test_run_offloaded_without_cap_runs_plainly() -> None:
     # The MagicMock attribute is not an asyncio.Semaphore, so this falls back to a plain thread.
     result = await provider._run_offloaded(lambda value: value * 2, 21)
     assert result == 42
+
+
+@pytest.mark.asyncio
+async def test_run_offloaded_timed_returns_result_and_execution_seconds() -> None:
+    """_run_offloaded_timed forwards args and reports the callable's own execution time."""
+    provider = _make_provider()
+
+    def _work(value: int) -> int:
+        time.sleep(0.05)
+        return value * 2
+
+    result, seconds = await provider._run_offloaded_timed(_work, 21)
+    assert result == 42
+    assert seconds >= 0.05
 
 
 @pytest.mark.asyncio

--- a/tests/providers/smart_fades/test_provider.py
+++ b/tests/providers/smart_fades/test_provider.py
@@ -18,7 +18,6 @@ from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.models.audio_analysis import AudioAnalysisData, AudioAnalysisError
 from music_assistant.providers.smart_fades.provider import SmartFadesProvider
-from music_assistant.providers.smart_fades.vocal_activity import infer_firered_chunk
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 # Synthetic 120 BPM drum pattern (kick-hat-snare-hat): 44100 Hz, stereo, float32, ~15.7s
@@ -496,12 +495,12 @@ async def test_vocal_inference_starts_before_beat_finishes(
             await asyncio.wait_for(vocal_started.wait(), timeout=1)
             beat_finished = True
             return np.array([0.0, 0.5]), np.array([0.0]), 4
-        if func is infer_firered_chunk:
+        if func is SmartFadesProvider._timed_infer_firered_chunk:
             assert beat_started.is_set()
             vocal_started.set()
             features = args[1]
             assert isinstance(features, np.ndarray)
-            return np.zeros((len(features), 3), dtype=np.float32)
+            return np.zeros((len(features), 3), dtype=np.float32), 0.0
         if func.__name__ == "_infer_musical_key":
             assert beat_finished
             return "C", "major"
@@ -530,7 +529,7 @@ async def test_final_inference_cancellation_stops_long_vocal_loop(
 
     async def run_offloaded(func: Callable[..., object], *_args: object) -> object:
         nonlocal vocal_calls
-        if func is infer_firered_chunk:
+        if func is SmartFadesProvider._timed_infer_firered_chunk:
             vocal_calls += 1
             vocal_started.set()
         await never_finish.wait()
@@ -566,7 +565,7 @@ async def test_beat_failure_cancels_vocal_inference(
             # Fail only once the vocal branch is in flight, so cancellation is observable.
             await asyncio.wait_for(vocal_started.wait(), timeout=1)
             return np.array([0.0]), np.array([]), 0
-        if func is infer_firered_chunk:
+        if func is SmartFadesProvider._timed_infer_firered_chunk:
             vocal_started.set()
             try:
                 await never_finish.wait()

--- a/tests/providers/smart_fades/test_provider.py
+++ b/tests/providers/smart_fades/test_provider.py
@@ -18,6 +18,7 @@ from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.models.audio_analysis import AudioAnalysisData, AudioAnalysisError
 from music_assistant.providers.smart_fades.provider import SmartFadesProvider
+from music_assistant.providers.smart_fades.vocal_activity import infer_firered_chunk
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 # Synthetic 120 BPM drum pattern (kick-hat-snare-hat): 44100 Hz, stereo, float32, ~15.7s
@@ -495,18 +496,24 @@ async def test_vocal_inference_starts_before_beat_finishes(
             await asyncio.wait_for(vocal_started.wait(), timeout=1)
             beat_finished = True
             return np.array([0.0, 0.5]), np.array([0.0]), 4
-        if func is SmartFadesProvider._timed_infer_firered_chunk:
+        if func is infer_firered_chunk:
             assert beat_started.is_set()
             vocal_started.set()
             features = args[1]
             assert isinstance(features, np.ndarray)
-            return np.zeros((len(features), 3), dtype=np.float32), 0.0
+            return np.zeros((len(features), 3), dtype=np.float32)
         if func.__name__ == "_infer_musical_key":
             assert beat_finished
             return "C", "major"
         raise AssertionError(f"unexpected offload: {func}")
 
-    with patch.object(provider, "_run_offloaded", side_effect=run_offloaded):
+    async def run_offloaded_timed(func: Callable[..., object], *args: object) -> object:
+        return await run_offloaded(func, *args), 0.0
+
+    with (
+        patch.object(provider, "_run_offloaded", side_effect=run_offloaded),
+        patch.object(provider, "_run_offloaded_timed", side_effect=run_offloaded_timed),
+    ):
         beat_key, vocal = await provider._run_final_inference(
             np.zeros((10, 128), dtype=np.float32),
             None,
@@ -529,13 +536,19 @@ async def test_final_inference_cancellation_stops_long_vocal_loop(
 
     async def run_offloaded(func: Callable[..., object], *_args: object) -> object:
         nonlocal vocal_calls
-        if func is SmartFadesProvider._timed_infer_firered_chunk:
+        if func is infer_firered_chunk:
             vocal_calls += 1
             vocal_started.set()
         await never_finish.wait()
         raise AssertionError("unreachable")
 
-    with patch.object(provider, "_run_offloaded", side_effect=run_offloaded):
+    async def run_offloaded_timed(func: Callable[..., object], *args: object) -> object:
+        return await run_offloaded(func, *args), 0.0
+
+    with (
+        patch.object(provider, "_run_offloaded", side_effect=run_offloaded),
+        patch.object(provider, "_run_offloaded_timed", side_effect=run_offloaded_timed),
+    ):
         task = asyncio.create_task(
             provider._run_final_inference(
                 np.zeros((10, 128), dtype=np.float32),
@@ -565,7 +578,7 @@ async def test_beat_failure_cancels_vocal_inference(
             # Fail only once the vocal branch is in flight, so cancellation is observable.
             await asyncio.wait_for(vocal_started.wait(), timeout=1)
             return np.array([0.0]), np.array([]), 0
-        if func is SmartFadesProvider._timed_infer_firered_chunk:
+        if func is infer_firered_chunk:
             vocal_started.set()
             try:
                 await never_finish.wait()
@@ -574,8 +587,12 @@ async def test_beat_failure_cancels_vocal_inference(
                 raise
         raise AssertionError(f"unexpected offload: {func}")
 
+    async def run_offloaded_timed(func: Callable[..., object], *args: object) -> object:
+        return await run_offloaded(func, *args), 0.0
+
     with (
         patch.object(provider, "_run_offloaded", side_effect=run_offloaded),
+        patch.object(provider, "_run_offloaded_timed", side_effect=run_offloaded_timed),
         pytest.raises(AudioAnalysisError, match="no rhythmic beat"),
     ):
         await asyncio.wait_for(


### PR DESCRIPTION
# What does this implement/fix?

Smart crossfades sometimes cut the outgoing track off 15-26s before its natural end, or shipped a 0.4s emergency handover where a short blend was fine. Two planner defects:

- Vocal masks were all-or-nothing: if either deck lacked a validated FireRed timeline (any track last analyzed before analysis v3), **all** vocal protections silently disabled — including the audible-trim guard — and huge cuts shipped.
- When every candidate was rejected, the planner fell straight to the 0.4s emergency handoff, even when a 1-2 bar fade at a later anchor would have passed every policy.

Changes:

- Build each deck's vocal masks independently; protections engage per deck with whatever data is available (cross-deck collision scoring still requires both decks).
- Apply the short-fade audible-trim guard regardless of vocal-data availability — missing data no longer disables protection (verified-instrumental tracks already had it).
- Add `RescueAnchorGenerator`: when every regular candidate is rejected, modest 1-2 bar fades anchored near the audible end go through full policy scoring before falling back to the emergency handoff.
- Log FireRed vocal-inference **compute** time instead of wall time — the old span included queueing behind the beat model on the single analysis permit, inflating the number ~10x.
- Per-deck vocal metrics (`outgoing_vocal_fade_seconds`) now populate with one-sided data.

Validated with a plan-level corpus A/B (20 pairs): with full vocal data on both decks, every plan is byte-identical to `dev`; with a stale side, 13 pairs recover 4-15.5s of previously cut audio and none regress to emergency handoffs.

**Related issue (if applicable):**

- related issue N/A (reported directly from listening sessions)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
