### PR TITLE
Ask Music Timeline bonuses after every placement

### DIFF
--- a/music_assistant/providers/music_quiz/answer_types/timeline.py
+++ b/music_assistant/providers/music_quiz/answer_types/timeline.py
@@ -293,24 +293,23 @@ class TimelineAnswerType(QuizAnswerType):
                 points=placement_scores.get(player_id, 0),
             )
             bonus_results: list[TimelineBonusResult] = []
-            if placement_correctness[player_id]:
-                for bonus_answer in self._bonus_answers_by_type(timeline_state, player_id).values():
-                    timestamps.append(bonus_answer.submitted_at)
-                    definition = definitions.get(bonus_answer.bonus_type)
-                    if definition is None:
-                        raise InvalidDataError("Timeline bonus answer has no matching definition")
-                    is_correct = self._is_bonus_correct(
-                        timeline_state.candidate,
-                        definition,
-                        bonus_answer,
+            for bonus_answer in self._bonus_answers_by_type(timeline_state, player_id).values():
+                timestamps.append(bonus_answer.submitted_at)
+                definition = definitions.get(bonus_answer.bonus_type)
+                if definition is None:
+                    raise InvalidDataError("Timeline bonus answer has no matching definition")
+                is_correct = self._is_bonus_correct(
+                    timeline_state.candidate,
+                    definition,
+                    bonus_answer,
+                )
+                bonus_results.append(
+                    TimelineBonusResult(
+                        bonus_type=bonus_answer.bonus_type,
+                        is_correct=is_correct,
+                        points=BONUS_POINTS if is_correct else 0,
                     )
-                    bonus_results.append(
-                        TimelineBonusResult(
-                            bonus_type=bonus_answer.bonus_type,
-                            is_correct=is_correct,
-                            points=BONUS_POINTS if is_correct else 0,
-                        )
-                    )
+                )
             pending_results[player_id] = TimelineAnswerResult(
                 placement=placement_result,
                 bonuses=sorted(bonus_results, key=lambda item: item.bonus_type.value),
@@ -563,14 +562,7 @@ class TimelineAnswerType(QuizAnswerType):
             next_entry_id=submission.next_entry_id,
             answered_at=submitted_at,
         )
-        if (
-            not self._is_correct_placement(
-                state.placement_snapshot,
-                state.candidate.entry.release_year,
-                state.placements[player_id],
-            )
-            or not state.bonus_definitions
-        ):
+        if not state.bonus_definitions:
             state.finished_at[player_id] = submitted_at
 
     def _submit_bonus_text(
@@ -637,14 +629,8 @@ class TimelineAnswerType(QuizAnswerType):
         player_id: str,
         bonus_type: TimelineBonusType,
     ) -> None:
-        """Require a correct placement and the next configured bonus."""
-        placement = self._require_placement(state, player_id)
-        if not self._is_correct_placement(
-            state.placement_snapshot,
-            state.candidate.entry.release_year,
-            placement,
-        ):
-            raise MusicQuizInvalidAnswerError("Timeline bonuses require a correct placement")
+        """Require a locked placement and the next configured bonus."""
+        self._require_placement(state, player_id)
         answered_types = self._bonus_answers_by_type(state, player_id)
         if bonus_type in answered_types:
             raise MusicQuizInvalidAnswerError(

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -3049,8 +3049,8 @@ async def test_music_timeline_ready_cancels_intermediate_auto_advance() -> None:
 
 
 @pytest.mark.asyncio
-async def test_music_timeline_finish_skips_unanswered_bonus() -> None:
-    """Keep finish as a backward-compatible way to skip a bonus."""
+async def test_music_timeline_wrong_placement_accepts_bonus_and_finish() -> None:
+    """Accept bonuses after a wrong placement and keep finish available to skip one."""
     definitions: list[TimelineBonusDefinition] = [
         TimelineFreeTextBonusDefinition(
             bonus_type=TimelineBonusType.ARTIST,
@@ -3092,8 +3092,8 @@ async def test_music_timeline_finish_skips_unanswered_bonus() -> None:
                 {
                     "answer_type": "timeline",
                     "action": "place",
-                    "previous_entry_id": "anchor",
-                    "next_entry_id": None,
+                    "previous_entry_id": None,
+                    "next_entry_id": "anchor",
                 },
             ),
         )
@@ -3119,8 +3119,10 @@ async def test_music_timeline_finish_skips_unanswered_bonus() -> None:
     game = plugin._game
     assert game is not None
     assert game.phase == MusicQuizPhase.REVEAL
-    assert game.players[player_ids["Alice"]].score == 1250
+    assert game.players[player_ids["Alice"]].score == 250
     assert revealed["you"]["answer"]["finished"] is True
+    assert revealed["you"]["answer"]["correct"] is False
+    assert revealed["you"]["answer"]["points"] == 0
     assert revealed["you"]["answer"]["bonus_results"] == [
         {"bonus_type": "artist", "correct": True, "points": 250}
     ]

--- a/tests/providers/music_quiz/test_timeline.py
+++ b/tests/providers/music_quiz/test_timeline.py
@@ -34,12 +34,10 @@ from music_assistant.providers.music_quiz.models import (
     TimelineBonusOption,
     TimelineBonusType,
     TimelineCandidate,
-    TimelineChoiceBonusAnswer,
     TimelineEntry,
     TimelineFreeTextBonusDefinition,
     TimelineMultipleChoiceBonusDefinition,
     TimelineRoundState,
-    TimelineTextBonusAnswer,
 )
 
 ANSWER_TYPE = TimelineAnswerType()
@@ -407,13 +405,20 @@ def test_reveal_always_inserts_entry_in_deterministic_order() -> None:
     assert "same-aa" not in {entry.entry_id for entry in state.placement_snapshot}
 
 
-def test_placement_locks_and_completes_immediately_without_bonuses() -> None:
-    """Lock the first valid placement and complete immediately when bonuses are off."""
+@pytest.mark.parametrize(
+    "placement",
+    [_correct_placement(), TimelinePlacementSubmission(None, "anchor")],
+    ids=["correct", "incorrect"],
+)
+def test_placement_locks_and_completes_immediately_without_bonuses(
+    placement: TimelinePlacementSubmission,
+) -> None:
+    """Lock any valid placement and complete immediately when bonuses are off."""
     state = _state()
     game = _game(state)
     player = game.players["p1"]
 
-    ANSWER_TYPE.submit(game, state, player, _correct_placement(), 12)
+    ANSWER_TYPE.submit(game, state, player, placement, 12)
 
     assert state.placements["p1"].answered_at == 12
     assert ANSWER_TYPE.is_player_complete(state, "p1") is True
@@ -421,8 +426,8 @@ def test_placement_locks_and_completes_immediately_without_bonuses() -> None:
         ANSWER_TYPE.submit(game, state, player, _correct_placement(), 13)
 
 
-def test_incorrect_placement_finishes_and_cannot_receive_bonus_results() -> None:
-    """Complete wrong placements immediately and ignore inconsistent bonus data."""
+def test_incorrect_placement_accepts_serializes_and_scores_bonuses() -> None:
+    """Offer and independently score every configured bonus after a wrong placement."""
     definitions = [
         TimelineFreeTextBonusDefinition(bonus_type=TimelineBonusType.ARTIST),
         _choice_definition(),
@@ -430,62 +435,82 @@ def test_incorrect_placement_finishes_and_cannot_receive_bonus_results() -> None
     state = _state(bonus_definitions=definitions)
     game = _game(
         state,
-        ("text", "choice"),
         artist_mode=TimelineBonusMode.FREE_TEXT,
         title_mode=TimelineBonusMode.MULTIPLE_CHOICE,
     )
+    player = game.players["p1"]
     wrong_placement = TimelinePlacementSubmission(None, "anchor")
-    for player_id, submitted_at in (("text", 1.0), ("choice", 2.0)):
-        ANSWER_TYPE.submit(
-            game,
-            state,
-            game.players[player_id],
-            wrong_placement,
-            submitted_at,
-        )
-        assert state.finished_at[player_id] == submitted_at
+    ANSWER_TYPE.submit(game, state, player, wrong_placement, 1)
 
     personal = cast(
         "dict[str, Any]",
-        ANSWER_TYPE.serialize_personal_player(state, "text", revealed=False),
+        ANSWER_TYPE.serialize_personal_player(state, "p1", revealed=False),
     )
-    assert personal["answer"]["finished"] is True
-    rejected_submissions = {
-        "text": TimelineBonusTextSubmission(TimelineBonusType.ARTIST, "Artist"),
-        "choice": TimelineBonusChoiceSubmission(TimelineBonusType.TITLE, "correct-option"),
-    }
-    for player_id, submission in rejected_submissions.items():
-        with pytest.raises(MusicQuizInvalidAnswerError, match="after finishing"):
-            ANSWER_TYPE.submit(game, state, game.players[player_id], submission, 3)
-
-    state.finished_at.clear()
-    for player_id, submission in rejected_submissions.items():
-        with pytest.raises(MusicQuizInvalidAnswerError, match="correct placement"):
-            ANSWER_TYPE.submit(game, state, game.players[player_id], submission, 3)
-
-    state.finished_at.update({"text": 1.0, "choice": 2.0})
-    state.bonus_answers = {
-        "text": [
-            TimelineTextBonusAnswer(
-                bonus_type=TimelineBonusType.ARTIST,
-                submitted_at=3,
-                value="Current Secret Artist",
-            )
-        ],
-        "choice": [
-            TimelineChoiceBonusAnswer(
-                bonus_type=TimelineBonusType.TITLE,
-                submitted_at=4,
-                option_id="correct-option",
-            )
-        ],
+    assert ANSWER_TYPE.is_player_complete(state, "p1") is False
+    assert personal["answer"] == {
+        "previous_entry_id": None,
+        "next_entry_id": "anchor",
+        "answered_at": 1,
+        "bonuses": [],
+        "finished": False,
     }
 
+    ANSWER_TYPE.submit(
+        game,
+        state,
+        player,
+        TimelineBonusTextSubmission(TimelineBonusType.ARTIST, "Wrong Artist"),
+        2,
+    )
+    ANSWER_TYPE.submit(
+        game,
+        state,
+        player,
+        TimelineBonusChoiceSubmission(TimelineBonusType.TITLE, "correct-option"),
+        3,
+    )
+
+    assert ANSWER_TYPE.serialize_public_player(state, "p1", revealed=False) == {
+        "answered": True,
+        "placed": True,
+        "artist_bonus_answered": True,
+        "title_bonus_answered": True,
+    }
     ended_at = ANSWER_TYPE.reveal(game, state)
 
-    assert ended_at == 2.0
-    assert all(not result.bonuses for result in state.results.values())
-    assert all(player.score == 0 for player in game.players.values())
+    assert ended_at == 3
+    result = state.results["p1"]
+    assert result.placement.is_correct is False
+    assert result.placement.points == 0
+    assert [(bonus.bonus_type, bonus.is_correct, bonus.points) for bonus in result.bonuses] == [
+        (TimelineBonusType.ARTIST, False, 0),
+        (TimelineBonusType.TITLE, True, 250),
+    ]
+    assert player.score == 250
+    public = cast(
+        "dict[str, Any]",
+        ANSWER_TYPE.serialize_public_player(state, "p1", revealed=True),
+    )
+    assert public["last_answer"] == {
+        "placement": {
+            "previous_entry_id": None,
+            "next_entry_id": "anchor",
+            "correct": False,
+            "points": 0,
+        },
+        "artist": {"correct": False, "points": 0},
+        "title": {"correct": True, "points": 250},
+    }
+    personal = cast(
+        "dict[str, Any]",
+        ANSWER_TYPE.serialize_personal_player(state, "p1", revealed=True),
+    )
+    assert personal["answer"]["correct"] is False
+    assert personal["answer"]["points"] == 0
+    assert personal["answer"]["bonus_results"] == [
+        {"bonus_type": "artist", "correct": False, "points": 0},
+        {"bonus_type": "title", "correct": True, "points": 250},
+    ]
 
 
 def test_final_configured_bonus_completes_at_submission_timestamp() -> None:
@@ -734,7 +759,7 @@ def test_artist_choice_and_title_text_modes_score_independently() -> None:
 
 
 def test_reveal_scores_speed_ranked_placements_and_fixed_bonuses() -> None:
-    """Rank only correct placements by speed and award 250 per correct bonus."""
+    """Rank only correct placements by speed and score bonuses independently."""
     definitions = [
         TimelineFreeTextBonusDefinition(
             bonus_type=TimelineBonusType.ARTIST,
@@ -771,18 +796,20 @@ def test_reveal_scores_speed_ranked_placements_and_fixed_bonuses() -> None:
         TimelineBonusChoiceSubmission(TimelineBonusType.TITLE, "correct-option"),
         5,
     )
-    state.bonus_answers["p2"] = [
-        TimelineTextBonusAnswer(
-            bonus_type=TimelineBonusType.ARTIST,
-            submitted_at=2,
-            value="wrong",
-        ),
-        TimelineChoiceBonusAnswer(
-            bonus_type=TimelineBonusType.TITLE,
-            submitted_at=3,
-            option_id="correct-option",
-        ),
-    ]
+    ANSWER_TYPE.submit(
+        game,
+        state,
+        game.players["p2"],
+        TimelineBonusTextSubmission(TimelineBonusType.ARTIST, "wrong"),
+        2,
+    )
+    ANSWER_TYPE.submit(
+        game,
+        state,
+        game.players["p2"],
+        TimelineBonusChoiceSubmission(TimelineBonusType.TITLE, "correct-option"),
+        3,
+    )
     ANSWER_TYPE.submit(game, state, game.players["p3"], TimelineFinishSubmission(), 6)
 
     ended_at = ANSWER_TYPE.reveal(game, state)
@@ -792,9 +819,9 @@ def test_reveal_scores_speed_ranked_placements_and_fixed_bonuses() -> None:
     assert state.results["p1"].placement.points == 500
     assert state.results["p2"].placement.points == 0
     assert [result.points for result in state.results["p1"].bonuses] == [250, 250]
-    assert state.results["p2"].bonuses == []
+    assert [result.points for result in state.results["p2"].bonuses] == [0, 250]
     assert game.players["p1"].score == 1000
-    assert game.players["p2"].score == 0
+    assert game.players["p2"].score == 250
     assert game.players["p3"].score == 1000
 
 


### PR DESCRIPTION
# What does this implement/fix?

Music Timeline only offered artist and title bonuses after a correct placement, so those questions could be skipped entirely.

- Offer configured bonuses after every placement
- Score placement and bonus answers independently
- Keep finish and skip behavior unchanged

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked: https://github.com/music-assistant/frontend/pull/2149
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
