### PR TITLE
Improve remote connection stability

### DIFF
--- a/music_assistant/controllers/webserver/remote_access/__init__.py
+++ b/music_assistant/controllers/webserver/remote_access/__init__.py
@@ -8,6 +8,7 @@ bridging them to the local WebSocket API.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
@@ -63,10 +64,12 @@ class RemoteAccessManager:
         self.mass = webserver.mass
         self.logger = webserver.logger.getChild("remote_access")
         self.gateway: WebRTCGateway | None = None
+        self._gateway_lock = asyncio.Lock()
         self._remote_id: str
         self._certificate: RTCCertificate
         self._enabled: bool = False
         self._using_ha_cloud: bool = False
+        self._target_using_ha_cloud: bool = False
         self._on_unload_callbacks: list[Callable[[], None]] = []
 
     async def setup(self) -> None:
@@ -80,20 +83,21 @@ class RemoteAccessManager:
         self._register_api_commands()
         self.mass.subscribe(self._on_providers_updated, EventType.PROVIDERS_UPDATED)
         if self._enabled:
-            await self._schedule_start()
+            self._schedule_start()
 
     async def close(self) -> None:
         """Cleanup on exit."""
-        self.mass.cancel_timer(TASK_ID_START_GATEWAY)
+        self._enabled = False
         await self.stop()
         for unload_cb in self._on_unload_callbacks:
             unload_cb()
 
     async def stop(self) -> None:
         """Stop the remote access gateway."""
-        if self.gateway:
-            await self.gateway.stop()
-            self.gateway = None
+        self.mass.cancel_timer(TASK_ID_START_GATEWAY)
+        self.mass.cancel_task(TASK_ID_START_GATEWAY)
+        async with self._gateway_lock:
+            await self._stop_gateway_locked()
 
     async def get_ice_servers(self) -> list[dict[str, str]]:
         """
@@ -143,25 +147,49 @@ class RemoteAccessManager:
         """Return the persistent WebRTC DTLS certificate."""
         return self._certificate
 
-    async def _schedule_start(self) -> None:
-        """Schedule a debounced gateway start, cancelling any existing connection first."""
-        # Cancel any pending timer
+    def _schedule_start(self) -> None:
+        """Schedule a debounced gateway restart."""
         self.mass.cancel_timer(TASK_ID_START_GATEWAY)
-        # Stop any existing gateway
-        await self.stop()
-        # Schedule new start
         self.logger.debug("Scheduling remote access gateway start in %s seconds", STARTUP_DELAY)
         self.mass.call_later(
             STARTUP_DELAY,
-            self._start_gateway,
+            self._restart_gateway,
             task_id=TASK_ID_START_GATEWAY,
         )
 
+    def _can_start_gateway(self) -> bool:
+        """Return whether remote access currently allows a gateway start."""
+        return self._enabled
+
     async def _start_gateway(self) -> None:
-        """Start the remote access gateway (internal implementation)."""
-        if not self._enabled:
+        """Start the remote access gateway if it is not already running."""
+        self.mass.cancel_timer(TASK_ID_START_GATEWAY)
+        async with self._gateway_lock:
+            if self.is_running:
+                self.logger.debug("Remote access gateway is already running")
+                return
+            await self._start_gateway_locked()
+
+    async def _restart_gateway(self) -> None:
+        """Replace the remote access gateway with a freshly configured instance."""
+        async with self._gateway_lock:
+            if self.is_running:
+                ha_cloud_available, ice_servers = await self._get_ha_cloud_status()
+                self._target_using_ha_cloud = bool(ha_cloud_available and ice_servers)
+                if self._target_using_ha_cloud == self._using_ha_cloud:
+                    self.logger.debug("Remote access mode settled before restart")
+                    return
+            await self._stop_gateway_locked()
+            await self._start_gateway_locked()
+
+    async def _start_gateway_locked(self) -> None:
+        """Start the remote access gateway while holding the lifecycle lock."""
+        if not self._can_start_gateway():
             self.logger.debug("Remote access disabled, skipping start")
             return
+
+        if self.gateway is not None:
+            await self._stop_gateway_locked()
 
         # imported here (and the certificate built here) so aiortc/PyAV is only
         # loaded when remote access is actually enabled, never at idle
@@ -178,14 +206,18 @@ class RemoteAccessManager:
         local_ws_url += "ws"
 
         ha_cloud_available, ice_servers = await self._get_ha_cloud_status()
-        self._using_ha_cloud = bool(ha_cloud_available and ice_servers)
+        using_ha_cloud = bool(ha_cloud_available and ice_servers)
+        self._target_using_ha_cloud = using_ha_cloud
+        if not self._can_start_gateway():
+            self.logger.debug("Remote access disabled while preparing gateway")
+            return
 
-        mode = "optimized" if self._using_ha_cloud else "basic"
+        mode = "optimized" if using_ha_cloud else "basic"
         self.logger.info("Starting remote access in %s mode", mode)
 
         sendspin_url = f"ws://{format_ip_for_url(str(self.mass.streams.publish_ip))}:8927/sendspin"
 
-        self.gateway = WebRTCGateway(
+        gateway = WebRTCGateway(
             http_session=self.mass.http_session,
             remote_id=self._remote_id,
             certificate=self._certificate,
@@ -200,7 +232,24 @@ class RemoteAccessManager:
             set_sendspin_player_callback=self.webserver.set_sendspin_player_for_webrtc_session,
         )
 
-        await self.gateway.start()
+        try:
+            await gateway.start()
+        except BaseException:
+            await gateway.stop()
+            raise
+        if not self._can_start_gateway():
+            await gateway.stop()
+            return
+        self.gateway = gateway
+        self._using_ha_cloud = using_ha_cloud
+
+    async def _stop_gateway_locked(self) -> None:
+        """Stop the remote access gateway while holding the lifecycle lock."""
+        if self.gateway is None:
+            return
+        gateway = self.gateway
+        await gateway.stop()
+        self.gateway = None
 
     async def _on_providers_updated(self, event: MassEvent) -> None:
         """
@@ -215,9 +264,10 @@ class RemoteAccessManager:
         ha_cloud_available, ice_servers = await self._get_ha_cloud_status()
         new_using_ha_cloud = bool(ha_cloud_available and ice_servers)
 
-        if new_using_ha_cloud != self._using_ha_cloud:
+        if new_using_ha_cloud != self._target_using_ha_cloud:
+            self._target_using_ha_cloud = new_using_ha_cloud
             self.logger.info("HA Cloud status changed, restarting remote access")
-            await self._schedule_start()
+            self._schedule_start()
 
     async def _get_ha_cloud_status(self) -> tuple[bool, list[dict[str, str]] | None]:
         """
@@ -279,7 +329,7 @@ class RemoteAccessManager:
             self.mass.config.set(f"{CONF_CORE}/{CONF_KEY_MAIN}/{CONF_ENABLED}", enabled)
             if self._enabled and not self.is_running:
                 await self._start_gateway()
-            elif not self._enabled and self.is_running:
+            elif not self._enabled:
                 await self.stop()
             if changed:
                 self.mass.signal_event(

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -44,15 +44,19 @@ class WebRTCSession:
     data_channel: Any = None
     local_ws: Any = None
     message_queue: asyncio.Queue[str] = field(default_factory=asyncio.Queue)
+    data_channel_setup_task: asyncio.Task[None] | None = None
     forward_to_local_task: asyncio.Task[None] | None = None
     forward_from_local_task: asyncio.Task[None] | None = None
+    data_channel_active: bool = False
     # Sendspin channel - bridges to internal sendspin server
     sendspin_channel: Any = None
     sendspin_ws: Any = None
     sendspin_queue: asyncio.Queue[str | bytes] = field(default_factory=asyncio.Queue)
     sendspin_player_id: str | None = None  # Extracted from first sendspin auth message
+    sendspin_setup_task: asyncio.Task[None] | None = None
     sendspin_to_local_task: asyncio.Task[None] | None = None
     sendspin_from_local_task: asyncio.Task[None] | None = None
+    sendspin_channel_active: bool = False
 
 
 class WebRTCGateway:
@@ -405,10 +409,28 @@ class WebRTCGateway:
         def on_datachannel(channel: Any) -> None:
             if channel.label == "sendspin":
                 session.sendspin_channel = channel
+                session.sendspin_channel_active = True
+                self._register_sendspin_channel_handlers(session)
                 task = asyncio.create_task(self._setup_sendspin_channel(session))
+                session.sendspin_setup_task = task
+
+                def clear_setup_task(completed_task: asyncio.Task[None]) -> None:
+                    if session.sendspin_setup_task is completed_task:
+                        session.sendspin_setup_task = None
+
+                task.add_done_callback(clear_setup_task)
             else:
                 session.data_channel = channel
+                session.data_channel_active = True
+                self._register_data_channel_handlers(session)
                 task = asyncio.create_task(self._setup_data_channel(session))
+                session.data_channel_setup_task = task
+
+                def clear_data_setup_task(completed_task: asyncio.Task[None]) -> None:
+                    if session.data_channel_setup_task is completed_task:
+                        session.data_channel_setup_task = None
+
+                task.add_done_callback(clear_data_setup_task)
             self._background_tasks.add(task)
             task.add_done_callback(self._background_tasks.discard)
 
@@ -557,26 +579,87 @@ class WebRTCGateway:
             # Include session_id in URL so server can track WebRTC sessions
             ws_url = f"{self.local_ws_url}?webrtc_session_id={session.session_id}"
             session.local_ws = await self.http_session.ws_connect(ws_url)
-            loop = asyncio.get_event_loop()
+            if not session.data_channel_active:
+                await self._close_data_channel_bridge(session)
+                return
 
             # Store task references for proper cleanup
             session.forward_to_local_task = asyncio.create_task(self._forward_to_local(session))
             session.forward_from_local_task = asyncio.create_task(self._forward_from_local(session))
-
-            @channel.on("message")  # type: ignore[untyped-decorator]
-            def on_message(message: str) -> None:
-                # Called from aiortc thread, use call_soon_threadsafe
-                # Only queue message if session is still active
-                if session.forward_to_local_task and not session.forward_to_local_task.done():
-                    loop.call_soon_threadsafe(session.message_queue.put_nowait, message)
-
-            @channel.on("close")  # type: ignore[untyped-decorator]
-            def on_close() -> None:
-                # Called from aiortc thread, use call_soon_threadsafe to schedule task
-                asyncio.run_coroutine_threadsafe(self._close_session(session.session_id), loop)
-
         except Exception:
             self.logger.exception("Failed to connect to local WebSocket")
+            await self._close_data_channel_bridge(session)
+            channel.close()
+
+    def _register_data_channel_handlers(self, session: WebRTCSession) -> None:
+        """
+        Register API handlers before the remote peer can send its first message.
+
+        :param session: The WebRTC session.
+        """
+        channel = session.data_channel
+        if channel is None:
+            return
+        loop = asyncio.get_running_loop()
+
+        @channel.on("message")  # type: ignore[untyped-decorator]
+        def on_message(message: str) -> None:
+            def enqueue_message() -> None:
+                if not session.data_channel_active:
+                    return
+                if (
+                    session.forward_to_local_task is None
+                    or not session.forward_to_local_task.done()
+                ):
+                    session.message_queue.put_nowait(message)
+
+            loop.call_soon_threadsafe(enqueue_message)
+
+        @channel.on("close")  # type: ignore[untyped-decorator]
+        def on_close() -> None:
+            session.data_channel_active = False
+
+            def schedule_close() -> None:
+                if session.session_id not in self.sessions:
+                    return
+                task = asyncio.create_task(self._close_session(session.session_id))
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
+
+            loop.call_soon_threadsafe(schedule_close)
+
+    async def _close_data_channel_bridge(self, session: WebRTCSession) -> None:
+        """
+        Close the local API bridge for a WebRTC session.
+
+        :param session: The WebRTC session.
+        """
+        session.data_channel_active = False
+        current_task = asyncio.current_task()
+        tasks = [
+            task
+            for task in (
+                session.data_channel_setup_task,
+                session.forward_to_local_task,
+                session.forward_from_local_task,
+            )
+            if task is not None and task is not current_task
+        ]
+        local_ws = session.local_ws
+        session.data_channel_setup_task = None
+        session.forward_to_local_task = None
+        session.forward_from_local_task = None
+        session.local_ws = None
+        session.message_queue = asyncio.Queue()
+
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        for task in tasks:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        if local_ws and not local_ws.closed:
+            await local_ws.close()
 
     async def _forward_to_local(self, session: WebRTCSession) -> None:
         """
@@ -697,33 +780,10 @@ class WebRTCGateway:
         if not session:
             return
 
-        # Cancel forwarding tasks first to prevent race conditions
-        if session.forward_to_local_task and not session.forward_to_local_task.done():
-            session.forward_to_local_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await session.forward_to_local_task
-
-        if session.forward_from_local_task and not session.forward_from_local_task.done():
-            session.forward_from_local_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await session.forward_from_local_task
-
-        # Cancel sendspin forwarding tasks
-        if session.sendspin_to_local_task and not session.sendspin_to_local_task.done():
-            session.sendspin_to_local_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await session.sendspin_to_local_task
-
-        if session.sendspin_from_local_task and not session.sendspin_from_local_task.done():
-            session.sendspin_from_local_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await session.sendspin_from_local_task
+        await self._close_data_channel_bridge(session)
+        await self._close_sendspin_bridge(session)
 
         # Close connections
-        if session.local_ws and not session.local_ws.closed:
-            await session.local_ws.close()
-        if session.sendspin_ws and not session.sendspin_ws.closed:
-            await session.sendspin_ws.close()
         if session.data_channel:
             session.data_channel.close()
         if session.sendspin_channel:
@@ -741,25 +801,11 @@ class WebRTCGateway:
             return
 
         try:
-            loop = asyncio.get_event_loop()
-
-            @channel.on("message")  # type: ignore[untyped-decorator]
-            def on_message(message: str | bytes) -> None:
-                # Queue if task not yet created (None) or still running.
-                # Only drop when task exists and is done (shutdown).
-                if (
-                    session.sendspin_to_local_task is None
-                    or not session.sendspin_to_local_task.done()
-                ):
-                    loop.call_soon_threadsafe(session.sendspin_queue.put_nowait, message)
-
-            @channel.on("close")  # type: ignore[untyped-decorator]
-            def on_close() -> None:
-                if session.sendspin_ws and not session.sendspin_ws.closed:
-                    asyncio.run_coroutine_threadsafe(session.sendspin_ws.close(), loop)
-
             session.sendspin_ws = await self.http_session.ws_connect(self.sendspin_url)
             self.logger.debug("Sendspin channel connected for session %s", session.session_id)
+            if not session.sendspin_channel_active:
+                await self._close_sendspin_bridge(session)
+                return
 
             # Start forwarding tasks - queued messages will be processed
             session.sendspin_to_local_task = asyncio.create_task(
@@ -774,13 +820,78 @@ class WebRTCGateway:
                 "Failed to connect sendspin channel to internal server for session %s",
                 session.session_id,
             )
-            # Clean up partial state on failure
-            if session.sendspin_to_local_task:
-                session.sendspin_to_local_task.cancel()
-            if session.sendspin_from_local_task:
-                session.sendspin_from_local_task.cancel()
-            if session.sendspin_ws and not session.sendspin_ws.closed:
-                await session.sendspin_ws.close()
+            await self._close_sendspin_bridge(session)
+            channel.close()
+
+    def _register_sendspin_channel_handlers(self, session: WebRTCSession) -> None:
+        """
+        Register Sendspin handlers before the remote peer can send its first message.
+
+        :param session: The WebRTC session.
+        """
+        channel = session.sendspin_channel
+        if channel is None:
+            return
+        loop = asyncio.get_running_loop()
+
+        @channel.on("message")  # type: ignore[untyped-decorator]
+        def on_message(message: str | bytes) -> None:
+            def enqueue_message() -> None:
+                if not session.sendspin_channel_active:
+                    return
+                if (
+                    session.sendspin_to_local_task is None
+                    or not session.sendspin_to_local_task.done()
+                ):
+                    session.sendspin_queue.put_nowait(message)
+
+            loop.call_soon_threadsafe(enqueue_message)
+
+        @channel.on("close")  # type: ignore[untyped-decorator]
+        def on_close() -> None:
+            session.sendspin_channel_active = False
+
+            def schedule_cleanup() -> None:
+                if session.session_id not in self.sessions:
+                    return
+                task = asyncio.create_task(self._close_sendspin_bridge(session))
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
+
+            loop.call_soon_threadsafe(schedule_cleanup)
+
+    async def _close_sendspin_bridge(self, session: WebRTCSession) -> None:
+        """
+        Close the internal Sendspin bridge for a WebRTC session.
+
+        :param session: The WebRTC session.
+        """
+        session.sendspin_channel_active = False
+        current_task = asyncio.current_task()
+        tasks = [
+            task
+            for task in (
+                session.sendspin_setup_task,
+                session.sendspin_to_local_task,
+                session.sendspin_from_local_task,
+            )
+            if task is not None and task is not current_task
+        ]
+        sendspin_ws = session.sendspin_ws
+        session.sendspin_setup_task = None
+        session.sendspin_to_local_task = None
+        session.sendspin_from_local_task = None
+        session.sendspin_ws = None
+        session.sendspin_queue = asyncio.Queue()
+
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        for task in tasks:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        if sendspin_ws and not sendspin_ws.closed:
+            await sendspin_ws.close()
 
     async def _forward_sendspin_to_local(self, session: WebRTCSession) -> None:
         """

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -1,6 +1,9 @@
 """Tests for remote access feature."""
 
+import asyncio
 import base64
+from collections.abc import Callable
+from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
 from urllib.parse import urlparse
 
@@ -8,7 +11,12 @@ import pytest
 from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection
 from aiortc.rtcdtlstransport import RTCCertificate
 
-from music_assistant.controllers.webserver.remote_access import RemoteAccessInfo
+from music_assistant.controllers.webserver.remote_access import (
+    STARTUP_DELAY,
+    TASK_ID_START_GATEWAY,
+    RemoteAccessInfo,
+    RemoteAccessManager,
+)
 from music_assistant.controllers.webserver.remote_access.gateway import (
     WebRTCGateway,
     WebRTCSession,
@@ -79,6 +87,128 @@ async def test_remote_access_info_dataclass() -> None:
     assert info.remote_id == "VVPN3TLP34YMGIZDINCEKQKSIR"
     assert info.using_ha_cloud is False
     assert info.signaling_url == "wss://signaling.music-assistant.io/ws"
+
+
+def _create_remote_access_manager() -> RemoteAccessManager:
+    """Create an enabled remote access manager with mocked dependencies."""
+    webserver = Mock()
+    webserver.mass = Mock()
+    webserver.logger = Mock()
+    manager = RemoteAccessManager(webserver)
+    manager._enabled = True
+    return manager
+
+
+def test_remote_access_debounces_restart_without_dropping_gateway() -> None:
+    """Keep the active gateway connected while a replacement is being debounced."""
+    manager = _create_remote_access_manager()
+    gateway = Mock()
+    gateway.stop = AsyncMock()
+    manager.gateway = gateway
+
+    manager._schedule_start()
+
+    gateway.stop.assert_not_awaited()
+    cast("Mock", manager.mass.cancel_timer).assert_called_once_with(TASK_ID_START_GATEWAY)
+    cast("Mock", manager.mass.call_later).assert_called_once_with(
+        STARTUP_DELAY,
+        manager._restart_gateway,
+        task_id=TASK_ID_START_GATEWAY,
+    )
+
+
+async def test_remote_access_stop_cancels_pending_restart() -> None:
+    """Cancel a restart after its debounce timer has promoted it to a task."""
+    manager = _create_remote_access_manager()
+    gateway = Mock()
+    gateway.stop = AsyncMock()
+    manager.gateway = gateway
+
+    await manager.stop()
+
+    cast("Mock", manager.mass.cancel_timer).assert_called_once_with(TASK_ID_START_GATEWAY)
+    cast("Mock", manager.mass.cancel_task).assert_called_once_with(TASK_ID_START_GATEWAY)
+    gateway.stop.assert_awaited_once_with()
+    assert manager.gateway is None
+
+
+async def test_remote_access_serializes_concurrent_starts() -> None:
+    """Create only one gateway when immediate start requests overlap."""
+    manager = _create_remote_access_manager()
+    start_entered = asyncio.Event()
+    allow_start = asyncio.Event()
+    gateway = Mock()
+    gateway.is_running = True
+
+    async def start_gateway() -> None:
+        start_entered.set()
+        await allow_start.wait()
+        manager.gateway = gateway
+
+    with patch.object(
+        manager,
+        "_start_gateway_locked",
+        new=AsyncMock(side_effect=start_gateway),
+    ) as start_gateway_locked:
+        first_start = asyncio.create_task(manager._start_gateway())
+        await start_entered.wait()
+        second_start = asyncio.create_task(manager._start_gateway())
+        await asyncio.sleep(0)
+        allow_start.set()
+        await asyncio.gather(first_start, second_start)
+
+    start_gateway_locked.assert_awaited_once()
+
+
+async def test_remote_access_provider_update_storm_schedules_one_restart() -> None:
+    """Schedule one restart when concurrent provider updates detect the same mode change."""
+    manager = _create_remote_access_manager()
+    ice_servers = [{"urls": "turn:example.com"}]
+
+    with (
+        patch.object(
+            manager,
+            "_get_ha_cloud_status",
+            new=AsyncMock(return_value=(True, ice_servers)),
+        ),
+        patch.object(manager, "_schedule_start") as schedule_start,
+    ):
+        await asyncio.gather(*(manager._on_providers_updated(Mock()) for _ in range(10)))
+
+    schedule_start.assert_called_once_with()
+    assert manager._target_using_ha_cloud is True
+
+
+async def test_remote_access_skips_restart_after_mode_flap_settles() -> None:
+    """Keep the current gateway when a fresh status check matches its active mode."""
+    manager = _create_remote_access_manager()
+    gateway = Mock()
+    gateway.is_running = True
+    manager.gateway = gateway
+    manager._target_using_ha_cloud = True
+
+    with (
+        patch.object(
+            manager,
+            "_get_ha_cloud_status",
+            new=AsyncMock(return_value=(False, None)),
+        ),
+        patch.object(
+            manager,
+            "_stop_gateway_locked",
+            new=AsyncMock(),
+        ) as stop_gateway,
+        patch.object(
+            manager,
+            "_start_gateway_locked",
+            new=AsyncMock(),
+        ) as start_gateway,
+    ):
+        await manager._restart_gateway()
+
+    stop_gateway.assert_not_awaited()
+    start_gateway.assert_not_awaited()
+    assert manager._target_using_ha_cloud is False
 
 
 async def test_webrtc_gateway_initialization(mock_certificate: Mock) -> None:
@@ -272,6 +402,304 @@ async def test_webrtc_gateway_handle_client_disconnected(mock_certificate: Mock)
 
     # Session should be removed
     assert session_id not in gateway.sessions
+
+
+async def test_sendspin_handler_queues_message_before_setup_runs(
+    mock_certificate: Mock,
+) -> None:
+    """Queue the first Sendspin message as soon as its data channel is announced."""
+    gateway = WebRTCGateway(
+        http_session=Mock(),
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+    )
+    session_id = "sendspin-session"
+    await gateway._create_session(session_id)
+    session = gateway.sessions[session_id]
+    callbacks: dict[str, Callable[..., None]] = {}
+    channel = Mock()
+    channel.label = "sendspin"
+
+    def register_callback(
+        event: str,
+    ) -> Callable[[Callable[..., None]], Callable[..., None]]:
+        def decorator(callback: Callable[..., None]) -> Callable[..., None]:
+            callbacks[event] = callback
+            return callback
+
+        return decorator
+
+    channel.on.side_effect = register_callback
+
+    try:
+        with patch.object(gateway, "_setup_sendspin_channel", new=AsyncMock()):
+            session.peer_connection.emit("datachannel", channel)
+            message = '{"type":"auth","client_id":"web-player"}'
+            callbacks["message"](message)
+            await asyncio.sleep(0)
+            assert session.sendspin_queue.get_nowait() == message
+    finally:
+        await gateway._close_session(session_id)
+
+
+async def test_api_handler_queues_message_before_setup_runs(
+    mock_certificate: Mock,
+) -> None:
+    """Queue the first API message as soon as its data channel is announced."""
+    gateway = WebRTCGateway(
+        http_session=Mock(),
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+    )
+    session_id = "api-session"
+    await gateway._create_session(session_id)
+    session = gateway.sessions[session_id]
+    callbacks: dict[str, Callable[..., None]] = {}
+    channel = Mock()
+    channel.label = "ma-api"
+
+    def register_callback(
+        event: str,
+    ) -> Callable[[Callable[..., None]], Callable[..., None]]:
+        def decorator(callback: Callable[..., None]) -> Callable[..., None]:
+            callbacks[event] = callback
+            return callback
+
+        return decorator
+
+    channel.on.side_effect = register_callback
+
+    try:
+        with patch.object(gateway, "_setup_data_channel", new=AsyncMock()):
+            session.peer_connection.emit("datachannel", channel)
+            message = '{"command":"server/info"}'
+            callbacks["message"](message)
+            await asyncio.sleep(0)
+            assert session.message_queue.get_nowait() == message
+    finally:
+        await gateway._close_session(session_id)
+
+
+async def test_sendspin_setup_failure_stops_accepting_messages(
+    mock_certificate: Mock,
+) -> None:
+    """Drop queued and future messages when the internal audio bridge cannot connect."""
+    http_session = Mock()
+    http_session.ws_connect = AsyncMock(side_effect=RuntimeError("connection failed"))
+    gateway = WebRTCGateway(
+        http_session=http_session,
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+    )
+    session = WebRTCSession(session_id="sendspin-session", peer_connection=Mock())
+    callbacks: dict[str, Callable[..., None]] = {}
+    channel = Mock()
+    session.sendspin_channel = channel
+    session.sendspin_channel_active = True
+
+    def register_callback(
+        event: str,
+    ) -> Callable[[Callable[..., None]], Callable[..., None]]:
+        def decorator(callback: Callable[..., None]) -> Callable[..., None]:
+            callbacks[event] = callback
+            return callback
+
+        return decorator
+
+    channel.on.side_effect = register_callback
+    gateway._register_sendspin_channel_handlers(session)
+    callbacks["message"]("queued before setup")
+    await asyncio.sleep(0)
+    assert session.sendspin_queue.qsize() == 1
+
+    await gateway._setup_sendspin_channel(session)
+    callbacks["message"]("sent after failure")
+    await asyncio.sleep(0)
+
+    assert session.sendspin_channel_active is False
+    assert session.sendspin_queue.empty()
+    channel.close.assert_called_once_with()
+
+
+async def test_sendspin_close_during_setup_closes_internal_bridge(
+    mock_certificate: Mock,
+) -> None:
+    """Close a late internal bridge when its remote data channel is already gone."""
+    connect_started = asyncio.Event()
+    allow_connect = asyncio.Event()
+    internal_ws = AsyncMock()
+    internal_ws.closed = False
+
+    async def connect_internal(_url: str) -> AsyncMock:
+        connect_started.set()
+        await allow_connect.wait()
+        return internal_ws
+
+    http_session = Mock()
+    http_session.ws_connect = AsyncMock(side_effect=connect_internal)
+    gateway = WebRTCGateway(
+        http_session=http_session,
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+    )
+    session = WebRTCSession(session_id="sendspin-session", peer_connection=Mock())
+    callbacks: dict[str, Callable[..., None]] = {}
+    channel = Mock()
+    session.sendspin_channel = channel
+    session.sendspin_channel_active = True
+
+    def register_callback(
+        event: str,
+    ) -> Callable[[Callable[..., None]], Callable[..., None]]:
+        def decorator(callback: Callable[..., None]) -> Callable[..., None]:
+            callbacks[event] = callback
+            return callback
+
+        return decorator
+
+    channel.on.side_effect = register_callback
+    gateway._register_sendspin_channel_handlers(session)
+
+    setup_task = asyncio.create_task(gateway._setup_sendspin_channel(session))
+    await connect_started.wait()
+    callbacks["close"]()
+    allow_connect.set()
+    await setup_task
+
+    internal_ws.close.assert_awaited_once_with()
+    assert session.sendspin_ws is None
+    assert session.sendspin_to_local_task is None
+    assert session.sendspin_from_local_task is None
+
+
+async def test_sendspin_channel_close_cleans_forwarding_tasks(
+    mock_certificate: Mock,
+) -> None:
+    """Cancel forwarding tasks when the remote audio data channel closes."""
+    gateway = WebRTCGateway(
+        http_session=Mock(),
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+    )
+    session = WebRTCSession(session_id="sendspin-session", peer_connection=Mock())
+    gateway.sessions[session.session_id] = session
+    callbacks: dict[str, Callable[..., None]] = {}
+    channel = Mock()
+    session.sendspin_channel = channel
+    session.sendspin_channel_active = True
+    sendspin_ws = AsyncMock()
+    sendspin_ws.closed = False
+    session.sendspin_ws = sendspin_ws
+
+    async def wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    to_local = asyncio.create_task(wait_forever())
+    from_local = asyncio.create_task(wait_forever())
+    session.sendspin_to_local_task = to_local
+    session.sendspin_from_local_task = from_local
+
+    def register_callback(
+        event: str,
+    ) -> Callable[[Callable[..., None]], Callable[..., None]]:
+        def decorator(callback: Callable[..., None]) -> Callable[..., None]:
+            callbacks[event] = callback
+            return callback
+
+        return decorator
+
+    channel.on.side_effect = register_callback
+    gateway._register_sendspin_channel_handlers(session)
+    callbacks["close"]()
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if to_local.done() and from_local.done() and not gateway._background_tasks:
+            break
+
+    assert session.sendspin_channel_active is False
+    assert to_local.cancelled()
+    assert from_local.cancelled()
+    assert vars(session)["sendspin_to_local_task"] is None
+    assert vars(session)["sendspin_from_local_task"] is None
+    assert session.sendspin_ws is None
+    sendspin_ws.close.assert_awaited_once_with()
+    gateway.sessions.pop(session.session_id)
+
+
+async def test_sendspin_session_close_cancels_inflight_setup(
+    mock_certificate: Mock,
+) -> None:
+    """Cancel a pending internal audio connection before closing its WebRTC session."""
+    connect_started = asyncio.Event()
+
+    async def connect_internal(_url: str) -> None:
+        connect_started.set()
+        await asyncio.Event().wait()
+
+    http_session = Mock()
+    http_session.ws_connect = AsyncMock(side_effect=connect_internal)
+    gateway = WebRTCGateway(
+        http_session=http_session,
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+    )
+    peer_connection = Mock()
+    peer_connection.close = AsyncMock()
+    session = WebRTCSession(
+        session_id="sendspin-session",
+        peer_connection=peer_connection,
+    )
+    session.sendspin_channel = Mock()
+    session.sendspin_channel_active = True
+    setup_task = asyncio.create_task(gateway._setup_sendspin_channel(session))
+    session.sendspin_setup_task = setup_task
+    gateway.sessions[session.session_id] = session
+    await connect_started.wait()
+
+    await gateway._close_session(session.session_id)
+
+    assert setup_task.cancelled()
+    assert vars(session)["sendspin_setup_task"] is None
+    assert session.session_id not in vars(gateway)["sessions"]
+    peer_connection.close.assert_awaited_once_with()
+
+
+async def test_api_session_close_cancels_inflight_setup(
+    mock_certificate: Mock,
+) -> None:
+    """Cancel a pending local API connection before closing its WebRTC session."""
+    connect_started = asyncio.Event()
+
+    async def connect_local(_url: str) -> None:
+        connect_started.set()
+        await asyncio.Event().wait()
+
+    http_session = Mock()
+    http_session.ws_connect = AsyncMock(side_effect=connect_local)
+    gateway = WebRTCGateway(
+        http_session=http_session,
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+    )
+    peer_connection = Mock()
+    peer_connection.close = AsyncMock()
+    session = WebRTCSession(
+        session_id="api-session",
+        peer_connection=peer_connection,
+    )
+    session.data_channel = Mock()
+    session.data_channel_active = True
+    setup_task = asyncio.create_task(gateway._setup_data_channel(session))
+    session.data_channel_setup_task = setup_task
+    gateway.sessions[session.session_id] = session
+    await connect_started.wait()
+
+    await gateway._close_session(session.session_id)
+
+    assert setup_task.cancelled()
+    assert vars(session)["data_channel_setup_task"] is None
+    assert session.session_id not in vars(gateway)["sessions"]
+    peer_connection.close.assert_awaited_once_with()
 
 
 async def test_webrtc_gateway_reconnection_logic(mock_certificate: Mock) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Remote WebRTC sessions could briefly disconnect during provider updates, while fast clients could lose their first control or audio message as a connection started.

- Keep the active remote connection online until a serialized restart is actually needed.
- Preserve early control and audio messages while their local bridges connect.
- Cancel pending restarts and connection tasks cleanly during disconnects and shutdown.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.