### PR TITLE
Organize metadata controller methods

### DIFF
--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -323,6 +323,12 @@ class MetaDataController(
         # on-demand lookups are not stored in the library db, so normalize on the way out
         return lyrics, normalize_lrc_lyrics(lrc_lyrics)
 
+    async def get_diagnostics(self) -> dict[str, SerializableType] | None:
+        """Return diagnostics info for this controller to include in diagnostics reports."""
+        if not self._corrupt_metadata_rows:
+            return None
+        return {"corrupt_metadata_rows": cast("SerializableType", self._corrupt_metadata_rows)}
+
     async def _get_track_lyrics(
         self,
         track: Track,
@@ -364,12 +370,6 @@ class MetaDataController(
             if metadata and (metadata.lyrics or metadata.lrc_lyrics):
                 return metadata.lyrics, metadata.lrc_lyrics
         return None, None
-
-    async def get_diagnostics(self) -> dict[str, SerializableType] | None:
-        """Return diagnostics info for this controller to include in diagnostics reports."""
-        if not self._corrupt_metadata_rows:
-            return None
-        return {"corrupt_metadata_rows": cast("SerializableType", self._corrupt_metadata_rows)}
 
     def _register_maintenance_tasks(self) -> None:
         """Register the recurring metadata maintenance background tasks."""


### PR DESCRIPTION
# What does this implement/fix?

Keeps the metadata controller aligned with the project's method ordering rules.

- Moves diagnostics above private helpers.
- Leaves runtime behavior unchanged.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.