### PR TITLE
Tidal: reliability fixes, API client cleanup and faster tests

### DIFF
--- a/music_assistant/providers/tidal/api_client.py
+++ b/music_assistant/providers/tidal/api_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.errors import (
     LoginFailed,
@@ -37,16 +37,14 @@ class TidalAPIClient:
         self.logger = provider.logger
         self.mass = provider.mass
 
-    async def get(
-        self, endpoint: str, **kwargs: Any
-    ) -> dict[str, Any] | tuple[dict[str, Any], str]:
+    async def get(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
         """Get data from Tidal API."""
-        return await self._request("GET", endpoint, **kwargs)
+        data, _ = await self._request("GET", endpoint, **kwargs)
+        return data
 
-    async def get_data(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
-        """Get data from Tidal API, discarding headers/ETags."""
-        result = await self.get(endpoint, **kwargs)
-        return result[0] if isinstance(result, tuple) else result
+    async def get_with_etag(self, endpoint: str, **kwargs: Any) -> tuple[dict[str, Any], str]:
+        """Get data from Tidal API, returning the response ETag as well."""
+        return await self._request("GET", endpoint, **kwargs)
 
     async def post(
         self,
@@ -62,7 +60,8 @@ class TidalAPIClient:
         else:
             kwargs["json"] = data
 
-        return cast("dict[str, Any]", await self._request("POST", endpoint, **kwargs))
+        result, _ = await self._request("POST", endpoint, **kwargs)
+        return result
 
     async def put(
         self,
@@ -82,19 +81,21 @@ class TidalAPIClient:
         else:
             kwargs["json"] = data
 
-        return cast("dict[str, Any]", await self._request("PUT", endpoint, **kwargs))
+        result, _ = await self._request("PUT", endpoint, **kwargs)
+        return result
 
     async def delete(
         self, endpoint: str, data: dict[str, Any] | None = None, **kwargs: Any
     ) -> dict[str, Any]:
         """Delete data from Tidal API."""
         kwargs["json"] = data
-        return cast("dict[str, Any]", await self._request("DELETE", endpoint, **kwargs))
+        result, _ = await self._request("DELETE", endpoint, **kwargs)
+        return result
 
     @throttle_with_retries
     async def _request(
         self, method: str, endpoint: str, **kwargs: Any
-    ) -> dict[str, Any] | tuple[dict[str, Any], str]:
+    ) -> tuple[dict[str, Any], str]:
         """Handle API requests internally."""
         if not await self.auth.ensure_valid_token():
             raise LoginFailed("Failed to authenticate with Tidal")
@@ -118,19 +119,27 @@ class TidalAPIClient:
         if self.auth.country_code:
             params["countryCode"] = self.auth.country_code
 
-        # Extract special handling flags
-        return_etag = kwargs.pop("return_etag", False)
-
         self.logger.debug("Making %s request to Tidal API: %s", method, endpoint)
 
         async with self.mass.http_session.request(
             method, url, headers=headers, params=params, **kwargs
         ) as response:
-            return await self._handle_response(response, return_etag)
+            if response.status != 401:
+                return await self._handle_response(response)
 
-    async def _handle_response(
-        self, response: ClientResponse, return_etag: bool = False
-    ) -> dict[str, Any] | tuple[dict[str, Any], str]:
+        # The token was rejected before its known expiry (e.g. invalidated
+        # server-side): force a refresh and retry the request once.
+        self.logger.debug("Got 401 from Tidal API, forcing token refresh and retrying")
+        if not await self.auth.refresh_token():
+            raise LoginFailed("Authentication failed")
+        headers["Authorization"] = f"Bearer {self.auth.access_token}"
+
+        async with self.mass.http_session.request(
+            method, url, headers=headers, params=params, **kwargs
+        ) as response:
+            return await self._handle_response(response)
+
+    async def _handle_response(self, response: ClientResponse) -> tuple[dict[str, Any], str]:
         """Handle API response and common error conditions."""
         if response.status == 401:
             raise LoginFailed("Authentication failed")
@@ -149,13 +158,10 @@ class TidalAPIClient:
                 data = {"success": True}
             else:
                 data = await response.json()
-
-            if return_etag:
-                etag = response.headers.get("ETag", "")
-                return data, etag
-            return data
         except json.JSONDecodeError as err:
             raise ResourceTemporarilyUnavailable("Failed to parse response") from err
+
+        return data, response.headers.get("ETag", "")
 
     async def paginate(
         self,
@@ -168,20 +174,18 @@ class TidalAPIClient:
         """Paginate through all items from a Tidal API endpoint."""
         offset = 0
         cursor = None
+        extra_params = kwargs.pop("params", None) or {}
 
         while True:
             params = {"limit": limit}
+            params.update(extra_params)
             if cursor_based:
                 if cursor:
                     params["cursor"] = cursor
             else:
                 params["offset"] = offset
 
-            if "params" in kwargs:
-                params.update(kwargs.pop("params"))
-
-            api_result = await self.get(endpoint, params=params, **kwargs)
-            response = api_result[0] if isinstance(api_result, tuple) else api_result
+            response = await self.get(endpoint, params=params, **kwargs)
 
             items = response.get(item_key, [])
             if not items:

--- a/music_assistant/providers/tidal/auth_manager.py
+++ b/music_assistant/providers/tidal/auth_manager.py
@@ -1,5 +1,6 @@
 """Authentication manager for Tidal integration."""
 
+import asyncio
 import json
 import random
 import time
@@ -23,6 +24,9 @@ if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
 
 TOKEN_REFRESH_BUFFER = 60 * 7  # 7 minutes
+# Minimum time between two token refreshes, so that (concurrent) requests
+# hitting 401s cannot hammer the token endpoint with refresh calls.
+TOKEN_REFRESH_COOLDOWN = 30
 
 
 @dataclass
@@ -82,6 +86,8 @@ class TidalAuthManager:
         self.update_config = config_updater
         self.logger = logger
         self._auth_info: dict[str, Any] | None = None
+        self._refresh_lock = asyncio.Lock()
+        self._last_refresh: float = 0.0
         self.user = TidalUser()
 
     async def initialize(self, auth_data: str) -> bool:
@@ -133,46 +139,16 @@ class TidalAuthManager:
         return await self.refresh_token()
 
     async def refresh_token(self) -> bool:
-        """Refresh the auth token."""
-        if not self._auth_info:
-            return False
-
-        refresh_token = self._auth_info.get("refresh_token")
-        if not refresh_token:
-            return False
-
-        client_id = self._auth_info.get("client_id", app_var("tidal_client_id"))
-
-        data = {
-            "refresh_token": refresh_token,
-            "client_id": client_id,
-            "grant_type": "refresh_token",
-            "scope": "r_usr w_usr w_sub",
-        }
-
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-        async with self.http_session.post(
-            f"{AUTH_URL}/token", data=data, headers=headers
-        ) as response:
-            if response.status != 200:
-                self.logger.error("Failed to refresh token: %s", await response.text())
+        """Refresh the auth token (single-flight, with a short cooldown)."""
+        async with self._refresh_lock:
+            # A refresh that just completed (e.g. by a concurrent request that
+            # hit the same 401) is considered good: don't hit the token
+            # endpoint again, let the caller retry with the current token.
+            if time.time() - self._last_refresh < TOKEN_REFRESH_COOLDOWN:
+                return True
+            if not await self._perform_refresh():
                 return False
-
-            token_data = await response.json()
-
-            # Update auth info
-            self._auth_info["access_token"] = token_data["access_token"]
-            if "refresh_token" in token_data:
-                self._auth_info["refresh_token"] = token_data["refresh_token"]
-
-            # Update expiration
-            if "expires_in" in token_data:
-                self._auth_info["expires_at"] = time.time() + token_data["expires_in"]
-
-            # Store updated auth info
-            self.update_config(self._auth_info)
-
+            self._last_refresh = time.time()
             return True
 
     async def update_user_info(self, user_info: dict[str, Any], session_id: str) -> None:
@@ -299,3 +275,46 @@ class TidalAuthManager:
         auth_data["client_secret"] = client_secret
 
         return auth_data
+
+    async def _perform_refresh(self) -> bool:
+        """Perform the actual token refresh request."""
+        if not self._auth_info:
+            return False
+
+        refresh_token = self._auth_info.get("refresh_token")
+        if not refresh_token:
+            return False
+
+        client_id = self._auth_info.get("client_id", app_var("tidal_client_id"))
+
+        data = {
+            "refresh_token": refresh_token,
+            "client_id": client_id,
+            "grant_type": "refresh_token",
+            "scope": "r_usr w_usr w_sub",
+        }
+
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        async with self.http_session.post(
+            f"{AUTH_URL}/token", data=data, headers=headers
+        ) as response:
+            if response.status != 200:
+                self.logger.error("Failed to refresh token: %s", await response.text())
+                return False
+
+            token_data = await response.json()
+
+            # Update auth info
+            self._auth_info["access_token"] = token_data["access_token"]
+            if "refresh_token" in token_data:
+                self._auth_info["refresh_token"] = token_data["refresh_token"]
+
+            # Update expiration
+            if "expires_in" in token_data:
+                self._auth_info["expires_at"] = time.time() + token_data["expires_in"]
+
+            # Store updated auth info
+            self.update_config(self._auth_info)
+
+            return True

--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING, Any
 
 from aiohttp.client_exceptions import ClientError
@@ -102,10 +101,10 @@ class TidalMediaManager:
     async def get_track(self, prov_track_id: str) -> Track:
         """Get track details."""
         try:
-            track_obj, lyrics = await asyncio.gather(
-                self.api.get(f"tracks/{prov_track_id}"),
-                self._get_lyrics(prov_track_id),
-            )
+            # Fetch the track first so a nonexistent track doesn't cost an
+            # extra (throttled) lyrics request.
+            track_obj = await self.api.get(f"tracks/{prov_track_id}")
+            lyrics = await self._get_lyrics(prov_track_id)
             return parse_track(self.provider, track_obj, lyrics=lyrics)
         except (ClientError, KeyError, ValueError) as err:
             raise MediaNotFoundError(f"Track {prov_track_id} not found") from err
@@ -250,7 +249,8 @@ class TidalMediaManager:
         # a missing/failed lyrics response.
         try:
             return await self.api.get(f"tracks/{prov_track_id}/lyrics")
-        except ClientError, MusicAssistantError:
+        except (ClientError, MusicAssistantError) as err:
+            self.logger.debug("Failed to fetch lyrics for track %s: %s", prov_track_id, err)
             return None
 
     def _process_tracks(self, items: list[dict[str, Any]], offset: int) -> list[Track]:

--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from contextlib import suppress
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 from aiohttp.client_exceptions import ClientError
 from music_assistant_models.enums import MediaType
-from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.errors import (
+    MediaNotFoundError,
+    MusicAssistantError,
+)
 from music_assistant_models.media_items import SearchResults
 
 from .constants import FAVORITE_TRACKS_PLAYLIST_ID, FAVORITES_TRACKS, PAGES_MIX, PLAYLISTS
@@ -53,7 +56,7 @@ class TidalMediaManager:
         if not media_type_strings:
             return parsed_results
 
-        results = await self.api.get_data(
+        results = await self.api.get(
             "search",
             params={
                 "query": search_query.replace("'", ""),
@@ -83,7 +86,7 @@ class TidalMediaManager:
     async def get_artist(self, prov_artist_id: str) -> Artist:
         """Get artist details."""
         try:
-            data = await self.api.get_data(f"artists/{prov_artist_id}")
+            data = await self.api.get(f"artists/{prov_artist_id}")
             return parse_artist(self.provider, data)
         except (ClientError, KeyError, ValueError) as err:
             raise MediaNotFoundError(f"Artist {prov_artist_id} not found") from err
@@ -91,7 +94,7 @@ class TidalMediaManager:
     async def get_album(self, prov_album_id: str) -> Album:
         """Get album details."""
         try:
-            data = await self.api.get_data(f"albums/{prov_album_id}")
+            data = await self.api.get(f"albums/{prov_album_id}")
             return parse_album(self.provider, data)
         except (ClientError, KeyError, ValueError) as err:
             raise MediaNotFoundError(f"Album {prov_album_id} not found") from err
@@ -99,12 +102,10 @@ class TidalMediaManager:
     async def get_track(self, prov_track_id: str) -> Track:
         """Get track details."""
         try:
-            track_obj = await self.api.get_data(f"tracks/{prov_track_id}")
-
-            lyrics = None
-            with suppress(MediaNotFoundError):
-                lyrics = await self.api.get_data(f"tracks/{prov_track_id}/lyrics")
-
+            track_obj, lyrics = await asyncio.gather(
+                self.api.get(f"tracks/{prov_track_id}"),
+                self._get_lyrics(prov_track_id),
+            )
             return parse_track(self.provider, track_obj, lyrics=lyrics)
         except (ClientError, KeyError, ValueError) as err:
             raise MediaNotFoundError(f"Track {prov_track_id} not found") from err
@@ -118,7 +119,7 @@ class TidalMediaManager:
             return await self._get_mix_details(prov_playlist_id[4:])
 
         try:
-            data = await self.api.get_data(f"{PLAYLISTS}/{prov_playlist_id}")
+            data = await self.api.get(f"{PLAYLISTS}/{prov_playlist_id}")
             return parse_playlist(self.provider, data)
         except MediaNotFoundError:
             return await self._get_mix_details(prov_playlist_id)
@@ -129,7 +130,7 @@ class TidalMediaManager:
         """Get details for a Tidal Mix."""
         try:
             params = {"mixId": prov_mix_id, "deviceType": "BROWSER"}
-            tidal_mix = await self.api.get_data(PAGES_MIX, params=params)
+            tidal_mix = await self.api.get(PAGES_MIX, params=params)
 
             mix_obj = {
                 "id": prov_mix_id,
@@ -154,7 +155,7 @@ class TidalMediaManager:
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
         """Get album tracks."""
         try:
-            data = await self.api.get_data(f"albums/{prov_album_id}/tracks", params={"limit": 250})
+            data = await self.api.get(f"albums/{prov_album_id}/tracks", params={"limit": 250})
             return [parse_track(self.provider, x) for x in data.get("items", [])]
         except (ClientError, KeyError, ValueError) as err:
             raise MediaNotFoundError(f"Album {prov_album_id} not found") from err
@@ -162,9 +163,7 @@ class TidalMediaManager:
     async def get_artist_albums(self, prov_artist_id: str) -> list[Album]:
         """Get artist albums."""
         try:
-            data = await self.api.get_data(
-                f"artists/{prov_artist_id}/albums", params={"limit": 250}
-            )
+            data = await self.api.get(f"artists/{prov_artist_id}/albums", params={"limit": 250})
             return [parse_album(self.provider, x) for x in data.get("items", [])]
         except (ClientError, KeyError, ValueError) as err:
             raise MediaNotFoundError(f"Artist {prov_artist_id} not found") from err
@@ -172,7 +171,7 @@ class TidalMediaManager:
     async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
         """Get artist top tracks."""
         try:
-            data = await self.api.get_data(
+            data = await self.api.get(
                 f"artists/{prov_artist_id}/toptracks", params={"limit": 10, "offset": 0}
             )
             return [parse_track(self.provider, x) for x in data.get("items", [])]
@@ -182,7 +181,7 @@ class TidalMediaManager:
     async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
         """Get similar tracks."""
         try:
-            data = await self.api.get_data(f"tracks/{prov_track_id}/radio", params={"limit": limit})
+            data = await self.api.get(f"tracks/{prov_track_id}/radio", params={"limit": limit})
             return [parse_track(self.provider, x) for x in data.get("items", [])]
         except (ClientError, KeyError, ValueError) as err:
             raise MediaNotFoundError(f"Track {prov_track_id} not found") from err
@@ -199,7 +198,7 @@ class TidalMediaManager:
             return await self._get_mix_tracks(prov_playlist_id[4:], page_size, offset)
 
         try:
-            data = await self.api.get_data(
+            data = await self.api.get(
                 f"{PLAYLISTS}/{prov_playlist_id}/tracks",
                 params={"limit": page_size, "offset": offset},
             )
@@ -210,7 +209,7 @@ class TidalMediaManager:
     async def _get_favorite_tracks(self, limit: int, offset: int) -> list[Track]:
         """Get the user's favorite tracks in descending order (newest first)."""
         try:
-            data = await self.api.get_data(
+            data = await self.api.get(
                 f"users/{self.provider.auth.user_id}/{FAVORITES_TRACKS}",
                 params={
                     "limit": limit,
@@ -227,7 +226,7 @@ class TidalMediaManager:
         """Get tracks from a mix."""
         try:
             params = {"mixId": mix_id, "deviceType": "BROWSER"}
-            data = await self.api.get_data(PAGES_MIX, params=params)
+            data = await self.api.get(PAGES_MIX, params=params)
 
             # Mix tracks are usually in the second row
             rows = data.get("rows", [])
@@ -244,6 +243,15 @@ class TidalMediaManager:
             return self._process_tracks(paged_items, offset)
         except (ClientError, KeyError, ValueError) as err:
             raise MediaNotFoundError(f"Mix {mix_id} not found") from err
+
+    async def _get_lyrics(self, prov_track_id: str) -> dict[str, str] | None:
+        """Get lyrics for a track, returning None when unavailable."""
+        # Lyrics are optional enrichment: never fail the track lookup on
+        # a missing/failed lyrics response.
+        try:
+            return await self.api.get(f"tracks/{prov_track_id}/lyrics")
+        except ClientError, MusicAssistantError:
+            return None
 
     def _process_tracks(self, items: list[dict[str, Any]], offset: int) -> list[Track]:
         result = []

--- a/music_assistant/providers/tidal/parsers.py
+++ b/music_assistant/providers/tidal/parsers.py
@@ -56,7 +56,7 @@ def parse_artist(provider: TidalProvider, artist_obj: dict[str, Any]) -> Artist:
     if "created" in artist_obj:
         with suppress(ValueError):
             artist.date_added = datetime.fromisoformat(artist_obj["created"])
-    if artist_obj_data["picture"]:
+    if artist_obj_data.get("picture"):
         picture_id = artist_obj_data["picture"].replace("-", "/")
         image_url = f"{RESOURCES_URL}/{picture_id}/750x750.jpg"
         artist.metadata.images = UniqueList(
@@ -198,7 +198,7 @@ def parse_track(
                     bit_depth=24 if hi_res_lossless else 16,
                 ),
                 url=f"https://tidal.com/track/{track_id}",
-                available=track_obj_data["streamReady"],
+                available=track_obj_data.get("streamReady", True),  # Default to available
             )
         },
         disc_number=track_obj_data.get("volumeNumber", 0) or 0,
@@ -207,31 +207,35 @@ def parse_track(
     if "isrc" in track_obj_data:
         track.external_ids.add((ExternalID.ISRC, track_obj_data["isrc"]))
     track.artists = UniqueList()
-    for track_artist in track_obj_data["artists"]:
-        artist = parse_artist(provider, track_artist)
+    for track_artist in track_obj_data.get("artists", []):
+        try:
+            artist = parse_artist(provider, track_artist)
+        except (KeyError, TypeError) as err:
+            provider.logger.warning("Error parsing artist in track %s: %s", name, err)
+            continue
         track.artists.append(artist)
     # metadata
     if "created" in track_obj:
         with suppress(ValueError):
             track.date_added = datetime.fromisoformat(track_obj["created"])
-    track.metadata.explicit = track_obj_data["explicit"]
-    track.metadata.popularity = track_obj_data["popularity"]
+    track.metadata.explicit = track_obj_data.get("explicit", False)
+    track.metadata.popularity = track_obj_data.get("popularity", 0)
     if "copyright" in track_obj_data:
         track.metadata.copyright = track_obj_data["copyright"]
     if lyrics and "lyrics" in lyrics:
         track.metadata.lyrics = lyrics["lyrics"]
     if lyrics and "subtitles" in lyrics:
         track.metadata.lrc_lyrics = lyrics["subtitles"]
-    if track_obj_data["album"]:
+    if album_obj := track_obj_data.get("album"):
         # Here we use an ItemMapping as Tidal returns
         # minimal data when getting an Album from a Track
         track.album = provider.get_item_mapping(
             media_type=MediaType.ALBUM,
-            key=str(track_obj_data["album"]["id"]),
-            name=track_obj_data["album"]["title"],
+            key=str(album_obj["id"]),
+            name=album_obj["title"],
         )
-        if track_obj_data["album"]["cover"]:
-            picture_id = track_obj_data["album"]["cover"].replace("-", "/")
+        if album_obj.get("cover"):
+            picture_id = album_obj["cover"].replace("-", "/")
             image_url = f"{RESOURCES_URL}/{picture_id}/750x750.jpg"
             track.metadata.images = UniqueList(
                 [

--- a/music_assistant/providers/tidal/parsers.py
+++ b/music_assistant/providers/tidal/parsers.py
@@ -226,13 +226,13 @@ def parse_track(
         track.metadata.lyrics = lyrics["lyrics"]
     if lyrics and "subtitles" in lyrics:
         track.metadata.lrc_lyrics = lyrics["subtitles"]
-    if album_obj := track_obj_data.get("album"):
+    if (album_obj := track_obj_data.get("album")) and album_obj.get("id"):
         # Here we use an ItemMapping as Tidal returns
         # minimal data when getting an Album from a Track
         track.album = provider.get_item_mapping(
             media_type=MediaType.ALBUM,
             key=str(album_obj["id"]),
-            name=album_obj["title"],
+            name=album_obj.get("title") or "",
         )
         if album_obj.get("cover"):
             picture_id = album_obj["cover"].replace("-", "/")

--- a/music_assistant/providers/tidal/playlist.py
+++ b/music_assistant/providers/tidal/playlist.py
@@ -41,9 +41,7 @@ class TidalPlaylistManager:
         """Add tracks to playlist."""
         try:
             # Get ETag first
-            api_result = await self.api.get(f"{PLAYLISTS}/{prov_playlist_id}", return_etag=True)
-            playlist_obj = api_result[0] if isinstance(api_result, tuple) else api_result
-            etag = api_result[1] if isinstance(api_result, tuple) else None
+            playlist_obj, etag = await self.api.get_with_etag(f"{PLAYLISTS}/{prov_playlist_id}")
 
             data = {
                 "onArtifactNotFound": "SKIP",
@@ -63,8 +61,7 @@ class TidalPlaylistManager:
         """Remove tracks from playlist."""
         try:
             # Get ETag first
-            api_result = await self.api.get(f"{PLAYLISTS}/{prov_playlist_id}", return_etag=True)
-            etag = api_result[1] if isinstance(api_result, tuple) else None
+            _, etag = await self.api.get_with_etag(f"{PLAYLISTS}/{prov_playlist_id}")
 
             # Tidal uses 0-based indices in URL path
             indices = ",".join(str(pos - 1) for pos in positions)

--- a/music_assistant/providers/tidal/provider.py
+++ b/music_assistant/providers/tidal/provider.py
@@ -121,14 +121,13 @@ class TidalProvider(MusicProvider):
         if not await self.auth.initialize(json.dumps(auth_data)):
             raise LoginFailed("Failed to authenticate with Tidal")
 
-        api_result = await self.api.get("sessions")
-        user_info = api_result[0] if isinstance(api_result, tuple) else api_result
+        user_info = await self.api.get("sessions")
         logged_in_user = await self.get_user(str(user_info.get("userId")))
         await self.auth.update_user_info(logged_in_user, str(user_info.get("sessionId")))
 
     async def get_user(self, prov_user_id: str) -> dict[str, Any]:
         """Get user information."""
-        return await self.api.get_data(f"users/{prov_user_id}")
+        return await self.api.get(f"users/{prov_user_id}")
 
     @use_cache(3600 * 24 * 14)
     async def search(

--- a/music_assistant/providers/tidal/recommendations.py
+++ b/music_assistant/providers/tidal/recommendations.py
@@ -50,72 +50,66 @@ class TidalRecommendationManager:
         module_content_types: dict[str, MediaType] = {}
         module_page_names: dict[str, str] = {}
 
-        try:
-            all_tidal_configs = await self.mass.config.get_provider_configs(ProviderType.MUSIC)
-            tidal_configs = [
-                config for config in all_tidal_configs if config.domain == self.provider.domain
-            ]
-            sorted_instances = sorted(tidal_configs, key=lambda x: x.instance_id)
-            show_user_identifier = len(sorted_instances) > 1
+        all_tidal_configs = await self.mass.config.get_provider_configs(ProviderType.MUSIC)
+        tidal_configs = [
+            config for config in all_tidal_configs if config.domain == self.provider.domain
+        ]
+        sorted_instances = sorted(tidal_configs, key=lambda x: x.instance_id)
+        show_user_identifier = len(sorted_instances) > 1
 
-            for page_path in pages:
-                parser = await self.get_page_content(page_path)
-                page_name = page_path.split("/")[-1].replace("_", " ").title()
+        for page_path in pages:
+            parser = await self.get_page_content(page_path)
+            page_name = page_path.split("/")[-1].replace("_", " ").title()
 
-                for module_info in parser._module_map:
-                    title = module_info.get("title", "Unknown")
-                    if not title or title == "Unknown" or "Videos" in title:
-                        continue
+            for module_info in parser.modules:
+                title = module_info.get("title", "Unknown")
+                if not title or title == "Unknown" or "Videos" in title:
+                    continue
 
-                    items, content_type = parser.get_module_items(module_info)
-                    if not items:
-                        continue
+                items, content_type = parser.get_module_items(module_info)
+                if not items:
+                    continue
 
-                    key = f"{self.auth.user_id}_{title}"
-                    if key not in combined_modules:
-                        combined_modules[key] = []
-                        module_content_types[key] = content_type
-                        module_page_names[key] = page_name
+                key = f"{self.auth.user_id}_{title}"
+                if key not in combined_modules:
+                    combined_modules[key] = []
+                    module_content_types[key] = content_type
+                    module_page_names[key] = page_name
 
-                    combined_modules[key].extend(items)
+                combined_modules[key].extend(items)
 
-            for key, items in combined_modules.items():
-                user_id_prefix = f"{self.auth.user_id}_"
-                title = key.removeprefix(user_id_prefix)
+        for key, items in combined_modules.items():
+            user_id_prefix = f"{self.auth.user_id}_"
+            title = key.removeprefix(user_id_prefix)
 
-                unique_items = UniqueList(items)
-                item_id = "".join(
-                    c for c in key.lower().replace(" ", "_") if c.isalnum() or c == "_"
+            unique_items = UniqueList(items)
+            item_id = "".join(c for c in key.lower().replace(" ", "_") if c.isalnum() or c == "_")
+            content_type = module_content_types.get(key, MediaType.PLAYLIST)
+            page_name = module_page_names.get(key, "Tidal")
+
+            folder_name = title
+            if show_user_identifier:
+                raw_user_name = (
+                    self.auth.user.profile_name
+                    or self.auth.user.user_name
+                    or str(self.auth.user_id)
                 )
-                content_type = module_content_types.get(key, MediaType.PLAYLIST)
-                page_name = module_page_names.get(key, "Tidal")
+                user_name = raw_user_name.split("@", 1)[0]
+                folder_name = f"{title} ({user_name})"
 
-                folder_name = title
-                if show_user_identifier:
-                    raw_user_name = (
-                        self.auth.user.profile_name
-                        or self.auth.user.user_name
-                        or str(self.auth.user_id)
-                    )
-                    user_name = raw_user_name.split("@", 1)[0]
-                    folder_name = f"{title} ({user_name})"
-
-                results.append(
-                    RecommendationFolder(
-                        item_id=item_id,
-                        name=folder_name,
-                        provider=self.provider.instance_id,
-                        items=UniqueList[MediaItemType | ItemMapping | BrowseFolder](unique_items),
-                        subtitle=f"From {page_name} • {len(unique_items)} items",
-                        translation_key=item_id,
-                        icon="mdi-playlist-music"
-                        if content_type == MediaType.PLAYLIST
-                        else "mdi-album",
-                    )
+            results.append(
+                RecommendationFolder(
+                    item_id=item_id,
+                    name=folder_name,
+                    provider=self.provider.instance_id,
+                    items=UniqueList[MediaItemType | ItemMapping | BrowseFolder](unique_items),
+                    subtitle=f"From {page_name} • {len(unique_items)} items",
+                    translation_key=item_id,
+                    icon="mdi-playlist-music"
+                    if content_type == MediaType.PLAYLIST
+                    else "mdi-album",
                 )
-
-        except Exception:
-            self.logger.exception("Error fetching recommendations")
+            )
 
         return results
 
@@ -126,7 +120,7 @@ class TidalRecommendationManager:
 
         try:
             locale = self.mass.metadata.locale.replace("_", "-")
-            api_result = await self.api.get(
+            data = await self.api.get(
                 page_path,
                 base_url=WEB_BASE_URL,
                 params={
@@ -136,17 +130,12 @@ class TidalRecommendationManager:
                 },
             )
 
-            data = api_result[0] if isinstance(api_result, tuple) else api_result
             parser = TidalPageParser(self.provider)
             parser.parse_page_structure(data or {}, page_path)
 
             await self.mass.cache.set(
                 key=page_path,
-                data={
-                    "module_map": parser._module_map,
-                    "content_map": parser._content_map,
-                    "parsed_at": parser._parsed_at,
-                },
+                data=parser.to_cache(),
                 provider=self.provider.instance_id,
                 category=CACHE_CATEGORY_RECOMMENDATIONS,
                 expiration=self.page_cache_ttl,

--- a/music_assistant/providers/tidal/recommendations.py
+++ b/music_assistant/providers/tidal/recommendations.py
@@ -118,29 +118,28 @@ class TidalRecommendationManager:
         if cached := await TidalPageParser.from_cache(self.provider, page_path):
             return cached
 
-        try:
-            locale = self.mass.metadata.locale.replace("_", "-")
-            data = await self.api.get(
-                page_path,
-                base_url=WEB_BASE_URL,
-                params={
-                    "locale": locale,
-                    "deviceType": "BROWSER",
-                    "countryCode": self.auth.country_code or "US",
-                },
-            )
+        # Let fetch/parse errors propagate: swallowing them here would make
+        # recommendations() succeed with an empty result, which the caching
+        # wrapper would then store for the full TTL.
+        locale = self.mass.metadata.locale.replace("_", "-")
+        data = await self.api.get(
+            page_path,
+            base_url=WEB_BASE_URL,
+            params={
+                "locale": locale,
+                "deviceType": "BROWSER",
+                "countryCode": self.auth.country_code or "US",
+            },
+        )
 
-            parser = TidalPageParser(self.provider)
-            parser.parse_page_structure(data or {}, page_path)
+        parser = TidalPageParser(self.provider)
+        parser.parse_page_structure(data or {}, page_path)
 
-            await self.mass.cache.set(
-                key=page_path,
-                data=parser.to_cache(),
-                provider=self.provider.instance_id,
-                category=CACHE_CATEGORY_RECOMMENDATIONS,
-                expiration=self.page_cache_ttl,
-            )
-            return parser
-        except Exception:
-            self.logger.exception("Error fetching Tidal page %s", page_path)
-            return TidalPageParser(self.provider)
+        await self.mass.cache.set(
+            key=page_path,
+            data=parser.to_cache(),
+            provider=self.provider.instance_id,
+            category=CACHE_CATEGORY_RECOMMENDATIONS,
+            expiration=self.page_cache_ttl,
+        )
+        return parser

--- a/music_assistant/providers/tidal/streaming.py
+++ b/music_assistant/providers/tidal/streaming.py
@@ -55,7 +55,7 @@ class TidalStreamingManager:
 
         # 3. Get playback info
         async with self.api.throttler.bypass():
-            api_result = await self.api.get(
+            stream_data = await self.api.get(
                 f"tracks/{track.item_id}/playbackinfopostpaywall",
                 params={
                     "playbackmode": "STREAM",
@@ -63,8 +63,6 @@ class TidalStreamingManager:
                     "audioquality": quality,
                 },
             )
-
-        stream_data = api_result[0] if isinstance(api_result, tuple) else api_result
 
         # 4. Parse stream URL
         manifest_type = stream_data.get("manifestMimeType", "")
@@ -230,10 +228,7 @@ class TidalStreamingManager:
             return None
 
         # Lookup by ISRC
-        api_result = await self.api.get(
-            "tracks", params={"filter[isrc]": isrc}, base_url=OPEN_API_URL
-        )
-        data = api_result[0] if isinstance(api_result, tuple) else api_result
+        data = await self.api.get("tracks", params={"filter[isrc]": isrc}, base_url=OPEN_API_URL)
 
         data_items = data.get("data", [])
         if not data_items:

--- a/music_assistant/providers/tidal/tidal_page_parser.py
+++ b/music_assistant/providers/tidal/tidal_page_parser.py
@@ -35,6 +35,19 @@ class TidalPageParser:
         self._page_path: str | None = None
         self._parsed_at: int = 0
 
+    @property
+    def modules(self) -> list[dict[str, Any]]:
+        """Return the parsed page modules."""
+        return self._module_map
+
+    def to_cache(self) -> dict[str, Any]:
+        """Return the parsed page state as a cacheable dict."""
+        return {
+            "module_map": self._module_map,
+            "content_map": self._content_map,
+            "parsed_at": self._parsed_at,
+        }
+
     def parse_page_structure(self, page_data: dict[str, Any], page_path: str) -> None:
         """Parse Tidal page structure into indexed modules."""
         self._page_path = page_path

--- a/tests/providers/tidal/conftest.py
+++ b/tests/providers/tidal/conftest.py
@@ -1,0 +1,28 @@
+"""Fixtures for Tidal provider tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def no_throttling() -> Generator[None]:
+    """
+    Disable rate limiting and retry backoff during tests.
+
+    The API client's throttler is class-level shared state: its real-time
+    rate window would otherwise carry over between tests and make every
+    test wait it out.
+    """
+    with (
+        patch(
+            "music_assistant.helpers.throttle_retry.Throttler.acquire",
+            new=AsyncMock(return_value=0.0),
+        ),
+        patch(
+            "music_assistant.helpers.throttle_retry.asyncio.sleep",
+            new_callable=AsyncMock,
+        ),
+    ):
+        yield

--- a/tests/providers/tidal/conftest.py
+++ b/tests/providers/tidal/conftest.py
@@ -14,6 +14,10 @@ def no_throttling() -> Generator[None]:
     The API client's throttler is class-level shared state: its real-time
     rate window would otherwise carry over between tests and make every
     test wait it out.
+
+    Note: the sleep patch targets the attribute on the shared asyncio
+    module, so asyncio.sleep is mocked process-wide while each test in
+    this directory runs. Keep that in mind for timing-dependent tests.
     """
     with (
         patch(

--- a/tests/providers/tidal/test_api_client.py
+++ b/tests/providers/tidal/test_api_client.py
@@ -1,7 +1,7 @@
 """Test Tidal API Client."""
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 from aiohttp import ClientResponse
@@ -55,16 +55,44 @@ async def test_get_success(api_client: TidalAPIClient, provider_mock: Mock) -> N
 
 
 async def test_get_401_error(api_client: TidalAPIClient, provider_mock: Mock) -> None:
-    """Test GET request with 401 error."""
+    """Test GET request with 401 error and a failing token refresh."""
     response = AsyncMock(spec=ClientResponse)
     response.status = 401
 
     request_ctx = AsyncMock()
     request_ctx.__aenter__.return_value = response
     provider_mock.mass.http_session.request = MagicMock(return_value=request_ctx)
+    provider_mock.auth.refresh_token.return_value = False
 
     with pytest.raises(LoginFailed):
         await api_client.get("test/endpoint")
+
+    provider_mock.auth.refresh_token.assert_called_once()
+
+
+async def test_get_401_refreshes_token_and_retries(
+    api_client: TidalAPIClient, provider_mock: Mock
+) -> None:
+    """Test that a 401 response forces a token refresh and retries the request once."""
+    response_401 = AsyncMock(spec=ClientResponse)
+    response_401.status = 401
+
+    response_ok = AsyncMock(spec=ClientResponse)
+    response_ok.status = 200
+    response_ok.json.return_value = {"data": "test"}
+
+    ctx1 = AsyncMock()
+    ctx1.__aenter__.return_value = response_401
+    ctx2 = AsyncMock()
+    ctx2.__aenter__.return_value = response_ok
+    provider_mock.mass.http_session.request = MagicMock(side_effect=[ctx1, ctx2])
+    provider_mock.auth.refresh_token.return_value = True
+
+    result = await api_client.get("test/endpoint")
+
+    assert result == {"data": "test"}
+    provider_mock.auth.refresh_token.assert_called_once()
+    assert provider_mock.mass.http_session.request.call_count == 2
 
 
 async def test_get_404_error(api_client: TidalAPIClient, provider_mock: Mock) -> None:
@@ -83,8 +111,7 @@ async def test_get_404_error(api_client: TidalAPIClient, provider_mock: Mock) ->
 
 async def test_get_429_error(api_client: TidalAPIClient, provider_mock: Mock) -> None:
     """Test GET request with 429 error."""
-    with patch("asyncio.sleep"):
-        response = AsyncMock(spec=ClientResponse)
+    response = AsyncMock(spec=ClientResponse)
     response.status = 429
     response.headers = {"Retry-After": "10"}
 
@@ -145,6 +172,33 @@ async def test_paginate(api_client: TidalAPIClient, provider_mock: Mock) -> None
     assert len(items) == 4
     assert items[0]["id"] == 1
     assert items[3]["id"] == 4
+
+
+async def test_paginate_preserves_params_across_pages(
+    api_client: TidalAPIClient, provider_mock: Mock
+) -> None:
+    """Test that caller-supplied params are sent on every page, not just the first."""
+    response1 = AsyncMock(spec=ClientResponse)
+    response1.status = 200
+    response1.json.return_value = {"items": [{"id": 1}, {"id": 2}]}
+
+    response2 = AsyncMock(spec=ClientResponse)
+    response2.status = 200
+    response2.json.return_value = {"items": []}
+
+    ctx1 = AsyncMock()
+    ctx1.__aenter__.return_value = response1
+    ctx2 = AsyncMock()
+    ctx2.__aenter__.return_value = response2
+    provider_mock.mass.http_session.request = MagicMock(side_effect=[ctx1, ctx2])
+
+    items: list[dict[str, Any]] = []
+    async for item in api_client.paginate("test/endpoint", limit=2, params={"order": "DATE"}):
+        items.append(item)
+
+    assert len(items) == 2
+    for call in provider_mock.mass.http_session.request.call_args_list:
+        assert call[1]["params"]["order"] == "DATE"
 
 
 async def test_delete_success(api_client: TidalAPIClient, provider_mock: Mock) -> None:

--- a/tests/providers/tidal/test_auth_manager.py
+++ b/tests/providers/tidal/test_auth_manager.py
@@ -101,6 +101,28 @@ async def test_refresh_token_failure(
     assert await auth_manager.refresh_token() is False
 
 
+async def test_refresh_token_cooldown(
+    auth_manager: TidalAuthManager, http_session: AsyncMock
+) -> None:
+    """Test a refresh right after a successful one skips the token endpoint."""
+    auth_manager._auth_info = {
+        "refresh_token": "refresh",
+        "client_id": "client_id",
+    }
+
+    response = AsyncMock()
+    response.status = 200
+    response.json.return_value = {
+        "access_token": "new_token",
+        "expires_in": 3600,
+    }
+    http_session.post.return_value.__aenter__.return_value = response
+
+    assert await auth_manager.refresh_token() is True
+    assert await auth_manager.refresh_token() is True
+    assert http_session.post.call_count == 1
+
+
 @patch("music_assistant.providers.tidal.auth_manager.pkce")
 @patch("music_assistant.providers.tidal.auth_manager.app_var")
 @pytest.mark.usefixtures("auth_manager")

--- a/tests/providers/tidal/test_library.py
+++ b/tests/providers/tidal/test_library.py
@@ -19,7 +19,7 @@ def provider_mock() -> Mock:
     provider.instance_id = "tidal_instance"
     provider.auth.user_id = "12345"
     provider.api = AsyncMock()
-    provider.api.get_data.return_value = {"items": []}
+    provider.api.get.return_value = {"items": []}
     provider.api.paginate = MagicMock()
 
     # Configure async iterator for paginate

--- a/tests/providers/tidal/test_media.py
+++ b/tests/providers/tidal/test_media.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import RetriesExhausted
 from music_assistant_models.media_items import ItemMapping
 
 from music_assistant.providers.tidal.media import TidalMediaManager
@@ -147,6 +148,25 @@ async def test_get_track(
     provider_mock.api.get.assert_any_call("tracks/1")
     provider_mock.api.get.assert_any_call("tracks/1/lyrics")
     mock_parse_track.assert_called_once()
+
+
+@patch("music_assistant.providers.tidal.media.parse_track")
+async def test_get_track_tolerates_lyrics_failure(
+    mock_parse_track: Mock, media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test get_track still returns the track when the lyrics lookup fails."""
+    provider_mock.api.get.side_effect = [
+        {"id": 1, "title": "Test Track"},  # Track data
+        RetriesExhausted("lyrics lookup failed"),  # Lyrics data
+    ]
+    mock_parse_track.return_value = Mock(item_id="1")
+
+    track = await media_manager.get_track("1")
+
+    assert track.item_id == "1"
+    mock_parse_track.assert_called_once_with(
+        provider_mock, {"id": 1, "title": "Test Track"}, lyrics=None
+    )
 
 
 @patch("music_assistant.providers.tidal.media.parse_playlist")

--- a/tests/providers/tidal/test_media.py
+++ b/tests/providers/tidal/test_media.py
@@ -19,7 +19,7 @@ def provider_mock() -> Mock:
     provider.auth.user_id = "12345"
     provider.auth.country_code = "US"
     provider.api = AsyncMock()
-    provider.api.get_data.return_value = {}
+    provider.api.get.return_value = {}
     provider.api.paginate = MagicMock()
 
     async def async_iter(*_args: Any, **_kwargs: Any) -> Any:
@@ -63,7 +63,7 @@ async def test_search(
     provider_mock: Mock,
 ) -> None:
     """Test search."""
-    provider_mock.api.get_data.return_value = {
+    provider_mock.api.get.return_value = {
         "artists": {"items": [{"id": 1}]},
         "albums": {"items": [{"id": 1}]},
         "tracks": {"items": [{"id": 1}]},
@@ -89,7 +89,7 @@ async def test_search(
     mock_parse_track.assert_called()
     mock_parse_playlist.assert_called()
 
-    provider_mock.api.get_data.assert_called_with(
+    provider_mock.api.get.assert_called_with(
         "search",
         params={
             "query": "query",
@@ -104,13 +104,13 @@ async def test_get_artist(
     mock_parse_artist: Mock, media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
     """Test get_artist."""
-    provider_mock.api.get_data.return_value = {"id": 1, "name": "Test Artist"}
+    provider_mock.api.get.return_value = {"id": 1, "name": "Test Artist"}
     mock_parse_artist.return_value = Mock(item_id="1")
 
     artist = await media_manager.get_artist("1")
 
     assert artist.item_id == "1"
-    provider_mock.api.get_data.assert_called_with("artists/1")
+    provider_mock.api.get.assert_called_with("artists/1")
     mock_parse_artist.assert_called_once()
 
 
@@ -119,13 +119,13 @@ async def test_get_album(
     mock_parse_album: Mock, media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
     """Test get_album."""
-    provider_mock.api.get_data.return_value = {"id": 1, "title": "Test Album"}
+    provider_mock.api.get.return_value = {"id": 1, "title": "Test Album"}
     mock_parse_album.return_value = Mock(item_id="1")
 
     album = await media_manager.get_album("1")
 
     assert album.item_id == "1"
-    provider_mock.api.get_data.assert_called_with("albums/1")
+    provider_mock.api.get.assert_called_with("albums/1")
     mock_parse_album.assert_called_once()
 
 
@@ -134,7 +134,7 @@ async def test_get_track(
     mock_parse_track: Mock, media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
     """Test get_track."""
-    provider_mock.api.get_data.side_effect = [
+    provider_mock.api.get.side_effect = [
         {"id": 1, "title": "Test Track"},  # Track data
         {"lyrics": "Test Lyrics"},  # Lyrics data
     ]
@@ -143,9 +143,9 @@ async def test_get_track(
     track = await media_manager.get_track("1")
 
     assert track.item_id == "1"
-    assert provider_mock.api.get_data.call_count == 2
-    provider_mock.api.get_data.assert_any_call("tracks/1")
-    provider_mock.api.get_data.assert_any_call("tracks/1/lyrics")
+    assert provider_mock.api.get.call_count == 2
+    provider_mock.api.get.assert_any_call("tracks/1")
+    provider_mock.api.get.assert_any_call("tracks/1/lyrics")
     mock_parse_track.assert_called_once()
 
 
@@ -154,13 +154,13 @@ async def test_get_playlist(
     mock_parse_playlist: Mock, media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
     """Test get_playlist."""
-    provider_mock.api.get_data.return_value = {"uuid": "1", "title": "Test Playlist"}
+    provider_mock.api.get.return_value = {"uuid": "1", "title": "Test Playlist"}
     mock_parse_playlist.return_value = Mock(item_id="1")
 
     playlist = await media_manager.get_playlist("1")
 
     assert playlist.item_id == "1"
-    provider_mock.api.get_data.assert_called_with("playlists/1")
+    provider_mock.api.get.assert_called_with("playlists/1")
     mock_parse_playlist.assert_called_once()
 
 
@@ -169,14 +169,14 @@ async def test_get_album_tracks(
     mock_parse_track: Mock, media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
     """Test get_album_tracks."""
-    provider_mock.api.get_data.return_value = {"items": [{"id": 1}]}
+    provider_mock.api.get.return_value = {"items": [{"id": 1}]}
     mock_parse_track.return_value = Mock(item_id="1")
 
     tracks = await media_manager.get_album_tracks("1")
 
     assert len(tracks) == 1
     assert tracks[0].item_id == "1"
-    provider_mock.api.get_data.assert_called_with(
+    provider_mock.api.get.assert_called_with(
         "albums/1/tracks",
         params={"limit": 250},
     )
@@ -187,14 +187,14 @@ async def test_get_artist_albums(
     mock_parse_album: Mock, media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
     """Test get_artist_albums."""
-    provider_mock.api.get_data.return_value = {"items": [{"id": 1}]}
+    provider_mock.api.get.return_value = {"items": [{"id": 1}]}
     mock_parse_album.return_value = Mock(item_id="1")
 
     albums = await media_manager.get_artist_albums("1")
 
     assert len(albums) == 1
     assert albums[0].item_id == "1"
-    provider_mock.api.get_data.assert_called_with(
+    provider_mock.api.get.assert_called_with(
         "artists/1/albums",
         params={"limit": 250},
     )
@@ -205,14 +205,14 @@ async def test_get_artist_toptracks(
     mock_parse_track: Mock, media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
     """Test get_artist_toptracks."""
-    provider_mock.api.get_data.return_value = {"items": [{"id": 1}]}
+    provider_mock.api.get.return_value = {"items": [{"id": 1}]}
     mock_parse_track.return_value = Mock(item_id="1")
 
     tracks = await media_manager.get_artist_toptracks("1")
 
     assert len(tracks) == 1
     assert tracks[0].item_id == "1"
-    provider_mock.api.get_data.assert_called_with(
+    provider_mock.api.get.assert_called_with(
         "artists/1/toptracks",
         params={"limit": 10, "offset": 0},
     )
@@ -223,14 +223,14 @@ async def test_get_playlist_tracks(
     mock_parse_track: Mock, media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
     """Test get_playlist_tracks."""
-    provider_mock.api.get_data.return_value = {"items": [{"id": 1}]}
+    provider_mock.api.get.return_value = {"items": [{"id": 1}]}
     mock_parse_track.return_value = Mock(item_id="1")
 
     tracks = await media_manager.get_playlist_tracks("1")
 
     assert len(tracks) == 1
     assert tracks[0].item_id == "1"
-    provider_mock.api.get_data.assert_called_with(
+    provider_mock.api.get.assert_called_with(
         "playlists/1/tracks",
         params={"limit": 200, "offset": 0},
     )
@@ -245,7 +245,7 @@ async def test_get_playlist_favorite_tracks(
     assert playlist.item_id == "favorite_tracks"
     assert playlist.name == "Favorite Tracks"
     assert not playlist.is_editable
-    provider_mock.api.get_data.assert_not_called()
+    provider_mock.api.get.assert_not_called()
 
 
 @patch("music_assistant.providers.tidal.media.parse_track")
@@ -253,14 +253,14 @@ async def test_get_playlist_tracks_favorite_tracks(
     mock_parse_track: Mock, media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
     """Test get_playlist_tracks returns favorite tracks ordered by date descending."""
-    provider_mock.api.get_data.return_value = {"items": [{"item": {"id": 1}}]}
+    provider_mock.api.get.return_value = {"items": [{"item": {"id": 1}}]}
     mock_parse_track.return_value = Mock(item_id="1")
 
     tracks = await media_manager.get_playlist_tracks("favorite_tracks", page=0)
 
     assert len(tracks) == 1
     assert tracks[0].item_id == "1"
-    provider_mock.api.get_data.assert_called_with(
+    provider_mock.api.get.assert_called_with(
         "users/12345/favorites/tracks",
         params={"limit": 200, "offset": 0, "order": "DATE", "orderDirection": "DESC"},
     )

--- a/tests/providers/tidal/test_media_extended.py
+++ b/tests/providers/tidal/test_media_extended.py
@@ -19,7 +19,7 @@ def provider_mock() -> Mock:
     provider.auth.user_id = "12345"
     provider.auth.country_code = "US"
     provider.api = AsyncMock()
-    provider.api.get_data.return_value = {}
+    provider.api.get.return_value = {}
     provider.logger = Mock()
 
     def get_item_mapping(media_type: MediaType, key: str, name: str) -> ItemMapping:
@@ -46,7 +46,7 @@ async def test_get_playlist_mix(
     mock_parse_playlist: Mock, media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
     """Test get_playlist with mix ID."""
-    provider_mock.api.get_data.return_value = {
+    provider_mock.api.get.return_value = {
         "title": "My Mix",
         "rows": [
             {"modules": [{"mix": {"images": {"MEDIUM": {"url": "http://example.com/mix.jpg"}}}}]},
@@ -58,7 +58,7 @@ async def test_get_playlist_mix(
     playlist = await media_manager.get_playlist("mix_123")
 
     assert playlist.item_id == "mix_123"
-    provider_mock.api.get_data.assert_called_with(
+    provider_mock.api.get.assert_called_with(
         "pages/mix",
         params={"mixId": "123", "deviceType": "BROWSER"},
     )
@@ -73,7 +73,7 @@ async def test_get_playlist_fallback_to_mix(
 ) -> None:
     """Test get_playlist falls back to mix lookup on MediaNotFoundError."""
     # First call raises error, second succeeds
-    provider_mock.api.get_data.side_effect = [
+    provider_mock.api.get.side_effect = [
         MediaNotFoundError("Playlist not found"),
         {
             "title": "My Mix",
@@ -85,11 +85,11 @@ async def test_get_playlist_fallback_to_mix(
     playlist = await media_manager.get_playlist("123")
 
     assert playlist.item_id == "123"
-    assert provider_mock.api.get_data.call_count == 2
+    assert provider_mock.api.get.call_count == 2
     # First call as playlist
-    provider_mock.api.get_data.assert_any_call("playlists/123")
+    provider_mock.api.get.assert_any_call("playlists/123")
     # Second call as mix
-    provider_mock.api.get_data.assert_any_call(
+    provider_mock.api.get.assert_any_call(
         "pages/mix",
         params={"mixId": "123", "deviceType": "BROWSER"},
     )
@@ -100,13 +100,13 @@ async def test_get_similar_tracks(
     mock_parse_track: Mock, media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
     """Test get_similar_tracks."""
-    provider_mock.api.get_data.return_value = {"items": [{"id": 1}, {"id": 2}, {"id": 3}]}
+    provider_mock.api.get.return_value = {"items": [{"id": 1}, {"id": 2}, {"id": 3}]}
     mock_parse_track.return_value = Mock(item_id="1")
 
     tracks = await media_manager.get_similar_tracks("123", limit=25)
 
     assert len(tracks) == 3
-    provider_mock.api.get_data.assert_called_with(
+    provider_mock.api.get.assert_called_with(
         "tracks/123/radio",
         params={"limit": 25},
     )
@@ -117,7 +117,7 @@ async def test_get_playlist_tracks_mix(
     mock_parse_track: Mock, media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
     """Test get_playlist_tracks with mix ID."""
-    provider_mock.api.get_data.return_value = {
+    provider_mock.api.get.return_value = {
         "rows": [
             {},  # First row is mix info
             {  # Second row has tracks
@@ -142,7 +142,7 @@ async def test_get_playlist_tracks_mix(
     assert len(tracks) == 2
     assert tracks[0].position == 1
     assert tracks[1].position == 2
-    provider_mock.api.get_data.assert_called_with(
+    provider_mock.api.get.assert_called_with(
         "pages/mix",
         params={"mixId": "123", "deviceType": "BROWSER"},
     )
@@ -152,7 +152,7 @@ async def test_get_mix_details_no_rows(
     media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
     """Test _get_mix_details raises error when no rows."""
-    provider_mock.api.get_data.return_value = {"rows": []}
+    provider_mock.api.get.return_value = {"rows": []}
 
     with pytest.raises(MediaNotFoundError, match="Mix 123 has no tracks"):
         await media_manager.get_playlist_tracks("mix_123")
@@ -160,7 +160,7 @@ async def test_get_mix_details_no_rows(
 
 async def test_search_empty_results(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
     """Test search with empty results."""
-    provider_mock.api.get_data.return_value = {}
+    provider_mock.api.get.return_value = {}
 
     results = await media_manager.search("query", [MediaType.ARTIST])
 

--- a/tests/providers/tidal/test_parsers.py
+++ b/tests/providers/tidal/test_parsers.py
@@ -93,3 +93,25 @@ def test_parse_playlist(
     is_mix = "mix" in example.name
     parsed = parse_playlist(provider_mock, data, is_mix=is_mix).to_dict()
     assert snapshot == parsed
+
+
+def test_parse_track_partial_album(provider_mock: Mock) -> None:
+    """Test track parsing tolerates partial album objects."""
+    track_obj = {
+        "id": 123,
+        "title": "Test Track",
+        "duration": 100,
+        "artists": [{"id": 1, "name": "Test Artist", "picture": None}],
+        "album": {"id": 456},  # No title or cover
+    }
+
+    track = parse_track(provider_mock, track_obj)
+
+    assert track.album is not None
+    assert track.album.item_id == "456"
+    assert track.album.name == ""
+
+    # An album without an id is useless: no mapping should be created
+    track_obj["album"] = {"title": "Test Album"}
+    track = parse_track(provider_mock, track_obj)
+    assert track.album is None

--- a/tests/providers/tidal/test_playlist.py
+++ b/tests/providers/tidal/test_playlist.py
@@ -47,11 +47,11 @@ async def test_add_playlist_tracks(
 ) -> None:
     """Test add_playlist_tracks."""
     # Mock get response with ETag
-    provider_mock.api.get.return_value = ({"numberOfTracks": 5}, "etag_123")
+    provider_mock.api.get_with_etag.return_value = ({"numberOfTracks": 5}, "etag_123")
 
     await playlist_manager.add_tracks("1", ["track_1", "track_2"])
 
-    provider_mock.api.get.assert_called_with("playlists/1", return_etag=True)
+    provider_mock.api.get_with_etag.assert_called_with("playlists/1")
     provider_mock.api.post.assert_called_with(
         "playlists/1/items",
         data={
@@ -70,12 +70,12 @@ async def test_remove_playlist_tracks(
 ) -> None:
     """Test remove_playlist_tracks."""
     # Mock get response with ETag
-    provider_mock.api.get.return_value = ({}, "etag_123")
+    provider_mock.api.get_with_etag.return_value = ({}, "etag_123")
 
     # Positions are 1-based in MA, converted to 0-based for Tidal
     await playlist_manager.remove_tracks("1", (1, 3))
 
-    provider_mock.api.get.assert_called_with("playlists/1", return_etag=True)
+    provider_mock.api.get_with_etag.assert_called_with("playlists/1")
     provider_mock.api.delete.assert_called_with(
         "playlists/1/items/0,2",
         headers={"If-None-Match": "etag_123"},

--- a/tests/providers/tidal/test_provider.py
+++ b/tests/providers/tidal/test_provider.py
@@ -80,7 +80,7 @@ async def test_handle_async_init_success(provider: TidalProvider) -> None:
         patch.object(provider.auth, "update_user_info", new_callable=AsyncMock),
     ):
         mock_init.return_value = True
-        mock_get.return_value = ({"userId": "12345", "sessionId": "session_123"}, None)
+        mock_get.return_value = {"userId": "12345", "sessionId": "session_123"}
         mock_get_user.return_value = {"id": "12345", "username": "testuser"}
 
         await provider.handle_async_init()
@@ -371,7 +371,7 @@ async def test_recommendations_delegates_to_recommendations_manager(
 
 async def test_get_user(provider: TidalProvider) -> None:
     """Test get_user fetches user data."""
-    with patch.object(provider.api, "get_data", new_callable=AsyncMock) as mock_get:
+    with patch.object(provider.api, "get", new_callable=AsyncMock) as mock_get:
         mock_get.return_value = {"id": "123", "username": "testuser"}
 
         user = await provider.get_user("123")

--- a/tests/providers/tidal/test_recommendations.py
+++ b/tests/providers/tidal/test_recommendations.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import ResourceTemporarilyUnavailable
 
 from music_assistant.providers.tidal.recommendations import TidalRecommendationManager
 
@@ -136,3 +137,19 @@ async def test_get_page_content(
 
         # Should cache result
         provider_mock.mass.cache.set.assert_called()
+
+
+async def test_get_page_content_propagates_api_errors(
+    recommendation_manager: TidalRecommendationManager, provider_mock: Mock
+) -> None:
+    """Test API failures propagate so an empty result is never cached."""
+    with patch(
+        "music_assistant.providers.tidal.recommendations.TidalPageParser"
+    ) as mock_parser_cls:
+        mock_parser_cls.from_cache = AsyncMock(return_value=None)
+        provider_mock.api.get.side_effect = ResourceTemporarilyUnavailable("API error")
+
+        with pytest.raises(ResourceTemporarilyUnavailable):
+            await recommendation_manager.get_page_content("pages/home")
+
+        provider_mock.mass.cache.set.assert_not_called()

--- a/tests/providers/tidal/test_recommendations.py
+++ b/tests/providers/tidal/test_recommendations.py
@@ -41,7 +41,7 @@ async def test_get_recommendations(
     """Test get_recommendations."""
     # Mock get_page_content to return a mock parser
     mock_parser = Mock()
-    mock_parser._module_map = [{"title": "Test Module"}]
+    mock_parser.modules = [{"title": "Test Module"}]
     mock_parser.get_module_items.return_value = (
         [Mock(item_id="rec_1", name="Recommendation 1")],
         MediaType.PLAYLIST,
@@ -77,14 +77,14 @@ async def test_get_recommendations_strips_at_symbol_when_multiple_instances(
     )
 
     parser_with_module = Mock()
-    parser_with_module._module_map = [{"title": "Test Module"}]
+    parser_with_module.modules = [{"title": "Test Module"}]
     parser_with_module.get_module_items.return_value = (
         [Mock(item_id="rec_1", name="Recommendation 1")],
         MediaType.PLAYLIST,
     )
 
     parser_empty = Mock()
-    parser_empty._module_map = []
+    parser_empty.modules = []
     parser_empty.get_module_items = Mock()
 
     with patch.object(
@@ -113,13 +113,13 @@ async def test_get_page_content(
 
         # Configure parser instance
         mock_parser_instance = mock_parser_cls.return_value
-        mock_parser_instance._module_map = []
-        mock_parser_instance._content_map = {}
-        mock_parser_instance._parsed_at = 1234567890
         mock_parser_instance.parse_page_structure = Mock()  # Ensure it's a synchronous mock
+        mock_parser_instance.to_cache = Mock(
+            return_value={"module_map": [], "content_map": {}, "parsed_at": 1234567890}
+        )
 
         # Mock API response
-        provider_mock.api.get.return_value = ({"rows": []}, "etag")
+        provider_mock.api.get.return_value = {"rows": []}
 
         parser = await recommendation_manager.get_page_content("pages/home")
 

--- a/tests/providers/tidal/test_streaming.py
+++ b/tests/providers/tidal/test_streaming.py
@@ -62,16 +62,13 @@ async def test_get_stream_details_lossless(
 ) -> None:
     """Test get_stream_details with LOSSLESS quality."""
     provider_mock.get_track.return_value = mock_track
-    provider_mock.api.get.return_value = (
-        {
-            "manifestMimeType": "application/vnd.tidal.bts",
-            "urls": ["https://example.com/stream.flac"],
-            "audioQuality": "LOSSLESS",
-            "sampleRate": 44100,
-            "bitDepth": 16,
-        },
-        None,
-    )
+    provider_mock.api.get.return_value = {
+        "manifestMimeType": "application/vnd.tidal.bts",
+        "urls": ["https://example.com/stream.flac"],
+        "audioQuality": "LOSSLESS",
+        "sampleRate": 44100,
+        "bitDepth": 16,
+    }
 
     stream_details = await streaming_manager.get_stream_details("123")
 
@@ -437,23 +434,14 @@ async def test_get_stream_details_with_isrc_fallback(
     lib_track.external_ids = [(ExternalID.ISRC, "US1234567890")]
     provider_mock.mass.music.tracks.get_library_item_by_prov_id.return_value = lib_track
 
-    provider_mock.api.get.return_value = (
-        {"data": [{"id": 456}]},  # ISRC lookup response
-        None,
-    )
-
-    # Stream details
     provider_mock.api.get.side_effect = [
-        ({"data": [{"id": 456}]}, None),  # ISRC lookup
-        (
-            {  # Stream details
-                "urls": ["https://example.com/stream.flac"],
-                "audioQuality": "LOSSLESS",
-                "sampleRate": 44100,
-                "bitDepth": 16,
-            },
-            None,
-        ),
+        {"data": [{"id": 456}]},  # ISRC lookup
+        {  # Stream details
+            "urls": ["https://example.com/stream.flac"],
+            "audioQuality": "LOSSLESS",
+            "sampleRate": 44100,
+            "bitDepth": 16,
+        },
     ]
 
     stream_details = await streaming_manager.get_stream_details("123")


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

- Fix `paginate()` dropping caller-supplied params after the first page.
- Recover from server-side token invalidation: a 401 now forces a token refresh and one retry instead of killing the provider until reload.
- Serialize token refreshes behind a lock with a 30s cooldown so concurrent 401s can't hammer the token endpoint.
- Stop caching an empty recommendations list for an hour after a transient error.
- Harden track/artist parsers against partial API objects (no more KeyError on missing `streamReady`, `artists`, `album`, etc.).
- Never fail a track lookup on a lyrics error, and skip the lyrics request entirely for nonexistent tracks.
- Clean up the API client: dedicated `get_with_etag()` replaces the `dict | tuple` return union and 8 tuple-unwrap call sites.
- Speed up the Tidal test suite from ~112s to ~0.3s by neutralizing the shared throttler in tests.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
