### PR TITLE
Include track duration and played duration in ListenBrainz submissions

### DIFF
--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -125,7 +125,10 @@ class ListenBrainzEventHandler(ScrobblerHelper):
         additional_info = {}
 
         if report.duration:
-            additional_info["duration"]=report.duration
+            additional_info["duration"] = report.duration
+
+        if report.seconds_played:
+            additional_info["duration_played"] = report.seconds_played
 
         # https://pylistenbrainz.readthedocs.io/en/latest/api_ref.html#class-listen
         return Listen(
@@ -136,7 +139,7 @@ class ListenBrainzEventHandler(ScrobblerHelper):
             release_mbid=report.album_mbid,
             recording_mbid=report.mbid,
             listening_from="music-assistant",
-            additional_info or None,
+            additional_info=additional_info or None,
         )
 
     async def _update_now_playing(self, report: MediaItemPlaybackProgressReport) -> None:

--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -122,6 +122,11 @@ class ListenBrainzEventHandler(ScrobblerHelper):
         # album artist and track number are not available without an extra API call
         # so they won't be scrobbled
 
+        additional_info = {}
+
+        if report.duration:
+            additional_info["duration"]=report.duration
+
         # https://pylistenbrainz.readthedocs.io/en/latest/api_ref.html#class-listen
         return Listen(
             track_name=self.get_name(report),
@@ -131,6 +136,7 @@ class ListenBrainzEventHandler(ScrobblerHelper):
             release_mbid=report.album_mbid,
             recording_mbid=report.mbid,
             listening_from="music-assistant",
+            additional_info or None,
         )
 
     async def _update_now_playing(self, report: MediaItemPlaybackProgressReport) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Music Assistant already knows the duration of the currently playing track. Including this in the ListenBrainz submission allows downstream consumers to calculate listening-time statistics without performing metadata lookups or relying on external databases.

I verified it with a live chain: Music Assistant → ListenBrainz provider → Multi-Scrobbler → Koito. After the change, new scrobbles include the duration and Koito correctly records the track length. 

Logs from Multi-Scrobbler:
```
[2026-07-18 08:13:50.124 -0400] TRACE  : [App] [API] [Ingress] [Listenbrainz] Recieved request Body
    body: {
      "listen_type": "single",
      "payload": [
        {
          "track_metadata": {
            "track_name": "I'm Tired",
            "artist_name": "Hank Williams, Jr.",
            "release_name": "Out of Left Field",
            "additional_info": {
              "duration": 198,
              "duration_played": 198,
              "listening_from": "music-assistant"
            }
          },
          "listened_at": 1784376830
        }
      ]
    }
```

**Related issue (if applicable):**

none

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
