### PR TITLE
Ignore WiiM's false PLAYING report while no media is loaded

### DIFF
--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -381,21 +381,19 @@ class WiimPlayer(Player):
             self.update_state()
             return
 
+        media = self.device.current_media
+        device_uri = media.uri if media and media.uri else ""
+        play_mode = self.device.play_mode
+
         # Playback state
-        if self.device.playing_status is not None:
-            self._attr_playback_state = SDK_TO_MA_STATE.get(
-                self.device.playing_status, PlaybackState.IDLE
-            )
+        if (new_state := self._resolve_playback_state(device_uri, play_mode)) is not None:
+            self._attr_playback_state = new_state
 
         # Group members
         group_members = self._wiim_controller.get_group_members(self.device.udn)
         self._attr_group_members = [
             f"{PLAYER_ID_PREFIX}{m.udn}" for m in group_members if m.udn != self.device.udn
         ]
-
-        media = self.device.current_media
-        device_uri = media.uri if media and media.uri else ""
-        play_mode = self.device.play_mode
 
         if play_mode and play_mode != SOURCE_NETWORK and play_mode in INPUT_MODE_SOURCES:
             self._attr_active_source = INPUT_MODE_SOURCES[play_mode].id
@@ -440,6 +438,32 @@ class WiimPlayer(Player):
 
         self._log_sdk_state_change()
         self.update_state()
+
+    def _resolve_playback_state(
+        self, device_uri: str, play_mode: str | None
+    ) -> PlaybackState | None:
+        """
+        Map the SDK playing status to a MA playback state.
+
+        Returns ``None`` when the current state should be kept: either no status
+        is known yet, or the report is implausible and should not propagate.
+
+        :param device_uri: The media URI currently loaded on the device ("" if none).
+        :param play_mode: The device's current play mode (input source).
+        """
+        if self.device.playing_status is None:
+            return None
+        new_state = SDK_TO_MA_STATE.get(self.device.playing_status, PlaybackState.IDLE)
+        # The device acks transport commands with a transient (false) PLAYING
+        # report while no media is loaded yet (observed during group session
+        # setup). Nothing can actually play in network mode without a URI, so
+        # keep the previous state instead of propagating the false start and
+        # the PLAYING->IDLE->PLAYING flicker it causes downstream. External
+        # inputs (line-in, Bluetooth, ...) legitimately play without a URI and
+        # are not affected.
+        if new_state == PlaybackState.PLAYING and play_mode == SOURCE_NETWORK and not device_uri:
+            return None
+        return new_state
 
     def _log_sdk_state_change(self) -> None:
         """Log a debug line whenever the SDK-reported URI or playing_status changes."""

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -451,9 +451,12 @@ class WiimPlayer(Player):
         :param device_uri: The media URI currently loaded on the device ("" if none).
         :param play_mode: The device's current play mode (input source).
         """
-        if self.device.playing_status is None:
+        # widened annotation: the SDK types playing_status as non-optional, but
+        # we stay tolerant of a None from mocks/edge paths (as the code always has)
+        sdk_status: PlayingStatus | None = self.device.playing_status
+        if sdk_status is None:
             return None
-        new_state = SDK_TO_MA_STATE.get(self.device.playing_status, PlaybackState.IDLE)
+        new_state = SDK_TO_MA_STATE.get(sdk_status, PlaybackState.IDLE)
         # The device acks transport commands with a transient (false) PLAYING
         # report while no media is loaded yet (observed during group session
         # setup). Nothing can actually play in network mode without a URI, so

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -7,6 +7,7 @@ from music_assistant_models.enums import PlaybackState, PlayerFeature
 from wiim import PlayingStatus
 from wiim.exceptions import WiimDeviceException, WiimRequestException
 
+from music_assistant.providers.wiim.constants import SOURCE_NETWORK
 from music_assistant.providers.wiim.player import SDK_TO_MA_STATE, WiimPlayer
 
 
@@ -106,6 +107,121 @@ class TestSDKStateMapping:
         for status in PlayingStatus:
             if status != PlayingStatus.UNKNOWN:
                 assert status in SDK_TO_MA_STATE, f"{status} not mapped"
+
+
+class TestFalsePlayingFilter:
+    """A uri-less PLAYING report in network mode must not become PLAYING state."""
+
+    def _make_player(self, provider: MagicMock, device: MagicMock) -> WiimPlayer:
+        player = WiimPlayer(provider=provider, player_id="uuid:test", device=device)
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+        return player
+
+    def test_false_playing_ack_is_suppressed(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """
+        The transient PLAYING ack without media loaded must keep the previous state.
+
+        The device acks (group) transport commands with a short false PLAYING
+        report before any track is loaded; propagating it causes a
+        PLAYING->IDLE->PLAYING flicker downstream.
+        """
+        mock_wiim_device.play_mode = SOURCE_NETWORK
+        mock_wiim_device.current_media = None
+        mock_wiim_device.playing_status = PlayingStatus.PLAYING
+        player = self._make_player(mock_provider, mock_wiim_device)
+        player._attr_playback_state = PlaybackState.IDLE
+
+        player._update_ma_state_from_sdk_cache()
+
+        assert player._attr_playback_state == PlaybackState.IDLE
+
+    def test_loading_without_uri_is_suppressed(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """LOADING maps to PLAYING and gets the same uri-less filter."""
+        mock_wiim_device.play_mode = SOURCE_NETWORK
+        mock_wiim_device.current_media = None
+        mock_wiim_device.playing_status = PlayingStatus.LOADING
+        player = self._make_player(mock_provider, mock_wiim_device)
+        player._attr_playback_state = PlaybackState.IDLE
+
+        player._update_ma_state_from_sdk_cache()
+
+        assert player._attr_playback_state == PlaybackState.IDLE
+
+    def test_playing_kept_when_uri_drops_mid_playback(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """The filter keeps the previous state; it never forces a playing player idle."""
+        mock_wiim_device.play_mode = SOURCE_NETWORK
+        mock_wiim_device.current_media = None
+        mock_wiim_device.playing_status = PlayingStatus.PLAYING
+        player = self._make_player(mock_provider, mock_wiim_device)
+        player._attr_playback_state = PlaybackState.PLAYING
+
+        player._update_ma_state_from_sdk_cache()
+
+        assert player._attr_playback_state == PlaybackState.PLAYING
+
+    def test_playing_accepted_once_uri_present(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """A PLAYING report with media loaded is a real start and passes through."""
+        media = MagicMock()
+        media.uri = "http://192.168.1.80:8097/single/abc/queue/item/uuid:test.flac"
+        mock_wiim_device.play_mode = SOURCE_NETWORK
+        mock_wiim_device.current_media = media
+        mock_wiim_device.playing_status = PlayingStatus.PLAYING
+        player = self._make_player(mock_provider, mock_wiim_device)
+        player._attr_playback_state = PlaybackState.IDLE
+
+        player._update_ma_state_from_sdk_cache()
+
+        assert player._attr_playback_state == PlaybackState.PLAYING
+
+    def test_external_input_playing_without_uri_accepted(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """External inputs legitimately play without a URI and must not be filtered."""
+        mock_wiim_device.play_mode = "Line In"
+        mock_wiim_device.current_media = None
+        mock_wiim_device.playing_status = PlayingStatus.PLAYING
+        player = self._make_player(mock_provider, mock_wiim_device)
+        player._attr_playback_state = PlaybackState.IDLE
+
+        player._update_ma_state_from_sdk_cache()
+
+        assert player._attr_playback_state == PlaybackState.PLAYING
+
+    def test_unknown_play_mode_trusts_device(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """Without a known play mode the device report is trusted (no suppression)."""
+        mock_wiim_device.play_mode = None
+        mock_wiim_device.current_media = None
+        mock_wiim_device.playing_status = PlayingStatus.PLAYING
+        player = self._make_player(mock_provider, mock_wiim_device)
+        player._attr_playback_state = PlaybackState.IDLE
+
+        player._update_ma_state_from_sdk_cache()
+
+        assert player._attr_playback_state == PlaybackState.PLAYING
+
+    def test_stopped_report_unaffected(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """The filter only guards PLAYING-mapped reports; STOPPED passes through."""
+        mock_wiim_device.play_mode = SOURCE_NETWORK
+        mock_wiim_device.current_media = None
+        mock_wiim_device.playing_status = PlayingStatus.STOPPED
+        player = self._make_player(mock_provider, mock_wiim_device)
+        player._attr_playback_state = PlaybackState.PLAYING
+
+        player._update_ma_state_from_sdk_cache()
+
+        assert player._attr_playback_state == PlaybackState.IDLE
 
 
 class TestSupportedFeatures:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #4815, hardening at the source: WiiM devices ack (group) transport commands with a transient `TransportState=PLAYING` while no media is loaded yet — observed in production logs as a ~14ms false PLAYING during group session setup, bouncing back through stopped a moment later. Propagating that report causes a PLAYING→IDLE→PLAYING flicker for every consumer (UI, playback tracker, group logic) and was the trigger for the sync-group race fixed in #4815.

The SDK→MA state mapping now keeps the previous playback state when a PLAYING(/LOADING)-mapped report arrives in **network mode without a media URI** — nothing can actually be playing then. External inputs (line-in, Bluetooth, …) legitimately play without a URI and are unaffected, and an unknown play mode trusts the device (no suppression). The filter only ever suppresses an implausible *transition*; it never forces a playing player to idle.

**Related issue (if applicable):**

- n/a (follow-up to #4815, found via log analysis)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
