### PR TITLE
Improve webrtc key file creation

### DIFF
--- a/music_assistant/helpers/webrtc_certificate.py
+++ b/music_assistant/helpers/webrtc_certificate.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import base64
 import logging
+import os
 import stat
 from datetime import timedelta
 from pathlib import Path
@@ -88,7 +89,9 @@ def _save_certificate(
         format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
     )
-    key_path.write_bytes(key_pem)
+    fd = os.open(key_path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "wb") as f:
+        f.write(key_pem)
 
     # Set restrictive permissions on private key (owner read/write only)
     key_path.chmod(stat.S_IRUSR | stat.S_IWUSR)

--- a/music_assistant/helpers/webrtc_certificate.py
+++ b/music_assistant/helpers/webrtc_certificate.py
@@ -91,10 +91,10 @@ def _save_certificate(
     )
     fd = os.open(key_path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
     with os.fdopen(fd, "wb") as f:
+        # O_TRUNC keeps a pre-existing file's mode, so tighten permissions on the
+        # fd before any key byte is written (owner read/write only)
+        os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
         f.write(key_pem)
-
-    # Set restrictive permissions on private key (owner read/write only)
-    key_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
 
 
 def _load_certificate(
@@ -129,9 +129,12 @@ def _load_certificate(
             LOGGER.warning("WebRTC private key does not match certificate, will regenerate")
             return None
 
-        # key files written by older versions may be world-readable; the save path
-        # only runs on regeneration, so tighten permissions on load as well
-        key_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        # older versions wrote the key with umask permissions before chmoding it;
+        # a crash in that window left it world-readable, and a valid pair is never
+        # rewritten, so repair permissions on load (owner read/write only)
+        mode = stat.S_IRUSR | stat.S_IWUSR
+        if stat.S_IMODE(key_path.stat().st_mode) != mode:
+            key_path.chmod(mode)
 
         return private_key, cert
     except Exception as err:

--- a/music_assistant/helpers/webrtc_certificate.py
+++ b/music_assistant/helpers/webrtc_certificate.py
@@ -129,6 +129,10 @@ def _load_certificate(
             LOGGER.warning("WebRTC private key does not match certificate, will regenerate")
             return None
 
+        # key files written by older versions may be world-readable; the save path
+        # only runs on regeneration, so tighten permissions on load as well
+        key_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
         return private_key, cert
     except Exception as err:
         LOGGER.warning("Failed to load WebRTC certificate: %s", err)

--- a/music_assistant/helpers/webrtc_certificate.py
+++ b/music_assistant/helpers/webrtc_certificate.py
@@ -123,6 +123,12 @@ def _load_certificate(
             LOGGER.warning("WebRTC private key is not an EC key, will regenerate")
             return None
 
+        # cert and key are written as two separate files; a crash between the writes
+        # leaves a mismatched pair that would otherwise fail every DTLS handshake
+        if private_key.public_key() != cert.public_key():
+            LOGGER.warning("WebRTC private key does not match certificate, will regenerate")
+            return None
+
         return private_key, cert
     except Exception as err:
         LOGGER.warning("Failed to load WebRTC certificate: %s", err)

--- a/tests/helpers/test_webrtc_certificate.py
+++ b/tests/helpers/test_webrtc_certificate.py
@@ -1,0 +1,40 @@
+"""Tests for the WebRTC DTLS certificate persistence."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from music_assistant.helpers.webrtc_certificate import (
+    KEY_FILENAME,
+    _get_or_create_certificate,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_certificate_is_persistent(tmp_path: Path) -> None:
+    """Repeated calls return the same keypair."""
+    key, cert = _get_or_create_certificate(str(tmp_path))
+    key2, cert2 = _get_or_create_certificate(str(tmp_path))
+    assert cert2 == cert
+    assert key2.public_key() == key.public_key()
+
+
+def test_mismatched_key_regenerates_pair(tmp_path: Path) -> None:
+    """A key file not matching the certificate yields a fresh consistent pair."""
+    _, cert = _get_or_create_certificate(str(tmp_path))
+    stray_key = ec.generate_private_key(ec.SECP256R1())
+    (tmp_path / KEY_FILENAME).write_bytes(
+        stray_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    key2, cert2 = _get_or_create_certificate(str(tmp_path))
+    assert key2.public_key() == cert2.public_key()
+    assert cert2 != cert

--- a/tests/helpers/test_webrtc_certificate.py
+++ b/tests/helpers/test_webrtc_certificate.py
@@ -56,3 +56,13 @@ def test_private_key_permissions_tightened_on_regeneration(tmp_path: Path) -> No
     (tmp_path / CERT_FILENAME).unlink()
     _get_or_create_certificate(str(tmp_path))
     assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+
+def test_private_key_permissions_tightened_on_load(tmp_path: Path) -> None:
+    """Loading a valid pair tightens a loose key file to owner-only access."""
+    _, cert = _get_or_create_certificate(str(tmp_path))
+    key_path = tmp_path / KEY_FILENAME
+    key_path.chmod(0o644)
+    _, cert2 = _get_or_create_certificate(str(tmp_path))
+    assert cert2 == cert
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600

--- a/tests/helpers/test_webrtc_certificate.py
+++ b/tests/helpers/test_webrtc_certificate.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import stat
 from typing import TYPE_CHECKING
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
 from music_assistant.helpers.webrtc_certificate import (
+    CERT_FILENAME,
     KEY_FILENAME,
     _get_or_create_certificate,
 )
@@ -38,3 +40,19 @@ def test_mismatched_key_regenerates_pair(tmp_path: Path) -> None:
     key2, cert2 = _get_or_create_certificate(str(tmp_path))
     assert key2.public_key() == cert2.public_key()
     assert cert2 != cert
+
+
+def test_private_key_created_with_restrictive_permissions(tmp_path: Path) -> None:
+    """A fresh private key file is owner read/write only."""
+    _get_or_create_certificate(str(tmp_path))
+    assert stat.S_IMODE((tmp_path / KEY_FILENAME).stat().st_mode) == 0o600
+
+
+def test_private_key_permissions_tightened_on_regeneration(tmp_path: Path) -> None:
+    """Regenerating over a loose-permissions key file restores owner-only access."""
+    _get_or_create_certificate(str(tmp_path))
+    key_path = tmp_path / KEY_FILENAME
+    key_path.chmod(0o644)
+    (tmp_path / CERT_FILENAME).unlink()
+    _get_or_create_certificate(str(tmp_path))
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600


### PR DESCRIPTION
# What does this implement/fix?

Improve webrtc key file creation:
- Create WebRTC DTLS private key with owner-only permissions
- Tighten permissions of already existing key too
- Regenerate WebRTC certificate when the private key does not match

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
