### PR TITLE
Remove redundant client disconnect loop from Sendspin provider unload

### DIFF
--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -422,23 +422,6 @@ class SendspinProvider(PlayerProvider):
         """
         self._unloading = True
         player_ids = [player.player_id for player in self.players]
-        # Disconnect all clients before stopping the server
-        clients = list(self.server_api.clients)
-        connected_clients = []
-        disconnect_tasks = []
-        for client in clients:
-            if client.connection is None:
-                continue
-            connected_clients.append(client)
-            disconnect_tasks.append(client.connection.disconnect(retry_connection=False))
-        if disconnect_tasks:
-            results = await asyncio.gather(*disconnect_tasks, return_exceptions=True)
-            for client, result in zip(connected_clients, results, strict=True):
-                if isinstance(result, Exception):
-                    self.logger.warning(
-                        "Error disconnecting client %s: %s", client.client_id, result
-                    )
-
         # Stop the Sendspin server
         await self.server_api.close()
 


### PR DESCRIPTION


# What does this implement/fix?

Remove redundant client disconnect loop from Sendspin provider unload.

SendspinServer.close() already disconnects all connected clients with disconnect(retry_connection=False), so the explicit per-client loop in unload() is redundant.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
