### PR TITLE
Don't allow ffmpeg to try range requests when using POST data

### DIFF
--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -546,6 +546,13 @@ def get_ffmpeg_args(
                 "-reconnect_on_http_error",
                 "5xx,429",
             ]
+            if "-post_data" in extra_input_args:
+                # ffmpeg does not include Range headers on POST reconnects, so byte-range
+                # seeking via reconnect is not available. Mark the stream non-seekable so
+                # demuxers do not attempt end-of-file probes (e.g. OGG duration detection)
+                # that would trigger Range-less restarts from byte 0. MA-initiated seeks
+                # still work via -ss decode-and-discard.
+                input_args += ["-seekable", "0"]
         if input_format.content_type.is_pcm():
             input_args += [
                 "-ac",


### PR DESCRIPTION
ffmpeg chooses not to include Rage headers when doing a POST reconnect. Because of this, we need to ensure that it knows to pull the whole stream and decode+discard to seek.

Fixes: #5210

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5210

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

