### PR TITLE
Migrate Tidal artist/album reads to official API

### DIFF
--- a/music_assistant/providers/tidal/api_client.py
+++ b/music_assistant/providers/tidal/api_client.py
@@ -65,6 +65,30 @@ class TidalAPIClient:
         )
         return JsonApiDocument(data)
 
+    async def paginate_jsonapi(
+        self,
+        endpoint: str,
+        include: Sequence[str] | None = None,
+        params: dict[str, Any] | None = None,
+        max_pages: int = 50,
+        **kwargs: Any,
+    ) -> AsyncGenerator[JsonApiDocument]:
+        """Yield successive JSON:API document pages, following the cursor links."""
+        cursor: str | None = None
+        for _ in range(max_pages):
+            page_params = dict(params or {})
+            if cursor:
+                page_params["page[cursor]"] = cursor
+            doc = await self.get_jsonapi(endpoint, include=include, params=page_params, **kwargs)
+            yield doc
+            cursor = doc.next_cursor
+            if not cursor:
+                return
+        # Reached the page cap while more pages remained: surface the truncation.
+        self.logger.warning(
+            "Stopped paginating %s after %d pages; results may be truncated", endpoint, max_pages
+        )
+
     async def post(
         self,
         endpoint: str,

--- a/music_assistant/providers/tidal/jsonapi.py
+++ b/music_assistant/providers/tidal/jsonapi.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import unquote
 
 
 class JsonApiDocument:
@@ -45,8 +46,14 @@ class JsonApiDocument:
         # The API returns either a full path with a page[cursor] query param
         # or the bare cursor value; callers only need the cursor.
         if "page[cursor]=" in next_link:
-            return next_link.split("page[cursor]=", 1)[1].split("&", 1)[0]
+            return unquote(next_link.split("page[cursor]=", 1)[1].split("&", 1)[0])
         return next_link
+
+    def resolve(self, identifier: dict[str, Any]) -> dict[str, Any] | None:
+        """Resolve a resource identifier ({type, id}) to its included resource."""
+        if "type" not in identifier or "id" not in identifier:
+            return None
+        return self._included.get((identifier["type"], identifier["id"]))
 
     def related(self, resource: dict[str, Any], relationship: str) -> list[dict[str, Any]]:
         """

--- a/music_assistant/providers/tidal/jsonapi.py
+++ b/music_assistant/providers/tidal/jsonapi.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import unquote
+from urllib.parse import parse_qs, urlparse
 
 
 class JsonApiDocument:
@@ -43,10 +43,11 @@ class JsonApiDocument:
         next_link = links.get("next")
         if not isinstance(next_link, str) or not next_link:
             return None
-        # The API returns either a full path with a page[cursor] query param
-        # or the bare cursor value; callers only need the cursor.
-        if "page[cursor]=" in next_link:
-            return unquote(next_link.split("page[cursor]=", 1)[1].split("&", 1)[0])
+        # The next link is a path with a page[cursor] query param, whose brackets
+        # may be percent-encoded (page%5Bcursor%5D). parse_qs decodes both the key
+        # and value; fall back to treating the whole link as a bare cursor.
+        if cursors := parse_qs(urlparse(next_link).query).get("page[cursor]"):
+            return cursors[0]
         return next_link
 
     def resolve(self, identifier: dict[str, Any]) -> dict[str, Any] | None:

--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -112,7 +112,7 @@ class TidalMediaManager:
             # track carries an image, matching the unofficial API's behaviour.
             doc = await self.api.get_jsonapi(
                 f"tracks/{prov_track_id}",
-                include=["artists", "albums", "albums.coverArt", "genres"],
+                include=["artists", "albums", "albums.coverArt", "genres", "credits"],
             )
             track = parse_track_v2(self.provider, doc, doc.data)
         except (ClientError, KeyError, ValueError) as err:
@@ -144,6 +144,112 @@ class TidalMediaManager:
         except (ClientError, KeyError, ValueError) as err:
             raise MediaNotFoundError(f"Playlist {prov_playlist_id} not found") from err
 
+    async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
+        """Get album tracks."""
+        tracks: list[Track] = []
+        try:
+            async for doc in self.api.paginate_jsonapi(
+                f"albums/{prov_album_id}/relationships/items",
+                include=["items.artists", "items.albums.coverArt"],
+            ):
+                for item in doc.data_list:
+                    if not (resource := doc.resolve(item)):
+                        continue
+                    track = parse_track_v2(self.provider, doc, resource)
+                    item_meta = item.get("meta") or {}
+                    track.track_number = item_meta.get("trackNumber", 0) or 0
+                    track.disc_number = item_meta.get("volumeNumber", 0) or 0
+                    tracks.append(track)
+        except (ClientError, KeyError, ValueError) as err:
+            raise MediaNotFoundError(f"Album {prov_album_id} not found") from err
+        return tracks
+
+    async def get_artist_albums(self, prov_artist_id: str) -> list[Album]:
+        """Get artist albums."""
+        albums: list[Album] = []
+        try:
+            async for doc in self.api.paginate_jsonapi(
+                f"artists/{prov_artist_id}/relationships/albums",
+                include=["albums.artists", "albums.coverArt"],
+            ):
+                for item in doc.data_list:
+                    if resource := doc.resolve(item):
+                        albums.append(parse_album_v2(self.provider, doc, resource))
+        except (ClientError, KeyError, ValueError) as err:
+            raise MediaNotFoundError(f"Artist {prov_artist_id} not found") from err
+        return albums
+
+    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
+        """Get artist top tracks."""
+        # Top tracks are a bounded, ranked list: the first page is enough.
+        try:
+            doc = await self.api.get_jsonapi(
+                f"artists/{prov_artist_id}/relationships/tracks",
+                params={"collapseBy": "FINGERPRINT"},
+                include=["tracks.artists", "tracks.albums.coverArt"],
+            )
+            return [
+                parse_track_v2(self.provider, doc, resource)
+                for item in doc.data_list
+                if (resource := doc.resolve(item))
+            ]
+        except (ClientError, KeyError, ValueError) as err:
+            raise MediaNotFoundError(f"Artist {prov_artist_id} not found") from err
+
+    async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
+        """Get similar tracks."""
+        # Similar tracks are a bounded, ranked list: the first page is enough.
+        try:
+            doc = await self.api.get_jsonapi(
+                f"tracks/{prov_track_id}/relationships/similarTracks",
+                include=["similarTracks.artists", "similarTracks.albums.coverArt"],
+            )
+            tracks = [
+                parse_track_v2(self.provider, doc, resource)
+                for item in doc.data_list
+                if (resource := doc.resolve(item))
+            ]
+            return tracks[:limit]
+        except (ClientError, KeyError, ValueError) as err:
+            raise MediaNotFoundError(f"Track {prov_track_id} not found") from err
+
+    async def get_similar_artists(self, prov_artist_id: str, limit: int = 25) -> list[Artist]:
+        """Get similar artists."""
+        # Similar artists are a bounded, ranked list: the first page is enough.
+        try:
+            doc = await self.api.get_jsonapi(
+                f"artists/{prov_artist_id}/relationships/similarArtists",
+                include=["similarArtists.profileArt"],
+            )
+            artists = [
+                parse_artist_v2(self.provider, doc, resource)
+                for item in doc.data_list
+                if (resource := doc.resolve(item))
+            ]
+            return artists[:limit]
+        except (ClientError, KeyError, ValueError) as err:
+            raise MediaNotFoundError(f"Artist {prov_artist_id} not found") from err
+
+    async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
+        """Get playlist tracks."""
+        page_size = 200
+        offset = page * page_size
+
+        if prov_playlist_id == FAVORITE_TRACKS_PLAYLIST_ID:
+            return await self._get_favorite_tracks(page_size, offset)
+
+        if prov_playlist_id.startswith("mix_"):
+            return await self._get_mix_tracks(prov_playlist_id[4:], page_size, offset)
+
+        try:
+            data = await self.api.get(
+                f"{PLAYLISTS}/{prov_playlist_id}/tracks",
+                params={"limit": page_size, "offset": offset},
+            )
+            return self._process_tracks(data.get("items", []), offset)
+        except MediaNotFoundError:
+            return await self._get_mix_tracks(prov_playlist_id, page_size, offset)
+
     async def _get_mix_details(self, prov_mix_id: str) -> Playlist:
         """Get details for a Tidal Mix."""
         try:
@@ -169,60 +275,6 @@ class TidalMediaManager:
             return parse_playlist(self.provider, mix_obj, is_mix=True)
         except (ClientError, KeyError, ValueError) as err:
             raise MediaNotFoundError(f"Mix {prov_mix_id} not found") from err
-
-    async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
-        """Get album tracks."""
-        try:
-            data = await self.api.get(f"albums/{prov_album_id}/tracks", params={"limit": 250})
-            return [parse_track(self.provider, x) for x in data.get("items", [])]
-        except (ClientError, KeyError, ValueError) as err:
-            raise MediaNotFoundError(f"Album {prov_album_id} not found") from err
-
-    async def get_artist_albums(self, prov_artist_id: str) -> list[Album]:
-        """Get artist albums."""
-        try:
-            data = await self.api.get(f"artists/{prov_artist_id}/albums", params={"limit": 250})
-            return [parse_album(self.provider, x) for x in data.get("items", [])]
-        except (ClientError, KeyError, ValueError) as err:
-            raise MediaNotFoundError(f"Artist {prov_artist_id} not found") from err
-
-    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
-        """Get artist top tracks."""
-        try:
-            data = await self.api.get(
-                f"artists/{prov_artist_id}/toptracks", params={"limit": 10, "offset": 0}
-            )
-            return [parse_track(self.provider, x) for x in data.get("items", [])]
-        except (ClientError, KeyError, ValueError) as err:
-            raise MediaNotFoundError(f"Artist {prov_artist_id} not found") from err
-
-    async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
-        """Get similar tracks."""
-        try:
-            data = await self.api.get(f"tracks/{prov_track_id}/radio", params={"limit": limit})
-            return [parse_track(self.provider, x) for x in data.get("items", [])]
-        except (ClientError, KeyError, ValueError) as err:
-            raise MediaNotFoundError(f"Track {prov_track_id} not found") from err
-
-    async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
-        """Get playlist tracks."""
-        page_size = 200
-        offset = page * page_size
-
-        if prov_playlist_id == FAVORITE_TRACKS_PLAYLIST_ID:
-            return await self._get_favorite_tracks(page_size, offset)
-
-        if prov_playlist_id.startswith("mix_"):
-            return await self._get_mix_tracks(prov_playlist_id[4:], page_size, offset)
-
-        try:
-            data = await self.api.get(
-                f"{PLAYLISTS}/{prov_playlist_id}/tracks",
-                params={"limit": page_size, "offset": offset},
-            )
-            return self._process_tracks(data.get("items", []), offset)
-        except MediaNotFoundError:
-            return await self._get_mix_tracks(prov_playlist_id, page_size, offset)
 
     async def _get_favorite_tracks(self, limit: int, offset: int) -> list[Track]:
         """Get the user's favorite tracks in descending order (newest first)."""

--- a/music_assistant/providers/tidal/parsers_v2.py
+++ b/music_assistant/providers/tidal/parsers_v2.py
@@ -210,6 +210,8 @@ def parse_track(provider: TidalProvider, doc: JsonApiDocument, resource: dict[st
         track.metadata.genres = genres
     if links := _parse_links(attributes):
         track.metadata.links = links
+    if performers := _parse_credits(doc, resource):
+        track.metadata.performers = performers
 
     bpm = attributes.get("bpm")
     musical_key = _parse_musical_key(attributes.get("key"), attributes.get("keyScale"))
@@ -253,6 +255,16 @@ def _split_title_version(title: str, version: str | None) -> tuple[str, str]:
 def _clean_biography(text: str) -> str:
     """Strip Tidal's internal [wimpLink] cross-reference markup from bio text."""
     return _WIMP_LINK_RE.sub("", text).strip()
+
+
+def _parse_credits(doc: JsonApiDocument, resource: dict[str, Any]) -> set[str] | None:
+    """Resolve the credits relationship to a set of contributor names."""
+    names = {
+        name
+        for credit in doc.related(resource, "credits")
+        if (name := credit.get("attributes", {}).get("name"))
+    }
+    return names or None
 
 
 def _parse_genres(doc: JsonApiDocument, resource: dict[str, Any]) -> set[str] | None:

--- a/music_assistant/providers/tidal/provider.py
+++ b/music_assistant/providers/tidal/provider.py
@@ -61,6 +61,7 @@ SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_PLAYLISTS_EDIT,
     ProviderFeature.PLAYLIST_CREATE,
     ProviderFeature.SIMILAR_TRACKS,
+    ProviderFeature.SIMILAR_ARTISTS,
     ProviderFeature.BROWSE,
     ProviderFeature.PLAYLIST_TRACKS_EDIT,
     ProviderFeature.RECOMMENDATIONS,
@@ -85,13 +86,6 @@ class TidalProvider(MusicProvider):
         self.playlists = TidalPlaylistManager(self)
         self.recommendations_manager = TidalRecommendationManager(self)
         self.streaming = TidalStreamingManager(self)
-
-    def _update_auth_config(self, auth_info: dict[str, Any]) -> None:
-        """Update auth config with new auth info."""
-        self._update_config_value(CONF_AUTH_TOKEN, auth_info["access_token"], encrypted=True)
-        self._update_config_value(CONF_REFRESH_TOKEN, auth_info["refresh_token"], encrypted=True)
-        self._update_config_value(CONF_EXPIRY_TIME, auth_info["expires_at"])
-        self._update_config_value(CONF_USER_ID, auth_info["userId"])
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
@@ -140,6 +134,11 @@ class TidalProvider(MusicProvider):
     async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
         """Get similar tracks for given track id."""
         return await self.media.get_similar_tracks(prov_track_id, limit)
+
+    @use_cache(3600 * 24, allow_expired_cache=True)
+    async def get_similar_artists(self, prov_artist_id: str, limit: int = 25) -> list[Artist]:
+        """Get similar artists for given artist id."""
+        return await self.media.get_similar_artists(prov_artist_id, limit)
 
     @use_cache(3600 * 24 * 30)
     async def get_artist(self, prov_artist_id: str) -> Artist:
@@ -242,3 +241,10 @@ class TidalProvider(MusicProvider):
     async def recommendations(self) -> list[RecommendationFolder]:
         """Get this provider's recommendations organized into folders."""
         return await self.recommendations_manager.get_recommendations()
+
+    def _update_auth_config(self, auth_info: dict[str, Any]) -> None:
+        """Update auth config with new auth info."""
+        self._update_config_value(CONF_AUTH_TOKEN, auth_info["access_token"], encrypted=True)
+        self._update_config_value(CONF_REFRESH_TOKEN, auth_info["refresh_token"], encrypted=True)
+        self._update_config_value(CONF_EXPIRY_TIME, auth_info["expires_at"])
+        self._update_config_value(CONF_USER_ID, auth_info["userId"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,12 +81,14 @@ mass = "music_assistant.__main__:main"
 # "claus" is Santa Claus, in the christmas_music genre description
 # "childrens" is the normalized form of the "Children's" audiobook genre (apostrophe stripped)
 # translations/*.json are machine-translated locale files (Lokalise); foreign words aren't typos
+# tidal fixtures are captured API responses; foreign album/track titles aren't typos
 ignore-words-list = "provid,hass,followings,childs,explict,additionals,commitish,nam,connexion,claus,childrens,"
 skip = """*.js,*.svg,\
 music_assistant/providers/itunes_podcasts/itunes_country_codes.json,\
 music_assistant/helpers/resources/genres/genre_mapping.json,\
 music_assistant/providers/sonic_analysis/vendored_clap/**,\
 music_assistant/translations/*.json,\
+tests/providers/tidal/fixtures/**,\
 NOTICE,\
 """
 

--- a/scripts/lint_baselines/private_methods_not_last.txt
+++ b/scripts/lint_baselines/private_methods_not_last.txt
@@ -73,8 +73,6 @@ music_assistant/providers/sonic_analysis/vendored_clap/clap_wrapper.py	4
 music_assistant/providers/sonic_analysis/vendored_clap/models/htsat.py	7
 music_assistant/providers/soundcloud/__init__.py	4
 music_assistant/providers/tidal/api_client.py	1
-music_assistant/providers/tidal/media.py	5
-music_assistant/providers/tidal/provider.py	24
 music_assistant/providers/tidal/tidal_page_parser.py	2
 music_assistant/providers/vban_receiver/stats.py	2
 music_assistant/providers/webdav/provider.py	4

--- a/tests/providers/tidal/fixtures/v2/album_items.json
+++ b/tests/providers/tidal/fixtures/v2/album_items.json
@@ -1,0 +1,936 @@
+{
+  "data": [
+    {
+      "id": "58756128",
+      "type": "tracks",
+      "meta": {
+        "volumeNumber": 1,
+        "trackNumber": 1,
+        "itemCursor": "IrhNZeXbnyfq"
+      }
+    },
+    {
+      "id": "58756129",
+      "type": "tracks",
+      "meta": {
+        "volumeNumber": 1,
+        "trackNumber": 2,
+        "itemCursor": "IrhNZeXbnyjy"
+      }
+    },
+    {
+      "id": "58756130",
+      "type": "tracks",
+      "meta": {
+        "volumeNumber": 1,
+        "trackNumber": 3,
+        "itemCursor": "IrhNZeXboFBq"
+      }
+    },
+    {
+      "id": "58756131",
+      "type": "tracks",
+      "meta": {
+        "volumeNumber": 1,
+        "trackNumber": 4,
+        "itemCursor": "IrhNZeXboFFy"
+      }
+    },
+    {
+      "id": "58756132",
+      "type": "tracks",
+      "meta": {
+        "volumeNumber": 1,
+        "trackNumber": 5,
+        "itemCursor": "IrhNZeXboFK6"
+      }
+    },
+    {
+      "id": "58756133",
+      "type": "tracks",
+      "meta": {
+        "volumeNumber": 1,
+        "trackNumber": 6,
+        "itemCursor": "IrhNZeXboFOE"
+      }
+    },
+    {
+      "id": "58756134",
+      "type": "tracks",
+      "meta": {
+        "volumeNumber": 1,
+        "trackNumber": 7,
+        "itemCursor": "IrhNZeXboFSM"
+      }
+    },
+    {
+      "id": "58756135",
+      "type": "tracks",
+      "meta": {
+        "volumeNumber": 1,
+        "trackNumber": 8,
+        "itemCursor": "IrhNZeXboFWU"
+      }
+    },
+    {
+      "id": "58756136",
+      "type": "tracks",
+      "meta": {
+        "volumeNumber": 1,
+        "trackNumber": 9,
+        "itemCursor": "IrhNZeXboFac"
+      }
+    },
+    {
+      "id": "58756137",
+      "type": "tracks",
+      "meta": {
+        "volumeNumber": 1,
+        "trackNumber": 10,
+        "itemCursor": "IrhNZeXboFek"
+      }
+    },
+    {
+      "id": "58756138",
+      "type": "tracks",
+      "meta": {
+        "volumeNumber": 1,
+        "trackNumber": 11,
+        "itemCursor": "IrhNZeXboFis"
+      }
+    }
+  ],
+  "links": {
+    "self": "/albums/58756127/relationships/items?include=items.albums.coverArt%2Citems.artists&countryCode=AT"
+  },
+  "included": [
+    {
+      "id": "58756127",
+      "type": "albums",
+      "attributes": {
+        "title": "Lukas Graham (Blue Album) (International Version)",
+        "barcodeId": "00602547852748",
+        "numberOfVolumes": 1,
+        "numberOfItems": 11,
+        "duration": "PT40M5S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2015-05-29",
+        "copyright": {
+          "text": "© 2016 Then We Take The World / Copenhagen Records / Universal Music"
+        },
+        "popularity": 0.13697256118982468,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/58756127",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "version": "International Version",
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPMMti8ralux",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/58756127/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4184211",
+      "type": "artists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "popularity": 0.8177526593208313,
+        "externalLinks": [
+          {
+            "href": "https://www.facebook.com/LukasGraham",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "http://instagram.com/lukasinstagraham",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://www.twitter.com/LukeTheDuke_",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4184211",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "iWOu0yW0IPMMti8ralux",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#775434",
+          "blurHash": "ULM7cP9G_29E?wxv%L%1~ojXD+NK_1ocE3xv",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "58756128",
+      "type": "tracks",
+      "attributes": {
+        "title": "7 Years",
+        "version": null,
+        "isrc": "USWB11506516",
+        "duration": "PT3M57S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MAJOR",
+        "bpm": 120.0,
+        "popularity": 0.7728257326881044,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756128",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756128/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756128/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756129",
+      "type": "tracks",
+      "attributes": {
+        "title": "Take The World By Storm",
+        "version": null,
+        "isrc": "USWB11506517",
+        "duration": "PT3M12S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "UNKNOWN",
+        "keyScale": "UNKNOWN",
+        "popularity": 0.28360111759247825,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756129",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756129/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756129/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756130",
+      "type": "tracks",
+      "attributes": {
+        "title": "Mama Said",
+        "version": null,
+        "isrc": "DKUM71400126",
+        "duration": "PT3M27S",
+        "copyright": {
+          "text": "℗ 2014 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Bb",
+        "keyScale": "MAJOR",
+        "bpm": 84.0,
+        "popularity": 0.5742448384952146,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756130",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756130/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756130/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756131",
+      "type": "tracks",
+      "attributes": {
+        "title": "Happy Home",
+        "version": null,
+        "isrc": "USWB11506519",
+        "duration": "PT3M39S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MINOR",
+        "bpm": 128.0,
+        "popularity": 0.2901687469791667,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756131",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756131/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756131/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756132",
+      "type": "tracks",
+      "attributes": {
+        "title": "Drunk In The Morning",
+        "version": null,
+        "isrc": "USWB11514268",
+        "duration": "PT3M23S",
+        "copyright": {
+          "text": "℗ 2015 Then We Take The World / Copenhagen Records"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "D",
+        "keyScale": "MAJOR",
+        "bpm": 93.0,
+        "popularity": 0.42337843281398246,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756132",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756132/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756132/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756133",
+      "type": "tracks",
+      "attributes": {
+        "title": "Better Than Yourself (Criminal Mind Pt. 2)",
+        "version": null,
+        "isrc": "DKUM71200983",
+        "duration": "PT4M26S",
+        "copyright": {
+          "text": "℗ 2012 Copenhagen Records / Universal Music"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "CSharp",
+        "keyScale": "MINOR",
+        "bpm": 100.0,
+        "popularity": 0.12433586178011624,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756133",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756133/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756133/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756134",
+      "type": "tracks",
+      "attributes": {
+        "title": "Don't You Worry 'Bout Me",
+        "version": null,
+        "isrc": "USWB11506522",
+        "duration": "PT3M10S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MAJOR",
+        "bpm": 89.0,
+        "popularity": 0.18735691491775092,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756134",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756134/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756134/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756135",
+      "type": "tracks",
+      "attributes": {
+        "title": "What Happened To Perfect",
+        "version": null,
+        "isrc": "USWB11506523",
+        "duration": "PT3M57S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "A",
+        "keyScale": "MAJOR",
+        "bpm": 140.0,
+        "popularity": 0.118327719706314,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756135",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756135/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756135/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756136",
+      "type": "tracks",
+      "attributes": {
+        "title": "Strip No More",
+        "version": null,
+        "isrc": "USWB11506525",
+        "duration": "PT3M26S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Bb",
+        "keyScale": "MAJOR",
+        "bpm": 131.0,
+        "popularity": 0.1873622267441245,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756136",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756136/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756136/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756137",
+      "type": "tracks",
+      "attributes": {
+        "title": "You're Not There",
+        "version": null,
+        "isrc": "USWB11506526",
+        "duration": "PT3M23S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "F",
+        "keyScale": "MAJOR",
+        "bpm": 92.0,
+        "popularity": 0.401522608112518,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756137",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756137/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756137/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756138",
+      "type": "tracks",
+      "attributes": {
+        "title": "Funeral",
+        "version": null,
+        "isrc": "USWB11506527",
+        "duration": "PT4M5S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MAJOR",
+        "bpm": 95.0,
+        "popularity": 0.21559125215374217,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756138",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756138/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756138/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/providers/tidal/fixtures/v2/artist_albums.json
+++ b/tests/providers/tidal/fixtures/v2/artist_albums.json
@@ -1,0 +1,2655 @@
+{
+  "data": [
+    {
+      "id": "541774424",
+      "type": "albums"
+    },
+    {
+      "id": "541781510",
+      "type": "albums"
+    },
+    {
+      "id": "541779641",
+      "type": "albums"
+    },
+    {
+      "id": "526469854",
+      "type": "albums"
+    },
+    {
+      "id": "524821384",
+      "type": "albums"
+    },
+    {
+      "id": "524818809",
+      "type": "albums"
+    },
+    {
+      "id": "516642294",
+      "type": "albums"
+    },
+    {
+      "id": "516639641",
+      "type": "albums"
+    },
+    {
+      "id": "516643645",
+      "type": "albums"
+    },
+    {
+      "id": "429399009",
+      "type": "albums"
+    },
+    {
+      "id": "429408903",
+      "type": "albums"
+    },
+    {
+      "id": "429400346",
+      "type": "albums"
+    },
+    {
+      "id": "402225791",
+      "type": "albums"
+    },
+    {
+      "id": "387207713",
+      "type": "albums"
+    },
+    {
+      "id": "387207703",
+      "type": "albums"
+    },
+    {
+      "id": "387296967",
+      "type": "albums"
+    },
+    {
+      "id": "355219323",
+      "type": "albums"
+    },
+    {
+      "id": "360196518",
+      "type": "albums"
+    },
+    {
+      "id": "359757539",
+      "type": "albums"
+    },
+    {
+      "id": "359762508",
+      "type": "albums"
+    }
+  ],
+  "links": {
+    "self": "/artists/4184211/relationships/albums?include=albums.artists%2Calbums.coverArt&countryCode=AT",
+    "next": "/artists/4184211/relationships/albums?include=albums.artists%2Calbums.coverArt&countryCode=AT&page%5Bcursor%5D=3nI1Esi",
+    "meta": {
+      "nextCursor": "3nI1Esi"
+    }
+  },
+  "included": [
+    {
+      "id": "355219323",
+      "type": "albums",
+      "attributes": {
+        "title": "Cheat Code",
+        "barcodeId": "797885103727",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M29S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2024-05-03",
+        "copyright": {
+          "text": "2024 United Records / Then We Take The World"
+        },
+        "popularity": 0.31104904413223267,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/355219323",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/355219323/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E009Ank0oaqp9",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/355219323/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "359757539",
+      "type": "albums",
+      "attributes": {
+        "title": "Cheat Code",
+        "barcodeId": "00602465641233",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M29S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2024-05-03",
+        "copyright": {
+          "text": "© 2024 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.2010607673854214,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/359757539",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/359757539/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E009Fz1CVzy8H",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/359757539/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "359762508",
+      "type": "albums",
+      "attributes": {
+        "title": "Cheat Code",
+        "barcodeId": "00602465669046",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M29S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2024-05-03",
+        "copyright": {
+          "text": "© 2024 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.07578221628095376,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/359762508",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/359762508/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E009Fz1H6zEWe",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/359762508/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "360196518",
+      "type": "albums",
+      "attributes": {
+        "title": "Cheat Code",
+        "barcodeId": "00602465669398",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M29S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2024-05-03",
+        "copyright": {
+          "text": "© 2024 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.16723878681659698,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "DOLBY_ATMOS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/360196518",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/360196518/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E00EONJzD1HIm",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/360196518/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "387207703",
+      "type": "albums",
+      "attributes": {
+        "title": "Seven Years",
+        "barcodeId": "054391243195",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M36S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2024-09-27",
+        "copyright": {
+          "text": "© 2024 Demon Time Entertainment, LLC/Warner Records Inc."
+        },
+        "popularity": 0.09645312101962597,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/387207703",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "24457487",
+              "type": "artists"
+            },
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/387207703/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E00PBSA2ZRLLn",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/387207703/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "387207713",
+      "type": "albums",
+      "attributes": {
+        "title": "Seven Years",
+        "barcodeId": "054391243218",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M36S",
+        "explicit": true,
+        "ai": false,
+        "releaseDate": "2024-09-27",
+        "copyright": {
+          "text": "© 2024 Demon Time Entertainment, LLC/Warner Records Inc."
+        },
+        "popularity": 0.36159467480047647,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/387207713",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "24457487",
+              "type": "artists"
+            },
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/387207713/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E00PBSA2ZRLPv",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/387207713/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "387296967",
+      "type": "albums",
+      "attributes": {
+        "title": "Seven Years",
+        "barcodeId": "054391243201",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M36S",
+        "explicit": true,
+        "ai": false,
+        "releaseDate": "2024-09-27",
+        "copyright": {
+          "text": "© 2024 Demon Time Entertainment, LLC/Warner Records Inc."
+        },
+        "popularity": 0.2531503140926361,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "DOLBY_ATMOS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/387296967",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "24457487",
+              "type": "artists"
+            },
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/387296967/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E00PBSAikIi51",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/387296967/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "402225791",
+      "type": "albums",
+      "attributes": {
+        "title": "Du ligner din mor",
+        "barcodeId": "196872697094",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M6S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2024-12-27",
+        "copyright": {
+          "text": "(P) 2024 Sony Music Entertainment Denmark A/S"
+        },
+        "popularity": 0.5139883160591125,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/402225791",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "8051290",
+              "type": "artists"
+            },
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/402225791/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0LhB5vluPuVt",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/402225791/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "429399009",
+      "type": "albums",
+      "attributes": {
+        "title": "You You You",
+        "barcodeId": "00602478083501",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M42S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2025-04-18",
+        "copyright": {
+          "text": "© 2025 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.2947263303011754,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/429399009",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/429399009/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0LryAn2KqbGb",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/429399009/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "429400346",
+      "type": "albums",
+      "attributes": {
+        "title": "You You You",
+        "barcodeId": "00602478083549",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M42S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2025-04-18",
+        "copyright": {
+          "text": "© 2025 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.20406164776917143,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/429400346",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/429400346/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0LryB5i8xP3m",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/429400346/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "429408903",
+      "type": "albums",
+      "attributes": {
+        "title": "You You You",
+        "barcodeId": "00602478083563",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M42S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2025-04-18",
+        "copyright": {
+          "text": "© 2025 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.1669788956642151,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "DOLBY_ATMOS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/429408903",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/429408903/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0LryB5iI4DFT",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/429408903/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "516639641",
+      "type": "albums",
+      "attributes": {
+        "title": "To Know A Girl",
+        "barcodeId": "00199957505222",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M2S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2026-04-24",
+        "copyright": {
+          "text": "© 2026 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.18133413378603142,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "DOLBY_ATMOS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/516639641",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2026-04-17T00:23:20Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/516639641/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0hlGZzkOA4jB",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/516639641/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "516642294",
+      "type": "albums",
+      "attributes": {
+        "title": "To Know A Girl",
+        "barcodeId": "00199957505154",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M2S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2026-04-24",
+        "copyright": {
+          "text": "© 2026 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.0835844688732561,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/516642294",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2026-04-17T00:32:52Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/516642294/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0hlGZzowrSQ0",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/516642294/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "516643645",
+      "type": "albums",
+      "attributes": {
+        "title": "To Know A Girl",
+        "barcodeId": "00199957505161",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M2S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2026-04-24",
+        "copyright": {
+          "text": "© 2026 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.11736994202118811,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/516643645",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2026-04-17T00:37:58Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/516643645/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0hlGZzoy0wnl",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/516643645/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "524818809",
+      "type": "albums",
+      "attributes": {
+        "title": "Second Chance",
+        "barcodeId": "00199957978675",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M7S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2026-05-22",
+        "copyright": {
+          "text": "© 2026 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.16214905881518296,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/524818809",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2026-05-15T00:48:36Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/524818809/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0hqY2Hc3EZIH",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/524818809/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "524821384",
+      "type": "albums",
+      "attributes": {
+        "title": "Second Chance",
+        "barcodeId": "00199957981125",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M7S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2026-05-22",
+        "copyright": {
+          "text": "© 2026 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.32409922160575444,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/524821384",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2026-05-15T00:56:02Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/524821384/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0hqY2Hgbvg8K",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/524821384/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "526469854",
+      "type": "albums",
+      "attributes": {
+        "title": "Second Chance",
+        "barcodeId": "00199957981132",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M7S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2026-05-22",
+        "copyright": {
+          "text": "© 2026 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.2149270789533166,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "DOLBY_ATMOS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/526469854",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2026-05-20T08:31:16Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/526469854/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0hqaatbvEa1c",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/526469854/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "541774424",
+      "type": "albums",
+      "attributes": {
+        "title": "Good Times",
+        "barcodeId": "00881061200840",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M4S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2026-07-17",
+        "copyright": {
+          "text": "© 2026 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.0,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "DOLBY_ATMOS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/541774424",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2026-07-10T00:24:08Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/541774424/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0i18DEpvaV6q",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/541774424/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "541779641",
+      "type": "albums",
+      "attributes": {
+        "title": "Good Times",
+        "barcodeId": "00881061200819",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M4S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2026-07-17",
+        "copyright": {
+          "text": "© 2026 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.0,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/541779641",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2026-07-10T00:50:49Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/541779641/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0i18DEq1H1wP",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/541779641/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "541781510",
+      "type": "albums",
+      "attributes": {
+        "title": "Good Times",
+        "barcodeId": "00881061200826",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M4S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2026-07-17",
+        "copyright": {
+          "text": "© 2026 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.0,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/541781510",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2026-07-10T00:58:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/541781510/relationships/artists?countryCode=AT"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0i18DEuYqpiy",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/541781510/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "24457487",
+      "type": "artists",
+      "attributes": {
+        "name": "LG Malique",
+        "popularity": 0.49929164195161246,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/24457487",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "4184211",
+      "type": "artists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "popularity": 0.8177526593208313,
+        "externalLinks": [
+          {
+            "href": "https://www.facebook.com/LukasGraham",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "http://instagram.com/lukasinstagraham",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://www.twitter.com/LukeTheDuke_",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4184211",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "8051290",
+      "type": "artists",
+      "attributes": {
+        "name": "Benjamin Hav",
+        "popularity": 0.6843016147613525,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/8051290",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "2xpmpI1s9E009Ank0oaqp9",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/0aae8e06/f792/48e3/a46f/6b998f4aa5d9/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0aae8e06/f792/48e3/a46f/6b998f4aa5d9/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0aae8e06/f792/48e3/a46f/6b998f4aa5d9/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0aae8e06/f792/48e3/a46f/6b998f4aa5d9/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0aae8e06/f792/48e3/a46f/6b998f4aa5d9/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0aae8e06/f792/48e3/a46f/6b998f4aa5d9/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0aae8e06/f792/48e3/a46f/6b998f4aa5d9/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#4F2A1E",
+          "blurHash": "UkQldq-:*0D,Szt6sANHyYRSQ-xo-VM|N[xZ",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E009Fz1CVzy8H",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/4b439c3c/242c/4179/aa11/99cafe6d0c58/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4b439c3c/242c/4179/aa11/99cafe6d0c58/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4b439c3c/242c/4179/aa11/99cafe6d0c58/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4b439c3c/242c/4179/aa11/99cafe6d0c58/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4b439c3c/242c/4179/aa11/99cafe6d0c58/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4b439c3c/242c/4179/aa11/99cafe6d0c58/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4b439c3c/242c/4179/aa11/99cafe6d0c58/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#480E05",
+          "blurHash": "UkQldq-:*0D,Szt6sANHyYRSQ-xo-VNGN[xZ",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E009Fz1H6zEWe",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/e3a1581b/cb95/40f8/a87e/57fac3ca36c1/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e3a1581b/cb95/40f8/a87e/57fac3ca36c1/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e3a1581b/cb95/40f8/a87e/57fac3ca36c1/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e3a1581b/cb95/40f8/a87e/57fac3ca36c1/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e3a1581b/cb95/40f8/a87e/57fac3ca36c1/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e3a1581b/cb95/40f8/a87e/57fac3ca36c1/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e3a1581b/cb95/40f8/a87e/57fac3ca36c1/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#480E05",
+          "blurHash": "UkQldq-:*0D,Szt6sANHyYRSQ-xo-VNGN[xZ",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E00EONJzD1HIm",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/e71e727e/2056/40d1/8968/8b447814e795/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e71e727e/2056/40d1/8968/8b447814e795/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e71e727e/2056/40d1/8968/8b447814e795/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e71e727e/2056/40d1/8968/8b447814e795/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e71e727e/2056/40d1/8968/8b447814e795/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e71e727e/2056/40d1/8968/8b447814e795/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e71e727e/2056/40d1/8968/8b447814e795/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#480E05",
+          "blurHash": "UkQldq-:*0D,Szt6sANHyYRSQ-xo-VNGN[xZ",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E00PBSA2ZRLLn",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/b5cd458e/2e2d/454b/9aa7/7115798cd89e/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b5cd458e/2e2d/454b/9aa7/7115798cd89e/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b5cd458e/2e2d/454b/9aa7/7115798cd89e/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b5cd458e/2e2d/454b/9aa7/7115798cd89e/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b5cd458e/2e2d/454b/9aa7/7115798cd89e/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b5cd458e/2e2d/454b/9aa7/7115798cd89e/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b5cd458e/2e2d/454b/9aa7/7115798cd89e/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#0D0B09",
+          "blurHash": "U354?5oe08NJs.fRWDj@0kaz~6odNKj@xXWD",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E00PBSA2ZRLPv",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/da701885/be7e/4f4e/88de/f93cd0f8a4e0/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/da701885/be7e/4f4e/88de/f93cd0f8a4e0/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/da701885/be7e/4f4e/88de/f93cd0f8a4e0/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/da701885/be7e/4f4e/88de/f93cd0f8a4e0/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/da701885/be7e/4f4e/88de/f93cd0f8a4e0/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/da701885/be7e/4f4e/88de/f93cd0f8a4e0/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/da701885/be7e/4f4e/88de/f93cd0f8a4e0/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#0E0C09",
+          "blurHash": "U354?5oe08NJs.fRWWj@0kaz~6odNKj@xXWD",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E00PBSAikIi51",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/ce341f6d/deeb/4be5/a2db/1507f3cb9c61/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ce341f6d/deeb/4be5/a2db/1507f3cb9c61/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ce341f6d/deeb/4be5/a2db/1507f3cb9c61/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ce341f6d/deeb/4be5/a2db/1507f3cb9c61/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ce341f6d/deeb/4be5/a2db/1507f3cb9c61/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ce341f6d/deeb/4be5/a2db/1507f3cb9c61/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ce341f6d/deeb/4be5/a2db/1507f3cb9c61/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#0E0C09",
+          "blurHash": "U354?5oe08NJs.fRWWj@0kaz~6odNKj@xXWD",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0LhB5vluPuVt",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/3687955c/d67e/4624/9529/5fdac9363b1f/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3687955c/d67e/4624/9529/5fdac9363b1f/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3687955c/d67e/4624/9529/5fdac9363b1f/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3687955c/d67e/4624/9529/5fdac9363b1f/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3687955c/d67e/4624/9529/5fdac9363b1f/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3687955c/d67e/4624/9529/5fdac9363b1f/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3687955c/d67e/4624/9529/5fdac9363b1f/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#2C160B",
+          "blurHash": "USQ=pWWA{3oyL%xa%1ae-:RkE#j[;3j@OXoL",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0LryAn2KqbGb",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/14d5c6f1/f3a2/4497/8418/9198bfff05b7/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/14d5c6f1/f3a2/4497/8418/9198bfff05b7/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/14d5c6f1/f3a2/4497/8418/9198bfff05b7/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/14d5c6f1/f3a2/4497/8418/9198bfff05b7/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/14d5c6f1/f3a2/4497/8418/9198bfff05b7/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/14d5c6f1/f3a2/4497/8418/9198bfff05b7/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/14d5c6f1/f3a2/4497/8418/9198bfff05b7/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#8A6E37",
+          "blurHash": "UGLDi8?^0rRPtR%1M{XS1nMx^aaK-:RQRkt7",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0LryB5i8xP3m",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/750ee7b5/87e4/4821/a8e9/1c50419e1860/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/750ee7b5/87e4/4821/a8e9/1c50419e1860/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/750ee7b5/87e4/4821/a8e9/1c50419e1860/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/750ee7b5/87e4/4821/a8e9/1c50419e1860/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/750ee7b5/87e4/4821/a8e9/1c50419e1860/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/750ee7b5/87e4/4821/a8e9/1c50419e1860/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/750ee7b5/87e4/4821/a8e9/1c50419e1860/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#8A6E37",
+          "blurHash": "UGLDi8?^0rRPtR%1M{XS1nMx^aaK-:RQRkt7",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0LryB5iI4DFT",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/5ced1e2e/e8cd/477e/8495/16c93291b770/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5ced1e2e/e8cd/477e/8495/16c93291b770/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5ced1e2e/e8cd/477e/8495/16c93291b770/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5ced1e2e/e8cd/477e/8495/16c93291b770/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5ced1e2e/e8cd/477e/8495/16c93291b770/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5ced1e2e/e8cd/477e/8495/16c93291b770/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5ced1e2e/e8cd/477e/8495/16c93291b770/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#8A6E37",
+          "blurHash": "UGLDi8?^0rRPtR%1M{XS1nMx^aaK-:RQRkt7",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0hlGZzkOA4jB",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/f2a39194/999f/4132/90ce/66343f46afd4/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2a39194/999f/4132/90ce/66343f46afd4/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2a39194/999f/4132/90ce/66343f46afd4/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2a39194/999f/4132/90ce/66343f46afd4/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2a39194/999f/4132/90ce/66343f46afd4/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2a39194/999f/4132/90ce/66343f46afd4/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2a39194/999f/4132/90ce/66343f46afd4/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#62625E",
+          "blurHash": "UCQJWD%M_2t7xua|R*WV~pj[9Fj[WBWBt6WB",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0hlGZzowrSQ0",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/22b1c8d3/f30d/4b78/936b/5b9c4b6f1f34/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/22b1c8d3/f30d/4b78/936b/5b9c4b6f1f34/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/22b1c8d3/f30d/4b78/936b/5b9c4b6f1f34/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/22b1c8d3/f30d/4b78/936b/5b9c4b6f1f34/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/22b1c8d3/f30d/4b78/936b/5b9c4b6f1f34/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/22b1c8d3/f30d/4b78/936b/5b9c4b6f1f34/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/22b1c8d3/f30d/4b78/936b/5b9c4b6f1f34/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#62625E",
+          "blurHash": "UCQJWD%M_2t7xua|R*WV~pj[9Fj[WBWBt6WB",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0hlGZzoy0wnl",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/881131df/4c5b/4888/bd1e/245082bf7205/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/881131df/4c5b/4888/bd1e/245082bf7205/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/881131df/4c5b/4888/bd1e/245082bf7205/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/881131df/4c5b/4888/bd1e/245082bf7205/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/881131df/4c5b/4888/bd1e/245082bf7205/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/881131df/4c5b/4888/bd1e/245082bf7205/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/881131df/4c5b/4888/bd1e/245082bf7205/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#62625E",
+          "blurHash": "UCQJWD%M_2t7xua|R*WV~pj[9Fj[WBWBt6WB",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0hqY2Hc3EZIH",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/53e1660c/684b/40e7/9872/a6ad324a05bd/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53e1660c/684b/40e7/9872/a6ad324a05bd/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53e1660c/684b/40e7/9872/a6ad324a05bd/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53e1660c/684b/40e7/9872/a6ad324a05bd/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53e1660c/684b/40e7/9872/a6ad324a05bd/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53e1660c/684b/40e7/9872/a6ad324a05bd/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53e1660c/684b/40e7/9872/a6ad324a05bd/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#767672",
+          "blurHash": "UFP%Igj?_2of%Mj[RkWB~pWB9FofM{Rjxuxa",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0hqY2Hgbvg8K",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/dfa00f3f/353e/420a/bafd/b8847fde8b9b/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/dfa00f3f/353e/420a/bafd/b8847fde8b9b/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/dfa00f3f/353e/420a/bafd/b8847fde8b9b/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/dfa00f3f/353e/420a/bafd/b8847fde8b9b/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/dfa00f3f/353e/420a/bafd/b8847fde8b9b/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/dfa00f3f/353e/420a/bafd/b8847fde8b9b/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/dfa00f3f/353e/420a/bafd/b8847fde8b9b/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#767672",
+          "blurHash": "UFP%Igj?_2of%Mj[RkWB~pWB9FofM{Rjxuxa",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0hqaatbvEa1c",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/cb85fb22/e90b/423e/b19b/ceacfb35609a/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cb85fb22/e90b/423e/b19b/ceacfb35609a/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cb85fb22/e90b/423e/b19b/ceacfb35609a/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cb85fb22/e90b/423e/b19b/ceacfb35609a/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cb85fb22/e90b/423e/b19b/ceacfb35609a/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cb85fb22/e90b/423e/b19b/ceacfb35609a/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cb85fb22/e90b/423e/b19b/ceacfb35609a/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#767672",
+          "blurHash": "UFP%Igj?_2of%Mj[RkWB~pWB9FofM{Rjxuxa",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0i18DEpvaV6q",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/c1cc977f/4a40/4e0b/b7c9/9f60815219d6/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c1cc977f/4a40/4e0b/b7c9/9f60815219d6/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c1cc977f/4a40/4e0b/b7c9/9f60815219d6/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c1cc977f/4a40/4e0b/b7c9/9f60815219d6/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c1cc977f/4a40/4e0b/b7c9/9f60815219d6/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c1cc977f/4a40/4e0b/b7c9/9f60815219d6/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c1cc977f/4a40/4e0b/b7c9/9f60815219d6/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#545450",
+          "blurHash": "UVN^VZof~pxuWBofofR*~pkB9GWB%LWBRjt7",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0i18DEq1H1wP",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/2956f1b3/b58f/4ea1/9489/47110ac49679/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2956f1b3/b58f/4ea1/9489/47110ac49679/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2956f1b3/b58f/4ea1/9489/47110ac49679/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2956f1b3/b58f/4ea1/9489/47110ac49679/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2956f1b3/b58f/4ea1/9489/47110ac49679/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2956f1b3/b58f/4ea1/9489/47110ac49679/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2956f1b3/b58f/4ea1/9489/47110ac49679/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#545450",
+          "blurHash": "UVN^VZof~pxuWBofofR*~pkB9GWB%LWBRjt7",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0i18DEuYqpiy",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/3c3dba5a/f24a/4dc3/af21/5cac55c14479/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3c3dba5a/f24a/4dc3/af21/5cac55c14479/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3c3dba5a/f24a/4dc3/af21/5cac55c14479/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3c3dba5a/f24a/4dc3/af21/5cac55c14479/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3c3dba5a/f24a/4dc3/af21/5cac55c14479/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3c3dba5a/f24a/4dc3/af21/5cac55c14479/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3c3dba5a/f24a/4dc3/af21/5cac55c14479/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#545450",
+          "blurHash": "UVN^VZof~pxuWBofofR*~pkB9GWB%LWBRjt7",
+          "status": "OK"
+        }
+      }
+    }
+  ]
+}

--- a/tests/providers/tidal/fixtures/v2/artist_toptracks.json
+++ b/tests/providers/tidal/fixtures/v2/artist_toptracks.json
@@ -1,0 +1,2931 @@
+{
+  "data": [
+    {
+      "id": "58503071",
+      "type": "tracks"
+    },
+    {
+      "id": "94189625",
+      "type": "tracks"
+    },
+    {
+      "id": "58503073",
+      "type": "tracks"
+    },
+    {
+      "id": "58503080",
+      "type": "tracks"
+    },
+    {
+      "id": "121563484",
+      "type": "tracks"
+    },
+    {
+      "id": "402225792",
+      "type": "tracks"
+    },
+    {
+      "id": "58503075",
+      "type": "tracks"
+    },
+    {
+      "id": "150847283",
+      "type": "tracks"
+    },
+    {
+      "id": "46675793",
+      "type": "tracks"
+    },
+    {
+      "id": "118421111",
+      "type": "tracks"
+    },
+    {
+      "id": "13536359",
+      "type": "tracks"
+    },
+    {
+      "id": "242149003",
+      "type": "tracks"
+    },
+    {
+      "id": "46675784",
+      "type": "tracks"
+    },
+    {
+      "id": "79492732",
+      "type": "tracks"
+    },
+    {
+      "id": "46675792",
+      "type": "tracks"
+    },
+    {
+      "id": "46675790",
+      "type": "tracks"
+    },
+    {
+      "id": "242744824",
+      "type": "tracks"
+    },
+    {
+      "id": "104340964",
+      "type": "tracks"
+    },
+    {
+      "id": "204855617",
+      "type": "tracks"
+    },
+    {
+      "id": "58503074",
+      "type": "tracks"
+    }
+  ],
+  "links": {
+    "self": "/artists/4184211/relationships/tracks?include=tracks.albums.coverArt%2Ctracks.artists&countryCode=AT&collapseBy=FINGERPRINT",
+    "next": "/artists/4184211/relationships/tracks?include=tracks.albums.coverArt%2Ctracks.artists&countryCode=AT&collapseBy=FINGERPRINT&page%5Bcursor%5D=3nI1Esi",
+    "meta": {
+      "nextCursor": "3nI1Esi"
+    }
+  },
+  "included": [
+    {
+      "id": "104340961",
+      "type": "albums",
+      "attributes": {
+        "title": "Lukas Graham (International Version)",
+        "barcodeId": "00602577549045",
+        "numberOfVolumes": 1,
+        "numberOfItems": 13,
+        "duration": "PT44M26S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2012-03-26",
+        "copyright": {
+          "text": "© 2012 Copenhagen Records / Universal Music"
+        },
+        "popularity": 0.28222558579746027,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/104340961",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzHlApMH8dCWP",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/104340961/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "118421110",
+      "type": "albums",
+      "attributes": {
+        "title": "Lie",
+        "barcodeId": "00602508242403",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2019-09-27",
+        "copyright": {
+          "text": "© 2019 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.2251062561289688,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/118421110",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzHqa0tvts1Fg",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/118421110/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "121563483",
+      "type": "albums",
+      "attributes": {
+        "title": "HERE (For Christmas)",
+        "barcodeId": "00602508479434",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT4M1S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2019-11-08",
+        "copyright": {
+          "text": "© 2019 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.2651028850675421,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/121563483",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzHvl1FGtArb9",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/121563483/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "13536358",
+      "type": "albums",
+      "attributes": {
+        "title": "Drunk In The Morning",
+        "barcodeId": "00602527963853",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M29S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2012-02-13",
+        "copyright": {
+          "text": "© 2012 Copenhagen Records / Universal Music"
+        },
+        "popularity": 0.43792587518692017,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/13536358",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IP0yLMFG6iZU",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/13536358/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "150847282",
+      "type": "albums",
+      "attributes": {
+        "title": "Share That Love (feat. G-Eazy)",
+        "barcodeId": "054391936868",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M52S",
+        "explicit": true,
+        "ai": false,
+        "releaseDate": "2020-08-20",
+        "copyright": {
+          "text": "© 2020 Warner Records Inc. for the world excluding Germany, Austria, Switzerland, Finland, Sweden, Norway, Denmark, and France."
+        },
+        "popularity": 0.4399145841598511,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/150847282",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzIBhooiwvXaU",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/150847282/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "204855615",
+      "type": "albums",
+      "attributes": {
+        "title": "Most People",
+        "barcodeId": "00602445086368",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M21S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2021-12-24",
+        "copyright": {
+          "text": "© 2021 CYB3RPVNK, under exclusive license to Universal Music GmbH"
+        },
+        "popularity": 0.22120009547372382,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/204855615",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2021-11-12T00:37:03Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9Dzdjr8V9qdZSv",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/204855615/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "242149002",
+      "type": "albums",
+      "attributes": {
+        "title": "Wish You Were Here (feat. Khalid)",
+        "barcodeId": "054391888525",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M56S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2022-08-19",
+        "copyright": {
+          "text": "© 2022 Warner Records Inc. for the world excluding Germany, Austria, Switzerland, Finland, Sweden, Norway, Denmark, and France."
+        },
+        "popularity": 0.48744139075279236,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/242149002",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9Dze56cXwCJWpm",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/242149002/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "242744823",
+      "type": "albums",
+      "attributes": {
+        "title": "Wish You Were Here",
+        "barcodeId": "00602448253804",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M56S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2022-08-19",
+        "copyright": {
+          "text": "© 2022 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.18676196311960816,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/242744823",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2022-08-12T01:43:27Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9Dze56eQ56UBe7",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/242744823/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "402225791",
+      "type": "albums",
+      "attributes": {
+        "title": "Du ligner din mor",
+        "barcodeId": "196872697094",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M6S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2024-12-27",
+        "copyright": {
+          "text": "(P) 2024 Sony Music Entertainment Denmark A/S"
+        },
+        "popularity": 0.5139883160591125,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/402225791",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0LhB5vluPuVt",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/402225791/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "46675782",
+      "type": "albums",
+      "attributes": {
+        "title": "Lukas Graham (Blue Album)",
+        "barcodeId": "00602547421586",
+        "numberOfVolumes": 1,
+        "numberOfItems": 12,
+        "duration": "PT40M9S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2015-05-29",
+        "copyright": {
+          "text": "© 2015 Then We Take The World / Copenhagen Records / Universal Music"
+        },
+        "popularity": 0.6042775586194471,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/46675782",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "createdAt": "2015-06-11T00:43:15Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPH0I1XB5kJu",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/46675782/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58503070",
+      "type": "albums",
+      "attributes": {
+        "title": "Lukas Graham",
+        "barcodeId": "093624920496",
+        "numberOfVolumes": 1,
+        "numberOfItems": 11,
+        "duration": "PT40M5S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2015-05-29",
+        "copyright": {
+          "text": "© 2016 Warner Records Inc."
+        },
+        "popularity": 0.7911876602126244,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/58503070",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPMMt532Fc2K",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/58503070/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "79492731",
+      "type": "albums",
+      "attributes": {
+        "title": "Off To See The World",
+        "barcodeId": "00602567109679",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M4S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2017-09-22",
+        "copyright": {
+          "text": "© 2017 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.0527633318074913,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/79492731",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPX2DkbBYAT3",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/79492731/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "94189624",
+      "type": "albums",
+      "attributes": {
+        "title": "Love Someone",
+        "barcodeId": "054391948205",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M25S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2018-09-07",
+        "copyright": {
+          "text": "© 2018 Warner Records Inc. for the world excluding Germany, Austria, Switzerland, Finland, Sweden, Norway, Denmark, and France."
+        },
+        "popularity": 0.0724703375051117,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/94189624",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2018-08-28T01:10:09Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPhZoDX2OjnY",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/94189624/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "3526386",
+      "type": "artists",
+      "attributes": {
+        "name": "My Little Pony",
+        "popularity": 0.585465669631958,
+        "externalLinks": [
+          {
+            "href": "https://facebook.com/mylittlepony",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "https://instagram.com/mylittlepony",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://tiktok.com/@mylittlepony",
+            "meta": {
+              "type": "TIKTOK"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/3526386",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3637952",
+      "type": "artists",
+      "attributes": {
+        "name": "R3HAB",
+        "popularity": 0.804061444829247,
+        "externalLinks": [
+          {
+            "href": "https://www.facebook.com/r3hab/",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "http://instagram.com/r3hab/ ",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://twitter.com/r3hab",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/3637952",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "4184211",
+      "type": "artists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "popularity": 0.8177526593208313,
+        "externalLinks": [
+          {
+            "href": "https://www.facebook.com/LukasGraham",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "http://instagram.com/lukasinstagraham",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://www.twitter.com/LukeTheDuke_",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4184211",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "4916222",
+      "type": "artists",
+      "attributes": {
+        "name": "Khalid",
+        "popularity": 0.8778374699379375,
+        "externalLinks": [
+          {
+            "href": "https://www.facebook.com/thegreatkhalid/",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "https://twitter.com/thegreatkhalid/",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4916222",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "5072967",
+      "type": "artists",
+      "attributes": {
+        "name": "G-Eazy",
+        "popularity": 0.8324434757232666,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/g_eazy",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/5072967",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "8051290",
+      "type": "artists",
+      "attributes": {
+        "name": "Benjamin Hav",
+        "popularity": 0.6843016147613525,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/8051290",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzHlApMH8dCWP",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/53c2b303/af21/422d/9b60/0e3189e43d70/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53c2b303/af21/422d/9b60/0e3189e43d70/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53c2b303/af21/422d/9b60/0e3189e43d70/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53c2b303/af21/422d/9b60/0e3189e43d70/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53c2b303/af21/422d/9b60/0e3189e43d70/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53c2b303/af21/422d/9b60/0e3189e43d70/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53c2b303/af21/422d/9b60/0e3189e43d70/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#5B411E",
+          "blurHash": "U6E2dm?E.5wI:Q~9RkV[9waLxZR+0NEN9b-.",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzHqa0tvts1Fg",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/eb57ec8b/fcd5/4c75/9009/b90c2938bc3e/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/eb57ec8b/fcd5/4c75/9009/b90c2938bc3e/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/eb57ec8b/fcd5/4c75/9009/b90c2938bc3e/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/eb57ec8b/fcd5/4c75/9009/b90c2938bc3e/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/eb57ec8b/fcd5/4c75/9009/b90c2938bc3e/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/eb57ec8b/fcd5/4c75/9009/b90c2938bc3e/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/eb57ec8b/fcd5/4c75/9009/b90c2938bc3e/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7E4329",
+          "blurHash": "UBHdW.@Z01X9~B[U%0I@0$I@=ZJB9vK5Vsoz",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzHvl1FGtArb9",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/56d1d0ac/1ba4/417e/b36e/7deeb3edd4eb/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/56d1d0ac/1ba4/417e/b36e/7deeb3edd4eb/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/56d1d0ac/1ba4/417e/b36e/7deeb3edd4eb/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/56d1d0ac/1ba4/417e/b36e/7deeb3edd4eb/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/56d1d0ac/1ba4/417e/b36e/7deeb3edd4eb/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/56d1d0ac/1ba4/417e/b36e/7deeb3edd4eb/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/56d1d0ac/1ba4/417e/b36e/7deeb3edd4eb/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7A6458",
+          "blurHash": "UmKK+gMxIpxs~Tt6kAae%Ns,t7aes:W;oeWB",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzIBhooiwvXaU",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/67930f16/33b7/43da/84b8/5de7505543e3/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/67930f16/33b7/43da/84b8/5de7505543e3/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/67930f16/33b7/43da/84b8/5de7505543e3/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/67930f16/33b7/43da/84b8/5de7505543e3/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/67930f16/33b7/43da/84b8/5de7505543e3/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/67930f16/33b7/43da/84b8/5de7505543e3/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/67930f16/33b7/43da/84b8/5de7505543e3/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#992E31",
+          "blurHash": "U5Fem6M{1cEfw|t7iwOr2[Ri|_ae1HS~AC].",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9Dzdjr8V9qdZSv",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/5abd7c43/0a4b/404d/854e/a93a52277c87/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5abd7c43/0a4b/404d/854e/a93a52277c87/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5abd7c43/0a4b/404d/854e/a93a52277c87/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5abd7c43/0a4b/404d/854e/a93a52277c87/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5abd7c43/0a4b/404d/854e/a93a52277c87/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5abd7c43/0a4b/404d/854e/a93a52277c87/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5abd7c43/0a4b/404d/854e/a93a52277c87/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#AF413A",
+          "blurHash": "U5RUQo%L*Hx[zynjXSbH[nbaMfoe+hniTbaf",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9Dze56cXwCJWpm",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/c9a20903/e4c7/413e/ba2a/7a3dec280a76/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c9a20903/e4c7/413e/ba2a/7a3dec280a76/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c9a20903/e4c7/413e/ba2a/7a3dec280a76/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c9a20903/e4c7/413e/ba2a/7a3dec280a76/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c9a20903/e4c7/413e/ba2a/7a3dec280a76/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c9a20903/e4c7/413e/ba2a/7a3dec280a76/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c9a20903/e4c7/413e/ba2a/7a3dec280a76/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#243B43",
+          "blurHash": "UPKx6c01xYD*~V?aNGIVxt%Lt7RkxtWCRjt6",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9Dze56eQ56UBe7",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/113ce480/4bd3/4a1b/b169/a60c0fee21a4/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/113ce480/4bd3/4a1b/b169/a60c0fee21a4/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/113ce480/4bd3/4a1b/b169/a60c0fee21a4/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/113ce480/4bd3/4a1b/b169/a60c0fee21a4/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/113ce480/4bd3/4a1b/b169/a60c0fee21a4/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/113ce480/4bd3/4a1b/b169/a60c0fee21a4/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/113ce480/4bd3/4a1b/b169/a60c0fee21a4/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#243B43",
+          "blurHash": "UPKx6d01xZD*~V?aNGIVxt%Lt7RkxtWCRjt6",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0LhB5vluPuVt",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/3687955c/d67e/4624/9529/5fdac9363b1f/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3687955c/d67e/4624/9529/5fdac9363b1f/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3687955c/d67e/4624/9529/5fdac9363b1f/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3687955c/d67e/4624/9529/5fdac9363b1f/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3687955c/d67e/4624/9529/5fdac9363b1f/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3687955c/d67e/4624/9529/5fdac9363b1f/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3687955c/d67e/4624/9529/5fdac9363b1f/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#2C160B",
+          "blurHash": "USQ=pWWA{3oyL%xa%1ae-:RkE#j[;3j@OXoL",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IP0yLMFG6iZU",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/b332ccc0/345c/4876/9a1c/dd18f441d5f7/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b332ccc0/345c/4876/9a1c/dd18f441d5f7/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b332ccc0/345c/4876/9a1c/dd18f441d5f7/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b332ccc0/345c/4876/9a1c/dd18f441d5f7/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b332ccc0/345c/4876/9a1c/dd18f441d5f7/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b332ccc0/345c/4876/9a1c/dd18f441d5f7/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b332ccc0/345c/4876/9a1c/dd18f441d5f7/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#1B0E09",
+          "blurHash": "U3EL1aKH0%Dm01}q0Osp0BIu=vtN0zAasC%K",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPH0I1XB5kJu",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/e18fa4a5/8015/40c1/8076/b88240d3ff4a/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e18fa4a5/8015/40c1/8076/b88240d3ff4a/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e18fa4a5/8015/40c1/8076/b88240d3ff4a/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e18fa4a5/8015/40c1/8076/b88240d3ff4a/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e18fa4a5/8015/40c1/8076/b88240d3ff4a/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e18fa4a5/8015/40c1/8076/b88240d3ff4a/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e18fa4a5/8015/40c1/8076/b88240d3ff4a/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#486094",
+          "blurHash": "ULAUUgtVtRRitp%iV?kDWCROt8a$ISV=RPt8",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPMMt532Fc2K",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/b77a9395/fdf7/454f/8b9c/907fde6d07e6/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b77a9395/fdf7/454f/8b9c/907fde6d07e6/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b77a9395/fdf7/454f/8b9c/907fde6d07e6/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b77a9395/fdf7/454f/8b9c/907fde6d07e6/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b77a9395/fdf7/454f/8b9c/907fde6d07e6/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b77a9395/fdf7/454f/8b9c/907fde6d07e6/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b77a9395/fdf7/454f/8b9c/907fde6d07e6/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#765438",
+          "blurHash": "ULM7cP9G_29E?wxv%L%1~ojXD+NK_1ocE3xv",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPX2DkbBYAT3",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/ee2c3f74/e0f3/4dad/aec0/501d956b7878/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee2c3f74/e0f3/4dad/aec0/501d956b7878/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee2c3f74/e0f3/4dad/aec0/501d956b7878/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee2c3f74/e0f3/4dad/aec0/501d956b7878/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee2c3f74/e0f3/4dad/aec0/501d956b7878/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee2c3f74/e0f3/4dad/aec0/501d956b7878/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee2c3f74/e0f3/4dad/aec0/501d956b7878/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7B7233",
+          "blurHash": "U9B|T^Ma00wZvypJNERn00o#~oWu9XMx-?xn",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPhZoDX2OjnY",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/0ac915da/e558/403a/b8fe/5f346de96ce2/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0ac915da/e558/403a/b8fe/5f346de96ce2/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0ac915da/e558/403a/b8fe/5f346de96ce2/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0ac915da/e558/403a/b8fe/5f346de96ce2/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0ac915da/e558/403a/b8fe/5f346de96ce2/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0ac915da/e558/403a/b8fe/5f346de96ce2/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0ac915da/e558/403a/b8fe/5f346de96ce2/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#5B2728",
+          "blurHash": "UCHB0z00?^9F=g~WE1NGACn4t69Z02NH-TD%",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "104340964",
+      "type": "tracks",
+      "attributes": {
+        "title": "Drunk In The Morning",
+        "version": null,
+        "isrc": "DKUM71200883",
+        "duration": "PT3M26S",
+        "copyright": {
+          "text": "℗ 2012 Copenhagen Records / Universal Music"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MAJOR",
+        "bpm": 92.0,
+        "popularity": 0.49679726287862863,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/104340964",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2019-02-18T16:37:06Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/104340964/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "104340961",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/104340964/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "118421111",
+      "type": "tracks",
+      "attributes": {
+        "title": "Lie",
+        "version": null,
+        "isrc": "USWB11902022",
+        "duration": "PT3M",
+        "copyright": {
+          "text": "a Copenhagen Records / Then We Take The World release; ℗ 2019 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "F",
+        "keyScale": "MAJOR",
+        "bpm": 92.0,
+        "popularity": 0.39150648633849927,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/118421111",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2019-09-20T06:50:27Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/118421111/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "118421110",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/118421111/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "121563484",
+      "type": "tracks",
+      "attributes": {
+        "title": "HERE (For Christmas)",
+        "version": null,
+        "isrc": "USWB11902814",
+        "duration": "PT4M1S",
+        "copyright": {
+          "text": "a Copenhagen Records / Then We Take The World release; ℗ 2019 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MAJOR",
+        "bpm": 115.0,
+        "popularity": 0.556719500381777,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/121563484",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2019-11-01T19:56:22Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/121563484/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "121563483",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/121563484/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "13536359",
+      "type": "tracks",
+      "attributes": {
+        "title": "Drunk In The Morning",
+        "version": null,
+        "isrc": "DKUM71200030",
+        "duration": "PT3M29S",
+        "copyright": {
+          "text": "℗ 2012 Copenhagen Records / Universal Music"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MAJOR",
+        "bpm": 92.0,
+        "popularity": 0.1261610177324897,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/13536359",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2012-02-04T11:50:10Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/13536359/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "13536358",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/13536359/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "150847283",
+      "type": "tracks",
+      "attributes": {
+        "title": "Share That Love (feat. G-Eazy)",
+        "version": null,
+        "isrc": "USWB12002076",
+        "duration": "PT2M52S",
+        "copyright": {
+          "text": "℗ 2020 Warner Records Inc. for the world excluding Germany, Austria, Switzerland, Finland, Sweden, Norway, Denmark, and France."
+        },
+        "explicit": true,
+        "ai": false,
+        "key": "D",
+        "keyScale": "MAJOR",
+        "bpm": 156.0,
+        "popularity": 0.37235357249051326,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/150847283",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2020-08-03T21:35:07Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            },
+            {
+              "id": "5072967",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/150847283/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "150847282",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/150847283/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "204855617",
+      "type": "tracks",
+      "attributes": {
+        "title": "Most People",
+        "version": null,
+        "isrc": "AEA2D2100143",
+        "duration": "PT2M21S",
+        "copyright": {
+          "text": "℗ 2021 CYB3RPVNK, under exclusive license to Universal Music GmbH"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "E",
+        "keyScale": "MAJOR",
+        "bpm": 114.0,
+        "popularity": 0.41894942234550386,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/204855617",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2021-11-12T00:37:03Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3637952",
+              "type": "artists"
+            },
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/204855617/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "204855615",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/204855617/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "242149003",
+      "type": "tracks",
+      "attributes": {
+        "title": "Wish You Were Here (feat. Khalid)",
+        "version": null,
+        "isrc": "USWB12201688",
+        "duration": "PT2M56S",
+        "copyright": {
+          "text": "℗ 2022 Warner Records Inc. for the world excluding Germany, Austria, Switzerland, Finland, Sweden, Norway, Denmark, and France."
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Ab",
+        "keyScale": "MAJOR",
+        "bpm": 106.0,
+        "popularity": 0.1603768922218786,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/242149003",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2022-08-09T03:47:24Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            },
+            {
+              "id": "4916222",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/242149003/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "242149002",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/242149003/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "242744824",
+      "type": "tracks",
+      "attributes": {
+        "title": "Wish You Were Here",
+        "version": null,
+        "isrc": "USWB12201688",
+        "duration": "PT2M56S",
+        "copyright": {
+          "text": "℗ 2022 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Ab",
+        "keyScale": "MAJOR",
+        "bpm": 106.0,
+        "popularity": 0.4384265456172178,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/242744824",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2022-08-12T01:43:27Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            },
+            {
+              "id": "4916222",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/242744824/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "242744823",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/242744824/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "402225792",
+      "type": "tracks",
+      "attributes": {
+        "title": "Du ligner din mor",
+        "version": null,
+        "isrc": "DKADG2400768",
+        "duration": "PT3M6S",
+        "copyright": {
+          "text": "(P) 2024 Sony Music Entertainment Denmark A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "E",
+        "keyScale": "MAJOR",
+        "bpm": 107.0,
+        "popularity": 0.672352135181427,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/402225792",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2024-11-27T11:31:36Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "8051290",
+              "type": "artists"
+            },
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/402225792/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "402225791",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/402225792/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "46675784",
+      "type": "tracks",
+      "attributes": {
+        "title": "Take The World By Storm",
+        "version": null,
+        "isrc": "USWB11506517",
+        "duration": "PT3M12S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Bb",
+        "keyScale": "MINOR",
+        "bpm": 88.0,
+        "popularity": 0.2032164290373476,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/46675784",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2015-06-11T00:43:15Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/46675784/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "46675782",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/46675784/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "46675790",
+      "type": "tracks",
+      "attributes": {
+        "title": "What Happened To Perfect",
+        "version": null,
+        "isrc": "USWB11506523",
+        "duration": "PT3M57S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "A",
+        "keyScale": "MAJOR",
+        "bpm": 140.0,
+        "popularity": 0.214944888484677,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/46675790",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2015-06-11T00:43:15Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/46675790/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "46675782",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/46675790/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "46675792",
+      "type": "tracks",
+      "attributes": {
+        "title": "Strip No More",
+        "version": null,
+        "isrc": "USWB11506525",
+        "duration": "PT3M28S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Bb",
+        "keyScale": "MAJOR",
+        "bpm": 131.0,
+        "popularity": 0.6362892389297485,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/46675792",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2015-06-11T00:43:15Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/46675792/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "46675782",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/46675792/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "46675793",
+      "type": "tracks",
+      "attributes": {
+        "title": "You're Not There",
+        "version": null,
+        "isrc": "USWB11506526",
+        "duration": "PT3M21S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "F",
+        "keyScale": "MAJOR",
+        "bpm": 92.0,
+        "popularity": 0.2314735970992938,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/46675793",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2015-06-11T00:43:15Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/46675793/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "46675782",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/46675793/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58503071",
+      "type": "tracks",
+      "attributes": {
+        "title": "7 Years",
+        "version": null,
+        "isrc": "USWB11506516",
+        "duration": "PT3M57S",
+        "copyright": {
+          "text": "℗ 2015 Warner Records Inc."
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MAJOR",
+        "bpm": 120.0,
+        "popularity": 0.5438648964509503,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58503071",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-18T18:20:27Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58503071/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58503070",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58503071/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58503073",
+      "type": "tracks",
+      "attributes": {
+        "title": "Mama Said",
+        "version": null,
+        "isrc": "USWB11600081",
+        "duration": "PT3M27S",
+        "copyright": {
+          "text": "℗ 2016 Warner Records Inc."
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Bb",
+        "keyScale": "MAJOR",
+        "bpm": 84.0,
+        "popularity": 0.35428630692972113,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58503073",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-18T18:20:27Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58503073/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58503070",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58503073/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58503074",
+      "type": "tracks",
+      "attributes": {
+        "title": "Happy Home",
+        "version": null,
+        "isrc": "USWB11600034",
+        "duration": "PT3M39S",
+        "copyright": {
+          "text": "℗ 2016 Warner Records Inc."
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MINOR",
+        "bpm": 128.0,
+        "popularity": 0.1261610177324897,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58503074",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-18T18:20:27Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58503074/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58503070",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58503074/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58503075",
+      "type": "tracks",
+      "attributes": {
+        "title": "Drunk in the Morning",
+        "version": null,
+        "isrc": "USWB11600035",
+        "duration": "PT3M23S",
+        "copyright": {
+          "text": "℗ 2015 Warner Records Inc."
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "D",
+        "keyScale": "MAJOR",
+        "bpm": 93.0,
+        "popularity": 0.1845211686977195,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58503075",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-18T18:20:27Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58503075/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58503070",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58503075/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58503080",
+      "type": "tracks",
+      "attributes": {
+        "title": "You're Not There",
+        "version": null,
+        "isrc": "USWB11600037",
+        "duration": "PT3M23S",
+        "copyright": {
+          "text": "℗ 2016 Warner Records Inc."
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "F",
+        "keyScale": "MAJOR",
+        "bpm": 92.0,
+        "popularity": 0.1943943385832289,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58503080",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-18T18:20:27Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58503080/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58503070",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58503080/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "79492732",
+      "type": "tracks",
+      "attributes": {
+        "title": "Off To See The World",
+        "version": null,
+        "isrc": "USWB11701563",
+        "duration": "PT3M4S",
+        "copyright": {
+          "text": "A Copenhagen Records / Then We Take The World release; ℗ 2017 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "G",
+        "keyScale": "MAJOR",
+        "bpm": 107.0,
+        "popularity": 0.35981553269930383,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/79492732",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2017-10-02T22:30:02Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            },
+            {
+              "id": "3526386",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/79492732/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "79492731",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/79492732/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "94189625",
+      "type": "tracks",
+      "attributes": {
+        "title": "Love Someone",
+        "version": null,
+        "isrc": "USWB11801903",
+        "duration": "PT3M25S",
+        "copyright": {
+          "text": "℗ 2018 Warner Records Inc."
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "E",
+        "keyScale": "MAJOR",
+        "bpm": 86.0,
+        "popularity": 0.48828778148762936,
+        "accessType": "PUBLIC",
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/94189625",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2018-08-28T01:10:09Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/94189625/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "94189624",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/94189625/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/providers/tidal/fixtures/v2/similar_artists.json
+++ b/tests/providers/tidal/fixtures/v2/similar_artists.json
@@ -1,0 +1,1651 @@
+{
+  "data": [
+    {
+      "id": "9205306",
+      "type": "artists"
+    },
+    {
+      "id": "4394210",
+      "type": "artists"
+    },
+    {
+      "id": "4826351",
+      "type": "artists"
+    },
+    {
+      "id": "17476",
+      "type": "artists"
+    },
+    {
+      "id": "3553886",
+      "type": "artists"
+    },
+    {
+      "id": "5618930",
+      "type": "artists"
+    },
+    {
+      "id": "8155176",
+      "type": "artists"
+    },
+    {
+      "id": "4927349",
+      "type": "artists"
+    },
+    {
+      "id": "8583514",
+      "type": "artists"
+    },
+    {
+      "id": "4804285",
+      "type": "artists"
+    },
+    {
+      "id": "3995478",
+      "type": "artists"
+    },
+    {
+      "id": "8812",
+      "type": "artists"
+    },
+    {
+      "id": "4989822",
+      "type": "artists"
+    },
+    {
+      "id": "6590715",
+      "type": "artists"
+    },
+    {
+      "id": "8996003",
+      "type": "artists"
+    },
+    {
+      "id": "71849227",
+      "type": "artists"
+    },
+    {
+      "id": "5747802",
+      "type": "artists"
+    },
+    {
+      "id": "7367609",
+      "type": "artists"
+    },
+    {
+      "id": "8070834",
+      "type": "artists"
+    },
+    {
+      "id": "7879416",
+      "type": "artists"
+    }
+  ],
+  "links": {
+    "self": "/artists/4184211/relationships/similarArtists?include=similarArtists.profileArt&countryCode=AT",
+    "next": "/artists/4184211/relationships/similarArtists?include=similarArtists.profileArt&countryCode=AT&page%5Bcursor%5D=3nI1Esi",
+    "meta": {
+      "nextCursor": "3nI1Esi"
+    }
+  },
+  "included": [
+    {
+      "id": "17476",
+      "type": "artists",
+      "attributes": {
+        "name": "Christopher",
+        "popularity": 0.687865207450213,
+        "externalLinks": [
+          {
+            "href": "https://facebook.com/ChristopherMusicDk",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "https://instagram.com/christophermusiccom",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://christophermusic.dk",
+            "meta": {
+              "type": "OFFICIAL_HOMEPAGE"
+            }
+          },
+          {
+            "href": "https://tiktok.com/@christophermusiccom",
+            "meta": {
+              "type": "TIKTOK"
+            }
+          },
+          {
+            "href": "https://twitter.com/StopherMusic",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/17476",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "dDmYD0OBhSklbbny",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/17476/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "3553886",
+      "type": "artists",
+      "attributes": {
+        "name": "Mads Langer",
+        "popularity": 0.6583492755889893,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3553886",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGPBTX51E0M",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/3553886/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "3995478",
+      "type": "artists",
+      "attributes": {
+        "name": "Ed Sheeran",
+        "popularity": 0.9478464722633362,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/edsheeran ",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/3995478",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGPCjGX8qoy",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/3995478/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4394210",
+      "type": "artists",
+      "attributes": {
+        "name": "Imagine Dragons",
+        "popularity": 0.903693437576294,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/imaginedragons",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4394210",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQSme3YdUm",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4394210/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4804285",
+      "type": "artists",
+      "attributes": {
+        "name": "James Arthur",
+        "popularity": 0.8358675837516785,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/4804285",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQUKkh58Hl",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4804285/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4826351",
+      "type": "artists",
+      "attributes": {
+        "name": "A Great Big World",
+        "popularity": 0.7094548344612122,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/4826351",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQUKu6ggYz",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4826351/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4927349",
+      "type": "artists",
+      "attributes": {
+        "name": "James Bay",
+        "popularity": 0.7884899973869324,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/jamesbaymusic",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4927349",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQUeGI7opl",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4927349/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4989822",
+      "type": "artists",
+      "attributes": {
+        "name": "Charlie Puth",
+        "popularity": 0.8677024841308594,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/4989822",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQUeiSPS9S",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4989822/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "5618930",
+      "type": "artists",
+      "attributes": {
+        "name": "James TW",
+        "popularity": 0.6475415075580073,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/5618930",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGRlddf5ZWS",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/5618930/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "5747802",
+      "type": "artists",
+      "attributes": {
+        "name": "Shawn Mendes",
+        "popularity": 0.8970066905021667,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/shawnmendes",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/5747802",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGRlxDsFN9W",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/5747802/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "6590715",
+      "type": "artists",
+      "attributes": {
+        "name": "Julia Michaels",
+        "popularity": 0.8020834922790527,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/6590715",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGT3GPOOFSH",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/6590715/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "71849227",
+      "type": "artists",
+      "attributes": {
+        "name": "Niall Horan",
+        "popularity": 0.5836346397014275,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/71849227",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "iX4YeXf08C5CLG2yw8SV",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/71849227/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "7367609",
+      "type": "artists",
+      "attributes": {
+        "name": "Dean Lewis",
+        "popularity": 0.8024351876034125,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/7367609",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGUKYzf6hLt",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/7367609/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "7879416",
+      "type": "artists",
+      "attributes": {
+        "name": "Ruth B.",
+        "popularity": 0.7645173072814941,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/7879416",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGUM7rDXsd4",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/7879416/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "8070834",
+      "type": "artists",
+      "attributes": {
+        "name": "Chord Overstreet",
+        "popularity": 0.6422351001898581,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/8070834",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGVbYWGIgL6",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/8070834/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "8155176",
+      "type": "artists",
+      "attributes": {
+        "name": "Niall Horan",
+        "popularity": 0.7992809414863586,
+        "externalLinks": [
+          {
+            "href": "https://instagram.com/niallhoran",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://niallhoran.com",
+            "meta": {
+              "type": "OFFICIAL_HOMEPAGE"
+            }
+          },
+          {
+            "href": "https://tiktok.com/@niallhoran",
+            "meta": {
+              "type": "TIKTOK"
+            }
+          },
+          {
+            "href": "https://twitter.com/niallofficial",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/8155176",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "MIXED"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGVbrj8uzI6",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/8155176/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "8583514",
+      "type": "artists",
+      "attributes": {
+        "name": "Lewis Capaldi",
+        "popularity": 0.821123099996505,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/8583514",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGVd7NprytA",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/8583514/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "8812",
+      "type": "artists",
+      "attributes": {
+        "name": "Coldplay",
+        "popularity": 0.9104413949533393,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/8812",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "9Uwk47MKGpAYj1G",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/8812/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "8996003",
+      "type": "artists",
+      "attributes": {
+        "name": "Maximillian",
+        "popularity": 0.5322948098182678,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/8996003",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGVeMtF7zal",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/8996003/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "9205306",
+      "type": "artists",
+      "attributes": {
+        "name": "Daniel Schulz",
+        "popularity": 0.5788896083831787,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/9205306",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGWu6EPHDLa",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/9205306/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "9Uwk47MKGpAYj1G",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/b4579672/5b91/4679/a27a/288f097a4da5/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b4579672/5b91/4679/a27a/288f097a4da5/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b4579672/5b91/4679/a27a/288f097a4da5/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b4579672/5b91/4679/a27a/288f097a4da5/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#120A12",
+          "blurHash": "U8D%#Rs90cs;nbWXa#a|0cWn}KR%szxHR*WU",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGPBTX51E0M",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/1cc73ced/1771/4b10/b66e/93cc6bb14316/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1cc73ced/1771/4b10/b66e/93cc6bb14316/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1cc73ced/1771/4b10/b66e/93cc6bb14316/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1cc73ced/1771/4b10/b66e/93cc6bb14316/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#161E2F",
+          "blurHash": "UYJ*elNG_NRP~pWBIVWBE1j[s9j[Ipj[s.fj",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGPCjGX8qoy",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/05d72ae4/319f/4237/821f/1d7af9ec8acf/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/05d72ae4/319f/4237/821f/1d7af9ec8acf/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/05d72ae4/319f/4237/821f/1d7af9ec8acf/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/05d72ae4/319f/4237/821f/1d7af9ec8acf/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7B5B4B",
+          "blurHash": "UBB3g0004.~q$$t7I=WA4m-;x]8_tRRiRj%M",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQSme3YdUm",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/b5fc9952/f318/48ee/94f7/1d1f390f2871/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b5fc9952/f318/48ee/94f7/1d1f390f2871/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b5fc9952/f318/48ee/94f7/1d1f390f2871/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b5fc9952/f318/48ee/94f7/1d1f390f2871/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#70503C",
+          "blurHash": "U36aL]E10fxu~BM|EM%20gs:-Us.9axa$*Io",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQUKkh58Hl",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/6d2c23b3/a122/4439/acfd/8245fe6c05cd/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6d2c23b3/a122/4439/acfd/8245fe6c05cd/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6d2c23b3/a122/4439/acfd/8245fe6c05cd/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6d2c23b3/a122/4439/acfd/8245fe6c05cd/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#243554",
+          "blurHash": "UFCj3FVqKR00F~I9?wRO9GITxG_3D%%MITW;",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQUKu6ggYz",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/25a587ee/eda3/4523/bec9/eee6ec319d73/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/25a587ee/eda3/4523/bec9/eee6ec319d73/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/25a587ee/eda3/4523/bec9/eee6ec319d73/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/25a587ee/eda3/4523/bec9/eee6ec319d73/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#3E3C6E",
+          "blurHash": "Uj8E1SWaR=jXtWWFfns+R;axoHoHWGofj;WC",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQUeGI7opl",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/1dabcbd7/173e/46f2/91af/bd478eeae36a/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1dabcbd7/173e/46f2/91af/bd478eeae36a/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1dabcbd7/173e/46f2/91af/bd478eeae36a/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1dabcbd7/173e/46f2/91af/bd478eeae36a/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#4A4319",
+          "blurHash": "U+Jt-cRPx@Rk~qoIt7WBtTt7NHt6ozWsRjof",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQUeiSPS9S",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/bbdedec7/aba7/4fc8/ac5a/9616dd522819/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/bbdedec7/aba7/4fc8/ac5a/9616dd522819/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/bbdedec7/aba7/4fc8/ac5a/9616dd522819/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/bbdedec7/aba7/4fc8/ac5a/9616dd522819/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#6A0E07",
+          "blurHash": "UJIWyY4TMK?b00?^kXM{9to}xZV@%#MxxGRj",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGRlddf5ZWS",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/b90906fa/599d/4ae4/ae11/b7fccfd6687c/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b90906fa/599d/4ae4/ae11/b7fccfd6687c/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b90906fa/599d/4ae4/ae11/b7fccfd6687c/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b90906fa/599d/4ae4/ae11/b7fccfd6687c/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#54504A",
+          "blurHash": "U8FPEK4T%L_4Dg%iM{IAM{t6%NMxxtofRiof",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGRlxDsFN9W",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/42b307e2/d48d/4ea2/a64a/2a5694ac4eb3/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/42b307e2/d48d/4ea2/a64a/2a5694ac4eb3/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/42b307e2/d48d/4ea2/a64a/2a5694ac4eb3/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/42b307e2/d48d/4ea2/a64a/2a5694ac4eb3/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#131311",
+          "blurHash": "U59%*Qs:~pf89Gxu%M-:Rj%Lt7of~pR*D%M{",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGT3GPOOFSH",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/ce73e516/af74/4fe9/81ba/9b20caac9f99/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ce73e516/af74/4fe9/81ba/9b20caac9f99/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ce73e516/af74/4fe9/81ba/9b20caac9f99/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ce73e516/af74/4fe9/81ba/9b20caac9f99/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#634231",
+          "blurHash": "U6ASVrt70g0#t75S=wR+9uEM}?t7=xI;xu={",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGUKYzf6hLt",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/cbea85bd/1163/4fa8/a390/cd57e4d02de4/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cbea85bd/1163/4fa8/a390/cd57e4d02de4/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cbea85bd/1163/4fa8/a390/cd57e4d02de4/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cbea85bd/1163/4fa8/a390/cd57e4d02de4/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#355079",
+          "blurHash": "UXFZmk.9.9I8TOM_M_t8IVV?ROtRITofWBog",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGUM7rDXsd4",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/f1c3b881/2c8e/4b51/a8a7/bacde1cfaa9e/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f1c3b881/2c8e/4b51/a8a7/bacde1cfaa9e/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f1c3b881/2c8e/4b51/a8a7/bacde1cfaa9e/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f1c3b881/2c8e/4b51/a8a7/bacde1cfaa9e/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#676767",
+          "blurHash": "UTPjGc9F~q?b?bxuRjM{%MofIUM{-;ayIUj[",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGVbYWGIgL6",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/1a573c71/a2b6/4fb1/bc8d/685b9c1e04f5/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1a573c71/a2b6/4fb1/bc8d/685b9c1e04f5/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1a573c71/a2b6/4fb1/bc8d/685b9c1e04f5/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1a573c71/a2b6/4fb1/bc8d/685b9c1e04f5/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#5D4339",
+          "blurHash": "UfGk|8-;R+aJ_NbvS4RPbcoLxaRjIUV@j[WV",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGVbrj8uzI6",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/6f4a1201/b1e5/451d/9f78/538a1ab92b05/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6f4a1201/b1e5/451d/9f78/538a1ab92b05/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6f4a1201/b1e5/451d/9f78/538a1ab92b05/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6f4a1201/b1e5/451d/9f78/538a1ab92b05/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7B5F3F",
+          "blurHash": "UFEy0i~UENE201bJs-aKou9FRjt74o%1xtbw",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGVd7NprytA",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/bee09376/f217/46ba/b1e2/4b99405d0d13/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/bee09376/f217/46ba/b1e2/4b99405d0d13/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/bee09376/f217/46ba/b1e2/4b99405d0d13/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/bee09376/f217/46ba/b1e2/4b99405d0d13/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#6E3A3A",
+          "blurHash": "UKIW}]^+=z~pu3%29u-;E4IpM{xab1xaxFj]",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGVeMtF7zal",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/03975f04/8470/497b/bf3a/59446bc21562/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/03975f04/8470/497b/bf3a/59446bc21562/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/03975f04/8470/497b/bf3a/59446bc21562/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/03975f04/8470/497b/bf3a/59446bc21562/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#6C6C6C",
+          "blurHash": "UBO|b2%M~qWB~qfQRjofxuWBD%of%MayM{of",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGWu6EPHDLa",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/b3eb3a5f/3af9/45cb/ad9f/163d50a89704/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b3eb3a5f/3af9/45cb/ad9f/163d50a89704/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b3eb3a5f/3af9/45cb/ad9f/163d50a89704/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b3eb3a5f/3af9/45cb/ad9f/163d50a89704/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#255467",
+          "blurHash": "UaD_Nq%fysIUTLRPIVtlM{aei_ozS5kDxYV@",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "dDmYD0OBhSklbbny",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/c83fee69/46cf/41da/acd5/49e397b6a43e/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c83fee69/46cf/41da/acd5/49e397b6a43e/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c83fee69/46cf/41da/acd5/49e397b6a43e/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c83fee69/46cf/41da/acd5/49e397b6a43e/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#6B6B6B",
+          "blurHash": "UZMtaOD%~q-;D%xu-;RjWBofM{RjofRjofof",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iX4YeXf08C5CLG2yw8SV",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/4d25eecd/5e61/438b/8115/1850a3ac2538/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4d25eecd/5e61/438b/8115/1850a3ac2538/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4d25eecd/5e61/438b/8115/1850a3ac2538/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4d25eecd/5e61/438b/8115/1850a3ac2538/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#8C6E44",
+          "blurHash": "U%O2ZvxZ~9R+-8R*Rks.w^WWS4oKW;jtjGj[",
+          "status": "OK"
+        }
+      }
+    }
+  ]
+}

--- a/tests/providers/tidal/fixtures/v2/similar_tracks.json
+++ b/tests/providers/tidal/fixtures/v2/similar_tracks.json
@@ -1,0 +1,3226 @@
+{
+  "data": [
+    {
+      "id": "53893678",
+      "type": "tracks"
+    },
+    {
+      "id": "53943554",
+      "type": "tracks"
+    },
+    {
+      "id": "62300893",
+      "type": "tracks"
+    },
+    {
+      "id": "58756137",
+      "type": "tracks"
+    },
+    {
+      "id": "31260702",
+      "type": "tracks"
+    },
+    {
+      "id": "53893677",
+      "type": "tracks"
+    },
+    {
+      "id": "50221259",
+      "type": "tracks"
+    },
+    {
+      "id": "77624180",
+      "type": "tracks"
+    },
+    {
+      "id": "45191318",
+      "type": "tracks"
+    },
+    {
+      "id": "62300896",
+      "type": "tracks"
+    },
+    {
+      "id": "42211996",
+      "type": "tracks"
+    },
+    {
+      "id": "31260707",
+      "type": "tracks"
+    },
+    {
+      "id": "58756132",
+      "type": "tracks"
+    },
+    {
+      "id": "50142416",
+      "type": "tracks"
+    },
+    {
+      "id": "53893676",
+      "type": "tracks"
+    },
+    {
+      "id": "54728057",
+      "type": "tracks"
+    },
+    {
+      "id": "56489250",
+      "type": "tracks"
+    },
+    {
+      "id": "45191319",
+      "type": "tracks"
+    },
+    {
+      "id": "57454792",
+      "type": "tracks"
+    },
+    {
+      "id": "72947838",
+      "type": "tracks"
+    }
+  ],
+  "links": {
+    "self": "/tracks/58756128/relationships/similarTracks?include=similarTracks.albums.coverArt%2CsimilarTracks.artists&countryCode=AT",
+    "next": "/tracks/58756128/relationships/similarTracks?include=similarTracks.albums.coverArt%2CsimilarTracks.artists&countryCode=AT&page%5Bcursor%5D=3nI1Esi",
+    "meta": {
+      "nextCursor": "3nI1Esi"
+    }
+  },
+  "included": [
+    {
+      "id": "31260696",
+      "type": "albums",
+      "attributes": {
+        "title": "x (Deluxe Edition)",
+        "barcodeId": "825646284535",
+        "numberOfVolumes": 1,
+        "numberOfItems": 16,
+        "duration": "PT1H5M56S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2014-06-23",
+        "copyright": {
+          "text": "© 2014 Asylum Records UK, a Warner Music UK Company"
+        },
+        "popularity": 0.7854247125445359,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/31260696",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "createdAt": "2014-06-19T21:46:58Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPBZnc3EzkBy",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/31260696/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "42211995",
+      "type": "albums",
+      "attributes": {
+        "title": "See You Again (feat. Charlie Puth)",
+        "barcodeId": "075679927750",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M50S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2015-03-10",
+        "copyright": {
+          "text": "© 2015 Universal Studios Motion Picture Artwork, Artwork Title, and Photos"
+        },
+        "popularity": 0.44159202802912334,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/42211995",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPGv73Y9rbe9",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/42211995/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "45191316",
+      "type": "albums",
+      "attributes": {
+        "title": "Blurryface",
+        "barcodeId": "075679928160",
+        "numberOfVolumes": 1,
+        "numberOfItems": 14,
+        "duration": "PT52M23S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2015-05-19",
+        "copyright": {
+          "text": "© 2015 Fueled By Ramen LLC for the United States and WEA International Inc. for the world outside of the United States. A Warner Music Group Company"
+        },
+        "popularity": 0.867475196632913,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/45191316",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPGyyXN6ygJK",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/45191316/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "50142415",
+      "type": "albums",
+      "attributes": {
+        "title": "Lost Boy",
+        "barcodeId": "886445456929",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT4M35S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2015-08-21",
+        "copyright": {
+          "text": "(P) 2015 Columbia Records, a Division of Sony Music Entertainment"
+        },
+        "popularity": 0.4394757385162127,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/50142415",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPMCYPinayAf",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/50142415/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "50221258",
+      "type": "albums",
+      "attributes": {
+        "title": "One Call Away",
+        "barcodeId": "075679919809",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M12S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2015-08-21",
+        "copyright": {
+          "text": "© 2015 Artist Partner Group, Inc"
+        },
+        "popularity": 0.3561509615081082,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/50221258",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPMCYivZQHFI",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/50221258/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "53893673",
+      "type": "albums",
+      "attributes": {
+        "title": "Purpose (Deluxe)",
+        "barcodeId": "00602547587466",
+        "numberOfVolumes": 1,
+        "numberOfItems": 18,
+        "duration": "PT1H6M16S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2015-11-13",
+        "copyright": {
+          "text": "© 2015 Def Jam Recordings, a division of UMG Recordings, Inc."
+        },
+        "popularity": 0.7670407805714341,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/53893673",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "version": "Deluxe",
+        "createdAt": "2015-11-10T01:47:54Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPMGSOB2Ipc3",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/53893673/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "53943552",
+      "type": "albums",
+      "attributes": {
+        "title": "Handwritten (Revisited)",
+        "barcodeId": "00602547656865",
+        "numberOfVolumes": 1,
+        "numberOfItems": 16,
+        "duration": "PT56M41S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2015-04-14",
+        "copyright": {
+          "text": "© 2015 Island Records, a division of UMG Recordings, Inc."
+        },
+        "popularity": 0.6113652424388194,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/53943552",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPMGSh9lH4Gw",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/53943552/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "54728054",
+      "type": "albums",
+      "attributes": {
+        "title": "A Head Full of Dreams",
+        "barcodeId": "825646982141",
+        "numberOfVolumes": 1,
+        "numberOfItems": 11,
+        "duration": "PT45M51S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2015-12-04",
+        "copyright": {
+          "text": "© 2015 Parlophone Records Limited, a Warner Music Group Company"
+        },
+        "popularity": 0.7746921445680881,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/54728054",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "createdAt": "2015-12-01T20:40:11Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPMHjzogMsC4",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/54728054/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "56489245",
+      "type": "albums",
+      "attributes": {
+        "title": "Nine Track Mind",
+        "barcodeId": "075679917850",
+        "numberOfVolumes": 1,
+        "numberOfItems": 13,
+        "duration": "PT44M59S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2016-01-29",
+        "copyright": {
+          "text": "© 2016 Artist Partners for the United States and WEA International Inc. for the world outside of the United States. A Warner Music Group Company."
+        },
+        "popularity": 0.5835381754015838,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/56489245",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPMKIvFPLPdN",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/56489245/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "57454791",
+      "type": "albums",
+      "attributes": {
+        "title": "i hate u, i love u  (feat. olivia o'brien)",
+        "barcodeId": "075679914217",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M47S",
+        "explicit": true,
+        "ai": false,
+        "releaseDate": "2016-02-17",
+        "copyright": {
+          "text": "2016"
+        },
+        "popularity": 0.4134263867466999,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/57454791",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPMLaqXn4Fbl",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/57454791/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756127",
+      "type": "albums",
+      "attributes": {
+        "title": "Lukas Graham (Blue Album) (International Version)",
+        "barcodeId": "00602547852748",
+        "numberOfVolumes": 1,
+        "numberOfItems": 11,
+        "duration": "PT40M5S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2015-05-29",
+        "copyright": {
+          "text": "© 2016 Then We Take The World / Copenhagen Records / Universal Music"
+        },
+        "popularity": 0.7480961442649546,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/58756127",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "version": "International Version",
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPMMti8ralux",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/58756127/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "62300892",
+      "type": "albums",
+      "attributes": {
+        "title": "25",
+        "barcodeId": "634904074067",
+        "numberOfVolumes": 1,
+        "numberOfItems": 11,
+        "duration": "PT48M26S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2015-11-20",
+        "copyright": {
+          "text": "XL Recordings Ltd"
+        },
+        "popularity": 0.8034527614428424,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/62300892",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPRZAPXDhp3K",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/62300892/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "72947835",
+      "type": "albums",
+      "attributes": {
+        "title": "Illuminate (Deluxe)",
+        "barcodeId": "00602557612486",
+        "numberOfVolumes": 1,
+        "numberOfItems": 16,
+        "duration": "PT55M31S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2016-09-23",
+        "copyright": {
+          "text": "© 2016 Island Records, a division of UMG Recordings, Inc."
+        },
+        "popularity": 0.6816771742219944,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/72947835",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "version": "Deluxe",
+        "createdAt": "2017-04-18T18:56:33Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPWtDoKtnh8n",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/72947835/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "77624176",
+      "type": "albums",
+      "attributes": {
+        "title": "Illuminate (Deluxe)",
+        "barcodeId": "00602557612547",
+        "numberOfVolumes": 1,
+        "numberOfItems": 16,
+        "duration": "PT55M31S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2016-09-23",
+        "copyright": {
+          "text": "© 2016 Island Records, a division of UMG Recordings, Inc."
+        },
+        "popularity": 0.651458804521635,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/77624176",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "version": "Deluxe",
+        "createdAt": "2017-08-18T21:30:05Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPWzeVjezjaI",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/77624176/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "3520382",
+      "type": "artists",
+      "attributes": {
+        "name": "Wiz khalifa",
+        "popularity": 0.8930611702600125,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/wizkhalifa",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/3520382",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3521920",
+      "type": "artists",
+      "attributes": {
+        "name": "Adele",
+        "popularity": 0.9271941184997559,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/Adele",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/3521920",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3638248",
+      "type": "artists",
+      "attributes": {
+        "name": "Selena Gomez",
+        "popularity": 0.9149596095085144,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/selenagomez",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/3638248",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3639248",
+      "type": "artists",
+      "attributes": {
+        "name": "Justin Bieber",
+        "popularity": 0.9415434002876282,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3639248",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3995478",
+      "type": "artists",
+      "attributes": {
+        "name": "Ed Sheeran",
+        "popularity": 0.9478464722633362,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/edsheeran ",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/3995478",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "4184211",
+      "type": "artists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "popularity": 0.8177526593208313,
+        "externalLinks": [
+          {
+            "href": "http://instagram.com/lukasinstagraham",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://www.twitter.com/LukeTheDuke_",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4184211",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "4664877",
+      "type": "artists",
+      "attributes": {
+        "name": "twenty one pilots",
+        "popularity": 0.8562991432279426,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/twentyonepilots",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4664877",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "4989822",
+      "type": "artists",
+      "attributes": {
+        "name": "Charlie Puth",
+        "popularity": 0.8677024841308594,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/4989822",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "5747802",
+      "type": "artists",
+      "attributes": {
+        "name": "Shawn Mendes",
+        "popularity": 0.8970066905021667,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/shawnmendes",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/5747802",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "7121283",
+      "type": "artists",
+      "attributes": {
+        "name": "gnash",
+        "popularity": 0.6905220746994019,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/7121283",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "7142197",
+      "type": "artists",
+      "attributes": {
+        "name": "Olivia O'Brien",
+        "popularity": 0.7149463295936584,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/7142197",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "7879416",
+      "type": "artists",
+      "attributes": {
+        "name": "Ruth B.",
+        "popularity": 0.7645173072814941,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/7879416",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "8812",
+      "type": "artists",
+      "attributes": {
+        "name": "Coldplay",
+        "popularity": 0.9104413949533393,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/coldplay",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/8812",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "iWOu0yW0IPBZnc3EzkBy",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/2d3b0000/55e1/4a0f/8675/640c45c872a4/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2d3b0000/55e1/4a0f/8675/640c45c872a4/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2d3b0000/55e1/4a0f/8675/640c45c872a4/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2d3b0000/55e1/4a0f/8675/640c45c872a4/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2d3b0000/55e1/4a0f/8675/640c45c872a4/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2d3b0000/55e1/4a0f/8675/640c45c872a4/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2d3b0000/55e1/4a0f/8675/640c45c872a4/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#118337",
+          "blurHash": "UP2nB2e:l%fjf*epf*e:eWfjZRe:f*fkfQf*",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPGv73Y9rbe9",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/84396546/3e74/424f/a4ab/40faefe87165/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/84396546/3e74/424f/a4ab/40faefe87165/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/84396546/3e74/424f/a4ab/40faefe87165/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/84396546/3e74/424f/a4ab/40faefe87165/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/84396546/3e74/424f/a4ab/40faefe87165/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/84396546/3e74/424f/a4ab/40faefe87165/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/84396546/3e74/424f/a4ab/40faefe87165/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#747370",
+          "blurHash": "UIE.|c~q00M|009G%M-;~p-;ofWBozfkIUM{",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPGyyXN6ygJK",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/d8f08936/a1f3/48ac/b163/435bcaee90fd/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/d8f08936/a1f3/48ac/b163/435bcaee90fd/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/d8f08936/a1f3/48ac/b163/435bcaee90fd/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/d8f08936/a1f3/48ac/b163/435bcaee90fd/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/d8f08936/a1f3/48ac/b163/435bcaee90fd/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/d8f08936/a1f3/48ac/b163/435bcaee90fd/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/d8f08936/a1f3/48ac/b163/435bcaee90fd/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#402521",
+          "blurHash": "U35}aJ.800H?xaX8V@r?00M{_3x]Ior?t8Or",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPMCYPinayAf",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/6ed738f2/31b0/4a18/a5bd/4032dbc8cb05/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6ed738f2/31b0/4a18/a5bd/4032dbc8cb05/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6ed738f2/31b0/4a18/a5bd/4032dbc8cb05/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6ed738f2/31b0/4a18/a5bd/4032dbc8cb05/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6ed738f2/31b0/4a18/a5bd/4032dbc8cb05/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6ed738f2/31b0/4a18/a5bd/4032dbc8cb05/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6ed738f2/31b0/4a18/a5bd/4032dbc8cb05/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#1F1F1F",
+          "blurHash": "U1TSUA~q?b~q~qj[ayj[_3j[9Fay~qj[j[j[",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPMCYivZQHFI",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/ca2b9b8c/eae2/403b/a722/af074af92764/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ca2b9b8c/eae2/403b/a722/af074af92764/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ca2b9b8c/eae2/403b/a722/af074af92764/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ca2b9b8c/eae2/403b/a722/af074af92764/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ca2b9b8c/eae2/403b/a722/af074af92764/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ca2b9b8c/eae2/403b/a722/af074af92764/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ca2b9b8c/eae2/403b/a722/af074af92764/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#906C39",
+          "blurHash": "UzO3ZANI~f$~-moKNHkBNIazs.j@bYj[soay",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPMGSOB2Ipc3",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/0fdbbb9a/d598/4efa/a52b/c3dfde73e0ca/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0fdbbb9a/d598/4efa/a52b/c3dfde73e0ca/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0fdbbb9a/d598/4efa/a52b/c3dfde73e0ca/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0fdbbb9a/d598/4efa/a52b/c3dfde73e0ca/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0fdbbb9a/d598/4efa/a52b/c3dfde73e0ca/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0fdbbb9a/d598/4efa/a52b/c3dfde73e0ca/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0fdbbb9a/d598/4efa/a52b/c3dfde73e0ca/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#090908",
+          "blurHash": "U4A^LBIU00~qD%Rj_3WB00j[V@9GIUjZxuRk",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPMGSh9lH4Gw",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/643ec887/1992/4838/9512/8cdd6f665cdc/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/643ec887/1992/4838/9512/8cdd6f665cdc/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/643ec887/1992/4838/9512/8cdd6f665cdc/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/643ec887/1992/4838/9512/8cdd6f665cdc/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/643ec887/1992/4838/9512/8cdd6f665cdc/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/643ec887/1992/4838/9512/8cdd6f665cdc/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/643ec887/1992/4838/9512/8cdd6f665cdc/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#04090B",
+          "blurHash": "U56au3E100~VR5WCbws:4:xa?G9atRxtWBIp",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPMHjzogMsC4",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/7e3dd7c5/5b53/49ec/a885/740c85ddc2aa/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/7e3dd7c5/5b53/49ec/a885/740c85ddc2aa/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/7e3dd7c5/5b53/49ec/a885/740c85ddc2aa/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/7e3dd7c5/5b53/49ec/a885/740c85ddc2aa/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/7e3dd7c5/5b53/49ec/a885/740c85ddc2aa/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/7e3dd7c5/5b53/49ec/a885/740c85ddc2aa/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/7e3dd7c5/5b53/49ec/a885/740c85ddc2aa/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#5D4C1D",
+          "blurHash": "UTF62*j[_4j]j[fQjtfQ~Af8v}j?oLfQbHfQ",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPMKIvFPLPdN",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/f2927784/e7f3/485d/a824/8d866d112204/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2927784/e7f3/485d/a824/8d866d112204/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2927784/e7f3/485d/a824/8d866d112204/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2927784/e7f3/485d/a824/8d866d112204/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2927784/e7f3/485d/a824/8d866d112204/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2927784/e7f3/485d/a824/8d866d112204/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2927784/e7f3/485d/a824/8d866d112204/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#906C39",
+          "blurHash": "UzO3ZANI~f$~-moKNHkBNIazs.j@bYj[soay",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPMLaqXn4Fbl",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/80ed3731/6bf3/455f/95ad/c18006131f1d/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/80ed3731/6bf3/455f/95ad/c18006131f1d/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/80ed3731/6bf3/455f/95ad/c18006131f1d/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/80ed3731/6bf3/455f/95ad/c18006131f1d/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/80ed3731/6bf3/455f/95ad/c18006131f1d/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/80ed3731/6bf3/455f/95ad/c18006131f1d/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/80ed3731/6bf3/455f/95ad/c18006131f1d/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#6E3E2E",
+          "blurHash": "UTFFHm={IoR+%%X8n$s:0yI:t6ayv}smS4R+",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPMMti8ralux",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#775434",
+          "blurHash": "ULM7cP9G_29E?wxv%L%1~ojXD+NK_1ocE3xv",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPRZAPXDhp3K",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/9fb9417d/ab64/42a9/a4d2/22052d5217d0/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9fb9417d/ab64/42a9/a4d2/22052d5217d0/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9fb9417d/ab64/42a9/a4d2/22052d5217d0/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9fb9417d/ab64/42a9/a4d2/22052d5217d0/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9fb9417d/ab64/42a9/a4d2/22052d5217d0/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9fb9417d/ab64/42a9/a4d2/22052d5217d0/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9fb9417d/ab64/42a9/a4d2/22052d5217d0/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#27241C",
+          "blurHash": "UGH2J[D%00-;~pWB9GRjIot7M{Rj?bWBIUxu",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPWtDoKtnh8n",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/9cdbb25e/b598/4d06/ace1/394aa0bd95cf/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9cdbb25e/b598/4d06/ace1/394aa0bd95cf/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9cdbb25e/b598/4d06/ace1/394aa0bd95cf/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9cdbb25e/b598/4d06/ace1/394aa0bd95cf/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9cdbb25e/b598/4d06/ace1/394aa0bd95cf/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9cdbb25e/b598/4d06/ace1/394aa0bd95cf/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9cdbb25e/b598/4d06/ace1/394aa0bd95cf/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#2C5358",
+          "blurHash": "U9A-t:4Wrpml?+HsNyt7zoR,RnpHOutmnNs7",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPWzeVjezjaI",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/44c6aca1/c3c2/4593/9b04/54c5592c434b/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/44c6aca1/c3c2/4593/9b04/54c5592c434b/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/44c6aca1/c3c2/4593/9b04/54c5592c434b/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/44c6aca1/c3c2/4593/9b04/54c5592c434b/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/44c6aca1/c3c2/4593/9b04/54c5592c434b/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/44c6aca1/c3c2/4593/9b04/54c5592c434b/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/44c6aca1/c3c2/4593/9b04/54c5592c434b/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#2C5358",
+          "blurHash": "U9A-t:4Wrpml?+HsNyt7zoR,RnpHOutmnNs7",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "31260702",
+      "type": "tracks",
+      "attributes": {
+        "title": "Photograph",
+        "version": null,
+        "isrc": "GBAHS1400094",
+        "duration": "PT4M19S",
+        "copyright": {
+          "text": "℗ 2014 Warner Music UK Limited"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "A",
+        "keyScale": "MAJOR",
+        "bpm": 108.0,
+        "popularity": 0.8354885482139354,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/31260702",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2014-06-19T21:46:58Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3995478",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/31260702/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "31260696",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/31260702/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "31260707",
+      "type": "tracks",
+      "attributes": {
+        "title": "Thinking out Loud",
+        "version": null,
+        "isrc": "GBAHS1400099",
+        "duration": "PT4M42S",
+        "copyright": {
+          "text": "℗ 2014 Warner Music UK Limited"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "D",
+        "keyScale": "MAJOR",
+        "bpm": 156.0,
+        "popularity": 0.8424934008276181,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/31260707",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2014-06-19T21:46:58Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3995478",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/31260707/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "31260696",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/31260707/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "42211996",
+      "type": "tracks",
+      "attributes": {
+        "title": "See You Again (feat. Charlie Puth)",
+        "version": null,
+        "isrc": "USAT21500313",
+        "duration": "PT3M50S",
+        "copyright": {
+          "text": "℗ 2015 Universal Studios and Atlantic Recording Corporation"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Bb",
+        "keyScale": "MAJOR",
+        "bpm": 162.0,
+        "popularity": 0.7614529972174989,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/42211996",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2015-02-21T23:30:33Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3520382",
+              "type": "artists"
+            },
+            {
+              "id": "4989822",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/42211996/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "42211995",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/42211996/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "45191318",
+      "type": "tracks",
+      "attributes": {
+        "title": "Stressed Out",
+        "version": null,
+        "isrc": "USAT21500597",
+        "duration": "PT3M22S",
+        "copyright": {
+          "text": "℗ 2015 Fueled By Ramen LLC"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "A",
+        "keyScale": "MINOR",
+        "bpm": 85.0,
+        "popularity": 0.88480468905335,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/45191318",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2015-05-07T11:28:06Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4664877",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/45191318/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "45191316",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/45191318/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "45191319",
+      "type": "tracks",
+      "attributes": {
+        "title": "Ride",
+        "version": null,
+        "isrc": "USAT21500598",
+        "duration": "PT3M35S",
+        "copyright": {
+          "text": "℗ 2015 Fueled By Ramen LLC"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "UNKNOWN",
+        "keyScale": "UNKNOWN",
+        "bpm": 150.0,
+        "popularity": 0.8231904801702743,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/45191319",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2015-05-07T11:28:06Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4664877",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/45191319/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "45191316",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/45191319/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "50142416",
+      "type": "tracks",
+      "attributes": {
+        "title": "Lost Boy",
+        "version": null,
+        "isrc": "USSM11506787",
+        "duration": "PT4M35S",
+        "copyright": {
+          "text": "(P) 2015 Columbia Records, a Division of Sony Music Entertainment"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "G",
+        "keyScale": "MAJOR",
+        "bpm": 123.0,
+        "popularity": 0.689855394004871,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/50142416",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2015-08-14T23:50:00Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "7879416",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/50142416/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "50142415",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/50142416/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "50221259",
+      "type": "tracks",
+      "attributes": {
+        "title": "One Call Away",
+        "version": null,
+        "isrc": "USAT21502703",
+        "duration": "PT3M12S",
+        "copyright": {
+          "text": "℗ 2015 Atlantic Records Group LLC"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "CSharp",
+        "keyScale": "MAJOR",
+        "bpm": 91.0,
+        "popularity": 0.6432444275600088,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/50221259",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2015-08-17T18:00:11Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4989822",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/50221259/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "50221258",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/50221259/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "53893676",
+      "type": "tracks",
+      "attributes": {
+        "title": "What Do You Mean?",
+        "version": null,
+        "isrc": "USUM71511919",
+        "duration": "PT3M26S",
+        "copyright": {
+          "text": "℗ 2015 Def Jam Recordings, a division of UMG Recordings, Inc."
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Ab",
+        "keyScale": "MAJOR",
+        "bpm": 125.0,
+        "popularity": 0.7490618085244708,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/53893676",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2015-11-10T01:47:54Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3639248",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/53893676/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "53893673",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/53893676/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "53893677",
+      "type": "tracks",
+      "attributes": {
+        "title": "Sorry",
+        "version": null,
+        "isrc": "USUM71516760",
+        "duration": "PT3M21S",
+        "copyright": {
+          "text": "℗ 2015 Def Jam Recordings, a division of UMG Recordings, Inc."
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Bb",
+        "keyScale": "MAJOR",
+        "bpm": 100.0,
+        "popularity": 0.7979944133584991,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/53893677",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2015-11-10T01:47:54Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3639248",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/53893677/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "53893673",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/53893677/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "53893678",
+      "type": "tracks",
+      "attributes": {
+        "title": "Love Yourself",
+        "version": null,
+        "isrc": "USUM71516761",
+        "duration": "PT3M54S",
+        "copyright": {
+          "text": "℗ 2015 Def Jam Recordings, a division of UMG Recordings, Inc."
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "E",
+        "keyScale": "MAJOR",
+        "bpm": 100.0,
+        "popularity": 0.7975121266111723,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/53893678",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2015-11-10T01:47:54Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3639248",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/53893678/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "53893673",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/53893678/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "53943554",
+      "type": "tracks",
+      "attributes": {
+        "title": "Stitches",
+        "version": null,
+        "isrc": "USUM71500658",
+        "duration": "PT3M27S",
+        "copyright": {
+          "text": "℗ 2015 Island Records, a division of UMG Recordings, Inc."
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "CSharp",
+        "keyScale": "MAJOR",
+        "bpm": 150.0,
+        "popularity": 0.7153256704055145,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/53943554",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2015-11-11T07:37:10Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "5747802",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/53943554/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "53943552",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/53943554/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "54728057",
+      "type": "tracks",
+      "attributes": {
+        "title": "Hymn for the Weekend",
+        "version": null,
+        "isrc": "GBAYE1500979",
+        "duration": "PT4M18S",
+        "copyright": {
+          "text": "under exclusive licence to Parlophone Records Limited, ℗ 2015 Coldplay"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "C",
+        "keyScale": "MINOR",
+        "bpm": 90.0,
+        "popularity": 0.8277972689051376,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/54728057",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2015-12-01T20:40:11Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "8812",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/54728057/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "54728054",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/54728057/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "56489250",
+      "type": "tracks",
+      "attributes": {
+        "title": "We Don't Talk Anymore (feat. Selena Gomez)",
+        "version": null,
+        "isrc": "USAT21502909",
+        "duration": "PT3M38S",
+        "copyright": {
+          "text": "℗ 2016 Atlantic Records Group LLC"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "CSharp",
+        "keyScale": "MINOR",
+        "bpm": 100.0,
+        "popularity": 0.7203424562960383,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/56489250",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-01-22T00:15:22Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4989822",
+              "type": "artists"
+            },
+            {
+              "id": "3638248",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/56489250/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "56489245",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/56489250/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "57454792",
+      "type": "tracks",
+      "attributes": {
+        "title": "i hate u, i love u (feat. olivia o'brien)",
+        "version": null,
+        "isrc": "USAT21600124",
+        "duration": "PT3M47S",
+        "copyright": {
+          "text": "2016"
+        },
+        "explicit": true,
+        "ai": false,
+        "key": "CSharp",
+        "keyScale": "MAJOR",
+        "bpm": 185.0,
+        "popularity": 0.6122237111817322,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/57454792",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-02-18T15:55:10Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "7121283",
+              "type": "artists"
+            },
+            {
+              "id": "7142197",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/57454792/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "57454791",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/57454792/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756132",
+      "type": "tracks",
+      "attributes": {
+        "title": "Drunk In The Morning",
+        "version": null,
+        "isrc": "USWB11514268",
+        "duration": "PT3M23S",
+        "copyright": {
+          "text": "℗ 2015 Then We Take The World / Copenhagen Records"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "D",
+        "keyScale": "MAJOR",
+        "bpm": 93.0,
+        "popularity": 0.42337843281398246,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756132",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756132/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756132/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756137",
+      "type": "tracks",
+      "attributes": {
+        "title": "You're Not There",
+        "version": null,
+        "isrc": "USWB11506526",
+        "duration": "PT3M23S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "F",
+        "keyScale": "MAJOR",
+        "bpm": 92.0,
+        "popularity": 0.401522608112518,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756137",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756137/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756137/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "62300893",
+      "type": "tracks",
+      "attributes": {
+        "title": "Hello",
+        "version": null,
+        "isrc": "GBBKS1500214",
+        "duration": "PT4M56S",
+        "copyright": {
+          "text": "XL Recordings Ltd"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Ab",
+        "keyScale": "MAJOR",
+        "bpm": 156.0,
+        "popularity": 0.8082332248228918,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/62300893",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-06-23T13:00:06Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3521920",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/62300893/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "62300892",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/62300893/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "62300896",
+      "type": "tracks",
+      "attributes": {
+        "title": "When We Were Young",
+        "version": null,
+        "isrc": "GBBKS1500217",
+        "duration": "PT4M51S",
+        "copyright": {
+          "text": "XL Recordings Ltd"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MAJOR",
+        "bpm": 144.0,
+        "popularity": 0.7558899153280346,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/62300896",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-06-23T13:00:06Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3521920",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/62300896/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "62300892",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/62300896/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "72947838",
+      "type": "tracks",
+      "attributes": {
+        "title": "Mercy",
+        "version": null,
+        "isrc": "USUM71603531",
+        "duration": "PT3M29S",
+        "copyright": {
+          "text": "℗ 2016 UMG Recordings, Inc."
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "D",
+        "keyScale": "MAJOR",
+        "bpm": 148.0,
+        "popularity": 0.716960662608698,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/72947838",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2017-04-18T18:56:33Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "5747802",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/72947838/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "72947835",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/72947838/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "77624180",
+      "type": "tracks",
+      "attributes": {
+        "title": "Treat You Better",
+        "version": null,
+        "isrc": "USUM71604711",
+        "duration": "PT3M8S",
+        "copyright": {
+          "text": "℗ 2016 UMG Recordings, Inc."
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "CSharp",
+        "keyScale": "MAJOR",
+        "bpm": 83.0,
+        "popularity": 0.6754693602039435,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/77624180",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2017-08-18T21:30:05Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "5747802",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/77624180/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "77624176",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/77624180/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/providers/tidal/fixtures/v2/track_credits.json
+++ b/tests/providers/tidal/fixtures/v2/track_credits.json
@@ -1,0 +1,425 @@
+{
+  "data": {
+    "id": "58756128",
+    "type": "tracks",
+    "attributes": {
+      "title": "7 Years",
+      "version": null,
+      "isrc": "USWB11506516",
+      "duration": "PT3M57S",
+      "copyright": {
+        "text": "℗ 2015 Universal Music A/S"
+      },
+      "explicit": false,
+      "ai": false,
+      "key": "Eb",
+      "keyScale": "MAJOR",
+      "bpm": 120.0,
+      "popularity": 0.7728257326881044,
+      "accessType": "PUBLIC",
+      "availability": [
+        "STREAM",
+        "DJ"
+      ],
+      "mediaTags": [
+        "LOSSLESS"
+      ],
+      "toneTags": [],
+      "externalLinks": [
+        {
+          "href": "https://tidal.com/browse/track/58756128",
+          "meta": {
+            "type": "TIDAL_SHARING"
+          }
+        }
+      ],
+      "spotlighted": false,
+      "createdAt": "2016-03-25T03:36:55Z"
+    },
+    "relationships": {
+      "albums": {
+        "data": [
+          {
+            "id": "58756127",
+            "type": "albums"
+          }
+        ],
+        "links": {
+          "self": "/tracks/58756128/relationships/albums?countryCode=AT"
+        }
+      },
+      "credits": {
+        "data": [
+          {
+            "id": "827Wzzg9sfyhjOXwuKvD3ZHQRifhjxqlTh05jEoyOqbmdUGWVHVznsHqGH",
+            "type": "credits"
+          },
+          {
+            "id": "827Wzzg9sfyhjOXnNHGmRh8vWRqsURm0oWTdTKNUSTGttAXvXFo2sVfkob",
+            "type": "credits"
+          },
+          {
+            "id": "827Wzzg9sfyhjOXxoZXGWk3JcuVpIRl4cVLFpCJMCS1mr7UO1mco6vT2a8",
+            "type": "credits"
+          },
+          {
+            "id": "827Wzzg9sfyhjOXlWTUp81CTOYWvIApRdddeqmrAQ1pXFYEsfMyWTDOb93",
+            "type": "credits"
+          },
+          {
+            "id": "827Wzzg9sfyhjOXmuJxMFKP6Pt1MY5UGfGqw9fADW5GA1LeC7JP4nuzUFX",
+            "type": "credits"
+          },
+          {
+            "id": "827Wzzg9sfyhjOXliT0iJLQVX1fX19aKqqJYSLsHrumZY5h9licAONny4H",
+            "type": "credits"
+          },
+          {
+            "id": "827Wzzg9sfyhjOXlTeN03NwpICDwYjzm6Pfx6luzcai7l3CzfnIscQ4K6p",
+            "type": "credits"
+          },
+          {
+            "id": "827Wzzg9sfyhjOXxr9lWWhFP4AwKb1UYenA0eI4HqPPwEVoJUshDz81hWo",
+            "type": "credits"
+          },
+          {
+            "id": "827Wzzg9sfyhjOXx6L7BH5bGtaj5EVBoWUkjtWjS4q7Z87L75ZVoCefkeG",
+            "type": "credits"
+          },
+          {
+            "id": "827Wzzg9sfyhjOXy3GRWy8CkgbyvhLzMlCRiEkXlAVPD5Fx8VKWfKRhvxT",
+            "type": "credits"
+          },
+          {
+            "id": "827Wzzg9sfyhjOXy5nkWjmpZ9uVRmy3jtzY3LsthptzqKBp1YzigDd8F3n",
+            "type": "credits"
+          },
+          {
+            "id": "827Wzzg9sfyhjOXlxWX0HdwEQ7Mhk56p31Aen2Zgqixio6SBakLLFkk2Fx",
+            "type": "credits"
+          },
+          {
+            "id": "827Wzzg9sfyhjOXlxHfpwgCCVPvYHv9mVkyGatRfxEhwCVfS7ebr2sklSy",
+            "type": "credits"
+          },
+          {
+            "id": "827Wzzg9sfyhjOXmfLLTRGFlHIZE0ZEonDhjq4mppmfaytE6iTBhnOyM8m",
+            "type": "credits"
+          },
+          {
+            "id": "827Wzzg9sfyhjOXlTiaRXnNe9m04nYKNoaDFGh6cLkhiAK9Fxx577ZdzGv",
+            "type": "credits"
+          }
+        ],
+        "links": {
+          "self": "/tracks/58756128/relationships/credits?countryCode=AT"
+        }
+      },
+      "artists": {
+        "data": [
+          {
+            "id": "4184211",
+            "type": "artists"
+          }
+        ],
+        "links": {
+          "self": "/tracks/58756128/relationships/artists?countryCode=AT"
+        }
+      },
+      "genres": {
+        "data": [
+          {
+            "id": "1",
+            "type": "genres"
+          }
+        ],
+        "links": {
+          "self": "/tracks/58756128/relationships/genres?countryCode=AT"
+        }
+      }
+    }
+  },
+  "links": {
+    "self": "/tracks/58756128?include=albums.coverArt%2Cartists%2Ccredits%2Cgenres&countryCode=AT"
+  },
+  "included": [
+    {
+      "id": "58756127",
+      "type": "albums",
+      "attributes": {
+        "title": "Lukas Graham (Blue Album) (International Version)",
+        "barcodeId": "00602547852748",
+        "numberOfVolumes": 1,
+        "numberOfItems": 11,
+        "duration": "PT40M5S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2015-05-29",
+        "copyright": {
+          "text": "© 2016 Then We Take The World / Copenhagen Records / Universal Music"
+        },
+        "popularity": 0.7480961442649546,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/58756127",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "version": "International Version",
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPMMti8ralux",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/58756127/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4184211",
+      "type": "artists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "popularity": 0.8177526593208313,
+        "externalLinks": [
+          {
+            "href": "https://www.facebook.com/LukasGraham",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "http://instagram.com/lukasinstagraham",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://www.twitter.com/LukeTheDuke_",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4184211",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "iWOu0yW0IPMMti8ralux",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#775434",
+          "blurHash": "ULM7cP9G_29E?wxv%L%1~ojXD+NK_1ocE3xv",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXlTeN03NwpICDwYjzm6Pfx6luzcai7l3CzfnIscQ4K6p",
+      "type": "credits",
+      "attributes": {
+        "name": "David LaBrel",
+        "role": "Composer"
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXlTiaRXnNe9m04nYKNoaDFGh6cLkhiAK9Fxx577ZdzGv",
+      "type": "credits",
+      "attributes": {
+        "name": "Robin Florent",
+        "role": "Second Engineer"
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXlWTUp81CTOYWvIApRdddeqmrAQ1pXFYEsfMyWTDOb93",
+      "type": "credits",
+      "attributes": {
+        "name": "Morten Pilegaard",
+        "role": "Composer"
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXliT0iJLQVX1fX19aKqqJYSLsHrumZY5h9licAONny4H",
+      "type": "credits",
+      "attributes": {
+        "name": "Lukas Forchhammer",
+        "role": "Composer"
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXlxHfpwgCCVPvYHv9mVkyGatRfxEhwCVfS7ebr2sklSy",
+      "type": "credits",
+      "attributes": {
+        "name": "Robin Florent",
+        "role": "Mixing"
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXlxWX0HdwEQ7Mhk56p31Aen2Zgqixio6SBakLLFkk2Fx",
+      "type": "credits",
+      "attributes": {
+        "name": "David LaBrel",
+        "role": "Lyricist"
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXmfLLTRGFlHIZE0ZEonDhjq4mppmfaytE6iTBhnOyM8m",
+      "type": "credits",
+      "attributes": {
+        "name": "Delbert Bowers",
+        "role": "Mixing Engineer"
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXmuJxMFKP6Pt1MY5UGfGqw9fADW5GA1LeC7JP4nuzUFX",
+      "type": "credits",
+      "attributes": {
+        "name": "Stefan Forrest",
+        "role": "Composer"
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXnNHGmRh8vWRqsURm0oWTdTKNUSTGttAXvXFo2sVfkob",
+      "type": "credits",
+      "attributes": {
+        "name": "Future Animals",
+        "role": "Producer"
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXwuKvD3ZHQRifhjxqlTh05jEoyOqbmdUGWVHVznsHqGH",
+      "type": "credits",
+      "attributes": {
+        "name": "Pilo",
+        "role": "Producer"
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXx6L7BH5bGtaj5EVBoWUkjtWjS4q7Z87L75ZVoCefkeG",
+      "type": "credits",
+      "attributes": {
+        "name": "Morten Ristorp",
+        "role": "Lyricist"
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXxoZXGWk3JcuVpIRl4cVLFpCJMCS1mr7UO1mco6vT2a8",
+      "type": "credits",
+      "attributes": {
+        "name": "Morten Ristorp",
+        "role": "Composer"
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXxr9lWWhFP4AwKb1UYenA0eI4HqPPwEVoJUshDz81hWo",
+      "type": "credits",
+      "attributes": {
+        "name": "Morten Pilegaard",
+        "role": "Lyricist"
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXy3GRWy8CkgbyvhLzMlCRiEkXlAVPD5Fx8VKWfKRhvxT",
+      "type": "credits",
+      "attributes": {
+        "name": "Stefan Forrest",
+        "role": "Lyricist"
+      }
+    },
+    {
+      "id": "827Wzzg9sfyhjOXy5nkWjmpZ9uVRmy3jtzY3LsthptzqKBp1YzigDd8F3n",
+      "type": "credits",
+      "attributes": {
+        "name": "Lukas Forchhammer",
+        "role": "Lyricist"
+      }
+    },
+    {
+      "id": "1",
+      "type": "genres",
+      "attributes": {
+        "genreName": "Pop"
+      }
+    }
+  ]
+}

--- a/tests/providers/tidal/test_api_client.py
+++ b/tests/providers/tidal/test_api_client.py
@@ -221,6 +221,52 @@ async def test_paginate_preserves_params_across_pages(
         assert call[1]["params"]["order"] == "DATE"
 
 
+async def test_paginate_jsonapi_follows_cursor(
+    api_client: TidalAPIClient, provider_mock: Mock
+) -> None:
+    """Test paginate_jsonapi follows links.next and stops when the cursor runs out."""
+    page1 = AsyncMock(spec=ClientResponse)
+    page1.status = 200
+    page1.json.return_value = {
+        "data": [{"type": "tracks", "id": "1"}],
+        "links": {"next": "/x?countryCode=AT&page[cursor]=NEXT%3D123&other=1"},
+    }
+    page2 = AsyncMock(spec=ClientResponse)
+    page2.status = 200
+    page2.json.return_value = {"data": [{"type": "tracks", "id": "2"}]}
+
+    ctx1 = AsyncMock()
+    ctx1.__aenter__.return_value = page1
+    ctx2 = AsyncMock()
+    ctx2.__aenter__.return_value = page2
+    provider_mock.mass.http_session.request = MagicMock(side_effect=[ctx1, ctx2])
+
+    docs = [doc async for doc in api_client.paginate_jsonapi("tracks")]
+
+    assert len(docs) == 2
+    assert [d.data_list[0]["id"] for d in docs] == ["1", "2"]
+    assert provider_mock.mass.http_session.request.call_count == 2
+    # the second request carried the (url-decoded) cursor from page 1's next link
+    second_params = provider_mock.mass.http_session.request.call_args_list[1][1]["params"]
+    assert second_params["page[cursor]"] == "NEXT=123"
+
+
+async def test_paginate_jsonapi_caps_pages(api_client: TidalAPIClient, provider_mock: Mock) -> None:
+    """Test paginate_jsonapi stops at max_pages and warns when more pages remain."""
+    response = AsyncMock(spec=ClientResponse)
+    response.status = 200
+    # every page advertises a next cursor, so the cap is what stops iteration
+    response.json.return_value = {"data": [], "links": {"next": "/x?page[cursor]=C"}}
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value = response
+    provider_mock.mass.http_session.request = MagicMock(return_value=ctx)
+
+    docs = [doc async for doc in api_client.paginate_jsonapi("x", max_pages=2)]
+
+    assert len(docs) == 2
+    provider_mock.logger.warning.assert_called_once()
+
+
 async def test_delete_success(api_client: TidalAPIClient, provider_mock: Mock) -> None:
     """Test successful DELETE request."""
     response = AsyncMock(spec=ClientResponse)

--- a/tests/providers/tidal/test_jsonapi.py
+++ b/tests/providers/tidal/test_jsonapi.py
@@ -67,3 +67,12 @@ def test_next_cursor() -> None:
     assert doc.next_cursor == "abc123"
     bare = JsonApiDocument({"links": {"next": "rawcursor"}})
     assert bare.next_cursor == "rawcursor"
+
+
+def test_next_cursor_percent_encoded_brackets() -> None:
+    """Test the cursor is extracted when the bracket key is percent-encoded."""
+    # This is the real form Tidal returns: page%5Bcursor%5D=<value>.
+    doc = JsonApiDocument(
+        {"links": {"next": "/x?include=items.profileArt&page%5Bcursor%5D=eyJpZCI6Mzk3fQ"}}
+    )
+    assert doc.next_cursor == "eyJpZCI6Mzk3fQ"

--- a/tests/providers/tidal/test_media.py
+++ b/tests/providers/tidal/test_media.py
@@ -1,5 +1,7 @@
 """Test Tidal Media Manager."""
 
+import json
+import pathlib
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -8,7 +10,15 @@ from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import RetriesExhausted
 from music_assistant_models.media_items import ItemMapping
 
+from music_assistant.providers.tidal.jsonapi import JsonApiDocument
 from music_assistant.providers.tidal.media import TidalMediaManager
+
+FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures" / "v2"
+
+
+def _load_doc(name: str) -> JsonApiDocument:
+    with open(FIXTURES_DIR / name) as f:
+        return JsonApiDocument(json.load(f))
 
 
 @pytest.fixture
@@ -152,7 +162,7 @@ async def test_get_track(
 
     assert result.item_id == "1"
     provider_mock.api.get_jsonapi.assert_called_with(
-        "tracks/1", include=["artists", "albums", "albums.coverArt", "genres"]
+        "tracks/1", include=["artists", "albums", "albums.coverArt", "genres", "credits"]
     )
     provider_mock.api.get.assert_called_with("tracks/1/lyrics")
     assert track.metadata.lyrics == "Test Lyrics"
@@ -176,6 +186,77 @@ async def test_get_track_tolerates_lyrics_failure(
     mock_parse_track.assert_called_once_with(provider_mock, doc, doc.data)
 
 
+async def test_get_album_tracks(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
+    """Test album tracks read from the official relationship endpoint with ordering."""
+    doc = _load_doc("album_items.json")
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    tracks = await media_manager.get_album_tracks("58756127")
+
+    assert len(tracks) == 11
+    assert tracks[0].name == "7 Years"
+    assert tracks[0].track_number == 1
+    assert tracks[0].disc_number == 1
+    assert tracks[0].album is not None
+
+
+async def test_get_artist_albums(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
+    """Test artist albums read from the official relationship endpoint."""
+    doc = _load_doc("artist_albums.json")
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    albums = await media_manager.get_artist_albums("4184211")
+
+    assert len(albums) == 20
+    assert all(album.item_id for album in albums)
+
+
+async def test_get_artist_toptracks(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
+    """Test artist top tracks read from the official relationship endpoint."""
+    provider_mock.api.get_jsonapi.return_value = _load_doc("artist_toptracks.json")
+
+    tracks = await media_manager.get_artist_toptracks("4184211")
+
+    assert len(tracks) == 20
+    provider_mock.api.get_jsonapi.assert_called_with(
+        "artists/4184211/relationships/tracks",
+        params={"collapseBy": "FINGERPRINT"},
+        include=["tracks.artists", "tracks.albums.coverArt"],
+    )
+
+
+async def test_get_similar_tracks_respects_limit(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test similar tracks are read from the official endpoint and capped to the limit."""
+    provider_mock.api.get_jsonapi.return_value = _load_doc("similar_tracks.json")
+
+    tracks = await media_manager.get_similar_tracks("58756128", limit=5)
+
+    assert len(tracks) == 5
+
+
+async def test_get_similar_artists(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
+    """Test similar artists read from the official relationship endpoint."""
+    provider_mock.api.get_jsonapi.return_value = _load_doc("similar_artists.json")
+
+    artists = await media_manager.get_similar_artists("4184211")
+
+    assert len(artists) == 20
+    provider_mock.api.get_jsonapi.assert_called_with(
+        "artists/4184211/relationships/similarArtists",
+        include=["similarArtists.profileArt"],
+    )
+
+
 @patch("music_assistant.providers.tidal.media.parse_playlist")
 async def test_get_playlist(
     mock_parse_playlist: Mock, media_manager: TidalMediaManager, provider_mock: Mock
@@ -189,60 +270,6 @@ async def test_get_playlist(
     assert playlist.item_id == "1"
     provider_mock.api.get.assert_called_with("playlists/1")
     mock_parse_playlist.assert_called_once()
-
-
-@patch("music_assistant.providers.tidal.media.parse_track")
-async def test_get_album_tracks(
-    mock_parse_track: Mock, media_manager: TidalMediaManager, provider_mock: Mock
-) -> None:
-    """Test get_album_tracks."""
-    provider_mock.api.get.return_value = {"items": [{"id": 1}]}
-    mock_parse_track.return_value = Mock(item_id="1")
-
-    tracks = await media_manager.get_album_tracks("1")
-
-    assert len(tracks) == 1
-    assert tracks[0].item_id == "1"
-    provider_mock.api.get.assert_called_with(
-        "albums/1/tracks",
-        params={"limit": 250},
-    )
-
-
-@patch("music_assistant.providers.tidal.media.parse_album")
-async def test_get_artist_albums(
-    mock_parse_album: Mock, media_manager: TidalMediaManager, provider_mock: Mock
-) -> None:
-    """Test get_artist_albums."""
-    provider_mock.api.get.return_value = {"items": [{"id": 1}]}
-    mock_parse_album.return_value = Mock(item_id="1")
-
-    albums = await media_manager.get_artist_albums("1")
-
-    assert len(albums) == 1
-    assert albums[0].item_id == "1"
-    provider_mock.api.get.assert_called_with(
-        "artists/1/albums",
-        params={"limit": 250},
-    )
-
-
-@patch("music_assistant.providers.tidal.media.parse_track")
-async def test_get_artist_toptracks(
-    mock_parse_track: Mock, media_manager: TidalMediaManager, provider_mock: Mock
-) -> None:
-    """Test get_artist_toptracks."""
-    provider_mock.api.get.return_value = {"items": [{"id": 1}]}
-    mock_parse_track.return_value = Mock(item_id="1")
-
-    tracks = await media_manager.get_artist_toptracks("1")
-
-    assert len(tracks) == 1
-    assert tracks[0].item_id == "1"
-    provider_mock.api.get.assert_called_with(
-        "artists/1/toptracks",
-        params={"limit": 10, "offset": 0},
-    )
 
 
 @patch("music_assistant.providers.tidal.media.parse_track")

--- a/tests/providers/tidal/test_media_extended.py
+++ b/tests/providers/tidal/test_media_extended.py
@@ -7,6 +7,7 @@ from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import ItemMapping
 
+from music_assistant.providers.tidal.jsonapi import JsonApiDocument
 from music_assistant.providers.tidal.media import TidalMediaManager
 
 
@@ -95,20 +96,26 @@ async def test_get_playlist_fallback_to_mix(
     )
 
 
-@patch("music_assistant.providers.tidal.media.parse_track")
+@patch("music_assistant.providers.tidal.media.parse_track_v2")
 async def test_get_similar_tracks(
     mock_parse_track: Mock, media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
-    """Test get_similar_tracks."""
-    provider_mock.api.get.return_value = {"items": [{"id": 1}, {"id": 2}, {"id": 3}]}
+    """Test get_similar_tracks reads from the official relationship endpoint."""
+    doc = JsonApiDocument(
+        {
+            "data": [{"type": "tracks", "id": str(i)} for i in range(10)],
+            "included": [{"type": "tracks", "id": str(i), "attributes": {}} for i in range(10)],
+        }
+    )
+    provider_mock.api.get_jsonapi.return_value = doc
     mock_parse_track.return_value = Mock(item_id="1")
 
-    tracks = await media_manager.get_similar_tracks("123", limit=25)
+    tracks = await media_manager.get_similar_tracks("123", limit=3)
 
     assert len(tracks) == 3
-    provider_mock.api.get.assert_called_with(
-        "tracks/123/radio",
-        params={"limit": 25},
+    provider_mock.api.get_jsonapi.assert_called_with(
+        "tracks/123/relationships/similarTracks",
+        include=["similarTracks.artists", "similarTracks.albums.coverArt"],
     )
 
 

--- a/tests/providers/tidal/test_parsers_v2.py
+++ b/tests/providers/tidal/test_parsers_v2.py
@@ -138,6 +138,15 @@ def test_split_title_version(
     assert _split_title_version(title, version) == (expected_name, expected_version)
 
 
+def test_parse_track_credits(provider_mock: Mock) -> None:
+    """Test track credits are resolved into performers."""
+    doc = _load("track_credits.json")
+    track = parse_track(provider_mock, doc, doc.data)
+
+    assert track.metadata.performers
+    assert "Lukas Forchhammer" in track.metadata.performers
+
+
 def test_parse_track_no_includes(provider_mock: Mock) -> None:
     """Test a track with unresolved relationships still parses core fields."""
     doc = JsonApiDocument(


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Builds on the previous Tidal PR (stacked).

Continues moving the Tidal provider onto the official `openapi.tidal.com/v2`
API. The first PR did the single-item reads (track/album/artist); this one
does the relationship reads you hit while browsing:

- Album tracks, artist albums and top tracks
- Similar tracks, plus similar **artists** (new: the provider didn't expose
  similar artists before)
- Track **credits** now populate performer metadata

Adds a small cursor-pagination helper for the official API's paged
relationships. Playback, lyrics and recommendations stay unofficial as
before. Parsers are tested against real captured responses.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
