### PR TITLE
Fix audio details for native sync groups

### DIFF
--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -46,6 +46,7 @@ from music_assistant.controllers.player_queues.helpers import (
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     set_current_user,
 )
+from music_assistant.helpers.audio import resolve_output_player_ids
 from music_assistant.helpers.util import get_changed_keys, percentage
 from music_assistant.models.player import Player
 
@@ -286,12 +287,10 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
 
     def _get_output_player_ids(self, player: Player) -> set[str]:
         """Return destination player IDs represented in the processing chain."""
-        output_player_ids = {player.protocol_parent_id or player.player_id}
-        for member_id in player.state.group_members:
-            member = self.mass.players.get_player(member_id)
-            output_player_id = member.protocol_parent_id if member else None
-            output_player_ids.add(output_player_id or member_id)
-        return output_player_ids
+        return resolve_output_player_ids(
+            self.mass,
+            (player.player_id, *player.state.group_members),
+        )
 
     def _get_flow_queue_stream_index(
         self, queue: PlayerQueue, player: Player

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -13,7 +13,7 @@ import logging
 import os
 import re
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from functools import partial
@@ -112,6 +112,7 @@ from music_assistant.helpers.audio import (
     parse_extinf_metadata,
     realtime_pcm_pacer,
     resample_pcm_audio,
+    resolve_output_player_ids,
 )
 from music_assistant.helpers.dsp import filter_to_ffmpeg_params
 from music_assistant.helpers.ffmpeg import (
@@ -1146,6 +1147,7 @@ class StreamsAudio:
         queue_id: str | None = None,
         session_id: str | None = None,
         queue_item_id: str | None = None,
+        shared_player_ids: Iterable[str] = (),
     ) -> AudioOutputPlan:
         """
         Return executable filters and matching output details for a player.
@@ -1157,12 +1159,11 @@ class StreamsAudio:
         :param queue_id: Explicit queue identifier for the processing snapshot.
         :param session_id: Explicit queue session identifier for the processing snapshot.
         :param queue_item_id: Queue item for a single-item output path.
+        :param shared_player_ids: Additional players receiving the same encoded output.
         """
         filter_params: list[str] = []
         player = self.mass.players.get_player(player_id)
-        destination_player_id = (
-            player.protocol_parent_id if player and player.protocol_parent_id else player_id
-        )
+        destination_player_id = resolve_output_player_ids(self.mass, (player_id,)).pop()
         if player:
             dsp_config_id = self._resolve_player_dsp_config_id(player)
             dsp = self._resolve_player_dsp_config(player)
@@ -1228,6 +1229,7 @@ class StreamsAudio:
                 queue_id=queue_id,
                 session_id=session_id,
                 queue_item_id=queue_item_id,
+                shared_player_ids=shared_player_ids,
             )
         self.logger.log(
             VERBOSE_LOG_LEVEL,

--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING
@@ -18,7 +19,7 @@ from music_assistant_models.audio_processing import (
 from music_assistant_models.dsp import DSPState
 from music_assistant_models.enums import ContentType, CrossfadeMode, VolumeNormalizationMode
 
-from music_assistant.helpers.audio import get_bit_rate
+from music_assistant.helpers.audio import get_bit_rate, resolve_output_player_ids
 
 if TYPE_CHECKING:
     from music_assistant_models.media_items import AudioFormat
@@ -191,6 +192,7 @@ class AudioProcessingManager:
         queue_id: str,
         session_id: str,
         queue_item_id: str | None = None,
+        shared_player_ids: Iterable[str] = (),
     ) -> bool:
         """
         Store an effective player output.
@@ -200,6 +202,7 @@ class AudioProcessingManager:
         :param queue_id: Queue identifier that owns the output.
         :param session_id: Queue session identifier that owns the output.
         :param queue_item_id: Queue item for single-item output, or None for flow output.
+        :param shared_player_ids: Additional players receiving the same encoded output.
         :return: Whether the effective output changed.
         """
         session = self._get_session(queue_id, session_id)
@@ -208,17 +211,30 @@ class AudioProcessingManager:
         self._prune_played_items(queue_id, session)
         if queue_item_id is not None and self._is_played_item(queue_id, queue_item_id):
             return False
-        entry = _AudioOutputEntry(
-            details=deepcopy(output_plan.output_details),
-            input_format=deepcopy(output_plan.input_format),
-            handoff_format=deepcopy(output_plan.handoff_format),
-            dsp_config_id=output_plan.dsp_config_id,
+        destination_player_ids = resolve_output_player_ids(
+            self.mass,
+            (player_id, *shared_player_ids),
         )
-        entry.details.player_ids = [player_id]
-        item_outputs = session.outputs.setdefault(queue_item_id, {})
-        if item_outputs.get(player_id) == entry:
+        entries: dict[str, _AudioOutputEntry] = {}
+        for destination_player_id in sorted(destination_player_ids):
+            details = deepcopy(output_plan.output_details)
+            details.player_ids = [destination_player_id]
+            entries[destination_player_id] = _AudioOutputEntry(
+                details=details,
+                input_format=deepcopy(output_plan.input_format),
+                handoff_format=deepcopy(output_plan.handoff_format),
+                dsp_config_id=output_plan.dsp_config_id,
+            )
+        item_outputs = session.outputs.get(queue_item_id)
+        if item_outputs is not None and all(
+            item_outputs.get(destination_player_id) == entry
+            for destination_player_id, entry in entries.items()
+        ):
             return False
-        item_outputs[player_id] = entry
+        if item_outputs is None:
+            session.outputs[queue_item_id] = entries
+        else:
+            item_outputs.update(entries)
         current_changed = self._publish_all(queue_id, session)
         queue = self.mass.player_queues.get(queue_id)
         if current_changed or (

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -781,6 +781,7 @@ class StreamsController(CoreController):
                 queue_id=queue_id,
                 session_id=session_id,
                 queue_item_id=queue_item.queue_item_id,
+                shared_player_ids=player.state.group_members,
             )
             filter_params = output_plan.filter_params
             # Fast path for live AudioSource: when the player accepts WAV at the
@@ -991,6 +992,7 @@ class StreamsController(CoreController):
             output_format,
             queue_id=queue_id,
             session_id=session_id,
+            shared_player_ids=player.state.group_members,
         )
 
         # all checks passed, start streaming!

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -7,7 +7,7 @@ import logging
 import re
 import struct
 import urllib.parse
-from collections.abc import AsyncGenerator, Iterator
+from collections.abc import AsyncGenerator, Iterable, Iterator
 from contextlib import aclosing
 from io import BytesIO
 from typing import TYPE_CHECKING, Final
@@ -51,6 +51,21 @@ SLOW_PROVIDERS = ("tidal", "ytmusic", "apple_music")
 _MIME_TYPE_OVERRIDES: Final[dict[str, str]] = {
     "mp3": "audio/mpeg",
 }
+
+
+def resolve_output_player_ids(mass: MusicAssistant, player_ids: Iterable[str]) -> set[str]:
+    """
+    Return user-facing player identifiers for audio output destinations.
+
+    :param mass: Music Assistant instance.
+    :param player_ids: Player identifiers to resolve.
+    """
+    output_player_ids: set[str] = set()
+    for player_id in player_ids:
+        player = mass.players.get_player(player_id)
+        protocol_parent_id = player.protocol_parent_id if player else None
+        output_player_ids.add(protocol_parent_id or player_id)
+    return output_player_ids
 
 
 def get_mime_type(format_str: str) -> str:

--- a/tests/controllers/player_queues/test_playback_tracker_outputs.py
+++ b/tests/controllers/player_queues/test_playback_tracker_outputs.py
@@ -18,7 +18,7 @@ def test_output_player_ids_resolve_protocol_parents() -> None:
         SimpleNamespace(mass=SimpleNamespace(players=SimpleNamespace(get_player=get_player))),
     )
     player = MagicMock(player_id="queue-1", protocol_parent_id=None)
-    player.state.group_members = ["protocol-1", "missing-player"]
+    player.state.group_members = ["queue-1", "protocol-1", "player-1", "missing-player"]
     protocol_player = MagicMock(protocol_parent_id="player-1")
     get_player.side_effect = lambda player_id: (
         protocol_player if player_id == "protocol-1" else None

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.audio_processing import (
@@ -39,6 +39,7 @@ from music_assistant.controllers.streams.audio_processing import (
     get_audio_quality,
     get_normalization_details,
 )
+from music_assistant.controllers.streams.controller import StreamsController
 
 
 def _format(
@@ -136,6 +137,87 @@ def test_audio_processing_manager_attaches_grouped_chain() -> None:
     )
 
 
+def test_manager_registers_native_group_as_one_output_batch() -> None:
+    """One native stream registers every destination once and is idempotent."""
+    manager, mass, _queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()
+    mass.player_queues.signal_update.reset_mock()
+
+    assert manager.update_output(
+        "player-1",
+        output_plan,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+        shared_player_ids=("player-1", "player-2"),
+    )
+
+    chain = cast("AudioProcessingChain", streamdetails.audio_processing)
+    assert len(chain.outputs) == 1
+    assert chain.outputs[0].player_ids == ["player-1", "player-2"]
+    mass.player_queues.signal_update.assert_called_once_with("queue-1")
+
+    mass.player_queues.signal_update.reset_mock()
+    assert not manager.update_output(
+        "player-1",
+        output_plan,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+        shared_player_ids=("player-1", "player-2"),
+    )
+    mass.player_queues.signal_update.assert_not_called()
+
+
+def test_manager_resolves_and_deduplicates_protocol_destinations() -> None:
+    """Protocol children and their parent share one visible destination."""
+    manager, mass, _queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()
+    protocol_child = SimpleNamespace(protocol_parent_id="player-2")
+    mass.players.get_player.side_effect = lambda player_id: (
+        protocol_child if player_id == "protocol-2" else None
+    )
+
+    assert manager.update_output(
+        "player-1",
+        output_plan,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+        shared_player_ids=("protocol-2", "player-2"),
+    )
+
+    chain = cast("AudioProcessingChain", streamdetails.audio_processing)
+    assert chain.outputs[0].player_ids == ["player-1", "player-2"]
+
+
+def test_manager_rejects_stale_shared_output_atomically() -> None:
+    """A stale producer cannot register any member of a shared output."""
+    manager, mass, queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()
+    queue_data.session_id = "session-2"
+    mass.player_queues.signal_update.reset_mock()
+
+    assert not manager.update_output(
+        "player-1",
+        output_plan,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+        shared_player_ids=("player-2",),
+    )
+    assert streamdetails.audio_processing is None
+    mass.player_queues.signal_update.assert_not_called()
+
+    queue_data.session_id = "session-1"
+    assert manager.update_output(
+        "player-1",
+        output_plan,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+    chain = cast("AudioProcessingChain", streamdetails.audio_processing)
+    assert chain.outputs[0].player_ids == ["player-1"]
+
+
 def test_preset_identity_update_republishes_current_chain() -> None:
     """Preset updates follow a changed config owner even when output details match."""
     manager, mass, _queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()
@@ -169,14 +251,14 @@ def test_preset_identity_update_republishes_current_chain() -> None:
 def test_retain_outputs_signals_current_chain_change() -> None:
     """Pruning a current output publishes the reduced chain."""
     manager, mass, _queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()
-    for player_id in ("player-1", "player-2"):
-        manager.update_output(
-            player_id,
-            output_plan,
-            queue_id="queue-1",
-            session_id="session-1",
-            queue_item_id="item-1",
-        )
+    manager.update_output(
+        "player-1",
+        output_plan,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+        shared_player_ids=("player-2",),
+    )
     mass.player_queues.signal_update.reset_mock()
 
     assert manager.retain_outputs("queue-1", {"player-1"})
@@ -410,7 +492,44 @@ def test_player_output_plan_matches_ffmpeg_filters() -> None:
     assert plan.dsp_config_id == "player-1"
     assert plan.output_details.source_channel == AudioChannel.FL
     assert plan.output_details.output_format == output_format
-    mass.streams.audio_processing.update_output.assert_called_once()
+    mass.streams.audio_processing.update_output.assert_called_once_with(
+        "player-1",
+        plan,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+        shared_player_ids=(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_stream_handler_shares_native_group_members(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The regular single-item HTTP stream registers native group members."""
+    controller, request, group_members = _native_stream_handler_context(monkeypatch)
+
+    with pytest.raises(_OutputPlanRequested):
+        await controller.serve_queue_item_stream(request)
+
+    assert controller.audio.get_player_output_plan.call_args.kwargs["shared_player_ids"] is (
+        group_members
+    )
+
+
+@pytest.mark.asyncio
+async def test_flow_stream_handler_shares_native_group_members(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The regular flow HTTP stream registers native group members."""
+    controller, request, group_members = _native_stream_handler_context(monkeypatch)
+
+    with pytest.raises(_OutputPlanRequested):
+        await controller.serve_queue_flow_stream(request)
+
+    assert controller.audio.get_player_output_plan.call_args.kwargs["shared_player_ids"] is (
+        group_members
+    )
 
 
 def test_protocol_output_uses_parent_settings(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -552,6 +671,7 @@ def _manager_context(
     mass.player_queues.get_active_queue.return_value = queue
     mass.player_queues.get_item.return_value = queue_item
     mass.player_queues.queue_data_or_none.return_value = queue_data
+    mass.players.get_player.return_value = None
     manager = AudioProcessingManager(mass)
     pcm_format = _format(ContentType.PCM_S24LE, 96000, 24)
     manager.start_session("queue-1", "session-1")
@@ -589,3 +709,82 @@ def _streamdetails(item_id: str = "item-1") -> StreamDetails:
         audio_format=_format(ContentType.FLAC, 96000, 24, bit_rate=3200),
         media_type=MediaType.TRACK,
     )
+
+
+class _OutputPlanRequested(Exception):
+    """Signal that a stream handler reached output planning."""
+
+
+def _native_stream_handler_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Any, MagicMock, list[str]]:
+    """Return a native HTTP stream handler prepared to stop at output planning."""
+    mass = MagicMock()
+    streamdetails = _streamdetails()
+    queue_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="item-1",
+        name="Track",
+        duration=180,
+        streamdetails=streamdetails,
+        media_item=None,
+        media_type=MediaType.TRACK,
+        extra_attributes={},
+        image=None,
+    )
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        current_item=queue_item,
+        crossfade_enabled=False,
+        overlay_enabled=False,
+        overlay_source=None,
+    )
+    queue_data = SimpleNamespace(session_id="session-1")
+    mass.player_queues.get.return_value = queue
+    mass.player_queues.queue_data.return_value = queue_data
+    mass.player_queues.get_item.return_value = queue_item
+    mass.config.get_raw_core_config_value.return_value = 8
+    mass.config.get_raw_player_config_value.return_value = "disabled"
+
+    group_members = ["player-1", "player-2"]
+    player = MagicMock(player_id="player-1", protocol_parent_id=None)
+    player.state.group_members = group_members
+    player.state.supported_features = set()
+    player.state.name = "Player"
+    player.get_config_value.return_value = "default"
+    mass.players.get_player.return_value = player
+
+    pcm_format = _format(ContentType.PCM_F32LE, 48000, 32)
+    output_format = _format(ContentType.FLAC, 48000, 24)
+    audio = MagicMock()
+    audio.select_pcm_format = AsyncMock(return_value=pcm_format)
+    audio.select_flow_pcm_format = AsyncMock(return_value=pcm_format)
+    audio.get_output_format = AsyncMock(return_value=output_format)
+    audio.get_player_output_plan.side_effect = _OutputPlanRequested
+
+    controller = cast("Any", object.__new__(StreamsController))
+    controller.mass = mass
+    controller.audio = audio
+    controller.logger = MagicMock()
+    controller._log_request = MagicMock()
+    controller._update_audio_processing_context = MagicMock()
+    controller._active_output_streams = 0
+
+    response = MagicMock()
+    response.prepare = AsyncMock()
+    monkeypatch.setattr(
+        "music_assistant.controllers.streams.controller.web.StreamResponse",
+        MagicMock(return_value=response),
+    )
+    request = MagicMock()
+    request.method = "GET"
+    request.headers = {}
+    request.match_info = {
+        "queue_id": "queue-1",
+        "session_id": "session-1",
+        "queue_item_id": "item-1",
+        "player_id": "player-1",
+        "fmt": "flac",
+    }
+    return controller, request, group_members

--- a/tests/helpers/test_audio.py
+++ b/tests/helpers/test_audio.py
@@ -2,7 +2,28 @@
 
 from __future__ import annotations
 
-from music_assistant.helpers.audio import build_concat_filelist
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from music_assistant.helpers.audio import build_concat_filelist, resolve_output_player_ids
+
+
+def test_resolve_output_player_ids_resolves_parents_and_duplicates() -> None:
+    """Output destinations use user-facing protocol parents without duplicates."""
+    mass = MagicMock()
+    players = {
+        "leader": SimpleNamespace(protocol_parent_id=None),
+        "protocol-child": SimpleNamespace(protocol_parent_id="child"),
+        "child": SimpleNamespace(protocol_parent_id=None),
+    }
+    mass.players.get_player.side_effect = players.get
+
+    result = resolve_output_player_ids(
+        mass,
+        ("leader", "leader", "protocol-child", "child"),
+    )
+
+    assert result == {"leader", "child"}
 
 
 def test_build_concat_filelist_plain_paths() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Native sync groups share one encoded HTTP stream, but audio processing details only reported the group leader.

- Register all native sync destinations in one atomic, deduplicated batch.
- Resolve protocol players to their visible parent consistently while keeping provider fanout per player.
- Add regression coverage for grouping, stale sessions, pruning, and native handler isolation.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
