### PR TITLE
Include synchronized players in audio chains

### DIFF
--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -46,6 +46,7 @@ from music_assistant.controllers.player_queues.helpers import (
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     set_current_user,
 )
+from music_assistant.helpers.audio import resolve_output_player_ids
 from music_assistant.helpers.util import get_changed_keys, percentage
 from music_assistant.models.player import Player
 
@@ -286,12 +287,10 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
 
     def _get_output_player_ids(self, player: Player) -> set[str]:
         """Return destination player IDs represented in the processing chain."""
-        output_player_ids = {player.protocol_parent_id or player.player_id}
-        for member_id in player.state.group_members:
-            member = self.mass.players.get_player(member_id)
-            output_player_id = member.protocol_parent_id if member else None
-            output_player_ids.add(output_player_id or member_id)
-        return output_player_ids
+        return resolve_output_player_ids(
+            self.mass,
+            [player.player_id, *player.state.group_members],
+        )
 
     def _get_flow_queue_stream_index(
         self, queue: PlayerQueue, player: Player

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -13,7 +13,7 @@ import logging
 import os
 import re
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from functools import partial
@@ -112,6 +112,7 @@ from music_assistant.helpers.audio import (
     parse_extinf_metadata,
     realtime_pcm_pacer,
     resample_pcm_audio,
+    resolve_output_player_ids,
 )
 from music_assistant.helpers.dsp import filter_to_ffmpeg_params
 from music_assistant.helpers.ffmpeg import (
@@ -1142,6 +1143,7 @@ class StreamsAudio:
         input_format: AudioFormat,
         output_format: AudioFormat,
         *,
+        shared_player_ids: Iterable[str] | None = None,
         handoff_format: AudioFormat | None = None,
         queue_id: str | None = None,
         session_id: str | None = None,
@@ -1153,6 +1155,8 @@ class StreamsAudio:
         :param player_id: Destination player identifier.
         :param input_format: PCM format entering player-specific processing.
         :param output_format: Furthest downstream output format known to the server.
+        :param shared_player_ids: Additional players receiving this identical output path.
+            An empty iterable marks a path that can gain shared destinations later.
         :param handoff_format: Earlier provider handoff format when it differs.
         :param queue_id: Explicit queue identifier for the processing snapshot.
         :param session_id: Explicit queue session identifier for the processing snapshot.
@@ -1163,6 +1167,12 @@ class StreamsAudio:
         destination_player_id = (
             player.protocol_parent_id if player and player.protocol_parent_id else player_id
         )
+        resolved_shared_player_ids = (
+            resolve_output_player_ids(self.mass, shared_player_ids) - {destination_player_id}
+            if shared_player_ids is not None
+            else None
+        )
+        destination_player_ids = {destination_player_id, *(resolved_shared_player_ids or ())}
         if player:
             dsp_config_id = self._resolve_player_dsp_config_id(player)
             dsp = self._resolve_player_dsp_config(player)
@@ -1202,7 +1212,7 @@ class StreamsAudio:
             filter_params.append("alimiter=limit=-2dB:level=false:asc=true")
 
         output_details = AudioOutputDetails(
-            player_ids=[destination_player_id],
+            player_ids=sorted(destination_player_ids),
             dsp=AudioDSPDetails(
                 state=dsp_state,
                 input_gain=dsp.input_gain if dsp.enabled else 0.0,
@@ -1225,6 +1235,7 @@ class StreamsAudio:
             self.mass.streams.audio_processing.update_output(
                 destination_player_id,
                 output_plan,
+                shared_player_ids=resolved_shared_player_ids,
                 queue_id=queue_id,
                 session_id=session_id,
                 queue_item_id=queue_item_id,

--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING
@@ -74,6 +75,7 @@ class _AudioProcessingSession:
     session_id: str
     items: dict[str, _AudioProcessingItem] = field(default_factory=dict)
     outputs: dict[str | None, dict[str, _AudioOutputEntry]] = field(default_factory=dict)
+    shared_output_templates: dict[str | None, _AudioOutputEntry] = field(default_factory=dict)
 
 
 class AudioProcessingManager:
@@ -188,6 +190,7 @@ class AudioProcessingManager:
         player_id: str,
         output_plan: AudioOutputPlan,
         *,
+        shared_player_ids: Iterable[str] | None = None,
         queue_id: str,
         session_id: str,
         queue_item_id: str | None = None,
@@ -197,6 +200,8 @@ class AudioProcessingManager:
 
         :param player_id: Destination player identifier.
         :param output_plan: Effective output processing and private intermediate formats.
+        :param shared_player_ids: Additional players receiving this identical output path.
+            An empty iterable marks a path that can gain shared destinations later.
         :param queue_id: Queue identifier that owns the output.
         :param session_id: Queue session identifier that owns the output.
         :param queue_item_id: Queue item for single-item output, or None for flow output.
@@ -208,17 +213,36 @@ class AudioProcessingManager:
         self._prune_played_items(queue_id, session)
         if queue_item_id is not None and self._is_played_item(queue_id, queue_item_id):
             return False
-        entry = _AudioOutputEntry(
-            details=deepcopy(output_plan.output_details),
-            input_format=deepcopy(output_plan.input_format),
-            handoff_format=deepcopy(output_plan.handoff_format),
-            dsp_config_id=output_plan.dsp_config_id,
-        )
-        entry.details.player_ids = [player_id]
+
+        destination_player_ids = {player_id}
+        if shared_player_ids is not None:
+            destination_player_ids.update(shared_player_ids)
+
+        entries: dict[str, _AudioOutputEntry] = {}
+        for destination_player_id in destination_player_ids:
+            entry = _AudioOutputEntry(
+                details=deepcopy(output_plan.output_details),
+                input_format=deepcopy(output_plan.input_format),
+                handoff_format=deepcopy(output_plan.handoff_format),
+                dsp_config_id=output_plan.dsp_config_id,
+            )
+            entry.details.player_ids = [destination_player_id]
+            entries[destination_player_id] = entry
+
+        if shared_player_ids is None:
+            session.shared_output_templates.pop(queue_item_id, None)
+        else:
+            session.shared_output_templates[queue_item_id] = deepcopy(entries[player_id])
+
         item_outputs = session.outputs.setdefault(queue_item_id, {})
-        if item_outputs.get(player_id) == entry:
+        changed_entries = {
+            destination_player_id: entry
+            for destination_player_id, entry in entries.items()
+            if item_outputs.get(destination_player_id) != entry
+        }
+        if not changed_entries:
             return False
-        item_outputs[player_id] = entry
+        item_outputs.update(changed_entries)
         current_changed = self._publish_all(queue_id, session)
         queue = self.mass.player_queues.get(queue_id)
         if current_changed or (
@@ -231,11 +255,11 @@ class AudioProcessingManager:
 
     def retain_outputs(self, queue_id: str, player_ids: set[str]) -> bool:
         """
-        Drop outputs for players no longer attached to a queue.
+        Reconcile outputs with players attached to a queue.
 
         :param queue_id: Queue identifier.
-        :param player_ids: Player identifiers that still belong to the output.
-        :return: Whether pruning published an updated current chain.
+        :param player_ids: Player identifiers that belong to the output.
+        :return: Whether reconciliation published an updated current chain.
         """
         session = self._sessions.get(queue_id)
         if session is None:
@@ -247,6 +271,13 @@ class AudioProcessingManager:
                 for player_id, output in outputs.items()
                 if player_id in player_ids
             }
+            if template := session.shared_output_templates.get(queue_item_id):
+                added_player_ids = player_ids - retained.keys()
+                if queue_id not in outputs:
+                    added_player_ids.discard(queue_id)
+                for player_id in sorted(added_player_ids):
+                    retained[player_id] = deepcopy(template)
+                    retained[player_id].details.player_ids = [player_id]
             if retained == outputs:
                 continue
             changed = True
@@ -254,6 +285,7 @@ class AudioProcessingManager:
                 session.outputs[queue_item_id] = retained
             else:
                 del session.outputs[queue_item_id]
+                session.shared_output_templates.pop(queue_item_id, None)
         if not changed:
             return False
         current_changed = self._publish_all(queue_id, session)
@@ -278,6 +310,9 @@ class AudioProcessingManager:
                     ):
                         entry.details.dsp.preset_id = preset_id
                         changed = True
+            for entry in session.shared_output_templates.values():
+                if entry.dsp_config_id == player_id:
+                    entry.details.dsp.preset_id = preset_id
             if changed and self._publish_all(queue_id, session):
                 self.mass.player_queues.signal_update(queue_id)
 
@@ -409,6 +444,7 @@ class AudioProcessingManager:
         for queue_item in queue_data.items[: queue_data.queue.current_index]:
             session.items.pop(queue_item.queue_item_id, None)
             session.outputs.pop(queue_item.queue_item_id, None)
+            session.shared_output_templates.pop(queue_item.queue_item_id, None)
             if queue_item.streamdetails:
                 queue_item.streamdetails.audio_processing = None
 

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -778,6 +778,7 @@ class StreamsController(CoreController):
                 player_id=player.player_id,
                 input_format=pcm_format,
                 output_format=output_format,
+                shared_player_ids=player.state.group_members,
                 queue_id=queue_id,
                 session_id=session_id,
                 queue_item_id=queue_item.queue_item_id,
@@ -989,6 +990,7 @@ class StreamsController(CoreController):
             player.player_id,
             flow_pcm_format,
             output_format,
+            shared_player_ids=player.state.group_members,
             queue_id=queue_id,
             session_id=session_id,
         )

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -7,7 +7,7 @@ import logging
 import re
 import struct
 import urllib.parse
-from collections.abc import AsyncGenerator, Iterator
+from collections.abc import AsyncGenerator, Iterable, Iterator
 from contextlib import aclosing
 from io import BytesIO
 from typing import TYPE_CHECKING, Final
@@ -666,6 +666,26 @@ def get_bit_rate(fmt: AudioFormat) -> int:
     if fmt.bit_rate:
         return int(fmt.bit_rate / 1000) if fmt.bit_rate >= 10000 else fmt.bit_rate
     return int((calculate_content_length(fmt, seconds=1) / 1000) * 8)
+
+
+def resolve_output_player_ids(
+    mass: MusicAssistant,
+    player_ids: Iterable[str],
+) -> set[str]:
+    """
+    Resolve output destinations to their user-facing player identifiers.
+
+    :param mass: Music Assistant instance.
+    :param player_ids: Player or protocol-player identifiers to resolve.
+    :return: Deduplicated user-facing player identifiers.
+    """
+    resolved_ids: set[str] = set()
+    for player_id in player_ids:
+        player = mass.players.get_player(player_id)
+        resolved_ids.add(
+            player.protocol_parent_id if player and player.protocol_parent_id else player_id
+        )
+    return resolved_ids
 
 
 def is_grouping_preventing_dsp(player: Player) -> bool:

--- a/tests/controllers/player_queues/test_playback_tracker_outputs.py
+++ b/tests/controllers/player_queues/test_playback_tracker_outputs.py
@@ -18,7 +18,7 @@ def test_output_player_ids_resolve_protocol_parents() -> None:
         SimpleNamespace(mass=SimpleNamespace(players=SimpleNamespace(get_player=get_player))),
     )
     player = MagicMock(player_id="queue-1", protocol_parent_id=None)
-    player.state.group_members = ["protocol-1", "missing-player"]
+    player.state.group_members = ["queue-1", "protocol-1", "player-1", "missing-player"]
     protocol_player = MagicMock(protocol_parent_id="player-1")
     get_player.side_effect = lambda player_id: (
         protocol_player if player_id == "protocol-1" else None

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -136,6 +136,76 @@ def test_audio_processing_manager_attaches_grouped_chain() -> None:
     )
 
 
+def test_shared_output_destinations_are_registered_atomically() -> None:
+    """One shared output publishes all destinations in a single queue update."""
+    manager, mass, _queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()
+    mass.player_queues.signal_update.reset_mock()
+
+    assert manager.update_output(
+        "leader",
+        output_plan,
+        shared_player_ids={"leader", "sync-child"},
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+
+    assert streamdetails.audio_processing is not None
+    assert len(streamdetails.audio_processing.outputs) == 1
+    assert streamdetails.audio_processing.outputs[0].player_ids == ["leader", "sync-child"]
+    mass.player_queues.signal_update.assert_called_once_with("queue-1")
+
+    mass.player_queues.signal_update.reset_mock()
+    assert not manager.update_output(
+        "leader",
+        output_plan,
+        shared_player_ids={"sync-child"},
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+    mass.player_queues.signal_update.assert_not_called()
+
+
+def test_shared_output_adds_member_without_stream_restart() -> None:
+    """A late native-sync member inherits the active shared output path."""
+    manager, mass, _queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()
+    manager.update_output(
+        "leader",
+        output_plan,
+        shared_player_ids=(),
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+    mass.player_queues.signal_update.reset_mock()
+
+    assert manager.retain_outputs("queue-1", {"queue-1", "leader", "late-member"})
+
+    assert streamdetails.audio_processing is not None
+    assert streamdetails.audio_processing.outputs[0].player_ids == ["late-member", "leader"]
+    mass.player_queues.signal_update.assert_called_once_with("queue-1")
+
+
+def test_independent_output_does_not_add_group_member() -> None:
+    """Membership changes do not expand an independently processed output."""
+    manager, mass, _queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()
+    manager.update_output(
+        "leader",
+        output_plan,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+    mass.player_queues.signal_update.reset_mock()
+
+    assert not manager.retain_outputs("queue-1", {"leader", "independent-member"})
+
+    assert streamdetails.audio_processing is not None
+    assert streamdetails.audio_processing.outputs[0].player_ids == ["leader"]
+    mass.player_queues.signal_update.assert_not_called()
+
+
 def test_preset_identity_update_republishes_current_chain() -> None:
     """Preset updates follow a changed config owner even when output details match."""
     manager, mass, _queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()
@@ -169,14 +239,14 @@ def test_preset_identity_update_republishes_current_chain() -> None:
 def test_retain_outputs_signals_current_chain_change() -> None:
     """Pruning a current output publishes the reduced chain."""
     manager, mass, _queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()
-    for player_id in ("player-1", "player-2"):
-        manager.update_output(
-            player_id,
-            output_plan,
-            queue_id="queue-1",
-            session_id="session-1",
-            queue_item_id="item-1",
-        )
+    manager.update_output(
+        "player-1",
+        output_plan,
+        shared_player_ids={"player-2"},
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
     mass.player_queues.signal_update.reset_mock()
 
     assert manager.retain_outputs("queue-1", {"player-1"})
@@ -283,9 +353,11 @@ def test_manager_rejects_superseded_and_cleared_sessions() -> None:
     assert not manager.update_output(
         "stale-player",
         lossless_plan,
+        shared_player_ids={"stale-child"},
         queue_id="queue-1",
         session_id="session-1",
     )
+    assert streamdetails.audio_processing is None
 
     manager.update_item_context(
         "queue-1",
@@ -419,7 +491,11 @@ def test_protocol_output_uses_parent_settings(monkeypatch: pytest.MonkeyPatch) -
     player = MagicMock(player_id="protocol-1", protocol_parent_id="player-1")
     player.state.active_group = None
     player.state.synced_to = None
-    mass.players.get_player.return_value = player
+    shared_player = MagicMock(player_id="protocol-2", protocol_parent_id="player-2")
+    mass.players.get_player.side_effect = lambda player_id: {
+        "protocol-1": player,
+        "protocol-2": shared_player,
+    }.get(player_id)
     mass.config.get_player_dsp_config.return_value = DSPConfig(enabled=False)
     mass.config.get_raw_player_config_value.side_effect = lambda _player_id, _key, default: (
         False if isinstance(default, bool) else "right"
@@ -436,11 +512,12 @@ def test_protocol_output_uses_parent_settings(monkeypatch: pytest.MonkeyPatch) -
         "protocol-1",
         pcm_format,
         pcm_format,
+        shared_player_ids={"protocol-1", "protocol-2"},
         queue_id="queue-1",
         session_id="session-1",
     )
 
-    assert plan.output_details.player_ids == ["player-1"]
+    assert plan.output_details.player_ids == ["player-1", "player-2"]
     assert plan.output_details.dsp.preset_id == "parent-preset"
     assert plan.dsp_config_id == "player-1"
     assert plan.output_details.source_channel == AudioChannel.FR
@@ -448,6 +525,14 @@ def test_protocol_output_uses_parent_settings(monkeypatch: pytest.MonkeyPatch) -
     assert {call.args[0] for call in mass.config.get_raw_player_config_value.call_args_list} == {
         "player-1"
     }
+    mass.streams.audio_processing.update_output.assert_called_once_with(
+        "player-1",
+        plan,
+        shared_player_ids={"player-2"},
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id=None,
+    )
 
 
 def test_single_member_group_uses_child_dsp_preset() -> None:

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.audio_processing import (
@@ -39,6 +39,7 @@ from music_assistant.controllers.streams.audio_processing import (
     get_audio_quality,
     get_normalization_details,
 )
+from music_assistant.controllers.streams.controller import StreamsController
 
 
 def _format(
@@ -482,7 +483,44 @@ def test_player_output_plan_matches_ffmpeg_filters() -> None:
     assert plan.dsp_config_id == "player-1"
     assert plan.output_details.source_channel == AudioChannel.FL
     assert plan.output_details.output_format == output_format
-    mass.streams.audio_processing.update_output.assert_called_once()
+    mass.streams.audio_processing.update_output.assert_called_once_with(
+        "player-1",
+        plan,
+        shared_player_ids=None,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_stream_handler_shares_native_group_members(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The regular single-item HTTP stream registers native group members."""
+    controller, request, group_members = _native_stream_handler_context(monkeypatch)
+
+    with pytest.raises(_OutputPlanRequested):
+        await controller.serve_queue_item_stream(request)
+
+    assert controller.audio.get_player_output_plan.call_args.kwargs["shared_player_ids"] is (
+        group_members
+    )
+
+
+@pytest.mark.asyncio
+async def test_flow_stream_handler_shares_native_group_members(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The regular flow HTTP stream registers native group members."""
+    controller, request, group_members = _native_stream_handler_context(monkeypatch)
+
+    with pytest.raises(_OutputPlanRequested):
+        await controller.serve_queue_flow_stream(request)
+
+    assert controller.audio.get_player_output_plan.call_args.kwargs["shared_player_ids"] is (
+        group_members
+    )
 
 
 def test_protocol_output_uses_parent_settings(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -674,3 +712,82 @@ def _streamdetails(item_id: str = "item-1") -> StreamDetails:
         audio_format=_format(ContentType.FLAC, 96000, 24, bit_rate=3200),
         media_type=MediaType.TRACK,
     )
+
+
+class _OutputPlanRequested(Exception):
+    """Signal that a stream handler reached output planning."""
+
+
+def _native_stream_handler_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Any, MagicMock, list[str]]:
+    """Return a native HTTP stream handler prepared to stop at output planning."""
+    mass = MagicMock()
+    streamdetails = _streamdetails()
+    queue_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="item-1",
+        name="Track",
+        duration=180,
+        streamdetails=streamdetails,
+        media_item=None,
+        media_type=MediaType.TRACK,
+        extra_attributes={},
+        image=None,
+    )
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        current_item=queue_item,
+        crossfade_enabled=False,
+        overlay_enabled=False,
+        overlay_source=None,
+    )
+    queue_data = SimpleNamespace(session_id="session-1")
+    mass.player_queues.get.return_value = queue
+    mass.player_queues.queue_data.return_value = queue_data
+    mass.player_queues.get_item.return_value = queue_item
+    mass.config.get_raw_core_config_value.return_value = 8
+    mass.config.get_raw_player_config_value.return_value = "disabled"
+
+    group_members = ["player-1", "player-2"]
+    player = MagicMock(player_id="player-1", protocol_parent_id=None)
+    player.state.group_members = group_members
+    player.state.supported_features = set()
+    player.state.name = "Player"
+    player.get_config_value.return_value = "default"
+    mass.players.get_player.return_value = player
+
+    pcm_format = _format(ContentType.PCM_F32LE, 48000, 32)
+    output_format = _format(ContentType.FLAC, 48000, 24)
+    audio = MagicMock()
+    audio.select_pcm_format = AsyncMock(return_value=pcm_format)
+    audio.select_flow_pcm_format = AsyncMock(return_value=pcm_format)
+    audio.get_output_format = AsyncMock(return_value=output_format)
+    audio.get_player_output_plan.side_effect = _OutputPlanRequested
+
+    controller = cast("Any", object.__new__(StreamsController))
+    controller.mass = mass
+    controller.audio = audio
+    controller.logger = MagicMock()
+    controller._log_request = MagicMock()
+    controller._update_audio_processing_context = MagicMock()
+    controller._active_output_streams = 0
+
+    response = MagicMock()
+    response.prepare = AsyncMock()
+    monkeypatch.setattr(
+        "music_assistant.controllers.streams.controller.web.StreamResponse",
+        MagicMock(return_value=response),
+    )
+    request = MagicMock()
+    request.method = "GET"
+    request.headers = {}
+    request.match_info = {
+        "queue_id": "queue-1",
+        "session_id": "session-1",
+        "queue_item_id": "item-1",
+        "player_id": "player-1",
+        "fmt": "flac",
+    }
+    return controller, request, group_members

--- a/tests/helpers/test_audio.py
+++ b/tests/helpers/test_audio.py
@@ -2,7 +2,28 @@
 
 from __future__ import annotations
 
-from music_assistant.helpers.audio import build_concat_filelist
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from music_assistant.helpers.audio import build_concat_filelist, resolve_output_player_ids
+
+
+def test_resolve_output_player_ids_resolves_parents_and_duplicates() -> None:
+    """Output destinations use visible protocol parents without duplicates."""
+    mass = MagicMock()
+    players = {
+        "leader": SimpleNamespace(protocol_parent_id=None),
+        "protocol-child": SimpleNamespace(protocol_parent_id="child"),
+        "child": SimpleNamespace(protocol_parent_id=None),
+    }
+    mass.players.get_player.side_effect = players.get
+
+    result = resolve_output_player_ids(
+        mass,
+        ("leader", "leader", "protocol-child", "child", "missing", "missing"),
+    )
+
+    assert result == {"leader", "child", "missing"}
 
 
 def test_build_concat_filelist_plain_paths() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Audio processing details only listed the sync leader even when the same output stream was shared with synchronized players.

- Include all players sharing a queue output in the audio processing chain
- Keep independently processed player outputs separate
- Reconcile members that join or leave during playback

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.