### PR TITLE
Add DSP gain and balance filters

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -30,7 +30,7 @@ from music_assistant_models.audio_processing import (
     AudioOutputDetails,
     AudioQueueProcessing,
 )
-from music_assistant_models.dsp import AudioChannel, DSPConfig, DSPState
+from music_assistant_models.dsp import AudioChannel, DSPConfig, DSPFilter, DSPState
 from music_assistant_models.enums import (
     ContentType,
     CrossfadeMode,
@@ -1189,11 +1189,18 @@ class StreamsAudio:
             dsp_state = DSPState.ENABLED if dsp.enabled else DSPState.DISABLED
 
         enabled_filters = [dsp_filter for dsp_filter in dsp.filters if dsp_filter.enabled]
+        # a neutral filter (0 dB gain, centered balance) emits no params; exclude
+        # it so it is not reported as an active, non-bit-perfect stage
+        effective_filters: list[DSPFilter] = []
         if dsp.enabled:
             if dsp.input_gain != 0:
                 filter_params.append(f"volume={dsp.input_gain}dB")
             for dsp_filter in enabled_filters:
-                filter_params.extend(filter_to_ffmpeg_params(dsp_filter, input_format))
+                params = filter_to_ffmpeg_params(dsp_filter, input_format)
+                if not params:
+                    continue
+                filter_params.extend(params)
+                effective_filters.append(dsp_filter)
             if dsp.output_gain != 0:
                 filter_params.append(f"volume={dsp.output_gain}dB")
 
@@ -1216,7 +1223,7 @@ class StreamsAudio:
             dsp=AudioDSPDetails(
                 state=dsp_state,
                 input_gain=dsp.input_gain if dsp.enabled else 0.0,
-                filters=enabled_filters if dsp.enabled else [],
+                filters=effective_filters,
                 output_gain=dsp.output_gain if dsp.enabled else 0.0,
                 output_limiter=limiter_enabled,
                 preset_id=dsp.preset_id,

--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -609,10 +609,12 @@ def _is_bit_perfect(
     ):
         return False
     details = output.details
+    # an enabled DSP with no effective filters and no gain leaves samples untouched
+    dsp_alters_audio = details.dsp.state == DSPState.ENABLED and (
+        bool(details.dsp.filters) or details.dsp.input_gain != 0 or details.dsp.output_gain != 0
+    )
     return not (
-        details.dsp.state == DSPState.ENABLED
-        or details.dsp.output_limiter
-        or details.source_channel is not None
+        dsp_alters_audio or details.dsp.output_limiter or details.source_channel is not None
     )
 
 

--- a/music_assistant/helpers/dsp.py
+++ b/music_assistant/helpers/dsp.py
@@ -156,12 +156,15 @@ def filter_to_ffmpeg_params(dsp_filter: DSPFilter, input_format: AudioFormat) ->
     if isinstance(dsp_filter, GainFilter) and dsp_filter.gain != 0:
         filter_params.append(f"volume={dsp_filter.gain}dB")
     if isinstance(dsp_filter, BalanceFilter) and dsp_filter.balance != 0:
-        # attenuate only the channel opposite the slider direction, so there is
-        # no positive gain and thus no clipping risk
-        attenuation = (100 - abs(dsp_filter.balance)) / 100
-        if dsp_filter.balance > 0:
-            filter_params.append(f"pan=stereo|FL={attenuation}*FL|FR=FR")
-        else:
-            filter_params.append(f"pan=stereo|FL=FL|FR={attenuation}*FR")
+        # balance is a stereo operation; on a non-stereo source the FL/FR pan
+        # expression would output silence, so only apply it to stereo streams
+        if input_format.channels == 2:
+            # attenuate only the channel opposite the slider direction, so there is
+            # no positive gain and thus no clipping risk
+            attenuation = (100 - abs(dsp_filter.balance)) / 100
+            if dsp_filter.balance > 0:
+                filter_params.append(f"pan=stereo|FL={attenuation}*FL|FR=FR")
+            else:
+                filter_params.append(f"pan=stereo|FL=FL|FR={attenuation}*FR")
 
     return filter_params

--- a/music_assistant/helpers/dsp.py
+++ b/music_assistant/helpers/dsp.py
@@ -5,7 +5,9 @@ from typing import TYPE_CHECKING
 
 from music_assistant_models.dsp import (
     AudioChannel,
+    BalanceFilter,
     DSPFilter,
+    GainFilter,
     ParametricEQBandType,
     ParametricEQFilter,
     ToneControlFilter,
@@ -22,7 +24,7 @@ def filter_to_ffmpeg_params(dsp_filter: DSPFilter, input_format: AudioFormat) ->
     Convert a DSP filter model to FFmpeg filter parameters.
 
     Args:
-        dsp_filter: DSP filter configuration (ParametricEQ or ToneControl)
+        dsp_filter: DSP filter configuration
         input_format: Audio format containing sample rate
 
     Returns:
@@ -151,5 +153,15 @@ def filter_to_ffmpeg_params(dsp_filter: DSPFilter, input_format: AudioFormat) ->
             filter_params.append(
                 f"equalizer=frequency=9000:width=18000:width_type=h:gain={dsp_filter.treble_level}"
             )
+    if isinstance(dsp_filter, GainFilter) and dsp_filter.gain != 0:
+        filter_params.append(f"volume={dsp_filter.gain}dB")
+    if isinstance(dsp_filter, BalanceFilter) and dsp_filter.balance != 0:
+        # attenuate only the channel opposite the slider direction, so there is
+        # no positive gain and thus no clipping risk
+        attenuation = (100 - abs(dsp_filter.balance)) / 100
+        if dsp_filter.balance > 0:
+            filter_params.append(f"pan=stereo|FL={attenuation}*FL|FR=FR")
+        else:
+            filter_params.append(f"pan=stereo|FL=FL|FR={attenuation}*FR")
 
     return filter_params

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -493,6 +493,31 @@ def test_player_output_plan_matches_ffmpeg_filters() -> None:
     )
 
 
+def test_player_output_plan_excludes_neutral_filters() -> None:
+    """A filter that emits no FFmpeg params is left out of the reported chain."""
+    mass = MagicMock()
+    mass.players.get_player.return_value = None
+    mass.config.get_player_dsp_config.return_value = DSPConfig(
+        enabled=True,
+        filters=[ToneControlFilter(enabled=True)],
+    )
+    mass.config.get_raw_player_config_value.return_value = "stereo"
+    audio = StreamsAudio(cast("Any", mass))
+    audio_format = _format(ContentType.PCM_F32LE, 48000, 32)
+
+    plan = audio.get_player_output_plan(
+        "player-1",
+        audio_format,
+        audio_format,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+
+    assert plan.output_details.dsp.filters == []
+    assert not any(param.startswith("equalizer=") for param in plan.filter_params)
+
+
 @pytest.mark.asyncio
 async def test_single_stream_handler_shares_native_group_members(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/helpers/test_dsp.py
+++ b/tests/helpers/test_dsp.py
@@ -56,6 +56,13 @@ def test_balance_filter_zero_is_passthrough() -> None:
     assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == []
 
 
+def test_balance_filter_mono_is_skipped() -> None:
+    """Test that balance is skipped on a mono source (stereo-only operation)."""
+    dsp_filter = BalanceFilter(enabled=True, balance=40)
+    mono_format = AudioFormat(sample_rate=48000, channels=1)
+    assert filter_to_ffmpeg_params(dsp_filter, mono_format) == []
+
+
 def test_tone_control_filter() -> None:
     """Test that tone control levels map to equalizer filters, omitting zero levels."""
     dsp_filter = ToneControlFilter(enabled=True, bass_level=4.0, mid_level=0.0, treble_level=-2.0)

--- a/tests/helpers/test_dsp.py
+++ b/tests/helpers/test_dsp.py
@@ -1,0 +1,124 @@
+"""Tests for the DSP helpers."""
+
+import math
+
+from music_assistant_models.dsp import (
+    AudioChannel,
+    BalanceFilter,
+    GainFilter,
+    ParametricEQBand,
+    ParametricEQBandType,
+    ParametricEQFilter,
+    ToneControlFilter,
+)
+from music_assistant_models.media_items.audio_format import AudioFormat
+
+from music_assistant.helpers.dsp import filter_to_ffmpeg_params
+
+INPUT_FORMAT = AudioFormat(sample_rate=48000)
+
+
+def test_gain_filter() -> None:
+    """Test that a gain filter maps to a volume filter in dB."""
+    dsp_filter = GainFilter(enabled=True, gain=5.5)
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == ["volume=5.5dB"]
+    dsp_filter = GainFilter(enabled=True, gain=-15.0)
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == ["volume=-15.0dB"]
+
+
+def test_gain_filter_zero_is_passthrough() -> None:
+    """Test that a gain filter with 0 dB gain emits no ffmpeg filter."""
+    dsp_filter = GainFilter(enabled=True, gain=0.0)
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == []
+
+
+def test_balance_filter_right() -> None:
+    """Test that balance towards the right attenuates only the left channel."""
+    dsp_filter = BalanceFilter(enabled=True, balance=40)
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == ["pan=stereo|FL=0.6*FL|FR=FR"]
+
+
+def test_balance_filter_left() -> None:
+    """Test that balance towards the left attenuates only the right channel."""
+    dsp_filter = BalanceFilter(enabled=True, balance=-40)
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == ["pan=stereo|FL=FL|FR=0.6*FR"]
+
+
+def test_balance_filter_full_deflection_mutes_opposite_channel() -> None:
+    """Test that full balance deflection fully mutes the opposite channel."""
+    dsp_filter = BalanceFilter(enabled=True, balance=100)
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == ["pan=stereo|FL=0.0*FL|FR=FR"]
+
+
+def test_balance_filter_zero_is_passthrough() -> None:
+    """Test that a centered balance filter emits no ffmpeg filter."""
+    dsp_filter = BalanceFilter(enabled=True, balance=0)
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == []
+
+
+def test_tone_control_filter() -> None:
+    """Test that tone control levels map to equalizer filters, omitting zero levels."""
+    dsp_filter = ToneControlFilter(enabled=True, bass_level=4.0, mid_level=0.0, treble_level=-2.0)
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == [
+        "equalizer=frequency=100:width=200:width_type=h:gain=4.0",
+        "equalizer=frequency=9000:width=18000:width_type=h:gain=-2.0",
+    ]
+
+
+def test_tone_control_filter_neutral_is_passthrough() -> None:
+    """Test that a tone control filter with all levels at 0 emits no ffmpeg filter."""
+    dsp_filter = ToneControlFilter(enabled=True, bass_level=0.0, mid_level=0.0, treble_level=0.0)
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == []
+
+
+def test_parametric_eq_preamp() -> None:
+    """Test that a parametric EQ preamp maps to a volume filter."""
+    dsp_filter = ParametricEQFilter(enabled=True, preamp=-3.0, per_channel_preamp={}, bands=[])
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == ["volume=-3.0dB"]
+
+
+def test_parametric_eq_per_channel_preamp() -> None:
+    """Test that per-channel preamp maps to a pan filter with linear per-channel gains."""
+    dsp_filter = ParametricEQFilter(
+        enabled=True,
+        preamp=0.0,
+        per_channel_preamp={AudioChannel.FL: -6.0},
+        bands=[],
+    )
+    expected_gain = 10 ** (-6.0 / 20)
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == [
+        f"pan=stereo|FL={expected_gain}*FL|FR=FR"
+    ]
+
+
+def test_parametric_eq_peak_band() -> None:
+    """Test that an enabled peak band maps to a biquad filter with cookbook coefficients."""
+    band = ParametricEQBand(
+        frequency=1000.0,
+        q=1.0,
+        gain=3.0,
+        type=ParametricEQBandType.PEAK,
+        enabled=True,
+        channel=AudioChannel.FL,
+    )
+    dsp_filter = ParametricEQFilter(enabled=True, per_channel_preamp={}, bands=[band])
+
+    a = math.sqrt(10 ** (3.0 / 20))
+    w_0 = 2 * math.pi * 1000.0 / 48000
+    alpha = math.sin(w_0) / 2
+    b0 = 1 + alpha * a
+    b1 = -2 * math.cos(w_0)
+    b2 = 1 - alpha * a
+    a0 = 1 + alpha / a
+    a1 = -2 * math.cos(w_0)
+    a2 = 1 - alpha / a
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == [
+        f"biquad=b0={b0}:b1={b1}:b2={b2}:a0={a0}:a1={a1}:a2={a2}:c=FL"
+    ]
+
+
+def test_parametric_eq_disabled_band_skipped() -> None:
+    """Test that disabled parametric EQ bands are skipped."""
+    band = ParametricEQBand(enabled=False, gain=6.0)
+    dsp_filter = ParametricEQFilter(enabled=True, per_channel_preamp={}, bands=[band])
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == []


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Adds two new sound adjustments to the audio pipeline:

- Gain - adjusts the overall volume up or down by a set amount.
- Balance - shifts the sound left or right between the speakers. To do this it quietens the opposite side rather than boosting the near side, so the audio never gets louder than the original and there's no risk of distortion.

If either control is left at its centre/zero setting, it's skipped entirely and has no effect on the sound.

Added unit tests in `tests/helpers/test_dsp.py` covering the volume change, the left/right balance direction, the quieting amount, and that a centred/zero setting is left untouched.

Frontend PR: https://github.com/music-assistant/frontend/pull/2154

**Related issue (if applicable):**

- related issue 

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [X] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [X] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
