### PR TITLE
Report UGP MP3 quality correctly

### DIFF
--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -28,7 +28,7 @@ from music_assistant.constants import (
 )
 from music_assistant.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads
 
-from .ffmpeg import get_ffmpeg_stream
+from .ffmpeg import DEFAULT_MP3_BIT_RATE, get_ffmpeg_stream
 from .process import AsyncProcess, communicate
 
 if TYPE_CHECKING:
@@ -571,8 +571,9 @@ def calculate_content_length(
         # Source: https://z-issue.com/wp/flac-compression-level-comparison/
         # Real-world variance: 65-85% depending on audio content.
         return int(pcm_size * 0.747)
-    if fmt.content_type in (ContentType.MP3, ContentType.OGG):
-        # CBR 320kbps as set in get_ffmpeg_args
+    if fmt.content_type == ContentType.MP3:
+        return int(((DEFAULT_MP3_BIT_RATE * 1000) / 8) * seconds)
+    if fmt.content_type == ContentType.OGG:
         return int((320000 / 8) * seconds)
     if fmt.content_type in (ContentType.AAC, ContentType.M4A):
         # CBR 256kbps as set in get_ffmpeg_args

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -29,6 +29,7 @@ LOGGER = logging.getLogger("ffmpeg")
 MINIMAL_FFMPEG_VERSION = 6
 CACHE_ATTR_LIBSOXR_PRESENT: Final[str] = "libsoxr_present"
 CACHE_ATTR_FFMPEG_VERSION: Final[str] = "ffmpeg_version"
+DEFAULT_MP3_BIT_RATE: Final[int] = 320
 
 # Regex patterns to extract audio format details from ffmpeg's stderr output.
 # Examples of the lines we parse:
@@ -600,7 +601,7 @@ def get_ffmpeg_args(
     elif output_format.content_type == ContentType.AAC:
         output_args = ["-f", "adts", "-c:a", "aac", "-b:a", "256k"]
     elif output_format.content_type == ContentType.MP3:
-        output_args = ["-f", "mp3", "-b:a", "320k"]
+        output_args = ["-f", "mp3", "-b:a", f"{DEFAULT_MP3_BIT_RATE}k"]
     elif output_format.content_type == ContentType.WAV:
         pcm_format = ContentType.from_bit_depth(output_format.bit_depth)
         output_args = [

--- a/music_assistant/providers/universal_group/constants.py
+++ b/music_assistant/providers/universal_group/constants.py
@@ -8,6 +8,8 @@ from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType, ContentType
 from music_assistant_models.media_items import AudioFormat
 
+from music_assistant.helpers.ffmpeg import DEFAULT_MP3_BIT_RATE
+
 UGP_PREFIX: Final[str] = "ugp_"
 
 # Grace period (seconds) before a universal group releases its members after
@@ -30,7 +32,13 @@ UGP_OUTPUT_FLAC_48000_24: Final[str] = "flac_48000_24"
 # multiplexer runs at exactly the rate the encoder needs.
 UGP_OUTPUT_FORMATS: Final[dict[str, tuple[AudioFormat, str]]] = {
     UGP_OUTPUT_MP3: (
-        AudioFormat(content_type=ContentType.MP3, sample_rate=44100, bit_depth=16),
+        AudioFormat(
+            content_type=ContentType.MP3,
+            codec_type=ContentType.MP3,
+            sample_rate=44100,
+            bit_depth=16,
+            bit_rate=DEFAULT_MP3_BIT_RATE,
+        ),
         "mp3",
     ),
     UGP_OUTPUT_FLAC_44100_16: (

--- a/tests/helpers/test_audio.py
+++ b/tests/helpers/test_audio.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from music_assistant.helpers.audio import build_concat_filelist, resolve_output_player_ids
+from music_assistant_models.enums import ContentType
+from music_assistant_models.media_items import AudioFormat
+
+from music_assistant.helpers.audio import (
+    build_concat_filelist,
+    calculate_content_length,
+    resolve_output_player_ids,
+)
+from music_assistant.helpers.ffmpeg import DEFAULT_MP3_BIT_RATE
 
 
 def test_resolve_output_player_ids_resolves_parents_and_duplicates() -> None:
@@ -24,6 +32,15 @@ def test_resolve_output_player_ids_resolves_parents_and_duplicates() -> None:
     )
 
     assert result == {"leader", "child", "missing"}
+
+
+def test_mp3_content_length_uses_encoder_bitrate() -> None:
+    """MP3 size estimation uses the bitrate configured for FFmpeg encoding."""
+    seconds = 2
+    assert calculate_content_length(
+        AudioFormat(content_type=ContentType.MP3),
+        seconds,
+    ) == int(((DEFAULT_MP3_BIT_RATE * 1000) / 8) * seconds)
 
 
 def test_build_concat_filelist_plain_paths() -> None:

--- a/tests/providers/universal_group/test_constants.py
+++ b/tests/providers/universal_group/test_constants.py
@@ -1,0 +1,61 @@
+"""Tests for Universal Group output formats."""
+
+from music_assistant_models.audio_processing import (
+    AudioFidelity,
+    AudioOutputDetails,
+    AudioQuality,
+)
+from music_assistant_models.enums import ContentType
+from music_assistant_models.media_items import AudioFormat
+
+from music_assistant.controllers.streams.audio_processing import get_audio_quality
+from music_assistant.helpers.ffmpeg import get_ffmpeg_args
+from music_assistant.providers.universal_group.constants import (
+    UGP_OUTPUT_MP3,
+    resolve_ugp_output_format,
+)
+
+
+def test_resolve_ugp_mp3_output_format() -> None:
+    """Resolve the complete objective format and effective quality for UGP MP3 output."""
+    audio_format, extension = resolve_ugp_output_format(UGP_OUTPUT_MP3)
+
+    assert extension == "mp3"
+    assert audio_format.content_type == ContentType.MP3
+    assert audio_format.codec_type == ContentType.MP3
+    assert audio_format.sample_rate == 44100
+    assert audio_format.bit_depth == 16
+    assert audio_format.bit_rate == 320
+    assert get_audio_quality(audio_format) == AudioQuality.STANDARD
+
+
+def test_ugp_mp3_output_details_serialization() -> None:
+    """Serialize the UGP MP3 codec, bitrate and effective quality for clients."""
+    audio_format, _ = resolve_ugp_output_format(UGP_OUTPUT_MP3)
+    output_details = AudioOutputDetails(
+        output_format=audio_format,
+        fidelity=AudioFidelity(quality=get_audio_quality(audio_format)),
+    )
+
+    payload = output_details.to_dict()
+
+    assert payload["output_format"]["content_type"] == ContentType.MP3.value
+    assert payload["output_format"]["codec_type"] == ContentType.MP3.value
+    assert payload["output_format"]["bit_rate"] == 320
+    assert payload["fidelity"]["quality"] == AudioQuality.STANDARD.value
+
+
+def test_ugp_mp3_bitrate_matches_ffmpeg_encoder() -> None:
+    """Keep UGP MP3 bitrate metadata aligned with the FFmpeg encoder."""
+    output_format, _ = resolve_ugp_output_format(UGP_OUTPUT_MP3)
+    input_format = AudioFormat(
+        content_type=ContentType.PCM_F32LE,
+        sample_rate=output_format.sample_rate,
+        bit_depth=32,
+        channels=2,
+    )
+
+    ffmpeg_args = get_ffmpeg_args(input_format, output_format, [])
+    bitrate_index = ffmpeg_args.index("-b:a")
+
+    assert ffmpeg_args[bitrate_index + 1] == f"{output_format.bit_rate}k"


### PR DESCRIPTION
# What does this implement/fix?

Universal Group Player MP3 streams were encoded at 320 kbps but published without codec or bitrate metadata, causing their audio-chain quality to appear unknown.

- Share the MP3 encoder bitrate with the UGP output format metadata.
- Report MP3 codec and 320 kbps bitrate for Standard quality classification.
- Cover resolved fields, serialized output details, and encoder agreement.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.