### PR TITLE
Migrate Tidal search to the official API

### DIFF
--- a/music_assistant/providers/tidal/jsonapi.py
+++ b/music_assistant/providers/tidal/jsonapi.py
@@ -55,6 +55,16 @@ class JsonApiDocument:
             return None
         return self._included.get((identifier["type"], identifier["id"]))
 
+    def linkage_ids(self, resource: dict[str, Any], relationship: str) -> set[str]:
+        """Return the ids of a resource's relationship linkage (no include needed)."""
+        rel = (resource.get("relationships") or {}).get(relationship) or {}
+        linkage = rel.get("data")
+        if linkage is None:
+            return set()
+        if isinstance(linkage, dict):
+            linkage = [linkage]
+        return {str(item["id"]) for item in linkage if item.get("id")}
+
     def related(self, resource: dict[str, Any], relationship: str) -> list[dict[str, Any]]:
         """
         Resolve a resource's relationship to the included resource objects.

--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import urllib.parse
 from typing import TYPE_CHECKING, Any
 
 from aiohttp.client_exceptions import ClientError
@@ -14,14 +15,13 @@ from music_assistant_models.media_items import SearchResults
 
 from .constants import FAVORITE_TRACKS_PLAYLIST_ID, FAVORITES_TRACKS, PAGES_MIX, PLAYLISTS
 from .parsers import (
-    parse_album,
-    parse_artist,
     parse_favorite_tracks_playlist,
     parse_playlist,
     parse_track,
 )
 from .parsers_v2 import parse_album as parse_album_v2
 from .parsers_v2 import parse_artist as parse_artist_v2
+from .parsers_v2 import parse_playlist as parse_playlist_v2
 from .parsers_v2 import parse_track as parse_track_v2
 
 if TYPE_CHECKING:
@@ -43,47 +43,51 @@ class TidalMediaManager:
         self, search_query: str, media_types: list[MediaType], limit: int = 5
     ) -> SearchResults:
         """Perform search on Tidal."""
-        parsed_results = SearchResults()
-        media_type_strings = []
+        results = SearchResults()
+        wanted = set(media_types)
 
-        if MediaType.ARTIST in media_types:
-            media_type_strings.append("artists")
-        if MediaType.ALBUM in media_types:
-            media_type_strings.append("albums")
-        if MediaType.TRACK in media_types:
-            media_type_strings.append("tracks")
-        if MediaType.PLAYLIST in media_types:
-            media_type_strings.append("playlists")
+        # Build the includes for the requested types only, keeping under the
+        # official API's 10-included-resource cap. Track album covers are
+        # included so track results carry artwork; standalone album results
+        # trade artist names for staying within the cap.
+        includes: list[str] = []
+        if MediaType.TRACK in wanted:
+            includes += ["tracks.artists", "tracks.albums.coverArt"]
+        if MediaType.ALBUM in wanted:
+            includes.append("albums.coverArt")
+        if MediaType.ARTIST in wanted:
+            includes.append("artists.profileArt")
+        if MediaType.PLAYLIST in wanted:
+            includes.append("playlists.coverArt")
+        if not includes:
+            return results
 
-        if not media_type_strings:
-            return parsed_results
+        query = urllib.parse.quote(search_query, safe="")
+        doc = await self.api.get_jsonapi(f"searchResults/{query}", include=includes)
+        data = doc.data
 
-        results = await self.api.get(
-            "search",
-            params={
-                "query": search_query.replace("'", ""),
-                "limit": limit,
-                "types": ",".join(media_type_strings),
-            },
-        )
-
-        if "artists" in results and results["artists"].get("items"):
-            parsed_results.artists = [
-                parse_artist(self.provider, x) for x in results["artists"]["items"]
+        # Slice the resources before parsing so we only parse up to `limit` items.
+        if MediaType.TRACK in wanted:
+            results.tracks = [
+                parse_track_v2(self.provider, doc, res)
+                for res in doc.related(data, "tracks")[:limit]
             ]
-        if "albums" in results and results["albums"].get("items"):
-            parsed_results.albums = [
-                parse_album(self.provider, x) for x in results["albums"]["items"]
+        if MediaType.ALBUM in wanted:
+            results.albums = [
+                parse_album_v2(self.provider, doc, res)
+                for res in doc.related(data, "albums")[:limit]
             ]
-        if "playlists" in results and results["playlists"].get("items"):
-            parsed_results.playlists = [
-                parse_playlist(self.provider, x) for x in results["playlists"]["items"]
+        if MediaType.ARTIST in wanted:
+            results.artists = [
+                parse_artist_v2(self.provider, doc, res)
+                for res in doc.related(data, "artists")[:limit]
             ]
-        if "tracks" in results and results["tracks"].get("items"):
-            parsed_results.tracks = [
-                parse_track(self.provider, x) for x in results["tracks"]["items"]
+        if MediaType.PLAYLIST in wanted:
+            results.playlists = [
+                parse_playlist_v2(self.provider, doc, res)
+                for res in doc.related(data, "playlists")[:limit]
             ]
-        return parsed_results
+        return results
 
     async def get_artist(self, prov_artist_id: str) -> Artist:
         """Get artist details."""

--- a/music_assistant/providers/tidal/parsers_v2.py
+++ b/music_assistant/providers/tidal/parsers_v2.py
@@ -23,6 +23,7 @@ from music_assistant_models.media_items import (
     AudioMetadata,
     MediaItemImage,
     MediaItemLink,
+    Playlist,
     ProviderMapping,
     Track,
     UniqueList,
@@ -231,6 +232,48 @@ def parse_track(provider: TidalProvider, doc: JsonApiDocument, resource: dict[st
             track.metadata.images = UniqueList([image])
 
     return track
+
+
+def parse_playlist(
+    provider: TidalProvider, doc: JsonApiDocument, resource: dict[str, Any]
+) -> Playlist:
+    """Parse an official Tidal playlist resource to a generic Playlist."""
+    playlist_id = str(resource["id"])
+    attributes: dict[str, Any] = resource.get("attributes", {})
+    # A playlist is editable when the authenticated user is one of its owners.
+    # This needs the "owners" relationship to be present; search omits it (it
+    # would exceed the include cap), so search results are non-editable by design.
+    owner_ids = doc.linkage_ids(resource, "owners")
+    user_id = str(provider.auth.user_id) if provider.auth.user_id else None
+    is_editable = bool(user_id and user_id in owner_ids)
+    owner_name = "Tidal"
+    if is_editable:
+        owner_name = provider.auth.user.profile_name or provider.auth.user.user_name or str(user_id)
+
+    playlist = Playlist(
+        item_id=playlist_id,
+        provider=provider.instance_id,
+        name=attributes.get("name", "Unknown"),
+        owner=owner_name,
+        provider_mappings={
+            ProviderMapping(
+                item_id=playlist_id,
+                provider_domain=provider.domain,
+                provider_instance=provider.instance_id,
+                url=f"https://tidal.com/playlist/{playlist_id}",
+                is_unique=is_editable,
+            )
+        },
+        is_editable=is_editable,
+    )
+    if description := attributes.get("description"):
+        playlist.metadata.description = description
+    if created := attributes.get("createdAt"):
+        with suppress(ValueError):
+            playlist.date_added = datetime.fromisoformat(created)
+    if image := _resolve_image(provider, doc, resource, "coverArt"):
+        playlist.metadata.images = UniqueList([image])
+    return playlist
 
 
 def _split_title_version(title: str, version: str | None) -> tuple[str, str]:

--- a/tests/providers/tidal/fixtures/v2/search.json
+++ b/tests/providers/tidal/fixtures/v2/search.json
@@ -1,0 +1,7955 @@
+{
+  "data": {
+    "id": "lukas%20graham",
+    "type": "searchResults",
+    "attributes": {
+      "trackingId": "c93d7f4d-49b0-4b3c-83fa-2daf3d94e73d"
+    },
+    "relationships": {
+      "albums": {
+        "data": [
+          {
+            "id": "58756127",
+            "type": "albums"
+          },
+          {
+            "id": "96969306",
+            "type": "albums"
+          },
+          {
+            "id": "271190385",
+            "type": "albums"
+          },
+          {
+            "id": "104340961",
+            "type": "albums"
+          },
+          {
+            "id": "524818809",
+            "type": "albums"
+          },
+          {
+            "id": "121563483",
+            "type": "albums"
+          },
+          {
+            "id": "242744823",
+            "type": "albums"
+          },
+          {
+            "id": "118421110",
+            "type": "albums"
+          },
+          {
+            "id": "254074183",
+            "type": "albums"
+          },
+          {
+            "id": "429400346",
+            "type": "albums"
+          },
+          {
+            "id": "270125433",
+            "type": "albums"
+          },
+          {
+            "id": "16562158",
+            "type": "albums"
+          },
+          {
+            "id": "197218765",
+            "type": "albums"
+          },
+          {
+            "id": "187840424",
+            "type": "albums"
+          },
+          {
+            "id": "151974458",
+            "type": "albums"
+          },
+          {
+            "id": "216347341",
+            "type": "albums"
+          },
+          {
+            "id": "17574778",
+            "type": "albums"
+          },
+          {
+            "id": "140268720",
+            "type": "albums"
+          },
+          {
+            "id": "105537508",
+            "type": "albums"
+          },
+          {
+            "id": "516643645",
+            "type": "albums"
+          }
+        ],
+        "links": {
+          "self": "/searchResults/lukas%20graham/relationships/albums?countryCode=AT",
+          "next": "/searchResults/lukas%20graham/relationships/albums?countryCode=AT&page%5Bcursor%5D=3nI1Esi",
+          "meta": {
+            "nextCursor": "3nI1Esi"
+          }
+        }
+      },
+      "artists": {
+        "data": [
+          {
+            "id": "4184211",
+            "type": "artists"
+          },
+          {
+            "id": "4394210",
+            "type": "artists"
+          },
+          {
+            "id": "4826351",
+            "type": "artists"
+          },
+          {
+            "id": "8155176",
+            "type": "artists"
+          },
+          {
+            "id": "4927349",
+            "type": "artists"
+          },
+          {
+            "id": "8583514",
+            "type": "artists"
+          },
+          {
+            "id": "4804285",
+            "type": "artists"
+          },
+          {
+            "id": "3995478",
+            "type": "artists"
+          },
+          {
+            "id": "8812",
+            "type": "artists"
+          },
+          {
+            "id": "9916090",
+            "type": "artists"
+          },
+          {
+            "id": "4816276",
+            "type": "artists"
+          },
+          {
+            "id": "9212055",
+            "type": "artists"
+          },
+          {
+            "id": "17476",
+            "type": "artists"
+          },
+          {
+            "id": "4021356",
+            "type": "artists"
+          },
+          {
+            "id": "4835141",
+            "type": "artists"
+          },
+          {
+            "id": "3887405",
+            "type": "artists"
+          },
+          {
+            "id": "9309054",
+            "type": "artists"
+          },
+          {
+            "id": "43949368",
+            "type": "artists"
+          },
+          {
+            "id": "78144738",
+            "type": "artists"
+          },
+          {
+            "id": "77395432",
+            "type": "artists"
+          }
+        ],
+        "links": {
+          "self": "/searchResults/lukas%20graham/relationships/artists?countryCode=AT",
+          "next": "/searchResults/lukas%20graham/relationships/artists?countryCode=AT&page%5Bcursor%5D=3nI1Esi",
+          "meta": {
+            "nextCursor": "3nI1Esi"
+          }
+        }
+      },
+      "playlists": {
+        "data": [
+          {
+            "id": "67dc80a4-563f-4046-abd7-99945a6ae866",
+            "type": "playlists"
+          },
+          {
+            "id": "0fa30617-662a-42fc-ad16-fb699f3636b7",
+            "type": "playlists"
+          },
+          {
+            "id": "f3ed269b-b53d-4515-8c83-e2c4e697d93b",
+            "type": "playlists"
+          },
+          {
+            "id": "1b5bf92a-6edb-4839-a56c-0877643c4aba",
+            "type": "playlists"
+          },
+          {
+            "id": "69cf3625-b4c9-4f39-8076-fa7d3cd7784c",
+            "type": "playlists"
+          },
+          {
+            "id": "55905c86-7fb0-49ae-a574-43d14c61053f",
+            "type": "playlists"
+          },
+          {
+            "id": "acaf9642-4257-4857-950a-fbe2187e1fa3",
+            "type": "playlists"
+          },
+          {
+            "id": "3a10b48f-abd8-4577-ad25-0e6c44eebd11",
+            "type": "playlists"
+          },
+          {
+            "id": "11f23764-7e5d-4a86-af62-ff7fd202c113",
+            "type": "playlists"
+          },
+          {
+            "id": "c7e1ac7f-7689-4d99-8a3a-392f6c2a984e",
+            "type": "playlists"
+          },
+          {
+            "id": "46288e2b-ad6d-4387-a9b7-c9557418c2de",
+            "type": "playlists"
+          },
+          {
+            "id": "be10e8d9-cb8c-451d-9232-154676bb2456",
+            "type": "playlists"
+          },
+          {
+            "id": "34dbff57-88b8-4fb5-b09a-e4a79c107ffb",
+            "type": "playlists"
+          },
+          {
+            "id": "14c63d93-6f57-4540-9f95-a3bee7a8f66b",
+            "type": "playlists"
+          },
+          {
+            "id": "a2fd217b-3992-44a4-afc7-0a49360104a9",
+            "type": "playlists"
+          },
+          {
+            "id": "dc417540-3605-47a3-a054-600119de0c69",
+            "type": "playlists"
+          },
+          {
+            "id": "238482f9-60ff-44a3-b1ea-369eeddbebf6",
+            "type": "playlists"
+          },
+          {
+            "id": "3a98bd93-3b70-47ab-adfa-6735802bcc75",
+            "type": "playlists"
+          },
+          {
+            "id": "bc7e69ca-4609-4bc1-8c73-1396a1fc12c2",
+            "type": "playlists"
+          },
+          {
+            "id": "f0b21ffe-88af-41c4-bba1-0f1524a315c0",
+            "type": "playlists"
+          }
+        ],
+        "links": {
+          "self": "/searchResults/lukas%20graham/relationships/playlists?countryCode=AT",
+          "next": "/searchResults/lukas%20graham/relationships/playlists?countryCode=AT&page%5Bcursor%5D=3nI1Esi",
+          "meta": {
+            "nextCursor": "3nI1Esi"
+          }
+        }
+      },
+      "tracks": {
+        "data": [
+          {
+            "id": "58756128",
+            "type": "tracks"
+          },
+          {
+            "id": "96969310",
+            "type": "tracks"
+          },
+          {
+            "id": "58756130",
+            "type": "tracks"
+          },
+          {
+            "id": "121563484",
+            "type": "tracks"
+          },
+          {
+            "id": "104340964",
+            "type": "tracks"
+          },
+          {
+            "id": "242744824",
+            "type": "tracks"
+          },
+          {
+            "id": "16562159",
+            "type": "tracks"
+          },
+          {
+            "id": "183310109",
+            "type": "tracks"
+          },
+          {
+            "id": "118421111",
+            "type": "tracks"
+          },
+          {
+            "id": "151974459",
+            "type": "tracks"
+          },
+          {
+            "id": "79492732",
+            "type": "tracks"
+          },
+          {
+            "id": "58756132",
+            "type": "tracks"
+          },
+          {
+            "id": "197218768",
+            "type": "tracks"
+          },
+          {
+            "id": "58756137",
+            "type": "tracks"
+          },
+          {
+            "id": "359762509",
+            "type": "tracks"
+          },
+          {
+            "id": "270125434",
+            "type": "tracks"
+          },
+          {
+            "id": "187840426",
+            "type": "tracks"
+          },
+          {
+            "id": "96969308",
+            "type": "tracks"
+          },
+          {
+            "id": "96969307",
+            "type": "tracks"
+          },
+          {
+            "id": "58756131",
+            "type": "tracks"
+          }
+        ],
+        "links": {
+          "self": "/searchResults/lukas%20graham/relationships/tracks?countryCode=AT",
+          "next": "/searchResults/lukas%20graham/relationships/tracks?countryCode=AT&page%5Bcursor%5D=3nI1Esi",
+          "meta": {
+            "nextCursor": "3nI1Esi"
+          }
+        }
+      }
+    }
+  },
+  "links": {
+    "self": "/searchResults/lukas%20graham?include=albums.coverArt%2Cartists.profileArt%2Cplaylists.coverArt%2Ctracks.albums.coverArt%2Ctracks.artists&countryCode=AT"
+  },
+  "included": [
+    {
+      "id": "104340961",
+      "type": "albums",
+      "attributes": {
+        "title": "Lukas Graham (International Version)",
+        "barcodeId": "00602577549045",
+        "numberOfVolumes": 1,
+        "numberOfItems": 13,
+        "duration": "PT44M26S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2012-03-26",
+        "copyright": {
+          "text": "© 2012 Copenhagen Records / Universal Music"
+        },
+        "popularity": 0.28222558579746027,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/104340961",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzHlApMH8dCWP",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/104340961/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "105537508",
+      "type": "albums",
+      "attributes": {
+        "title": "Love Someone (Piano Demo)",
+        "barcodeId": "00602577612565",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M43S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2018-09-07",
+        "copyright": {
+          "text": "© 2019 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.3406352400779724,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/105537508",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "version": "Piano Demo",
+        "createdAt": "2019-03-09T09:27:44Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzHlC7uRRsGaW",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/105537508/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "118421110",
+      "type": "albums",
+      "attributes": {
+        "title": "Lie",
+        "barcodeId": "00602508242403",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2019-09-27",
+        "copyright": {
+          "text": "© 2019 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.2251062561289688,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/118421110",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzHqa0tvts1Fg",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/118421110/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "121563483",
+      "type": "albums",
+      "attributes": {
+        "title": "HERE (For Christmas)",
+        "barcodeId": "00602508479434",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT4M1S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2019-11-08",
+        "copyright": {
+          "text": "© 2019 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.2651028850675421,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/121563483",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzHvl1FGtArb9",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/121563483/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "140268720",
+      "type": "albums",
+      "attributes": {
+        "title": "Love Songs",
+        "barcodeId": "00602507215149",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M11S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2020-05-01",
+        "copyright": {
+          "text": "© 2020 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.36036545038223267,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/140268720",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzI6NlQNXvfH6",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/140268720/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "151974458",
+      "type": "albums",
+      "attributes": {
+        "title": "Share That Love",
+        "barcodeId": "00602435074399",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M52S",
+        "explicit": true,
+        "ai": false,
+        "releaseDate": "2020-08-20",
+        "copyright": {
+          "text": "© 2020 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.15355200198589303,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/151974458",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzIBj73pfCXuK",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/151974458/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "16562158",
+      "type": "albums",
+      "attributes": {
+        "title": "Ordinary Things",
+        "barcodeId": "00602537142378",
+        "numberOfVolumes": 1,
+        "numberOfItems": 2,
+        "duration": "PT7M48S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2011-10-17",
+        "copyright": {
+          "text": "© 2012 Copenhagen Records / Universal Music"
+        },
+        "popularity": 0.22785941478408922,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/16562158",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IP12D92rfpiy",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/16562158/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "17574778",
+      "type": "albums",
+      "attributes": {
+        "title": "Drunk In The Morning",
+        "barcodeId": "00602537184873",
+        "numberOfVolumes": 1,
+        "numberOfItems": 2,
+        "duration": "PT7M48S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2012-02-13",
+        "copyright": {
+          "text": "© 2012 Copenhagen Records / Universal Music"
+        },
+        "popularity": 0.19949200687605953,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/17574778",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IP13V4e80gy8",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/17574778/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "183310108",
+      "type": "albums",
+      "attributes": {
+        "title": "Happy For You",
+        "barcodeId": "00602438209729",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M46S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2021-05-14",
+        "copyright": {
+          "text": "© 2021 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.15674805818705734,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/183310108",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzIRjjbKwbezQ",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/183310108/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "187840424",
+      "type": "albums",
+      "attributes": {
+        "title": "Happy For You",
+        "barcodeId": "00602438493135",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M46S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2021-05-14",
+        "copyright": {
+          "text": "© 2021 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.1944491907265111,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/187840424",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzIRousRzcbG0",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/187840424/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "197218765",
+      "type": "albums",
+      "attributes": {
+        "title": "Call My Name",
+        "barcodeId": "00602438847563",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M21S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2021-09-17",
+        "copyright": {
+          "text": "© 2021 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.15884875030410214,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/197218765",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2021-09-10T02:09:11Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzIX8uWQsa7XR",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/197218765/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "216347341",
+      "type": "albums",
+      "attributes": {
+        "title": "All Of It All",
+        "barcodeId": "00602445593170",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M59S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2022-02-18",
+        "copyright": {
+          "text": "© 2022 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.19219816221894997,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/216347341",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzdpDiJhF8ddJ",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/216347341/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "242744823",
+      "type": "albums",
+      "attributes": {
+        "title": "Wish You Were Here",
+        "barcodeId": "00602448253804",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M56S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2022-08-19",
+        "copyright": {
+          "text": "© 2022 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.18676196311960816,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/242744823",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2022-08-12T01:43:27Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9Dze56eQ56UBe7",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/242744823/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "254074183",
+      "type": "albums",
+      "attributes": {
+        "title": "Last Christmas",
+        "barcodeId": "00602448718938",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M35S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2022-10-21",
+        "copyright": {
+          "text": "© 2022 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.17295020859346277,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/254074183",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzeATDcCskrvX",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/254074183/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "270125433",
+      "type": "albums",
+      "attributes": {
+        "title": "Home Movies",
+        "barcodeId": "00602455070449",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M16S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2023-01-13",
+        "copyright": {
+          "text": "© 2023 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.43128702044487,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/270125433",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzeL27Fn4jJ7z",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/270125433/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "271190385",
+      "type": "albums",
+      "attributes": {
+        "title": "4 (The Pink Album)",
+        "barcodeId": "00602448492173",
+        "numberOfVolumes": 1,
+        "numberOfItems": 11,
+        "duration": "PT33M45S",
+        "explicit": true,
+        "ai": false,
+        "releaseDate": "2023-01-20",
+        "copyright": {
+          "text": "© 2023 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.35705821313900377,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/271190385",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzeL3PBqL4wkv",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/271190385/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "359762508",
+      "type": "albums",
+      "attributes": {
+        "title": "Cheat Code",
+        "barcodeId": "00602465669046",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M29S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2024-05-03",
+        "copyright": {
+          "text": "© 2024 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.07578221628095376,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/359762508",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E009Fz1H6zEWe",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/359762508/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "429400346",
+      "type": "albums",
+      "attributes": {
+        "title": "You You You",
+        "barcodeId": "00602478083549",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M42S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2025-04-18",
+        "copyright": {
+          "text": "© 2025 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.20406164776917143,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/429400346",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0LryB5i8xP3m",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/429400346/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "516643645",
+      "type": "albums",
+      "attributes": {
+        "title": "To Know A Girl",
+        "barcodeId": "00199957505161",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M2S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2026-04-24",
+        "copyright": {
+          "text": "© 2026 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.11736994202118811,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/516643645",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2026-04-17T00:37:58Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0hlGZzoy0wnl",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/516643645/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "524818809",
+      "type": "albums",
+      "attributes": {
+        "title": "Second Chance",
+        "barcodeId": "00199957978675",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M7S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2026-05-22",
+        "copyright": {
+          "text": "© 2026 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.16214905881518296,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/524818809",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2026-05-15T00:48:36Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0hqY2Hc3EZIH",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/524818809/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756127",
+      "type": "albums",
+      "attributes": {
+        "title": "Lukas Graham (Blue Album) (International Version)",
+        "barcodeId": "00602547852748",
+        "numberOfVolumes": 1,
+        "numberOfItems": 11,
+        "duration": "PT40M5S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2015-05-29",
+        "copyright": {
+          "text": "© 2016 Then We Take The World / Copenhagen Records / Universal Music"
+        },
+        "popularity": 0.7480961442649546,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/58756127",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "version": "International Version",
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPMMti8ralux",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/58756127/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "79492731",
+      "type": "albums",
+      "attributes": {
+        "title": "Off To See The World",
+        "barcodeId": "00602567109679",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M4S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2017-09-22",
+        "copyright": {
+          "text": "© 2017 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.0527633318074913,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/79492731",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPX2DkbBYAT3",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/79492731/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "96969306",
+      "type": "albums",
+      "attributes": {
+        "title": "3 (The Purple Album)",
+        "barcodeId": "00602577188152",
+        "numberOfVolumes": 1,
+        "numberOfItems": 10,
+        "duration": "PT33M11S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2018-10-26",
+        "copyright": {
+          "text": "© 2018 Universal Music (Denmark) A/S"
+        },
+        "popularity": 0.5127724778932936,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/96969306",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPhcQZI4DfoU",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/96969306/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "17476",
+      "type": "artists",
+      "attributes": {
+        "name": "Christopher",
+        "popularity": 0.687865207450213,
+        "externalLinks": [
+          {
+            "href": "https://facebook.com/ChristopherMusicDk",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "https://instagram.com/christophermusiccom",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://christophermusic.dk",
+            "meta": {
+              "type": "OFFICIAL_HOMEPAGE"
+            }
+          },
+          {
+            "href": "https://tiktok.com/@christophermusiccom",
+            "meta": {
+              "type": "TIKTOK"
+            }
+          },
+          {
+            "href": "https://twitter.com/StopherMusic",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/17476",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "dDmYD0OBhSklbbny",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/17476/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "3526386",
+      "type": "artists",
+      "attributes": {
+        "name": "My Little Pony",
+        "popularity": 0.585465669631958,
+        "externalLinks": [
+          {
+            "href": "https://facebook.com/mylittlepony",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "https://instagram.com/mylittlepony",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://tiktok.com/@mylittlepony",
+            "meta": {
+              "type": "TIKTOK"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/3526386",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3887405",
+      "type": "artists",
+      "attributes": {
+        "name": "Nikolaj Grandjean",
+        "popularity": 0.4668424725532532,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3887405",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmX9grPBhCsdoAWJ4rb",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/3887405/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "3995478",
+      "type": "artists",
+      "attributes": {
+        "name": "Ed Sheeran",
+        "popularity": 0.9478464722633362,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/edsheeran ",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/3995478",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGPCjGX8qoy",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/3995478/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4021356",
+      "type": "artists",
+      "attributes": {
+        "name": "Isaak",
+        "popularity": 0.5182207422371169,
+        "externalLinks": [
+          {
+            "href": "https://instagram.com/isaak.music",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://tiktok.com/@isaak.music",
+            "meta": {
+              "type": "TIKTOK"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4021356",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "MIXED"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQRq2ganRe",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4021356/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4184211",
+      "type": "artists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "popularity": 0.8177526593208313,
+        "externalLinks": [
+          {
+            "href": "https://www.facebook.com/LukasGraham",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "http://instagram.com/lukasinstagraham",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://www.twitter.com/LukeTheDuke_",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4184211",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQS9r2Hufh",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4184211/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4394210",
+      "type": "artists",
+      "attributes": {
+        "name": "Imagine Dragons",
+        "popularity": 0.903693437576294,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/imaginedragons",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4394210",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQSme3YdUm",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4394210/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "43949368",
+      "type": "artists",
+      "attributes": {
+        "name": "Graham Lucas",
+        "popularity": 0.0,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/43949368",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0M2YL6dY7HrJ",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/43949368/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4804285",
+      "type": "artists",
+      "attributes": {
+        "name": "James Arthur",
+        "popularity": 0.8358675837516785,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/4804285",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQUKkh58Hl",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4804285/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4816276",
+      "type": "artists",
+      "attributes": {
+        "name": "MØ",
+        "popularity": 0.7571531844655853,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/MOMOMOYOUTH",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4816276",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQUKpQ1ASE",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4816276/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4826351",
+      "type": "artists",
+      "attributes": {
+        "name": "A Great Big World",
+        "popularity": 0.7094548344612122,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/4826351",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQUKu6ggYz",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4826351/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4835141",
+      "type": "artists",
+      "attributes": {
+        "name": "Brandon Beal",
+        "popularity": 0.5644338987586129,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/4835141",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQUKymCz4b",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4835141/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "4916222",
+      "type": "artists",
+      "attributes": {
+        "name": "Khalid",
+        "popularity": 0.8778374699379375,
+        "externalLinks": [
+          {
+            "href": "https://www.facebook.com/thegreatkhalid/",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "https://twitter.com/thegreatkhalid/",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4916222",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "4927349",
+      "type": "artists",
+      "attributes": {
+        "name": "James Bay",
+        "popularity": 0.7884899973869324,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/jamesbaymusic",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4927349",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQUeGI7opl",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4927349/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "5072967",
+      "type": "artists",
+      "attributes": {
+        "name": "G-Eazy",
+        "popularity": 0.8324434757232666,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/g_eazy",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/5072967",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "5551529",
+      "type": "artists",
+      "attributes": {
+        "name": "Mickey Guyton",
+        "popularity": 0.653368353843689,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/MickeyGuyton",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/5551529",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "7158528",
+      "type": "artists",
+      "attributes": {
+        "name": "Hanin Dhiya",
+        "popularity": 0.41335575931646706,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/7158528",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false
+      }
+    },
+    {
+      "id": "77395432",
+      "type": "artists",
+      "attributes": {
+        "name": "Lucas Graham sr",
+        "popularity": 0.0,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/77395432",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0hlCiWuKHA5X",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/77395432/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "78144738",
+      "type": "artists",
+      "attributes": {
+        "name": "Lucas Graham crp",
+        "popularity": 0.0,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/78144738",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0hlGawCJFqdw",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/78144738/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "8155176",
+      "type": "artists",
+      "attributes": {
+        "name": "Niall Horan",
+        "popularity": 0.7992809414863586,
+        "externalLinks": [
+          {
+            "href": "https://instagram.com/niallhoran",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://niallhoran.com",
+            "meta": {
+              "type": "OFFICIAL_HOMEPAGE"
+            }
+          },
+          {
+            "href": "https://tiktok.com/@niallhoran",
+            "meta": {
+              "type": "TIKTOK"
+            }
+          },
+          {
+            "href": "https://twitter.com/niallofficial",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/8155176",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "MIXED"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGVbrj8uzI6",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/8155176/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "8583514",
+      "type": "artists",
+      "attributes": {
+        "name": "Lewis Capaldi",
+        "popularity": 0.821123099996505,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/8583514",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGVd7NprytA",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/8583514/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "8812",
+      "type": "artists",
+      "attributes": {
+        "name": "Coldplay",
+        "popularity": 0.9104413949533393,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/coldplay",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/8812",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "9Uwk47MKGpAYj1G",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/8812/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "9212055",
+      "type": "artists",
+      "attributes": {
+        "name": "Hennedub",
+        "popularity": 0.5085860565170292,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/9212055",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGWu6J2WSAP",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/9212055/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "9309054",
+      "type": "artists",
+      "attributes": {
+        "name": "Lucas Graham",
+        "popularity": 0.23300576210021973,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/9309054",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0MT5JcmnWV2e",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/9309054/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "9916090",
+      "type": "artists",
+      "attributes": {
+        "name": "Lukas Leon",
+        "popularity": 0.413241225410072,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/9916090",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPcMGCnSPgZx",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/9916090/relationships/profileArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0DkdgDt9Nh8a3Qeyuj5hO0fOXJcEllT695d8wkSf4UgDTNIOd",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/1550fe16/352b/4a7b/a55f/3a01f505adbd/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1550fe16/352b/4a7b/a55f/3a01f505adbd/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1550fe16/352b/4a7b/a55f/3a01f505adbd/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1550fe16/352b/4a7b/a55f/3a01f505adbd/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#857035",
+          "blurHash": "UYN,[4x]~q%M~qIUD%j[%gV@ITazIUWBt7WV",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0Ee6YZC8daBfBUEXWfJAQazLz1NFIYDoPmrMk5AVoSTSZC23G",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/119b9764/21ee/49b9/9cab/6eafced573cd/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/119b9764/21ee/49b9/9cab/6eafced573cd/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/119b9764/21ee/49b9/9cab/6eafced573cd/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/119b9764/21ee/49b9/9cab/6eafced573cd/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#903F40",
+          "blurHash": "UkI#AS+ut8I@~U-lWAW=oIadobWUN2NLWEt7",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0EqRRYV7mEj6hfOelobv9wEirRvDOOAY4rusERge4OCTSQZhR",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/f78619fa/2165/4d9b/b3ba/fa736551d2b4/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f78619fa/2165/4d9b/b3ba/fa736551d2b4/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f78619fa/2165/4d9b/b3ba/fa736551d2b4/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f78619fa/2165/4d9b/b3ba/fa736551d2b4/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#51433A",
+          "blurHash": "UcL}BGt7?cof~pj[oIayMxaft7ofofkCbIj@",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0FkiS3GPnAhZG22b52hgWd7jE7J4v6YRVvA17FKxfgN6lFTYE",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/6ee4118f/af62/4be8/b2a2/231d522fcec8/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6ee4118f/af62/4be8/b2a2/231d522fcec8/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6ee4118f/af62/4be8/b2a2/231d522fcec8/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6ee4118f/af62/4be8/b2a2/231d522fcec8/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7A2846",
+          "blurHash": "UFGjh63aJQ}Lom+:avkaI;v_v|OF]@KlK3^R",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0GrxPwmDWDgc9iqaxziywfYvPeSP4URjjjvHXgre3Emn9KiG2",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/43dc4111/df53/412f/8f42/66405f29a7d9/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/43dc4111/df53/412f/8f42/66405f29a7d9/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/43dc4111/df53/412f/8f42/66405f29a7d9/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/43dc4111/df53/412f/8f42/66405f29a7d9/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#6B5D31",
+          "blurHash": "U4D+VH%Ijt-,+b$%fQ-mjtfQfQfQ@[-mfQ~8",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0H41GGuAoI3BQpBMKR1RYtViNG2heSkjqxkKsMAxohAoLhvu5",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/5378ec5c/7c7f/45a9/bad6/6161aff68f0f/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5378ec5c/7c7f/45a9/bad6/6161aff68f0f/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5378ec5c/7c7f/45a9/bad6/6161aff68f0f/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5378ec5c/7c7f/45a9/bad6/6161aff68f0f/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#496092",
+          "blurHash": "UIABMCo$fRtUo%o#fQt9fRfQfQfQtptSfQx_",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0H41mjyh7247PiVHHmrTX99QzX175TpfxhRxaU0sRhSjXUtkr",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/fd4e23e8/df81/4997/aab4/37f191c6c6de/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/fd4e23e8/df81/4997/aab4/37f191c6c6de/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/fd4e23e8/df81/4997/aab4/37f191c6c6de/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/fd4e23e8/df81/4997/aab4/37f191c6c6de/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#705037",
+          "blurHash": "UDL|[pD*j[9G?coffQt7j@fQfQfQ?wt7fQxu",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0HzMvNrvttyCfazg7UdiKfntn4z1jmWVgZ84kEkIJSJKj3R01",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/c0a19a62/ecd0/4eec/8f4b/065ee36acabe/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c0a19a62/ecd0/4eec/8f4b/065ee36acabe/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c0a19a62/ecd0/4eec/8f4b/065ee36acabe/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c0a19a62/ecd0/4eec/8f4b/065ee36acabe/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#48291B",
+          "blurHash": "UKK^s{8=xvNXQ%Mpxbx=a8nVsqa_.8t6aht8",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0J624umKP1QHh70Cvk1Vi11CwI6CFMfZucFpcJqyjWsrWk4KE",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/c2bbb5b7/c5ce/4a20/b629/eed1db23fb50/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c2bbb5b7/c5ce/4a20/b629/eed1db23fb50/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c2bbb5b7/c5ce/4a20/b629/eed1db23fb50/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c2bbb5b7/c5ce/4a20/b629/eed1db23fb50/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#883554",
+          "blurHash": "UDNZ^t0I0#aMOlrraiX9ZLRnyDxt-oWEs9WB",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0KDXfo1PIBXPeynraiPwGf70EaoDBo9hBPRzWXw58lY9hMP3u",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/2f203a7b/0566/417e/aa6e/263efceb5cc2/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2f203a7b/0566/417e/aa6e/263efceb5cc2/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2f203a7b/0566/417e/aa6e/263efceb5cc2/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2f203a7b/0566/417e/aa6e/263efceb5cc2/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#86663A",
+          "blurHash": "U9DJko^%VYEN3ED*r=%M0RyEIURP*0NGtRni",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0KE4zjb1t1dy42us8rgDzHl50kpgICJ28P3TDeEEITT3NiIVf",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/312474d7/aecf/4c96/8c8d/68eebe818ee0/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/312474d7/aecf/4c96/8c8d/68eebe818ee0/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/312474d7/aecf/4c96/8c8d/68eebe818ee0/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/312474d7/aecf/4c96/8c8d/68eebe818ee0/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#6C6B6B",
+          "blurHash": "UWO3|T?b?bxu~qD%D%of%MM{RjWBD$ofxuay",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr1600CqUw4EKGqjq3p7xtoSzRa5jMdbJ1sT97JfGv8K12GuSdN",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/d139ef67/585e/47f9/a91d/b474b7dbd477/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/d139ef67/585e/47f9/a91d/b474b7dbd477/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/d139ef67/585e/47f9/a91d/b474b7dbd477/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/d139ef67/585e/47f9/a91d/b474b7dbd477/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#6F482E",
+          "blurHash": "UXMj2J4;nir?~BTfNHxCWBo#bvW.kD$ys,WE",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr16DBpoKbZbSAc6NPMF777aoBLtxxWRmU80jX5AmO5rHgQAo6d",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/c8a587dd/0e0c/4f59/a1e4/8dadc21480cc/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c8a587dd/0e0c/4f59/a1e4/8dadc21480cc/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c8a587dd/0e0c/4f59/a1e4/8dadc21480cc/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c8a587dd/0e0c/4f59/a1e4/8dadc21480cc/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#692AAA",
+          "blurHash": "UXI:;Z0dNu%N}#DoWUtLJ3RjsAnhI|o{jvx0",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr17K4UJezLmb2RFvFyGAqBSSWsjbW99f9VgWjwSS3ecWQSo6Ta",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/400947bf/62f3/430b/a187/a19b0a8274b4/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/400947bf/62f3/430b/a187/a19b0a8274b4/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/400947bf/62f3/430b/a187/a19b0a8274b4/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/400947bf/62f3/430b/a187/a19b0a8274b4/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#904170",
+          "blurHash": "UUIW]OV%?Ht38=%7IpNEI[-Xx]xtyBwIWBIp",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr17KbT9KPM2IojoV9NhnYLNAlAxfPusezZXMMZBEXWGfGtzzAE",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/194f425d/5f6d/4bdb/9fcc/ea9cb6bfcfa0/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/194f425d/5f6d/4bdb/9fcc/ea9cb6bfcfa0/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/194f425d/5f6d/4bdb/9fcc/ea9cb6bfcfa0/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/194f425d/5f6d/4bdb/9fcc/ea9cb6bfcfa0/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#562766",
+          "blurHash": "UCNQAR0I5?nnO;rraLXSvdRpozs.,-WEt7V[",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr18FCNS16hC1BFIyfageu97YCeKObmJE57NskrGf75SXQ3PNyP",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/1b4047a5/20f3/48b2/8f3f/5e91d594288b/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1b4047a5/20f3/48b2/8f3f/5e91d594288b/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1b4047a5/20f3/48b2/8f3f/5e91d594288b/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1b4047a5/20f3/48b2/8f3f/5e91d594288b/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#565007",
+          "blurHash": "UyHU%XR?ayRj~UR=ayWAxtWYj[s.Rmk9j[of",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr1BY5VYjbxfcs3b2z2OczGTQ2aKlcK9nddbySfAX6SysMzR8QC",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/85f79ade/79d0/41f4/aa6e/665e11b5e2b2/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/85f79ade/79d0/41f4/aa6e/665e11b5e2b2/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/85f79ade/79d0/41f4/aa6e/665e11b5e2b2/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/85f79ade/79d0/41f4/aa6e/665e11b5e2b2/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#3E5586",
+          "blurHash": "UNEMqg_1M_NO~W?FRiR.t3s+adjsb}o#oJxw",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr1BYtnMcpGRp4TVrFtWMrN9AGw5AurJzKjqknGIHcyHeZmjVoI",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/b9f69863/4be2/462a/b316/df3272d60319/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b9f69863/4be2/462a/b316/df3272d60319/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b9f69863/4be2/462a/b316/df3272d60319/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b9f69863/4be2/462a/b316/df3272d60319/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#614D34",
+          "blurHash": "UKI4U%xZ~U9u}:NH?Gay5SNHaK-nE1WVRks.",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzHlApMH8dCWP",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/53c2b303/af21/422d/9b60/0e3189e43d70/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53c2b303/af21/422d/9b60/0e3189e43d70/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53c2b303/af21/422d/9b60/0e3189e43d70/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53c2b303/af21/422d/9b60/0e3189e43d70/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53c2b303/af21/422d/9b60/0e3189e43d70/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53c2b303/af21/422d/9b60/0e3189e43d70/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53c2b303/af21/422d/9b60/0e3189e43d70/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#5B411E",
+          "blurHash": "U6E2dm?E.5wI:Q~9RkV[9waLxZR+0NEN9b-.",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzHlC7uRRsGaW",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/ed97048a/821a/41e8/8e51/a51e6347adc9/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ed97048a/821a/41e8/8e51/a51e6347adc9/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ed97048a/821a/41e8/8e51/a51e6347adc9/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ed97048a/821a/41e8/8e51/a51e6347adc9/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ed97048a/821a/41e8/8e51/a51e6347adc9/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ed97048a/821a/41e8/8e51/a51e6347adc9/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ed97048a/821a/41e8/8e51/a51e6347adc9/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#454545",
+          "blurHash": "UBKK==00?b9F-;~qIURjD%WBay9F00M{%MD%",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzHqa0tvts1Fg",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/eb57ec8b/fcd5/4c75/9009/b90c2938bc3e/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/eb57ec8b/fcd5/4c75/9009/b90c2938bc3e/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/eb57ec8b/fcd5/4c75/9009/b90c2938bc3e/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/eb57ec8b/fcd5/4c75/9009/b90c2938bc3e/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/eb57ec8b/fcd5/4c75/9009/b90c2938bc3e/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/eb57ec8b/fcd5/4c75/9009/b90c2938bc3e/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/eb57ec8b/fcd5/4c75/9009/b90c2938bc3e/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7E4329",
+          "blurHash": "UBHdW.@Z01X9~B[U%0I@0$I@=ZJB9vK5Vsoz",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzHvl1FGtArb9",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/56d1d0ac/1ba4/417e/b36e/7deeb3edd4eb/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/56d1d0ac/1ba4/417e/b36e/7deeb3edd4eb/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/56d1d0ac/1ba4/417e/b36e/7deeb3edd4eb/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/56d1d0ac/1ba4/417e/b36e/7deeb3edd4eb/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/56d1d0ac/1ba4/417e/b36e/7deeb3edd4eb/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/56d1d0ac/1ba4/417e/b36e/7deeb3edd4eb/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/56d1d0ac/1ba4/417e/b36e/7deeb3edd4eb/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7A6458",
+          "blurHash": "UmKK+gMxIpxs~Tt6kAae%Ns,t7aes:W;oeWB",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzI6NlQNXvfH6",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/8a589490/68e9/4050/824b/da869dfbda02/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8a589490/68e9/4050/824b/da869dfbda02/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8a589490/68e9/4050/824b/da869dfbda02/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8a589490/68e9/4050/824b/da869dfbda02/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8a589490/68e9/4050/824b/da869dfbda02/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8a589490/68e9/4050/824b/da869dfbda02/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8a589490/68e9/4050/824b/da869dfbda02/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#73706B",
+          "blurHash": "UHM@ZPxuacof~pIVIUj[DiM{D*Rj00xu-;t7",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzIBj73pfCXuK",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/b1f18e67/fe73/4d56/881a/a9cdca1cfa88/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b1f18e67/fe73/4d56/881a/a9cdca1cfa88/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b1f18e67/fe73/4d56/881a/a9cdca1cfa88/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b1f18e67/fe73/4d56/881a/a9cdca1cfa88/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b1f18e67/fe73/4d56/881a/a9cdca1cfa88/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b1f18e67/fe73/4d56/881a/a9cdca1cfa88/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b1f18e67/fe73/4d56/881a/a9cdca1cfa88/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#972E32",
+          "blurHash": "U4FU{FR*0}JR-VWVr=J*2Zn%{zs:1bJRAX]n",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzIRjjbKwbezQ",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/75023806/bcb0/471f/80f2/6d3b62e0e435/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/75023806/bcb0/471f/80f2/6d3b62e0e435/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/75023806/bcb0/471f/80f2/6d3b62e0e435/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/75023806/bcb0/471f/80f2/6d3b62e0e435/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/75023806/bcb0/471f/80f2/6d3b62e0e435/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/75023806/bcb0/471f/80f2/6d3b62e0e435/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/75023806/bcb0/471f/80f2/6d3b62e0e435/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#6C442A",
+          "blurHash": "UCHx1o]~00PB0002t6?HBW-:}?$z019G-:%f",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzIRousRzcbG0",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/4e25c000/d1f1/416f/8e28/3cc7a527fa77/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4e25c000/d1f1/416f/8e28/3cc7a527fa77/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4e25c000/d1f1/416f/8e28/3cc7a527fa77/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4e25c000/d1f1/416f/8e28/3cc7a527fa77/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4e25c000/d1f1/416f/8e28/3cc7a527fa77/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4e25c000/d1f1/416f/8e28/3cc7a527fa77/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4e25c000/d1f1/416f/8e28/3cc7a527fa77/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7C5843",
+          "blurHash": "UKI|~}~A03u5RO9G0LM_9vNHt7s.S6xt-ooe",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzIX8uWQsa7XR",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/48e3071c/bef6/4cd0/a327/cf133178431f/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/48e3071c/bef6/4cd0/a327/cf133178431f/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/48e3071c/bef6/4cd0/a327/cf133178431f/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/48e3071c/bef6/4cd0/a327/cf133178431f/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/48e3071c/bef6/4cd0/a327/cf133178431f/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/48e3071c/bef6/4cd0/a327/cf133178431f/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/48e3071c/bef6/4cd0/a327/cf133178431f/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#5D4D0B",
+          "blurHash": "U8Exww_f00U1~0:lERBj0ftHsQIxTMFzwa,r",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzdpDiJhF8ddJ",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/7de39c5c/9e1f/4b51/a56f/e5eff4ad2178/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/7de39c5c/9e1f/4b51/a56f/e5eff4ad2178/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/7de39c5c/9e1f/4b51/a56f/e5eff4ad2178/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/7de39c5c/9e1f/4b51/a56f/e5eff4ad2178/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/7de39c5c/9e1f/4b51/a56f/e5eff4ad2178/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/7de39c5c/9e1f/4b51/a56f/e5eff4ad2178/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/7de39c5c/9e1f/4b51/a56f/e5eff4ad2178/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#8A2A58",
+          "blurHash": "UBFfwR2S1D]X1p[d|5AA=zEexHt7F?n+spxH",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9Dze56eQ56UBe7",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/113ce480/4bd3/4a1b/b169/a60c0fee21a4/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/113ce480/4bd3/4a1b/b169/a60c0fee21a4/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/113ce480/4bd3/4a1b/b169/a60c0fee21a4/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/113ce480/4bd3/4a1b/b169/a60c0fee21a4/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/113ce480/4bd3/4a1b/b169/a60c0fee21a4/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/113ce480/4bd3/4a1b/b169/a60c0fee21a4/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/113ce480/4bd3/4a1b/b169/a60c0fee21a4/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#243B43",
+          "blurHash": "UPKx6d01xZD*~V?aNGIVxt%Lt7RkxtWCRjt6",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzeATDcCskrvX",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/c08949f2/c7f8/4b63/934e/ce9dc8d31eb3/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c08949f2/c7f8/4b63/934e/ce9dc8d31eb3/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c08949f2/c7f8/4b63/934e/ce9dc8d31eb3/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c08949f2/c7f8/4b63/934e/ce9dc8d31eb3/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c08949f2/c7f8/4b63/934e/ce9dc8d31eb3/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c08949f2/c7f8/4b63/934e/ce9dc8d31eb3/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c08949f2/c7f8/4b63/934e/ce9dc8d31eb3/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#9D0000",
+          "blurHash": "U7Q#XKTcS{?G;7VtnPozZixZqDNu?uyCl8My",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzeL27Fn4jJ7z",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/88c75220/d98a/4aba/b841/eabb6a8fc7ee/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/88c75220/d98a/4aba/b841/eabb6a8fc7ee/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/88c75220/d98a/4aba/b841/eabb6a8fc7ee/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/88c75220/d98a/4aba/b841/eabb6a8fc7ee/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/88c75220/d98a/4aba/b841/eabb6a8fc7ee/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/88c75220/d98a/4aba/b841/eabb6a8fc7ee/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/88c75220/d98a/4aba/b841/eabb6a8fc7ee/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#5B403C",
+          "blurHash": "UIMjXK%GE0-=.7a$t7oz_LMzxaITMybbt8NG",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzeL3PBqL4wkv",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/c88d62f1/1919/4a6c/97e5/7395baa947f9/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c88d62f1/1919/4a6c/97e5/7395baa947f9/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c88d62f1/1919/4a6c/97e5/7395baa947f9/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c88d62f1/1919/4a6c/97e5/7395baa947f9/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c88d62f1/1919/4a6c/97e5/7395baa947f9/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c88d62f1/1919/4a6c/97e5/7395baa947f9/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c88d62f1/1919/4a6c/97e5/7395baa947f9/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#A94777",
+          "blurHash": "UcL^9X-CozV@|}=zNZoMjGV@s;n%EKNZRjxH",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E009Fz1H6zEWe",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/e3a1581b/cb95/40f8/a87e/57fac3ca36c1/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e3a1581b/cb95/40f8/a87e/57fac3ca36c1/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e3a1581b/cb95/40f8/a87e/57fac3ca36c1/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e3a1581b/cb95/40f8/a87e/57fac3ca36c1/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e3a1581b/cb95/40f8/a87e/57fac3ca36c1/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e3a1581b/cb95/40f8/a87e/57fac3ca36c1/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e3a1581b/cb95/40f8/a87e/57fac3ca36c1/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#480E05",
+          "blurHash": "UkQldq-:*0D,Szt6sANHyYRSQ-xo-VNGN[xZ",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0LryB5i8xP3m",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/750ee7b5/87e4/4821/a8e9/1c50419e1860/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/750ee7b5/87e4/4821/a8e9/1c50419e1860/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/750ee7b5/87e4/4821/a8e9/1c50419e1860/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/750ee7b5/87e4/4821/a8e9/1c50419e1860/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/750ee7b5/87e4/4821/a8e9/1c50419e1860/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/750ee7b5/87e4/4821/a8e9/1c50419e1860/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/750ee7b5/87e4/4821/a8e9/1c50419e1860/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#8A6E37",
+          "blurHash": "UGLDi8?^0rRPtR%1M{XS1nMx^aaK-:RQRkt7",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0M2YL6dY7HrJ",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/6951d0b6/2fd8/4c5a/aa49/6a12173e3fc2/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6951d0b6/2fd8/4c5a/aa49/6a12173e3fc2/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6951d0b6/2fd8/4c5a/aa49/6a12173e3fc2/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6951d0b6/2fd8/4c5a/aa49/6a12173e3fc2/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6951d0b6/2fd8/4c5a/aa49/6a12173e3fc2/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6951d0b6/2fd8/4c5a/aa49/6a12173e3fc2/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6951d0b6/2fd8/4c5a/aa49/6a12173e3fc2/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#663B87",
+          "blurHash": "U7Ln%J0[Q=N#0bnPo|RjnBkCo[k9f:f8ofj?",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0MT5JcmnWV2e",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/0a1aafb1/0b26/4155/9ed8/cd740d1b49e2/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0a1aafb1/0b26/4155/9ed8/cd740d1b49e2/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0a1aafb1/0b26/4155/9ed8/cd740d1b49e2/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0a1aafb1/0b26/4155/9ed8/cd740d1b49e2/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0a1aafb1/0b26/4155/9ed8/cd740d1b49e2/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0a1aafb1/0b26/4155/9ed8/cd740d1b49e2/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0a1aafb1/0b26/4155/9ed8/cd740d1b49e2/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#522610",
+          "blurHash": "U39ixP0$57=^?uENiv=v}s9^NGxFt1EOoM$$",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0hlCiWuKHA5X",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/e10a9480/f154/4917/b949/4e83bfac17b0/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e10a9480/f154/4917/b949/4e83bfac17b0/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e10a9480/f154/4917/b949/4e83bfac17b0/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e10a9480/f154/4917/b949/4e83bfac17b0/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e10a9480/f154/4917/b949/4e83bfac17b0/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e10a9480/f154/4917/b949/4e83bfac17b0/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e10a9480/f154/4917/b949/4e83bfac17b0/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#437E82",
+          "blurHash": "UwHzIoWCofWB~BofWVof={WBj?a#s.oya#j[",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0hlGZzoy0wnl",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/881131df/4c5b/4888/bd1e/245082bf7205/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/881131df/4c5b/4888/bd1e/245082bf7205/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/881131df/4c5b/4888/bd1e/245082bf7205/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/881131df/4c5b/4888/bd1e/245082bf7205/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/881131df/4c5b/4888/bd1e/245082bf7205/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/881131df/4c5b/4888/bd1e/245082bf7205/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/881131df/4c5b/4888/bd1e/245082bf7205/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#62625E",
+          "blurHash": "UCQJWD%M_2t7xua|R*WV~pj[9Fj[WBWBt6WB",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0hlGawCJFqdw",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/e9a9ed62/740f/497f/8d04/79cc21da1741/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9a9ed62/740f/497f/8d04/79cc21da1741/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9a9ed62/740f/497f/8d04/79cc21da1741/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9a9ed62/740f/497f/8d04/79cc21da1741/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9a9ed62/740f/497f/8d04/79cc21da1741/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9a9ed62/740f/497f/8d04/79cc21da1741/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9a9ed62/740f/497f/8d04/79cc21da1741/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7E3920",
+          "blurHash": "ULLL:rSN0On$3Gs.-QoJ04WUTHoe#ie:n6Nd",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0hqY2Hc3EZIH",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/53e1660c/684b/40e7/9872/a6ad324a05bd/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53e1660c/684b/40e7/9872/a6ad324a05bd/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53e1660c/684b/40e7/9872/a6ad324a05bd/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53e1660c/684b/40e7/9872/a6ad324a05bd/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53e1660c/684b/40e7/9872/a6ad324a05bd/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53e1660c/684b/40e7/9872/a6ad324a05bd/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/53e1660c/684b/40e7/9872/a6ad324a05bd/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#767672",
+          "blurHash": "UFP%Igj?_2of%Mj[RkWB~pWB9FofM{Rjxuxa",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "9Uwk47MKGpAYj1G",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/b4579672/5b91/4679/a27a/288f097a4da5/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b4579672/5b91/4679/a27a/288f097a4da5/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b4579672/5b91/4679/a27a/288f097a4da5/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b4579672/5b91/4679/a27a/288f097a4da5/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#120A12",
+          "blurHash": "U8D%#Rs90cs;nbWXa#a|0cWn}KR%szxHR*WU",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmX9grPBhCsdoAWJ4rb",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/9c837938/f8cb/4dde/b9ec/0fffd1d168a7/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9c837938/f8cb/4dde/b9ec/0fffd1d168a7/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9c837938/f8cb/4dde/b9ec/0fffd1d168a7/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9c837938/f8cb/4dde/b9ec/0fffd1d168a7/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9c837938/f8cb/4dde/b9ec/0fffd1d168a7/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9c837938/f8cb/4dde/b9ec/0fffd1d168a7/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9c837938/f8cb/4dde/b9ec/0fffd1d168a7/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#6B3222",
+          "blurHash": "UQS6J0jY~pt7IURk%2s:ofWBRjofogWVWVfP",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGPCjGX8qoy",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/05d72ae4/319f/4237/821f/1d7af9ec8acf/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/05d72ae4/319f/4237/821f/1d7af9ec8acf/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/05d72ae4/319f/4237/821f/1d7af9ec8acf/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/05d72ae4/319f/4237/821f/1d7af9ec8acf/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7B5B4B",
+          "blurHash": "UBB3g0004.~q$$t7I=WA4m-;x]8_tRRiRj%M",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQRq2ganRe",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/c4728578/cab5/4a49/bdf7/2ad13969e13b/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c4728578/cab5/4a49/bdf7/2ad13969e13b/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c4728578/cab5/4a49/bdf7/2ad13969e13b/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c4728578/cab5/4a49/bdf7/2ad13969e13b/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#33757B",
+          "blurHash": "USEqEkvzPVo~uPW=v~$*M{kCwci_%MWBMxxZ",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQS9r2Hufh",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/4b92c829/c654/4a4d/a00c/0e17b1be4ffa/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4b92c829/c654/4a4d/a00c/0e17b1be4ffa/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4b92c829/c654/4a4d/a00c/0e17b1be4ffa/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4b92c829/c654/4a4d/a00c/0e17b1be4ffa/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#675242",
+          "blurHash": "UBLhMSE1h2t6_4M_-;Mx5Ut700j?%MoLV[oz",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQSme3YdUm",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/b5fc9952/f318/48ee/94f7/1d1f390f2871/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b5fc9952/f318/48ee/94f7/1d1f390f2871/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b5fc9952/f318/48ee/94f7/1d1f390f2871/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b5fc9952/f318/48ee/94f7/1d1f390f2871/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#70503C",
+          "blurHash": "U36aL]E10fxu~BM|EM%20gs:-Us.9axa$*Io",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQUKkh58Hl",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/6d2c23b3/a122/4439/acfd/8245fe6c05cd/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6d2c23b3/a122/4439/acfd/8245fe6c05cd/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6d2c23b3/a122/4439/acfd/8245fe6c05cd/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6d2c23b3/a122/4439/acfd/8245fe6c05cd/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#243554",
+          "blurHash": "UFCj3FVqKR00F~I9?wRO9GITxG_3D%%MITW;",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQUKpQ1ASE",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/646a8136/ab17/4b8f/a836/781dc0c09753/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/646a8136/ab17/4b8f/a836/781dc0c09753/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/646a8136/ab17/4b8f/a836/781dc0c09753/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/646a8136/ab17/4b8f/a836/781dc0c09753/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#735938",
+          "blurHash": "UKO{s.8w~q-nD$ogt7tR?ItRD$oLV?xaofM{",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQUKu6ggYz",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/25a587ee/eda3/4523/bec9/eee6ec319d73/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/25a587ee/eda3/4523/bec9/eee6ec319d73/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/25a587ee/eda3/4523/bec9/eee6ec319d73/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/25a587ee/eda3/4523/bec9/eee6ec319d73/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#3E3C6E",
+          "blurHash": "Uj8E1SWaR=jXtWWFfns+R;axoHoHWGofj;WC",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQUKymCz4b",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/e16b24bc/557e/442b/8ba0/63326f7b9231/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e16b24bc/557e/442b/8ba0/63326f7b9231/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e16b24bc/557e/442b/8ba0/63326f7b9231/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e16b24bc/557e/442b/8ba0/63326f7b9231/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#6F6F6F",
+          "blurHash": "UaK-qP_3~qay_3?bWBD%RjxuWBM{t7WBIUxu",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQUeGI7opl",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/1dabcbd7/173e/46f2/91af/bd478eeae36a/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1dabcbd7/173e/46f2/91af/bd478eeae36a/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1dabcbd7/173e/46f2/91af/bd478eeae36a/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1dabcbd7/173e/46f2/91af/bd478eeae36a/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#4A4319",
+          "blurHash": "U+Jt-cRPx@Rk~qoIt7WBtTt7NHt6ozWsRjof",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGVbrj8uzI6",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/6f4a1201/b1e5/451d/9f78/538a1ab92b05/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6f4a1201/b1e5/451d/9f78/538a1ab92b05/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6f4a1201/b1e5/451d/9f78/538a1ab92b05/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6f4a1201/b1e5/451d/9f78/538a1ab92b05/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7B5F3F",
+          "blurHash": "UFEy0i~UENE201bJs-aKou9FRjt74o%1xtbw",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGVd7NprytA",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/bee09376/f217/46ba/b1e2/4b99405d0d13/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/bee09376/f217/46ba/b1e2/4b99405d0d13/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/bee09376/f217/46ba/b1e2/4b99405d0d13/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/bee09376/f217/46ba/b1e2/4b99405d0d13/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#6E3A3A",
+          "blurHash": "UKIW}]^+=z~pu3%29u-;E4IpM{xab1xaxFj]",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGWu6J2WSAP",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/fdeb1322/5cd9/40d0/89d3/f01f3ed003f0/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/fdeb1322/5cd9/40d0/89d3/f01f3ed003f0/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/fdeb1322/5cd9/40d0/89d3/f01f3ed003f0/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/fdeb1322/5cd9/40d0/89d3/f01f3ed003f0/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#004C73",
+          "blurHash": "UPL5RWyX0%-;ITE2~WR+KQo}t8RjcZwHIUaJ",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "dDmYD0OBhSklbbny",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/c83fee69/46cf/41da/acd5/49e397b6a43e/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c83fee69/46cf/41da/acd5/49e397b6a43e/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c83fee69/46cf/41da/acd5/49e397b6a43e/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c83fee69/46cf/41da/acd5/49e397b6a43e/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#6B6B6B",
+          "blurHash": "UZMtaOD%~q-;D%xu-;RjWBofM{RjofRjofof",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IP12D92rfpiy",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/ee440a34/bbce/4bbf/ade6/ff2431627cf0/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee440a34/bbce/4bbf/ade6/ff2431627cf0/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee440a34/bbce/4bbf/ade6/ff2431627cf0/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee440a34/bbce/4bbf/ade6/ff2431627cf0/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee440a34/bbce/4bbf/ade6/ff2431627cf0/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee440a34/bbce/4bbf/ade6/ff2431627cf0/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee440a34/bbce/4bbf/ade6/ff2431627cf0/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#040407",
+          "blurHash": "UnKKl_xYjYRj~pRjofofNHRkt7oLV@t6WARj",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IP13V4e80gy8",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/892e28ff/cac7/4e4a/8887/4bcd07bcf8ff/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/892e28ff/cac7/4e4a/8887/4bcd07bcf8ff/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/892e28ff/cac7/4e4a/8887/4bcd07bcf8ff/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/892e28ff/cac7/4e4a/8887/4bcd07bcf8ff/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/892e28ff/cac7/4e4a/8887/4bcd07bcf8ff/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/892e28ff/cac7/4e4a/8887/4bcd07bcf8ff/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/892e28ff/cac7/4e4a/8887/4bcd07bcf8ff/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#8D7037",
+          "blurHash": "U6HARdQ=~S021k$kXRwH02THVZ~Tve$x9wx]",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPMMti8ralux",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a5cea54/6b22/401c/a186/6796bb96fa67/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#775434",
+          "blurHash": "ULM7cP9G_29E?wxv%L%1~ojXD+NK_1ocE3xv",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPX2DkbBYAT3",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/ee2c3f74/e0f3/4dad/aec0/501d956b7878/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee2c3f74/e0f3/4dad/aec0/501d956b7878/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee2c3f74/e0f3/4dad/aec0/501d956b7878/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee2c3f74/e0f3/4dad/aec0/501d956b7878/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee2c3f74/e0f3/4dad/aec0/501d956b7878/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee2c3f74/e0f3/4dad/aec0/501d956b7878/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ee2c3f74/e0f3/4dad/aec0/501d956b7878/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7B7233",
+          "blurHash": "U9B|T^Ma00wZvypJNERn00o#~oWu9XMx-?xn",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPcMGCnSPgZx",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/9e66cdbf/1a92/423b/990f/a92107b702a0/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9e66cdbf/1a92/423b/990f/a92107b702a0/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9e66cdbf/1a92/423b/990f/a92107b702a0/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9e66cdbf/1a92/423b/990f/a92107b702a0/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9e66cdbf/1a92/423b/990f/a92107b702a0/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9e66cdbf/1a92/423b/990f/a92107b702a0/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9e66cdbf/1a92/423b/990f/a92107b702a0/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#4E4141",
+          "blurHash": "U15EvyE100~Wx_E1wa^,-pInIp-=~qV@4UtS",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPhcQZI4DfoU",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/f8ee5969/14a7/4e9f/be35/7438ff44eddf/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f8ee5969/14a7/4e9f/be35/7438ff44eddf/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f8ee5969/14a7/4e9f/be35/7438ff44eddf/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f8ee5969/14a7/4e9f/be35/7438ff44eddf/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f8ee5969/14a7/4e9f/be35/7438ff44eddf/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f8ee5969/14a7/4e9f/be35/7438ff44eddf/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f8ee5969/14a7/4e9f/be35/7438ff44eddf/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#8454B0",
+          "blurHash": "UYHvjdxct7V@-H%4R#kCWGRjs;jcIoR$Rks=",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "0fa30617-662a-42fc-ad16-fb699f3636b7",
+      "type": "playlists",
+      "attributes": {
+        "name": "2010s Love Songs",
+        "description": "From the decade that brought us UGGs, Athleisure and the Cinnamon Challenge, these are the love songs of the 2010s. (Cover: A Star Is Born Soundtrack, UMG)",
+        "bounded": true,
+        "duration": "PT3H19M16S",
+        "numberOfItems": 50,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/0fa30617-662a-42fc-ad16-fb699f3636b7",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/0fa30617-662a-42fc-ad16-fb699f3636b7?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/0fa30617-662a-42fc-ad16-fb699f3636b7?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/0fa30617-662a-42fc-ad16-fb699f3636b7?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2020-01-29T16:45:16.508Z",
+        "lastModifiedAt": "2024-02-13T13:11:15.343Z",
+        "accessType": "PUBLIC",
+        "playlistType": "EDITORIAL",
+        "numberOfFollowers": 12317
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0DkdgDt9Nh8a3Qeyuj5hO0fOXJcEllT695d8wkSf4UgDTNIOd",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/0fa30617-662a-42fc-ad16-fb699f3636b7/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "11f23764-7e5d-4a86-af62-ff7fd202c113",
+      "type": "playlists",
+      "attributes": {
+        "name": "lukas graham",
+        "description": "",
+        "bounded": true,
+        "duration": "PT1H49M33S",
+        "numberOfItems": 31,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/11f23764-7e5d-4a86-af62-ff7fd202c113",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/11f23764-7e5d-4a86-af62-ff7fd202c113?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/11f23764-7e5d-4a86-af62-ff7fd202c113?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/11f23764-7e5d-4a86-af62-ff7fd202c113?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2015-07-03T18:52:53.428Z",
+        "lastModifiedAt": "2024-03-11T17:19:21.183Z",
+        "accessType": "PUBLIC",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0EdIfkH9RiZ5pk1eNqr95Disbybwr061Jk1Jwpt3EtdbSRlGF",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/11f23764-7e5d-4a86-af62-ff7fd202c113/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "14c63d93-6f57-4540-9f95-a3bee7a8f66b",
+      "type": "playlists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "description": "",
+        "bounded": true,
+        "duration": "PT33M9S",
+        "numberOfItems": 11,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/14c63d93-6f57-4540-9f95-a3bee7a8f66b",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/14c63d93-6f57-4540-9f95-a3bee7a8f66b?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/14c63d93-6f57-4540-9f95-a3bee7a8f66b?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/14c63d93-6f57-4540-9f95-a3bee7a8f66b?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2023-01-25T15:24:15.725Z",
+        "lastModifiedAt": "2023-01-29T17:21:31.148Z",
+        "accessType": "PUBLIC",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0Ee6YZC8daBfBUEXWfJAQazLz1NFIYDoPmrMk5AVoSTSZC23G",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/14c63d93-6f57-4540-9f95-a3bee7a8f66b/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "1b5bf92a-6edb-4839-a56c-0877643c4aba",
+      "type": "playlists",
+      "attributes": {
+        "name": "'10s: Dolby Atmos",
+        "description": "Experience the 2010s in Dolby Atmos. (Cover: Selena Gomez / Photo: Rovi)    ",
+        "bounded": true,
+        "duration": "PT12H37M45S",
+        "numberOfItems": 205,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/1b5bf92a-6edb-4839-a56c-0877643c4aba",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/1b5bf92a-6edb-4839-a56c-0877643c4aba?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/1b5bf92a-6edb-4839-a56c-0877643c4aba?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/1b5bf92a-6edb-4839-a56c-0877643c4aba?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2022-06-15T14:58:07.777Z",
+        "lastModifiedAt": "2026-05-19T16:23:58.243Z",
+        "accessType": "PUBLIC",
+        "playlistType": "EDITORIAL",
+        "numberOfFollowers": 4486
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0EqRRYV7mEj6hfOelobv9wEirRvDOOAY4rusERge4OCTSQZhR",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/1b5bf92a-6edb-4839-a56c-0877643c4aba/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "238482f9-60ff-44a3-b1ea-369eeddbebf6",
+      "type": "playlists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "description": "",
+        "bounded": true,
+        "duration": "PT50M37S",
+        "numberOfItems": 15,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/238482f9-60ff-44a3-b1ea-369eeddbebf6",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/238482f9-60ff-44a3-b1ea-369eeddbebf6?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/238482f9-60ff-44a3-b1ea-369eeddbebf6?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/238482f9-60ff-44a3-b1ea-369eeddbebf6?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2022-11-12T11:07:30.801Z",
+        "lastModifiedAt": "2025-01-05T17:31:11.036Z",
+        "accessType": "PUBLIC",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0FkiS3GPnAhZG22b52hgWd7jE7J4v6YRVvA17FKxfgN6lFTYE",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/238482f9-60ff-44a3-b1ea-369eeddbebf6/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "34dbff57-88b8-4fb5-b09a-e4a79c107ffb",
+      "type": "playlists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "description": "All Lukas Graham songs, that I listen to",
+        "bounded": true,
+        "duration": "PT1H34M2S",
+        "numberOfItems": 28,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/34dbff57-88b8-4fb5-b09a-e4a79c107ffb",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/34dbff57-88b8-4fb5-b09a-e4a79c107ffb?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/34dbff57-88b8-4fb5-b09a-e4a79c107ffb?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/34dbff57-88b8-4fb5-b09a-e4a79c107ffb?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2023-07-09T20:39:18.174Z",
+        "lastModifiedAt": "2023-07-09T20:43:24.501Z",
+        "accessType": "PUBLIC",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0GrxPwmDWDgc9iqaxziywfYvPeSP4URjjjvHXgre3Emn9KiG2",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/34dbff57-88b8-4fb5-b09a-e4a79c107ffb/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "3a10b48f-abd8-4577-ad25-0e6c44eebd11",
+      "type": "playlists",
+      "attributes": {
+        "name": "Lukas Graham ",
+        "description": "",
+        "bounded": true,
+        "duration": "PT1H13M5S",
+        "numberOfItems": 22,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/3a10b48f-abd8-4577-ad25-0e6c44eebd11",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/3a10b48f-abd8-4577-ad25-0e6c44eebd11?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/3a10b48f-abd8-4577-ad25-0e6c44eebd11?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/3a10b48f-abd8-4577-ad25-0e6c44eebd11?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2016-04-11T18:53:28.613Z",
+        "lastModifiedAt": "2023-02-28T15:06:29.465Z",
+        "accessType": "PUBLIC",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0H41GGuAoI3BQpBMKR1RYtViNG2heSkjqxkKsMAxohAoLhvu5",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/3a10b48f-abd8-4577-ad25-0e6c44eebd11/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "3a98bd93-3b70-47ab-adfa-6735802bcc75",
+      "type": "playlists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "description": "",
+        "bounded": true,
+        "duration": "PT2H6M52S",
+        "numberOfItems": 35,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/3a98bd93-3b70-47ab-adfa-6735802bcc75",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/3a98bd93-3b70-47ab-adfa-6735802bcc75?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/3a98bd93-3b70-47ab-adfa-6735802bcc75?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/3a98bd93-3b70-47ab-adfa-6735802bcc75?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2022-10-18T14:44:57.678Z",
+        "lastModifiedAt": "2022-11-15T14:33:24.578Z",
+        "accessType": "PUBLIC",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0H41mjyh7247PiVHHmrTX99QzX175TpfxhRxaU0sRhSjXUtkr",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/3a98bd93-3b70-47ab-adfa-6735802bcc75/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "46288e2b-ad6d-4387-a9b7-c9557418c2de",
+      "type": "playlists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "description": "Greatest  hits",
+        "bounded": true,
+        "duration": "PT1H4M42S",
+        "numberOfItems": 19,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/46288e2b-ad6d-4387-a9b7-c9557418c2de",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/46288e2b-ad6d-4387-a9b7-c9557418c2de?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/46288e2b-ad6d-4387-a9b7-c9557418c2de?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/46288e2b-ad6d-4387-a9b7-c9557418c2de?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2022-08-15T15:22:24.664Z",
+        "lastModifiedAt": "2023-09-18T15:32:48.782Z",
+        "accessType": "PUBLIC",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0HzMvNrvttyCfazg7UdiKfntn4z1jmWVgZ84kEkIJSJKj3R01",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/46288e2b-ad6d-4387-a9b7-c9557418c2de/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "55905c86-7fb0-49ae-a574-43d14c61053f",
+      "type": "playlists",
+      "attributes": {
+        "name": "Størst er kærligheden",
+        "description": "På Valentinsdag skal kærligheden fejres lidt ekstra, uanset om man er nyforelsket eller har levet sammen i mange år. Vi kan ikke hjælpe til med blomster eller chokoladeæske, men vi kan definitivt give dig musikken til en romantisk stund med din udkårne. Her findes sange om kærlighedens mange sider, fra Lukas Grahams \"Love Someone\" om kærlighedens helende kraft over Marvin Gayes opfordring i den stilfuldt sexede ”Let’s Get It On” til Sades indfølte hymne til sammenhold.",
+        "bounded": true,
+        "duration": "PT3H55M56S",
+        "numberOfItems": 62,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/55905c86-7fb0-49ae-a574-43d14c61053f",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/55905c86-7fb0-49ae-a574-43d14c61053f?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/55905c86-7fb0-49ae-a574-43d14c61053f?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/55905c86-7fb0-49ae-a574-43d14c61053f?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2012-02-14T11:30:56.516Z",
+        "lastModifiedAt": "2023-01-23T09:12:18.139Z",
+        "accessType": "PUBLIC",
+        "playlistType": "EDITORIAL",
+        "numberOfFollowers": 698
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0J624umKP1QHh70Cvk1Vi11CwI6CFMfZucFpcJqyjWsrWk4KE",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/55905c86-7fb0-49ae-a574-43d14c61053f/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "67dc80a4-563f-4046-abd7-99945a6ae866",
+      "type": "playlists",
+      "attributes": {
+        "name": "Lukas Graham Essentials",
+        "description": "Lukas Graham tog først Danmark med storm og siden hele verden. Her får du nogle af gruppens bedste numre. Fra de tidlige funkhits til deres, store internationale pophits.\nCover: Lukas Graham / Photo: Press",
+        "bounded": true,
+        "duration": "PT1H7M37S",
+        "numberOfItems": 20,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/67dc80a4-563f-4046-abd7-99945a6ae866",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/67dc80a4-563f-4046-abd7-99945a6ae866?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/67dc80a4-563f-4046-abd7-99945a6ae866?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/67dc80a4-563f-4046-abd7-99945a6ae866?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2019-10-01T12:05:04.356Z",
+        "lastModifiedAt": "2020-12-17T09:08:44.828Z",
+        "accessType": "PUBLIC",
+        "playlistType": "EDITORIAL",
+        "numberOfFollowers": 645
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0KDXfo1PIBXPeynraiPwGf70EaoDBo9hBPRzWXw58lY9hMP3u",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/67dc80a4-563f-4046-abd7-99945a6ae866/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "69cf3625-b4c9-4f39-8076-fa7d3cd7784c",
+      "type": "playlists",
+      "attributes": {
+        "name": "2015! Songs of the Year",
+        "description": "Listen to 2015's biggest hits, finest moments and most treasured songs.(Cover: Kendrick Lamar - To Pimp a Butterfly, UMG)",
+        "bounded": true,
+        "duration": "PT6H57M7S",
+        "numberOfItems": 100,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/69cf3625-b4c9-4f39-8076-fa7d3cd7784c",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/69cf3625-b4c9-4f39-8076-fa7d3cd7784c?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/69cf3625-b4c9-4f39-8076-fa7d3cd7784c?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/69cf3625-b4c9-4f39-8076-fa7d3cd7784c?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2022-01-17T23:04:36.037Z",
+        "lastModifiedAt": "2025-01-06T14:43:38.071Z",
+        "accessType": "PUBLIC",
+        "playlistType": "EDITORIAL",
+        "numberOfFollowers": 3699
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0KE4zjb1t1dy42us8rgDzHl50kpgICJ28P3TDeEEITT3NiIVf",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/69cf3625-b4c9-4f39-8076-fa7d3cd7784c/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "a2fd217b-3992-44a4-afc7-0a49360104a9",
+      "type": "playlists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "description": "",
+        "bounded": true,
+        "duration": "PT45M28S",
+        "numberOfItems": 14,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/a2fd217b-3992-44a4-afc7-0a49360104a9",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/a2fd217b-3992-44a4-afc7-0a49360104a9?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/a2fd217b-3992-44a4-afc7-0a49360104a9?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/a2fd217b-3992-44a4-afc7-0a49360104a9?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2022-08-11T17:03:12.856Z",
+        "lastModifiedAt": "2023-07-03T08:50:38.545Z",
+        "accessType": "PUBLIC",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr1600CqUw4EKGqjq3p7xtoSzRa5jMdbJ1sT97JfGv8K12GuSdN",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/a2fd217b-3992-44a4-afc7-0a49360104a9/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "acaf9642-4257-4857-950a-fbe2187e1fa3",
+      "type": "playlists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "description": "",
+        "bounded": true,
+        "duration": "PT2H50M4S",
+        "numberOfItems": 51,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/acaf9642-4257-4857-950a-fbe2187e1fa3",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/acaf9642-4257-4857-950a-fbe2187e1fa3?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/acaf9642-4257-4857-950a-fbe2187e1fa3?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/acaf9642-4257-4857-950a-fbe2187e1fa3?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2022-02-18T21:42:26.492Z",
+        "lastModifiedAt": "2024-05-12T12:18:19.074Z",
+        "accessType": "PUBLIC",
+        "playlistType": "USER",
+        "numberOfFollowers": 2
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr16DBpoKbZbSAc6NPMF777aoBLtxxWRmU80jX5AmO5rHgQAo6d",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/acaf9642-4257-4857-950a-fbe2187e1fa3/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "bc7e69ca-4609-4bc1-8c73-1396a1fc12c2",
+      "type": "playlists",
+      "attributes": {
+        "name": "lukas graham",
+        "description": "",
+        "bounded": true,
+        "duration": "PT3H44M15S",
+        "numberOfItems": 67,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/bc7e69ca-4609-4bc1-8c73-1396a1fc12c2",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/bc7e69ca-4609-4bc1-8c73-1396a1fc12c2?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/bc7e69ca-4609-4bc1-8c73-1396a1fc12c2?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/bc7e69ca-4609-4bc1-8c73-1396a1fc12c2?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2022-05-24T05:36:16.016Z",
+        "lastModifiedAt": "2022-11-08T16:49:18.860Z",
+        "accessType": "PUBLIC",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr17K4UJezLmb2RFvFyGAqBSSWsjbW99f9VgWjwSS3ecWQSo6Ta",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/bc7e69ca-4609-4bc1-8c73-1396a1fc12c2/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "be10e8d9-cb8c-451d-9232-154676bb2456",
+      "type": "playlists",
+      "attributes": {
+        "name": "Valentinstag ",
+        "description": "Schmachtet, neckt euch, küsst und liebt euch! Was gibt es Schöneres als die Liebe? Wir können euch zwar nicht mit Blumen oder Pralinen versorgen, dafür aber mit einer wunderschönen Playlist für das perfekte Candlelight-Dinner mit euren Liebsten. (Foto: Unsplash)",
+        "bounded": true,
+        "duration": "PT4H12M10S",
+        "numberOfItems": 69,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/be10e8d9-cb8c-451d-9232-154676bb2456",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/be10e8d9-cb8c-451d-9232-154676bb2456?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/be10e8d9-cb8c-451d-9232-154676bb2456?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/be10e8d9-cb8c-451d-9232-154676bb2456?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2013-01-13T18:40:55.952Z",
+        "lastModifiedAt": "2025-11-11T13:16:15.799Z",
+        "accessType": "UNLISTED",
+        "playlistType": "EDITORIAL",
+        "numberOfFollowers": 21
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr17KbT9KPM2IojoV9NhnYLNAlAxfPusezZXMMZBEXWGfGtzzAE",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/be10e8d9-cb8c-451d-9232-154676bb2456/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "c7e1ac7f-7689-4d99-8a3a-392f6c2a984e",
+      "type": "playlists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "description": "",
+        "bounded": true,
+        "duration": "PT3H22M7S",
+        "numberOfItems": 58,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/c7e1ac7f-7689-4d99-8a3a-392f6c2a984e",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/c7e1ac7f-7689-4d99-8a3a-392f6c2a984e?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/c7e1ac7f-7689-4d99-8a3a-392f6c2a984e?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/c7e1ac7f-7689-4d99-8a3a-392f6c2a984e?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2022-01-12T14:22:17.694Z",
+        "lastModifiedAt": "2023-01-03T10:36:02.016Z",
+        "accessType": "PUBLIC",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr18FCNS16hC1BFIyfageu97YCeKObmJE57NskrGf75SXQ3PNyP",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/c7e1ac7f-7689-4d99-8a3a-392f6c2a984e/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "dc417540-3605-47a3-a054-600119de0c69",
+      "type": "playlists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "description": "",
+        "bounded": true,
+        "duration": "PT1H42M58S",
+        "numberOfItems": 29,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/dc417540-3605-47a3-a054-600119de0c69",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/dc417540-3605-47a3-a054-600119de0c69?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/dc417540-3605-47a3-a054-600119de0c69?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/dc417540-3605-47a3-a054-600119de0c69?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2016-03-10T09:59:48.083Z",
+        "lastModifiedAt": "2023-05-12T09:20:38.693Z",
+        "accessType": "PUBLIC",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr19Xv40R3ukkyQj44pGLLmeqtDDsqIPWuvKmIIriuh2e9huB57",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/dc417540-3605-47a3-a054-600119de0c69/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "f0b21ffe-88af-41c4-bba1-0f1524a315c0",
+      "type": "playlists",
+      "attributes": {
+        "name": "Lukas Graham",
+        "description": "",
+        "bounded": true,
+        "duration": "PT48M59S",
+        "numberOfItems": 14,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/f0b21ffe-88af-41c4-bba1-0f1524a315c0",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/f0b21ffe-88af-41c4-bba1-0f1524a315c0?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/f0b21ffe-88af-41c4-bba1-0f1524a315c0?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/f0b21ffe-88af-41c4-bba1-0f1524a315c0?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2022-08-07T14:36:10.469Z",
+        "lastModifiedAt": "2023-02-25T21:00:34.189Z",
+        "accessType": "PUBLIC",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr1BY5VYjbxfcs3b2z2OczGTQ2aKlcK9nddbySfAX6SysMzR8QC",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/f0b21ffe-88af-41c4-bba1-0f1524a315c0/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "f3ed269b-b53d-4515-8c83-e2c4e697d93b",
+      "type": "playlists",
+      "attributes": {
+        "name": "Tobias Rahim Essentials",
+        "description": "Tobias Rahim kan skrue et hit sammen. Og han har sin helt egen måde at gøre det på, hvor Rahim finder ind til en helt særlig vibe, der både rummer poesi, politisk bevidsthed, attitude og sårbarhed. Og så kan han også lave musik til dansegulvet og en solskinsdag. Her får du nogle af hans bedste numre.\nFoto: Presse",
+        "bounded": true,
+        "duration": "PT1H4M38S",
+        "numberOfItems": 20,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/f3ed269b-b53d-4515-8c83-e2c4e697d93b",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/f3ed269b-b53d-4515-8c83-e2c4e697d93b?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/f3ed269b-b53d-4515-8c83-e2c4e697d93b?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/f3ed269b-b53d-4515-8c83-e2c4e697d93b?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2020-07-21T08:57:33.483Z",
+        "lastModifiedAt": "2023-10-09T08:21:45.086Z",
+        "accessType": "PUBLIC",
+        "playlistType": "EDITORIAL",
+        "numberOfFollowers": 326
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr1BYtnMcpGRp4TVrFtWMrN9AGw5AurJzKjqknGIHcyHeZmjVoI",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/f3ed269b-b53d-4515-8c83-e2c4e697d93b/relationships/coverArt?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "104340964",
+      "type": "tracks",
+      "attributes": {
+        "title": "Drunk In The Morning",
+        "version": null,
+        "isrc": "DKUM71200883",
+        "duration": "PT3M26S",
+        "copyright": {
+          "text": "℗ 2012 Copenhagen Records / Universal Music"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MAJOR",
+        "bpm": 92.0,
+        "popularity": 0.49679726287862863,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/104340964",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2019-02-18T16:37:06Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/104340964/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "104340961",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/104340964/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "118421111",
+      "type": "tracks",
+      "attributes": {
+        "title": "Lie",
+        "version": null,
+        "isrc": "USWB11902022",
+        "duration": "PT3M",
+        "copyright": {
+          "text": "a Copenhagen Records / Then We Take The World release; ℗ 2019 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "F",
+        "keyScale": "MAJOR",
+        "bpm": 92.0,
+        "popularity": 0.39150648633849927,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/118421111",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2019-09-20T06:50:27Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/118421111/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "118421110",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/118421111/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "121563484",
+      "type": "tracks",
+      "attributes": {
+        "title": "HERE (For Christmas)",
+        "version": null,
+        "isrc": "USWB11902814",
+        "duration": "PT4M1S",
+        "copyright": {
+          "text": "a Copenhagen Records / Then We Take The World release; ℗ 2019 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MAJOR",
+        "bpm": 115.0,
+        "popularity": 0.556719500381777,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/121563484",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2019-11-01T19:56:22Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/121563484/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "121563483",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/121563484/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "151974459",
+      "type": "tracks",
+      "attributes": {
+        "title": "Share That Love",
+        "version": null,
+        "isrc": "USWB12002076",
+        "duration": "PT2M52S",
+        "copyright": {
+          "text": "℗ 2020 Universal Music (Denmark) A/S"
+        },
+        "explicit": true,
+        "ai": false,
+        "key": "D",
+        "keyScale": "MAJOR",
+        "bpm": 156.0,
+        "popularity": 0.39512356727745673,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/151974459",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2020-08-14T07:01:21Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            },
+            {
+              "id": "5072967",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/151974459/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "151974458",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/151974459/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "16562159",
+      "type": "tracks",
+      "attributes": {
+        "title": "Ordinary Things",
+        "version": null,
+        "isrc": "DKBV71106701",
+        "duration": "PT3M28S",
+        "copyright": {
+          "text": "℗ 2011 Copenhagen Records"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "FSharp",
+        "keyScale": "MINOR",
+        "bpm": 95.0,
+        "popularity": 0.37916279779807,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/16562159",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2012-07-31T12:19:51Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/16562159/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "16562158",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/16562159/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "183310109",
+      "type": "tracks",
+      "attributes": {
+        "title": "Happy For You",
+        "version": null,
+        "isrc": "USWB12100981",
+        "duration": "PT3M46S",
+        "copyright": {
+          "text": "℗ 2021 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "D",
+        "keyScale": "MAJOR",
+        "bpm": 136.0,
+        "popularity": 0.39584876396082097,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/183310109",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2021-05-07T03:30:09Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/183310109/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "183310108",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/183310109/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "187840426",
+      "type": "tracks",
+      "attributes": {
+        "title": "Happy For You",
+        "version": null,
+        "isrc": "USWB12101751",
+        "duration": "PT3M46S",
+        "copyright": {
+          "text": "℗ 2021 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Bb",
+        "keyScale": "MAJOR",
+        "bpm": 136.0,
+        "popularity": 0.35296993515289105,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/187840426",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2021-06-15T12:37:26Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            },
+            {
+              "id": "7158528",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/187840426/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "187840424",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/187840426/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "197218768",
+      "type": "tracks",
+      "attributes": {
+        "title": "Call My Name",
+        "version": null,
+        "isrc": "USWB12103083",
+        "duration": "PT3M21S",
+        "copyright": {
+          "text": "℗ 2021 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Bb",
+        "keyScale": "MAJOR",
+        "bpm": 111.0,
+        "popularity": 0.3306426507587327,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/197218768",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2021-09-10T02:09:11Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/197218768/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "197218765",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/197218768/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "242744824",
+      "type": "tracks",
+      "attributes": {
+        "title": "Wish You Were Here",
+        "version": null,
+        "isrc": "USWB12201688",
+        "duration": "PT2M56S",
+        "copyright": {
+          "text": "℗ 2022 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Ab",
+        "keyScale": "MAJOR",
+        "bpm": 106.0,
+        "popularity": 0.4384265456172178,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/242744824",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2022-08-12T01:43:27Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            },
+            {
+              "id": "4916222",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/242744824/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "242744823",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/242744824/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "270125434",
+      "type": "tracks",
+      "attributes": {
+        "title": "Home Movies",
+        "version": null,
+        "isrc": "USWB12207016",
+        "duration": "PT3M16S",
+        "copyright": {
+          "text": "℗ 2023 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "A",
+        "keyScale": "MAJOR",
+        "bpm": 162.0,
+        "popularity": 0.18150379267017436,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/270125434",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2023-01-06T00:52:32Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            },
+            {
+              "id": "5551529",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/270125434/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "270125433",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/270125434/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "359762509",
+      "type": "tracks",
+      "attributes": {
+        "title": "Cheat Code",
+        "version": null,
+        "isrc": "DKUM72400183",
+        "duration": "PT2M29S",
+        "copyright": {
+          "text": "℗ 2024 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "FSharp",
+        "keyScale": "MINOR",
+        "bpm": 115.0,
+        "popularity": 0.2933350440872456,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/359762509",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2024-04-26T01:00:30Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/359762509/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "359762508",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/359762509/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756128",
+      "type": "tracks",
+      "attributes": {
+        "title": "7 Years",
+        "version": null,
+        "isrc": "USWB11506516",
+        "duration": "PT3M57S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MAJOR",
+        "bpm": 120.0,
+        "popularity": 0.7728257326881044,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756128",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756128/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756128/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756130",
+      "type": "tracks",
+      "attributes": {
+        "title": "Mama Said",
+        "version": null,
+        "isrc": "DKUM71400126",
+        "duration": "PT3M27S",
+        "copyright": {
+          "text": "℗ 2014 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Bb",
+        "keyScale": "MAJOR",
+        "bpm": 84.0,
+        "popularity": 0.5742448384952146,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756130",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756130/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756130/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756131",
+      "type": "tracks",
+      "attributes": {
+        "title": "Happy Home",
+        "version": null,
+        "isrc": "USWB11506519",
+        "duration": "PT3M39S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MINOR",
+        "bpm": 128.0,
+        "popularity": 0.2901687469791667,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756131",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756131/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756131/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756132",
+      "type": "tracks",
+      "attributes": {
+        "title": "Drunk In The Morning",
+        "version": null,
+        "isrc": "USWB11514268",
+        "duration": "PT3M23S",
+        "copyright": {
+          "text": "℗ 2015 Then We Take The World / Copenhagen Records"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "D",
+        "keyScale": "MAJOR",
+        "bpm": 93.0,
+        "popularity": 0.42337843281398246,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756132",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756132/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756132/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "58756137",
+      "type": "tracks",
+      "attributes": {
+        "title": "You're Not There",
+        "version": null,
+        "isrc": "USWB11506526",
+        "duration": "PT3M23S",
+        "copyright": {
+          "text": "℗ 2015 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "F",
+        "keyScale": "MAJOR",
+        "bpm": 92.0,
+        "popularity": 0.401522608112518,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/58756137",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2016-03-25T03:36:55Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756137/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/58756137/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "79492732",
+      "type": "tracks",
+      "attributes": {
+        "title": "Off To See The World",
+        "version": null,
+        "isrc": "USWB11701563",
+        "duration": "PT3M4S",
+        "copyright": {
+          "text": "A Copenhagen Records / Then We Take The World release; ℗ 2017 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "G",
+        "keyScale": "MAJOR",
+        "bpm": 107.0,
+        "popularity": 0.35981553269930383,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/79492732",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2017-10-02T22:30:02Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            },
+            {
+              "id": "3526386",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/79492732/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "79492731",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/79492732/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "96969307",
+      "type": "tracks",
+      "attributes": {
+        "title": "Not A Damn Thing Changed",
+        "version": null,
+        "isrc": "USWB11801972",
+        "duration": "PT3M13S",
+        "copyright": {
+          "text": "a Copenhagen Records / Then We Take The World release; ℗ 2018 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "FSharp",
+        "keyScale": "MINOR",
+        "bpm": 85.0,
+        "popularity": 0.28771328311864003,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/96969307",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2018-10-19T13:53:32Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/96969307/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "96969306",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/96969307/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "96969308",
+      "type": "tracks",
+      "attributes": {
+        "title": "Lullaby",
+        "version": null,
+        "isrc": "USWB11801973",
+        "duration": "PT3M11S",
+        "copyright": {
+          "text": "a Copenhagen Records / Then We Take The World release; ℗ 2018 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Bb",
+        "keyScale": "MAJOR",
+        "bpm": 140.0,
+        "popularity": 0.32736367987273224,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/96969308",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2018-10-19T13:53:32Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/96969308/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "96969306",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/96969308/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    },
+    {
+      "id": "96969310",
+      "type": "tracks",
+      "attributes": {
+        "title": "Love Someone",
+        "version": null,
+        "isrc": "USWB11801903",
+        "duration": "PT3M25S",
+        "copyright": {
+          "text": "a Copenhagen Records / Then We Take The World release; ℗ 2018 Universal Music (Denmark) A/S"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "E",
+        "keyScale": "MAJOR",
+        "bpm": 86.0,
+        "popularity": 0.6567149634677466,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/96969310",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2018-10-19T13:53:32Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/96969310/relationships/artists?countryCode=AT"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "96969306",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/96969310/relationships/albums?countryCode=AT"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/providers/tidal/test_media.py
+++ b/tests/providers/tidal/test_media.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import RetriesExhausted
-from music_assistant_models.media_items import ItemMapping
+from music_assistant_models.media_items import ItemMapping, Playlist
 
 from music_assistant.providers.tidal.jsonapi import JsonApiDocument
 from music_assistant.providers.tidal.media import TidalMediaManager
@@ -61,53 +61,60 @@ def media_manager(provider_mock: Mock) -> TidalMediaManager:
     return TidalMediaManager(provider_mock)
 
 
-@patch("music_assistant.providers.tidal.media.parse_artist")
-@patch("music_assistant.providers.tidal.media.parse_album")
-@patch("music_assistant.providers.tidal.media.parse_track")
-@patch("music_assistant.providers.tidal.media.parse_playlist")
-async def test_search(
-    mock_parse_playlist: Mock,
-    mock_parse_track: Mock,
-    mock_parse_album: Mock,
-    mock_parse_artist: Mock,
-    media_manager: TidalMediaManager,
-    provider_mock: Mock,
-) -> None:
-    """Test search."""
-    provider_mock.api.get.return_value = {
-        "artists": {"items": [{"id": 1}]},
-        "albums": {"items": [{"id": 1}]},
-        "tracks": {"items": [{"id": 1}]},
-        "playlists": {"items": [{"uuid": "1"}]},
-    }
-
-    mock_parse_artist.return_value = Mock(item_id="1", media_type=MediaType.ARTIST)
-    mock_parse_album.return_value = Mock(item_id="1", media_type=MediaType.ALBUM)
-    mock_parse_track.return_value = Mock(item_id="1", media_type=MediaType.TRACK)
-    mock_parse_playlist.return_value = Mock(item_id="1", media_type=MediaType.PLAYLIST)
+async def test_search(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
+    """Test search reads all types from the official searchResults endpoint."""
+    provider_mock.api.get_jsonapi.return_value = _load_doc("search.json")
 
     results = await media_manager.search(
-        "query", [MediaType.ARTIST, MediaType.ALBUM, MediaType.TRACK, MediaType.PLAYLIST]
+        "lukas graham",
+        [MediaType.ARTIST, MediaType.ALBUM, MediaType.TRACK, MediaType.PLAYLIST],
+        limit=5,
     )
 
-    assert len(results.artists) == 1
-    assert len(results.albums) == 1
-    assert len(results.tracks) == 1
-    assert len(results.playlists) == 1
+    # 20 of each in the fixture, capped to the limit
+    assert len(results.tracks) == 5
+    assert len(results.albums) == 5
+    assert len(results.artists) == 5
+    assert len(results.playlists) == 5
+    assert results.tracks[0].name == "7 Years"
+    first_playlist = results.playlists[0]
+    assert isinstance(first_playlist, Playlist)
+    assert first_playlist.is_editable is False
 
-    mock_parse_artist.assert_called()
-    mock_parse_album.assert_called()
-    mock_parse_track.assert_called()
-    mock_parse_playlist.assert_called()
-
-    provider_mock.api.get.assert_called_with(
-        "search",
-        params={
-            "query": "query",
-            "types": "artists,albums,tracks,playlists",
-            "limit": 5,
-        },
+    provider_mock.api.get_jsonapi.assert_called_with(
+        "searchResults/lukas%20graham",
+        include=[
+            "tracks.artists",
+            "tracks.albums.coverArt",
+            "albums.coverArt",
+            "artists.profileArt",
+            "playlists.coverArt",
+        ],
     )
+
+
+async def test_search_single_type_and_query_encoding(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test search requests only the includes for the wanted types and encodes the query."""
+    provider_mock.api.get_jsonapi.return_value = _load_doc("search.json")
+
+    results = await media_manager.search("AC/DC", [MediaType.ARTIST])
+
+    assert results.tracks == []
+    provider_mock.api.get_jsonapi.assert_called_with(
+        "searchResults/AC%2FDC", include=["artists.profileArt"]
+    )
+
+
+async def test_search_no_types_short_circuits(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test search with no supported media types does not hit the API."""
+    results = await media_manager.search("x", [])
+
+    assert results.tracks == []
+    provider_mock.api.get_jsonapi.assert_not_called()
 
 
 @patch("music_assistant.providers.tidal.media.parse_artist_v2")

--- a/tests/providers/tidal/test_media_extended.py
+++ b/tests/providers/tidal/test_media_extended.py
@@ -167,7 +167,9 @@ async def test_get_mix_details_no_rows(
 
 async def test_search_empty_results(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
     """Test search with empty results."""
-    provider_mock.api.get.return_value = {}
+    provider_mock.api.get_jsonapi.return_value = JsonApiDocument(
+        {"data": {"id": "query", "type": "searchResults", "relationships": {}}}
+    )
 
     results = await media_manager.search("query", [MediaType.ARTIST])
 

--- a/tests/providers/tidal/test_parsers_v2.py
+++ b/tests/providers/tidal/test_parsers_v2.py
@@ -17,6 +17,7 @@ from music_assistant.providers.tidal.parsers_v2 import (
     _split_title_version,
     parse_album,
     parse_artist,
+    parse_playlist,
     parse_track,
 )
 
@@ -136,6 +137,48 @@ def test_split_title_version(
 ) -> None:
     """Test the title/version split trusts the explicit version attribute."""
     assert _split_title_version(title, version) == (expected_name, expected_version)
+
+
+def test_parse_playlist_editable(provider_mock: Mock) -> None:
+    """Test a playlist owned by the authenticated user is marked editable."""
+    doc = JsonApiDocument(
+        {
+            "data": {
+                "id": "pl-1",
+                "type": "playlists",
+                "attributes": {"name": "My List", "description": "mine", "playlistType": "USER"},
+                "relationships": {"owners": {"data": [{"id": "12345", "type": "owners"}]}},
+            }
+        }
+    )
+    provider_mock.auth.user_id = "12345"
+    provider_mock.auth.user.profile_name = "Me"
+    playlist = parse_playlist(provider_mock, doc, doc.data)
+
+    assert playlist.item_id == "pl-1"
+    assert playlist.name == "My List"
+    assert playlist.is_editable is True
+    assert playlist.owner == "Me"
+    assert playlist.metadata.description == "mine"
+
+
+def test_parse_playlist_not_owned(provider_mock: Mock) -> None:
+    """Test a playlist not owned by the user is not editable."""
+    doc = JsonApiDocument(
+        {
+            "data": {
+                "id": "pl-2",
+                "type": "playlists",
+                "attributes": {"name": "Editorial", "playlistType": "EDITORIAL"},
+                "relationships": {"owners": {"data": []}},
+            }
+        }
+    )
+    provider_mock.auth.user_id = "12345"
+    playlist = parse_playlist(provider_mock, doc, doc.data)
+
+    assert playlist.is_editable is False
+    assert playlist.owner == "Tidal"
 
 
 def test_parse_track_credits(provider_mock: Mock) -> None:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Builds on the previous Tidal PRs (stacked).

Moves `search()` onto the official `searchResults` endpoint (all types in one
call) and drops the apostrophe-stripping workaround. Adds a v2 playlist parser,
since search returns playlists. Tested against a real captured response.


**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
