### PR TITLE
Tidal openapi library reads

### DIFF
--- a/music_assistant/providers/tidal/_openapi_models.py
+++ b/music_assistant/providers/tidal/_openapi_models.py
@@ -38,6 +38,20 @@ class ExternalLink(TypedDict):
     meta: ExternalLinkMeta
 
 
+class PlaylistsAttributes(TypedDict):
+    accessType: Literal["PUBLIC", "UNLISTED"]
+    bounded: bool
+    createdAt: str
+    description: NotRequired[str]
+    duration: NotRequired[str]
+    externalLinks: list[ExternalLink]
+    lastModifiedAt: str
+    name: str
+    numberOfFollowers: int
+    numberOfItems: NotRequired[int]
+    playlistType: Literal["EDITORIAL", "USER", "MIX", "ARTIST"]
+
+
 class TracksAttributes(TypedDict):
     accessType: NotRequired[Literal["PUBLIC", "UNLISTED", "PRIVATE"]]
     ai: NotRequired[bool]

--- a/music_assistant/providers/tidal/jsonapi.py
+++ b/music_assistant/providers/tidal/jsonapi.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import unquote
+from urllib.parse import parse_qs, urlparse
 
 
 class JsonApiDocument:
@@ -43,10 +43,11 @@ class JsonApiDocument:
         next_link = links.get("next")
         if not isinstance(next_link, str) or not next_link:
             return None
-        # The API returns either a full path with a page[cursor] query param
-        # or the bare cursor value; callers only need the cursor.
-        if "page[cursor]=" in next_link:
-            return unquote(next_link.split("page[cursor]=", 1)[1].split("&", 1)[0])
+        # The next link is a path with a page[cursor] query param, whose brackets
+        # may be percent-encoded (page%5Bcursor%5D). parse_qs decodes both the key
+        # and value; fall back to treating the whole link as a bare cursor.
+        if cursors := parse_qs(urlparse(next_link).query).get("page[cursor]"):
+            return cursors[0]
         return next_link
 
     def resolve(self, identifier: dict[str, Any]) -> dict[str, Any] | None:

--- a/music_assistant/providers/tidal/library.py
+++ b/music_assistant/providers/tidal/library.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from aiohttp.client_exceptions import ClientError
@@ -9,25 +11,28 @@ from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import MediaNotFoundError, ResourceTemporarilyUnavailable
 
 from .constants import (
-    BASE_URL_V2,
     FAVORITES_ALBUMS,
     FAVORITES_ARTISTS,
     FAVORITES_MIXES,
     FAVORITES_PLAYLISTS,
     FAVORITES_TRACKS,
 )
-from .parsers import (
-    parse_album,
-    parse_artist,
-    parse_favorite_tracks_playlist,
-    parse_playlist,
-    parse_track,
-)
+from .parsers import parse_favorite_tracks_playlist
+from .parsers_v2 import parse_album as parse_album_v2
+from .parsers_v2 import parse_artist as parse_artist_v2
+from .parsers_v2 import parse_playlist as parse_playlist_v2
+from .parsers_v2 import parse_track as parse_track_v2
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
-    from music_assistant_models.media_items import Album, Artist, MediaItemType, Playlist, Track
+    from music_assistant_models.media_items import (
+        Album,
+        Artist,
+        MediaItemType,
+        Playlist,
+        Track,
+    )
 
     from .provider import TidalProvider
 
@@ -44,41 +49,54 @@ class TidalLibraryManager:
 
     async def get_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists."""
-        path = f"users/{self.auth.user_id}/{FAVORITES_ARTISTS}"
-        async for item in self.api.paginate(path):
-            if item and item.get("item") and item["item"].get("id"):
-                yield parse_artist(self.provider, item)
+        async for doc in self.api.paginate_jsonapi(
+            "userCollectionArtists/me/relationships/items", include=["items.profileArt"]
+        ):
+            for item in doc.data_list:
+                if resource := doc.resolve(item):
+                    artist = parse_artist_v2(self.provider, doc, resource)
+                    _set_date_added(artist, item)
+                    yield artist
 
     async def get_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums."""
-        path = f"users/{self.auth.user_id}/{FAVORITES_ALBUMS}"
-        async for item in self.api.paginate(path):
-            if item and item.get("item") and item["item"].get("id"):
-                yield parse_album(self.provider, item)
+        async for doc in self.api.paginate_jsonapi(
+            "userCollectionAlbums/me/relationships/items",
+            include=["items.artists", "items.coverArt"],
+        ):
+            for item in doc.data_list:
+                if resource := doc.resolve(item):
+                    album = parse_album_v2(self.provider, doc, resource)
+                    _set_date_added(album, item)
+                    yield album
 
     async def get_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks."""
-        path = f"users/{self.auth.user_id}/{FAVORITES_TRACKS}"
-        async for item in self.api.paginate(path):
-            if item and item.get("item") and item["item"].get("id"):
-                yield parse_track(self.provider, item)
+        async for doc in self.api.paginate_jsonapi(
+            "userCollectionTracks/me/relationships/items",
+            include=["items.artists", "items.albums.coverArt"],
+        ):
+            for item in doc.data_list:
+                if resource := doc.resolve(item):
+                    track = parse_track_v2(self.provider, doc, resource)
+                    _set_date_added(track, item)
+                    yield track
 
     async def get_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library playlists."""
-        # 1. Get favorite mixes
-        async for item in self.api.paginate(
-            FAVORITES_MIXES, item_key="items", base_url=BASE_URL_V2, cursor_based=True
+        # The official playlists collection returns both user playlists and
+        # favourited mixes (as MIX-type playlists).
+        async for doc in self.api.paginate_jsonapi(
+            "userCollectionPlaylists/me/relationships/items",
+            include=["items.coverArt", "items.owners"],
         ):
-            if item and item.get("id"):
-                yield parse_playlist(self.provider, item, is_mix=True)
+            for item in doc.data_list:
+                if resource := doc.resolve(item):
+                    playlist = parse_playlist_v2(self.provider, doc, resource)
+                    _set_date_added(playlist, item)
+                    yield playlist
 
-        # 2. Get user playlists
-        path = f"users/{self.auth.user_id}/playlistsAndFavoritePlaylists"
-        async for item in self.api.paginate(path):
-            if item and item.get("playlist") and item["playlist"].get("uuid"):
-                yield parse_playlist(self.provider, item)
-
-        # 3. Get the virtual favorite tracks playlist
+        # The virtual "favorite tracks" playlist is a Music Assistant construct.
         yield parse_favorite_tracks_playlist(self.provider)
 
     async def add_item(self, item: MediaItemType) -> bool:
@@ -161,3 +179,10 @@ class TidalLibraryManager:
             )
 
         return None, {}, False
+
+
+def _set_date_added(media_item: MediaItemType, item: dict[str, Any]) -> None:
+    """Set date_added from a userCollection linkage item's addedAt meta."""
+    if added := (item.get("meta") or {}).get("addedAt"):
+        with suppress(ValueError):
+            media_item.date_added = datetime.fromisoformat(added)

--- a/music_assistant/providers/tidal/parsers_v2.py
+++ b/music_assistant/providers/tidal/parsers_v2.py
@@ -32,7 +32,12 @@ from music_assistant_models.media_items import (
 from music_assistant.helpers.util import infer_album_type, parse_title_and_version
 
 if TYPE_CHECKING:
-    from ._openapi_models import AlbumsAttributes, ArtistsAttributes, TracksAttributes
+    from ._openapi_models import (
+        AlbumsAttributes,
+        ArtistsAttributes,
+        PlaylistsAttributes,
+        TracksAttributes,
+    )
     from .jsonapi import JsonApiDocument
     from .provider import TidalProvider
 
@@ -238,17 +243,30 @@ def parse_playlist(
     provider: TidalProvider, doc: JsonApiDocument, resource: dict[str, Any]
 ) -> Playlist:
     """Parse an official Tidal playlist resource to a generic Playlist."""
-    playlist_id = str(resource["id"])
-    attributes: dict[str, Any] = resource.get("attributes", {})
-    # A playlist is editable when the authenticated user is one of its owners.
-    # This needs the "owners" relationship to be present; search omits it (it
-    # would exceed the include cap), so search results are non-editable by design.
-    owner_ids = doc.linkage_ids(resource, "owners")
-    user_id = str(provider.auth.user_id) if provider.auth.user_id else None
-    is_editable = bool(user_id and user_id in owner_ids)
-    owner_name = "Tidal"
-    if is_editable:
-        owner_name = provider.auth.user.profile_name or provider.auth.user.user_name or str(user_id)
+    raw_id = str(resource["id"])
+    attributes: PlaylistsAttributes = resource.get("attributes", {})
+    # Mixes are exposed as playlists but keep the "mix_" item id so they open via
+    # the existing (unofficial) mix flow.
+    is_mix = attributes.get("playlistType") == "MIX"
+    if is_mix:
+        playlist_id = f"mix_{raw_id}"
+        owner_name = "Created by Tidal"
+        is_editable = False
+        url = f"https://tidal.com/mix/{raw_id}"
+    else:
+        playlist_id = raw_id
+        # A playlist is editable when the authenticated user is one of its owners.
+        # This needs the "owners" relationship to be present; search omits it (it
+        # would exceed the include cap), so search results are non-editable there.
+        owner_ids = doc.linkage_ids(resource, "owners")
+        user_id = str(provider.auth.user_id) if provider.auth.user_id else None
+        is_editable = bool(user_id and user_id in owner_ids)
+        owner_name = "Tidal"
+        if is_editable:
+            owner_name = (
+                provider.auth.user.profile_name or provider.auth.user.user_name or str(user_id)
+            )
+        url = f"https://tidal.com/playlist/{raw_id}"
 
     playlist = Playlist(
         item_id=playlist_id,
@@ -260,7 +278,7 @@ def parse_playlist(
                 item_id=playlist_id,
                 provider_domain=provider.domain,
                 provider_instance=provider.instance_id,
-                url=f"https://tidal.com/playlist/{playlist_id}",
+                url=url,
                 is_unique=is_editable,
             )
         },
@@ -268,9 +286,6 @@ def parse_playlist(
     )
     if description := attributes.get("description"):
         playlist.metadata.description = description
-    if created := attributes.get("createdAt"):
-        with suppress(ValueError):
-            playlist.date_added = datetime.fromisoformat(created)
     if image := _resolve_image(provider, doc, resource, "coverArt"):
         playlist.metadata.images = UniqueList([image])
     return playlist

--- a/scripts/tidal_openapi/generate_models.py
+++ b/scripts/tidal_openapi/generate_models.py
@@ -38,6 +38,7 @@ SEED_SCHEMAS = [
     "Tracks_Attributes",
     "Albums_Attributes",
     "Artists_Attributes",
+    "Playlists_Attributes",
 ]
 
 FILE_HEADER = '''"""

--- a/tests/providers/tidal/fixtures/v2/lib_albums.json
+++ b/tests/providers/tidal/fixtures/v2/lib_albums.json
@@ -1,0 +1,3150 @@
+{
+  "data": [
+    {
+      "id": "6886563",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2026-07-14T18:57:30.371Z"
+      }
+    },
+    {
+      "id": "516439336",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2026-06-01T10:44:43.896Z"
+      }
+    },
+    {
+      "id": "500568514",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2026-05-26T06:41:27.847Z"
+      }
+    },
+    {
+      "id": "3989420",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2026-04-09T07:58:21.318Z"
+      }
+    },
+    {
+      "id": "506805794",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2026-03-20T17:48:43.897Z"
+      }
+    },
+    {
+      "id": "441873720",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2026-03-20T17:48:38.156Z"
+      }
+    },
+    {
+      "id": "1485348",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2026-01-13T19:48:29.013Z"
+      }
+    },
+    {
+      "id": "93384881",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2025-12-14T18:08:40.784Z"
+      }
+    },
+    {
+      "id": "93384707",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2025-12-14T18:08:34.743Z"
+      }
+    },
+    {
+      "id": "473499922",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2025-11-28T07:58:57.445Z"
+      }
+    },
+    {
+      "id": "465415336",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2025-11-09T08:03:53.222Z"
+      }
+    },
+    {
+      "id": "456341828",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2025-11-04T23:35:54.576Z"
+      }
+    },
+    {
+      "id": "444540388",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2025-11-04T23:35:40.731Z"
+      }
+    },
+    {
+      "id": "469136021",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2025-10-29T12:53:05.340Z"
+      }
+    },
+    {
+      "id": "463257215",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2025-10-04T14:00:18.036Z"
+      }
+    },
+    {
+      "id": "14132684",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2025-08-23T19:12:10.543Z"
+      }
+    },
+    {
+      "id": "444464473",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2025-08-07T20:59:40.861Z"
+      }
+    },
+    {
+      "id": "434073284",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2025-05-30T15:40:14.041Z"
+      }
+    },
+    {
+      "id": "429144194",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2025-05-26T15:20:30.032Z"
+      }
+    },
+    {
+      "id": "96298048",
+      "type": "albums",
+      "meta": {
+        "addedAt": "2025-03-28T13:09:57.581Z"
+      }
+    }
+  ],
+  "links": {
+    "self": "/userCollectionAlbums/me/relationships/items?include=items.artists%2Citems.coverArt&locale=en-US",
+    "next": "/userCollectionAlbums/me/relationships/items?include=items.artists%2Citems.coverArt&locale=en-US&page%5Bcursor%5D=eyJpZCI6NjIwMDQ3MzAxLCJkYXRlQWRkZWQiOiIyMDI1LTAzLTI4VDEzOjA5OjU3LjU4MSIsInRpdGxlIjoiUGxhc3RpayBFbHZpcyAvIFZlbHZldCBFbHZpcyIsImFydGlzdE5hbWUiOiJTY290dCBEYXZpc29uIiwicmVsZWFzZURhdGUiOiIxOTg2LTAxLTAxVDAwOjAwOjAwIn0",
+    "meta": {
+      "nextCursor": "eyJpZCI6NjIwMDQ3MzAxLCJkYXRlQWRkZWQiOiIyMDI1LTAzLTI4VDEzOjA5OjU3LjU4MSIsInRpdGxlIjoiUGxhc3RpayBFbHZpcyAvIFZlbHZldCBFbHZpcyIsImFydGlzdE5hbWUiOiJTY290dCBEYXZpc29uIiwicmVsZWFzZURhdGUiOiIxOTg2LTAxLTAxVDAwOjAwOjAwIn0"
+    }
+  },
+  "included": [
+    {
+      "id": "14132684",
+      "type": "albums",
+      "attributes": {
+        "title": "The Best of Redbone - Come and Get Your Love",
+        "barcodeId": "805087966924",
+        "numberOfVolumes": 1,
+        "numberOfItems": 12,
+        "duration": "PT35M51S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "1976-01-01",
+        "copyright": {
+          "text": "© 2007 K-Tel"
+        },
+        "popularity": 0.41701946599340267,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/14132684",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "5051",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/14132684/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IP0zc2L3kB9w",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/14132684/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "1485348",
+      "type": "albums",
+      "attributes": {
+        "title": "Balance Of The Force",
+        "barcodeId": "0724385661051",
+        "numberOfVolumes": 1,
+        "numberOfItems": 9,
+        "duration": "PT1H10M39S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "1997-05-12",
+        "copyright": {
+          "text": "© 1997 Parlophone Records Ltd, a Warner Music Group Company"
+        },
+        "popularity": 0.2189982652787804,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/1485348",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "createdAt": "2008-01-09T17:25:24Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "35183",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/1485348/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "AmX9grPBhCq4H0TwCW8",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/1485348/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "3989420",
+      "type": "albums",
+      "attributes": {
+        "title": "The Simpsons Sing The Blues",
+        "barcodeId": "00720642430828",
+        "numberOfVolumes": 1,
+        "numberOfItems": 10,
+        "duration": "PT40M15S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "1990-01-01",
+        "copyright": {
+          "text": "© 1990 Geffen Records Inc."
+        },
+        "popularity": 0.10518218883385418,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/3989420",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "createdAt": "2010-05-29T01:46:39Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "34659",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/3989420/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "AmX9grPBhCsfgqSk5ke",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/3989420/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "429144194",
+      "type": "albums",
+      "attributes": {
+        "title": "The King of Miami (Droid Bishop Remix)",
+        "barcodeId": "5054288940294",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M58S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2025-04-18",
+        "copyright": {
+          "text": "Ancient Machine under exclusive license to Az"
+        },
+        "popularity": 0.10518218883385418,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/429144194",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "20527766",
+              "type": "artists"
+            },
+            {
+              "id": "5226676",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/429144194/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0LryA9wTFCi4",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/429144194/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "434073284",
+      "type": "albums",
+      "attributes": {
+        "title": "Digital Dreams",
+        "barcodeId": "196873148373",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT6M6S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2025-05-30",
+        "copyright": {
+          "text": "(P) 2025 Ultra Records, LLC"
+        },
+        "popularity": 0.17537505505783726,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/434073284",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2025-05-05T22:26:16Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "6065221",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/434073284/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0LxBjjXSbvCm",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/434073284/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "441873720",
+      "type": "albums",
+      "attributes": {
+        "title": "Unravelling",
+        "barcodeId": "5021732834430",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M58S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2025-01-01",
+        "copyright": {
+          "text": "Under Exclusive License to Warner Music UK Limited, © 2025 Torpack Limited"
+        },
+        "popularity": 0.5611710656059001,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/441873720",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2025-06-13T09:13:26Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "16335",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/441873720/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0M2RvyAybNzs",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/441873720/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "444464473",
+      "type": "albums",
+      "attributes": {
+        "title": "The Hill",
+        "barcodeId": "7316480937716",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M24S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2025-07-18",
+        "copyright": {
+          "text": "2025 Celladora Music"
+        },
+        "popularity": 0.13216612972719072,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/444464473",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "5226676",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/444464473/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0M2VmVFFyGzz",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/444464473/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "444540388",
+      "type": "albums",
+      "attributes": {
+        "title": "The Getaway (M10 Version)",
+        "barcodeId": "067004041460",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT4M35S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2025-07-18",
+        "copyright": {
+          "text": "The Strike Music LLC under exclusive license to Nettwerk Music Group Inc."
+        },
+        "popularity": 0.16441960332963088,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/444540388",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "15536",
+              "type": "artists"
+            },
+            {
+              "id": "6294546",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/444540388/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0M2VmoRyOfMW",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/444540388/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "456341828",
+      "type": "albums",
+      "attributes": {
+        "title": "A Dream Through Open Eyes (Deluxe Edition)",
+        "barcodeId": "067003183253",
+        "numberOfVolumes": 2,
+        "numberOfItems": 17,
+        "duration": "PT1H6M32S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2025-09-19",
+        "copyright": {
+          "text": "The Strike Music LLC under exclusive license to Nettwerk Music Group Inc."
+        },
+        "popularity": 0.17964294240955603,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/456341828",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "createdAt": "2025-08-25T23:29:21Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "15536",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/456341828/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0M7sNZ8XMzRQ",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/456341828/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "463257215",
+      "type": "albums",
+      "attributes": {
+        "title": "Syndicate",
+        "barcodeId": "196873309996",
+        "numberOfVolumes": 1,
+        "numberOfItems": 17,
+        "duration": "PT1H25M14S",
+        "explicit": true,
+        "ai": false,
+        "releaseDate": "2025-10-03",
+        "copyright": {
+          "text": "(P) 2025 Ultra Records, LLC"
+        },
+        "popularity": 0.30385460209236076,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/463257215",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "createdAt": "2025-09-26T22:30:09Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "6065221",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/463257215/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0MD8WzdM4P0n",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/463257215/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "465415336",
+      "type": "albums",
+      "attributes": {
+        "title": "Battle Lines (Original Mix)",
+        "barcodeId": "5053760141877",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT4M32S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2025-11-07",
+        "copyright": {
+          "text": "Mansion Sounds"
+        },
+        "popularity": 0.10446607740402107,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/465415336",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2025-10-07T11:41:23Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "33218",
+              "type": "artists"
+            },
+            {
+              "id": "7538453",
+              "type": "artists"
+            },
+            {
+              "id": "19065017",
+              "type": "artists"
+            },
+            {
+              "id": "19008444",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/465415336/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0MDB7T5yUjAc",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/465415336/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "469136021",
+      "type": "albums",
+      "attributes": {
+        "title": "Mad World",
+        "barcodeId": "198704812637",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT4M8S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2025-10-29",
+        "copyright": {
+          "text": "© 2025 Horsie In The Hedge Limited"
+        },
+        "popularity": 0.1939262934380149,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/469136021",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2025-10-24T16:28:11Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "6853265",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/469136021/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0MDGGFH1XFkf",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/469136021/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "473499922",
+      "type": "albums",
+      "attributes": {
+        "title": "In the Rearview Mirror",
+        "barcodeId": "859722644791",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT4M14S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2025-11-21",
+        "copyright": {
+          "text": "2025 Timecop1983 Music"
+        },
+        "popularity": 0.0612422578137849,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/473499922",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2025-11-12T20:22:10Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "5448657",
+              "type": "artists"
+            },
+            {
+              "id": "6944883",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/473499922/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0MISZ90HJH2w",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/473499922/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "500568514",
+      "type": "albums",
+      "attributes": {
+        "title": "Leather Temple",
+        "barcodeId": "00602488338226",
+        "numberOfVolumes": 1,
+        "numberOfItems": 10,
+        "duration": "PT38M40S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2026-02-26",
+        "copyright": {
+          "text": "© 2026 No Quarter Prod, exclusively distributed by Virgin Records France"
+        },
+        "popularity": 0.5172228366136551,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/500568514",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "createdAt": "2026-02-19T23:32:06Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "5122999",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/500568514/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0hfoob7Eng3Q",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/500568514/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "506805794",
+      "type": "albums",
+      "attributes": {
+        "title": "Be With You",
+        "barcodeId": "5026854782577",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M35S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2026-03-19",
+        "copyright": {
+          "text": "Under exclusive license to Warner Records Inc., © 2026 Torpack Ltd"
+        },
+        "popularity": 0.4553977609263215,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/506805794",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2026-03-13T12:03:17Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "16335",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/506805794/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0hfwZ5smYotg",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/506805794/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "516439336",
+      "type": "albums",
+      "attributes": {
+        "title": "Frontiers",
+        "barcodeId": "7316482343218",
+        "numberOfVolumes": 1,
+        "numberOfItems": 12,
+        "duration": "PT41M59S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2026-05-01",
+        "copyright": {
+          "text": "2026 Celladora Music"
+        },
+        "popularity": 0.060813701949717434,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/516439336",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "createdAt": "2026-04-16T12:19:10Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "5226676",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/516439336/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0hlGZN23Xlt0",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/516439336/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "6886563",
+      "type": "albums",
+      "attributes": {
+        "title": "Nobody's Perfect",
+        "barcodeId": "00602527755649",
+        "numberOfVolumes": 1,
+        "numberOfItems": 5,
+        "duration": "PT24M10S",
+        "explicit": true,
+        "ai": false,
+        "releaseDate": "2011-05-30",
+        "copyright": {
+          "text": "© 2011 Universal Republic Records"
+        },
+        "popularity": 0.19009675417564667,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/6886563",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2011-06-03T12:09:32Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3828746",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/6886563/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "AmX9grPBhCwXA3r9xRL",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/6886563/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "93384707",
+      "type": "albums",
+      "attributes": {
+        "title": "Cold Fact",
+        "barcodeId": "00602567952015",
+        "numberOfVolumes": 1,
+        "numberOfItems": 12,
+        "duration": "PT32M20S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "1970-01-01",
+        "copyright": {
+          "text": "© 1970 UMG Recordings, Inc."
+        },
+        "popularity": 0.7816523598962791,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/93384707",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "createdAt": "2018-08-10T04:08:05Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "17897940",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/93384707/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPhYWuijxL9z",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/93384707/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "93384881",
+      "type": "albums",
+      "attributes": {
+        "title": "Coming From Reality",
+        "barcodeId": "00602567954699",
+        "numberOfVolumes": 1,
+        "numberOfItems": 10,
+        "duration": "PT40M30S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "1971-01-01",
+        "copyright": {
+          "text": "© 1971 UMG Recordings, Inc."
+        },
+        "popularity": 0.6968580711881187,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/93384881",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "17897940",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/93384881/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPhYWuijxcjx",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/93384881/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "96298048",
+      "type": "albums",
+      "attributes": {
+        "title": "Plastik Elvis / Velvet Elvis",
+        "barcodeId": "9783990834121",
+        "numberOfVolumes": 1,
+        "numberOfItems": 2,
+        "duration": "PT6M10S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "1986-01-01",
+        "copyright": {
+          "text": "Ron Records"
+        },
+        "popularity": 0.10518218883385418,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/96298048",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "7830587",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/albums/96298048/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPhcOO0wx1IG",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/96298048/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "15536",
+      "type": "artists",
+      "attributes": {
+        "name": "The Strike",
+        "popularity": 0.5330637693405151,
+        "externalLinks": [
+          {
+            "href": "https://instagram.com/wearethestrike",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://wearethestrike.com",
+            "meta": {
+              "type": "OFFICIAL_HOMEPAGE"
+            }
+          },
+          {
+            "href": "https://tiktok.com/@wearethestrike1",
+            "meta": {
+              "type": "TIKTOK"
+            }
+          },
+          {
+            "href": "https://twitter.com/wearethestrike",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/15536",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "MIXED"
+      }
+    },
+    {
+      "id": "16335",
+      "type": "artists",
+      "attributes": {
+        "name": "Muse",
+        "popularity": 0.8431242950613788,
+        "externalLinks": [
+          {
+            "href": "https://facebook.com/muse",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "https://www.muse.mu/",
+            "meta": {
+              "type": "OFFICIAL_HOMEPAGE"
+            }
+          },
+          {
+            "href": "https://tiktok.com/@muse",
+            "meta": {
+              "type": "TIKTOK"
+            }
+          },
+          {
+            "href": "https://twitter.com/muse",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/16335",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "17897940",
+      "type": "artists",
+      "attributes": {
+        "name": "Rodriguez",
+        "popularity": 0.6974866986274719,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/17897940",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false
+      }
+    },
+    {
+      "id": "19008444",
+      "type": "artists",
+      "attributes": {
+        "name": "ProdByInsula",
+        "popularity": 0.2334182366262008,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/19008444",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false
+      }
+    },
+    {
+      "id": "19065017",
+      "type": "artists",
+      "attributes": {
+        "name": "Katya Gabeli",
+        "popularity": 0.23694795538790933,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/19065017",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false
+      }
+    },
+    {
+      "id": "20527766",
+      "type": "artists",
+      "attributes": {
+        "name": "LAU",
+        "popularity": 0.45761778950691223,
+        "externalLinks": [
+          {
+            "href": "https://www.facebook.com/laufaresmusic",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "https://instagram.com/laufares",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://laufares.com",
+            "meta": {
+              "type": "OFFICIAL_HOMEPAGE"
+            }
+          },
+          {
+            "href": "https://tiktok.com/@lau_fares",
+            "meta": {
+              "type": "TIKTOK"
+            }
+          },
+          {
+            "href": "https://twitter.com/lau_fares",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/20527766",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "MIXED"
+      }
+    },
+    {
+      "id": "33218",
+      "type": "artists",
+      "attributes": {
+        "name": "Roni Size",
+        "popularity": 0.6279333829879761,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/33218",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "34659",
+      "type": "artists",
+      "attributes": {
+        "name": "The Simpsons",
+        "popularity": 0.5269275307655334,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/34659",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "35183",
+      "type": "artists",
+      "attributes": {
+        "name": "Boymerang",
+        "popularity": 0.39522457122802734,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/35183",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3828746",
+      "type": "artists",
+      "attributes": {
+        "name": "Jessie J",
+        "popularity": 0.8298273086547852,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/JessieJ",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/3828746",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "5051",
+      "type": "artists",
+      "attributes": {
+        "name": "Redbone",
+        "popularity": 0.7184392346218355,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/5051",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "5122999",
+      "type": "artists",
+      "attributes": {
+        "name": "Carpenter Brut",
+        "popularity": 0.6749792098999023,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/5122999",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "5226676",
+      "type": "artists",
+      "attributes": {
+        "name": "Droid Bishop",
+        "popularity": 0.5241226553916931,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/5226676",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "5448657",
+      "type": "artists",
+      "attributes": {
+        "name": "Timecop1983",
+        "popularity": 0.6228141490465138,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/5448657",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "6065221",
+      "type": "artists",
+      "attributes": {
+        "name": "The Midnight",
+        "popularity": 0.693957704971215,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/6065221",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "6294546",
+      "type": "artists",
+      "attributes": {
+        "name": "Mitchell Tenpenny",
+        "popularity": 0.6496894935713802,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/6294546",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "6853265",
+      "type": "artists",
+      "attributes": {
+        "name": "GUNSHIP",
+        "popularity": 0.6658576726913452,
+        "externalLinks": [
+          {
+            "href": "https://facebook.com/gunshipmusic",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "https://instagram.com/gunshipmusic",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://gunshipmusic.com",
+            "meta": {
+              "type": "OFFICIAL_HOMEPAGE"
+            }
+          },
+          {
+            "href": "https://tiktok.com/@gunshipmusic",
+            "meta": {
+              "type": "TIKTOK"
+            }
+          },
+          {
+            "href": "https://twitter.com/gunshipmusic",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/6853265",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "MIXED"
+      }
+    },
+    {
+      "id": "6944883",
+      "type": "artists",
+      "attributes": {
+        "name": "Josh Dally",
+        "popularity": 0.4811485707759857,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/6944883",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "7538453",
+      "type": "artists",
+      "attributes": {
+        "name": "Reno Ka",
+        "popularity": 0.21228471398353577,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/7538453",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false
+      }
+    },
+    {
+      "id": "7830587",
+      "type": "artists",
+      "attributes": {
+        "name": "Scott Davison",
+        "popularity": 0.03476438671350479,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/7830587",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0LryA9wTFCi4",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/69f21b7b/d3f6/42f5/9502/99399e4e0129/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/69f21b7b/d3f6/42f5/9502/99399e4e0129/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/69f21b7b/d3f6/42f5/9502/99399e4e0129/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/69f21b7b/d3f6/42f5/9502/99399e4e0129/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/69f21b7b/d3f6/42f5/9502/99399e4e0129/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/69f21b7b/d3f6/42f5/9502/99399e4e0129/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/69f21b7b/d3f6/42f5/9502/99399e4e0129/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#3F477D",
+          "blurHash": "UC9%D2Na0J$%=RkCFonjGEsp#WSfKFj]#aWU",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0LxBjjXSbvCm",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/f7b734c0/a6e3/4829/ab7f/6ebedfc2da1a/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f7b734c0/a6e3/4829/ab7f/6ebedfc2da1a/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f7b734c0/a6e3/4829/ab7f/6ebedfc2da1a/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f7b734c0/a6e3/4829/ab7f/6ebedfc2da1a/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f7b734c0/a6e3/4829/ab7f/6ebedfc2da1a/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f7b734c0/a6e3/4829/ab7f/6ebedfc2da1a/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f7b734c0/a6e3/4829/ab7f/6ebedfc2da1a/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#173A4B",
+          "blurHash": "U14f8lyrI7nNq]%MKhIVD48w9~?wr_IUIAxD",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0M2RvyAybNzs",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/cc6dd38b/703f/4286/8862/7d7bac07b4ca/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cc6dd38b/703f/4286/8862/7d7bac07b4ca/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cc6dd38b/703f/4286/8862/7d7bac07b4ca/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cc6dd38b/703f/4286/8862/7d7bac07b4ca/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cc6dd38b/703f/4286/8862/7d7bac07b4ca/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cc6dd38b/703f/4286/8862/7d7bac07b4ca/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/cc6dd38b/703f/4286/8862/7d7bac07b4ca/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#398081",
+          "blurHash": "UIB|EM{zX-Kj%#UvI;KjHW9[K%S#wfZhoerr",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0M2VmVFFyGzz",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/91c5b570/a3e7/4680/9087/2bbfd33e7953/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/91c5b570/a3e7/4680/9087/2bbfd33e7953/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/91c5b570/a3e7/4680/9087/2bbfd33e7953/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/91c5b570/a3e7/4680/9087/2bbfd33e7953/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/91c5b570/a3e7/4680/9087/2bbfd33e7953/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/91c5b570/a3e7/4680/9087/2bbfd33e7953/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/91c5b570/a3e7/4680/9087/2bbfd33e7953/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#8E2A4C",
+          "blurHash": "U27,y0+H008H3VrW:kPV{:#mB%F_#rv~cEGF",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0M2VmoRyOfMW",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/95d03eb0/4154/4bce/9d33/764ceae75b0d/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/95d03eb0/4154/4bce/9d33/764ceae75b0d/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/95d03eb0/4154/4bce/9d33/764ceae75b0d/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/95d03eb0/4154/4bce/9d33/764ceae75b0d/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/95d03eb0/4154/4bce/9d33/764ceae75b0d/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/95d03eb0/4154/4bce/9d33/764ceae75b0d/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/95d03eb0/4154/4bce/9d33/764ceae75b0d/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#934B51",
+          "blurHash": "U6L_3U0y01J600^+K#nPLwwcxbRim:D%a1t9",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0M7sNZ8XMzRQ",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/4a4fe5f7/2fa8/4220/a72e/0846f20e84f8/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a4fe5f7/2fa8/4220/a72e/0846f20e84f8/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a4fe5f7/2fa8/4220/a72e/0846f20e84f8/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a4fe5f7/2fa8/4220/a72e/0846f20e84f8/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a4fe5f7/2fa8/4220/a72e/0846f20e84f8/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a4fe5f7/2fa8/4220/a72e/0846f20e84f8/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4a4fe5f7/2fa8/4220/a72e/0846f20e84f8/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#4E7889",
+          "blurHash": "UzHetmRRjZf6_NV[ayjtPUbbWBj@K5ofj[fR",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0MD8WzdM4P0n",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/58d02122/9118/4aa1/ba86/e3e59e0b371e/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/58d02122/9118/4aa1/ba86/e3e59e0b371e/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/58d02122/9118/4aa1/ba86/e3e59e0b371e/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/58d02122/9118/4aa1/ba86/e3e59e0b371e/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/58d02122/9118/4aa1/ba86/e3e59e0b371e/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/58d02122/9118/4aa1/ba86/e3e59e0b371e/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/58d02122/9118/4aa1/ba86/e3e59e0b371e/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#906066",
+          "blurHash": "UeBfq}M_NFof?KIoawt6%NRPWVkCXSi_flf+",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0MDB7T5yUjAc",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/00c34e07/0114/474e/96b4/5dad0abc0a4a/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/00c34e07/0114/474e/96b4/5dad0abc0a4a/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/00c34e07/0114/474e/96b4/5dad0abc0a4a/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/00c34e07/0114/474e/96b4/5dad0abc0a4a/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/00c34e07/0114/474e/96b4/5dad0abc0a4a/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/00c34e07/0114/474e/96b4/5dad0abc0a4a/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/00c34e07/0114/474e/96b4/5dad0abc0a4a/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#82624C",
+          "blurHash": "UYI#ZAo}_NS5${W;Rie-NGS4RPt7-;n$ofoe",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0MDGGFH1XFkf",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/6221f09d/8a57/4c7f/8575/38c73bceeac6/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6221f09d/8a57/4c7f/8575/38c73bceeac6/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6221f09d/8a57/4c7f/8575/38c73bceeac6/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6221f09d/8a57/4c7f/8575/38c73bceeac6/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6221f09d/8a57/4c7f/8575/38c73bceeac6/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6221f09d/8a57/4c7f/8575/38c73bceeac6/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6221f09d/8a57/4c7f/8575/38c73bceeac6/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#143137",
+          "blurHash": "UE68~ni_IUV@ysnORPWBxuaKR*ofn$WBV@of",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0MISZ90HJH2w",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/47ac0d11/d902/43d5/9d29/3c967031c46a/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/47ac0d11/d902/43d5/9d29/3c967031c46a/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/47ac0d11/d902/43d5/9d29/3c967031c46a/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/47ac0d11/d902/43d5/9d29/3c967031c46a/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/47ac0d11/d902/43d5/9d29/3c967031c46a/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/47ac0d11/d902/43d5/9d29/3c967031c46a/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/47ac0d11/d902/43d5/9d29/3c967031c46a/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#253F45",
+          "blurHash": "U255wl_4MJv$BgyX-qrYAj5+IqRj9HMyD%O:",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0hfoob7Eng3Q",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/27c0c61b/d97d/4661/ade7/13ce1eb5e30a/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/27c0c61b/d97d/4661/ade7/13ce1eb5e30a/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/27c0c61b/d97d/4661/ade7/13ce1eb5e30a/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/27c0c61b/d97d/4661/ade7/13ce1eb5e30a/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/27c0c61b/d97d/4661/ade7/13ce1eb5e30a/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/27c0c61b/d97d/4661/ade7/13ce1eb5e30a/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/27c0c61b/d97d/4661/ade7/13ce1eb5e30a/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7A6435",
+          "blurHash": "U9CO?hjZ03Nbb]xWE4j?D%t6FMn%~5NcIXah",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0hfwZ5smYotg",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/1a6a944d/221f/4098/a8ec/e62b68e53e47/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1a6a944d/221f/4098/a8ec/e62b68e53e47/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1a6a944d/221f/4098/a8ec/e62b68e53e47/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1a6a944d/221f/4098/a8ec/e62b68e53e47/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1a6a944d/221f/4098/a8ec/e62b68e53e47/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1a6a944d/221f/4098/a8ec/e62b68e53e47/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1a6a944d/221f/4098/a8ec/e62b68e53e47/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#0B0606",
+          "blurHash": "U5555-f69Fj[~Wf6IUjt%2f6s:f6D%f6-:ay",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0hlGZN23Xlt0",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/f3779a4f/80ff/41e0/8eb6/8e2980a8c34d/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f3779a4f/80ff/41e0/8eb6/8e2980a8c34d/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f3779a4f/80ff/41e0/8eb6/8e2980a8c34d/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f3779a4f/80ff/41e0/8eb6/8e2980a8c34d/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f3779a4f/80ff/41e0/8eb6/8e2980a8c34d/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f3779a4f/80ff/41e0/8eb6/8e2980a8c34d/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f3779a4f/80ff/41e0/8eb6/8e2980a8c34d/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#0B3A58",
+          "blurHash": "U88}47Md00%hrnxGaONF8w%M.9Mx%jr^sRxv",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmX9grPBhCq4H0TwCW8",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/b6d938b0/2e07/4fc1/8a68/6cd8217f5213/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b6d938b0/2e07/4fc1/8a68/6cd8217f5213/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b6d938b0/2e07/4fc1/8a68/6cd8217f5213/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b6d938b0/2e07/4fc1/8a68/6cd8217f5213/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b6d938b0/2e07/4fc1/8a68/6cd8217f5213/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b6d938b0/2e07/4fc1/8a68/6cd8217f5213/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b6d938b0/2e07/4fc1/8a68/6cd8217f5213/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#1F1F1F",
+          "blurHash": "U8S~x5xu-;%MxufQj[j[~qofD%WB%Mj[WBay",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmX9grPBhCsfgqSk5ke",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/c0cf1e3d/9008/43f3/93eb/1a8535ee9631/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c0cf1e3d/9008/43f3/93eb/1a8535ee9631/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c0cf1e3d/9008/43f3/93eb/1a8535ee9631/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c0cf1e3d/9008/43f3/93eb/1a8535ee9631/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c0cf1e3d/9008/43f3/93eb/1a8535ee9631/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c0cf1e3d/9008/43f3/93eb/1a8535ee9631/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c0cf1e3d/9008/43f3/93eb/1a8535ee9631/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#87472E",
+          "blurHash": "UQNa#A$d_CNe0;v}=qaeBo#+#9a#9hZQ#RR7",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmX9grPBhCwXA3r9xRL",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/723cf8d8/7101/4e71/88da/9ab4a328a689/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/723cf8d8/7101/4e71/88da/9ab4a328a689/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/723cf8d8/7101/4e71/88da/9ab4a328a689/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/723cf8d8/7101/4e71/88da/9ab4a328a689/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/723cf8d8/7101/4e71/88da/9ab4a328a689/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/723cf8d8/7101/4e71/88da/9ab4a328a689/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/723cf8d8/7101/4e71/88da/9ab4a328a689/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#29120E",
+          "blurHash": "U3G7eqt*019u0w-j7f-UQ;?FkWjE*Hv$;K}?",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IP0zc2L3kB9w",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/46d39f61/0a33/4969/bbb6/9d200eb4b4af/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/46d39f61/0a33/4969/bbb6/9d200eb4b4af/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/46d39f61/0a33/4969/bbb6/9d200eb4b4af/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/46d39f61/0a33/4969/bbb6/9d200eb4b4af/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/46d39f61/0a33/4969/bbb6/9d200eb4b4af/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/46d39f61/0a33/4969/bbb6/9d200eb4b4af/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/46d39f61/0a33/4969/bbb6/9d200eb4b4af/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#945037",
+          "blurHash": "UHJr{s=|J8kW-o=yoMf+{J$*JAof=2ogAXoz",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPhYWuijxL9z",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/9cdab6f0/f514/4dff/89a4/df66665ffeb0/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9cdab6f0/f514/4dff/89a4/df66665ffeb0/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9cdab6f0/f514/4dff/89a4/df66665ffeb0/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9cdab6f0/f514/4dff/89a4/df66665ffeb0/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9cdab6f0/f514/4dff/89a4/df66665ffeb0/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9cdab6f0/f514/4dff/89a4/df66665ffeb0/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/9cdab6f0/f514/4dff/89a4/df66665ffeb0/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#41678C",
+          "blurHash": "UoM*29s:~qbI-qoJ-;WXV?jZIUWq-:jYM|W=",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPhYWuijxcjx",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/4dc1e498/4cc5/434e/adbb/9c2d6aa36a00/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4dc1e498/4cc5/434e/adbb/9c2d6aa36a00/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4dc1e498/4cc5/434e/adbb/9c2d6aa36a00/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4dc1e498/4cc5/434e/adbb/9c2d6aa36a00/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4dc1e498/4cc5/434e/adbb/9c2d6aa36a00/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4dc1e498/4cc5/434e/adbb/9c2d6aa36a00/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4dc1e498/4cc5/434e/adbb/9c2d6aa36a00/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#614F46",
+          "blurHash": "UHFYx~_40fMx?GWB9Fa$IVITjEt38^el-:og",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPhcOO0wx1IG",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/ada66cc5/e38f/450d/bcd2/7a269116c1ef/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ada66cc5/e38f/450d/bcd2/7a269116c1ef/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ada66cc5/e38f/450d/bcd2/7a269116c1ef/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ada66cc5/e38f/450d/bcd2/7a269116c1ef/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ada66cc5/e38f/450d/bcd2/7a269116c1ef/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ada66cc5/e38f/450d/bcd2/7a269116c1ef/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ada66cc5/e38f/450d/bcd2/7a269116c1ef/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#9E0738",
+          "blurHash": "UOI;|.$j01.R0Ktl?bxGxt%MazIU~p-pV@bH",
+          "status": "OK"
+        }
+      }
+    }
+  ]
+}

--- a/tests/providers/tidal/fixtures/v2/lib_artists.json
+++ b/tests/providers/tidal/fixtures/v2/lib_artists.json
@@ -1,0 +1,1682 @@
+{
+  "data": [
+    {
+      "id": "3521742",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2026-04-02T16:12:46.763Z"
+      }
+    },
+    {
+      "id": "35183",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2026-01-13T19:48:20.008Z"
+      }
+    },
+    {
+      "id": "9463631",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2025-06-26T21:30:23.555Z"
+      }
+    },
+    {
+      "id": "3509650",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2024-12-25T17:48:46.031Z"
+      }
+    },
+    {
+      "id": "5164477",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2024-12-21T22:07:07.448Z"
+      }
+    },
+    {
+      "id": "3624635",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2024-12-14T13:13:34.632Z"
+      }
+    },
+    {
+      "id": "4513089",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2024-11-02T09:26:48.090Z"
+      }
+    },
+    {
+      "id": "13961",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2024-08-15T19:12:47.049Z"
+      }
+    },
+    {
+      "id": "1912",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2024-06-23T06:32:27.750Z"
+      }
+    },
+    {
+      "id": "4538611",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2024-06-21T17:11:58.051Z"
+      }
+    },
+    {
+      "id": "688",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2024-05-18T15:29:08.251Z"
+      }
+    },
+    {
+      "id": "3638212",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2024-05-11T22:05:22.824Z"
+      }
+    },
+    {
+      "id": "606",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2024-04-20T19:22:24.610Z"
+      }
+    },
+    {
+      "id": "4620892",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2024-02-10T09:01:58.785Z"
+      }
+    },
+    {
+      "id": "13867",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2024-02-09T17:35:34.103Z"
+      }
+    },
+    {
+      "id": "11146",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2024-01-27T11:39:44.615Z"
+      }
+    },
+    {
+      "id": "6944844",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2024-01-24T06:14:58.965Z"
+      }
+    },
+    {
+      "id": "3503529",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2023-08-10T22:34:48.940Z"
+      }
+    },
+    {
+      "id": "24965",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2023-06-14T08:02:53.908Z"
+      }
+    },
+    {
+      "id": "1727",
+      "type": "artists",
+      "meta": {
+        "addedAt": "2023-06-02T09:03:06.557Z"
+      }
+    }
+  ],
+  "links": {
+    "self": "/userCollectionArtists/me/relationships/items?include=items.profileArt&locale=en-US",
+    "next": "/userCollectionArtists/me/relationships/items?include=items.profileArt&locale=en-US&page%5Bcursor%5D=eyJpZCI6Mzk3Nzg2MjkxLCJkYXRlQWRkZWQiOiIyMDIzLTA2LTAyVDA5OjAzOjA2LjU1NyIsIm5hbWUiOiJPdXRrYXN0In0",
+    "meta": {
+      "nextCursor": "eyJpZCI6Mzk3Nzg2MjkxLCJkYXRlQWRkZWQiOiIyMDIzLTA2LTAyVDA5OjAzOjA2LjU1NyIsIm5hbWUiOiJPdXRrYXN0In0"
+    }
+  },
+  "included": [
+    {
+      "id": "11146",
+      "type": "artists",
+      "attributes": {
+        "name": "Fun Lovin' Criminals",
+        "popularity": 0.637256207244225,
+        "externalLinks": [
+          {
+            "href": "https://linktr.ee/FunLovinCriminals",
+            "meta": {
+              "type": "OFFICIAL_HOMEPAGE"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/11146",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "MIXED"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "dDmYD0OBhSkemPKw",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/11146/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "13867",
+      "type": "artists",
+      "attributes": {
+        "name": "Har Mar Superstar",
+        "popularity": 0.5092836618423462,
+        "externalLinks": [
+          {
+            "href": "https://facebook.com/http://facebook.com/harmarsuperstar",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "https://instagram.com/HarMarSuperstar",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://www.harmarsuperstar.com/",
+            "meta": {
+              "type": "OFFICIAL_HOMEPAGE"
+            }
+          },
+          {
+            "href": "https://twitter.com/HarMarSuperstar",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/13867",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "MIXED"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "dDmYD0OBhSkh57qx",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/13867/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "13961",
+      "type": "artists",
+      "attributes": {
+        "name": "Tom Petty",
+        "popularity": 0.8371281741254218,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/13961",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "dDmYD0OBhSkh5Ott",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/13961/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "1727",
+      "type": "artists",
+      "attributes": {
+        "name": "Outkast",
+        "popularity": 0.8677661926299315,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/1727",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "9Uwk47MKGp2bgOd",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/1727/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "1912",
+      "type": "artists",
+      "attributes": {
+        "name": "Wolfgang Ambros",
+        "popularity": 0.5896344778266899,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/1912",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "9Uwk47MKGp2cEQU",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/1912/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "24965",
+      "type": "artists",
+      "attributes": {
+        "name": "DJ Shadow",
+        "popularity": 0.7346473807591797,
+        "externalLinks": [
+          {
+            "href": "https://facebook.com/djshadow",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "https://instagram.com/djshadow",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://djshadow.com/",
+            "meta": {
+              "type": "OFFICIAL_HOMEPAGE"
+            }
+          },
+          {
+            "href": "https://tiktok.com/@djshadow",
+            "meta": {
+              "type": "TIKTOK"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/24965",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "dDmYD0OBhSpOt2cH",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/24965/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "3503529",
+      "type": "artists",
+      "attributes": {
+        "name": "Slade",
+        "popularity": 0.6954267621040344,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3503529",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGPBT9dgAUD",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/3503529/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "3509650",
+      "type": "artists",
+      "attributes": {
+        "name": "The Blind Boys of Alabama",
+        "popularity": 0.611082136631012,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3509650",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGPBT9kUor2",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/3509650/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "35183",
+      "type": "artists",
+      "attributes": {
+        "name": "Boymerang",
+        "popularity": 0.39522457122802734,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/35183",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "dDmYD0OBhSu6eU4Z",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/35183/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "3521742",
+      "type": "artists",
+      "attributes": {
+        "name": "High Contrast",
+        "popularity": 0.6726285048121236,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3521742",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGPBTIykQ42",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/3521742/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "3624635",
+      "type": "artists",
+      "attributes": {
+        "name": "Schneider TM",
+        "popularity": 0.450286865234375,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3624635",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGPBmfCS4KD",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/3624635/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "3638212",
+      "type": "artists",
+      "attributes": {
+        "name": "Voyager",
+        "popularity": 0.55536949634552,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3638212",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGPBmjxdnGs",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/3638212/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "4513089",
+      "type": "artists",
+      "attributes": {
+        "name": "Alabama Shakes",
+        "popularity": 0.7586725950241089,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/4513089",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQTOkrhDQ1",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4513089/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "4538611",
+      "type": "artists",
+      "attributes": {
+        "name": "Wanda",
+        "popularity": 0.6328100562095642,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/4538611",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGQTOuKjKEb",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4538611/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "4620892",
+      "type": "artists",
+      "attributes": {
+        "name": "FM Attack",
+        "popularity": 0.5484318137168884,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/4620892",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPcMGCZRnDPd",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/4620892/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "5164477",
+      "type": "artists",
+      "attributes": {
+        "name": "Nothing But Thieves",
+        "popularity": 0.751587450504303,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/nbthieves",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/5164477",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGRk5ECL9Md",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/5164477/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "606",
+      "type": "artists",
+      "attributes": {
+        "name": "Michael Jackson",
+        "popularity": 0.9420121908187866,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/606",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "2IdPgeX128VXqI",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/606/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "688",
+      "type": "artists",
+      "attributes": {
+        "name": "Chicane",
+        "popularity": 0.6856673370823063,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/688",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "2IdPgeX128VYNM",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/688/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "6944844",
+      "type": "artists",
+      "attributes": {
+        "name": "Paul Swoon",
+        "popularity": 0.032544318586587906,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/6944844",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [],
+          "links": {
+            "self": "/artists/6944844/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "9463631",
+      "type": "artists",
+      "attributes": {
+        "name": "Lazer Boomerang",
+        "popularity": 0.3608973519040371,
+        "externalLinks": [
+          {
+            "href": "https://facebook.com/lazerboomerang",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "https://instagram.com/lazerboomerang/",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://tiktok.com/@lazerboomerang",
+            "meta": {
+              "type": "TIKTOK"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/9463631",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "USER"
+      },
+      "relationships": {
+        "profileArt": {
+          "data": [
+            {
+              "id": "AmhFAmq4OGWujOpcCRt",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/artists/9463631/relationships/profileArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "2IdPgeX128VXqI",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/4eb3fd31/d6b7/4162/8fcc/c9a4ebee85d2/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4eb3fd31/d6b7/4162/8fcc/c9a4ebee85d2/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4eb3fd31/d6b7/4162/8fcc/c9a4ebee85d2/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4eb3fd31/d6b7/4162/8fcc/c9a4ebee85d2/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#564F41",
+          "blurHash": "UABg0i?w0O%100Di-.M|?bogjF%L%fx[RPIU",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2IdPgeX128VYNM",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/afb18ec4/99b0/45c4/9097/cbff9ef9410e/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/afb18ec4/99b0/45c4/9097/cbff9ef9410e/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/afb18ec4/99b0/45c4/9097/cbff9ef9410e/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/afb18ec4/99b0/45c4/9097/cbff9ef9410e/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#050709",
+          "blurHash": "UzLE7+t6-pof~payxuayD*WCWBj[t6ofayj[",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "9Uwk47MKGp2bgOd",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/8e235c1c/b742/4acf/aa94/1e12b74d455d/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8e235c1c/b742/4acf/aa94/1e12b74d455d/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8e235c1c/b742/4acf/aa94/1e12b74d455d/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8e235c1c/b742/4acf/aa94/1e12b74d455d/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#6B6058",
+          "blurHash": "UTJREfxa-pWB~p%2WBbH9GofIUj@bIWB%2Rj",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "9Uwk47MKGp2cEQU",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/bd5c4b8d/1291/4404/a278/1210330f731e/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/bd5c4b8d/1291/4404/a278/1210330f731e/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/bd5c4b8d/1291/4404/a278/1210330f731e/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/bd5c4b8d/1291/4404/a278/1210330f731e/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#805D4D",
+          "blurHash": "UrJ7]-xu_Nt8~qV@o}az?baxofflofRjWBt7",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGPBT9dgAUD",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/33c85354/b03c/4fc3/b6f4/8aa2dbb1c1d4/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/33c85354/b03c/4fc3/b6f4/8aa2dbb1c1d4/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/33c85354/b03c/4fc3/b6f4/8aa2dbb1c1d4/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/33c85354/b03c/4fc3/b6f4/8aa2dbb1c1d4/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#696969",
+          "blurHash": "UIN^e:?b~qD%%MayxuWB~qRjM{t7%MayWBof",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGPBT9kUor2",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/da60e82d/11f3/49fa/a938/9437497946db/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/da60e82d/11f3/49fa/a938/9437497946db/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/da60e82d/11f3/49fa/a938/9437497946db/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/da60e82d/11f3/49fa/a938/9437497946db/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#1D3E39",
+          "blurHash": "UED17=4TS#_3QS%#ozMd00-;R5M{y=MKozx]",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGPBTIykQ42",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/29d44628/34be/4e96/93d2/e2134373e687/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/29d44628/34be/4e96/93d2/e2134373e687/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/29d44628/34be/4e96/93d2/e2134373e687/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/29d44628/34be/4e96/93d2/e2134373e687/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#231B19",
+          "blurHash": "UfKx0a-;_Nxu-;jYR*WCRPbIRjjZIpWBs,of",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGPBmfCS4KD",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/28d9479b/22cb/45c1/9380/52e22a26c9ae/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/28d9479b/22cb/45c1/9380/52e22a26c9ae/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/28d9479b/22cb/45c1/9380/52e22a26c9ae/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/28d9479b/22cb/45c1/9380/52e22a26c9ae/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#5A291E",
+          "blurHash": "UIKT73+[.TIAD%-;VYMxtlNa%M-;firqn*RP",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGPBmjxdnGs",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/2c649211/7b1a/4a0b/b2ad/be7de7d3c7f6/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2c649211/7b1a/4a0b/b2ad/be7de7d3c7f6/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2c649211/7b1a/4a0b/b2ad/be7de7d3c7f6/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/2c649211/7b1a/4a0b/b2ad/be7de7d3c7f6/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#040909",
+          "blurHash": "U66ubFozIUkC8_RPx]jZ?^ozofWBDit7xuRQ",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQTOkrhDQ1",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/6d86f393/5ad3/4e85/8410/9ea22746c8f9/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6d86f393/5ad3/4e85/8410/9ea22746c8f9/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6d86f393/5ad3/4e85/8410/9ea22746c8f9/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/6d86f393/5ad3/4e85/8410/9ea22746c8f9/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#662F19",
+          "blurHash": "UZFrFlIpD*kC~WWCRjWBXnxtoLRj.7%2Ioay",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGQTOuKjKEb",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/1d045961/1235/48a4/9c7a/088e6cbd9eed/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1d045961/1235/48a4/9c7a/088e6cbd9eed/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1d045961/1235/48a4/9c7a/088e6cbd9eed/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1d045961/1235/48a4/9c7a/088e6cbd9eed/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#3E291E",
+          "blurHash": "UgD]h?ROofjZ~qM_WBWB?bWBaea}tRWXWBbH",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGRk5ECL9Md",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/694e3974/7999/49da/9c2f/a0816355ecae/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/694e3974/7999/49da/9c2f/a0816355ecae/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/694e3974/7999/49da/9c2f/a0816355ecae/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/694e3974/7999/49da/9c2f/a0816355ecae/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#745648",
+          "blurHash": "UhLqOmNG_3M_~q-;t6kC?aWXD%oJ%gRjRQR*",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "AmhFAmq4OGWujOpcCRt",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/b3234e3c/2e98/4940/a927/549345c87040/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b3234e3c/2e98/4940/a927/549345c87040/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b3234e3c/2e98/4940/a927/549345c87040/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/b3234e3c/2e98/4940/a927/549345c87040/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#693451",
+          "blurHash": "ULEMhLpJ%$9F~q%2WAM_KQRismxu5WI:bG%1",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "dDmYD0OBhSkemPKw",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/3216ab3b/1217/429a/a199/dd1a9d7bce77/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3216ab3b/1217/429a/a199/dd1a9d7bce77/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3216ab3b/1217/429a/a199/dd1a9d7bce77/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3216ab3b/1217/429a/a199/dd1a9d7bce77/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#020202",
+          "blurHash": "U58;V?M{IURj~qM{ayt700t7oft79F%MRjWB",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "dDmYD0OBhSkh57qx",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/fa23e4aa/6578/4ae3/b74c/8bb93b653af2/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/fa23e4aa/6578/4ae3/b74c/8bb93b653af2/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/fa23e4aa/6578/4ae3/b74c/8bb93b653af2/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/fa23e4aa/6578/4ae3/b74c/8bb93b653af2/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#4F1E19",
+          "blurHash": "UF8}_8xtIAWVQ6XRX8ayQ9j]%2oLIAWqn5of",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "dDmYD0OBhSkh5Ott",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/82795654/d521/4168/8424/29711ddf29d2/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/82795654/d521/4168/8424/29711ddf29d2/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/82795654/d521/4168/8424/29711ddf29d2/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/82795654/d521/4168/8424/29711ddf29d2/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#56432E",
+          "blurHash": "U25N}sNe01-T}?D*E2%1Myo0^*NHM|s:-pIV",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "dDmYD0OBhSpOt2cH",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/4095b8f7/bf96/4b4a/af6f/e954e025495b/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4095b8f7/bf96/4b4a/af6f/e954e025495b/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4095b8f7/bf96/4b4a/af6f/e954e025495b/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/4095b8f7/bf96/4b4a/af6f/e954e025495b/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#131313",
+          "blurHash": "U9Jkl#0000~q9F~qM{D%4nt7?b%MRjt7IUIU",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "dDmYD0OBhSu6eU4Z",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/f2217545/956e/4724/83ce/f14897747d29/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2217545/956e/4724/83ce/f14897747d29/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2217545/956e/4724/83ce/f14897747d29/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f2217545/956e/4724/83ce/f14897747d29/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#1F1F1F",
+          "blurHash": "UaLENU~qM{xu-;IUWB-;ofayj[ayofxut7M{",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPcMGCZRnDPd",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/a15ff8fb/eb9d/4dce/a5ad/d28de75231d6/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/a15ff8fb/eb9d/4dce/a5ad/d28de75231d6/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/a15ff8fb/eb9d/4dce/a5ad/d28de75231d6/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/a15ff8fb/eb9d/4dce/a5ad/d28de75231d6/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/a15ff8fb/eb9d/4dce/a5ad/d28de75231d6/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/a15ff8fb/eb9d/4dce/a5ad/d28de75231d6/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/a15ff8fb/eb9d/4dce/a5ad/d28de75231d6/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#934868",
+          "blurHash": "UfK]c=aeI.xH^-V[n%R%62M{ofjt%MxabHjb",
+          "status": "OK"
+        }
+      }
+    }
+  ]
+}

--- a/tests/providers/tidal/fixtures/v2/lib_playlists.json
+++ b/tests/providers/tidal/fixtures/v2/lib_playlists.json
@@ -1,0 +1,1870 @@
+{
+  "data": [
+    {
+      "id": "80d6d637-9dba-4984-bf2e-5dec5e4782e4",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2026-05-05T15:11:57.953747Z"
+      }
+    },
+    {
+      "id": "3f99dc4b-1524-4df0-a1c0-052de6ca5722",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2026-05-04T14:51:24.614322Z"
+      }
+    },
+    {
+      "id": "dfcfa5e1-52e3-4f74-ad20-44d71c582021",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2026-05-04T11:05:20.240218Z"
+      }
+    },
+    {
+      "id": "886e6090-7fdd-422a-9901-e69ad8601e49",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2026-04-21T15:59:55.391784Z"
+      }
+    },
+    {
+      "id": "00162145119b17bdebf4d4da90433e",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2026-04-20T15:11:21.224442Z"
+      }
+    },
+    {
+      "id": "6a9f7092-ea04-448f-8b8c-38cbe3e4d6d8",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2026-04-03T15:02:07.507305Z"
+      }
+    },
+    {
+      "id": "00835752c7cbccabf4f88802580c47",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2026-03-02T16:39:20.650126Z"
+      }
+    },
+    {
+      "id": "001551c78ebf2d6f7cd70511364337",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2026-02-23T07:28:45.411504Z"
+      }
+    },
+    {
+      "id": "001b71158cd58182a7fd08add7b18c",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2026-02-23T07:28:33.409646Z"
+      }
+    },
+    {
+      "id": "0f72f8b9-6d2f-416c-be04-9bde48e735ce",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2025-11-28T20:53:43.823872Z"
+      }
+    },
+    {
+      "id": "001201ec16324e0651f9e99a27217f",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2025-08-17T10:34:34.797357Z"
+      }
+    },
+    {
+      "id": "001bbe5560632fefbd89ea4e0a4f39",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2025-06-23T12:07:44.228705Z"
+      }
+    },
+    {
+      "id": "00109a13be2e75e2b4f3061e188725",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2025-06-23T12:07:28.581655Z"
+      }
+    },
+    {
+      "id": "001e849b188999a5b673ce4db37f4f",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2025-06-23T12:05:53.902820Z"
+      }
+    },
+    {
+      "id": "001a47427032b79e02dd72c3b9d65f",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2025-06-23T12:05:13.746120Z"
+      }
+    },
+    {
+      "id": "0011883bfcf036107d2d781c4ac36a",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2025-06-23T12:04:17.375052Z"
+      }
+    },
+    {
+      "id": "0013933ae431aa8835ad1029040136",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2025-06-23T12:04:00.418944Z"
+      }
+    },
+    {
+      "id": "001583b539faa4dca268ff875b778f",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2025-06-23T12:03:41.577171Z"
+      }
+    },
+    {
+      "id": "0012c28bc8c89a5991cd888365d956",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2025-06-23T12:03:16.050124Z"
+      }
+    },
+    {
+      "id": "0015664b81ceacae9c91ec9da096d8",
+      "type": "playlists",
+      "meta": {
+        "addedAt": "2025-06-23T12:02:20.874153Z"
+      }
+    }
+  ],
+  "links": {
+    "self": "/userCollectionPlaylists/me/relationships/items?include=items.coverArt%2Citems.owners&locale=en-US",
+    "next": "/userCollectionPlaylists/me/relationships/items?include=items.coverArt%2Citems.owners&locale=en-US&page%5Bcursor%5D=eyJpZCI6ImNkYjMyY2ZkLWUyODQtOWY1NS1jYWFhLTBmNzY3YzQwYTc1MSIsIm5hbWUiOiJDb21lIFNhaWwgQXdheSIsImFkZGVkQXQiOiIyMDI1LTA2LTIzVDEyOjAyOjIwLjg3NDE1M1oiLCJ1cGRhdGVkQXQiOiIyMDI1LTA2LTIzVDEyOjAyOjIwLjg3NDE1M1oiLCJpdGVtVHlwZSI6IkZBVk9SSVRFX01JWCIsImFydGlzdE5hbWUiOm51bGwsInJlbGVhc2VkQXQiOm51bGwsIm1peFR5cGUiOm51bGx9",
+    "meta": {
+      "nextCursor": "eyJpZCI6ImNkYjMyY2ZkLWUyODQtOWY1NS1jYWFhLTBmNzY3YzQwYTc1MSIsIm5hbWUiOiJDb21lIFNhaWwgQXdheSIsImFkZGVkQXQiOiIyMDI1LTA2LTIzVDEyOjAyOjIwLjg3NDE1M1oiLCJ1cGRhdGVkQXQiOiIyMDI1LTA2LTIzVDEyOjAyOjIwLjg3NDE1M1oiLCJpdGVtVHlwZSI6IkZBVk9SSVRFX01JWCIsImFydGlzdE5hbWUiOm51bGwsInJlbGVhc2VkQXQiOm51bGwsIm1peFR5cGUiOm51bGx9"
+    }
+  },
+  "included": [
+    {
+      "id": "2b7Vtuqr0DkawPbseJyRPJryYZKlZlXc1KyWeix4QKfsGxRFRCNfNebX3",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/65a53dde/8d90/4622/b960/e8020c7f884e/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/65a53dde/8d90/4622/b960/e8020c7f884e/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/65a53dde/8d90/4622/b960/e8020c7f884e/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/65a53dde/8d90/4622/b960/e8020c7f884e/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#7C3B79",
+          "blurHash": "U17nYA7Njs2^8^wHfR+tfRfRfQfQ00;1fR{c",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0H5NFZF6CvAs7Y8LGTDCDDM9Pv4wVVeRZxxJGuf9MNxW4AwPC",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/e20edc84/1724/44a8/aaa0/f32d42b27344/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e20edc84/1724/44a8/aaa0/f32d42b27344/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e20edc84/1724/44a8/aaa0/f32d42b27344/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e20edc84/1724/44a8/aaa0/f32d42b27344/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#A1315F",
+          "blurHash": "UGHm.a[C-BAB7x01M{-VyDI.bYNd}]=xoeI;",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0KOnyQKPOV2FoHTAbWbcujij9EvIzDVCjFU5cajrGYa43EfcW",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/e9448a9a/3ade/4f79/93d2/12e6d8d4b2eb/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9448a9a/3ade/4f79/93d2/12e6d8d4b2eb/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9448a9a/3ade/4f79/93d2/12e6d8d4b2eb/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9448a9a/3ade/4f79/93d2/12e6d8d4b2eb/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#19181C",
+          "blurHash": "U05ONk%M00M_M{ITWA%M00t7~qRi%N?bt7D%",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0MPVb0Bv9GdfSLS1vEu4qTWZHroBfGnLaiSzLrsOVXpVVQt3U",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/8979ac02/d1ba/4797/901f/d0c7b0e5b15e/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8979ac02/d1ba/4797/901f/d0c7b0e5b15e/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8979ac02/d1ba/4797/901f/d0c7b0e5b15e/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8979ac02/d1ba/4797/901f/d0c7b0e5b15e/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#A11916",
+          "blurHash": "UID+i2TxS5bcg*_4W?Io~EObbbs+KSxvsor?",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr0MRc9T9XSf3NTnbiu7rLhTRCQXPCfnUGuXHa4uuKUXdvlhBYP",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/f3b13bcf/cbcb/446f/bc14/17b9ea5b1c38/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f3b13bcf/cbcb/446f/bc14/17b9ea5b1c38/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f3b13bcf/cbcb/446f/bc14/17b9ea5b1c38/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/f3b13bcf/cbcb/446f/bc14/17b9ea5b1c38/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#580F07",
+          "blurHash": "UGFrej00oz^*17s$oLsp9f%FozIU4U~VWXD%",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2b7Vtuqr19YmDkEjwJ5guh7IXiqDVZG4DKipkUByRuTzARgsS0gGfoxJh",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/d8900392/554c/4719/9c6d/cf2220a3a07f/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/d8900392/554c/4719/9c6d/cf2220a3a07f/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/d8900392/554c/4719/9c6d/cf2220a3a07f/480x480.jpg",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/d8900392/554c/4719/9c6d/cf2220a3a07f/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#793868",
+          "blurHash": "UZEeJ?0wV[xb}^9safxanlWoj[j@NFxaj[WV",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "86EFpfvW5of7SDusNluawUwqytlhEfvP8OtLnB9gkGv9EfLgAv",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokOGNlZDdkMmUvMzQzMS80YTQyLzk5NDkvMDYxZmZkZDM4YTI3GiQzMWYzMWFiZi83ZmM0LzQ3OWMvYjhhZi8wYzQyZWI1M2Q1OWUaJDI3ZTY2ODE4L2ViOTAvNGMyNy9iMWMwL2MyYzgyNzMwNWI1MiILVHJhY2sgUmFkaW8iE0FsbCBZb3UgRXZlciBXYW50ZWQqByNFMkIwQUEwAg?token=ff8fd9d6809099051b692b37778a4c8eba715add",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokOGNlZDdkMmUvMzQzMS80YTQyLzk5NDkvMDYxZmZkZDM4YTI3GiQzMWYzMWFiZi83ZmM0LzQ3OWMvYjhhZi8wYzQyZWI1M2Q1OWUaJDI3ZTY2ODE4L2ViOTAvNGMyNy9iMWMwL2MyYzgyNzMwNWI1MiILVHJhY2sgUmFkaW8iE0FsbCBZb3UgRXZlciBXYW50ZWQqByNFMkIwQUEwAg?token=ff8fd9d6809099051b692b37778a4c8eba715add",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EIAFGIAFIMACKMAC/CAEQBhokOGNlZDdkMmUvMzQzMS80YTQyLzk5NDkvMDYxZmZkZDM4YTI3GiQzMWYzMWFiZi83ZmM0LzQ3OWMvYjhhZi8wYzQyZWI1M2Q1OWUaJDI3ZTY2ODE4L2ViOTAvNGMyNy9iMWMwL2MyYzgyNzMwNWI1MiILVHJhY2sgUmFkaW8iE0FsbCBZb3UgRXZlciBXYW50ZWQqByNFMkIwQUEwAg?token=261dfb23a150f0edf1660e1c3906d8b1e7af9273",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/ENwLGNwLIO4FKO4F/CAEQBhokOGNlZDdkMmUvMzQzMS80YTQyLzk5NDkvMDYxZmZkZDM4YTI3GiQzMWYzMWFiZi83ZmM0LzQ3OWMvYjhhZi8wYzQyZWI1M2Q1OWUaJDI3ZTY2ODE4L2ViOTAvNGMyNy9iMWMwL2MyYzgyNzMwNWI1MiILVHJhY2sgUmFkaW8iE0FsbCBZb3UgRXZlciBXYW50ZWQqByNFMkIwQUEwAg?token=fe3e2e7342acf2f0cb806b7e00505d1ec9334f35",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "status": "NONE"
+        }
+      }
+    },
+    {
+      "id": "86EFpfvW5of7SDvdG4e8fdH9rQnYDeAV6a2qyGjzTlY7qBoONF",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokYmM5MjhjMWYvZjUwYy80MGY3LzkwNjIvNmQyZTJiOTc3ZGY2GiQ4ZDE5MThiNy8xYWJjLzQxNmUvYmNjZi9lM2Q4YTk1Njk3ZmMaJDA1ZDcyYWU0LzMxOWYvNDIzNy84MjFmLzFkN2FmOWVjOGFjZiILVHJhY2sgUmFkaW8iDEhpZ2hlciBQb3dlcioHIzg5OTdGNzAC?token=15357cc79eade4617526aa11bf8646dc445b345b",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokYmM5MjhjMWYvZjUwYy80MGY3LzkwNjIvNmQyZTJiOTc3ZGY2GiQ4ZDE5MThiNy8xYWJjLzQxNmUvYmNjZi9lM2Q4YTk1Njk3ZmMaJDA1ZDcyYWU0LzMxOWYvNDIzNy84MjFmLzFkN2FmOWVjOGFjZiILVHJhY2sgUmFkaW8iDEhpZ2hlciBQb3dlcioHIzg5OTdGNzAC?token=15357cc79eade4617526aa11bf8646dc445b345b",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EIAFGIAFIMACKMAC/CAEQBhokYmM5MjhjMWYvZjUwYy80MGY3LzkwNjIvNmQyZTJiOTc3ZGY2GiQ4ZDE5MThiNy8xYWJjLzQxNmUvYmNjZi9lM2Q4YTk1Njk3ZmMaJDA1ZDcyYWU0LzMxOWYvNDIzNy84MjFmLzFkN2FmOWVjOGFjZiILVHJhY2sgUmFkaW8iDEhpZ2hlciBQb3dlcioHIzg5OTdGNzAC?token=bba5b49a66c4ae19f2a7b05db249d370a5eee821",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/ENwLGNwLIO4FKO4F/CAEQBhokYmM5MjhjMWYvZjUwYy80MGY3LzkwNjIvNmQyZTJiOTc3ZGY2GiQ4ZDE5MThiNy8xYWJjLzQxNmUvYmNjZi9lM2Q4YTk1Njk3ZmMaJDA1ZDcyYWU0LzMxOWYvNDIzNy84MjFmLzFkN2FmOWVjOGFjZiILVHJhY2sgUmFkaW8iDEhpZ2hlciBQb3dlcioHIzg5OTdGNzAC?token=632ea32c63ca718988cf29c7dd2d257bbf2a7362",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "status": "NONE"
+        }
+      }
+    },
+    {
+      "id": "86EFpfvW5of7SDwMs4HjAzb5pAirzHg4UiHb5jLbv9ljGffVrC",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokOTFjNWI1NzAvYTNlNy80NjgwLzkwODcvMmJiZmQzM2U3OTUzGiRmMDQ3MjgzNC8yNTg2LzQwZTMvODZhMC8wNTBjODM2ZGFiNDYaJDJjZWEzNTFjL2VjMTYvNDlhZC84MjQ3L2FmMzc3NTgyNWNhNCILVHJhY2sgUmFkaW8iCFRoZSBIaWxsKgcjREY1QTg0MAI?token=dc6704d2e585522510243acb7c8e350762401eb0",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokOTFjNWI1NzAvYTNlNy80NjgwLzkwODcvMmJiZmQzM2U3OTUzGiRmMDQ3MjgzNC8yNTg2LzQwZTMvODZhMC8wNTBjODM2ZGFiNDYaJDJjZWEzNTFjL2VjMTYvNDlhZC84MjQ3L2FmMzc3NTgyNWNhNCILVHJhY2sgUmFkaW8iCFRoZSBIaWxsKgcjREY1QTg0MAI?token=dc6704d2e585522510243acb7c8e350762401eb0",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EIAFGIAFIMACKMAC/CAEQBhokOTFjNWI1NzAvYTNlNy80NjgwLzkwODcvMmJiZmQzM2U3OTUzGiRmMDQ3MjgzNC8yNTg2LzQwZTMvODZhMC8wNTBjODM2ZGFiNDYaJDJjZWEzNTFjL2VjMTYvNDlhZC84MjQ3L2FmMzc3NTgyNWNhNCILVHJhY2sgUmFkaW8iCFRoZSBIaWxsKgcjREY1QTg0MAI?token=78690cc7cbd797957960f846ccd62d27d3158a3d",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/ENwLGNwLIO4FKO4F/CAEQBhokOTFjNWI1NzAvYTNlNy80NjgwLzkwODcvMmJiZmQzM2U3OTUzGiRmMDQ3MjgzNC8yNTg2LzQwZTMvODZhMC8wNTBjODM2ZGFiNDYaJDJjZWEzNTFjL2VjMTYvNDlhZC84MjQ3L2FmMzc3NTgyNWNhNCILVHJhY2sgUmFkaW8iCFRoZSBIaWxsKgcjREY1QTg0MAI?token=26f240e417fdba4c4f1cb8f7bde0537cae1c6233",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "status": "NONE"
+        }
+      }
+    },
+    {
+      "id": "86EFpfvW5of7SDwWFjLtHPI86yAIGCsdtGi2hkFEJ5PxfUalRG",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokYzg4ZDYyZjEvMTkxOS80YTZjLzk3ZTUvNzM5NWJhYTk0N2Y5GiQzMWRkMzI3NC8yYmEzLzQ2ODUvYjAxNy85NGQ0NDQ1NWI1NmEaJGQxMDhiMjc3LzgyZjkvNDc3Ny85MDc4LzQ3YWYxN2VmNDA1ZiILVHJhY2sgUmFkaW8iCkJ5IFRoZSBXYXkqByNGNzY3QjAwAg?token=ad872a2291c29a328d2b7093d95efdadbedeb203",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokYzg4ZDYyZjEvMTkxOS80YTZjLzk3ZTUvNzM5NWJhYTk0N2Y5GiQzMWRkMzI3NC8yYmEzLzQ2ODUvYjAxNy85NGQ0NDQ1NWI1NmEaJGQxMDhiMjc3LzgyZjkvNDc3Ny85MDc4LzQ3YWYxN2VmNDA1ZiILVHJhY2sgUmFkaW8iCkJ5IFRoZSBXYXkqByNGNzY3QjAwAg?token=ad872a2291c29a328d2b7093d95efdadbedeb203",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EIAFGIAFIMACKMAC/CAEQBhokYzg4ZDYyZjEvMTkxOS80YTZjLzk3ZTUvNzM5NWJhYTk0N2Y5GiQzMWRkMzI3NC8yYmEzLzQ2ODUvYjAxNy85NGQ0NDQ1NWI1NmEaJGQxMDhiMjc3LzgyZjkvNDc3Ny85MDc4LzQ3YWYxN2VmNDA1ZiILVHJhY2sgUmFkaW8iCkJ5IFRoZSBXYXkqByNGNzY3QjAwAg?token=d2c117f324366ec0abcf5fc7f7f113b91dab2ecb",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/ENwLGNwLIO4FKO4F/CAEQBhokYzg4ZDYyZjEvMTkxOS80YTZjLzk3ZTUvNzM5NWJhYTk0N2Y5GiQzMWRkMzI3NC8yYmEzLzQ2ODUvYjAxNy85NGQ0NDQ1NWI1NmEaJGQxMDhiMjc3LzgyZjkvNDc3Ny85MDc4LzQ3YWYxN2VmNDA1ZiILVHJhY2sgUmFkaW8iCkJ5IFRoZSBXYXkqByNGNzY3QjAwAg?token=43b7b1a27432aac01c313d6337edcdb6da100aca",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "status": "NONE"
+        }
+      }
+    },
+    {
+      "id": "86EFpfvW5of7SDx9cJxxWTn7Wb3bigLPQv5lGVZVP4xIPVh66o",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokODRhMTQ3YjUvNDhlNy80NjA3L2IwYzQvOGJlZTE1MTAxYmZkGiRjODJhYjhmMi9mNzdhLzRjNGEvYWY2NS8xNDM3NGQ4MmIzM2EaJDRiODg1YjExLzBhZjEvNGRlZS85NTgxLzMzYWE3ODQ4NjgxMSILVHJhY2sgUmFkaW8iB0JlYXQgSXQqByNDOEI0OEMwAg?token=4c2c0e7d7b96478dc56b79eb2e6d427b5cd50453",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokODRhMTQ3YjUvNDhlNy80NjA3L2IwYzQvOGJlZTE1MTAxYmZkGiRjODJhYjhmMi9mNzdhLzRjNGEvYWY2NS8xNDM3NGQ4MmIzM2EaJDRiODg1YjExLzBhZjEvNGRlZS85NTgxLzMzYWE3ODQ4NjgxMSILVHJhY2sgUmFkaW8iB0JlYXQgSXQqByNDOEI0OEMwAg?token=4c2c0e7d7b96478dc56b79eb2e6d427b5cd50453",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EIAFGIAFIMACKMAC/CAEQBhokODRhMTQ3YjUvNDhlNy80NjA3L2IwYzQvOGJlZTE1MTAxYmZkGiRjODJhYjhmMi9mNzdhLzRjNGEvYWY2NS8xNDM3NGQ4MmIzM2EaJDRiODg1YjExLzBhZjEvNGRlZS85NTgxLzMzYWE3ODQ4NjgxMSILVHJhY2sgUmFkaW8iB0JlYXQgSXQqByNDOEI0OEMwAg?token=5201a7824b60b902632df1d2f2b7a48d2298e7f9",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/ENwLGNwLIO4FKO4F/CAEQBhokODRhMTQ3YjUvNDhlNy80NjA3L2IwYzQvOGJlZTE1MTAxYmZkGiRjODJhYjhmMi9mNzdhLzRjNGEvYWY2NS8xNDM3NGQ4MmIzM2EaJDRiODg1YjExLzBhZjEvNGRlZS85NTgxLzMzYWE3ODQ4NjgxMSILVHJhY2sgUmFkaW8iB0JlYXQgSXQqByNDOEI0OEMwAg?token=00e528bf1361d636e09255c6db245f764967bb33",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "status": "NONE"
+        }
+      }
+    },
+    {
+      "id": "86EFpfvW5of7SDyf3giTLYdnF75YaogETilLBQ2NmU3DSDV4fX",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokNmVhOTNlZmIvNjc5NS80ZGM4LzkxODUvNzUxZGQ1YmE3NmRkGiQwMzYyNzcxMy9iN2QxLzQ4YjcvOWI4Yi8xZjZlMTdiNGY1N2IaJDNiMGI3NmQxLzc2NmYvNDA5MS84ZGY0L2VlYjc2Njc0OTEzOSILVHJhY2sgUmFkaW8iFkxvcyBBbmdlbGVzIChBU09UIDk4NCkqByNEMTU3N0QwAg?token=c84193832b8f1696f52fe3ecf32b11380c472bf0",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokNmVhOTNlZmIvNjc5NS80ZGM4LzkxODUvNzUxZGQ1YmE3NmRkGiQwMzYyNzcxMy9iN2QxLzQ4YjcvOWI4Yi8xZjZlMTdiNGY1N2IaJDNiMGI3NmQxLzc2NmYvNDA5MS84ZGY0L2VlYjc2Njc0OTEzOSILVHJhY2sgUmFkaW8iFkxvcyBBbmdlbGVzIChBU09UIDk4NCkqByNEMTU3N0QwAg?token=c84193832b8f1696f52fe3ecf32b11380c472bf0",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EIAFGIAFIMACKMAC/CAEQBhokNmVhOTNlZmIvNjc5NS80ZGM4LzkxODUvNzUxZGQ1YmE3NmRkGiQwMzYyNzcxMy9iN2QxLzQ4YjcvOWI4Yi8xZjZlMTdiNGY1N2IaJDNiMGI3NmQxLzc2NmYvNDA5MS84ZGY0L2VlYjc2Njc0OTEzOSILVHJhY2sgUmFkaW8iFkxvcyBBbmdlbGVzIChBU09UIDk4NCkqByNEMTU3N0QwAg?token=29ed16fb31346ab8bf39d1129d5944e2961f41fd",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/ENwLGNwLIO4FKO4F/CAEQBhokNmVhOTNlZmIvNjc5NS80ZGM4LzkxODUvNzUxZGQ1YmE3NmRkGiQwMzYyNzcxMy9iN2QxLzQ4YjcvOWI4Yi8xZjZlMTdiNGY1N2IaJDNiMGI3NmQxLzc2NmYvNDA5MS84ZGY0L2VlYjc2Njc0OTEzOSILVHJhY2sgUmFkaW8iFkxvcyBBbmdlbGVzIChBU09UIDk4NCkqByNEMTU3N0QwAg?token=854f70d95fcbff005dd262250f3e1b1c936ebe3d",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "status": "NONE"
+        }
+      }
+    },
+    {
+      "id": "86EFpfvW5of7SDyfFJ5yb0P2ra85biqC9fgtoLKIdSdMiq73qC",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokNGM4YWMyZjIvMzM3Mi80ZmY1LzgyMmUvODFhMDk3MTY0YmE0GiRkMTNkOGRjYi9kNGI1LzQ2NzEvYWVjOS9hOTRlOWZjNWVhYzMaJGNkMGExNWFhLzVkZTcvNGQ3ZC85ZDM5Lzc0MGZlMmQ1Yzg3MyILVHJhY2sgUmFkaW8iDkNvbWUgU2FpbCBBd2F5KgcjRDhDODk4MAI?token=8bb488a844c8322d361367ecd93858aac9fcb291",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokNGM4YWMyZjIvMzM3Mi80ZmY1LzgyMmUvODFhMDk3MTY0YmE0GiRkMTNkOGRjYi9kNGI1LzQ2NzEvYWVjOS9hOTRlOWZjNWVhYzMaJGNkMGExNWFhLzVkZTcvNGQ3ZC85ZDM5Lzc0MGZlMmQ1Yzg3MyILVHJhY2sgUmFkaW8iDkNvbWUgU2FpbCBBd2F5KgcjRDhDODk4MAI?token=8bb488a844c8322d361367ecd93858aac9fcb291",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EIAFGIAFIMACKMAC/CAEQBhokNGM4YWMyZjIvMzM3Mi80ZmY1LzgyMmUvODFhMDk3MTY0YmE0GiRkMTNkOGRjYi9kNGI1LzQ2NzEvYWVjOS9hOTRlOWZjNWVhYzMaJGNkMGExNWFhLzVkZTcvNGQ3ZC85ZDM5Lzc0MGZlMmQ1Yzg3MyILVHJhY2sgUmFkaW8iDkNvbWUgU2FpbCBBd2F5KgcjRDhDODk4MAI?token=359c13edf76a95447c5946129354c0b53231cd41",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/ENwLGNwLIO4FKO4F/CAEQBhokNGM4YWMyZjIvMzM3Mi80ZmY1LzgyMmUvODFhMDk3MTY0YmE0GiRkMTNkOGRjYi9kNGI1LzQ2NzEvYWVjOS9hOTRlOWZjNWVhYzMaJGNkMGExNWFhLzVkZTcvNGQ3ZC85ZDM5Lzc0MGZlMmQ1Yzg3MyILVHJhY2sgUmFkaW8iDkNvbWUgU2FpbCBBd2F5KgcjRDhDODk4MAI?token=7869bc7d0cd554500556e216ee4ef15645fde5c8",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "status": "NONE"
+        }
+      }
+    },
+    {
+      "id": "86EFpfvW5of7SDyfbzS70lbmPyZvlAAHCIFU95KGFhnwPcJszW",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokNGE1Y2VhNTQvNmIyMi80MDFjL2ExODYvNjc5NmJiOTZmYTY3GiQxY2M3M2NlZC8xNzcxLzRiMTAvYjY2ZS85M2NjNmJiMTQzMTYaJGUxNmIyNGJjLzU1N2UvNDQyYi84YmEwLzYzMzI2ZjdiOTIzMSILVHJhY2sgUmFkaW8iGFdoYXQgSGFwcGVuZWQgVG8gUGVyZmVjdCoHIzlBQjdFMzAC?token=3e66595beeab230956a08d6397ec56e2e2dd7b68",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokNGE1Y2VhNTQvNmIyMi80MDFjL2ExODYvNjc5NmJiOTZmYTY3GiQxY2M3M2NlZC8xNzcxLzRiMTAvYjY2ZS85M2NjNmJiMTQzMTYaJGUxNmIyNGJjLzU1N2UvNDQyYi84YmEwLzYzMzI2ZjdiOTIzMSILVHJhY2sgUmFkaW8iGFdoYXQgSGFwcGVuZWQgVG8gUGVyZmVjdCoHIzlBQjdFMzAC?token=3e66595beeab230956a08d6397ec56e2e2dd7b68",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EIAFGIAFIMACKMAC/CAEQBhokNGE1Y2VhNTQvNmIyMi80MDFjL2ExODYvNjc5NmJiOTZmYTY3GiQxY2M3M2NlZC8xNzcxLzRiMTAvYjY2ZS85M2NjNmJiMTQzMTYaJGUxNmIyNGJjLzU1N2UvNDQyYi84YmEwLzYzMzI2ZjdiOTIzMSILVHJhY2sgUmFkaW8iGFdoYXQgSGFwcGVuZWQgVG8gUGVyZmVjdCoHIzlBQjdFMzAC?token=50a83556fd34d14ba6bff714ef1af206492bf480",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/ENwLGNwLIO4FKO4F/CAEQBhokNGE1Y2VhNTQvNmIyMi80MDFjL2ExODYvNjc5NmJiOTZmYTY3GiQxY2M3M2NlZC8xNzcxLzRiMTAvYjY2ZS85M2NjNmJiMTQzMTYaJGUxNmIyNGJjLzU1N2UvNDQyYi84YmEwLzYzMzI2ZjdiOTIzMSILVHJhY2sgUmFkaW8iGFdoYXQgSGFwcGVuZWQgVG8gUGVyZmVjdCoHIzlBQjdFMzAC?token=863115d4e7c1530b69f412f34f6edac60693dac7",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "status": "NONE"
+        }
+      }
+    },
+    {
+      "id": "86EFpfvW5of7SDzPb00vBzPn384iSTyZyThvLpenH5PsuNXcpB",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokZjRhMTk2MmUvZDM4NC80NGQzL2E5OGYvYzJhZjNkNmRmMGEwGiQxNWU3MDRmMC9mYjE3LzQ3YWUvYTg0Ny8yZWQ5ZTRjNTgyMTEaJGMyMjdkZDA0LzJhYzEvNGMxNi84YjdhL2JkZDc3OWU2MDlmNSILVHJhY2sgUmFkaW8iCUludGVyY2VwdCoHIzg3RDdFMTAC?token=c0a1a5216a071496ca8351d36c91ac1cf812c654",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokZjRhMTk2MmUvZDM4NC80NGQzL2E5OGYvYzJhZjNkNmRmMGEwGiQxNWU3MDRmMC9mYjE3LzQ3YWUvYTg0Ny8yZWQ5ZTRjNTgyMTEaJGMyMjdkZDA0LzJhYzEvNGMxNi84YjdhL2JkZDc3OWU2MDlmNSILVHJhY2sgUmFkaW8iCUludGVyY2VwdCoHIzg3RDdFMTAC?token=c0a1a5216a071496ca8351d36c91ac1cf812c654",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EIAFGIAFIMACKMAC/CAEQBhokZjRhMTk2MmUvZDM4NC80NGQzL2E5OGYvYzJhZjNkNmRmMGEwGiQxNWU3MDRmMC9mYjE3LzQ3YWUvYTg0Ny8yZWQ5ZTRjNTgyMTEaJGMyMjdkZDA0LzJhYzEvNGMxNi84YjdhL2JkZDc3OWU2MDlmNSILVHJhY2sgUmFkaW8iCUludGVyY2VwdCoHIzg3RDdFMTAC?token=09c1ef8a36b11fdb30d5ea34f5345459ca07c984",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/ENwLGNwLIO4FKO4F/CAEQBhokZjRhMTk2MmUvZDM4NC80NGQzL2E5OGYvYzJhZjNkNmRmMGEwGiQxNWU3MDRmMC9mYjE3LzQ3YWUvYTg0Ny8yZWQ5ZTRjNTgyMTEaJGMyMjdkZDA0LzJhYzEvNGMxNi84YjdhL2JkZDc3OWU2MDlmNSILVHJhY2sgUmFkaW8iCUludGVyY2VwdCoHIzg3RDdFMTAC?token=378e31fc9015b01bdead838046d8e2dc3fbda268",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "status": "NONE"
+        }
+      }
+    },
+    {
+      "id": "86EFpfvW5of7SEW4nyvV7iTMJvPivM4QSxxphirWENBnjuimQQ",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokOTExYmI0Y2YvYTk2Ny80MTdkL2JhY2UvMWRmZDFhMWRhZGFjGiRlZDU5M2RlOS9hZGM3LzQ0YzUvYTYxMy85MjA4ZDM4NWQwZjUaJDQ0NzlhMTI3LzAzYTIvNGQzZC85ZjU1L2RhZTExYTI5YzVkZSILVHJhY2sgUmFkaW8iEkNsb3NlciBUbyBUaGUgRWRnZSoHI0Y2OTQ5NjAC?token=3033c8fc2c5c3236dc54ff8cb702523447e15bb9",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokOTExYmI0Y2YvYTk2Ny80MTdkL2JhY2UvMWRmZDFhMWRhZGFjGiRlZDU5M2RlOS9hZGM3LzQ0YzUvYTYxMy85MjA4ZDM4NWQwZjUaJDQ0NzlhMTI3LzAzYTIvNGQzZC85ZjU1L2RhZTExYTI5YzVkZSILVHJhY2sgUmFkaW8iEkNsb3NlciBUbyBUaGUgRWRnZSoHI0Y2OTQ5NjAC?token=3033c8fc2c5c3236dc54ff8cb702523447e15bb9",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EIAFGIAFIMACKMAC/CAEQBhokOTExYmI0Y2YvYTk2Ny80MTdkL2JhY2UvMWRmZDFhMWRhZGFjGiRlZDU5M2RlOS9hZGM3LzQ0YzUvYTYxMy85MjA4ZDM4NWQwZjUaJDQ0NzlhMTI3LzAzYTIvNGQzZC85ZjU1L2RhZTExYTI5YzVkZSILVHJhY2sgUmFkaW8iEkNsb3NlciBUbyBUaGUgRWRnZSoHI0Y2OTQ5NjAC?token=1a50665fcfa0002abc00bcb4dc77a60db6add63c",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/ENwLGNwLIO4FKO4F/CAEQBhokOTExYmI0Y2YvYTk2Ny80MTdkL2JhY2UvMWRmZDFhMWRhZGFjGiRlZDU5M2RlOS9hZGM3LzQ0YzUvYTYxMy85MjA4ZDM4NWQwZjUaJDQ0NzlhMTI3LzAzYTIvNGQzZC85ZjU1L2RhZTExYTI5YzVkZSILVHJhY2sgUmFkaW8iEkNsb3NlciBUbyBUaGUgRWRnZSoHI0Y2OTQ5NjAC?token=469db1f0c4a5ffa33c0c8581b0593ab7238e7289",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "status": "NONE"
+        }
+      }
+    },
+    {
+      "id": "86EFpfvW5of7SEWyOAR7wISmaf3YyQhW9Rx2glfqE4dm6yYd4r",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokMTk0OTY5NDYvMDhlYi80MjFkL2IyOGMvNzM5NTJhYzY2NGE0GiQwNTViMGViNy80Y2NkLzQxNjAvYWFjOC8yODAxOTA1MjFjMDQaJDNhYzNiMWRhLzE2ZGEvNDkxZC85NzBlL2NlNjVhZTRmOTkyNiILVHJhY2sgUmFkaW8iEkJhY2sgVG8gVGhlIEZ1dHVyZSoHI0IzNEY0ODAC?token=8401c2a802fbafde6e48de905331bf50cbcb2527",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokMTk0OTY5NDYvMDhlYi80MjFkL2IyOGMvNzM5NTJhYzY2NGE0GiQwNTViMGViNy80Y2NkLzQxNjAvYWFjOC8yODAxOTA1MjFjMDQaJDNhYzNiMWRhLzE2ZGEvNDkxZC85NzBlL2NlNjVhZTRmOTkyNiILVHJhY2sgUmFkaW8iEkJhY2sgVG8gVGhlIEZ1dHVyZSoHI0IzNEY0ODAC?token=8401c2a802fbafde6e48de905331bf50cbcb2527",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EIAFGIAFIMACKMAC/CAEQBhokMTk0OTY5NDYvMDhlYi80MjFkL2IyOGMvNzM5NTJhYzY2NGE0GiQwNTViMGViNy80Y2NkLzQxNjAvYWFjOC8yODAxOTA1MjFjMDQaJDNhYzNiMWRhLzE2ZGEvNDkxZC85NzBlL2NlNjVhZTRmOTkyNiILVHJhY2sgUmFkaW8iEkJhY2sgVG8gVGhlIEZ1dHVyZSoHI0IzNEY0ODAC?token=02ee1b14967d78f4c81dcd3b9f3bad3feba96ca6",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/ENwLGNwLIO4FKO4F/CAEQBhokMTk0OTY5NDYvMDhlYi80MjFkL2IyOGMvNzM5NTJhYzY2NGE0GiQwNTViMGViNy80Y2NkLzQxNjAvYWFjOC8yODAxOTA1MjFjMDQaJDNhYzNiMWRhLzE2ZGEvNDkxZC85NzBlL2NlNjVhZTRmOTkyNiILVHJhY2sgUmFkaW8iEkJhY2sgVG8gVGhlIEZ1dHVyZSoHI0IzNEY0ODAC?token=adb73467129494374da834b07b1bdbd2a6239c02",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "status": "NONE"
+        }
+      }
+    },
+    {
+      "id": "86EFpfvW5of7SEZ7tb6XrLhOeQSbNH5H5YdkFdE4yScfoNsOLm",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokNTQ1Y2NiMmMvMThmZS80OWYyLzliMGYvMGQzZGNkZTliMTlmGiRiZGM4ODkyMy9jYzU5LzQzZmUvOTI4MC8zNTMxYmMyMThkZWQaJDY1NDI5ZDMyLzJhYzAvNDQ2Ny85OWNjLzViOWRmMTVlMjgyNCILVHJhY2sgUmFkaW8iH0NoZWFwIFRocmlsbHMgKGZlYXQuIFNlYW4gUGF1bCkqByNEQTlDOUQwAg?token=5e9ed72334a7900a11e15977add02f4149ae7a6a",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EMACGMACIKABKKAB/CAEQBhokNTQ1Y2NiMmMvMThmZS80OWYyLzliMGYvMGQzZGNkZTliMTlmGiRiZGM4ODkyMy9jYzU5LzQzZmUvOTI4MC8zNTMxYmMyMThkZWQaJDY1NDI5ZDMyLzJhYzAvNDQ2Ny85OWNjLzViOWRmMTVlMjgyNCILVHJhY2sgUmFkaW8iH0NoZWFwIFRocmlsbHMgKGZlYXQuIFNlYW4gUGF1bCkqByNEQTlDOUQwAg?token=5e9ed72334a7900a11e15977add02f4149ae7a6a",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EIAFGIAFIMACKMAC/CAEQBhokNTQ1Y2NiMmMvMThmZS80OWYyLzliMGYvMGQzZGNkZTliMTlmGiRiZGM4ODkyMy9jYzU5LzQzZmUvOTI4MC8zNTMxYmMyMThkZWQaJDY1NDI5ZDMyLzJhYzAvNDQ2Ny85OWNjLzViOWRmMTVlMjgyNCILVHJhY2sgUmFkaW8iH0NoZWFwIFRocmlsbHMgKGZlYXQuIFNlYW4gUGF1bCkqByNEQTlDOUQwAg?token=7e71ee6a053a8203531b230aba4faa90bb73eb31",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/ENwLGNwLIO4FKO4F/CAEQBhokNTQ1Y2NiMmMvMThmZS80OWYyLzliMGYvMGQzZGNkZTliMTlmGiRiZGM4ODkyMy9jYzU5LzQzZmUvOTI4MC8zNTMxYmMyMThkZWQaJDY1NDI5ZDMyLzJhYzAvNDQ2Ny85OWNjLzViOWRmMTVlMjgyNCILVHJhY2sgUmFkaW8iH0NoZWFwIFRocmlsbHMgKGZlYXQuIFNlYW4gUGF1bCkqByNEQTlDOUQwAg?token=e1e5b6e4c5d41f8343b5ece3ccfd016f6acd144d",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "status": "NONE"
+        }
+      }
+    },
+    {
+      "id": "86EFpfvW5of7SZuAnUPbEPNobwTEtGDVtNmSyVLwrbDMkw4jJf",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://images.tidal.com/0/EIsCGIsCIKABKKAB/CAEQBRokMjhhMDYwNjgvNmI1OC80YzQ5L2I1MTUvYWNmNmQ2NzI1ZjUxIhBNeSBNb3N0IExpc3RlbmVkIghGRUJSVUFSWSoHI0ZCRDI5MzAE?token=a5274e17d49a70dff52f5abc139ffdbd160fbccc",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EIsCGIsCIKABKKAB/CAEQBRokMjhhMDYwNjgvNmI1OC80YzQ5L2I1MTUvYWNmNmQ2NzI1ZjUxIhBNeSBNb3N0IExpc3RlbmVkIghGRUJSVUFSWSoHI0ZCRDI5MzAE?token=a5274e17d49a70dff52f5abc139ffdbd160fbccc",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EJUEGJUEIMACKMAC/CAEQBRokMjhhMDYwNjgvNmI1OC80YzQ5L2I1MTUvYWNmNmQ2NzI1ZjUxIhBNeSBNb3N0IExpc3RlbmVkIghGRUJSVUFSWSoHI0ZCRDI5MzAE?token=a392ceafef2eda6cca72ff1d7a2199a371eaaa61",
+            "meta": {
+              "width": 480,
+              "height": 480
+            }
+          },
+          {
+            "href": "https://images.tidal.com/0/EOIJGOIJIO4FKO4F/CAEQBRokMjhhMDYwNjgvNmI1OC80YzQ5L2I1MTUvYWNmNmQ2NzI1ZjUxIhBNeSBNb3N0IExpc3RlbmVkIghGRUJSVUFSWSoHI0ZCRDI5MzAE?token=e6d731686c19687c42566f6044809ad0f8551fdd",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          }
+        ],
+        "visualMetadata": {
+          "status": "NONE"
+        }
+      }
+    },
+    {
+      "id": "00109a13be2e75e2b4f3061e188725",
+      "type": "playlists",
+      "attributes": {
+        "name": "All You Ever Wanted",
+        "description": "Sub Focus, Rag'n'Bone Man",
+        "bounded": false,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/mix/00109a13be2e75e2b4f3061e188725",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "createdAt": "2026-07-19T20:57:52.290Z",
+        "lastModifiedAt": "2026-07-19T20:57:52.290Z",
+        "accessType": "PUBLIC",
+        "playlistType": "MIX",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [],
+          "links": {
+            "self": "/playlists/00109a13be2e75e2b4f3061e188725/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "86EFpfvW5of7SDusNluawUwqytlhEfvP8OtLnB9gkGv9EfLgAv",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/00109a13be2e75e2b4f3061e188725/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "0011883bfcf036107d2d781c4ac36a",
+      "type": "playlists",
+      "attributes": {
+        "name": "Higher Power",
+        "description": "Coldplay",
+        "bounded": false,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/mix/0011883bfcf036107d2d781c4ac36a",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "createdAt": "2026-07-19T20:57:52.290Z",
+        "lastModifiedAt": "2026-07-19T20:57:52.290Z",
+        "accessType": "PUBLIC",
+        "playlistType": "MIX",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [],
+          "links": {
+            "self": "/playlists/0011883bfcf036107d2d781c4ac36a/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "86EFpfvW5of7SDvdG4e8fdH9rQnYDeAV6a2qyGjzTlY7qBoONF",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/0011883bfcf036107d2d781c4ac36a/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "001201ec16324e0651f9e99a27217f",
+      "type": "playlists",
+      "attributes": {
+        "name": "The Hill",
+        "description": "Droid Bishop",
+        "bounded": false,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/mix/001201ec16324e0651f9e99a27217f",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "createdAt": "2026-07-19T20:57:52.290Z",
+        "lastModifiedAt": "2026-07-19T20:57:52.290Z",
+        "accessType": "PUBLIC",
+        "playlistType": "MIX",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [],
+          "links": {
+            "self": "/playlists/001201ec16324e0651f9e99a27217f/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "86EFpfvW5of7SDwMs4HjAzb5pAirzHg4UiHb5jLbv9ljGffVrC",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/001201ec16324e0651f9e99a27217f/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "0012c28bc8c89a5991cd888365d956",
+      "type": "playlists",
+      "attributes": {
+        "name": "By The Way",
+        "description": "Lukas Graham",
+        "bounded": false,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/mix/0012c28bc8c89a5991cd888365d956",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "createdAt": "2026-07-19T20:57:52.290Z",
+        "lastModifiedAt": "2026-07-19T20:57:52.290Z",
+        "accessType": "PUBLIC",
+        "playlistType": "MIX",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [],
+          "links": {
+            "self": "/playlists/0012c28bc8c89a5991cd888365d956/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "86EFpfvW5of7SDwWFjLtHPI86yAIGCsdtGi2hkFEJ5PxfUalRG",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/0012c28bc8c89a5991cd888365d956/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "0013933ae431aa8835ad1029040136",
+      "type": "playlists",
+      "attributes": {
+        "name": "Beat It",
+        "description": "Michael Jackson",
+        "bounded": false,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/mix/0013933ae431aa8835ad1029040136",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "createdAt": "2026-07-19T20:57:52.290Z",
+        "lastModifiedAt": "2026-07-19T20:57:52.290Z",
+        "accessType": "PUBLIC",
+        "playlistType": "MIX",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [],
+          "links": {
+            "self": "/playlists/0013933ae431aa8835ad1029040136/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "86EFpfvW5of7SDx9cJxxWTn7Wb3bigLPQv5lGVZVP4xIPVh66o",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/0013933ae431aa8835ad1029040136/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "001551c78ebf2d6f7cd70511364337",
+      "type": "playlists",
+      "attributes": {
+        "name": "Los Angeles (ASOT 984)",
+        "description": "The Midnight",
+        "bounded": false,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/mix/001551c78ebf2d6f7cd70511364337",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "createdAt": "2026-07-19T20:57:52.290Z",
+        "lastModifiedAt": "2026-07-19T20:57:52.290Z",
+        "accessType": "PUBLIC",
+        "playlistType": "MIX",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [],
+          "links": {
+            "self": "/playlists/001551c78ebf2d6f7cd70511364337/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "86EFpfvW5of7SDyf3giTLYdnF75YaogETilLBQ2NmU3DSDV4fX",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/001551c78ebf2d6f7cd70511364337/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "0015664b81ceacae9c91ec9da096d8",
+      "type": "playlists",
+      "attributes": {
+        "name": "Come Sail Away",
+        "description": "Styx",
+        "bounded": false,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/mix/0015664b81ceacae9c91ec9da096d8",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "createdAt": "2026-07-19T20:57:52.290Z",
+        "lastModifiedAt": "2026-07-19T20:57:52.290Z",
+        "accessType": "PUBLIC",
+        "playlistType": "MIX",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [],
+          "links": {
+            "self": "/playlists/0015664b81ceacae9c91ec9da096d8/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "86EFpfvW5of7SDyfFJ5yb0P2ra85biqC9fgtoLKIdSdMiq73qC",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/0015664b81ceacae9c91ec9da096d8/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "001583b539faa4dca268ff875b778f",
+      "type": "playlists",
+      "attributes": {
+        "name": "What Happened To Perfect",
+        "description": "Lukas Graham",
+        "bounded": false,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/mix/001583b539faa4dca268ff875b778f",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "createdAt": "2026-07-19T20:57:52.290Z",
+        "lastModifiedAt": "2026-07-19T20:57:52.290Z",
+        "accessType": "PUBLIC",
+        "playlistType": "MIX",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [],
+          "links": {
+            "self": "/playlists/001583b539faa4dca268ff875b778f/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "86EFpfvW5of7SDyfbzS70lbmPyZvlAAHCIFU95KGFhnwPcJszW",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/001583b539faa4dca268ff875b778f/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "00162145119b17bdebf4d4da90433e",
+      "type": "playlists",
+      "attributes": {
+        "name": "Intercept",
+        "description": "Bert H, Edlan",
+        "bounded": false,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/mix/00162145119b17bdebf4d4da90433e",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "createdAt": "2026-07-19T20:57:52.290Z",
+        "lastModifiedAt": "2026-07-19T20:57:52.290Z",
+        "accessType": "PUBLIC",
+        "playlistType": "MIX",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [],
+          "links": {
+            "self": "/playlists/00162145119b17bdebf4d4da90433e/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "86EFpfvW5of7SDzPb00vBzPn384iSTyZyThvLpenH5PsuNXcpB",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/00162145119b17bdebf4d4da90433e/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "001a47427032b79e02dd72c3b9d65f",
+      "type": "playlists",
+      "attributes": {
+        "name": "Closer To The Edge",
+        "description": "Thirty Seconds To Mars",
+        "bounded": false,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/mix/001a47427032b79e02dd72c3b9d65f",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "createdAt": "2026-07-19T20:57:52.290Z",
+        "lastModifiedAt": "2026-07-19T20:57:52.290Z",
+        "accessType": "PUBLIC",
+        "playlistType": "MIX",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [],
+          "links": {
+            "self": "/playlists/001a47427032b79e02dd72c3b9d65f/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "86EFpfvW5of7SEW4nyvV7iTMJvPivM4QSxxphirWENBnjuimQQ",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/001a47427032b79e02dd72c3b9d65f/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "001bbe5560632fefbd89ea4e0a4f39",
+      "type": "playlists",
+      "attributes": {
+        "name": "Back To The Future",
+        "description": "Bastille",
+        "bounded": false,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/mix/001bbe5560632fefbd89ea4e0a4f39",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "createdAt": "2026-07-19T20:57:52.290Z",
+        "lastModifiedAt": "2026-07-19T20:57:52.290Z",
+        "accessType": "PUBLIC",
+        "playlistType": "MIX",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [],
+          "links": {
+            "self": "/playlists/001bbe5560632fefbd89ea4e0a4f39/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "86EFpfvW5of7SEWyOAR7wISmaf3YyQhW9Rx2glfqE4dm6yYd4r",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/001bbe5560632fefbd89ea4e0a4f39/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "001e849b188999a5b673ce4db37f4f",
+      "type": "playlists",
+      "attributes": {
+        "name": "Cheap Thrills (feat. Sean Paul)",
+        "description": "Sia",
+        "bounded": false,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/mix/001e849b188999a5b673ce4db37f4f",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "createdAt": "2026-07-19T20:57:52.290Z",
+        "lastModifiedAt": "2026-07-19T20:57:52.290Z",
+        "accessType": "PUBLIC",
+        "playlistType": "MIX",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [],
+          "links": {
+            "self": "/playlists/001e849b188999a5b673ce4db37f4f/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "86EFpfvW5of7SEZ7tb6XrLhOeQSbNH5H5YdkFdE4yScfoNsOLm",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/001e849b188999a5b673ce4db37f4f/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "00835752c7cbccabf4f88802580c47",
+      "type": "playlists",
+      "attributes": {
+        "name": "February 2026",
+        "description": "Wilkinson, Sub Focus, Rammstein and more",
+        "bounded": false,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/mix/00835752c7cbccabf4f88802580c47",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "createdAt": "2026-03-01T08:52:56.905Z",
+        "lastModifiedAt": "2026-03-01T08:52:56.905Z",
+        "accessType": "UNLISTED",
+        "playlistType": "MIX",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [
+            {
+              "id": "178100250",
+              "type": "users"
+            }
+          ],
+          "links": {
+            "self": "/playlists/00835752c7cbccabf4f88802580c47/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "86EFpfvW5of7SZuAnUPbEPNobwTEtGDVtNmSyVLwrbDMkw4jJf",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/00835752c7cbccabf4f88802580c47/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "0f72f8b9-6d2f-416c-be04-9bde48e735ce",
+      "type": "playlists",
+      "attributes": {
+        "name": "test-nonetype",
+        "description": "",
+        "bounded": true,
+        "duration": "PT4M28S",
+        "numberOfItems": 1,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/0f72f8b9-6d2f-416c-be04-9bde48e735ce",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/0f72f8b9-6d2f-416c-be04-9bde48e735ce?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/0f72f8b9-6d2f-416c-be04-9bde48e735ce?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/0f72f8b9-6d2f-416c-be04-9bde48e735ce?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2025-11-28T20:53:43.823Z",
+        "lastModifiedAt": "2025-11-28T20:53:46.172Z",
+        "accessType": "UNLISTED",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [
+            {
+              "id": "178100250",
+              "type": "users"
+            }
+          ],
+          "links": {
+            "self": "/playlists/0f72f8b9-6d2f-416c-be04-9bde48e735ce/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0DkawPbseJyRPJryYZKlZlXc1KyWeix4QKfsGxRFRCNfNebX3",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/0f72f8b9-6d2f-416c-be04-9bde48e735ce/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "3f99dc4b-1524-4df0-a1c0-052de6ca5722",
+      "type": "playlists",
+      "attributes": {
+        "name": "Daily Discovery May 4th 2026",
+        "description": "",
+        "bounded": true,
+        "duration": "PT39M25S",
+        "numberOfItems": 10,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/3f99dc4b-1524-4df0-a1c0-052de6ca5722",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/3f99dc4b-1524-4df0-a1c0-052de6ca5722?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/3f99dc4b-1524-4df0-a1c0-052de6ca5722?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/3f99dc4b-1524-4df0-a1c0-052de6ca5722?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2026-05-04T14:51:24.614Z",
+        "lastModifiedAt": "2026-05-04T14:51:24.866Z",
+        "accessType": "UNLISTED",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [
+            {
+              "id": "178100250",
+              "type": "users"
+            }
+          ],
+          "links": {
+            "self": "/playlists/3f99dc4b-1524-4df0-a1c0-052de6ca5722/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0H5NFZF6CvAs7Y8LGTDCDDM9Pv4wVVeRZxxJGuf9MNxW4AwPC",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/3f99dc4b-1524-4df0-a1c0-052de6ca5722/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "6a9f7092-ea04-448f-8b8c-38cbe3e4d6d8",
+      "type": "playlists",
+      "attributes": {
+        "name": "My Mix 1 April 3rd 2026",
+        "description": "",
+        "bounded": true,
+        "duration": "PT2H56M29S",
+        "numberOfItems": 40,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/6a9f7092-ea04-448f-8b8c-38cbe3e4d6d8",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/6a9f7092-ea04-448f-8b8c-38cbe3e4d6d8?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/6a9f7092-ea04-448f-8b8c-38cbe3e4d6d8?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/6a9f7092-ea04-448f-8b8c-38cbe3e4d6d8?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2026-04-03T15:02:07.507Z",
+        "lastModifiedAt": "2026-04-03T15:02:07.795Z",
+        "accessType": "UNLISTED",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [
+            {
+              "id": "178100250",
+              "type": "users"
+            }
+          ],
+          "links": {
+            "self": "/playlists/6a9f7092-ea04-448f-8b8c-38cbe3e4d6d8/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0KOnyQKPOV2FoHTAbWbcujij9EvIzDVCjFU5cajrGYa43EfcW",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/6a9f7092-ea04-448f-8b8c-38cbe3e4d6d8/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "80d6d637-9dba-4984-bf2e-5dec5e4782e4",
+      "type": "playlists",
+      "attributes": {
+        "name": "Daily Discovery 5.5.26",
+        "description": "",
+        "bounded": true,
+        "duration": "PT42M16S",
+        "numberOfItems": 10,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/80d6d637-9dba-4984-bf2e-5dec5e4782e4",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/80d6d637-9dba-4984-bf2e-5dec5e4782e4?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/80d6d637-9dba-4984-bf2e-5dec5e4782e4?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/80d6d637-9dba-4984-bf2e-5dec5e4782e4?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2026-05-05T15:11:57.953Z",
+        "lastModifiedAt": "2026-05-05T15:11:58.406Z",
+        "accessType": "UNLISTED",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [
+            {
+              "id": "178100250",
+              "type": "users"
+            }
+          ],
+          "links": {
+            "self": "/playlists/80d6d637-9dba-4984-bf2e-5dec5e4782e4/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0MPVb0Bv9GdfSLS1vEu4qTWZHroBfGnLaiSzLrsOVXpVVQt3U",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/80d6d637-9dba-4984-bf2e-5dec5e4782e4/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "886e6090-7fdd-422a-9901-e69ad8601e49",
+      "type": "playlists",
+      "attributes": {
+        "name": "My Mix 1 April 21st 2026",
+        "description": "",
+        "bounded": true,
+        "duration": "PT2H33M33S",
+        "numberOfItems": 40,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/886e6090-7fdd-422a-9901-e69ad8601e49",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/886e6090-7fdd-422a-9901-e69ad8601e49?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/886e6090-7fdd-422a-9901-e69ad8601e49?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/886e6090-7fdd-422a-9901-e69ad8601e49?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2026-04-21T15:59:55.391Z",
+        "lastModifiedAt": "2026-04-21T15:59:55.685Z",
+        "accessType": "UNLISTED",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [
+            {
+              "id": "178100250",
+              "type": "users"
+            }
+          ],
+          "links": {
+            "self": "/playlists/886e6090-7fdd-422a-9901-e69ad8601e49/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr0MRc9T9XSf3NTnbiu7rLhTRCQXPCfnUGuXHa4uuKUXdvlhBYP",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/886e6090-7fdd-422a-9901-e69ad8601e49/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "dfcfa5e1-52e3-4f74-ad20-44d71c582021",
+      "type": "playlists",
+      "attributes": {
+        "name": "My Mix 1 May 4th 2026",
+        "description": "",
+        "bounded": true,
+        "duration": "PT2H18M16S",
+        "numberOfItems": 40,
+        "externalLinks": [
+          {
+            "href": "https://listen.tidal.com/playlist/dfcfa5e1-52e3-4f74-ad20-44d71c582021",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/dfcfa5e1-52e3-4f74-ad20-44d71c582021?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_ANDROID"
+            }
+          },
+          {
+            "href": "https://tidal.com/playlist/dfcfa5e1-52e3-4f74-ad20-44d71c582021?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_IOS"
+            }
+          },
+          {
+            "href": "https://listen.tidal.com/playlist/dfcfa5e1-52e3-4f74-ad20-44d71c582021?play=true",
+            "meta": {
+              "type": "TIDAL_AUTOPLAY_WEB"
+            }
+          }
+        ],
+        "createdAt": "2026-05-04T11:05:20.240Z",
+        "lastModifiedAt": "2026-05-04T11:05:20.533Z",
+        "accessType": "UNLISTED",
+        "playlistType": "USER",
+        "numberOfFollowers": 0
+      },
+      "relationships": {
+        "owners": {
+          "data": [
+            {
+              "id": "178100250",
+              "type": "users"
+            }
+          ],
+          "links": {
+            "self": "/playlists/dfcfa5e1-52e3-4f74-ad20-44d71c582021/relationships/owners?countryCode=AT&locale=en-US"
+          }
+        },
+        "coverArt": {
+          "data": [
+            {
+              "id": "2b7Vtuqr19YmDkEjwJ5guh7IXiqDVZG4DKipkUByRuTzARgsS0gGfoxJh",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/playlists/dfcfa5e1-52e3-4f74-ad20-44d71c582021/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "178100250",
+      "type": "users",
+      "attributes": {
+        "username": "jozef@krush.at",
+        "country": "AT",
+        "email": "jozef@krush.at",
+        "emailVerified": true,
+        "developerAccessTier": "THIRD_PARTY"
+      }
+    }
+  ]
+}

--- a/tests/providers/tidal/fixtures/v2/lib_tracks.json
+++ b/tests/providers/tidal/fixtures/v2/lib_tracks.json
@@ -1,0 +1,4100 @@
+{
+  "data": [
+    {
+      "id": "96098350",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-15T14:46:06.129Z"
+      }
+    },
+    {
+      "id": "292482716",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-15T12:19:02.140Z"
+      }
+    },
+    {
+      "id": "251611169",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-15T12:09:53.067Z"
+      }
+    },
+    {
+      "id": "491159888",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-15T12:05:34.098Z"
+      }
+    },
+    {
+      "id": "6886568",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-14T19:05:45.216Z"
+      }
+    },
+    {
+      "id": "6886564",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-14T18:56:08.627Z"
+      }
+    },
+    {
+      "id": "76004353",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-14T15:23:32.536Z"
+      }
+    },
+    {
+      "id": "410492059",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-14T15:21:41.045Z"
+      }
+    },
+    {
+      "id": "293098632",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-14T15:18:53.331Z"
+      }
+    },
+    {
+      "id": "6886567",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-14T15:05:17.605Z"
+      }
+    },
+    {
+      "id": "278905665",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-14T06:30:46.129Z"
+      }
+    },
+    {
+      "id": "228809510",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-14T06:28:47.931Z"
+      }
+    },
+    {
+      "id": "151141801",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-14T06:21:28.405Z"
+      }
+    },
+    {
+      "id": "153517662",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-11T06:25:36.889Z"
+      }
+    },
+    {
+      "id": "182912245",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-10T18:06:59.982Z"
+      }
+    },
+    {
+      "id": "176288593",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-10T17:55:45.156Z"
+      }
+    },
+    {
+      "id": "172054372",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-10T17:50:36.543Z"
+      }
+    },
+    {
+      "id": "203203374",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-10T17:42:31.475Z"
+      }
+    },
+    {
+      "id": "286197968",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-10T13:08:53.295Z"
+      }
+    },
+    {
+      "id": "232894504",
+      "type": "tracks",
+      "meta": {
+        "addedAt": "2026-07-10T13:05:38.320Z"
+      }
+    }
+  ],
+  "links": {
+    "self": "/userCollectionTracks/me/relationships/items?include=items.albums.coverArt%2Citems.artists&locale=en-US",
+    "next": "/userCollectionTracks/me/relationships/items?include=items.albums.coverArt%2Citems.artists&locale=en-US&page%5Bcursor%5D=20",
+    "meta": {
+      "nextCursor": "20"
+    }
+  },
+  "included": [
+    {
+      "id": "151141792",
+      "type": "albums",
+      "attributes": {
+        "title": "A View of U",
+        "barcodeId": "5054429142679",
+        "numberOfVolumes": 1,
+        "numberOfItems": 11,
+        "duration": "PT39M54S",
+        "explicit": true,
+        "ai": false,
+        "releaseDate": "2020-10-09",
+        "copyright": {
+          "text": "Ninja Tune"
+        },
+        "popularity": 0.4341077151606918,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/151141792",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzIBj4YkDOXek",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/151141792/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "153517661",
+      "type": "albums",
+      "attributes": {
+        "title": "Missing Out (The Midnight Remix)",
+        "barcodeId": "195497143672",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M29S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2020-09-11",
+        "copyright": {
+          "text": "(C) 2020 Wasted Talent Records"
+        },
+        "popularity": 0.33992406725883484,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/153517661",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzIBlff00ACMz",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/153517661/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "172054370",
+      "type": "albums",
+      "attributes": {
+        "title": "Medicine At Midnight",
+        "barcodeId": "886448658054",
+        "numberOfVolumes": 1,
+        "numberOfItems": 9,
+        "duration": "PT36M36S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2021-02-05",
+        "copyright": {
+          "text": "(P) 2021 Roswell Records, Inc., under exclusive license to RCA Records"
+        },
+        "popularity": 0.6568642775208523,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/172054370",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "createdAt": "2021-02-02T16:12:21Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzIMOPDgvrhCq",
+              "type": "artworks"
+            },
+            {
+              "id": "2xpmpdbly5B68nd8xa4UAC",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/172054370/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "176288592",
+      "type": "albums",
+      "attributes": {
+        "title": "Evering Road (Deluxe)",
+        "barcodeId": "886448397465",
+        "numberOfVolumes": 1,
+        "numberOfItems": 16,
+        "duration": "PT52M23S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2021-03-05",
+        "copyright": {
+          "text": "(P) 2021 Insanity Records Limited under exclusive licence to Sony Music Entertainment UK Limited"
+        },
+        "popularity": 0.29555262922330655,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/176288592",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "createdAt": "2021-03-08T15:55:23Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzIMTZYjYVj3y",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/176288592/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "182912238",
+      "type": "albums",
+      "attributes": {
+        "title": "Life By Misadventure",
+        "barcodeId": "886449087358",
+        "numberOfVolumes": 1,
+        "numberOfItems": 15,
+        "duration": "PT54M13S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2021-05-07",
+        "copyright": {
+          "text": "(P) 2021 Sony Music Entertainment UK Limited"
+        },
+        "popularity": 0.5662041686934633,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/182912238",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzIRiTXxRJzaK",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/182912238/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "203203373",
+      "type": "albums",
+      "attributes": {
+        "title": "Set Me Free",
+        "barcodeId": "3616841458237",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M44S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2021-11-26",
+        "copyright": {
+          "text": "Elevate Records"
+        },
+        "popularity": 0.22688354994085894,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/203203373",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9Dzdjpoh6pq8EV",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/203203373/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "228809509",
+      "type": "albums",
+      "attributes": {
+        "title": "It’s Time",
+        "barcodeId": "00602445853892",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M20S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2022-05-20",
+        "copyright": {
+          "text": "© 2022 Sub Focus, under exclusive license to Universal Music Operations Limited"
+        },
+        "popularity": 0.08230207755464049,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/228809509",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzduaLFaEgj97",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/228809509/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "232894499",
+      "type": "albums",
+      "attributes": {
+        "title": "Hooked (Grafix Remix)",
+        "barcodeId": "5054197199547",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M21S",
+        "explicit": true,
+        "ai": false,
+        "releaseDate": "2019-11-01",
+        "copyright": {
+          "text": "© 2022 Musical Freedom Label Ltd."
+        },
+        "popularity": 0.14817543957209653,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/232894499",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzdzmdDSuQMWn",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/232894499/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "251611167",
+      "type": "albums",
+      "attributes": {
+        "title": "Kryptonite",
+        "barcodeId": "5053760017806",
+        "numberOfVolumes": 1,
+        "numberOfItems": 10,
+        "duration": "PT45M40S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2010-01-01",
+        "copyright": {
+          "text": "Breakbeat Kaos"
+        },
+        "popularity": 0.4579216148503375,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/251611167",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzeAPNhK538Ct",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/251611167/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "278905664",
+      "type": "albums",
+      "attributes": {
+        "title": "Shut It Down",
+        "barcodeId": "197338880203",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT2M59S",
+        "explicit": true,
+        "ai": false,
+        "releaseDate": "2023-04-06",
+        "copyright": {
+          "text": "2023 DnB Allstars Records"
+        },
+        "popularity": 0.18592001690895837,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/278905664",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzeLCTAhKoeDU",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/278905664/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "286197967",
+      "type": "albums",
+      "attributes": {
+        "title": "Baby Don't Hurt Me",
+        "barcodeId": "5054197640698",
+        "numberOfVolumes": 1,
+        "numberOfItems": 2,
+        "duration": "PT5M39S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2023-04-06",
+        "copyright": {
+          "text": "Under license to Warner Music UK Limited, © 2023 What A DJ Ltd"
+        },
+        "popularity": 0.5455810512157946,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/286197967",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2023-03-30T12:52:44Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzeQTsLoxaueN",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/286197967/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "292482715",
+      "type": "albums",
+      "attributes": {
+        "title": "Beautiful Lies VIP",
+        "barcodeId": "3617056552918",
+        "numberOfVolumes": 1,
+        "numberOfItems": 2,
+        "duration": "PT12M58S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2010-07-23",
+        "copyright": {
+          "text": "Hospital Records Limited"
+        },
+        "popularity": 0.2249284370826671,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/292482715",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2023-05-02T12:38:52Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzeVil64KKMiL",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/292482715/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "293098622",
+      "type": "albums",
+      "attributes": {
+        "title": "Evolve",
+        "barcodeId": "00602455526175",
+        "numberOfVolumes": 1,
+        "numberOfItems": 14,
+        "duration": "PT53M29S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2023-05-12",
+        "copyright": {
+          "text": "© 2023 Sub Focus, under exclusive license to Universal Music Operations Limited"
+        },
+        "popularity": 0.51727801768973,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/293098622",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "createdAt": "2023-05-05T00:43:15Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9DzeVk1mEzxvN4",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/293098622/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "410492056",
+      "type": "albums",
+      "attributes": {
+        "title": "Giants",
+        "barcodeId": "199066517260",
+        "numberOfVolumes": 1,
+        "numberOfItems": 1,
+        "duration": "PT3M35S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2025-02-03",
+        "copyright": {
+          "text": "(C) 2024 Culture Shock Music"
+        },
+        "popularity": 0.2063643354622511,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/410492056",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0LmSYEJjALLi",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/410492056/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "491159887",
+      "type": "albums",
+      "attributes": {
+        "title": "Your Way / Daydreamin",
+        "barcodeId": "8790001114715",
+        "numberOfVolumes": 1,
+        "numberOfItems": 2,
+        "duration": "PT12M33S",
+        "explicit": false,
+        "ai": false,
+        "releaseDate": "2010-04-26",
+        "copyright": {
+          "text": "Control"
+        },
+        "popularity": 0.12935283794639713,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/491159887",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2026-01-20T18:11:30Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "2xpmpI1s9E0MT41OHYKrMl",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/491159887/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "6886563",
+      "type": "albums",
+      "attributes": {
+        "title": "Nobody's Perfect",
+        "barcodeId": "00602527755649",
+        "numberOfVolumes": 1,
+        "numberOfItems": 5,
+        "duration": "PT24M10S",
+        "explicit": true,
+        "ai": false,
+        "releaseDate": "2011-05-30",
+        "copyright": {
+          "text": "© 2011 Universal Republic Records"
+        },
+        "popularity": 0.19009675417564667,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/6886563",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "SINGLE",
+        "albumType": "SINGLE",
+        "createdAt": "2011-06-03T12:09:32Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "AmX9grPBhCwXA3r9xRL",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/6886563/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "76004350",
+      "type": "albums",
+      "attributes": {
+        "title": "Mura Masa",
+        "barcodeId": "00602557607352",
+        "numberOfVolumes": 1,
+        "numberOfItems": 13,
+        "duration": "PT45M25S",
+        "explicit": true,
+        "ai": false,
+        "releaseDate": "2017-07-14",
+        "copyright": {
+          "text": "© 2017 Anchor Point Records, under exclusive licence to Polydor Records, a division of Universal Music Operations Limited"
+        },
+        "popularity": 0.6463357297668451,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/76004350",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPWyKhukUBge",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/76004350/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "96098333",
+      "type": "albums",
+      "attributes": {
+        "title": "A Star Is Born Soundtrack",
+        "barcodeId": "00602577077982",
+        "numberOfVolumes": 1,
+        "numberOfItems": 34,
+        "duration": "PT1H10M13S",
+        "explicit": true,
+        "ai": false,
+        "releaseDate": "2018-10-05",
+        "copyright": {
+          "text": "© 2018 Interscope Records, Motion Picture Artwork © 2018 Warner Bros. Entertainment Inc. Motion Picture Photography © 2018 Warner Bros. Entertainment Inc. and Metro-Goldwyn-Mayer Inc.,"
+        },
+        "popularity": 0.8189291062902302,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/album/96098333",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "type": "ALBUM",
+        "albumType": "ALBUM",
+        "createdAt": "2018-10-03T17:14:08Z"
+      },
+      "relationships": {
+        "coverArt": {
+          "data": [
+            {
+              "id": "iWOu0yW0IPhcNlIcMMk7",
+              "type": "artworks"
+            }
+          ],
+          "links": {
+            "self": "/albums/96098333/relationships/coverArt?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "17556142",
+      "type": "artists",
+      "attributes": {
+        "name": "Elipsa",
+        "popularity": 0.4619864172476161,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/17556142",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "27343",
+      "type": "artists",
+      "attributes": {
+        "name": "David Guetta",
+        "popularity": 0.921000312865376,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/27343",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "2753",
+      "type": "artists",
+      "attributes": {
+        "name": "Foo Fighters",
+        "popularity": 0.888942301273346,
+        "externalLinks": [
+          {
+            "href": "https://instagram.com/foofighters",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://foofighters.com/",
+            "meta": {
+              "type": "OFFICIAL_HOMEPAGE"
+            }
+          },
+          {
+            "href": "https://tiktok.com/@foofightersofficial",
+            "meta": {
+              "type": "TIKTOK"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/2753",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "MIXED"
+      }
+    },
+    {
+      "id": "34606964",
+      "type": "artists",
+      "attributes": {
+        "name": "sadHAPPY",
+        "popularity": 0.44434419201499925,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/34606964",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false
+      }
+    },
+    {
+      "id": "3533717",
+      "type": "artists",
+      "attributes": {
+        "name": "Gene Farris",
+        "popularity": 0.5427183508872986,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3533717",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3534754",
+      "type": "artists",
+      "attributes": {
+        "name": "Lady Gaga",
+        "popularity": 0.9353594588571071,
+        "externalLinks": [
+          {
+            "href": "https://twitter.com/ladygaga",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/3534754",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3540436",
+      "type": "artists",
+      "attributes": {
+        "name": "Sub Focus",
+        "popularity": 0.7512047005593518,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3540436",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3607591",
+      "type": "artists",
+      "attributes": {
+        "name": "Culture Shock",
+        "popularity": 0.6584804137941619,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3607591",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3633607",
+      "type": "artists",
+      "attributes": {
+        "name": "B-Complex",
+        "popularity": 0.556273877620697,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3633607",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3633614",
+      "type": "artists",
+      "attributes": {
+        "name": "Sigma",
+        "popularity": 0.6604413250116661,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3633614",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3636460",
+      "type": "artists",
+      "attributes": {
+        "name": "DJ Fresh",
+        "popularity": 0.6448258704644187,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3636460",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3637207",
+      "type": "artists",
+      "attributes": {
+        "name": "Netsky",
+        "popularity": 0.6924664101699105,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3637207",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3643168",
+      "type": "artists",
+      "attributes": {
+        "name": "Friction",
+        "popularity": 0.6071011530467868,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3643168",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3828746",
+      "type": "artists",
+      "attributes": {
+        "name": "Jessie J",
+        "popularity": 0.8298273086547852,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3828746",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3941595",
+      "type": "artists",
+      "attributes": {
+        "name": "Machinedrum",
+        "popularity": 0.6521112322807312,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3941595",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "3944800",
+      "type": "artists",
+      "attributes": {
+        "name": "NotioN",
+        "popularity": 0.645607590675354,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/3944800",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "4081743",
+      "type": "artists",
+      "attributes": {
+        "name": "Grafix",
+        "popularity": 0.6214684513986655,
+        "externalLinks": [
+          {
+            "href": "https://www.facebook.com/grafixmusicuk/",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "https://www.instagram.com/grafixmusicuk/?hl=en",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://twitter.com/grafixmusicuk",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4081743",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "4315444",
+      "type": "artists",
+      "attributes": {
+        "name": "A$AP Rocky",
+        "popularity": 0.9040014509499935,
+        "externalLinks": [
+          {
+            "href": "https://www.instagram.com/asaprocky",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://twitter.com/asvpxrocky/",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/4315444",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "4816163",
+      "type": "artists",
+      "attributes": {
+        "name": "Rag'n'Bone Man",
+        "popularity": 0.7788828015327454,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/4816163",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "5812786",
+      "type": "artists",
+      "attributes": {
+        "name": "Mura Masa",
+        "popularity": 0.7430038208319614,
+        "externalLinks": [
+          {
+            "href": "https://www.facebook.com/MuramasaMusic/",
+            "meta": {
+              "type": "FACEBOOK"
+            }
+          },
+          {
+            "href": "https://www.instagram.com/the_mura_masa/",
+            "meta": {
+              "type": "INSTAGRAM"
+            }
+          },
+          {
+            "href": "https://twitter.com/mura_masa_",
+            "meta": {
+              "type": "TWITTER"
+            }
+          },
+          {
+            "href": "https://tidal.com/browse/artist/5812786",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "6127816",
+      "type": "artists",
+      "attributes": {
+        "name": "Anne-Marie",
+        "popularity": 0.8399672508239746,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/6127816",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "6614115",
+      "type": "artists",
+      "attributes": {
+        "name": "HAYLA",
+        "popularity": 0.6508073806762695,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/6614115",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "7205813",
+      "type": "artists",
+      "attributes": {
+        "name": "The Ivy",
+        "popularity": 0.4947438831489373,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/7205813",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false
+      }
+    },
+    {
+      "id": "7809618",
+      "type": "artists",
+      "attributes": {
+        "name": "Tom Grennan",
+        "popularity": 0.6906343698501587,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/7809618",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "8980137",
+      "type": "artists",
+      "attributes": {
+        "name": "Mollie Collins",
+        "popularity": 0.477754181007505,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/8980137",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "9644098",
+      "type": "artists",
+      "attributes": {
+        "name": "Coi Leray",
+        "popularity": 0.8183435503601234,
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/artist/9644098",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "contributionsEnabled": false,
+        "ownerType": "LABEL"
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzIBj4YkDOXek",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/8ccda684/f204/4992/9e78/921644e02678/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8ccda684/f204/4992/9e78/921644e02678/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8ccda684/f204/4992/9e78/921644e02678/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8ccda684/f204/4992/9e78/921644e02678/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8ccda684/f204/4992/9e78/921644e02678/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8ccda684/f204/4992/9e78/921644e02678/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8ccda684/f204/4992/9e78/921644e02678/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#746349",
+          "blurHash": "U7F62{4V0tE400?tDgt3?wIv=;xZ00ng?dRk",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzIBlff00ACMz",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/73e90568/d3ef/43d6/9586/55881e4c6f8c/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/73e90568/d3ef/43d6/9586/55881e4c6f8c/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/73e90568/d3ef/43d6/9586/55881e4c6f8c/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/73e90568/d3ef/43d6/9586/55881e4c6f8c/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/73e90568/d3ef/43d6/9586/55881e4c6f8c/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/73e90568/d3ef/43d6/9586/55881e4c6f8c/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/73e90568/d3ef/43d6/9586/55881e4c6f8c/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#551B2E",
+          "blurHash": "U9DSIE}b00n70xoQx^b^DQn,%NI:4mw4-qkD",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzIMOPDgvrhCq",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/c438bd9e/3dcc/4c41/b212/0640c4e1e19f/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c438bd9e/3dcc/4c41/b212/0640c4e1e19f/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c438bd9e/3dcc/4c41/b212/0640c4e1e19f/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c438bd9e/3dcc/4c41/b212/0640c4e1e19f/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c438bd9e/3dcc/4c41/b212/0640c4e1e19f/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c438bd9e/3dcc/4c41/b212/0640c4e1e19f/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c438bd9e/3dcc/4c41/b212/0640c4e1e19f/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#85303C",
+          "blurHash": "URMNaN1YIjxwWMWRNEsqMHaHXowNvfs9J$og",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzIMTZYjYVj3y",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/1f1d5a09/7e05/4f1a/a6dc/b9587355d64b/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1f1d5a09/7e05/4f1a/a6dc/b9587355d64b/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1f1d5a09/7e05/4f1a/a6dc/b9587355d64b/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1f1d5a09/7e05/4f1a/a6dc/b9587355d64b/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1f1d5a09/7e05/4f1a/a6dc/b9587355d64b/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1f1d5a09/7e05/4f1a/a6dc/b9587355d64b/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/1f1d5a09/7e05/4f1a/a6dc/b9587355d64b/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#8E2365",
+          "blurHash": "UUGIfv$+Q,oz~XsDRPa|t,NZS5WXO?O9X7a$",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzIRiTXxRJzaK",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/0aa15ff8/3b11/4a6d/9aca/e2069b7b3f0f/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0aa15ff8/3b11/4a6d/9aca/e2069b7b3f0f/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0aa15ff8/3b11/4a6d/9aca/e2069b7b3f0f/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0aa15ff8/3b11/4a6d/9aca/e2069b7b3f0f/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0aa15ff8/3b11/4a6d/9aca/e2069b7b3f0f/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0aa15ff8/3b11/4a6d/9aca/e2069b7b3f0f/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0aa15ff8/3b11/4a6d/9aca/e2069b7b3f0f/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#825B51",
+          "blurHash": "UCAJi{oL00R*?HoL9tR*0Kj[~Cay4.a}?Hoe",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9Dzdjpoh6pq8EV",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/669fd5a4/24bf/43e2/b7e4/204e281f2d5b/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/669fd5a4/24bf/43e2/b7e4/204e281f2d5b/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/669fd5a4/24bf/43e2/b7e4/204e281f2d5b/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/669fd5a4/24bf/43e2/b7e4/204e281f2d5b/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/669fd5a4/24bf/43e2/b7e4/204e281f2d5b/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/669fd5a4/24bf/43e2/b7e4/204e281f2d5b/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/669fd5a4/24bf/43e2/b7e4/204e281f2d5b/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#3E4F5D",
+          "blurHash": "UfNKCqof-;ofxuj]R*j@~qayRQazM{aexabH",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzduaLFaEgj97",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/5bca2aa4/9800/4637/a9e8/a15a9eb4cc6d/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5bca2aa4/9800/4637/a9e8/a15a9eb4cc6d/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5bca2aa4/9800/4637/a9e8/a15a9eb4cc6d/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5bca2aa4/9800/4637/a9e8/a15a9eb4cc6d/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5bca2aa4/9800/4637/a9e8/a15a9eb4cc6d/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5bca2aa4/9800/4637/a9e8/a15a9eb4cc6d/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5bca2aa4/9800/4637/a9e8/a15a9eb4cc6d/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#356F95",
+          "blurHash": "UAAJ+u9u00~B%0ofIpV@00-n~W9aIpWA%2bv",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzdzmdDSuQMWn",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/c3b4d546/b7fc/4668/a657/201a4b60be68/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c3b4d546/b7fc/4668/a657/201a4b60be68/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c3b4d546/b7fc/4668/a657/201a4b60be68/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c3b4d546/b7fc/4668/a657/201a4b60be68/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c3b4d546/b7fc/4668/a657/201a4b60be68/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c3b4d546/b7fc/4668/a657/201a4b60be68/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/c3b4d546/b7fc/4668/a657/201a4b60be68/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#9E1717",
+          "blurHash": "UFJXU{|##O;L=YSjJ*5iATEe6gOZxI,qNEfl",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzeAPNhK538Ct",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/04a16df9/8218/420d/b2ec/3715cea636c0/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/04a16df9/8218/420d/b2ec/3715cea636c0/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/04a16df9/8218/420d/b2ec/3715cea636c0/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/04a16df9/8218/420d/b2ec/3715cea636c0/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/04a16df9/8218/420d/b2ec/3715cea636c0/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/04a16df9/8218/420d/b2ec/3715cea636c0/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/04a16df9/8218/420d/b2ec/3715cea636c0/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#970048",
+          "blurHash": "UVLNMf_M^+%fogV[ozxa.7niIoaLkCV[j[R*",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzeLCTAhKoeDU",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/8bad04fb/8156/4efe/b23a/3e25bb339107/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8bad04fb/8156/4efe/b23a/3e25bb339107/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8bad04fb/8156/4efe/b23a/3e25bb339107/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8bad04fb/8156/4efe/b23a/3e25bb339107/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8bad04fb/8156/4efe/b23a/3e25bb339107/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8bad04fb/8156/4efe/b23a/3e25bb339107/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/8bad04fb/8156/4efe/b23a/3e25bb339107/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#70739F",
+          "blurHash": "UDNwT:vCERno^utLM{Rpu6${xroO9t#Ab.JB",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzeQTsLoxaueN",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/ba12dcc3/7c30/4bc0/935d/6a8c5bf48836/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ba12dcc3/7c30/4bc0/935d/6a8c5bf48836/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ba12dcc3/7c30/4bc0/935d/6a8c5bf48836/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ba12dcc3/7c30/4bc0/935d/6a8c5bf48836/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ba12dcc3/7c30/4bc0/935d/6a8c5bf48836/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ba12dcc3/7c30/4bc0/935d/6a8c5bf48836/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/ba12dcc3/7c30/4bc0/935d/6a8c5bf48836/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#451530",
+          "blurHash": "U270AXsD0]JO$Sf7J5ax1XW.]=w}AmWU,vsp",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzeVil64KKMiL",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/aad04283/ef2c/41c2/8a30/6d417866c5a9/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/aad04283/ef2c/41c2/8a30/6d417866c5a9/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/aad04283/ef2c/41c2/8a30/6d417866c5a9/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/aad04283/ef2c/41c2/8a30/6d417866c5a9/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/aad04283/ef2c/41c2/8a30/6d417866c5a9/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/aad04283/ef2c/41c2/8a30/6d417866c5a9/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/aad04283/ef2c/41c2/8a30/6d417866c5a9/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#194122",
+          "blurHash": "UgOW+-WUxuV@9ZofV@R%~qt7ozfk?IWURjs:",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9DzeVk1mEzxvN4",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/3fcccb73/2ecf/426f/9517/2ad503cc2cb3/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3fcccb73/2ecf/426f/9517/2ad503cc2cb3/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3fcccb73/2ecf/426f/9517/2ad503cc2cb3/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3fcccb73/2ecf/426f/9517/2ad503cc2cb3/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3fcccb73/2ecf/426f/9517/2ad503cc2cb3/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3fcccb73/2ecf/426f/9517/2ad503cc2cb3/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3fcccb73/2ecf/426f/9517/2ad503cc2cb3/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#25354D",
+          "blurHash": "U66@.%s:00I:s=t7W9M{00WB~Wt7bWRjWF%2",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0LmSYEJjALLi",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/3d6cb810/4ae5/42ed/b4a9/3bc69a388562/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3d6cb810/4ae5/42ed/b4a9/3bc69a388562/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3d6cb810/4ae5/42ed/b4a9/3bc69a388562/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3d6cb810/4ae5/42ed/b4a9/3bc69a388562/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3d6cb810/4ae5/42ed/b4a9/3bc69a388562/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3d6cb810/4ae5/42ed/b4a9/3bc69a388562/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/3d6cb810/4ae5/42ed/b4a9/3bc69a388562/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#475F71",
+          "blurHash": "UCC@23I800%jyXW9Djs;MJxa%gIW5Ut5s%RQ",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpI1s9E0MT41OHYKrMl",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/e9b7cfce/ef1c/4348/ab84/af46df70a600/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9b7cfce/ef1c/4348/ab84/af46df70a600/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9b7cfce/ef1c/4348/ab84/af46df70a600/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9b7cfce/ef1c/4348/ab84/af46df70a600/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9b7cfce/ef1c/4348/ab84/af46df70a600/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9b7cfce/ef1c/4348/ab84/af46df70a600/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/e9b7cfce/ef1c/4348/ab84/af46df70a600/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#2F2B29",
+          "blurHash": "UPKT}QRj~Wof%MofWBfQ~Wt69ZWBWCWCj[j[",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "2xpmpdbly5B68nd8xa4UAC",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "VIDEO",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/videos/576b35f7/d3e6/4df3/a22f/c632569cb781/1280x1280.mp4",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/videos/576b35f7/d3e6/4df3/a22f/c632569cb781/1080x1080.mp4",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/videos/576b35f7/d3e6/4df3/a22f/c632569cb781/750x750.mp4",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/videos/576b35f7/d3e6/4df3/a22f/c632569cb781/640x640.mp4",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/videos/576b35f7/d3e6/4df3/a22f/c632569cb781/320x320.mp4",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/videos/576b35f7/d3e6/4df3/a22f/c632569cb781/160x160.mp4",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/videos/576b35f7/d3e6/4df3/a22f/c632569cb781/80x80.mp4",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "status": "PROCESSING"
+        }
+      }
+    },
+    {
+      "id": "AmX9grPBhCwXA3r9xRL",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/723cf8d8/7101/4e71/88da/9ab4a328a689/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/723cf8d8/7101/4e71/88da/9ab4a328a689/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/723cf8d8/7101/4e71/88da/9ab4a328a689/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/723cf8d8/7101/4e71/88da/9ab4a328a689/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/723cf8d8/7101/4e71/88da/9ab4a328a689/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/723cf8d8/7101/4e71/88da/9ab4a328a689/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/723cf8d8/7101/4e71/88da/9ab4a328a689/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#29120E",
+          "blurHash": "U3G7eqt*019u0w-j7f-UQ;?FkWjE*Hv$;K}?",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPWyKhukUBge",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/5ab7a684/863d/45be/86b5/751e52c56756/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5ab7a684/863d/45be/86b5/751e52c56756/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5ab7a684/863d/45be/86b5/751e52c56756/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5ab7a684/863d/45be/86b5/751e52c56756/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5ab7a684/863d/45be/86b5/751e52c56756/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5ab7a684/863d/45be/86b5/751e52c56756/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/5ab7a684/863d/45be/86b5/751e52c56756/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#3F3623",
+          "blurHash": "U#N,-:ae_NWVoft7oLf6%MWBMxofWBayt7of",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "iWOu0yW0IPhcNlIcMMk7",
+      "type": "artworks",
+      "attributes": {
+        "mediaType": "IMAGE",
+        "files": [
+          {
+            "href": "https://resources.tidal.com/images/0f5da3ec/db14/4df5/8189/53b74df80ce2/1280x1280.jpg",
+            "meta": {
+              "width": 1280,
+              "height": 1280
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0f5da3ec/db14/4df5/8189/53b74df80ce2/1080x1080.jpg",
+            "meta": {
+              "width": 1080,
+              "height": 1080
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0f5da3ec/db14/4df5/8189/53b74df80ce2/750x750.jpg",
+            "meta": {
+              "width": 750,
+              "height": 750
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0f5da3ec/db14/4df5/8189/53b74df80ce2/640x640.jpg",
+            "meta": {
+              "width": 640,
+              "height": 640
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0f5da3ec/db14/4df5/8189/53b74df80ce2/320x320.jpg",
+            "meta": {
+              "width": 320,
+              "height": 320
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0f5da3ec/db14/4df5/8189/53b74df80ce2/160x160.jpg",
+            "meta": {
+              "width": 160,
+              "height": 160
+            }
+          },
+          {
+            "href": "https://resources.tidal.com/images/0f5da3ec/db14/4df5/8189/53b74df80ce2/80x80.jpg",
+            "meta": {
+              "width": 80,
+              "height": 80
+            }
+          }
+        ],
+        "visualMetadata": {
+          "selectedPaletteColor": "#847346",
+          "blurHash": "UhI#rw9FozRj~pfRWCt6xuxuNGog-;s:ayM{",
+          "status": "OK"
+        }
+      }
+    },
+    {
+      "id": "151141801",
+      "type": "tracks",
+      "attributes": {
+        "title": "1000 Miles",
+        "version": null,
+        "isrc": "GBCFB2000362",
+        "duration": "PT5M41S",
+        "copyright": {
+          "text": "Ninja Tune"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "B",
+        "keyScale": "MAJOR",
+        "bpm": 85.0,
+        "popularity": 0.4830569222422289,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/151141801",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2020-08-06T10:22:00Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3941595",
+              "type": "artists"
+            },
+            {
+              "id": "3540436",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/151141801/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "151141792",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/151141801/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "153517662",
+      "type": "tracks",
+      "attributes": {
+        "title": "Missing Out",
+        "version": "The Midnight Remix",
+        "isrc": "DEVN52000063",
+        "duration": "PT3M29S",
+        "copyright": {
+          "text": "(P) 2020 Wasted Talent Records"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "CSharp",
+        "keyScale": "MAJOR",
+        "bpm": 100.0,
+        "popularity": 0.1450524882420249,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/153517662",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2020-08-28T20:53:34Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "7205813",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/153517662/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "153517661",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/153517662/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "172054372",
+      "type": "tracks",
+      "attributes": {
+        "title": "Making A Fire",
+        "version": null,
+        "isrc": "USRW32000007",
+        "duration": "PT4M15S",
+        "copyright": {
+          "text": "(P) 2020 Roswell Records, Inc., under exclusive license to RCA Records"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "A",
+        "keyScale": "MAJOR",
+        "bpm": 92.0,
+        "popularity": 0.5184580938842394,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/172054372",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2021-02-02T16:12:21Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "2753",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/172054372/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "172054370",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/172054372/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "176288593",
+      "type": "tracks",
+      "attributes": {
+        "title": "If Only",
+        "version": null,
+        "isrc": "GBARL2001195",
+        "duration": "PT3M31S",
+        "copyright": {
+          "text": "(P) 2021 Insanity Records Limited under exclusive licence to Sony Music Entertainment UK Limited"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "F",
+        "keyScale": "MINOR",
+        "bpm": 120.0,
+        "popularity": 0.12632788159064534,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/176288593",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2021-03-08T15:55:23Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "7809618",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/176288593/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "176288592",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/176288593/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "182912245",
+      "type": "tracks",
+      "attributes": {
+        "title": "Crossfire",
+        "version": null,
+        "isrc": "GBARL2001633",
+        "duration": "PT3M39S",
+        "copyright": {
+          "text": "(P) 2021 Sony Music Entertainment UK Limited"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "F",
+        "keyScale": "MAJOR",
+        "bpm": 144.0,
+        "popularity": 0.3655102443157622,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/182912245",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2021-05-04T17:59:22Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "4816163",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/182912245/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "182912238",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/182912245/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "203203374",
+      "type": "tracks",
+      "attributes": {
+        "title": "Set Me Free",
+        "version": null,
+        "isrc": "GBPWR2100114",
+        "duration": "PT3M44S",
+        "copyright": {
+          "text": "Elevate Records"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "UNKNOWN",
+        "keyScale": "UNKNOWN",
+        "bpm": 87.0,
+        "popularity": 0.5921849939700328,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/203203374",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2021-11-01T15:11:41Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3643168",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/203203374/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "203203373",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/203203374/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "228809510",
+      "type": "tracks",
+      "attributes": {
+        "title": "It's Time",
+        "version": null,
+        "isrc": "GBUM72202966",
+        "duration": "PT3M20S",
+        "copyright": {
+          "text": "℗ 2022 Sub Focus, under exclusive licence to Universal Music Operations Limited"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "C",
+        "keyScale": "MINOR",
+        "bpm": 87.0,
+        "popularity": 0.39187533135482094,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/228809510",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2022-05-13T01:00:10Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3540436",
+              "type": "artists"
+            },
+            {
+              "id": "3533717",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/228809510/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "228809509",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/228809510/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "232894504",
+      "type": "tracks",
+      "attributes": {
+        "title": "Hooked (Grafix Remix)",
+        "version": null,
+        "isrc": "NLZ542200828",
+        "duration": "PT3M21S",
+        "copyright": {
+          "text": "℗ 2022 Musical Freedom Label Ltd."
+        },
+        "explicit": true,
+        "ai": false,
+        "key": "G",
+        "keyScale": "MINOR",
+        "bpm": 87.0,
+        "popularity": 0.5040171888802258,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/232894504",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2022-06-09T13:10:38Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3944800",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/232894504/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "232894499",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/232894504/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "251611169",
+      "type": "tracks",
+      "attributes": {
+        "title": "Lassitude",
+        "version": "Original Mix",
+        "isrc": "GBKBH1033002",
+        "duration": "PT3M12S",
+        "copyright": {
+          "text": "Breakbeat Kaos"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "G",
+        "keyScale": "MAJOR",
+        "bpm": 172.0,
+        "popularity": 0.2821659340610593,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/251611169",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2022-10-01T01:00:14Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3636460",
+              "type": "artists"
+            },
+            {
+              "id": "3633614",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/251611169/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "251611167",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/251611169/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "278905665",
+      "type": "tracks",
+      "attributes": {
+        "title": "Shut It Down",
+        "version": null,
+        "isrc": "US39N2301252",
+        "duration": "PT2M59S",
+        "copyright": {
+          "text": "2023 DnB Allstars Records"
+        },
+        "explicit": true,
+        "ai": false,
+        "key": "FSharp",
+        "keyScale": "MAJOR",
+        "bpm": 86.0,
+        "popularity": 0.4587776752801539,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/278905665",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2023-02-25T01:48:47Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "8980137",
+              "type": "artists"
+            },
+            {
+              "id": "17556142",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/278905665/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "278905664",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/278905665/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "286197968",
+      "type": "tracks",
+      "attributes": {
+        "title": "Baby Don't Hurt Me",
+        "version": null,
+        "isrc": "UKWLG2300016",
+        "duration": "PT2M20S",
+        "copyright": {
+          "text": "Under exclusive licence to What A Music Limited, ℗ 2023 What A DJ Limited"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "C",
+        "keyScale": "MAJOR",
+        "bpm": 128.0,
+        "popularity": 0.7995002080788991,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/286197968",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2023-03-30T12:52:44Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "27343",
+              "type": "artists"
+            },
+            {
+              "id": "6127816",
+              "type": "artists"
+            },
+            {
+              "id": "9644098",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/286197968/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "286197967",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/286197968/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "292482716",
+      "type": "tracks",
+      "attributes": {
+        "title": "Beautiful Lies",
+        "version": "VIP",
+        "isrc": "GBCJY1016909",
+        "duration": "PT6M59S",
+        "copyright": {
+          "text": "- 2015"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "D",
+        "keyScale": "MINOR",
+        "bpm": 116.0,
+        "popularity": 0.5181876076487432,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/292482716",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2023-05-02T12:38:52Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3633607",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/292482716/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "292482715",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/292482716/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "293098632",
+      "type": "tracks",
+      "attributes": {
+        "title": "I Found You",
+        "version": null,
+        "isrc": "GBUM72301974",
+        "duration": "PT2M57S",
+        "copyright": {
+          "text": "℗ 2023 Sub Focus, under exclusive licence to Universal Music Operations Limited"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "A",
+        "keyScale": "MAJOR",
+        "bpm": 172.0,
+        "popularity": 0.4859076817788351,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/293098632",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2023-05-05T00:43:15Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3540436",
+              "type": "artists"
+            },
+            {
+              "id": "6614115",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/293098632/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "293098622",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/293098632/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "410492059",
+      "type": "tracks",
+      "attributes": {
+        "title": "Giants",
+        "version": null,
+        "isrc": "UKFTL1600329",
+        "duration": "PT3M35S",
+        "copyright": {
+          "text": "(P) 2024 Culture Shock Music"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "CSharp",
+        "keyScale": "MINOR",
+        "bpm": 87.0,
+        "popularity": 0.4021253187745783,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/410492059",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2025-01-09T13:08:18Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3607591",
+              "type": "artists"
+            },
+            {
+              "id": "4081743",
+              "type": "artists"
+            },
+            {
+              "id": "34606964",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/410492059/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "410492056",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/410492059/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "491159888",
+      "type": "tracks",
+      "attributes": {
+        "title": "Your Way",
+        "version": null,
+        "isrc": "NLCK41000690",
+        "duration": "PT6M",
+        "copyright": {
+          "text": "Control"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "Ab",
+        "keyScale": "MINOR",
+        "bpm": 88.0,
+        "popularity": 0.2691716442774269,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/491159888",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2026-01-20T18:11:30Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3637207",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/491159888/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "491159887",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/491159888/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "6886564",
+      "type": "tracks",
+      "attributes": {
+        "title": "Nobody's Perfect",
+        "version": null,
+        "isrc": "USUM71100947",
+        "duration": "PT4M20S",
+        "copyright": {
+          "text": "℗ 2011 Universal Republic Records"
+        },
+        "explicit": true,
+        "ai": false,
+        "key": "Bb",
+        "keyScale": "MAJOR",
+        "bpm": 164.0,
+        "popularity": 0.06716793089005813,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/6886564",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2011-06-03T12:09:32Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3828746",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/6886564/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "6886563",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/6886564/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "6886567",
+      "type": "tracks",
+      "attributes": {
+        "title": "Nobody's Perfect",
+        "version": "Netsky Full Vocal Remix",
+        "isrc": "USUM71105634",
+        "duration": "PT4M56S",
+        "copyright": {
+          "text": "℗ 2011 Universal Republic Records"
+        },
+        "explicit": true,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MAJOR",
+        "bpm": 172.0,
+        "popularity": 0.5170727669535173,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/6886567",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2011-06-03T12:09:32Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3828746",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/6886567/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "6886563",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/6886567/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "6886568",
+      "type": "tracks",
+      "attributes": {
+        "title": "Nobody's Perfect",
+        "version": "Steve Smart & Westfunk [Explicit Club]",
+        "isrc": "USUM71107066",
+        "duration": "PT5M54S",
+        "copyright": {
+          "text": "℗ 2011 Universal Republic Records"
+        },
+        "explicit": true,
+        "ai": false,
+        "key": "Eb",
+        "keyScale": "MAJOR",
+        "bpm": 125.0,
+        "popularity": 0.09220922389026665,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/6886568",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2011-06-03T12:09:32Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3828746",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/6886568/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "6886563",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/6886568/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "76004353",
+      "type": "tracks",
+      "attributes": {
+        "title": "Love$ick",
+        "version": null,
+        "isrc": "GBUM71605141",
+        "duration": "PT3M12S",
+        "copyright": {
+          "text": "℗ 2016 Anchor Point Records, under exclusive license to Polydor"
+        },
+        "explicit": true,
+        "ai": false,
+        "key": "CSharp",
+        "keyScale": "MAJOR",
+        "bpm": 89.0,
+        "popularity": 0.7203753125063882,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/76004353",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2017-07-07T00:24:12Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "5812786",
+              "type": "artists"
+            },
+            {
+              "id": "4315444",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/76004353/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "76004350",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/76004353/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    },
+    {
+      "id": "96098350",
+      "type": "tracks",
+      "attributes": {
+        "title": "Always Remember Us This Way",
+        "version": null,
+        "isrc": "USUM71813195",
+        "duration": "PT3M30S",
+        "copyright": {
+          "text": "℗ 2018 Interscope Records"
+        },
+        "explicit": false,
+        "ai": false,
+        "key": "F",
+        "keyScale": "MAJOR",
+        "bpm": 130.0,
+        "popularity": 0.7539664225746907,
+        "accessType": "PUBLIC",
+        "availability": [
+          "STREAM",
+          "DJ"
+        ],
+        "mediaTags": [
+          "HIRES_LOSSLESS",
+          "LOSSLESS"
+        ],
+        "toneTags": [],
+        "externalLinks": [
+          {
+            "href": "https://tidal.com/browse/track/96098350",
+            "meta": {
+              "type": "TIDAL_SHARING"
+            }
+          }
+        ],
+        "spotlighted": false,
+        "createdAt": "2018-10-03T17:14:08Z"
+      },
+      "relationships": {
+        "artists": {
+          "data": [
+            {
+              "id": "3534754",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/tracks/96098350/relationships/artists?countryCode=AT&locale=en-US"
+          }
+        },
+        "albums": {
+          "data": [
+            {
+              "id": "96098333",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/tracks/96098350/relationships/albums?countryCode=AT&locale=en-US"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/providers/tidal/test_jsonapi.py
+++ b/tests/providers/tidal/test_jsonapi.py
@@ -67,3 +67,12 @@ def test_next_cursor() -> None:
     assert doc.next_cursor == "abc123"
     bare = JsonApiDocument({"links": {"next": "rawcursor"}})
     assert bare.next_cursor == "rawcursor"
+
+
+def test_next_cursor_percent_encoded_brackets() -> None:
+    """Test the cursor is extracted when the bracket key is percent-encoded."""
+    # This is the real form Tidal returns: page%5Bcursor%5D=<value>.
+    doc = JsonApiDocument(
+        {"links": {"next": "/x?include=items.profileArt&page%5Bcursor%5D=eyJpZCI6Mzk3fQ"}}
+    )
+    assert doc.next_cursor == "eyJpZCI6Mzk3fQ"

--- a/tests/providers/tidal/test_library.py
+++ b/tests/providers/tidal/test_library.py
@@ -1,14 +1,24 @@
 """Test Tidal Library Manager."""
 
+import json
+import pathlib
 from collections.abc import AsyncGenerator
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 from music_assistant_models.enums import MediaType
 from music_assistant_models.media_items import ItemMapping
 
+from music_assistant.providers.tidal.jsonapi import JsonApiDocument
 from music_assistant.providers.tidal.library import TidalLibraryManager
+
+FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures" / "v2"
+
+
+def _load_doc(name: str) -> JsonApiDocument:
+    with open(FIXTURES_DIR / name) as f:
+        return JsonApiDocument(json.load(f))
 
 
 @pytest.fixture
@@ -51,106 +61,67 @@ def library_manager(provider_mock: Mock) -> TidalLibraryManager:
     return TidalLibraryManager(provider_mock)
 
 
-@patch("music_assistant.providers.tidal.library.parse_artist")
-async def test_get_artists(
-    mock_parse_artist: Mock, library_manager: TidalLibraryManager, provider_mock: Mock
-) -> None:
-    """Test get_artists."""
-    provider_mock.api.paginate.return_value = [
-        {"created": "2024-01-01T00:00:00", "item": {"id": 1, "name": "Test Artist"}}
-    ]
-    mock_parse_artist.return_value = Mock(item_id="1")
+async def test_get_artists(library_manager: TidalLibraryManager, provider_mock: Mock) -> None:
+    """Test library artists read from the official userCollection endpoint."""
+    doc = _load_doc("lib_artists.json")
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
 
     artists = [a async for a in library_manager.get_artists()]
 
-    assert len(artists) == 1
-    assert artists[0].item_id == "1"
-    provider_mock.api.paginate.assert_called_with(
-        "users/12345/favorites/artists",
-    )
-    mock_parse_artist.assert_called_once()
+    assert len(artists) == 20
+    assert artists[0].date_added is not None  # from the addedAt linkage meta
 
 
-@patch("music_assistant.providers.tidal.library.parse_album")
-async def test_get_albums(
-    mock_parse_album: Mock, library_manager: TidalLibraryManager, provider_mock: Mock
-) -> None:
-    """Test get_albums."""
-    provider_mock.api.paginate.return_value = [
-        {"created": "2024-01-01T00:00:00", "item": {"id": 1, "title": "Test Album"}}
-    ]
-    mock_parse_album.return_value = Mock(item_id="1")
+async def test_get_albums(library_manager: TidalLibraryManager, provider_mock: Mock) -> None:
+    """Test library albums read from the official userCollection endpoint."""
+    doc = _load_doc("lib_albums.json")
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
 
     albums = [a async for a in library_manager.get_albums()]
 
-    assert len(albums) == 1
-    assert albums[0].item_id == "1"
-    provider_mock.api.paginate.assert_called_with(
-        "users/12345/favorites/albums",
-    )
-    mock_parse_album.assert_called_once()
+    assert len(albums) == 20
+    assert albums[0].date_added is not None
 
 
-@patch("music_assistant.providers.tidal.library.parse_track")
-async def test_get_tracks(
-    mock_parse_track: Mock, library_manager: TidalLibraryManager, provider_mock: Mock
-) -> None:
-    """Test get_tracks."""
-    provider_mock.api.paginate.return_value = [
-        {"created": "2024-01-01T00:00:00", "item": {"id": 1, "title": "Test Track"}}
-    ]
-    mock_parse_track.return_value = Mock(item_id="1")
+async def test_get_tracks(library_manager: TidalLibraryManager, provider_mock: Mock) -> None:
+    """Test library tracks read from the official userCollection endpoint."""
+    doc = _load_doc("lib_tracks.json")
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
 
     tracks = [t async for t in library_manager.get_tracks()]
 
-    assert len(tracks) == 1
-    assert tracks[0].item_id == "1"
-    provider_mock.api.paginate.assert_called_with(
-        "users/12345/favorites/tracks",
-    )
-    mock_parse_track.assert_called_once()
+    assert len(tracks) == 20
+    assert tracks[0].date_added is not None
 
 
-@patch("music_assistant.providers.tidal.library.parse_playlist")
-async def test_get_playlists(
-    mock_parse_playlist: Mock, library_manager: TidalLibraryManager, provider_mock: Mock
-) -> None:
-    """Test get_playlists."""
-    # Mock mixes response
-    mixes_response = [{"id": "mix_1", "title": "Mix 1"}]
-    # Mock playlists response
-    playlists_response = [
-        {
-            "created": "2024-01-01T00:00:00",
-            "playlist": {"uuid": "pl_1", "title": "Playlist 1"},
-        }
-    ]
+async def test_get_playlists(library_manager: TidalLibraryManager, provider_mock: Mock) -> None:
+    """Test library playlists include mixes and the virtual favorites playlist."""
+    doc = _load_doc("lib_playlists.json")
 
-    # Configure paginate side effect
-    async def paginate_side_effect(endpoint: str, **_kwargs: Any) -> AsyncGenerator[dict[str, Any]]:
-        if "mixes" in endpoint:
-            for item in mixes_response:
-                yield item
-        else:
-            # The ignore[assignment] is needed because of the different return types
-            for item in playlists_response:  # type: ignore[assignment]
-                yield item
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
 
-    provider_mock.api.paginate.side_effect = paginate_side_effect
-
-    # Setup mock return values
-    mock_parse_playlist.side_effect = [
-        Mock(item_id="mix_1"),
-        Mock(item_id="pl_1"),
-    ]
+    provider_mock.api.paginate_jsonapi = _pages
 
     playlists = [p async for p in library_manager.get_playlists()]
 
-    assert len(playlists) == 3
-    assert playlists[0].item_id == "mix_1"
-    assert playlists[1].item_id == "pl_1"
-    assert playlists[2].item_id == "favorite_tracks"
-    assert mock_parse_playlist.call_count == 2
+    # 19 resolved playlists + the trailing virtual "favorite tracks" playlist
+    assert playlists[-1].item_id == "favorite_tracks"
+    # mixes come through the same collection with the "mix_" item id prefix
+    assert any(p.item_id.startswith("mix_") for p in playlists)
+    assert any(not p.item_id.startswith("mix_") for p in playlists[:-1])
 
 
 async def test_add_item_artist(library_manager: TidalLibraryManager, provider_mock: Mock) -> None:
@@ -236,12 +207,17 @@ async def test_remove_item_playlist(
 async def test_get_playlists_includes_favorite_tracks(
     library_manager: TidalLibraryManager, provider_mock: Mock
 ) -> None:
-    """Test that get_playlists yields the favorite tracks playlist as the first item."""
-    provider_mock.api.paginate.return_value = []
+    """Test that get_playlists yields the virtual favorite tracks playlist."""
+    empty = JsonApiDocument({"data": [], "included": []})
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield empty
+
+    provider_mock.api.paginate_jsonapi = _pages
 
     playlists = [p async for p in library_manager.get_playlists()]
 
-    assert len(playlists) >= 1
+    assert len(playlists) == 1
     assert playlists[0].item_id == "favorite_tracks"
     assert playlists[0].name == "Favorite Tracks"
     assert not playlists[0].is_editable


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Builds on the previous Tidal PRs (stacked).

Moves the library reads onto the official cursor-paginated `userCollection*`
endpoints (`date_added` from the `addedAt` meta). `get_playlists` simplifies:
the official collection returns user playlists and favourited mixes together,
so the separate unofficial mixes fetch is gone.

Also fixes cursor pagination: the real `next` link uses percent-encoded
brackets (`page%5Bcursor%5D`), which the extraction missed. Writes stay
unofficial for now. Tested against real captured responses.


**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
