### PR TITLE
Update music-assistant-models to 1.1.166

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "getmac==0.9.5",
   "mashumaro==3.20",
   "music-assistant-frontend==2.17.228",
-  "music-assistant-models==1.1.164",
+  "music-assistant-models==1.1.166",
   "mutagen==1.48.1",
   "orjson==3.11.6",
   "pillow==12.3.0",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -51,7 +51,7 @@ markdownify==1.2.3
 mashumaro==3.20
 modern_colorthief==0.2.1
 music-assistant-frontend==2.17.228
-music-assistant-models==1.1.164
+music-assistant-models==1.1.166
 mutagen==1.48.1
 niconico.py-ma==2.1.0.post2
 nnAudio==0.3.3

--- a/tests/providers/nicovideo/__snapshots__/test_converters.ambr
+++ b/tests/providers/nicovideo/__snapshots__/test_converters.ambr
@@ -2063,7 +2063,6 @@
       'sample_rate': 48000,
     }),
     'audio_processing': None,
-    'dsp': None,
     'duration': 2,
     'item_id': 'sm45285955',
     'loudness': -7000.0,


### PR DESCRIPTION
# What does this implement/fix?

Bumps `music-assistant-models` from 1.1.164 to 1.1.166.

The only functional model change in this range is [#310](https://github.com/music-assistant/models/pull/310), which removes the legacy `DSPDetails` class and the `StreamDetails.dsp` field (the server already uses the newer `AudioProcessingChain` / `AudioDSPDetails` models). Because of that removal, the nicovideo converter snapshot no longer serializes a `dsp` field, so the snapshot is regenerated to match.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [x] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
