### PR TITLE
Sort filesystem browse results in natural order

### DIFF
--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -2538,9 +2538,11 @@ class LocalFileSystemProvider(MusicProvider):
         return data
 
     async def _scandir(self, path: str) -> list[FileSystemItem]:
-        """List directory contents."""
+        """List directory contents in natural sort order."""
+        # raw scandir order depends on the underlying filesystem (e.g. hash order
+        # on ext4) so sort to make browse and folder playback order deterministic
         abs_path = self.get_absolute_path(path)
-        return await asyncio.to_thread(sorted_scandir, self.base_path, abs_path)
+        return await asyncio.to_thread(sorted_scandir, self.base_path, abs_path, sort=True)
 
     async def _read_file(self, path: str) -> bytes:
         """Read file contents. Override for network storage."""

--- a/music_assistant/providers/filesystem_local/helpers.py
+++ b/music_assistant/providers/filesystem_local/helpers.py
@@ -335,8 +335,8 @@ def sorted_scandir(base_path: str, sub_path: str, sort: bool = False) -> list[Fi
     """
 
     def nat_key(name: str) -> tuple[int | str, ...]:
-        """Sort key for natural sorting."""
-        return tuple(int(s) if s.isdigit() else s for s in re.split(r"(\d+)", name))
+        """Sort key for natural sorting, case insensitive to match the frontend sorting."""
+        return tuple(int(s) if s.isdigit() else s.casefold() for s in re.split(r"(\d+)", name))
 
     if base_path not in sub_path:
         sub_path = os.path.join(base_path, sub_path)

--- a/tests/providers/filesystem_local/__init__.py
+++ b/tests/providers/filesystem_local/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the filesystem local provider."""

--- a/tests/providers/filesystem_local/test_helpers.py
+++ b/tests/providers/filesystem_local/test_helpers.py
@@ -1,0 +1,34 @@
+"""Tests for the filesystem provider helpers."""
+
+from pathlib import Path
+
+from music_assistant.providers.filesystem_local.helpers import sorted_scandir
+
+
+def test_sorted_scandir_natural_order(tmp_path: Path) -> None:
+    """Entries are returned in natural, case insensitive order when sort is enabled."""
+    (tmp_path / "Incoming").mkdir()
+    (tmp_path / "albums").mkdir()
+    for name in ("10 - Third.flac", "2 - Second.flac", "1 - First.flac", "cover.jpg"):
+        (tmp_path / name).touch()
+
+    result = sorted_scandir(str(tmp_path), str(tmp_path), sort=True)
+
+    assert [item.filename for item in result] == [
+        "1 - First.flac",
+        "2 - Second.flac",
+        "10 - Third.flac",
+        "albums",
+        "cover.jpg",
+        "Incoming",
+    ]
+
+
+def test_sorted_scandir_unsorted_by_default(tmp_path: Path) -> None:
+    """Without the sort flag, entries are returned in raw scandir order."""
+    for name in ("b.flac", "a.flac"):
+        (tmp_path / name).touch()
+
+    result = sorted_scandir(str(tmp_path), str(tmp_path))
+
+    assert sorted(item.filename for item in result) == ["a.flac", "b.flac"]


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Directory enumeration order depends on the underlying filesystem, so browse results and folder playback followed raw readdir order, which on ext4 is hash order and appears scrambled. The frontend alphabetical sort only reorders the on screen list, so the queue still played in raw order when sending a folder to the queue.

Enable the existing natural sort in sorted_scandir for all directory listings and make its sort key case insensitive so the order matches the frontend localeCompare numeric sorting.

**Related issue (if applicable):**

- related issue https://github.com/orgs/music-assistant/discussions/5734#discussioncomment-17690000

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
