### PR TITLE
Support DSP filters that need a second audio input

### DIFF
--- a/music_assistant/helpers/dsp.py
+++ b/music_assistant/helpers/dsp.py
@@ -1,6 +1,7 @@
 """Helper functions for DSP filters."""
 
 import math
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from music_assistant_models.dsp import (
@@ -17,6 +18,25 @@ if TYPE_CHECKING:
     from music_assistant_models.media_items.audio_format import AudioFormat
 
 # ruff: noqa: PLR0915
+
+
+@dataclass(slots=True)
+class ComplexFilter:
+    """
+    A DSP filter fragment that pulls in one or more extra source inputs.
+
+    Represents a chain entry that cannot be expressed as a plain single-input
+    filter string, such as an FFmpeg ``afir`` convolution that needs an
+    impulse-response input.
+
+    :param body: The filter consuming the main input followed by each source in
+        order (e.g. "afir=gtype=gn").
+    :param sources: Sub-chains that each produce one extra input for ``body``
+        (e.g. "amovie='/x/ir.wav',aresample=48000").
+    """
+
+    body: str
+    sources: list[str] = field(default_factory=list)
 
 
 def filter_to_ffmpeg_params(dsp_filter: DSPFilter, input_format: AudioFormat) -> list[str]:

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -7,7 +7,7 @@ import logging
 import re
 import time
 from collections import deque
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
 from contextlib import suppress
 from copy import copy
 from dataclasses import dataclass
@@ -19,6 +19,7 @@ from music_assistant_models.helpers import get_global_cache_value, set_global_ca
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 
+from .dsp import ComplexFilter
 from .process import AsyncProcess, check_output
 from .util import close_async_generator
 
@@ -82,7 +83,7 @@ class FFMpeg(AsyncProcess):
         audio_input: AsyncGenerator[bytes] | str | int,
         input_format: AudioFormat,
         output_format: AudioFormat,
-        filter_params: list[str] | None = None,
+        filter_params: Sequence[str | ComplexFilter] | None = None,
         extra_args: list[str] | None = None,
         extra_input_args: list[str] | None = None,
         extra_output_args: list[str] | None = None,
@@ -359,7 +360,7 @@ async def get_ffmpeg_stream(
     audio_input: AsyncGenerator[bytes] | str,
     input_format: AudioFormat,
     output_format: AudioFormat,
-    filter_params: list[str] | None = None,
+    filter_params: Sequence[str | ComplexFilter] | None = None,
     extra_args: list[str] | None = None,
     chunk_size: int | None = None,
     extra_input_args: list[str] | None = None,
@@ -461,7 +462,7 @@ async def get_ffmpeg_overlay_stream(
 def get_ffmpeg_resample_filter(
     input_format: AudioFormat,
     output_format: AudioFormat,
-    filter_params: list[str],
+    filter_params: Sequence[str | ComplexFilter],
 ) -> str | None:
     """
     Return the resampling and dithering filter required for a format conversion.
@@ -476,7 +477,9 @@ def get_ffmpeg_resample_filter(
         return None
     libsoxr_support = get_global_cache_value(CACHE_ATTR_LIBSOXR_PRESENT)
     # loudnorm and libsoxr cannot be combined due to https://trac.ffmpeg.org/ticket/11323
-    if libsoxr_support and not any("loudnorm" in value for value in filter_params):
+    if libsoxr_support and not any(
+        "loudnorm" in value for value in filter_params if isinstance(value, str)
+    ):
         resample_filter = "aresample=resampler=soxr:precision=30"
     else:
         resample_filter = "aresample=resampler=swr"
@@ -490,7 +493,7 @@ def get_ffmpeg_resample_filter(
 def get_ffmpeg_args(
     input_format: AudioFormat,
     output_format: AudioFormat,
-    filter_params: list[str],
+    filter_params: Sequence[str | ComplexFilter],
     extra_args: list[str] | None = None,
     input_path: str = "-",
     output_path: str = "-",
@@ -654,9 +657,61 @@ def get_ffmpeg_args(
         filter_params.append(resample_filter)
 
     if filter_params and "-filter_complex" not in extra_args:
-        extra_args += ["-af", ",".join(filter_params)]
+        extra_args += _build_filtergraph_args(filter_params)
 
     return generic_args + input_args + extra_args + output_args
+
+
+def _build_filtergraph_args(filter_params: list[str | ComplexFilter]) -> list[str]:
+    """
+    Render a DSP filter chain to FFmpeg command-line arguments.
+
+    :param filter_params: Ordered chain of plain filter strings and/or complex
+        fragments that need extra source inputs.
+    """
+    if not any(isinstance(item, ComplexFilter) for item in filter_params):
+        simple = [item for item in filter_params if isinstance(item, str) and item]
+        return ["-af", ",".join(simple)] if simple else []
+
+    parts: list[str] = []
+    pending: list[str] = []
+    current = "0:a"
+    counter = 0
+
+    def next_label() -> str:
+        nonlocal counter
+        counter += 1
+        return f"dsp{counter}"
+
+    def flush_pending() -> None:
+        nonlocal current
+        if not pending:
+            return
+        label = next_label()
+        parts.append(f"[{current}]{','.join(pending)}[{label}]")
+        current = label
+        pending.clear()
+
+    for item in filter_params:
+        if isinstance(item, str):
+            if item:
+                pending.append(item)
+            continue
+        # a complex fragment closes the current simple run, pulls its own source
+        # inputs into the graph, then consumes the main pad plus those sources
+        flush_pending()
+        source_labels: list[str] = []
+        for source in item.sources:
+            label = next_label()
+            parts.append(f"{source}[{label}]")
+            source_labels.append(label)
+        label = next_label()
+        inputs = f"[{current}]" + "".join(f"[{sl}]" for sl in source_labels)
+        parts.append(f"{inputs}{item.body}[{label}]")
+        current = label
+    flush_pending()
+
+    return ["-filter_complex", ";".join(parts), "-map", f"[{current}]"]
 
 
 async def check_ffmpeg_version() -> None:

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -662,6 +662,51 @@ def get_ffmpeg_args(
     return generic_args + input_args + extra_args + output_args
 
 
+async def check_ffmpeg_version() -> None:
+    """Check if ffmpeg is present (with libsoxr support)."""
+    # check for FFmpeg presence
+    try:
+        returncode, output = await check_output("ffmpeg", "-version")
+    except FileNotFoundError:
+        raise AudioError(
+            "FFmpeg binary is missing from system. "
+            "Please install ffmpeg on your OS to enable playback."
+        )
+    if returncode != 0:
+        err_msg = "Error determining FFmpeg version on your system."
+        if returncode < 0:
+            # error below 0 is often illegal instruction
+            err_msg += " - Your CPU may be too old to run this version of FFmpeg."
+        err_msg += f" - Additional info: {returncode} {output.decode().strip()}"
+        raise AudioError(err_msg)
+    # parse version number from output
+    try:
+        version = output.decode().split("ffmpeg version ")[1].split(" ")[0].split("-")[0]
+    except IndexError:
+        raise AudioError(
+            "Error determining FFmpeg version on your system."
+            f"Additional info: {returncode} {output.decode().strip()}"
+        )
+    libsoxr_support = "enable-libsoxr" in output.decode()
+    # use globals as in-memory cache
+    await set_global_cache_values(
+        {CACHE_ATTR_LIBSOXR_PRESENT: libsoxr_support, CACHE_ATTR_FFMPEG_VERSION: version}
+    )
+
+    major_version = int("".join(char for char in version.split(".")[0] if not char.isalpha()))
+    if major_version < MINIMAL_FFMPEG_VERSION:
+        raise AudioError(
+            f"FFmpeg version {version} is not supported. "
+            f"Minimal version required is {MINIMAL_FFMPEG_VERSION}."
+        )
+
+    LOGGER.info(
+        "Detected ffmpeg version %s %s",
+        version,
+        "with libsoxr support" if libsoxr_support else "",
+    )
+
+
 def _build_filtergraph_args(filter_params: list[str | ComplexFilter]) -> list[str]:
     """
     Render a DSP filter chain to FFmpeg command-line arguments.
@@ -712,48 +757,3 @@ def _build_filtergraph_args(filter_params: list[str | ComplexFilter]) -> list[st
     flush_pending()
 
     return ["-filter_complex", ";".join(parts), "-map", f"[{current}]"]
-
-
-async def check_ffmpeg_version() -> None:
-    """Check if ffmpeg is present (with libsoxr support)."""
-    # check for FFmpeg presence
-    try:
-        returncode, output = await check_output("ffmpeg", "-version")
-    except FileNotFoundError:
-        raise AudioError(
-            "FFmpeg binary is missing from system. "
-            "Please install ffmpeg on your OS to enable playback."
-        )
-    if returncode != 0:
-        err_msg = "Error determining FFmpeg version on your system."
-        if returncode < 0:
-            # error below 0 is often illegal instruction
-            err_msg += " - Your CPU may be too old to run this version of FFmpeg."
-        err_msg += f" - Additional info: {returncode} {output.decode().strip()}"
-        raise AudioError(err_msg)
-    # parse version number from output
-    try:
-        version = output.decode().split("ffmpeg version ")[1].split(" ")[0].split("-")[0]
-    except IndexError:
-        raise AudioError(
-            "Error determining FFmpeg version on your system."
-            f"Additional info: {returncode} {output.decode().strip()}"
-        )
-    libsoxr_support = "enable-libsoxr" in output.decode()
-    # use globals as in-memory cache
-    await set_global_cache_values(
-        {CACHE_ATTR_LIBSOXR_PRESENT: libsoxr_support, CACHE_ATTR_FFMPEG_VERSION: version}
-    )
-
-    major_version = int("".join(char for char in version.split(".")[0] if not char.isalpha()))
-    if major_version < MINIMAL_FFMPEG_VERSION:
-        raise AudioError(
-            f"FFmpeg version {version} is not supported. "
-            f"Minimal version required is {MINIMAL_FFMPEG_VERSION}."
-        )
-
-    LOGGER.info(
-        "Detected ffmpeg version %s %s",
-        version,
-        "with libsoxr support" if libsoxr_support else "",
-    )

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -10,8 +10,10 @@ import pytest
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 
+from music_assistant.helpers.dsp import ComplexFilter
 from music_assistant.helpers.ffmpeg import (
     FFMpegStreamInfo,
+    _build_filtergraph_args,
     get_ffmpeg_args,
     get_ffmpeg_overlay_stream,
     parse_ffmpeg_duration,
@@ -319,3 +321,152 @@ async def test_overlay_stream_trims_leading_silence(
     # without trimming, the first second would be the overlay's silent intro;
     # the trim makes the tone play from the start, so the first second has signal
     assert any(output)
+
+
+# -- _build_filtergraph_args (DSP chain assembly) --
+
+
+def test_build_filtergraph_all_simple_uses_af() -> None:
+    """A chain of plain filters renders to a single -af comma chain."""
+    assert _build_filtergraph_args(["equalizer=x", "volume=3dB"]) == [
+        "-af",
+        "equalizer=x,volume=3dB",
+    ]
+
+
+def test_build_filtergraph_empty_returns_no_args() -> None:
+    """An empty chain produces no ffmpeg arguments."""
+    assert _build_filtergraph_args([]) == []
+
+
+def test_build_filtergraph_single_complex_fragment() -> None:
+    """A complex fragment renders a labelled -filter_complex graph with -map."""
+    result = _build_filtergraph_args([ComplexFilter("afir=gtype=gn", ["amovie='/ir.wav'"])])
+    assert result == [
+        "-filter_complex",
+        "amovie='/ir.wav'[dsp1];[0:a][dsp1]afir=gtype=gn[dsp2]",
+        "-map",
+        "[dsp2]",
+    ]
+
+
+def test_build_filtergraph_complex_between_simple_runs() -> None:
+    """Simple runs on either side of a complex fragment weave into labelled pads."""
+    result = _build_filtergraph_args(
+        [
+            "equalizer=x",
+            ComplexFilter("afir=gtype=gn", ["amovie='/ir.wav'"]),
+            "volume=2dB",
+        ]
+    )
+    assert result == [
+        "-filter_complex",
+        "[0:a]equalizer=x[dsp1];amovie='/ir.wav'[dsp2];"
+        "[dsp1][dsp2]afir=gtype=gn[dsp3];[dsp3]volume=2dB[dsp4]",
+        "-map",
+        "[dsp4]",
+    ]
+
+
+def test_build_filtergraph_multiple_sources() -> None:
+    """A fragment with several sources feeds them to the body after the main pad."""
+    result = _build_filtergraph_args([ComplexFilter("amerge", ["amovie=a", "amovie=b"])])
+    assert result == [
+        "-filter_complex",
+        "amovie=a[dsp1];amovie=b[dsp2];[0:a][dsp1][dsp2]amerge[dsp3]",
+        "-map",
+        "[dsp3]",
+    ]
+
+
+def test_get_ffmpeg_args_uses_af_without_complex_filter() -> None:
+    """Plain filter chains keep the -af path (no -filter_complex/-map)."""
+    fmt = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=48000, bit_depth=16, channels=2
+    )
+    args = get_ffmpeg_args(fmt, fmt, ["volume=-1dB"])
+    assert "-af" in args
+    assert "-filter_complex" not in args
+
+
+def test_get_ffmpeg_args_uses_filter_complex_with_complex_filter() -> None:
+    """A complex fragment switches the whole chain to -filter_complex with -map."""
+    fmt = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=48000, bit_depth=16, channels=2
+    )
+    args = get_ffmpeg_args(fmt, fmt, [ComplexFilter("afir=gtype=gn", ["amovie='/ir.wav'"])])
+    assert "-filter_complex" in args
+    assert "-map" in args
+    assert "-af" not in args
+
+
+def _wav_rms_db(path: Path) -> float:
+    """Return the overall RMS level of a wav file in dB via ffmpeg astats."""
+    output = subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "ffmpeg",
+            "-hide_banner",
+            "-nostats",
+            "-i",
+            str(path),
+            "-af",
+            "astats=measure_perchannel=none",
+            "-f",
+            "null",
+            "-",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stderr
+    for line in output.splitlines():
+        if "RMS level dB" in line:
+            return float(line.split("RMS level dB:")[-1])
+    raise AssertionError("no RMS level in astats output")
+
+
+def test_filtergraph_complex_runs_in_ffmpeg(tmp_path: Path) -> None:
+    """The generated -filter_complex graph is valid and an identity IR passes audio through."""
+    main = tmp_path / "main.wav"
+    ir = tmp_path / "ir.wav"
+    out = tmp_path / "out.wav"
+    subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=1000:duration=1:sample_rate=48000",
+            "-ac",
+            "2",
+            str(main),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    # a single-sample impulse is the identity IR: convolving with it returns the input
+    subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "aevalsrc=eq(n\\,0):d=0.01:s=48000:c=stereo",
+            str(ir),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    args = _build_filtergraph_args([ComplexFilter("afir=gtype=gn", [f"amovie='{ir}'"])])
+    result = subprocess.run(  # noqa: S603
+        ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y", "-i", str(main), *args, str(out)],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert out.exists()
+    # identity IR => output level matches input level
+    assert abs(_wav_rms_db(out) - _wav_rms_db(main)) < 0.5


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Right now every DSP filter has one audio input and one audio output, and the whole chain gets joined into a single `-af` argument for ffmpeg. That works for everything we have today, but it cannot handle a filter that needs a second input, such as an afir convolution, which is my next DSP filter, that reads an impulse response from a separate audio source.

So this PR allows the ffmpeg helper to build the filter chain in one of two ways. When every filter is a normal one input filter, the common case, it still produces the same single `-af` argument as before. When a filter needs an extra input, it produces a `-filter_complex` argument instead, which is the form ffmpeg needs when inputs have to be connected up by hand. A small `ComplexFilter` type describes a filter that needs those extra inputs, and a new helper function does the building.

This is groundwork for a convolution DSP filter that will follow in a separate PR. I am keeping the plumbing on its own so the tricky part, which is switching the chain over to `-filter_complex` without breaking the existing `-af` path, can be reviewed and tested by itself before the feature is built on top of it.

Nothing in the code creates a `ComplexFilter` yet, so in practice every chain still takes the exact same `-af` path it did before. A few function signatures were widened to also accept the new type, but they still accept the plain string lists that every current caller passes, so nothing else had to change.

Tests

`tests/helpers/test_ffmpeg.py` covers both sides:

- a normal chain still produces the same `-af` output, and an empty chain still produces no arguments, so there is no regression
- a filter that needs extra inputs produces the expected `-filter_complex` output with the inputs connected in the right order, including the cases where it sits between normal filters and where it has more than one extra input
- one test runs a real ffmpeg process with a generated identity impulse response and checks the audio comes out unchanged, so the output is proven to actually work, not just look right

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
