### PR TITLE
Make subsonic provider check for extension it uses

### DIFF
--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -110,8 +110,10 @@ class OpenSonicProvider(MusicProvider):
         port = self.config.get_value(CONF_PORT)
         port = int(str(port)) if port is not None else 443
         path = self.config.get_value(CONF_PATH)
+
         if path is None:
             path = ""
+
         self.conn = SonicConnection(
             str(self.config.get_value(CONF_BASE_URL)),
             username=str(self.config.get_value(CONF_USERNAME)),
@@ -121,6 +123,7 @@ class OpenSonicProvider(MusicProvider):
             server_path=str(path),
             app_name="Music Assistant",
         )
+
         try:
             success = await self.conn.ping()
             if not success:
@@ -135,15 +138,30 @@ class OpenSonicProvider(MusicProvider):
                 translation_owner=self.translation_owner,
                 translation_args=[self.config.get_value(CONF_BASE_URL)],
             ) from e
-        self._enable_podcasts = bool(self.config.get_value(CONF_ENABLE_PODCASTS))
+
         try:
             extensions: list[OpenSubsonicExtension] = await self.conn.get_open_subsonic_extensions()
-            for entry in extensions:
-                if entry.name == "songLyrics":
-                    self._id_lyrics = True
-                    break
-        except OSError:
-            self.logger.info("Failed to query server for OpenSubsonic extensions")
+        except OSError as e:
+            msg = "Failed to query server for OpenSubsonic extensions"
+            raise LoginFailed(
+                msg, translation_key="extension_failure", translation_owner=self.translation_owner
+            ) from e
+
+        formpost_supported = False
+        for entry in extensions:
+            if entry.name == "formpost":
+                formpost_supported = True
+            if entry.name == "songLyrics":
+                self._id_lyrics = True
+        if not formpost_supported:
+            msg = (
+                "Server does not support the 'formpost' OpenSubsonic extension, which is required."
+            )
+            raise LoginFailed(
+                msg, translation_key="formpost_missing", translation_owner=self.translation_owner
+            )
+
+        self._enable_podcasts = bool(self.config.get_value(CONF_ENABLE_PODCASTS))
         self._show_faves = bool(self.config.get_value(CONF_RECO_FAVES))
         self._show_new = bool(self.config.get_value(CONF_NEW_ALBUMS))
         self._show_played = bool(self.config.get_value(CONF_PLAYED_ALBUMS))

--- a/music_assistant/providers/opensubsonic/strings.json
+++ b/music_assistant/providers/opensubsonic/strings.json
@@ -65,6 +65,8 @@
   },
   "errors": {
     "connect_failed": "Failed to connect to {0}, check your settings.",
-    "create_playlist_failed": "Failed to create playlist with name '{0}'."
+    "create_playlist_failed": "Failed to create playlist with name '{0}'.",
+    "extension_failure": "Failed to query server for OpenSubsonic extensions",
+    "formpost_missing": "Server does not support the 'formpost' OpenSubsonic extension, which is required."
   }
 }

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1562,6 +1562,8 @@
   "provider.opensubsonic.config_entries.username.description": "Your username for this Open Subsonic server",
   "provider.opensubsonic.errors.connect_failed": "Failed to connect to {0}, check your settings.",
   "provider.opensubsonic.errors.create_playlist_failed": "Failed to create playlist with name '{0}'.",
+  "provider.opensubsonic.errors.extension_failure": "Failed to query server for OpenSubsonic extensions",
+  "provider.opensubsonic.errors.formpost_missing": "Server does not support the 'formpost' OpenSubsonic extension, which is required.",
   "provider.opensubsonic.manifest.description": "Stream music from your OpenSubsonic compatible server — your own cloud jukebox.",
   "provider.opensubsonic.media.recommendations.starred_items.name": "Starred Items",
   "provider.orf_radiothek.config_entries.catchup_proto.description": "Use 'progressive' (mp3) or 'hls' (m3u8) URLs from the broadcast detail.",


### PR DESCRIPTION
We recently bumped into a problem with a new Open Subsonic implementation that does not support the 'formpost' extension. This relies on that extension and should check for it early and fail early if it is not available.


**Related issue (if applicable):** 

- related issue https://github.com/music-assistant/support/issues/5877

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
