### PR TITLE
Show AirPlay metadata immediately

### DIFF
--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -384,6 +384,8 @@ and verify it against that release's `SHA256SUMS`. For local source development,
 **Commands** (named pipe):
 - Interactive commands sent via `AsyncNamedPipeWriter`
 - Examples: `ACTION=PLAY`, `ACTION=PAUSE`, `VOLUME=50`, `TITLE=Song Name`
+- MA creates the pipe and sends text metadata immediately after process start;
+  timeline-anchored metadata and artwork are refreshed once the receiver connects
 
 **Output** (stderr):
 - Normalized `[STATUS]` messages (connected/playing/paused/eof), logs and errors

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -132,9 +132,23 @@ class AirPlayStream:
         args = await self._build_cli_args(start_unix_ms, use_shared_ptp)
         self.player.logger.debug("Starting cliairplay for player %s", self.player.player_id)
         self._cli_proc = AsyncProcess(args, stdin=True, stdout=True, stderr=True, name="cliairplay")
-        await self._cli_proc.start()
-        self._cli_proc.attach_stderr_reader(self.mass.create_task(self._stderr_reader()))
-        self._stdout_reader_task = self.mass.create_task(self._stdout_reader())
+        try:
+            await self.commands_pipe.create()
+            await self._cli_proc.start()
+            self._cli_proc.attach_stderr_reader(self.mass.create_task(self._stderr_reader()))
+            self._stdout_reader_task = self.mass.create_task(self._stdout_reader())
+            metadata = self.player.current_media
+            if metadata is None and self.session:
+                metadata = self.session.media
+            if metadata:
+                progress = int(metadata.corrected_elapsed_time or 0)
+                await self.send_metadata(progress, metadata, send_artwork=False)
+        except BaseException:
+            try:
+                await self._cleanup_failed_start()
+            except Exception as err:
+                self.player.logger.warning("Failed to clean up cliairplay startup: %s", err)
+            raise
 
     async def wait_for_connection(self) -> None:
         """Wait for device connection to be established."""
@@ -225,8 +239,19 @@ class AirPlayStream:
             return
         await self._write_cli_command(command)
 
-    async def send_metadata(self, progress: int | None, metadata: PlayerMedia | None) -> None:
-        """Send metadata to player."""
+    async def send_metadata(
+        self,
+        progress: int | None,
+        metadata: PlayerMedia | None,
+        send_artwork: bool = True,
+    ) -> None:
+        """
+        Send metadata to player.
+
+        :param progress: Current playback position in seconds.
+        :param metadata: Media metadata to send.
+        :param send_artwork: Whether artwork should be rendered and sent.
+        """
         metadata_checksum: str | None = None
         duration = 0
         title = ""
@@ -267,13 +292,14 @@ class AirPlayStream:
                 if metadata_generation != self._metadata_generation:
                     return
                 if (
-                    metadata.image_url
+                    send_artwork
+                    and metadata.image_url
                     and needs_artwork
                     and metadata_generation not in self._artwork_render_generations
                 ):
                     self._artwork_render_generations.add(metadata_generation)
                     artwork_url = metadata.image_url
-                elif not metadata.image_url or not needs_artwork:
+                elif not send_artwork or not metadata.image_url or not needs_artwork:
                     self._metadata_checksum = metadata_checksum
             if progress is not None and abs(progress - self._last_progress_sent) >= 2:
                 self._last_progress_sent = progress
@@ -685,6 +711,28 @@ class AirPlayStream:
         """Remove all rendered artwork files owned by this stream."""
         for artwork_path in tuple(self._artwork_paths):
             await self._remove_artwork(artwork_path)
+
+    async def _cleanup_failed_start(self) -> None:
+        """Release all resources owned by a cliairplay process that failed to start."""
+        self._stopping = True
+        self._stopped = True
+        stdout_reader_task = self._stdout_reader_task
+        if stdout_reader_task and not stdout_reader_task.done():
+            stdout_reader_task.cancel()
+            try:
+                await stdout_reader_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as err:
+                self.player.logger.debug("cliairplay stdout reader cleanup failed: %s", err)
+        try:
+            if self._cli_proc and not self._cli_proc.closed:
+                await self._cli_proc.kill()
+        finally:
+            await self.commands_pipe.remove()
+            await self._cleanup_artwork()
+            self._cleanup_complete = True
+            self._cli_proc = None
 
     async def _write_cli_command(self, command: str) -> None:
         """Write an interactive command regardless of stream teardown state."""

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -91,21 +91,23 @@ class AirPlayStreamSession:
         # group start as plain unix epoch milliseconds: every member of the
         # sync group receives the exact same value (--start-unix-ms)
         self.start_unix_ms = int(self.start_time * 1000)
-        await asyncio.gather(
-            *[
-                self._start_client(p, self.start_unix_ms, self.use_shared_ptp)
-                for p in self.sync_clients
-            ]
-        )
-        self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
         try:
+            async with asyncio.TaskGroup() as task_group:
+                for player in self.sync_clients:
+                    task_group.create_task(
+                        self._start_client(player, self.start_unix_ms, self.use_shared_ptp)
+                    )
+            self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
             await asyncio.gather(
                 *[p.stream.wait_for_connection() for p in self.sync_clients if p.stream]
             )
-        except Exception:
+        except asyncio.CancelledError:
+            await self.stop()
+            raise
+        except Exception as err:
             # playback failed to start, cleanup
             await self.stop()
-            raise PlayerCommandFailed("Playback failed to start")
+            raise PlayerCommandFailed("Playback failed to start") from err
 
     async def stop(self) -> None:
         """Stop playback and cleanup."""

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -265,6 +265,121 @@ def test_temporary_paths_are_unique_per_stream() -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_queues_text_metadata_before_connection() -> None:
+    """Text metadata is queued as soon as cliairplay starts."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    metadata = MagicMock(corrected_elapsed_time=12.5)
+    player.current_media = metadata
+    process = MagicMock(closed=False)
+    process.start = AsyncMock()
+    operation_order: list[str] = []
+
+    async def create_pipe() -> None:
+        operation_order.append("pipe")
+
+    async def start_process() -> None:
+        operation_order.append("process")
+
+    async def send_metadata(*_args: Any, **_kwargs: Any) -> None:
+        operation_order.append("metadata")
+
+    def consume_task(awaitable: Any) -> MagicMock:
+        awaitable.close()
+        task = MagicMock()
+        task.done.return_value = True
+        return task
+
+    process.start.side_effect = start_process
+    player.provider.mass.create_task.side_effect = consume_task
+    with (
+        patch.object(stream, "_build_cli_args", new_callable=AsyncMock, return_value=["binary"]),
+        patch(
+            "music_assistant.providers.airplay.stream.AsyncProcess",
+            return_value=process,
+        ),
+        patch.object(stream.commands_pipe, "create", side_effect=create_pipe),
+        patch.object(stream, "send_metadata", side_effect=send_metadata) as send_metadata_mock,
+    ):
+        await stream.start(START_UNIX_MS)
+
+    assert operation_order == ["pipe", "process", "metadata"]
+    send_metadata_mock.assert_awaited_once_with(12, metadata, send_artwork=False)
+
+
+@pytest.mark.asyncio
+async def test_start_failure_cleans_up_process_and_pipe() -> None:
+    """A metadata write failure cannot leave a live cliairplay process or FIFO."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    metadata = MagicMock(corrected_elapsed_time=0)
+    player.current_media = metadata
+    process = MagicMock(closed=False)
+    process.start = AsyncMock()
+    process.kill = AsyncMock()
+
+    def consume_task(awaitable: Any) -> MagicMock:
+        awaitable.close()
+        task = MagicMock()
+        task.done.return_value = True
+        return task
+
+    player.provider.mass.create_task.side_effect = consume_task
+    with (
+        patch.object(stream, "_build_cli_args", new_callable=AsyncMock, return_value=["binary"]),
+        patch(
+            "music_assistant.providers.airplay.stream.AsyncProcess",
+            return_value=process,
+        ),
+        patch.object(stream.commands_pipe, "create", new_callable=AsyncMock),
+        patch.object(stream.commands_pipe, "remove", new_callable=AsyncMock) as remove_pipe,
+        patch.object(
+            stream,
+            "send_metadata",
+            new_callable=AsyncMock,
+            side_effect=OSError("metadata write failed"),
+        ),
+        pytest.raises(OSError, match="metadata write failed"),
+    ):
+        await stream.start(START_UNIX_MS)
+
+    process.kill.assert_awaited_once()
+    remove_pipe.assert_awaited_once()
+    assert stream._cli_proc is None
+    assert stream._cleanup_complete is True
+
+
+@pytest.mark.asyncio
+async def test_initial_metadata_skips_artwork() -> None:
+    """The pre-connect metadata push cannot delay setup on artwork rendering."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    stream._cli_proc = MagicMock(closed=False)
+    metadata = MagicMock(
+        title="Track",
+        artist="Artist",
+        album="Album",
+        duration=180,
+        image_url="image",
+    )
+
+    with (
+        patch.object(stream, "send_cli_command", new_callable=AsyncMock) as send_command,
+        patch.object(
+            stream,
+            "_render_and_send_artwork",
+            new_callable=AsyncMock,
+        ) as send_artwork,
+    ):
+        await stream.send_metadata(0, metadata, send_artwork=False)
+
+    send_command.assert_awaited_once()
+    assert send_command.await_args is not None
+    assert "TITLE=Track" in send_command.await_args.args[0]
+    send_artwork.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_wait_for_connection_pushes_metadata_immediately() -> None:
     """
     Track metadata is pushed the instant the device connects.

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -1,10 +1,13 @@
 """Unit tests for AirPlay stream session late-join logic."""
 
+import asyncio
 import time
+from collections.abc import AsyncGenerator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from music_assistant_models.errors import PlayerCommandFailed
 
 from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
 
@@ -69,6 +72,47 @@ def _captured_start_at(mock_start: AsyncMock) -> float:
     start_unix_ms = mock_start.call_args[0][1]
     assert isinstance(start_unix_ms, int)
     return start_unix_ms / 1000
+
+
+@pytest.mark.asyncio
+async def test_initial_client_failure_stops_started_clients() -> None:
+    """A partial group startup failure cancels siblings before session teardown."""
+    session = _make_session(time.time(), 0)
+    first_player: Any = session.sync_clients[0]
+    first_player.wait_start = 0
+    second_player = MagicMock(wait_start=0)
+    session.sync_clients.append(second_player)
+    first_started = asyncio.Event()
+    first_cancelled = asyncio.Event()
+
+    async def audio_source() -> AsyncGenerator[bytes]:
+        yield b""
+
+    async def start_client(player: Any, *_args: Any) -> None:
+        if player is first_player:
+            first_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                first_cancelled.set()
+                raise
+        await first_started.wait()
+        raise OSError("process failed")
+
+    with (
+        patch.object(
+            session,
+            "_start_client",
+            new_callable=AsyncMock,
+            side_effect=start_client,
+        ),
+        patch.object(session, "stop", new_callable=AsyncMock) as stop_session,
+        pytest.raises(PlayerCommandFailed, match="Playback failed to start"),
+    ):
+        await session.start(audio_source())
+
+    assert first_cancelled.is_set()
+    stop_session.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

AirPlay receivers could briefly show `cliairplay` before Music Assistant sent the real now-playing metadata.

- creates the command pipe before launching cliairplay
- sends text metadata immediately after process start, without waiting on artwork
- refreshes timeline-anchored metadata and artwork after connection as before
- makes grouped stream startup failure-atomic

Native Apple TV playback reliability is handled by music-assistant/airplay-cli#2.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.