### PR TITLE
Never persist expiring Apple Music artwork URLs

### DIFF
--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -9,7 +9,7 @@ DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
 
-DB_SCHEMA_VERSION: Final[int] = 54
+DB_SCHEMA_VERSION: Final[int] = 55
 
 # tracks longer that this will not be included in radio mode
 RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60

--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -892,6 +892,78 @@ async def migrate_database(  # noqa: PLR0915
         if repaired_lyrics_rows:
             logger.info("Normalized synced lyrics of %d track(s)", repaired_lyrics_rows)
 
+    if prev_version <= 54:
+        # apple music blobstore artwork URLs are presigned with a ~24h expiry and are
+        # no longer persisted: replace the stored (long-dead) signed URLs with the
+        # stable artwork token the provider resolves to a fresh URL on demand
+        migrated_artwork_rows = 0
+        for table, media_type_value in (
+            (DB_TABLE_ARTISTS, "artist"),
+            (DB_TABLE_ALBUMS, "album"),
+            (DB_TABLE_TRACKS, "track"),
+            (DB_TABLE_PLAYLISTS, "playlist"),
+        ):
+            table_columns = {
+                x["name"]
+                for x in await database.get_rows_from_query(f"PRAGMA table_info({table})", limit=0)
+            }
+            if "metadata" not in table_columns:
+                # guard against (test) databases with stand-in tables
+                continue
+            # the (provider_instance, item_id) -> provider item id lookup needed to
+            # derive each item's artwork token from its apple music mapping
+            apple_item_ids = {
+                (row["item_id"], row["provider_instance"]): row["provider_item_id"]
+                for row in await database.get_rows_from_query(
+                    f"SELECT item_id, provider_instance, provider_item_id "
+                    f"FROM {DB_TABLE_PROVIDER_MAPPINGS} "
+                    "WHERE media_type = :media_type AND provider_domain = 'apple_music'",
+                    {"media_type": media_type_value},
+                    limit=0,
+                )
+            }
+            async for db_row in database.iter_items(table):
+                if not db_row["metadata"] or "blobstore.apple.com" not in db_row["metadata"]:
+                    continue
+                try:
+                    metadata = json_loads(db_row["metadata"])
+                except ValueError:
+                    # corrupt metadata rows are handled elsewhere (diagnostics), skip here
+                    continue
+                images = metadata.get("images")
+                if not isinstance(images, list):
+                    continue
+                migrated_images = []
+                changed = False
+                for image in images:
+                    if not isinstance(image, dict) or "blobstore.apple.com" not in (
+                        image.get("path") or ""
+                    ):
+                        migrated_images.append(image)
+                        continue
+                    changed = True
+                    prov_item_id = apple_item_ids.get((db_row["item_id"], image.get("provider")))
+                    if prov_item_id is None:
+                        # no mapping left to resolve through; drop the dead url
+                        continue
+                    image["path"] = f"{media_type_value}/{prov_item_id}"
+                    image["remotely_accessible"] = False
+                    migrated_images.append(image)
+                if not changed:
+                    continue
+                metadata["images"] = migrated_images
+                await database.update(
+                    table,
+                    {"item_id": db_row["item_id"]},
+                    {"metadata": serialize_to_json(metadata)},
+                )
+                migrated_artwork_rows += 1
+        if migrated_artwork_rows:
+            logger.info(
+                "Migrated the Apple Music artwork of %d library item(s) to resolvable tokens",
+                migrated_artwork_rows,
+            )
+
     # NOTE: this genre restore runs after the <= 50 step on purpose: it inserts genres
     # with the current code/schema, so the external_ids column must be gone first.
     if prev_version <= 47:

--- a/music_assistant/providers/apple_music/constants.py
+++ b/music_assistant/providers/apple_music/constants.py
@@ -38,3 +38,10 @@ CONF_MUSIC_USER_TOKEN_TIMESTAMP = "music_user_token_timestamp"
 CACHE_CATEGORY_DECRYPT_KEY = 1
 MAX_ARTWORK_DIMENSION = 1000
 BLOBSTORE_DOMAIN = "blobstore.apple.com"
+# blobstore artwork URLs are presigned with a ~24h expiry, so resolved artwork
+# URLs may only be cached well below that lifetime
+ARTWORK_CACHE_EXPIRATION = 12 * 60 * 60
+# bust cached api responses that were parsed before artwork tokens existed
+# (they carry now-expired signed artwork URLs); bump when the parsed image
+# representation changes again
+PARSED_ITEM_CACHE_CHECKSUM = "artwork_tokens_v1"

--- a/music_assistant/providers/apple_music/media.py
+++ b/music_assistant/providers/apple_music/media.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.enums import MediaType
-from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
 from music_assistant_models.media_items import (
     Album,
     Artist,
@@ -18,7 +18,7 @@ from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.track_filter import filter_tracks
 
 from .constants import ARTWORK_CACHE_EXPIRATION, PARSED_ITEM_CACHE_CHECKSUM
-from .helpers.utils import is_catalog_id, is_library_id
+from .helpers.utils import is_catalog_id, is_library_id, translate_media_type_to_apple_type
 from .parsers import (
     format_artwork_url,
     parse_album,
@@ -162,22 +162,20 @@ class AppleMusicMediaManager:
         :param media_type: The media type value of the artwork token (album/track/...).
         :param prov_item_id: The provider item id of the item the artwork belongs to.
         """
-        if media_type == MediaType.ARTIST.value:
-            endpoint = f"catalog/{self.provider._storefront}/artists/{prov_item_id}"
-        elif media_type == MediaType.ALBUM.value:
-            if is_library_id(prov_item_id):
-                endpoint = f"me/library/albums/{prov_item_id}"
-            else:
-                endpoint = f"catalog/{self.provider._storefront}/albums/{prov_item_id}"
-        elif media_type == MediaType.TRACK.value:
-            endpoint = f"catalog/{self.provider._storefront}/songs/{prov_item_id}"
-        elif media_type == MediaType.PLAYLIST.value:
-            if not is_catalog_id(prov_item_id):
-                endpoint = f"me/library/playlists/{prov_item_id}"
-            else:
-                endpoint = f"catalog/{self.provider._storefront}/playlists/{prov_item_id}"
-        else:
+        try:
+            apple_type = translate_media_type_to_apple_type(MediaType(media_type))
+        except ValueError, MusicAssistantError:
             return None
+        # playlists use globalId ("pl.") catalog ids; all other types use the
+        # library id format to tell library and catalog items apart
+        if media_type == MediaType.PLAYLIST.value:
+            in_library = not is_catalog_id(prov_item_id)
+        else:
+            in_library = is_library_id(prov_item_id)
+        if in_library:
+            endpoint = f"me/library/{apple_type}/{prov_item_id}"
+        else:
+            endpoint = f"catalog/{self.provider._storefront}/{apple_type}/{prov_item_id}"
         response = await self.api.get_data(endpoint, include="catalog")
         item_obj = response["data"][0]
         attributes = item_obj.get("attributes") or {}

--- a/music_assistant/providers/apple_music/media.py
+++ b/music_assistant/providers/apple_music/media.py
@@ -17,8 +17,10 @@ from music_assistant_models.media_items import (
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.track_filter import filter_tracks
 
+from .constants import ARTWORK_CACHE_EXPIRATION, PARSED_ITEM_CACHE_CHECKSUM
 from .helpers.utils import is_catalog_id, is_library_id
 from .parsers import (
+    format_artwork_url,
     parse_album,
     parse_artist,
     parse_playlist,
@@ -41,7 +43,7 @@ class AppleMusicMediaManager:
         self.api = provider.api_client
         self.logger = provider.logger
 
-    @use_cache()
+    @use_cache(cache_checksum=PARSED_ITEM_CACHE_CHECKSUM)
     async def search(
         self,
         search_query: str,
@@ -104,14 +106,14 @@ class AppleMusicMediaManager:
             ]
         return searchresult
 
-    @use_cache()
+    @use_cache(cache_checksum=PARSED_ITEM_CACHE_CHECKSUM)
     async def get_artist(self, prov_artist_id: str) -> Artist:
         """Get full artist details by id."""
         endpoint = f"catalog/{self.provider._storefront}/artists/{prov_artist_id}"
         response = await self.api.get_data(endpoint, extend="editorialNotes")
         return cast("Artist", parse_artist(self.provider, response["data"][0]))
 
-    @use_cache()
+    @use_cache(cache_checksum=PARSED_ITEM_CACHE_CHECKSUM)
     async def get_album(self, prov_album_id: str) -> Album:
         """Get full album details by id."""
         if is_library_id(prov_album_id):
@@ -124,7 +126,7 @@ class AppleMusicMediaManager:
         is_favourite = rating_response.get(prov_album_id)
         return cast("Album", parse_album(self.provider, response["data"][0], is_favourite))
 
-    @use_cache()
+    @use_cache(cache_checksum=PARSED_ITEM_CACHE_CHECKSUM)
     async def get_track(self, prov_track_id: str) -> Track:
         """Get full track details by id."""
         endpoint = f"catalog/{self.provider._storefront}/songs/{prov_track_id}"
@@ -148,7 +150,45 @@ class AppleMusicMediaManager:
             library_id_override=library_id_override,
         )
 
-    @use_cache()
+    @use_cache(ARTWORK_CACHE_EXPIRATION, cache_checksum=PARSED_ITEM_CACHE_CHECKSUM)
+    async def get_artwork_url(self, media_type: str, prov_item_id: str) -> str | None:
+        """
+        Return the current artwork URL for the given item, if any.
+
+        Blobstore artwork URLs are presigned with a limited lifetime, so they are
+        resolved on demand (and cached well below the signature lifetime) instead
+        of being persisted anywhere.
+
+        :param media_type: The media type value of the artwork token (album/track/...).
+        :param prov_item_id: The provider item id of the item the artwork belongs to.
+        """
+        if media_type == MediaType.ARTIST.value:
+            endpoint = f"catalog/{self.provider._storefront}/artists/{prov_item_id}"
+        elif media_type == MediaType.ALBUM.value:
+            if is_library_id(prov_item_id):
+                endpoint = f"me/library/albums/{prov_item_id}"
+            else:
+                endpoint = f"catalog/{self.provider._storefront}/albums/{prov_item_id}"
+        elif media_type == MediaType.TRACK.value:
+            endpoint = f"catalog/{self.provider._storefront}/songs/{prov_item_id}"
+        elif media_type == MediaType.PLAYLIST.value:
+            if not is_catalog_id(prov_item_id):
+                endpoint = f"me/library/playlists/{prov_item_id}"
+            else:
+                endpoint = f"catalog/{self.provider._storefront}/playlists/{prov_item_id}"
+        else:
+            return None
+        response = await self.api.get_data(endpoint, include="catalog")
+        item_obj = response["data"][0]
+        attributes = item_obj.get("attributes") or {}
+        if not attributes.get("artwork"):
+            # library items may only carry artwork on their catalog counterpart
+            catalog_data = item_obj.get("relationships", {}).get("catalog", {}).get("data") or []
+            if catalog_data:
+                attributes = catalog_data[0].get("attributes") or {}
+        return format_artwork_url(attributes)
+
+    @use_cache(cache_checksum=PARSED_ITEM_CACHE_CHECKSUM)
     async def _get_regular_playlist(
         self,
         prov_playlist_id: str,
@@ -170,7 +210,7 @@ class AppleMusicMediaManager:
             library_id_override=library_id_override,
         )
 
-    @use_cache(allow_expired_cache=True)
+    @use_cache(cache_checksum=PARSED_ITEM_CACHE_CHECKSUM, allow_expired_cache=True)
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
         """Get all album tracks for given album id."""
         if is_library_id(prov_album_id):
@@ -199,7 +239,7 @@ class AppleMusicMediaManager:
             return await self._get_station_tracks(prov_playlist_id)
         return await self._get_playlist_tracks_cached(prov_playlist_id, page)
 
-    @use_cache(3600 * 3)
+    @use_cache(3600 * 3, cache_checksum=PARSED_ITEM_CACHE_CHECKSUM)
     async def _get_playlist_tracks_cached(
         self, prov_playlist_id: str, page: int = 0
     ) -> list[Track]:
@@ -262,7 +302,7 @@ class AppleMusicMediaManager:
             if t and t.get("id")
         ]
 
-    @use_cache(3600 * 24 * 7, allow_expired_cache=True)
+    @use_cache(3600 * 24 * 7, cache_checksum=PARSED_ITEM_CACHE_CHECKSUM, allow_expired_cache=True)
     async def get_artist_albums(self, prov_artist_id: str) -> list[Album]:
         """Get a list of all albums for the given artist."""
         endpoint = f"catalog/{self.provider._storefront}/artists/{prov_artist_id}/albums"
@@ -282,7 +322,7 @@ class AppleMusicMediaManager:
                 albums.append(cast("Album", parsed))
         return albums
 
-    @use_cache(3600 * 24 * 7, allow_expired_cache=True)
+    @use_cache(3600 * 24 * 7, cache_checksum=PARSED_ITEM_CACHE_CHECKSUM, allow_expired_cache=True)
     async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
         """Get a list of 10 most popular tracks for the given artist."""
         endpoint = f"catalog/{self.provider._storefront}/artists/{prov_artist_id}/view/top-songs"

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -45,6 +45,58 @@ def is_remotely_accessible_artwork_url(url: str) -> bool:
     return BLOBSTORE_DOMAIN not in hostname
 
 
+def format_artwork_url(attributes: dict[str, Any]) -> str | None:
+    """
+    Return the artwork URL from a raw api item object's (resolved) attributes, if any.
+
+    :param attributes: The attributes dict of the raw api item object.
+    """
+    if not (artwork := attributes.get("artwork")):
+        return None
+    if not (url := artwork.get("url")):
+        return None
+    if artwork.get("width") and artwork.get("height"):
+        url = url.format(
+            w=min(artwork["width"], MAX_ARTWORK_DIMENSION),
+            h=min(artwork["height"], MAX_ARTWORK_DIMENSION),
+        )
+    return cast("str", url)
+
+
+def parse_artwork_image(
+    provider: AppleMusicProvider,
+    media_type: MediaType,
+    item_id: str,
+    attributes: dict[str, Any],
+) -> MediaItemImage | None:
+    """
+    Parse the artwork of a raw api item object into a MediaItemImage, if any.
+
+    :param provider: The Apple Music provider instance.
+    :param media_type: The media type of the item the artwork belongs to.
+    :param item_id: The provider item id of the item the artwork belongs to.
+    :param attributes: The (resolved) attributes dict of the raw api item object.
+    """
+    if (url := format_artwork_url(attributes)) is None:
+        return None
+    if is_remotely_accessible_artwork_url(url):
+        return MediaItemImage(
+            provider=provider.instance_id,
+            type=ImageType.THUMB,
+            path=url,
+            remotely_accessible=True,
+        )
+    # blobstore artwork URLs are presigned with a ~24h expiry and must never be
+    # persisted: store a stable token instead, which is resolved to a freshly
+    # signed URL on demand (see AppleMusicProvider.resolve_image)
+    return MediaItemImage(
+        provider=provider.instance_id,
+        type=ImageType.THUMB,
+        path=f"{media_type.value}/{item_id}",
+        remotely_accessible=False,
+    )
+
+
 def parse_artist(provider: AppleMusicProvider, artist_obj: dict[str, Any]) -> Artist | ItemMapping:
     """Parse artist object to generic layout."""
     relationships = artist_obj.get("relationships", {})
@@ -79,21 +131,8 @@ def parse_artist(provider: AppleMusicProvider, artist_obj: dict[str, Any]) -> Ar
             )
         },
     )
-    if artwork := attributes.get("artwork"):
-        url = artwork["url"]
-        if artwork["width"] and artwork["height"]:
-            url = url.format(
-                w=min(artwork["width"], MAX_ARTWORK_DIMENSION),
-                h=min(artwork["height"], MAX_ARTWORK_DIMENSION),
-            )
-        artist.metadata.add_image(
-            MediaItemImage(
-                provider=provider.instance_id,
-                type=ImageType.THUMB,
-                path=url,
-                remotely_accessible=is_remotely_accessible_artwork_url(url),
-            )
-        )
+    if image := parse_artwork_image(provider, MediaType.ARTIST, artist_id, attributes):
+        artist.metadata.add_image(image)
     if genres := attributes.get("genreNames"):
         artist.metadata.genres = set(genres)
     if notes := attributes.get("editorialNotes"):
@@ -150,21 +189,8 @@ def parse_album(
         album.year = int(release_date.split("-")[0])
     if genres := attributes.get("genreNames"):
         album.metadata.genres = set(genres)
-    if artwork := attributes.get("artwork"):
-        url = artwork["url"]
-        if artwork["width"] and artwork["height"]:
-            url = url.format(
-                w=min(artwork["width"], MAX_ARTWORK_DIMENSION),
-                h=min(artwork["height"], MAX_ARTWORK_DIMENSION),
-            )
-        album.metadata.add_image(
-            MediaItemImage(
-                provider=provider.instance_id,
-                type=ImageType.THUMB,
-                path=url,
-                remotely_accessible=is_remotely_accessible_artwork_url(url),
-            )
-        )
+    if image := parse_artwork_image(provider, MediaType.ALBUM, album_id, attributes):
+        album.metadata.add_image(image)
     if album_copyright := attributes.get("copyright"):
         album.metadata.copyright = album_copyright
     if record_label := attributes.get("recordLabel"):
@@ -265,21 +291,8 @@ def parse_track(
             provider=provider.instance_id,
             name=album_name,
         )
-    if artwork := attributes.get("artwork"):
-        url = artwork["url"]
-        if artwork["width"] and artwork["height"]:
-            url = url.format(
-                w=min(artwork["width"], MAX_ARTWORK_DIMENSION),
-                h=min(artwork["height"], MAX_ARTWORK_DIMENSION),
-            )
-        track.metadata.add_image(
-            MediaItemImage(
-                provider=provider.instance_id,
-                type=ImageType.THUMB,
-                path=url,
-                remotely_accessible=is_remotely_accessible_artwork_url(url),
-            )
-        )
+    if image := parse_artwork_image(provider, MediaType.TRACK, track_id, attributes):
+        track.metadata.add_image(image)
     if genres := attributes.get("genreNames"):
         track.metadata.genres = set(genres)
     if composers := attributes.get("composerName"):
@@ -326,21 +339,8 @@ def parse_playlist(
         },
         is_editable=is_editable,
     )
-    if artwork := attributes.get("artwork"):
-        url = artwork["url"]
-        if artwork["width"] and artwork["height"]:
-            url = url.format(
-                w=min(artwork["width"], MAX_ARTWORK_DIMENSION),
-                h=min(artwork["height"], MAX_ARTWORK_DIMENSION),
-            )
-        playlist.metadata.add_image(
-            MediaItemImage(
-                provider=provider.instance_id,
-                type=ImageType.THUMB,
-                path=url,
-                remotely_accessible=True,
-            )
-        )
+    if image := parse_artwork_image(provider, MediaType.PLAYLIST, playlist_id, attributes):
+        playlist.metadata.add_image(image)
     if description := attributes.get("description"):
         playlist.metadata.description = description.get("standard")
     playlist.favorite = is_favourite or False
@@ -368,21 +368,8 @@ def parse_station_as_playlist(
             )
         },
     )
-    if artwork := attributes.get("artwork"):
-        url = artwork["url"]
-        if artwork.get("width") and artwork.get("height"):
-            url = url.format(
-                w=min(artwork["width"], MAX_ARTWORK_DIMENSION),
-                h=min(artwork["height"], MAX_ARTWORK_DIMENSION),
-            )
-        playlist.metadata.add_image(
-            MediaItemImage(
-                provider=provider.instance_id,
-                type=ImageType.THUMB,
-                path=url,
-                remotely_accessible=True,
-            )
-        )
+    if image := parse_artwork_image(provider, MediaType.PLAYLIST, station_id, attributes):
+        playlist.metadata.add_image(image)
     return playlist
 
 

--- a/music_assistant/providers/apple_music/provider.py
+++ b/music_assistant/providers/apple_music/provider.py
@@ -140,6 +140,11 @@ class AppleMusicProvider(MusicProvider):
         """Get all album tracks for given album id."""
         return await self.media_manager.get_album_tracks(prov_album_id)
 
+    async def resolve_image(self, path: str) -> str | bytes:
+        """Resolve an artwork token to a freshly signed artwork URL."""
+        media_type, _, item_id = path.partition("/")
+        return await self.media_manager.get_artwork_url(media_type, item_id) or ""
+
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
         """Get all playlist tracks for given playlist id."""
         return await self.media_manager.get_playlist_tracks(prov_playlist_id, page)

--- a/tests/controllers/music/test_music_migrations.py
+++ b/tests/controllers/music/test_music_migrations.py
@@ -361,3 +361,76 @@ async def test_migration_populates_fts_tables(database: DatabaseConnection) -> N
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'albums_fts'"
     )
     assert not rows
+
+
+async def test_migration_rewrites_apple_music_artwork_to_tokens(
+    database: DatabaseConnection,
+) -> None:
+    """Persisted (expired) blobstore artwork URLs are rewritten to resolvable tokens."""
+    await database.execute("ALTER TABLE albums ADD COLUMN metadata json")
+    await database.execute(
+        "CREATE TABLE provider_mappings([media_type] TEXT, [item_id] INTEGER, "
+        "[provider_domain] TEXT, [provider_instance] TEXT, [provider_item_id] TEXT)"
+    )
+    signed_url = "https://store-033.blobstore.apple.com/pic/image?X-Amz-Signature=dead"
+    metadata = {
+        "images": [
+            {
+                "type": "thumb",
+                "path": signed_url,
+                "provider": "apple_music--1",
+                "remotely_accessible": True,
+            },
+            {
+                "type": "fanart",
+                "path": "https://tadb/fanart.jpg",
+                "provider": "theaudiodb",
+                "remotely_accessible": True,
+            },
+            {
+                "type": "thumb",
+                "path": signed_url,
+                "provider": "apple_music--removed",
+                "remotely_accessible": True,
+            },
+        ]
+    }
+    await database.execute(
+        "INSERT INTO albums (item_id, metadata) VALUES (1, :metadata)",
+        {"metadata": json.dumps(metadata)},
+    )
+    # an unrelated row without apple artwork must be left untouched
+    await database.execute(
+        "INSERT INTO albums (item_id, metadata) VALUES (2, :metadata)",
+        {"metadata": json.dumps({"images": [{"path": "https://x/y.jpg", "provider": "spotify"}]})},
+    )
+    await database.execute(
+        "INSERT INTO provider_mappings "
+        "(media_type, item_id, provider_domain, provider_instance, provider_item_id) "
+        "VALUES ('album', 1, 'apple_music', 'apple_music--1', 'l.abc123')"
+    )
+    await database.commit()
+
+    mass = MagicMock()
+    mass.cache.clear = AsyncMock()
+    await migrate_database(
+        mass,
+        database,
+        MagicMock(),
+        prev_version=54,
+        create_tables=AsyncMock(),
+    )
+
+    rows = await database.get_rows_from_query(
+        "SELECT item_id, metadata FROM albums ORDER BY item_id"
+    )
+    images = json.loads(rows[0]["metadata"])["images"]
+    # the mapped entry became a token, the metadata-provider entry survived and
+    # the entry whose apple instance no longer exists was dropped
+    assert [(img["path"], img["provider"], img["remotely_accessible"]) for img in images] == [
+        ("album/l.abc123", "apple_music--1", False),
+        ("https://tadb/fanart.jpg", "theaudiodb", True),
+    ]
+    assert json.loads(rows[1]["metadata"])["images"] == [
+        {"path": "https://x/y.jpg", "provider": "spotify"}
+    ]

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -920,6 +920,37 @@ async def test_get_artwork_url_falls_back_to_catalog_attributes() -> None:
     assert url == "https://is1-ssl.mzstatic.com/image/thumb/Music/1000x1000bb.jpg"
 
 
+async def test_get_artwork_url_routes_library_tracks_to_library_endpoint() -> None:
+    """Library song tokens (uploaded music) resolve via me/library, not the catalog."""
+    provider = _create_provider_mock()
+    provider.api_client.get_data = AsyncMock(
+        return_value={"data": [{"id": "i.track1", "attributes": {"artwork": BLOBSTORE_ARTWORK}}]}
+    )
+
+    manager = AppleMusicMediaManager(provider)
+    url = await manager.get_artwork_url("track", "i.track1")
+
+    assert url == BLOBSTORE_ARTWORK["url"]
+    provider.api_client.get_data.assert_called_once_with(
+        "me/library/songs/i.track1", include="catalog"
+    )
+
+
+async def test_get_artwork_url_routes_catalog_tracks_to_catalog_endpoint() -> None:
+    """Catalog song tokens resolve via the catalog endpoint."""
+    provider = _create_provider_mock()
+    provider.api_client.get_data = AsyncMock(
+        return_value={"data": [{"id": "1440783625", "attributes": {"artwork": CATALOG_ARTWORK}}]}
+    )
+
+    manager = AppleMusicMediaManager(provider)
+    await manager.get_artwork_url("track", "1440783625")
+
+    provider.api_client.get_data.assert_called_once_with(
+        "catalog/us/songs/1440783625", include="catalog"
+    )
+
+
 async def test_get_artwork_url_unknown_media_type() -> None:
     """An unknown token media type resolves to nothing instead of raising."""
     provider = _create_provider_mock()

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -4,11 +4,27 @@ from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
+from music_assistant_models.enums import MediaType
 from music_assistant_models.media_items import Album, ItemMapping
 
 from music_assistant.providers.apple_music.library import _TRACK_PAGE_SIZE, AppleMusicLibraryManager
 from music_assistant.providers.apple_music.media import AppleMusicMediaManager
-from music_assistant.providers.apple_music.parsers import parse_album, parse_track
+from music_assistant.providers.apple_music.parsers import (
+    parse_album,
+    parse_artwork_image,
+    parse_track,
+)
+
+BLOBSTORE_ARTWORK = {
+    "url": "https://store-033.blobstore.apple.com/pic/image?X-Amz-Signature=abc",
+    "width": 1200,
+    "height": 1200,
+}
+CATALOG_ARTWORK = {
+    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music/{w}x{h}bb.jpg",
+    "width": 3000,
+    "height": 3000,
+}
 
 
 def _stream(items: list[dict[str, Any]]) -> MagicMock:
@@ -801,3 +817,112 @@ async def test_get_album_uses_catalog_endpoint_for_catalog_id() -> None:
     provider.api_client.get_data.assert_called_once_with(
         "catalog/us/albums/123456789", include="artists"
     )
+
+
+def test_parse_artwork_image_stores_stable_token_for_expiring_urls() -> None:
+    """Blobstore artwork (presigned, expiring) is stored as a resolvable token."""
+    provider = _create_provider_mock()
+
+    image = parse_artwork_image(
+        provider, MediaType.ALBUM, "l.album1", {"artwork": BLOBSTORE_ARTWORK}
+    )
+
+    assert image is not None
+    assert image.path == "album/l.album1"
+    assert image.remotely_accessible is False
+    assert image.provider == "apple_music_test"
+
+
+def test_parse_artwork_image_keeps_permanent_cdn_urls() -> None:
+    """Mzstatic artwork is permanent and stored as a directly accessible URL."""
+    provider = _create_provider_mock()
+
+    image = parse_artwork_image(
+        provider, MediaType.ALBUM, "1234567890", {"artwork": CATALOG_ARTWORK}
+    )
+
+    assert image is not None
+    assert image.path == "https://is1-ssl.mzstatic.com/image/thumb/Music/1000x1000bb.jpg"
+    assert image.remotely_accessible is True
+
+
+def test_parse_artwork_image_without_artwork() -> None:
+    """Items without (usable) artwork produce no image."""
+    provider = _create_provider_mock()
+
+    assert parse_artwork_image(provider, MediaType.ALBUM, "x", {}) is None
+    assert parse_artwork_image(provider, MediaType.ALBUM, "x", {"artwork": {"width": 1}}) is None
+
+
+def test_parse_album_stores_artwork_token_for_library_album() -> None:
+    """A library album with blobstore artwork ends up with a token image."""
+    provider = _create_provider_mock()
+    album_obj = {
+        "id": "l.album1",
+        "type": "library-albums",
+        "attributes": {
+            "name": "Uploaded Album",
+            "artistName": "Uploaded Artist",
+            "playParams": {"id": "l.album1"},
+            "artwork": BLOBSTORE_ARTWORK,
+        },
+        "relationships": {},
+    }
+
+    album = parse_album(provider, album_obj)
+
+    assert isinstance(album, Album)
+    assert [(image.path, image.remotely_accessible) for image in album.metadata.images or []] == [
+        ("album/l.album1", False)
+    ]
+
+
+async def test_get_artwork_url_returns_fresh_signed_url() -> None:
+    """The artwork token resolves to the current signed URL from the api."""
+    provider = _create_provider_mock()
+    provider.api_client.get_data = AsyncMock(
+        return_value={"data": [{"id": "l.album1", "attributes": {"artwork": BLOBSTORE_ARTWORK}}]}
+    )
+
+    manager = AppleMusicMediaManager(provider)
+    url = await manager.get_artwork_url("album", "l.album1")
+
+    assert url == BLOBSTORE_ARTWORK["url"]
+    provider.api_client.get_data.assert_called_once_with(
+        "me/library/albums/l.album1", include="catalog"
+    )
+
+
+async def test_get_artwork_url_falls_back_to_catalog_attributes() -> None:
+    """A library item without own artwork resolves via its catalog counterpart."""
+    provider = _create_provider_mock()
+    provider.api_client.get_data = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "id": "l.album1",
+                    "attributes": {"name": "Uploaded Album"},
+                    "relationships": {
+                        "catalog": {
+                            "data": [
+                                {"id": "123456789", "attributes": {"artwork": CATALOG_ARTWORK}}
+                            ]
+                        }
+                    },
+                }
+            ]
+        }
+    )
+
+    manager = AppleMusicMediaManager(provider)
+    url = await manager.get_artwork_url("album", "l.album1")
+
+    assert url == "https://is1-ssl.mzstatic.com/image/thumb/Music/1000x1000bb.jpg"
+
+
+async def test_get_artwork_url_unknown_media_type() -> None:
+    """An unknown token media type resolves to nothing instead of raising."""
+    provider = _create_provider_mock()
+    manager = AppleMusicMediaManager(provider)
+
+    assert await manager.get_artwork_url("bogus", "1") is None


### PR DESCRIPTION
# What does this implement/fix?

Apple Music serves user-library artwork from blobstore URLs that are presigned with a ~24h expiry. These URLs were persisted in the library database and in long-lived API response caches, so all such artwork broke once the signatures expired.

Instead of storing the signed URL, store a stable artwork token (media_type/item_id) marked as not remotely accessible. The image proxy resolves it on demand via the provider's resolve_image(), which derives the currently signed URL from the (short-lived, 12h cached) item detail
- the same pattern Plex/Jellyfin/OpenSubsonic use for auth-scoped artwork. Permanent mzstatic CDN artwork keeps being stored as a plain URL.

- deduplicate the artwork parsing of all five item parsers into parse_artwork_image, which decides between URL and token
- add AppleMusicMediaManager.get_artwork_url to resolve a token to the current signed URL, cached well below the signature lifetime
- bust existing cached API responses (they were parsed before artwork tokens existed and carry now-expired signed URLs)
- migrate persisted blobstore artwork URLs in the library database to resolvable tokens (db schema 55), dropping entries whose apple provider mapping no longer exists

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
