### PR TITLE
Apply user provider filter to in-library album tracks

### DIFF
--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -22,7 +22,6 @@ from music_assistant_models.media_items import (
 
 from music_assistant.constants import DB_TABLE_ALBUM_ARTISTS, DB_TABLE_ALBUM_TRACKS, DB_TABLE_ALBUMS
 from music_assistant.controllers.music.helpers import search_name_match_clause
-from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.compare import (
     compare_album,
     compare_artists,
@@ -335,7 +334,12 @@ class AlbumsController(MediaControllerBase[Album]):
                         track.album = album_mapping
             return album_tracks
 
-        db_items = await self.get_library_album_tracks(library_album.item_id)
+        # respect the current user's provider filter (if any) for both the
+        # in-library tracks and the live provider fetches below
+        allowed_providers = self._ensure_provider_filter(None)
+        db_items = await self.get_library_album_tracks(
+            library_album.item_id, provider_filter=allowed_providers
+        )
         result: list[Track] = list(db_items)
         if in_library_only:
             # return in-library items only
@@ -348,12 +352,10 @@ class AlbumsController(MediaControllerBase[Album]):
         unique_ids.update({f"{x.name.lower()}.{x.version.lower()}" for x in db_items})
         for db_item in db_items:
             unique_ids.update(x.item_id for x in db_item.provider_mappings)
-        user = get_current_user()
-        user_provider_filter = user.provider_filter if user and user.provider_filter else None
         for provider_mapping in library_album.provider_mappings:
             if (
-                user_provider_filter
-                and provider_mapping.provider_instance not in user_provider_filter
+                allowed_providers is not None
+                and provider_mapping.provider_instance not in allowed_providers
             ):
                 continue
             provider_tracks = await self._get_provider_album_tracks(
@@ -433,13 +435,20 @@ class AlbumsController(MediaControllerBase[Album]):
     async def get_library_album_tracks(
         self,
         item_id: str | int,
+        provider_filter: list[str] | None = None,
     ) -> list[Track]:
-        """Return in-database album tracks for the given database album."""
+        """
+        Return in-database album tracks for the given database album.
+
+        :param item_id: The library item ID of the album.
+        :param provider_filter: Optional provider instance ID(s) to limit the result to.
+        """
         db_id = int(item_id)  # ensure integer
         # pass the album id as preferred album so the track_album subquery in the
         # base query returns this album's disc/track numbers for tracks that
         # appear on multiple albums
         return await self.mass.music.tracks.get_library_items_by_query(
+            provider_filter=provider_filter,
             extra_query_parts=[
                 f"tracks.item_id IN (SELECT track_id FROM {DB_TABLE_ALBUM_TRACKS} "
                 "WHERE album_id = :album_id)"

--- a/tests/controllers/music/test_album_tracks_user_filter.py
+++ b/tests/controllers/music/test_album_tracks_user_filter.py
@@ -1,0 +1,89 @@
+"""Tests for user provider filtering on album track listings."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+from music_assistant_models.enums import AlbumType
+from music_assistant_models.media_items import (
+    Album,
+    Artist,
+    ProviderMapping,
+    Track,
+    UniqueList,
+)
+
+from music_assistant.mass import MusicAssistant
+
+pytestmark = pytest.mark.asyncio
+
+
+def _mapping(provider_instance: str, item_id: str) -> ProviderMapping:
+    return ProviderMapping(
+        item_id=item_id,
+        provider_domain=provider_instance.removesuffix("_inst"),
+        provider_instance=provider_instance,
+        in_library=True,
+    )
+
+
+async def _seed_album_with_mixed_provider_tracks(mass: MusicAssistant) -> Album:
+    """Seed a library album with one track per provider (prov_a/prov_b)."""
+    artist = Artist(
+        item_id="0",
+        provider="library",
+        name="Test Artist",
+        provider_mappings={_mapping("prov_a_inst", "artist_a")},
+    )
+    db_artist = await mass.music.artists.add_item_to_library(artist)
+    album = Album(
+        item_id="0",
+        provider="library",
+        name="Test Album",
+        album_type=AlbumType.ALBUM,
+        provider_mappings={_mapping("prov_a_inst", "album_a")},
+        artists=UniqueList([db_artist]),
+    )
+    db_album = await mass.music.albums.add_item_to_library(album)
+    for idx, (name, provider_instance, item_id) in enumerate(
+        [
+            ("Track Local", "prov_a_inst", "track_a"),
+            ("Track Streaming", "prov_b_inst", "track_b"),
+        ],
+        start=1,
+    ):
+        track = Track(
+            item_id="0",
+            provider="library",
+            name=name,
+            provider_mappings={_mapping(provider_instance, item_id)},
+            artists=UniqueList([db_artist]),
+            album=db_album,
+            disc_number=1,
+            track_number=idx,
+        )
+        await mass.music.tracks.add_item_to_library(track)
+    return db_album
+
+
+async def test_album_tracks_respect_user_provider_filter(mass: MusicAssistant) -> None:
+    """A restricted user must not see album tracks that only exist on other providers."""
+    db_album = await _seed_album_with_mixed_provider_tracks(mass)
+
+    # without a user provider filter, both tracks are returned
+    all_tracks = await mass.music.albums.tracks(db_album.item_id, "library")
+    assert {track.name for track in all_tracks} == {"Track Local", "Track Streaming"}
+
+    # a user restricted to prov_a must not see the prov_b-only track
+    with patch(
+        "music_assistant.controllers.music.media.base.get_current_user",
+        return_value=Mock(provider_filter=["prov_a_inst"]),
+    ):
+        filtered_tracks = await mass.music.albums.tracks(db_album.item_id, "library")
+        assert {track.name for track in filtered_tracks} == {"Track Local"}
+        # the in_library_only variant must apply the same filter
+        filtered_library_tracks = await mass.music.albums.tracks(
+            db_album.item_id, "library", in_library_only=True
+        )
+        assert {track.name for track in filtered_library_tracks} == {"Track Local"}


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The `album_tracks` listing only applied the user's provider filter to the live provider fetches, while the in-library tracks were returned unfiltered. A library track whose only provider mapping belongs to a provider the user has no access to (e.g. a Spotify liked song matched into the same album as local files) was therefore still shown to restricted users.

Filter the in-library tracks query with the same provider filter used for the provider fetches, covering the `in_library_only` path as well.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5887

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
