### PR TITLE
Fix slow album art loading over remote connections

### DIFF
--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -33,6 +33,9 @@ LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.remote_access")
 logging.getLogger("aioice").setLevel(logging.WARNING)
 logging.getLogger("aiortc").setLevel(logging.WARNING)
 
+# Max concurrent proxied fetches, so a burst of album-art requests stays bounded
+HTTP_PROXY_CONCURRENCY = 6
+
 
 @dataclass
 class WebRTCSession:
@@ -122,6 +125,8 @@ class WebRTCGateway:
 
         self.sessions: dict[str, WebRTCSession] = {}
         self._background_tasks: set[asyncio.Task[None]] = set()
+        # gateway-wide by design: normally a single remote client is connected
+        self._http_proxy_semaphore = asyncio.Semaphore(HTTP_PROXY_CONCURRENCY)
         self._signaling_ws: aiohttp.ClientWebSocketResponse | None = None
         self._running = False
         self._reconnect_delay = 10  # Wait 10 seconds before reconnecting
@@ -675,8 +680,12 @@ class WebRTCGateway:
                 try:
                     msg_data = json.loads(message)
                     if isinstance(msg_data, dict) and msg_data.get("type") == "http-proxy-request":
-                        # Handle HTTP proxy request
-                        await self._handle_http_proxy_request(session, msg_data)
+                        # handle off the receive loop so a slow fetch never blocks API traffic
+                        task = asyncio.create_task(
+                            self._handle_http_proxy_request(session, msg_data)
+                        )
+                        self._background_tasks.add(task)
+                        task.add_done_callback(self._background_tasks.discard)
                         continue
                 except json.JSONDecodeError, ValueError:
                     pass
@@ -736,39 +745,40 @@ class WebRTCGateway:
 
         self.logger.debug("HTTP proxy request: %s %s", method, local_http_url)
 
-        try:
-            # Use shared HTTP session for this request
-            async with self.http_session.request(
-                method, local_http_url, headers=headers
-            ) as response:
-                # Read response body
-                body = await response.read()
+        async with self._http_proxy_semaphore:
+            try:
+                # Use shared HTTP session for this request
+                async with self.http_session.request(
+                    method, local_http_url, headers=headers
+                ) as response:
+                    # Read response body
+                    body = await response.read()
 
-                # Prepare response data
-                response_data = {
+                    # Prepare response data
+                    response_data = {
+                        "type": "http-proxy-response",
+                        "id": request_id,
+                        "status": response.status,
+                        "headers": dict(response.headers),
+                        "body": body.hex(),  # Send as hex string to avoid encoding issues
+                    }
+
+                    # Send response back through data channel
+                    if session.data_channel and session.data_channel.readyState == "open":
+                        session.data_channel.send(json.dumps(response_data))
+
+            except Exception as err:
+                self.logger.exception("Error handling HTTP proxy request")
+                # Send error response
+                error_response = {
                     "type": "http-proxy-response",
                     "id": request_id,
-                    "status": response.status,
-                    "headers": dict(response.headers),
-                    "body": body.hex(),  # Send as hex string to avoid encoding issues
+                    "status": 500,
+                    "headers": {"Content-Type": "text/plain"},
+                    "body": str(err).encode().hex(),
                 }
-
-                # Send response back through data channel
                 if session.data_channel and session.data_channel.readyState == "open":
-                    session.data_channel.send(json.dumps(response_data))
-
-        except Exception as err:
-            self.logger.exception("Error handling HTTP proxy request")
-            # Send error response
-            error_response = {
-                "type": "http-proxy-response",
-                "id": request_id,
-                "status": 500,
-                "headers": {"Content-Type": "text/plain"},
-                "body": str(err).encode().hex(),
-            }
-            if session.data_channel and session.data_channel.readyState == "open":
-                session.data_channel.send(json.dumps(error_response))
+                    session.data_channel.send(json.dumps(error_response))
 
     async def _close_session(self, session_id: str) -> None:
         """

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -50,6 +50,7 @@ class WebRTCSession:
     data_channel_setup_task: asyncio.Task[None] | None = None
     forward_to_local_task: asyncio.Task[None] | None = None
     forward_from_local_task: asyncio.Task[None] | None = None
+    proxy_tasks: set[asyncio.Task[None]] = field(default_factory=set)
     data_channel_active: bool = False
     # Sendspin channel - bridges to internal sendspin server
     sendspin_channel: Any = None
@@ -650,10 +651,12 @@ class WebRTCGateway:
             )
             if task is not None and task is not current_task
         ]
+        tasks += [task for task in session.proxy_tasks if task is not current_task]
         local_ws = session.local_ws
         session.data_channel_setup_task = None
         session.forward_to_local_task = None
         session.forward_from_local_task = None
+        session.proxy_tasks = set()
         session.local_ws = None
         session.message_queue = asyncio.Queue()
 
@@ -684,8 +687,8 @@ class WebRTCGateway:
                         task = asyncio.create_task(
                             self._handle_http_proxy_request(session, msg_data)
                         )
-                        self._background_tasks.add(task)
-                        task.add_done_callback(self._background_tasks.discard)
+                        session.proxy_tasks.add(task)
+                        task.add_done_callback(session.proxy_tasks.discard)
                         continue
                 except json.JSONDecodeError, ValueError:
                     pass

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import base64
+import contextlib
+import json
 from collections.abc import Callable
 from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
@@ -863,3 +865,76 @@ async def test_http_proxy_request_cannot_change_host(
     assert parsed.port == 8095
     assert parsed.username is None
     assert "evil.com" not in (parsed.netloc or "")
+
+
+async def test_http_proxy_request_does_not_block_receive_loop(mock_certificate: Mock) -> None:
+    """A slow proxied image fetch must not stall API messages behind it in the receive loop."""
+    mock_session = Mock()
+    release = asyncio.Event()
+
+    def fake_request(_method: str, _url: str, **_kwargs: object) -> AsyncMock:
+        response = AsyncMock()
+        response.status = 200
+        response.headers = {}
+        response.read = AsyncMock(return_value=b"")
+
+        async def blocking_aenter(*_args: object) -> AsyncMock:
+            await release.wait()
+            return response
+
+        ctx = AsyncMock()
+        ctx.__aenter__ = blocking_aenter
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    mock_session.request = fake_request
+
+    gateway = WebRTCGateway(
+        http_session=mock_session,
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+        local_ws_url="ws://localhost:8095/ws",
+    )
+    session = WebRTCSession(session_id="s1", peer_connection=Mock())
+    session.local_ws = Mock()
+    session.local_ws.closed = False
+    session.local_ws.send_str = AsyncMock()
+    session.data_channel = Mock()
+    session.data_channel.readyState = "open"
+    session.data_channel.send = Mock()
+
+    proxy_message = json.dumps(
+        {"type": "http-proxy-request", "id": "1", "method": "GET", "path": "/imageproxy/x"}
+    )
+    api_message = '{"command": "ping"}'
+    session.message_queue.put_nowait(proxy_message)
+    session.message_queue.put_nowait(api_message)
+
+    forward_task = asyncio.create_task(gateway._forward_to_local(session))
+
+    try:
+        # The API message must get through while the proxy fetch is still blocked.
+        for _ in range(20):
+            if session.local_ws.send_str.await_args_list:
+                break
+            await asyncio.sleep(0.05)
+        assert not release.is_set()
+        session.local_ws.send_str.assert_awaited_with(api_message)
+
+        release.set()
+
+        for _ in range(20):
+            if session.data_channel.send.call_args_list:
+                break
+            await asyncio.sleep(0.05)
+        assert session.data_channel.send.call_args is not None
+        response_data = json.loads(session.data_channel.send.call_args[0][0])
+        assert response_data["id"] == "1"
+    finally:
+        session.local_ws.closed = True
+        forward_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await forward_task
+        for task in list(gateway._background_tasks):
+            with contextlib.suppress(asyncio.CancelledError):
+                await task

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -931,6 +931,8 @@ async def test_http_proxy_request_does_not_block_receive_loop(mock_certificate: 
         response_data = json.loads(session.data_channel.send.call_args[0][0])
         assert response_data["id"] == "1"
     finally:
+        # Unblock a still-pending fetch so cleanup can't hang on assertion failure
+        release.set()
         session.local_ws.closed = True
         forward_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -937,6 +937,58 @@ async def test_http_proxy_request_does_not_block_receive_loop(mock_certificate: 
         forward_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await forward_task
-        for task in list(gateway._background_tasks):
+        for task in list(session.proxy_tasks):
             with contextlib.suppress(asyncio.CancelledError):
                 await task
+
+
+async def test_close_data_channel_bridge_cancels_pending_proxy_tasks(
+    mock_certificate: Mock,
+) -> None:
+    """Closing a session's bridge must cancel its still-running proxy fetches."""
+    mock_session = Mock()
+    release = asyncio.Event()
+
+    def fake_request(_method: str, _url: str, **_kwargs: object) -> AsyncMock:
+        async def blocking_aenter(*_args: object) -> AsyncMock:
+            await release.wait()
+            return AsyncMock()
+
+        ctx = AsyncMock()
+        ctx.__aenter__ = blocking_aenter
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    mock_session.request = fake_request
+
+    gateway = WebRTCGateway(
+        http_session=mock_session,
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+        local_ws_url="ws://localhost:8095/ws",
+    )
+    session = WebRTCSession(session_id="s1", peer_connection=Mock())
+    session.local_ws = Mock()
+    session.local_ws.closed = False
+    session.local_ws.close = AsyncMock()
+    session.data_channel = Mock()
+    session.data_channel.readyState = "open"
+
+    session.message_queue.put_nowait(
+        json.dumps({"type": "http-proxy-request", "id": "1", "method": "GET", "path": "/img"})
+    )
+    session.forward_to_local_task = asyncio.create_task(gateway._forward_to_local(session))
+
+    try:
+        for _ in range(20):
+            if session.proxy_tasks:
+                break
+            await asyncio.sleep(0.05)
+        proxy_task = next(iter(session.proxy_tasks))
+
+        await gateway._close_data_channel_bridge(session)
+
+        assert proxy_task.cancelled()
+        assert not session.proxy_tasks
+    finally:
+        release.set()


### PR DESCRIPTION
# What does this implement/fix?

Over a remote connection (app.music-assistant.io / WebRTC), album art loads noticeably slowly, while on the local network it is fast. Remote clients tunnel every `/imageproxy` request as an `http-proxy-request` message over the single `ma-api` data channel, and the gateway handled each one **inline in the channel's receive loop** — so one slow image fetch stalled all API messages and every subsequent image behind it (head-of-line blocking).

- Dispatch each `http-proxy-request` off the receive loop onto a background task, so images load in parallel and API traffic is never blocked behind an image fetch.
- Bound the concurrency with a semaphore (6) so a burst of album-art requests can't spawn unbounded work or hammer thumbnail generation on constrained hardware.
- Add a regression test proving an API message gets through while an image fetch is still in flight.

No client changes needed: the frontend already correlates proxy responses strictly by `id`, so concurrent/out-of-order responses are handled as-is.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
