### PR TITLE
Fetch only needed Home Assistant entities instead of the full state dump

### DIFF
--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -543,7 +543,8 @@ class HomeAssistantProvider(PluginProvider):
                         )
                         return None
                     return cast("State", await response.json())
-            except ClientError as err:
+            except (ClientError, ValueError) as err:
+                # ValueError covers a malformed JSON body
                 self.logger.warning("Failed to fetch state for %s: %s", entity_id, err)
                 return None
 

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -16,6 +16,7 @@ from functools import partial
 from typing import TYPE_CHECKING, cast
 
 import shortuuid
+from aiohttp import ClientError
 from hass_client import HomeAssistantClient
 from hass_client.exceptions import BaseHassClientError
 from hass_client.utils import (
@@ -524,14 +525,27 @@ class HomeAssistantProvider(PluginProvider):
         semaphore = asyncio.Semaphore(STATE_FETCH_CONCURRENCY)
 
         async def _fetch_state(entity_id: str) -> State | None:
-            async with (
-                semaphore,
-                http_session.get(f"{ha_url}/api/states/{entity_id}", headers=headers) as response,
-            ):
-                if response.status != 200:
-                    # entity currently has no state (e.g. not available)
-                    return None
-                return cast("State", await response.json())
+            try:
+                async with (
+                    semaphore,
+                    http_session.get(
+                        f"{ha_url}/api/states/{entity_id}", headers=headers
+                    ) as response,
+                ):
+                    if response.status == 404:
+                        # entity currently has no state (e.g. not available)
+                        return None
+                    if response.status != 200:
+                        self.logger.warning(
+                            "Unexpected status %s fetching state for %s",
+                            response.status,
+                            entity_id,
+                        )
+                        return None
+                    return cast("State", await response.json())
+            except ClientError as err:
+                self.logger.warning("Failed to fetch state for %s: %s", entity_id, err)
+                return None
 
         async with asyncio.timeout(STATE_FETCH_TIMEOUT):
             states = await asyncio.gather(*(_fetch_state(entity_id) for entity_id in ids))

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -52,6 +52,8 @@ from music_assistant.models.plugin import PluginProvider
 from .constants import OFF_STATES, MediaPlayerEntityFeature
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from aiohttp import ClientSession
     from hass_client.models import CompressedState, Device, EntityStateEvent, State
     from music_assistant_models.config_entries import ProviderConfig
@@ -71,6 +73,13 @@ CONF_VOLUME_CONTROLS = "volume_controls"
 CONF_TTS_ENTITY = "tts_entity"
 CONF_AI_TASK_ENTITY = "ai_task_entity"
 FEATURE_DISCOVERY_TIMEOUT = 30
+STATE_FETCH_TIMEOUT = 30
+STATE_FETCH_CONCURRENCY = 8
+
+# Home Assistant entity domains Music Assistant can offer as player controls.
+CONTROL_DOMAINS = ("media_player", "switch", "input_boolean", "number", "input_number")
+# Home Assistant entity domains that back the TTS and AI Task features.
+FEATURE_DOMAINS = ("tts", "ai_task")
 
 
 async def setup(
@@ -190,7 +199,7 @@ async def get_config_entries(
         hass_prov = cast("HomeAssistantProvider", hass_prov)
         return (
             *base_entries,
-            *(await _get_config_entries(hass_prov.hass)),
+            *(await _get_config_entries(hass_prov)),
         )
 
     return (
@@ -231,14 +240,14 @@ async def get_config_entries(
     )
 
 
-async def _get_config_entries(hass: HomeAssistantClient) -> tuple[ConfigEntry, ...]:
+async def _get_config_entries(hass_prov: HomeAssistantProvider) -> tuple[ConfigEntry, ...]:
     """Return the (entity based) config entries."""
     all_power_entities: list[ConfigValueOption] = []
     all_mute_entities: list[ConfigValueOption] = []
     all_volume_entities: list[ConfigValueOption] = []
-    if not hass.connected:
+    if not hass_prov.hass.connected:
         return ()
-    states = await hass.get_states()
+    states = await hass_prov.get_states(domains=(*CONTROL_DOMAINS, *FEATURE_DOMAINS))
     tts_entities, ai_task_entities = _get_feature_entity_options(states)
     for state in states:
         entity_platform = state["entity_id"].split(".")[0]
@@ -482,6 +491,52 @@ class HomeAssistantProvider(PluginProvider):
             self.logger.warning("Failed to get HA user details: %s", err)
             return None, None, None
 
+    async def get_states(
+        self,
+        *,
+        entity_ids: list[str] | None = None,
+        domains: Collection[str] | None = None,
+    ) -> list[State]:
+        """
+        Return the current Home Assistant state for the requested entities.
+
+        Provide explicit entity IDs and/or a set of domains; only those entities
+        are fetched.
+
+        :param entity_ids: Explicit entity IDs to fetch the current state for.
+        :param domains: Entity domains whose entities should be fetched.
+        """
+        ids: set[str] = set(entity_ids or ())
+        if domains:
+            # resolve domains to entity_ids via the registry, which is far smaller
+            # than a full state dump (it carries no attributes)
+            registry = await self.hass.get_entity_registry()
+            ids.update(
+                entry["entity_id"]
+                for entry in registry
+                if entry["entity_id"].split(".", 1)[0] in domains
+            )
+        if not ids:
+            return []
+        # fetch each state via the REST api rather than the websocket: it is not subject
+        # to the websocket message size limit and lets us request individual entities
+        ha_url, headers, http_session = self._get_ha_http()
+        semaphore = asyncio.Semaphore(STATE_FETCH_CONCURRENCY)
+
+        async def _fetch_state(entity_id: str) -> State | None:
+            async with (
+                semaphore,
+                http_session.get(f"{ha_url}/api/states/{entity_id}", headers=headers) as response,
+            ):
+                if response.status != 200:
+                    # entity currently has no state (e.g. not available)
+                    return None
+                return cast("State", await response.json())
+
+        async with asyncio.timeout(STATE_FETCH_TIMEOUT):
+            states = await asyncio.gather(*(_fetch_state(entity_id) for entity_id in ids))
+        return [state for state in states if state is not None]
+
     async def resolve_image(self, path: str) -> bytes:
         """Resolve an image from an image path."""
         ha_url, headers, http_session = self._get_ha_http()
@@ -571,8 +626,7 @@ class HomeAssistantProvider(PluginProvider):
         }
         hass_states = {
             state["entity_id"]: state
-            for state in await self.hass.get_states()
-            if state["entity_id"] in control_entity_ids
+            for state in await self.get_states(entity_ids=list(control_entity_ids))
         }
         assert self._player_controls is not None  # for type checking
         for entity_id in control_entity_ids:
@@ -760,7 +814,8 @@ class HomeAssistantProvider(PluginProvider):
 
     async def _resolve_feature_entities(self) -> None:
         """Resolve configured or default Home Assistant feature entities."""
-        tts_entities, ai_task_entities = _get_feature_entity_options(await self.hass.get_states())
+        states = await self.get_states(domains=FEATURE_DOMAINS)
+        tts_entities, ai_task_entities = _get_feature_entity_options(states)
         self._tts_entity_id = _select_feature_entity(
             self.config.get_value(CONF_TTS_ENTITY), tts_entities
         )

--- a/music_assistant/providers/hass_players/helpers.py
+++ b/music_assistant/providers/hass_players/helpers.py
@@ -25,9 +25,12 @@ async def get_hass_media_players(
 ) -> AsyncGenerator[HassState]:
     """Return all HA state objects for (valid) media_player entities."""
     entity_registry = {x["entity_id"]: x for x in await hass_prov.hass.get_entity_registry()}
-    for state in await hass_prov.hass.get_states():
-        if not state["entity_id"].startswith("media_player"):
-            continue
+    # discover via the registry instead of a full state dump; entities without a
+    # unique_id are not registered and are therefore not discovered here
+    media_player_ids = [
+        entity_id for entity_id in entity_registry if entity_id.startswith("media_player.")
+    ]
+    for state in await hass_prov.get_states(entity_ids=media_player_ids):
         if "mass_player_type" in state["attributes"]:
             # filter out mass players
             continue

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -50,6 +50,24 @@ def _config(**values: str) -> MagicMock:
     return config
 
 
+def _mock_state_http(mass: MagicMock, states: list[dict[str, Any]]) -> None:
+    """Serve the given states via the mocked REST ``/api/states/<entity_id>`` endpoint."""
+    states_by_id = {state["entity_id"]: state for state in states}
+
+    def _get(url: str, headers: dict[str, str] | None = None) -> MagicMock:  # noqa: ARG001
+        entity_id = url.rsplit("/api/states/", 1)[-1]
+        state = states_by_id.get(entity_id)
+        response = MagicMock()
+        response.status = 200 if state is not None else 404
+        response.json = AsyncMock(return_value=state)
+        context = MagicMock()
+        context.__aenter__ = AsyncMock(return_value=response)
+        context.__aexit__ = AsyncMock(return_value=False)
+        return context
+
+    mass.http_session.get.side_effect = _get
+
+
 def _mass() -> MagicMock:
     """Return the Music Assistant dependencies used during provider startup."""
     mass = MagicMock()
@@ -66,26 +84,26 @@ class _HomeAssistantClient:
     def __init__(
         self,
         states: list[dict[str, Any]],
-        get_states_error: Exception | None = None,
+        registry_error: Exception | None = None,
         listener_error: Exception | None = None,
         connect_error: Exception | None = None,
-        block_get_states: bool = False,
+        block_registry: bool = False,
     ) -> None:
         self.connected = False
         self.disconnected = False
         self.listener_started = asyncio.Event()
         self.listener_cancelled = asyncio.Event()
         self.listener_stopped = asyncio.Event()
-        self.get_states_started = asyncio.Event()
-        self.get_states_cancelled = asyncio.Event()
-        self.get_states_stopped = asyncio.Event()
+        self.registry_started = asyncio.Event()
+        self.registry_cancelled = asyncio.Event()
+        self.registry_stopped = asyncio.Event()
         self.calls: list[str] = []
         self._states = states
-        self._get_states_error = get_states_error
+        self._registry_error = registry_error
         self._listener_error = listener_error
         self._connect_error = connect_error
-        self._get_states_result = (
-            asyncio.get_running_loop().create_future() if block_get_states else None
+        self._registry_result = (
+            asyncio.get_running_loop().create_future() if block_registry else None
         )
         self.send_command = AsyncMock(return_value={"response": {"data": "answer"}})
 
@@ -108,26 +126,26 @@ class _HomeAssistantClient:
             self.listener_cancelled.set()
             raise
         finally:
-            if self._get_states_result and not self._get_states_result.done():
-                self._get_states_result.cancel()
+            if self._registry_result and not self._registry_result.done():
+                self._registry_result.cancel()
             self.listener_stopped.set()
 
-    async def get_states(self) -> list[dict[str, Any]]:
-        """Return states after command responses can be received."""
+    async def get_entity_registry(self) -> list[dict[str, Any]]:
+        """Return the entity registry after command responses can be received."""
         await self.listener_started.wait()
-        self.calls.append("get_states")
-        self.get_states_started.set()
+        self.calls.append("get_entity_registry")
+        self.registry_started.set()
         try:
-            if self._get_states_result:
-                await self._get_states_result
-            if self._get_states_error:
-                raise self._get_states_error
-            return self._states
+            if self._registry_result:
+                await self._registry_result
+            if self._registry_error:
+                raise self._registry_error
+            return [{"entity_id": state["entity_id"]} for state in self._states]
         except asyncio.CancelledError:
-            self.get_states_cancelled.set()
+            self.registry_cancelled.set()
             raise
         finally:
-            self.get_states_stopped.set()
+            self.registry_stopped.set()
 
     async def disconnect(self) -> None:
         """Disconnect the client."""
@@ -142,11 +160,13 @@ async def _start_provider(
 ) -> AsyncIterator[tuple[HomeAssistantProvider, _HomeAssistantClient]]:
     """Start the provider with a connected mocked Home Assistant client."""
     hass = _HomeAssistantClient(states)
+    mass = _mass()
+    _mock_state_http(mass, states)
     manifest = MagicMock()
     manifest.domain = "hass"
     manifest.name = "Home Assistant"
     with patch("music_assistant.providers.hass.HomeAssistantClient", return_value=hass):
-        provider = await setup(_mass(), manifest, _config(**config_values))
+        provider = await setup(mass, manifest, _config(**config_values))
         assert isinstance(provider, HomeAssistantProvider)
         async with asyncio.timeout(1):
             await provider.handle_async_init()
@@ -164,7 +184,7 @@ async def test_feature_resolution_starts_listener_first() -> None:
     ]
 
     async with _start_provider(states) as (provider, hass):
-        assert hass.calls[:3] == ["connect", "start_listening", "get_states"]
+        assert hass.calls[:3] == ["connect", "start_listening", "get_entity_registry"]
         assert ProviderFeature.AI_QUERY in provider.supported_features
         assert ProviderFeature.TTS in provider.supported_features
 
@@ -186,7 +206,7 @@ async def test_feature_resolution_failure_cleans_up_connection() -> None:
     assert hass.listener_started.is_set()
     assert hass.listener_stopped.is_set()
     assert hass.disconnected
-    assert hass.calls == ["connect", "start_listening", "get_states", "disconnect"]
+    assert hass.calls == ["connect", "start_listening", "get_entity_registry", "disconnect"]
     assert provider._listen_task is None
 
 
@@ -217,7 +237,7 @@ async def test_listener_exit_terminates_pending_feature_resolution() -> None:
     hass = _HomeAssistantClient(
         [],
         listener_error=BaseHassClientError("Listener failed"),
-        block_get_states=True,
+        block_registry=True,
     )
     mass = _mass()
     manifest = MagicMock()
@@ -233,7 +253,7 @@ async def test_listener_exit_terminates_pending_feature_resolution() -> None:
 
     assert hass.listener_started.is_set()
     assert hass.listener_stopped.is_set()
-    assert hass.get_states_stopped.is_set()
+    assert hass.registry_stopped.is_set()
     assert hass.disconnected
     assert provider._listen_task is None
     mass.call_later.assert_not_called()
@@ -241,7 +261,7 @@ async def test_listener_exit_terminates_pending_feature_resolution() -> None:
 
 async def test_feature_resolution_timeout_cleans_up_connection() -> None:
     """Clean up startup when Home Assistant feature resolution times out."""
-    hass = _HomeAssistantClient([], block_get_states=True)
+    hass = _HomeAssistantClient([], block_registry=True)
     mass = _mass()
     manifest = MagicMock()
     manifest.domain = "hass"
@@ -254,15 +274,15 @@ async def test_feature_resolution_timeout_cleans_up_connection() -> None:
         assert isinstance(provider, HomeAssistantProvider)
         init_task = asyncio.create_task(provider.handle_async_init())
         async with asyncio.timeout(1):
-            await hass.get_states_started.wait()
+            await hass.registry_started.wait()
 
         with pytest.raises(
             SetupFailedError, match="Timed out while resolving Home Assistant feature entities"
         ):
             await init_task
 
-    assert hass.get_states_stopped.is_set()
-    assert hass.get_states_cancelled.is_set()
+    assert hass.registry_stopped.is_set()
+    assert hass.registry_cancelled.is_set()
     assert hass.listener_stopped.is_set()
     assert hass.listener_cancelled.is_set()
     assert hass.disconnected
@@ -272,7 +292,7 @@ async def test_feature_resolution_timeout_cleans_up_connection() -> None:
 
 async def test_feature_resolution_cancellation_cleans_up_connection() -> None:
     """Clean up startup when Home Assistant initialization is cancelled."""
-    hass = _HomeAssistantClient([], block_get_states=True)
+    hass = _HomeAssistantClient([], block_registry=True)
     mass = _mass()
     manifest = MagicMock()
     manifest.domain = "hass"
@@ -282,14 +302,14 @@ async def test_feature_resolution_cancellation_cleans_up_connection() -> None:
         assert isinstance(provider, HomeAssistantProvider)
         init_task = asyncio.create_task(provider.handle_async_init())
         async with asyncio.timeout(1):
-            await hass.get_states_started.wait()
+            await hass.registry_started.wait()
         init_task.cancel()
 
         with pytest.raises(asyncio.CancelledError):
             await init_task
 
-    assert hass.get_states_stopped.is_set()
-    assert hass.get_states_cancelled.is_set()
+    assert hass.registry_stopped.is_set()
+    assert hass.registry_cancelled.is_set()
     assert hass.listener_stopped.is_set()
     assert hass.listener_cancelled.is_set()
     assert hass.disconnected


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

On instances with a very large number of entities (reported with ~41k), the provider's `get_states` call makes Home Assistant reply with a single websocket message larger than the 16MB limit, killing the connection and preventing setup, it then retries every 5s forever. HA's `get_states` takes no arguments, so it can't be filtered.

This PR replaces the full state dumps with a `get_states` helper that discovers the required entities via the entity registry and then fetches their state over the REST API, so only the entities Music Assistant needs are transferred. Behaviour is unchanged on normal instances.

Note: media-player discovery now uses the entity registry, so a legacy `media_player` without a `unique_id` (unregistered) won't be discovered. This can be fixed by adding a `unique_id` to its config.

There is also a PR on the hass-client to improve logging if in the future the message size limit is still hit https://github.com/music-assistant/python-hass-client/pull/253

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5885

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
