### PR TITLE
Upgrade SiriusXM stream artwork URLs to https

### DIFF
--- a/music_assistant/providers/siriusxm/__init__.py
+++ b/music_assistant/providers/siriusxm/__init__.py
@@ -310,6 +310,10 @@ class SiriusXMProvider(MusicProvider):
                 image_url = next(
                     (i.url for i in channel.images if i.width == 300 and i.height == 300), None
                 )
+            if image_url and image_url.startswith("http://"):
+                # SiriusXM returns http image urls, upgrade to https to prevent
+                # mixed content blocking when the UI is served over https
+                image_url = "https://" + image_url.removeprefix("http://")
             self._current_stream_details.stream_metadata = StreamMetadata(
                 title=title,
                 artist=artist,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

SiriusXM's API returns per-track album art (and channel images) as plain http:// URLs. The stream metadata image is passed to the UI as-is, so browsers block it as mixed content when MA is accessed over https (e.g. via Nabu Casa or a TLS reverse proxy), leaving the artwork blank. The SiriusXM CDN serves the same assets over TLS, so simply upgrade the scheme.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5701

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
