### PR TITLE
Add secure Sendspin proxy for Cast receivers

### DIFF
--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -163,6 +163,11 @@ class WebserverController(CoreController):
             return self._auto_base_url
         return base_url.removesuffix("/")
 
+    @property
+    def sendspin_cast_base_url(self) -> str | None:
+        """Return the secure Sendspin proxy base URL for Cast receivers, if available."""
+        return self._sendspin_proxy.cast_base_url
+
     async def get_config_entries(
         self,
         action: str | None = None,
@@ -317,6 +322,13 @@ class WebserverController(CoreController):
         routes.append(("POST", "/setup", self._handle_setup))
         # add sendspin proxy route (authenticated WebSocket proxy to internal sendspin server)
         routes.append(("GET", "/sendspin", self._sendspin_proxy.handle_sendspin_proxy))
+        routes.append(
+            (
+                "GET",
+                "/sendspin-cast/{access_token}/sendspin",
+                self._sendspin_proxy.handle_cast_sendspin_proxy,
+            )
+        )
         await self.auth.setup()
         # start the webserver
         all_ip_addresses = await get_ip_addresses(include_ipv6=True)

--- a/music_assistant/controllers/webserver/sendspin_proxy.py
+++ b/music_assistant/controllers/webserver/sendspin_proxy.py
@@ -1,9 +1,9 @@
 """
 Sendspin WebSocket proxy handler for Music Assistant.
 
-This module provides an authenticated WebSocket proxy to the internal Sendspin server,
-allowing web clients to connect through the main webserver instead of requiring direct
-access to the Sendspin port.
+This module provides WebSocket proxies to the internal Sendspin server. Browser clients
+authenticate interactively, while Cast receivers use a capability URL that is only
+advertised when the main webserver is available over HTTPS.
 """
 
 from __future__ import annotations
@@ -12,7 +12,9 @@ import asyncio
 import contextlib
 import json
 import logging
+import secrets
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
 import aiohttp
 from aiohttp import ClientConnectorError, WSMsgType, web
@@ -44,6 +46,15 @@ class SendspinProxyHandler:
         self.webserver = webserver
         self.mass = webserver.mass
         self.logger = LOGGER
+        self._cast_access_token = secrets.token_urlsafe(32)
+
+    @property
+    def cast_base_url(self) -> str | None:
+        """Return the capability URL for Cast clients when HTTPS is configured."""
+        base_url = self.webserver.base_url
+        if urlsplit(base_url).scheme.lower() != "https":
+            return None
+        return f"{base_url}/sendspin-cast/{self._cast_access_token}"
 
     @property
     def internal_sendspin_url(self) -> str:
@@ -102,6 +113,23 @@ class SendspinProxyHandler:
                 await wsock.close(code=4001, message=b"Authentication error")
                 return wsock
 
+        return await self._connect_and_proxy(request, wsock)
+
+    async def handle_cast_sendspin_proxy(self, request: web.Request) -> web.WebSocketResponse:
+        """Proxy a Cast receiver authorized by an unguessable capability URL."""
+        access_token = request.match_info.get("access_token", "")
+        if not secrets.compare_digest(access_token, self._cast_access_token):
+            raise web.HTTPNotFound
+
+        wsock = web.WebSocketResponse(heartbeat=25)
+        await wsock.prepare(request)
+        self.logger.debug("Sendspin Cast proxy connection from %s", request.remote)
+        return await self._connect_and_proxy(request, wsock)
+
+    async def _connect_and_proxy(
+        self, request: web.Request, wsock: web.WebSocketResponse
+    ) -> web.WebSocketResponse:
+        """Connect an authorized client WebSocket to the internal Sendspin server."""
         # The internal Sendspin server may not be ready yet during startup
         # (it starts in the provider load phase, after the webserver).
         # Retry a few times with backoff to handle this race condition.
@@ -126,7 +154,7 @@ class SendspinProxyHandler:
             self.logger.exception("Failed to connect to internal Sendspin server")
             await wsock.close(code=1011, message=b"Internal server error")
             return wsock
-        self.logger.debug("Sendspin proxy authenticated and connected for %s", request.remote)
+        self.logger.debug("Sendspin proxy connected for %s", request.remote)
 
         try:
             await self._proxy_messages(wsock, internal_ws)

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
     from music_assistant_models.event import MassEvent
     from pychromecast.generated.cast_channel_pb2 import CastMessage
 
+    from music_assistant.mass import MusicAssistant
     from music_assistant.models.player import Player
     from music_assistant.providers.sendspin.provider import SendspinProvider
 
@@ -77,6 +78,14 @@ _CAST_LOG_LEVEL_MAP: dict[str, int] = {
     "info": logging.INFO,
     "debug": logging.DEBUG,
 }
+
+
+def get_sendspin_server_url(mass: MusicAssistant) -> tuple[str, bool]:
+    """Return the Sendspin Cast base URL and whether it uses the secure proxy."""
+    if secure_proxy_url := mass.webserver.sendspin_cast_base_url:
+        return secure_proxy_url, True
+    publish_ip = mass.streams.publish_ip
+    return f"ws://{format_ip_for_url(publish_ip)}:8927", False
 
 
 class SendspinCastController(BaseController):
@@ -622,12 +631,11 @@ class SendspinChromecastBridge:
         The Cast app uses this info to connect its JS Sendspin client
         back to the server with the same client_id.
         """
-        # The Sendspin server runs on its own port (8927), NOT through
-        # the MA webserver or streams server. Use publish_ip directly.
-        publish_ip = self.mass.streams.publish_ip
-        # sendspin-js's SendspinCore appends `/sendspin` to baseUrl when constructing
-        # the WebSocket URL. Send the bare server URL here so it ends up correct.
-        server_url = f"ws://{format_ip_for_url(publish_ip)}:8927"
+        # A Cast receiver loaded over HTTPS cannot connect to an insecure WebSocket.
+        # When the MA webserver has an HTTPS base URL, use its capability-protected
+        # proxy. sendspin-js converts the HTTPS base URL to WSS and appends `/sendspin`.
+        # Keep the direct LAN WebSocket as the fallback for existing installations.
+        server_url, uses_secure_proxy = get_sendspin_server_url(self.mass)
         raw_delay = self.mass.config.get_raw_player_config_value(
             self._bridge_client_id, CONF_SENDSPIN_STATIC_DELAY
         )
@@ -656,9 +664,9 @@ class SendspinChromecastBridge:
 
         await self.mass.loop.run_in_executor(None, send)
         self.logger.debug(
-            "Sent Sendspin config to Cast app on %s: serverUrl=%s, playerId=%s, syncDelay=%dms",
+            "Sent Sendspin config to Cast app on %s: transport=%s, playerId=%s, syncDelay=%dms",
             self.cast_player.display_name,
-            message["serverUrl"],
+            "secure proxy" if uses_secure_proxy else "direct WebSocket",
             self._bridge_client_id,
             sync_delay,
         )

--- a/tests/providers/chromecast/test_sendspin_bridge.py
+++ b/tests/providers/chromecast/test_sendspin_bridge.py
@@ -1,0 +1,34 @@
+"""Tests for the Chromecast Sendspin bridge."""
+
+from unittest.mock import MagicMock
+
+from music_assistant.providers.chromecast.sendspin_bridge import get_sendspin_server_url
+
+
+def test_sendspin_server_url_uses_secure_proxy() -> None:
+    """Prefer the HTTPS capability URL when the webserver exposes one."""
+    mass = MagicMock()
+    mass.webserver.sendspin_cast_base_url = "https://music.example.test/sendspin-cast/token"
+
+    assert get_sendspin_server_url(mass) == (
+        "https://music.example.test/sendspin-cast/token",
+        True,
+    )
+
+
+def test_sendspin_server_url_falls_back_to_direct_ipv4() -> None:
+    """Keep the existing direct WebSocket transport without an HTTPS proxy."""
+    mass = MagicMock()
+    mass.webserver.sendspin_cast_base_url = None
+    mass.streams.publish_ip = "192.0.2.10"
+
+    assert get_sendspin_server_url(mass) == ("ws://192.0.2.10:8927", False)
+
+
+def test_sendspin_server_url_formats_direct_ipv6() -> None:
+    """Preserve bracket formatting for the direct IPv6 fallback."""
+    mass = MagicMock()
+    mass.webserver.sendspin_cast_base_url = None
+    mass.streams.publish_ip = "2001:db8::10"
+
+    assert get_sendspin_server_url(mass) == ("ws://[2001:db8::10]:8927", False)

--- a/tests/test_sendspin_proxy.py
+++ b/tests/test_sendspin_proxy.py
@@ -18,6 +18,7 @@ def mock_webserver() -> MagicMock:
     webserver.mass = MagicMock()
     webserver.mass.streams.bind_ip = "0.0.0.0"
     webserver.mass.http_session = MagicMock()
+    webserver.base_url = "http://192.0.2.10:8095"
     return webserver
 
 
@@ -124,6 +125,57 @@ class TestSendspinProxyRetry:
 
         assert mock_ws_connect.call_count == 1
         mock_ws_response.close.assert_called_once_with(code=1011, message=b"Internal server error")
+        assert result is mock_ws_response
+
+
+class TestSendspinCastProxy:
+    """Tests for the capability-protected Cast proxy endpoint."""
+
+    def test_cast_base_url_requires_https(
+        self, handler: SendspinProxyHandler, mock_webserver: MagicMock
+    ) -> None:
+        """The Cast proxy must never advertise its bearer token over plain HTTP."""
+        assert handler.cast_base_url is None
+
+        mock_webserver.base_url = "https://music.example.test/ma"
+        secure_base_url = SendspinProxyHandler(mock_webserver).cast_base_url
+        assert secure_base_url is not None
+        assert secure_base_url.startswith("https://music.example.test/ma/sendspin-cast/")
+
+    async def test_invalid_cast_capability_is_rejected(self, handler: SendspinProxyHandler) -> None:
+        """An invalid capability token must be rejected before WebSocket upgrade."""
+        request = MagicMock()
+        request.match_info = {"access_token": "invalid"}
+
+        with pytest.raises(web.HTTPNotFound):
+            await handler.handle_cast_sendspin_proxy(request)
+
+    async def test_valid_cast_capability_connects_proxy(
+        self, handler: SendspinProxyHandler, mock_webserver: MagicMock
+    ) -> None:
+        """A valid capability token may connect without interactive user auth."""
+        mock_webserver.base_url = "https://music.example.test"
+        cast_base_url = handler.cast_base_url
+        assert cast_base_url is not None
+        access_token = cast_base_url.rsplit("/", 1)[-1]
+        request = MagicMock()
+        request.match_info = {"access_token": access_token}
+        request.remote = "192.0.2.20"
+        mock_ws_response = AsyncMock(spec=web.WebSocketResponse)
+
+        with (
+            patch("aiohttp.web.WebSocketResponse", return_value=mock_ws_response),
+            patch.object(
+                handler,
+                "_connect_and_proxy",
+                new_callable=AsyncMock,
+                return_value=mock_ws_response,
+            ) as mock_connect,
+        ):
+            result = await handler.handle_cast_sendspin_proxy(request)
+
+        mock_ws_response.prepare.assert_awaited_once_with(request)
+        mock_connect.assert_awaited_once_with(request, mock_ws_response)
         assert result is mock_ws_response
 
 


### PR DESCRIPTION
# What does this implement/fix?

Adds a capability-protected WSS proxy for Sendspin Cast receivers when Music Assistant has an HTTPS base URL. Chromecast Sendspin bridges use it automatically, while existing installations keep the direct LAN `ws://` fallback. The authenticated `/sendspin` endpoint remains unchanged.

This addresses mixed-content failures on HTTPS-loaded Cast receivers, including AirServer on Philips Titan OS.

Paired receiver change: https://github.com/Sendspin/cast/pull/89

**Related issue (if applicable):**

- No related issue

## Validation

- `pytest -s -q tests/test_sendspin_proxy.py tests/providers/chromecast/test_sendspin_bridge.py tests/providers/chromecast/test_flow_stream_underrun.py` — 18 passed after rebasing onto the latest `dev`
- `pre-commit run --all-files` — passed
- the paired Cast receiver was built locally; `yarn build`, `yarn lint:check`, and `yarn prettier:check` passed
- a locally built Music Assistant wheel was deployed in a disposable Home Assistant OS add-on and tested with the registered `main` development Cast receiver, whose deployed bundle contains the paired receiver path-retention fix
- the Philips Titan OS/AirServer TV connected through the complete capability URL (`/sendspin-cast/<capability>/sendspin`), established the secure WebSocket, received the Sendspin client hello, and started the FLAC stream
- mixed-group playback was verified with a Sonos One and the Philips TV in the same sync group; I confirmed that both endpoints were audibly playing
- the Sonos AirPlay bridge reported an established connection, and the Cast receiver's reported sync offset settled around -4 to -5 ms during the observed session
- test-harness note: force-reinstalling the locally built wheel over the nightly image replaced files that the official container injects after wheel installation. The disposable add-on therefore also injected the project-pinned `cliairplay-linux-x86_64` helper. This was required only by the local test-image construction and is not a change required by this PR

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
