### PR TITLE
Fix 'Player xy disconnected prematurely...' in MusicCast on pause

### DIFF
--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -166,7 +166,6 @@ class MusicCastPlayer(Player):
             PlayerFeature.PLAY_MEDIA,
             PlayerFeature.VOLUME_SET,
             PlayerFeature.VOLUME_MUTE,
-            PlayerFeature.PAUSE,  # for non MA control, see pause method
             PlayerFeature.POWER,
             PlayerFeature.SELECT_SOURCE,
             PlayerFeature.NEXT_PREVIOUS,
@@ -356,10 +355,14 @@ class MusicCastPlayer(Player):
         # player._current_media tells queue controller what is playing
         # and player.set_current_media is the helper function
         # do not access the queue controller to gain playback information here
+        self._attr_supported_features.add(PlayerFeature.PAUSE)  # we support pause...
         if (
             self.upnp_update_helper.current_uri is not None
             and self.upnp_update_helper.controlled_by_mass
         ):
+            self._attr_supported_features.discard(
+                PlayerFeature.PAUSE
+            )  # ...unless we are controlled by MA
             self.set_current_media(uri=self.upnp_update_helper.current_uri, clear_all=True)
         elif self.zone_device.is_client:
             _server = self.zone_device.group_server


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
MusicCast has some issues with pause over upnp, which is known and was already handled in the player's pause method silently, but never signaled via PlayerFeature. I got a couple of 'Player xy disconnected prematurely' warnings in the log when pausing, which disappear when we set/ unset the ProviderFeature instead.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
