### PR TITLE
Hide flow mode sample rate when disabled

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -359,6 +359,7 @@ CONF_ENTRY_FLOW_MODE_SAMPLE_RATE = ConfigEntry(
         ConfigValueOption(FLOW_MODE_SAMPLE_RATE_HIGHEST),
     ],
     default_value=FLOW_MODE_SAMPLE_RATE_SMART,
+    depends_on=CONF_FLOW_MODE,
     category="protocol_generic",
     advanced=True,
     requires_reload=True,


### PR DESCRIPTION
# What does this implement/fix?

The Flow Mode sample rate setting was shown while Flow Mode was disabled.

- Hide the sample rate setting until Flow Mode is enabled.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) - `bugfix`
- [ ] New feature (non-breaking change which adds functionality) - `new-feature`
- [ ] Enhancement to an existing feature - `enhancement`
- [ ] New music/player/metadata/plugin provider - `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) - `breaking-change`
- [ ] Refactor (no behaviour change) - `refactor`
- [ ] Documentation only - `documentation`
- [ ] Maintenance / chore - `maintenance`
- [ ] CI / workflow change - `ci`
- [ ] Dependencies bump - `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.