### PR TITLE
Enable 24-bit audio on supported Sonos players

### DIFF
--- a/music_assistant/providers/sonos/const.py
+++ b/music_assistant/providers/sonos/const.py
@@ -78,17 +78,6 @@ UNSUPPORTED_MODELS_NATIVE_ANNOUNCEMENTS = ("Play:1", "Play:3")
 NON_HIRES_MODELS = (
     "Play:1",
     "Play:3",
-    "Play:5 Gen2",
-    "One",
-    "One SL",
-    "Beam",
-    "Playbar",
-    "Playbase",
     "Connect",
     "Connect:Amp",
-    "Port",
-    "Amp",
-    "Move",
-    "Symfonisk Bookshelf",
-    "Symfonisk Table Lamp",
 )


### PR DESCRIPTION
# What does this implement/fix?

Sonos incorrectly treated several S2 players that support 24-bit audio as 16-bit-only.

- Enables 24-bit/48 kHz playback for supported Sonos models, including Port.
- Keeps Play:1, Play:3, Connect, and Connect:Amp on the 16-bit compatibility list.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.