### PR TITLE
Fix cast group unreachable after leadership handover

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3489,6 +3489,18 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 filtered_native_remove,
             )
             if filtered_native_add or filtered_native_remove:
+                if PlayerFeature.SET_MEMBERS not in parent_player.state.supported_features:
+                    # Players whose group membership is managed externally
+                    # (e.g. Google Cast groups, defined in the Google Home app)
+                    # do not implement set_members. Skip instead of hitting the
+                    # base model's NotImplementedError, which aborts callers
+                    # such as _cleanup_player_memberships mid-flight.
+                    self.logger.debug(
+                        "Not calling set_members on native player %s: "
+                        "player does not support SET_MEMBERS",
+                        parent_player.state.name,
+                    )
+                    return
                 self.logger.info(
                     "Calling set_members on native player %s with add=%s, remove=%s",
                     parent_player.state.name,

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3490,16 +3490,6 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             )
             if filtered_native_add or filtered_native_remove:
                 if PlayerFeature.SET_MEMBERS not in parent_player.state.supported_features:
-                    # Players whose group membership is managed externally
-                    # (e.g. Google Cast groups, defined in the Google Home app)
-                    # do not implement set_members. Skip instead of hitting the
-                    # base model's NotImplementedError, which aborts callers
-                    # such as _cleanup_player_memberships mid-flight.
-                    self.logger.debug(
-                        "Not calling set_members on native player %s: "
-                        "player does not support SET_MEMBERS",
-                        parent_player.state.name,
-                    )
                     return
                 self.logger.info(
                     "Calling set_members on native player %s with add=%s, remove=%s",

--- a/music_assistant/providers/chromecast/provider.py
+++ b/music_assistant/providers/chromecast/provider.py
@@ -155,15 +155,6 @@ class ChromecastProvider(PlayerProvider):
             if castplayer:
                 assert isinstance(castplayer, ChromecastPlayer)  # for type checking
                 castplayer.cast_info.update(disc_info)
-                # Re-link the running socket client to the browser's current
-                # mDNS services. If the device dropped off the network entirely
-                # and re-announced (e.g. a cast group whose leadership moved to
-                # another speaker, which changes the mDNS instance name), the
-                # CastBrowser has created a fresh services set for this uuid;
-                # the long-lived SocketClient still iterates its original,
-                # now-orphaned set and retries the dead host/port forever.
-                # SocketClient explicitly supports in-place modification of the
-                # set and picks up changes on the next reconnect attempt.
                 socket_client = castplayer.cc.socket_client
                 if socket_client.services != disc_info.services:
                     socket_client.services.clear()

--- a/music_assistant/providers/chromecast/provider.py
+++ b/music_assistant/providers/chromecast/provider.py
@@ -155,6 +155,19 @@ class ChromecastProvider(PlayerProvider):
             if castplayer:
                 assert isinstance(castplayer, ChromecastPlayer)  # for type checking
                 castplayer.cast_info.update(disc_info)
+                # Re-link the running socket client to the browser's current
+                # mDNS services. If the device dropped off the network entirely
+                # and re-announced (e.g. a cast group whose leadership moved to
+                # another speaker, which changes the mDNS instance name), the
+                # CastBrowser has created a fresh services set for this uuid;
+                # the long-lived SocketClient still iterates its original,
+                # now-orphaned set and retries the dead host/port forever.
+                # SocketClient explicitly supports in-place modification of the
+                # set and picks up changes on the next reconnect attempt.
+                socket_client = castplayer.cc.socket_client
+                if socket_client.services != disc_info.services:
+                    socket_client.services.clear()
+                    socket_client.services.update(disc_info.services)
                 self.mass.loop.call_soon_threadsafe(castplayer.update_state)
                 # An unavailable player may be a passive multichannel endpoint that
                 # slipped past the discovery filter (e.g. incomplete multizone info

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -159,6 +159,42 @@ class TestCacheInvalidationAfterGrouping:
         # In a real scenario, this would clear all players' caches
 
 
+class TestNativeSetMembersGuard:
+    """Test the SET_MEMBERS feature guard on native set_members forwarding."""
+
+    async def test_native_set_members_skipped_without_feature(self, mock_mass: MagicMock) -> None:
+        """
+        Test that set_members is not called on a player without SET_MEMBERS support.
+
+        Regression test for: NotImplementedError raised from
+        _cleanup_player_memberships when removing a member from a native player
+        whose group membership is managed externally (e.g. a Google Cast group,
+        which never advertises SET_MEMBERS).
+        """
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        # a native group-like player WITHOUT SET_MEMBERS in supported_features,
+        # whose set_members behaves like the Player base class (raises)
+        parent = MockPlayer(provider, "cast_group", "Cast Group")
+        parent._attr_group_members = ["cast_group", "member"]
+        parent.set_members = AsyncMock(  # type: ignore[method-assign]
+            side_effect=NotImplementedError(
+                "set_members needs to be implemented when PlayerFeature.SET_MEMBERS is set"
+            )
+        )
+        member = MockPlayer(provider, "member", "Member")
+
+        controller._players = {"cast_group": parent, "member": member}
+        mock_mass.players = controller
+
+        # must complete without raising NotImplementedError
+        await controller._handle_set_members_with_protocols(
+            parent, player_ids_to_add=[], player_ids_to_remove=["member"]
+        )
+        parent.set_members.assert_not_called()
+
+
 class TestGroupUngroup:
     """Test group and ungroup commands."""
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes two related defects that leave a Google Cast **group** permanently unreachable after group leadership moves to another speaker (e.g. when the leader reboots or gets a new DHCP lease), observed twice in four days in my production setup (server 2.9.9, but the affected code is identical back through at least 2.9.8).

**1. Stale socket-client services after re-discovery** (`providers/chromecast/provider.py`)

When a cast group's leadership is handed over, the group re-announces under a **new mDNS instance name**. If the old records expired first, pychromecast's `CastBrowser` re-add path creates a **fresh services set** for the uuid (`discovery.py`, `_add_update_service`). The already-registered player's long-lived `SocketClient` still iterates its original, now-orphaned set — so it retries the dead host/port every 5s forever, and every play request to the group silently goes nowhere until the server is restarted.

Observed live: MA retrying `10.0.0.171:32189` in a loop while an mDNS browse *from inside the same container* showed the group at `10.0.0.219:32189`.

`SocketClient`'s docstring explicitly supports the fix: *"The list of services may be modified, for example if speaker group leadership is handed over. SocketClient will catch modifications to the list when attempting reconnect."* This PR syncs the client's set with the browser's current view in the re-discovery fast path.

**2. Unguarded native `set_members` forwarding** (`controllers/players/controller.py`)

`_handle_set_members_with_protocols` forwards native member changes to `parent_player.set_members()` without checking `PlayerFeature.SET_MEMBERS` — unlike the GROUP-player path a few lines above, which does check. Cast groups never advertise SET_MEMBERS (membership is defined in the Google Home app), so member-drop cleanup hits the `Player` base class `NotImplementedError`:

```
File ".../controllers/players/controller.py", line 3281, in _handle_set_members_with_protocols
  await parent_player.set_members(...)
File ".../models/player.py", line 611, in set_members
  raise NotImplementedError("set_members needs to be implemented when PlayerFeature.SET_MEMBERS is set")
```

`_cleanup_player_memberships` suppresses `UnsupportedFeaturedException` but **not** `NotImplementedError`, so membership cleanup aborts mid-flight and group state stays wedged — compounding defect 1. This PR mirrors the existing feature guard and adds a regression test (verified to fail without the fix).

**Related issue (if applicable):**

- none found — searched server + support for `set_members`, cast-group leadership/stale-address reports

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

(Both defects are also present in `stable` — the touched code is byte-identical in the 2.9.8 and 2.9.9 images — so `backport-to-stable` may be appropriate.)

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes. *(mypy reports 84 pre-existing errors on unmodified `dev` in unrelated files — identical count with and without this change; no errors in the touched files. All other hooks pass.)*
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable. *(`tests/controllers/players/` + `tests/providers/chromecast/`: 53 passed; new regression test fails without the controller fix.)*
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. *(n/a)*
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. *(n/a)*
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. *(n/a)*
