### PR TITLE
Add descriptive error body to imageproxy 400 rejections

### DIFF
--- a/music_assistant/controllers/metadata/constants.py
+++ b/music_assistant/controllers/metadata/constants.py
@@ -107,4 +107,7 @@ _IMAGE_ID_CACHE_TTL = 86400 * 365
 # to bound PIL memory + thumbnail cache cardinality; expand if a real use case appears.
 _ALLOWED_IMAGEPROXY_SIZES = frozenset({0, 80, 160, 256, 512, 1024})
 
+# Human-readable form of the allowed sizes, used in error responses.
+_ALLOWED_IMAGEPROXY_SIZES_STR = ", ".join(str(size) for size in sorted(_ALLOWED_IMAGEPROXY_SIZES))
+
 _IMAGEPROXY_PATH_PREFIX = "/imageproxy/"

--- a/music_assistant/controllers/metadata/images.py
+++ b/music_assistant/controllers/metadata/images.py
@@ -46,6 +46,7 @@ from music_assistant.helpers.security import is_safe_path
 
 from .constants import (
     _ALLOWED_IMAGEPROXY_SIZES,
+    _ALLOWED_IMAGEPROXY_SIZES_STR,
     _IMAGE_ID_CACHE_TTL,
     _IMAGE_ID_LRU_MAX,
     _IMAGEPROXY_CONTENT_TYPES,
@@ -335,13 +336,20 @@ class ImageProxyMixin:
             return web.Response(status=400)
         image_id = request.path[len(_IMAGEPROXY_PATH_PREFIX) :].rstrip("/").lower()
         if len(image_id) != 64 or any(c not in "0123456789abcdef" for c in image_id):
-            return web.Response(status=400)
+            return web.Response(status=400, text="Invalid image id")
         try:
             size = int(request.query.get("size", "0"))
         except ValueError:
-            return web.Response(status=400)
+            return web.Response(
+                status=400,
+                text=f"Invalid size parameter: must be one of {_ALLOWED_IMAGEPROXY_SIZES_STR}.",
+            )
         if size not in _ALLOWED_IMAGEPROXY_SIZES:
-            return web.Response(status=400)
+            return web.Response(
+                status=400,
+                text=f"Unsupported size {size}: must be one of {_ALLOWED_IMAGEPROXY_SIZES_STR} "
+                "(0 = original size).",
+            )
         resolved = await self.resolve_image_id(image_id)
         if resolved is None:
             return web.Response(status=404)

--- a/tests/controllers/metadata/test_image_proxy.py
+++ b/tests/controllers/metadata/test_image_proxy.py
@@ -452,6 +452,19 @@ async def test_handle_imageproxy_rejects_extra_path_segments(
     assert bad.status == 400
 
 
+async def test_handle_imageproxy_rejects_unsupported_size(
+    metadata_controller: MetaDataController,
+) -> None:
+    """A size outside the allowed set is rejected with a non-empty reason body."""
+    image_id = metadata_controller.compute_image_id("filesystem", "/local/cover.jpg")
+    request = MagicMock()
+    request.path = f"/imageproxy/{image_id}"
+    request.query = {"size": "300"}
+    bad = await metadata_controller.handle_imageproxy(request)
+    assert bad.status == 400
+    assert bad.text
+
+
 def test_is_svg_data() -> None:
     """SVG bytes are detected by content, regardless of file extension."""
     # plain root element


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The `/imageproxy/<image_id>` endpoint rejected an invalid image id or an unsupported `size` value with a bare 400 and an empty body, making failures impossible to diagnose from the client side. In the linked issue, a client requesting `size=300` (not in the allowed set) surfaced as an indistinguishable empty 400, which led to a lengthy misdiagnosis.

Each rejection now carries a short reason in the response body

No behavioral change to which requests are accepted.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5875

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
