### PR TITLE
Recover Sendspin bridge clients stuck in a stale disabled state

### DIFF
--- a/music_assistant/providers/sendspin/bridge_manager.py
+++ b/music_assistant/providers/sendspin/bridge_manager.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Protocol, cast
 
 from music_assistant_models.enums import EventType
 
-from music_assistant.constants import CONF_PLAYERS
+from music_assistant.constants import CONF_PLAYERS, CONF_PROTOCOL_PARENT_ID
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -115,6 +115,8 @@ class SendspinBridgeManagerBase[BridgeT: SendspinBridge](ABC):
             if self._has_bridge(player_id):
                 await self.remove_bridge(player_id, permanent=True)
             return
+        if client_id:
+            await self._heal_stale_client_disable(player, client_id)
         if not self._lifecycle_allows_bridge(player):
             if self._has_bridge(player_id):
                 await self.remove_bridge(player_id)
@@ -278,6 +280,32 @@ class SendspinBridgeManagerBase[BridgeT: SendspinBridge](ABC):
         if not raw_conf:
             return True
         return bool(raw_conf.get("enabled", True))
+
+    async def _heal_stale_client_disable(self, player: Player, client_id: str) -> None:
+        """
+        Re-enable a bridge client whose disabled state lost its owning parent.
+
+        :param player: The base player a bridge is wanted for.
+        :param client_id: The Sendspin bridge client_id computed for the player.
+        """
+        raw_conf = self.mass.config.get(f"{CONF_PLAYERS}/{client_id}")
+        if not raw_conf or raw_conf.get("enabled", True):
+            return
+        if self.sendspin_server is None or not self._is_player_enabled(player.player_id):
+            return
+        # MAC-based client ids outlive the UUID-based parent ids they were
+        # disabled under; without the parent there is no UI toggle to undo it.
+        values = raw_conf.get("values") or {}
+        parent_id = values.get(CONF_PROTOCOL_PARENT_ID)
+        if parent_id and self.mass.config.get(f"{CONF_PLAYERS}/{parent_id}"):
+            # the parent the disable was made under still exists - respect it
+            return
+        self.logger.info(
+            "Re-enabling Sendspin bridge client %s for %s: former parent no longer exists",
+            client_id,
+            player.display_name,
+        )
+        await self.mass.config.save_player_config(client_id, {"enabled": True})
 
     async def _on_player_config_updated(self, event: MassEvent) -> None:
         """Re-evaluate the bridge of a player affected by a config change."""

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -335,6 +335,19 @@ class SendspinProvider(PlayerProvider):
             case _:
                 self.logger.error("Unknown sendspin event: %s", event)
 
+    def on_player_enabled(self, player_id: str) -> None:
+        """Call (by config manager) when a player gets enabled."""
+        # A client that connected while disabled has no player object;
+        # replay the add event so re-enabling takes effect immediately.
+        if (
+            self.server_api.get_client(player_id) is not None
+            and self.mass.players.get_player(player_id) is None
+        ):
+            event_version = self._begin_client_event(player_id)
+            self.mass.create_task(self._handle_client_added(player_id, event_version))
+            return
+        super().on_player_enabled(player_id)
+
     def register_bridge_identifiers(
         self, client_id: str, identifiers: dict[IdentifierType, str]
     ) -> None:

--- a/tests/providers/sendspin/test_bridge_manager.py
+++ b/tests/providers/sendspin/test_bridge_manager.py
@@ -80,6 +80,11 @@ def _make_environment() -> tuple[
         side_effect=lambda key, default=None: player_configs.get(key, default)
     )
 
+    async def fake_save_player_config(player_id: str, values: dict[str, Any]) -> None:
+        player_configs.setdefault(f"players/{player_id}", {}).update(values)
+
+    mass.config.save_player_config = AsyncMock(side_effect=fake_save_player_config)
+
     provider = MagicMock()
     provider.mass = mass
     provider.logger = logging.getLogger("test.bridge_manager")
@@ -126,14 +131,20 @@ class TestBridgeLifecycleReconciliation:
     @pytest.mark.asyncio
     async def test_bridge_removed_when_bridge_client_disabled(self) -> None:
         """Test the bridge is torn down when its own Sendspin client gets disabled."""
-        manager, _, player, _, player_configs = _make_environment()
+        manager, mass, player, _, player_configs = _make_environment()
         await manager.evaluate_bridge(player)
         assert manager.get_bridge("player_1") is not None
 
-        player_configs["players/spb_player_1"] = {"enabled": False}
+        # a user-made disable carries the parent link the toggle was rendered under
+        player_configs["players/player_1"] = {"enabled": True}
+        player_configs["players/spb_player_1"] = {
+            "enabled": False,
+            "values": {"protocol_parent_id": "player_1"},
+        }
         await manager.evaluate_bridge(player)
 
         assert manager.get_bridge("player_1") is None
+        mass.config.save_player_config.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_bridge_not_created_for_unregistered_player(self) -> None:
@@ -163,7 +174,11 @@ class TestBridgeLifecycleReconciliation:
     async def test_config_event_on_bridge_client_recreates_bridge(self) -> None:
         """Test a config event on the bridge client id re-evaluates the base player."""
         manager, _, player, _, player_configs = _make_environment()
-        player_configs["players/spb_player_1"] = {"enabled": False}
+        player_configs["players/player_1"] = {"enabled": True}
+        player_configs["players/spb_player_1"] = {
+            "enabled": False,
+            "values": {"protocol_parent_id": "player_1"},
+        }
         await manager.evaluate_bridge(player)
         assert manager.get_bridge("player_1") is None
 
@@ -174,6 +189,45 @@ class TestBridgeLifecycleReconciliation:
         await manager._on_player_config_updated(event)
 
         assert manager.get_bridge("player_1") is not None
+
+    @pytest.mark.asyncio
+    async def test_stale_disabled_client_reenabled_when_parent_gone(self) -> None:
+        """Test a client disabled under a no-longer-existing parent is re-enabled."""
+        manager, mass, player, _, player_configs = _make_environment()
+        # e.g. left behind by a cascade-disable from a parent player whose
+        # config was removed (device re-setup changed its player id)
+        player_configs["players/spb_player_1"] = {
+            "enabled": False,
+            "values": {"protocol_parent_id": "cc_old_uuid"},
+        }
+
+        await manager.evaluate_bridge(player)
+
+        mass.config.save_player_config.assert_awaited_once_with("spb_player_1", {"enabled": True})
+        assert manager.get_bridge("player_1") is not None
+
+    @pytest.mark.asyncio
+    async def test_stale_disabled_client_without_parent_link_reenabled(self) -> None:
+        """Test a disabled client without any parent link is re-enabled."""
+        manager, mass, player, _, player_configs = _make_environment()
+        player_configs["players/spb_player_1"] = {"enabled": False}
+
+        await manager.evaluate_bridge(player)
+
+        mass.config.save_player_config.assert_awaited_once_with("spb_player_1", {"enabled": True})
+        assert manager.get_bridge("player_1") is not None
+
+    @pytest.mark.asyncio
+    async def test_no_heal_when_base_player_disabled(self) -> None:
+        """Test a stale client disable is left alone while the base player is disabled."""
+        manager, mass, player, _, player_configs = _make_environment()
+        player_configs["players/player_1"] = {"enabled": False}
+        player_configs["players/spb_player_1"] = {"enabled": False}
+
+        await manager.evaluate_bridge(player)
+
+        mass.config.save_player_config.assert_not_awaited()
+        assert manager.get_bridge("player_1") is None
 
     @pytest.mark.asyncio
     async def test_stale_bridge_rebuilt_after_sendspin_reload(self) -> None:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The failing speakers in the linked issue log `Ignoring disabled sendspin client: spb_...` on every discovery. I traced that to the client-added handler, The client's stored config says `enabled: false`, so MA skips it.

The disable was written automatically on behalf of a parent player that no longer exists. Bridge client ids are MAC-based and survive device re-setups; the parent ids (Cast UUIDs) don't. Since the enable toggle only renders under the parent, a stranded disable can't be undone from the UI.

Thie PR:

- Re-enables a bridge client when the parent it was disabled under no longer exists in config. A disable under a still-existing parent is respected.
- Re-enabling an already-connected Sendspin client now replays the client-added flow instead of doing nothing until restart.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5894

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
