### PR TITLE
Remove the fixed output limiter

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -101,7 +101,6 @@ CONF_USERNAME: Final[str] = "username"
 CONF_PASSWORD: Final[str] = "password"
 CONF_VOLUME_NORMALIZATION: Final[str] = "volume_normalization"
 CONF_VOLUME_NORMALIZATION_TARGET: Final[str] = "volume_normalization_target"
-CONF_OUTPUT_LIMITER: Final[str] = "output_limiter"
 CONF_PLAYER_DSP: Final[str] = "player_dsp"
 CONF_PLAYER_DSP_PRESETS: Final[str] = "player_dsp_presets"
 CONF_OUTPUT_CHANNELS: Final[str] = "output_channels"
@@ -429,16 +428,6 @@ CONF_ENTRY_VOLUME_NORMALIZATION_TARGET = ConfigEntry(
     advanced=True,
     requires_reload=True,
 )
-
-CONF_ENTRY_OUTPUT_LIMITER = ConfigEntry(
-    key=CONF_OUTPUT_LIMITER,
-    type=ConfigEntryType.BOOLEAN,
-    default_value=True,
-    category="playback",
-    advanced=True,
-    requires_reload=True,
-)
-
 
 # Note: the crossfade_mode select entry (standard/smart) is built dynamically in the config
 # controller because its options and default depend on smart fades availability.

--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -158,7 +158,7 @@ async def migrate(data: dict[str, Any]) -> bool:  # noqa: PLR0915
 
     # Drop the stored value of the removed output limiter player setting; clipping protection
     # is now an explicit Safety Limiter DSP filter instead of a fixed output stage.
-    # TODO: remove after 2.11 release
+    # TODO: remove after 2.10 release
     if _migrate_output_limiter(data):
         changed = True
 

--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -32,6 +32,9 @@ from music_assistant.controllers.player_queues.constants import (
 
 LOGGER = logging.getLogger(__name__)
 
+# removed player config key, only referenced by its migration
+LEGACY_CONF_OUTPUT_LIMITER = "output_limiter"
+
 
 async def migrate(data: dict[str, Any]) -> bool:  # noqa: PLR0915
     """Migrate the persistent settings data in-place; return True if anything changed."""
@@ -151,6 +154,12 @@ async def migrate(data: dict[str, Any]) -> bool:  # noqa: PLR0915
     # their (now obsolete) universal player wrappers back onto them.
     # TODO: remove after 2.11 release
     if _migrate_local_audio_attribution_stubs(data):
+        changed = True
+
+    # Drop the stored value of the removed output limiter player setting; clipping protection
+    # is now an explicit Safety Limiter DSP filter instead of a fixed output stage.
+    # TODO: remove after 2.11 release
+    if _migrate_output_limiter(data):
         changed = True
 
     return changed
@@ -567,3 +576,21 @@ def _migrate_fully_kiosk_multi_instance(data: dict[str, Any]) -> bool:
         len(legacy_ids),
     )
     return True
+
+
+def _migrate_output_limiter(data: dict[str, Any]) -> bool:
+    """Remove the stored values of the removed per-player output limiter setting."""
+    all_player_configs = data.get(CONF_PLAYERS, {})
+    if not isinstance(all_player_configs, dict):
+        return False
+    changed = False
+    for player_cfg in all_player_configs.values():
+        if not isinstance(player_cfg, dict):
+            continue
+        player_values = player_cfg.get("values")
+        if isinstance(player_values, dict) and LEGACY_CONF_OUTPUT_LIMITER in player_values:
+            del player_values[LEGACY_CONF_OUTPUT_LIMITER]
+            changed = True
+    if changed:
+        LOGGER.info("Removed the obsolete output limiter setting from the player configuration(s)")
+    return changed

--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -46,7 +46,6 @@ from music_assistant.constants import (
     CONF_ENTRY_MIN_VOLUME,
     CONF_ENTRY_OUTPUT_CHANNELS,
     CONF_ENTRY_OUTPUT_CODEC,
-    CONF_ENTRY_OUTPUT_LIMITER,
     CONF_ENTRY_PLAY_MEDIA_OVERRIDES_GROUP,
     CONF_ENTRY_PLAYER_ICON,
     CONF_ENTRY_PLAYER_ICON_GROUP,
@@ -618,10 +617,6 @@ class PlayerConfigMixin:
         # some base entries for all player types
         # note that these may NOT be playback/audio related
         entries += [
-            # the output limiter is applied per-player in the output filter chain (DSP stage), so
-            # unlike the other playback settings (crossfade/volume normalization) which moved to the
-            # queue config, it stays a player setting
-            CONF_ENTRY_OUTPUT_LIMITER,
             CONF_ENTRY_TTS_PRE_ANNOUNCE,
             ConfigEntry(
                 key=CONF_PRE_ANNOUNCE_CHIME_URL,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -56,7 +56,6 @@ from music_assistant_models.streamdetails import MultiPartPath, StreamMetadata
 from music_assistant.constants import (
     CONF_CROSSFADE_DURATION,
     CONF_ENTRY_CROSSFADE_DIFFERENT_SAMPLE_RATES,
-    CONF_ENTRY_OUTPUT_LIMITER,
     CONF_ENTRY_VOLUME_NORMALIZATION_TARGET,
     CONF_FLOW_MODE_SAMPLE_RATE,
     CONF_OUTPUT_CHANNELS,
@@ -1123,20 +1122,6 @@ class StreamsAudio:
         finally:
             await remove_file(temp_file)
 
-    def is_output_limiter_enabled(self, player: Player) -> bool:
-        """Check if the player has the output limiter enabled."""
-        deciding_player_id = player.protocol_parent_id or player.player_id
-        if player.state.active_group:
-            deciding_player_id = player.state.active_group
-        elif player.state.synced_to:
-            deciding_player_id = player.state.synced_to
-        output_limiter_enabled = self.mass.config.get_raw_player_config_value(
-            deciding_player_id,
-            CONF_ENTRY_OUTPUT_LIMITER.key,
-            CONF_ENTRY_OUTPUT_LIMITER.default_value,
-        )
-        return bool(output_limiter_enabled)
-
     def get_player_output_plan(
         self,
         player_id: str,
@@ -1176,7 +1161,6 @@ class StreamsAudio:
         if player:
             dsp_config_id = self._resolve_player_dsp_config_id(player)
             dsp = self._resolve_player_dsp_config(player)
-            limiter_enabled = self.is_output_limiter_enabled(player)
             configured_dsp = self.mass.config.get_player_dsp_config(dsp_config_id)
             if configured_dsp.enabled and not dsp.enabled and is_grouping_preventing_dsp(player):
                 dsp_state = DSPState.DISABLED_BY_UNSUPPORTED_GROUP
@@ -1185,7 +1169,6 @@ class StreamsAudio:
         else:
             dsp_config_id = player_id
             dsp = self.mass.config.get_player_dsp_config(player_id)
-            limiter_enabled = True
             dsp_state = DSPState.ENABLED if dsp.enabled else DSPState.DISABLED
 
         enabled_filters = [dsp_filter for dsp_filter in dsp.filters if dsp_filter.enabled]
@@ -1215,9 +1198,6 @@ class StreamsAudio:
             source_channel = AudioChannel.FR
             filter_params.append("pan=mono|c0=FR")
 
-        if limiter_enabled:
-            filter_params.append("alimiter=limit=-2dB:level=false:asc=true")
-
         output_details = AudioOutputDetails(
             player_ids=sorted(destination_player_ids),
             dsp=AudioDSPDetails(
@@ -1225,7 +1205,6 @@ class StreamsAudio:
                 input_gain=dsp.input_gain if dsp.enabled else 0.0,
                 filters=effective_filters,
                 output_gain=dsp.output_gain if dsp.enabled else 0.0,
-                output_limiter=limiter_enabled,
                 preset_id=dsp.preset_id,
             ),
             source_channel=source_channel,

--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -613,9 +613,7 @@ def _is_bit_perfect(
     dsp_alters_audio = details.dsp.state == DSPState.ENABLED and (
         bool(details.dsp.filters) or details.dsp.input_gain != 0 or details.dsp.output_gain != 0
     )
-    return not (
-        dsp_alters_audio or details.dsp.output_limiter or details.source_channel is not None
-    )
+    return not (dsp_alters_audio or details.source_channel is not None)
 
 
 def _output_details_equal_ignoring_players(

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -1245,20 +1245,19 @@ class SendspinPlaybackSession:
         except Exception:
             filter_params = ()
             output_plan = None
-        custom_filter_graph = any(
-            param.strip() and not param.strip().startswith("alimiter=") for param in filter_params
-        )
+        custom_filter_graph = any(param.strip() for param in filter_params)
         requires_transform = dsp_enabled or output_channels != "stereo" or custom_filter_graph
-        if output_plan is not None:
-            if not requires_transform:
-                output_plan.output_details.dsp.output_limiter = False
-            if self._queue_id is not None and self._queue_session_id is not None:
-                self.player.mass.streams.audio_processing.update_output(
-                    output_plan.output_details.player_ids[0],
-                    output_plan,
-                    queue_id=self._queue_id,
-                    session_id=self._queue_session_id,
-                )
+        if (
+            output_plan is not None
+            and self._queue_id is not None
+            and self._queue_session_id is not None
+        ):
+            self.player.mass.streams.audio_processing.update_output(
+                output_plan.output_details.player_ids[0],
+                output_plan,
+                queue_id=self._queue_id,
+                session_id=self._queue_session_id,
+            )
         return _PipelineConfig(
             requires_transform=requires_transform,
             output_channels=output_channels,

--- a/music_assistant/strings.json
+++ b/music_assistant/strings.json
@@ -226,10 +226,6 @@
         "wav": "Lossless but uncompressed — highest bandwidth. Only needed for players that can't handle FLAC."
       }
     },
-    "output_limiter": {
-      "label": "Enable limiting to prevent clipping",
-      "description": "Activates a limiter that prevents audio distortion by making loud peaks quieter."
-    },
     "play_media_overrides_group": {
       "label": "Play Media overrides active group",
       "description": "When this player is currently captured by an active group or sync session, an explicit Play Media command (e.g. starting a new playlist or track from Home Assistant) will release this player from the group/sync and play the new media directly on this player. Disable this to keep the legacy behavior where Play Media is redirected to the group leader. Other commands (next/prev/pause/resume) are always forwarded to the group leader as they act on the existing playback."

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -180,8 +180,6 @@
   "common.config_entries.output_codec.options.flac": "FLAC (lossless, compressed)",
   "common.config_entries.output_codec.options.mp3": "MP3 (lossy)",
   "common.config_entries.output_codec.options.wav": "WAV (lossless, uncompressed)",
-  "common.config_entries.output_limiter.description": "Activates a limiter that prevents audio distortion by making loud peaks quieter.",
-  "common.config_entries.output_limiter.label": "Enable limiting to prevent clipping",
   "common.config_entries.password.description": "The password to authenticate to the remote server.",
   "common.config_entries.password.label": "Password",
   "common.config_entries.play_media_overrides_group.description": "When this player is currently captured by an active group or sync session, an explicit Play Media command (e.g. starting a new playlist or track from Home Assistant) will release this player from the group/sync and play the new media directly on this player. Disable this to keep the legacy behavior where Play Media is redirected to the group leader. Other commands (next/prev/pause/resume) are always forwarded to the group leader as they act on the existing playback.",

--- a/tests/controllers/config/test_config_protocol_defaults.py
+++ b/tests/controllers/config/test_config_protocol_defaults.py
@@ -140,7 +140,7 @@ async def test_protocol_prefixed_reset_to_default_sticks(mass: MusicAssistant) -
     # set the prefixed value to a non-default, alongside an unrelated parent change
     await mass.config.save_player_config(
         PARENT_ID,
-        {PREFIXED_KEY: FLOW_MODE_SAMPLE_RATE_BIT_PERFECT, "output_limiter": False},
+        {PREFIXED_KEY: FLOW_MODE_SAMPLE_RATE_BIT_PERFECT, "tts_pre_announce": False},
     )
     config = await mass.config.get_player_config(PARENT_ID)
     assert config.values[PREFIXED_KEY].value == FLOW_MODE_SAMPLE_RATE_BIT_PERFECT
@@ -190,12 +190,12 @@ async def test_full_form_save_does_not_persist_prefixed_copy_on_parent(
 
     await mass.config.save_player_config(
         PARENT_ID,
-        {PREFIXED_KEY: FLOW_MODE_SAMPLE_RATE_BIT_PERFECT, "output_limiter": False},
+        {PREFIXED_KEY: FLOW_MODE_SAMPLE_RATE_BIT_PERFECT, "tts_pre_announce": False},
     )
 
     stored = _parent_stored_values(mass)
     # parent-level (non-protocol) change is fine to persist
-    assert stored.get("output_limiter") is False
+    assert stored.get("tts_pre_announce") is False
     # protocol-prefixed entries are virtual mirrors of the child and must never live on the parent
     assert not any(CONF_PROTOCOL_KEY_SPLITTER in key for key in stored)
 

--- a/tests/controllers/config/test_migrations.py
+++ b/tests/controllers/config/test_migrations.py
@@ -1,0 +1,26 @@
+"""Tests for (settings.json) config migrations."""
+
+from typing import Any
+
+from music_assistant.controllers.config.migrations import _migrate_output_limiter
+
+
+def test_migrate_output_limiter_drops_stored_values() -> None:
+    """The removed output limiter setting is dropped, other player values are kept."""
+    data: dict[str, Any] = {
+        "players": {
+            "p1": {"player_id": "p1", "values": {"output_limiter": False, "flow_mode": True}},
+            "p2": {"player_id": "p2", "values": {"output_limiter": True}},
+            "p3": {"player_id": "p3", "values": {}},
+        }
+    }
+    assert _migrate_output_limiter(data) is True
+    assert data["players"]["p1"]["values"] == {"flow_mode": True}
+    assert data["players"]["p2"]["values"] == {}
+    assert data["players"]["p3"]["values"] == {}
+
+
+def test_migrate_output_limiter_noop_when_absent() -> None:
+    """Migration reports no change when no player stored the setting."""
+    data: dict[str, Any] = {"players": {"p1": {"player_id": "p1", "values": {"flow_mode": True}}}}
+    assert _migrate_output_limiter(data) is False

--- a/tests/controllers/config/test_player_queue_config.py
+++ b/tests/controllers/config/test_player_queue_config.py
@@ -43,7 +43,7 @@ def test_migrate_player_queue_settings_moves_only_queue_keys() -> None:
                 "values": {
                     "crossfade_duration": 12,
                     "volume_normalization": False,
-                    "output_limiter": True,  # player/DSP stage -> stays on the player
+                    "tts_pre_announce": False,  # player-scoped -> stays on the player
                     "smart_fades_mode": "disabled",  # legacy off -> consumed, nothing carried over
                 },
             },
@@ -52,7 +52,7 @@ def test_migrate_player_queue_settings_moves_only_queue_keys() -> None:
     }
     assert _migrate(data) is True
     # moved keys (and the consumed legacy smart_fades_mode) are gone from the player config
-    assert data["players"]["p1"]["values"] == {"output_limiter": True}
+    assert data["players"]["p1"]["values"] == {"tts_pre_announce": False}
     # ...and now live under the per-queue config (queue_id == player_id)
     assert data["player_queues"]["p1"]["values"] == {
         "crossfade_duration": 12,
@@ -65,7 +65,7 @@ def test_migrate_player_queue_settings_moves_only_queue_keys() -> None:
 def test_migrate_player_queue_settings_noop_when_nothing_to_move() -> None:
     """Migration reports no change when there are no queue-scoped values to move."""
     data: dict[str, Any] = {
-        "players": {"p1": {"player_id": "p1", "values": {"output_limiter": True}}}
+        "players": {"p1": {"player_id": "p1", "values": {"tts_pre_announce": False}}}
     }
     assert _migrate(data) is False
     assert "player_queues" not in data

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -470,14 +470,12 @@ def test_player_output_plan_matches_ffmpeg_filters() -> None:
     )
 
     assert plan.filter_params[0] == "volume=-1.0dB"
-    assert "pan=mono|c0=FL" in plan.filter_params
-    assert plan.filter_params[-1] == "alimiter=limit=-2dB:level=false:asc=true"
+    assert plan.filter_params[-1] == "pan=mono|c0=FL"
     assert plan.output_details.dsp == AudioDSPDetails(
         state=DSPState.ENABLED,
         input_gain=-1.0,
         filters=[ToneControlFilter(enabled=True, bass_level=2.0)],
         output_gain=-0.5,
-        output_limiter=True,
         preset_id="night",
     )
     assert plan.dsp_config_id == "player-1"
@@ -584,7 +582,6 @@ def test_protocol_output_uses_parent_settings(monkeypatch: pytest.MonkeyPatch) -
     assert plan.output_details.dsp.preset_id == "parent-preset"
     assert plan.dsp_config_id == "player-1"
     assert plan.output_details.source_channel == AudioChannel.FR
-    assert not plan.output_details.dsp.output_limiter
     assert {call.args[0] for call in mass.config.get_raw_player_config_value.call_args_list} == {
         "player-1"
     }

--- a/tests/providers/sendspin/test_playback_processing.py
+++ b/tests/providers/sendspin/test_playback_processing.py
@@ -20,10 +20,10 @@ if TYPE_CHECKING:
     import pytest
 
 
-def test_limiter_is_not_reported_when_shared_channel_skips_it(
+def test_empty_plan_does_not_require_transform(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A limiter-only plan reflects that the shared Sendspin channel bypasses it."""
+    """A plan without filters keeps the member on the shared Sendspin channel."""
     player = MagicMock(player_id="leader")
     player.mass.config.get_player_dsp_config.return_value = DSPConfig(enabled=False)
     player.mass.config.get_raw_player_config_value.return_value = "stereo"
@@ -35,11 +35,11 @@ def test_limiter_is_not_reported_when_shared_channel_skips_it(
     )
     output_details = AudioOutputDetails(
         player_ids=["member"],
-        dsp=AudioDSPDetails(output_limiter=True),
+        dsp=AudioDSPDetails(),
         output_format=pcm_format,
     )
     output_plan = AudioOutputPlan(
-        filter_params=["alimiter=limit=-2dB:level=false:asc=true"],
+        filter_params=[],
         output_details=output_details,
         input_format=pcm_format,
     )
@@ -53,7 +53,6 @@ def test_limiter_is_not_reported_when_shared_channel_skips_it(
     config = session._read_pipeline_config("member")
 
     assert not config.requires_transform
-    assert not output_details.dsp.output_limiter
     player.mass.streams.audio_processing.update_output.assert_called_once_with(
         "member",
         output_plan,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Removes the fixed -2 dB limiter that was appended to every player's output filter chain, along with its per-player "Enable limiting to prevent clipping" setting.

**Related issue (if applicable):**

- related issue 

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
