### PR TITLE
Fix AirPlay 2 pairing credentials not persisted to live player config

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -1011,9 +1011,15 @@ class AirPlayPlayer(Player):
         credentials = await self._active_pairing.finish_pairing(pin=str(pin))
         self._active_pairing = None
 
-        # Store credentials with the protocol-specific key
+        # Store credentials with the protocol-specific key. `values` only feeds the
+        # ConfigEntry response of this (read-only) config/players/get_entries call, so
+        # without also persisting to the live config here, stream.py's subsequent
+        # config.get_value(cred_key) lookup at play time finds nothing and cliairplay
+        # falls back to asking for interactive pairing again, even though pairing just
+        # succeeded (see _reset_pairing below, which already does this for its case).
         cred_key = self._get_credentials_key(protocol)
         values[cred_key] = credentials
+        self.config.update({cred_key: credentials})
 
         self.logger.info(f"Finished {protocol_name} pairing for {self.display_name}")
 

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -1011,14 +1011,9 @@ class AirPlayPlayer(Player):
         credentials = await self._active_pairing.finish_pairing(pin=str(pin))
         self._active_pairing = None
 
-        # Store credentials with the protocol-specific key. `values` only feeds the
-        # ConfigEntry response of this (read-only) config/players/get_entries call, so
-        # without also persisting here, stream.py's subsequent config.get_value(cred_key)
-        # lookup at play time finds nothing and cliairplay falls back to asking for
-        # interactive pairing again, even though pairing just succeeded. Go through
-        # save_player_config (not a raw config.update) so the SECURE_STRING credentials
-        # are encrypted at rest and survive a server restart, same as any other player
-        # config change.
+        # Store credentials with the protocol-specific key. The get_entries action
+        # flow never persists `values` itself, so save the credentials through
+        # save_player_config to make them live and persisted (encrypted) right away.
         cred_key = self._get_credentials_key(protocol)
         values[cred_key] = credentials
         await self.mass.config.save_player_config(self.player_id, {cred_key: credentials})
@@ -1037,10 +1032,8 @@ class AirPlayPlayer(Player):
         if values is not None:
             values[cred_key] = None
             values[CONF_AP2PASSWORD] = None
-        # save_player_config (not a raw config.update) so the reset is actually
-        # persisted to disk, not just the in-memory config - otherwise a restart
-        # would resurrect the "reset" credentials from the still-unchanged stored
-        # config, silently re-pairing the device with stale keys.
+        # Persist the cleared credentials immediately so a restart cannot
+        # resurrect them from the stored config.
         await self.mass.config.save_player_config(
             self.player_id, {cred_key: None, CONF_AP2PASSWORD: None}
         )

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -1013,13 +1013,15 @@ class AirPlayPlayer(Player):
 
         # Store credentials with the protocol-specific key. `values` only feeds the
         # ConfigEntry response of this (read-only) config/players/get_entries call, so
-        # without also persisting to the live config here, stream.py's subsequent
-        # config.get_value(cred_key) lookup at play time finds nothing and cliairplay
-        # falls back to asking for interactive pairing again, even though pairing just
-        # succeeded (see _reset_pairing below, which already does this for its case).
+        # without also persisting here, stream.py's subsequent config.get_value(cred_key)
+        # lookup at play time finds nothing and cliairplay falls back to asking for
+        # interactive pairing again, even though pairing just succeeded. Go through
+        # save_player_config (not a raw config.update) so the SECURE_STRING credentials
+        # are encrypted at rest and survive a server restart, same as any other player
+        # config change.
         cred_key = self._get_credentials_key(protocol)
         values[cred_key] = credentials
-        self.config.update({cred_key: credentials})
+        await self.mass.config.save_player_config(self.player_id, {cred_key: credentials})
 
         self.logger.info(f"Finished {protocol_name} pairing for {self.display_name}")
 
@@ -1035,7 +1037,13 @@ class AirPlayPlayer(Player):
         if values is not None:
             values[cred_key] = None
             values[CONF_AP2PASSWORD] = None
-        self.config.update({cred_key: None, CONF_AP2PASSWORD: None})
+        # save_player_config (not a raw config.update) so the reset is actually
+        # persisted to disk, not just the in-memory config - otherwise a restart
+        # would resurrect the "reset" credentials from the still-unchanged stored
+        # config, silently re-pairing the device with stale keys.
+        await self.mass.config.save_player_config(
+            self.player_id, {cred_key: None, CONF_AP2PASSWORD: None}
+        )
 
     def _on_player_media_updated(self) -> None:
         """Handle callback when the current media of the player is updated."""

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -13,6 +13,7 @@ from music_assistant.constants import CONF_SYNC_ADJUST
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_PCM_FORMAT,
     CONF_AIRPLAY_CREDENTIALS,
+    CONF_AP2PASSWORD,
     CONF_ENCRYPTION,
     CONF_FORCE_RAOP,
     CONF_HIRES_PLAYBACK,
@@ -246,12 +247,14 @@ def _make_pin_required_player(**overrides: object) -> AirPlayPlayer:
     )
     player._active_pairing = AsyncMock()
     player._active_pairing.finish_pairing = AsyncMock(return_value=FAKE_HAP_CREDENTIALS)
+    player.mass.config.save_player_config = AsyncMock()  # type: ignore[attr-defined]
     return player
 
 
 @pytest.mark.asyncio
 async def test_finish_pairing_persists_credentials_to_live_config() -> None:
-    """A successful pairing must write the credentials into the live player config.
+    """
+    A successful pairing must persist the credentials, not just report them.
 
     Regression test: pairing computed valid HAP credentials and logged success
     ("Finished AirPlay pairing for ...") but only stored them in the transient
@@ -260,6 +263,10 @@ async def test_finish_pairing_persists_credentials_to_live_config() -> None:
     attempt then found nothing, no --auth was passed to cliairplay, and it fell
     back to asking for interactive pairing again even though pairing had just
     succeeded (observed with an LG webOS TV as an AirPlay 2 hass_players target).
+
+    The persistence must go through save_player_config (not a raw config.update)
+    so the SECURE_STRING credentials are (a) encrypted at rest and (b) actually
+    survive a server restart instead of only living in the in-memory config copy.
     """
     player = _make_pin_required_player()
     pairing_session = player._active_pairing  # captured before _finish_pairing clears it
@@ -271,10 +278,10 @@ async def test_finish_pairing_persists_credentials_to_live_config() -> None:
     # the response payload for the UI/API caller must contain the credentials...
     assert values[CONF_AIRPLAY_CREDENTIALS] == FAKE_HAP_CREDENTIALS
     # ...but that alone is not enough: config/players/get_entries never persists
-    # `values` anywhere, so the live PlayerConfig must be updated explicitly too
-    # (mirroring what _reset_pairing already does for the clear-credentials case).
-    player.config.update.assert_called_once_with(  # type: ignore[attr-defined]
-        {CONF_AIRPLAY_CREDENTIALS: FAKE_HAP_CREDENTIALS}
+    # `values` anywhere, so the change must be written through the real config
+    # persistence path (mirroring what _reset_pairing does for the clear case).
+    player.mass.config.save_player_config.assert_awaited_once_with(  # type: ignore[attr-defined]
+        player.player_id, {CONF_AIRPLAY_CREDENTIALS: FAKE_HAP_CREDENTIALS}
     )
     # the finished pairing session must be cleared so a stray second pairing
     # attempt from the device-side subprocess can't be mistaken for it
@@ -289,8 +296,8 @@ async def test_finish_pairing_raop_uses_raop_credentials_key() -> None:
 
     await player._finish_pairing(values, StreamingProtocol.RAOP, "RAOP")
 
-    player.config.update.assert_called_once_with(  # type: ignore[attr-defined]
-        {CONF_RAOP_CREDENTIALS: FAKE_HAP_CREDENTIALS}
+    player.mass.config.save_player_config.assert_awaited_once_with(  # type: ignore[attr-defined]
+        player.player_id, {CONF_RAOP_CREDENTIALS: FAKE_HAP_CREDENTIALS}
     )
 
 
@@ -303,7 +310,27 @@ async def test_finish_pairing_without_active_session_does_not_persist() -> None:
 
     await player._finish_pairing(values, StreamingProtocol.AIRPLAY2, "AirPlay")
 
-    player.config.update.assert_not_called()  # type: ignore[attr-defined]
+    player.mass.config.save_player_config.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_reset_pairing_persists_cleared_credentials() -> None:
+    """
+    Resetting pairing must also persist through save_player_config.
+
+    A raw config.update() alone (the previous implementation) never survives a
+    restart: the still-unchanged stored config would resurrect the "reset"
+    credentials from disk, silently re-pairing the device with stale keys.
+    """
+    player = _make_pin_required_player()
+    values: dict[str, object] = {CONF_AIRPLAY_CREDENTIALS: FAKE_HAP_CREDENTIALS}
+
+    await player._reset_pairing(values, StreamingProtocol.AIRPLAY2, "AirPlay")
+
+    assert values[CONF_AIRPLAY_CREDENTIALS] is None
+    player.mass.config.save_player_config.assert_awaited_once_with(  # type: ignore[attr-defined]
+        player.player_id, {CONF_AIRPLAY_CREDENTIALS: None, CONF_AP2PASSWORD: None}
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -1,6 +1,7 @@
 """Unit tests for AirPlay player."""
 
 import time
+from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -24,6 +25,9 @@ from music_assistant.providers.airplay.constants import (
     StreamingProtocol,
 )
 from music_assistant.providers.airplay.player import AirPlayPlayer
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ConfigValueType
 
 # _airplay._tcp features bitmask with the AirPlay 2 feature bits set (bit 38/48).
 AP2_FEATURES = "0x4A7FDFD5,0x3C177FDE"
@@ -230,7 +234,7 @@ async def test_airplay2_pairing_fails_without_ipv4_address() -> None:
 FAKE_HAP_CREDENTIALS = "ab" * 96  # 192 hex chars, as produced by cliairplay --pair-setup
 
 
-def _make_pin_required_player(**overrides: object) -> AirPlayPlayer:
+def _make_pin_required_player() -> AirPlayPlayer:
     """Create a player whose discovery info requires PIN pairing (flags bit 0x8)."""
     airplay_info = MagicMock()
     airplay_info.properties = {b"flags": b"0x8"}
@@ -243,48 +247,33 @@ def _make_pin_required_player(**overrides: object) -> AirPlayPlayer:
         model="OLED48C17LB",
         raop_discovery_info=None,
         airplay_discovery_info=airplay_info,
-        **overrides,
     )
     player._active_pairing = AsyncMock()
     player._active_pairing.finish_pairing = AsyncMock(return_value=FAKE_HAP_CREDENTIALS)
-    player.mass.config.save_player_config = AsyncMock()  # type: ignore[attr-defined]
+    cast("MagicMock", player.mass.config).save_player_config = AsyncMock()
     return player
 
 
 @pytest.mark.asyncio
 async def test_finish_pairing_persists_credentials_to_live_config() -> None:
     """
-    A successful pairing must persist the credentials, not just report them.
+    Finishing pairing persists the credentials through save_player_config.
 
-    Regression test: pairing computed valid HAP credentials and logged success
-    ("Finished AirPlay pairing for ...") but only stored them in the transient
-    `values` dict returned by the (read-only) config/players/get_entries call.
-    stream.py's `config.get_value(CONF_AIRPLAY_CREDENTIALS)` at the next play
-    attempt then found nothing, no --auth was passed to cliairplay, and it fell
-    back to asking for interactive pairing again even though pairing had just
-    succeeded (observed with an LG webOS TV as an AirPlay 2 hass_players target).
-
-    The persistence must go through save_player_config (not a raw config.update)
-    so the SECURE_STRING credentials are (a) encrypted at rest and (b) actually
-    survive a server restart instead of only living in the in-memory config copy.
+    The get_entries action flow never persists `values` itself, so without the
+    explicit save the next play attempt finds no credentials and the device
+    asks for pairing again.
     """
     player = _make_pin_required_player()
-    pairing_session = player._active_pairing  # captured before _finish_pairing clears it
-    values: dict[str, object] = {CONF_PAIRING_PIN: "1234"}
+    pairing_session = cast("AsyncMock", player._active_pairing)
+    values: dict[str, ConfigValueType] = {CONF_PAIRING_PIN: "1234"}
 
     await player._finish_pairing(values, StreamingProtocol.AIRPLAY2, "AirPlay")
 
     pairing_session.finish_pairing.assert_awaited_once_with(pin="1234")
-    # the response payload for the UI/API caller must contain the credentials...
     assert values[CONF_AIRPLAY_CREDENTIALS] == FAKE_HAP_CREDENTIALS
-    # ...but that alone is not enough: config/players/get_entries never persists
-    # `values` anywhere, so the change must be written through the real config
-    # persistence path (mirroring what _reset_pairing does for the clear case).
-    player.mass.config.save_player_config.assert_awaited_once_with(  # type: ignore[attr-defined]
+    cast("MagicMock", player.mass.config).save_player_config.assert_awaited_once_with(
         player.player_id, {CONF_AIRPLAY_CREDENTIALS: FAKE_HAP_CREDENTIALS}
     )
-    # the finished pairing session must be cleared so a stray second pairing
-    # attempt from the device-side subprocess can't be mistaken for it
     assert player._active_pairing is None
 
 
@@ -292,11 +281,11 @@ async def test_finish_pairing_persists_credentials_to_live_config() -> None:
 async def test_finish_pairing_raop_uses_raop_credentials_key() -> None:
     """RAOP (AirPlay 1) pairing must persist under the RAOP-specific config key."""
     player = _make_pin_required_player()
-    values: dict[str, object] = {CONF_PAIRING_PIN: "1234"}
+    values: dict[str, ConfigValueType] = {CONF_PAIRING_PIN: "1234"}
 
     await player._finish_pairing(values, StreamingProtocol.RAOP, "RAOP")
 
-    player.mass.config.save_player_config.assert_awaited_once_with(  # type: ignore[attr-defined]
+    cast("MagicMock", player.mass.config).save_player_config.assert_awaited_once_with(
         player.player_id, {CONF_RAOP_CREDENTIALS: FAKE_HAP_CREDENTIALS}
     )
 
@@ -306,29 +295,23 @@ async def test_finish_pairing_without_active_session_does_not_persist() -> None:
     """No active pairing session means nothing should be written to config."""
     player = _make_pin_required_player()
     player._active_pairing = None
-    values: dict[str, object] = {CONF_PAIRING_PIN: "1234"}
+    values: dict[str, ConfigValueType] = {CONF_PAIRING_PIN: "1234"}
 
     await player._finish_pairing(values, StreamingProtocol.AIRPLAY2, "AirPlay")
 
-    player.mass.config.save_player_config.assert_not_awaited()  # type: ignore[attr-defined]
+    cast("MagicMock", player.mass.config).save_player_config.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_reset_pairing_persists_cleared_credentials() -> None:
-    """
-    Resetting pairing must also persist through save_player_config.
-
-    A raw config.update() alone (the previous implementation) never survives a
-    restart: the still-unchanged stored config would resurrect the "reset"
-    credentials from disk, silently re-pairing the device with stale keys.
-    """
+    """Resetting pairing persists the cleared credentials so a restart cannot revive them."""
     player = _make_pin_required_player()
-    values: dict[str, object] = {CONF_AIRPLAY_CREDENTIALS: FAKE_HAP_CREDENTIALS}
+    values: dict[str, ConfigValueType] = {CONF_AIRPLAY_CREDENTIALS: FAKE_HAP_CREDENTIALS}
 
     await player._reset_pairing(values, StreamingProtocol.AIRPLAY2, "AirPlay")
 
     assert values[CONF_AIRPLAY_CREDENTIALS] is None
-    player.mass.config.save_player_config.assert_awaited_once_with(  # type: ignore[attr-defined]
+    cast("MagicMock", player.mass.config).save_player_config.assert_awaited_once_with(
         player.player_id, {CONF_AIRPLAY_CREDENTIALS: None, CONF_AP2PASSWORD: None}
     )
 

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -17,6 +17,7 @@ from music_assistant.providers.airplay.constants import (
     CONF_FORCE_RAOP,
     CONF_HIRES_PLAYBACK,
     CONF_IGNORE_VOLUME,
+    CONF_PAIRING_PIN,
     CONF_RAOP_CREDENTIALS,
     CONF_STORED_VOLUME,
     StreamingProtocol,
@@ -223,6 +224,86 @@ async def test_airplay2_pairing_fails_without_ipv4_address() -> None:
         pytest.raises(PlayerCommandFailed, match="requires an IPv4"),
     ):
         await player._start_pairing(StreamingProtocol.AIRPLAY2, "AirPlay")
+
+
+FAKE_HAP_CREDENTIALS = "ab" * 96  # 192 hex chars, as produced by cliairplay --pair-setup
+
+
+def _make_pin_required_player(**overrides: object) -> AirPlayPlayer:
+    """Create a player whose discovery info requires PIN pairing (flags bit 0x8)."""
+    airplay_info = MagicMock()
+    airplay_info.properties = {b"flags": b"0x8"}
+    player = AirPlayPlayer(
+        provider=MagicMock(),
+        player_id="test_player",
+        display_name="Wohnzimmer TV",
+        address="127.0.0.1",
+        manufacturer="LG",
+        model="OLED48C17LB",
+        raop_discovery_info=None,
+        airplay_discovery_info=airplay_info,
+        **overrides,
+    )
+    player._active_pairing = AsyncMock()
+    player._active_pairing.finish_pairing = AsyncMock(return_value=FAKE_HAP_CREDENTIALS)
+    return player
+
+
+@pytest.mark.asyncio
+async def test_finish_pairing_persists_credentials_to_live_config() -> None:
+    """A successful pairing must write the credentials into the live player config.
+
+    Regression test: pairing computed valid HAP credentials and logged success
+    ("Finished AirPlay pairing for ...") but only stored them in the transient
+    `values` dict returned by the (read-only) config/players/get_entries call.
+    stream.py's `config.get_value(CONF_AIRPLAY_CREDENTIALS)` at the next play
+    attempt then found nothing, no --auth was passed to cliairplay, and it fell
+    back to asking for interactive pairing again even though pairing had just
+    succeeded (observed with an LG webOS TV as an AirPlay 2 hass_players target).
+    """
+    player = _make_pin_required_player()
+    pairing_session = player._active_pairing  # captured before _finish_pairing clears it
+    values: dict[str, object] = {CONF_PAIRING_PIN: "1234"}
+
+    await player._finish_pairing(values, StreamingProtocol.AIRPLAY2, "AirPlay")
+
+    pairing_session.finish_pairing.assert_awaited_once_with(pin="1234")
+    # the response payload for the UI/API caller must contain the credentials...
+    assert values[CONF_AIRPLAY_CREDENTIALS] == FAKE_HAP_CREDENTIALS
+    # ...but that alone is not enough: config/players/get_entries never persists
+    # `values` anywhere, so the live PlayerConfig must be updated explicitly too
+    # (mirroring what _reset_pairing already does for the clear-credentials case).
+    player.config.update.assert_called_once_with(  # type: ignore[attr-defined]
+        {CONF_AIRPLAY_CREDENTIALS: FAKE_HAP_CREDENTIALS}
+    )
+    # the finished pairing session must be cleared so a stray second pairing
+    # attempt from the device-side subprocess can't be mistaken for it
+    assert player._active_pairing is None
+
+
+@pytest.mark.asyncio
+async def test_finish_pairing_raop_uses_raop_credentials_key() -> None:
+    """RAOP (AirPlay 1) pairing must persist under the RAOP-specific config key."""
+    player = _make_pin_required_player()
+    values: dict[str, object] = {CONF_PAIRING_PIN: "1234"}
+
+    await player._finish_pairing(values, StreamingProtocol.RAOP, "RAOP")
+
+    player.config.update.assert_called_once_with(  # type: ignore[attr-defined]
+        {CONF_RAOP_CREDENTIALS: FAKE_HAP_CREDENTIALS}
+    )
+
+
+@pytest.mark.asyncio
+async def test_finish_pairing_without_active_session_does_not_persist() -> None:
+    """No active pairing session means nothing should be written to config."""
+    player = _make_pin_required_player()
+    player._active_pairing = None
+    values: dict[str, object] = {CONF_PAIRING_PIN: "1234"}
+
+    await player._finish_pairing(values, StreamingProtocol.AIRPLAY2, "AirPlay")
+
+    player.config.update.assert_not_called()  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this implement/fix?

Fixes #5895 — AirPlay 2 pairing to an LG webOS TV reported success, but the very next playback attempt still failed and `cliairplay` fell back to asking for interactive pairing again.

Root cause: `AirPlayPlayer._finish_pairing()` computes the HAP credentials and logs `"Finished AirPlay pairing for ..."`, but only stores them into the transient `values` dict returned by the (read-only, `CONFIG_PLAYERS_READ`-scoped) `config/players/get_entries` call. Nothing on that call path writes the value back into the player's live `PlayerConfig`, so `stream.py`'s `self.player.config.get_value(CONF_AIRPLAY_CREDENTIALS)` at play time finds nothing, no `--auth` is passed to `cliairplay`, and it asks for pairing again — even though pairing had just succeeded.

The sibling method `_reset_pairing()` a few lines below already persists correctly via `self.config.update(...)` for the clear-credentials case; `_finish_pairing()` was simply missing the equivalent call for the success case.

Fix: add the missing `self.config.update({cred_key: credentials})` call, mirroring `_reset_pairing`.

**Verified against real hardware** (LG OLED48C17LB, webOS 03.53.45, AirPlay 2 via the `hass_players` provider): before the fix, pairing followed by an immediate `play_media` reproduced the bug exactly (pairing succeeds, then `cliap2` asks for pairing again, second PIN prompt can't be answered — `"No active pairing session"`). With the fix applied, the same pair-then-play sequence streams successfully with no second pairing prompt.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
