### PR TITLE
Restore Siri Remote playback controls

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 from typing import Final
 
 from music_assistant_models.enums import ContentType, PlayerFeature
@@ -19,6 +19,16 @@ class StreamingProtocol(IntEnum):
 
     RAOP = 1  # AirPlay 1 (RAOP)
     AIRPLAY2 = 2  # AirPlay 2
+
+
+class AirPlayRemoteCommand(StrEnum):
+    """Transport commands received from an AirPlay receiver."""
+
+    PLAY = "play"
+    PAUSE = "pause"
+    PLAY_PAUSE = "play_pause"
+    NEXT = "next"
+    PREVIOUS = "previous"
 
 
 CONF_VOLUME_START: Final[str] = "volume_start"

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -39,6 +39,7 @@ from .constants import (
     DACP_DISCOVERY_TYPE,
     FALLBACK_VOLUME,
     RAOP_DISCOVERY_TYPE,
+    AirPlayRemoteCommand,
     StreamingProtocol,
 )
 from .helpers import convert_airplay_volume, get_cli_binary, get_model_info
@@ -138,6 +139,24 @@ class AirPlayProvider(PlayerProvider):
             ready_task.cancel()
             exit_task.cancel()
             await asyncio.gather(ready_task, exit_task, return_exceptions=True)
+
+    def handle_remote_command(self, player: AirPlayPlayer, command: AirPlayRemoteCommand) -> None:
+        """Dispatch a transport command received from an AirPlay receiver."""
+        player_id = player.player_id
+        match command:
+            case AirPlayRemoteCommand.PLAY:
+                # Some receivers echo play as confirmation of a command from MA.
+                if player.playback_state != PlaybackState.PLAYING:
+                    self.mass.create_task(self.mass.players.cmd_play(player_id))
+            case AirPlayRemoteCommand.PAUSE:
+                if player.playback_state == PlaybackState.PLAYING:
+                    self.mass.create_task(self.mass.players.cmd_pause(player_id))
+            case AirPlayRemoteCommand.PLAY_PAUSE:
+                self.mass.create_task(self.mass.players.cmd_play_pause(player_id))
+            case AirPlayRemoteCommand.NEXT:
+                self.mass.create_task(self.mass.players.cmd_next_track(player_id))
+            case AirPlayRemoteCommand.PREVIOUS:
+                self.mass.create_task(self.mass.players.cmd_previous_track(player_id))
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
@@ -584,16 +603,13 @@ class AirPlayProvider(PlayerProvider):
                 or player.device_info.manufacturer.lower() == "apple"
             )
             if path == "/ctrl-int/1/nextitem":
-                self.mass.create_task(self.mass.players.cmd_next_track(player_id))
+                self.handle_remote_command(player, AirPlayRemoteCommand.NEXT)
             elif path == "/ctrl-int/1/previtem":
-                self.mass.create_task(self.mass.players.cmd_previous_track(player_id))
+                self.handle_remote_command(player, AirPlayRemoteCommand.PREVIOUS)
             elif path == "/ctrl-int/1/play":
-                # sometimes this request is sent by a device as confirmation of a play command
-                # we ignore this if the player is already playing
-                if player.playback_state != PlaybackState.PLAYING:
-                    self.mass.create_task(self.mass.players.cmd_play(player_id))
+                self.handle_remote_command(player, AirPlayRemoteCommand.PLAY)
             elif path == "/ctrl-int/1/playpause":
-                self.mass.create_task(self.mass.players.cmd_play_pause(player_id))
+                self.handle_remote_command(player, AirPlayRemoteCommand.PLAY_PAUSE)
             elif path == "/ctrl-int/1/stop":
                 self.mass.create_task(self.mass.players.cmd_stop(player_id))
             elif path == "/ctrl-int/1/volumeup":
@@ -608,8 +624,7 @@ class AirPlayProvider(PlayerProvider):
                     active_queue.queue_id, not active_queue.shuffle_enabled
                 )
             elif path == "/ctrl-int/1/pause":
-                if player.state.playback_state == PlaybackState.PLAYING:
-                    self.mass.create_task(self.mass.players.cmd_pause(player_id))
+                self.handle_remote_command(player, AirPlayRemoteCommand.PAUSE)
             elif path == "/ctrl-int/1/discrete-pause":
                 # Some devices send discrete-pause right before device-prevent-playback=1
                 # when switching to another source. We debounce the pause to avoid

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -31,6 +31,7 @@ from music_assistant.providers.airplay.constants import (
     CONF_ENCRYPTION,
     CONF_PASSWORD,
     CONF_RAOP_CREDENTIALS,
+    AirPlayRemoteCommand,
     StreamingProtocol,
 )
 from music_assistant.providers.airplay.helpers import (
@@ -485,6 +486,7 @@ class AirPlayStream:
           [STATUS] route protocol=<raop|airplay2> flow=<...> timing=<ntp|ptp> buffered=<0|1>
           [STATUS] latency lead_ms=<int> device_min_frames=<int> device_max_frames=<int>
           [STATUS] mrp path=<command> status=<http status>
+          [EVENT] remote command=<play|pause|play_pause|next|previous>
         """
         if not self._cli_proc:
             return
@@ -502,7 +504,22 @@ class AirPlayStream:
                     self._parse_mrp_status(line)
                 elif "[STATUS] latency" in line:
                     self._parse_latency_status(line)
+                elif line.startswith("[EVENT] remote command="):
+                    self._parse_remote_event(line)
                 self.player.logger.log(VERBOSE_LOG_LEVEL, line)
+
+    def _parse_remote_event(self, line: str) -> None:
+        """Dispatch a normalized remote command reported by cliairplay."""
+        command_value = line.removeprefix("[EVENT] remote command=").strip()
+        try:
+            command = AirPlayRemoteCommand(command_value)
+        except ValueError:
+            self.player.logger.warning(
+                "Ignoring unknown cliairplay remote command: %s", command_value
+            )
+            return
+        prov = cast("AirPlayProvider", self.prov)
+        prov.handle_remote_command(self.player, command)
 
     def _parse_mrp_status(self, line: str) -> None:
         """Parse the [STATUS] mrp line and log the now-playing push result."""

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -10,7 +10,11 @@ import pytest
 from music_assistant_models.enums import ContentType, PlaybackState
 from music_assistant_models.media_items import AudioFormat
 
-from music_assistant.providers.airplay.constants import CONF_ENCRYPTION, StreamingProtocol
+from music_assistant.providers.airplay.constants import (
+    CONF_ENCRYPTION,
+    AirPlayRemoteCommand,
+    StreamingProtocol,
+)
 from music_assistant.providers.airplay.stream import AirPlayStream
 
 START_UNIX_MS = 1_750_000_000_000
@@ -252,6 +256,55 @@ def test_parse_latency_status() -> None:
     assert stream.latency_lead_ms == 1750
     assert stream.device_min_frames == 11025
     assert stream.device_max_frames == 88200
+
+
+@pytest.mark.parametrize(
+    ("value", "command"),
+    [
+        ("play", AirPlayRemoteCommand.PLAY),
+        ("pause", AirPlayRemoteCommand.PAUSE),
+        ("play_pause", AirPlayRemoteCommand.PLAY_PAUSE),
+        ("next", AirPlayRemoteCommand.NEXT),
+        ("previous", AirPlayRemoteCommand.PREVIOUS),
+    ],
+)
+def test_parse_remote_event(value: str, command: AirPlayRemoteCommand) -> None:
+    """A normalized CLI remote event is dispatched against its own player."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+
+    stream._parse_remote_event(f"[EVENT] remote command={value}")
+
+    player.provider.handle_remote_command.assert_called_once_with(player, command)
+
+
+def test_parse_remote_event_rejects_unknown_command(caplog: pytest.LogCaptureFixture) -> None:
+    """An unknown CLI remote event is reported and ignored."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+
+    with caplog.at_level(logging.WARNING):
+        stream._parse_remote_event("[EVENT] remote command=unsupported")
+
+    player.provider.handle_remote_command.assert_not_called()
+    assert "Ignoring unknown cliairplay remote command: unsupported" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stdout_reader_dispatches_remote_events_once() -> None:
+    """The CLI stdout reader dispatches each normalized remote event exactly once."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    process = MagicMock()
+    output = "".join(f"[EVENT] remote command={command}\n" for command in AirPlayRemoteCommand)
+    process.read = AsyncMock(side_effect=[output.encode(), b""])
+    stream._cli_proc = process
+
+    await stream._stdout_reader()
+
+    assert player.provider.handle_remote_command.call_args_list == [
+        call(player, command) for command in AirPlayRemoteCommand
+    ]
 
 
 def test_temporary_paths_are_unique_per_stream() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Modern Apple TVs send Siri Remote transport commands over the encrypted AirPlay event channel instead of DACP, so the commands were acknowledged but never reached Music Assistant.

- Handles normalized play, pause, play/pause, next, and previous events for the active AirPlay stream.
- Reuses the same command dispatch for modern event callbacks and the existing DACP fallback.
- Adds regression coverage for every command, unknown events, and exactly-once stdout dispatch.

Depends on [music-assistant/airplay-cli#6](https://github.com/music-assistant/airplay-cli/pull/6). After that PR merges, the `v0.1.1` release workflow will open the server binary pin update.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.