### PR TITLE
Fix container build: pin numkong to 7.7.0 (7.7.1 ships no wheels)

### DIFF
--- a/music_assistant/providers/sonic_similarity/manifest.json
+++ b/music_assistant/providers/sonic_similarity/manifest.json
@@ -7,6 +7,7 @@
   "codeowners": ["@music-assistant"],
   "requirements": [
     "usearch==2.25.3",
+    "numkong==7.7.0",
     "transformers==5.6.2",
     "huggingface-hub==1.22.0"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -55,6 +55,7 @@ music-assistant-models==1.1.166
 mutagen==1.48.1
 niconico.py-ma==2.1.0.post2
 nnAudio==0.3.3
+numkong==7.7.0
 numpy==2.3.5
 onedrive-personal-sdk==0.1.7
 orjson==3.11.6


### PR DESCRIPTION
# What does this implement/fix?

The container build (and thus the dev Auto Release) fails while installing requirements:

```
error: command 'gcc' failed: No such file or directory
× Failed to build `numkong==7.7.1`
hint: `numkong` (v7.7.1) was included because `usearch` (v2.25.3) depends on `numkong`
```

`numkong` is an unpinned transitive dependency of `usearch` (Sonic Similarity provider). Version `7.7.1`, published 2026-07-21, ships an **sdist only — no wheels**. The nightly resolves transitive deps fresh, picked up 7.7.1, and fell back to compiling the C extension from source, which fails because the build image has no `gcc`. Every earlier release (incl. 7.7.0) ships cp314 wheels.

Pin `numkong==7.7.0` in the Sonic Similarity manifest so resolution uses the last wheel-shipping release. `usearch==2.25.3` declares `numkong` with no version bound, so there is no conflict. Pin can be dropped once numkong publishes wheels again.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
