### PR TITLE
Fix next-track enqueue after delayed player start

### DIFF
--- a/music_assistant/controllers/player_queues/stream_feeder.py
+++ b/music_assistant/controllers/player_queues/stream_feeder.py
@@ -98,13 +98,30 @@ class StreamFeederMixin(_PlayerQueuesBase):
             return
 
         async def _enqueue_next_item_on_player(next_item: QueueItem) -> None:
-            if (
-                not queue.active
-                or queue_data.session_id != session_id
-                or queue.state != PlaybackState.PLAYING
+            async with self.mass.players.wait_for_player_update(
+                queue_id,
+                attribute_name="playback_state",
+                attribute_value=PlaybackState.PLAYING,
             ):
-                # queue is not active anymore or session_id does not match, so we bail out
+                pass
+
+            player = self.mass.players.get_player(queue_id)
+            if (
+                player is None
+                or player.state.playback_state != PlaybackState.PLAYING
+                or player.state.active_source not in (queue.queue_id, None)
+                or queue_data.session_id != session_id
+                or queue.flow_mode
+            ):
                 return
+
+            current_index = queue.index_in_buffer
+            if current_index is None:
+                return
+            current_next = self.get_next_item(queue_id, current_index)
+            if current_next is None or current_next.queue_item_id != next_item.queue_item_id:
+                return
+
             await self.mass.players.enqueue_next_media(
                 player_id=queue_id,
                 media=await self.player_media_from_queue_item(next_item),

--- a/music_assistant/controllers/player_queues/stream_feeder.py
+++ b/music_assistant/controllers/player_queues/stream_feeder.py
@@ -98,6 +98,7 @@ class StreamFeederMixin(_PlayerQueuesBase):
             return
 
         async def _enqueue_next_item_on_player(next_item: QueueItem) -> None:
+            # Player state updates can lag behind queue loading, so wait before validating.
             async with self.mass.players.wait_for_player_update(
                 queue_id,
                 attribute_name="playback_state",

--- a/tests/controllers/player_queues/test_stream_feeder.py
+++ b/tests/controllers/player_queues/test_stream_feeder.py
@@ -87,21 +87,6 @@ async def test_enqueue_next_item_waits_for_playing_player_update() -> None:
     assert controller._queue_data["q1"].next_item_id_enqueued == "next"
 
 
-class _BlockingWaitForPlayerUpdate:
-    """Async context manager that blocks until the test releases it."""
-
-    def __init__(self) -> None:
-        self.entered = asyncio.Event()
-        self.released = asyncio.Event()
-
-    async def __aenter__(self) -> None:
-        self.entered.set()
-        await self.released.wait()
-
-    async def __aexit__(self, *args: object) -> bool:
-        return False
-
-
 def _make_queue_item(queue_id: str, item_id: str) -> QueueItem:
     """Build a minimal playable queue item."""
     return QueueItem(

--- a/tests/controllers/player_queues/test_stream_feeder.py
+++ b/tests/controllers/player_queues/test_stream_feeder.py
@@ -1,0 +1,112 @@
+"""Regression tests for delayed next-track enqueueing in the player queue stream feeder."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import PlaybackState
+from music_assistant_models.player_queue import PlayerQueue
+from music_assistant_models.queue_item import QueueItem
+
+from music_assistant.controllers.player_queues import PlayerQueuesController
+from music_assistant.controllers.player_queues.state import PlayerQueueData
+
+
+async def test_enqueue_next_item_waits_for_playing_player_update() -> None:
+    """The queued next item is enqueued after the player update reports PLAYING."""
+    controller = PlayerQueuesController.__new__(PlayerQueuesController)
+    controller.logger = MagicMock()
+
+    wait_entered = asyncio.Event()
+    release_wait = asyncio.Event()
+
+    @asynccontextmanager
+    async def wait_for_player_update(*_args: object, **_kwargs: object) -> AsyncIterator[None]:
+        wait_entered.set()
+        await release_wait.wait()
+        yield
+
+    player_state = SimpleNamespace(
+        playback_state=PlaybackState.IDLE,
+        active_source="q1",
+    )
+    player = SimpleNamespace(state=player_state)
+
+    mass = MagicMock()
+    mass.players = MagicMock()
+    mass.players.wait_for_player_update = MagicMock(side_effect=wait_for_player_update)
+    mass.players.get_player = MagicMock(return_value=player)
+    mass.players.enqueue_next_media = AsyncMock()
+    controller.mass = mass
+
+    current_item = _make_queue_item("q1", "current")
+    next_item = _make_queue_item("q1", "next")
+    queue = PlayerQueue(
+        queue_id="q1",
+        active=True,
+        display_name="Q1",
+        available=True,
+        items=2,
+        state=PlaybackState.IDLE,
+        current_index=0,
+        index_in_buffer=0,
+        current_item=current_item,
+    )
+    controller._queue_data = {
+        "q1": PlayerQueueData(
+            queue=queue,
+            items=[current_item, next_item],
+            session_id="session-1",
+        )
+    }
+
+    controller._enqueue_next_item("q1", next_item)
+    enqueue_callback = mass.call_later.call_args.args[1]
+    enqueue_task = asyncio.create_task(enqueue_callback(next_item))
+    await asyncio.sleep(0)
+
+    assert wait_entered.is_set()
+    mass.players.enqueue_next_media.assert_not_awaited()
+
+    player_state.playback_state = PlaybackState.PLAYING
+    release_wait.set()
+    await enqueue_task
+
+    mass.players.wait_for_player_update.assert_called_once_with(
+        "q1",
+        attribute_name="playback_state",
+        attribute_value=PlaybackState.PLAYING,
+    )
+    mass.players.enqueue_next_media.assert_awaited_once()
+    assert mass.players.enqueue_next_media.await_args.kwargs["player_id"] == "q1"
+    assert mass.players.enqueue_next_media.await_args.kwargs["media"].queue_item_id == "next"
+    assert controller._queue_data["q1"].next_item_id_enqueued == "next"
+
+
+class _BlockingWaitForPlayerUpdate:
+    """Async context manager that blocks until the test releases it."""
+
+    def __init__(self) -> None:
+        self.entered = asyncio.Event()
+        self.released = asyncio.Event()
+
+    async def __aenter__(self) -> None:
+        self.entered.set()
+        await self.released.wait()
+
+    async def __aexit__(self, *args: object) -> bool:
+        return False
+
+
+def _make_queue_item(queue_id: str, item_id: str) -> QueueItem:
+    """Build a minimal playable queue item."""
+    return QueueItem(
+        queue_id=queue_id,
+        queue_item_id=item_id,
+        name=item_id,
+        duration=60,
+    )


### PR DESCRIPTION
# What does this implement/fix?

A delayed player-state update could make the one-shot enqueue callback see stale idle state and abandon the next track. Wait for the player to report playback before validating that the queue session and next item are still current.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project AI Policy for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.