### PR TITLE
Fix next-track enqueue after dynamic queue reindex

### DIFF
--- a/music_assistant/controllers/player_queues/stream_feeder.py
+++ b/music_assistant/controllers/player_queues/stream_feeder.py
@@ -116,10 +116,10 @@ class StreamFeederMixin(_PlayerQueuesBase):
             ):
                 return
 
-            current_index = queue.index_in_buffer
-            if current_index is None:
+            current_item = queue.current_item
+            if current_item is None:
                 return
-            current_next = self.get_next_item(queue_id, current_index)
+            current_next = self.get_next_item(queue_id, current_item.queue_item_id)
             if current_next is None or current_next.queue_item_id != next_item.queue_item_id:
                 return
 

--- a/tests/controllers/player_queues/test_stream_feeder.py
+++ b/tests/controllers/player_queues/test_stream_feeder.py
@@ -8,6 +8,7 @@ from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from music_assistant_models.enums import PlaybackState
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
@@ -16,8 +17,13 @@ from music_assistant.controllers.player_queues import PlayerQueuesController
 from music_assistant.controllers.player_queues.state import PlayerQueueData
 
 
-async def test_enqueue_next_item_waits_for_playing_player_update() -> None:
-    """The queued next item is enqueued after the player update reports PLAYING."""
+@pytest.mark.parametrize(
+    "index_in_buffer",
+    [0, 1],
+    ids=["aligned-buffer-index", "dynamic-queue-reindexed"],
+)
+async def test_enqueue_next_item_waits_for_playing_player_update(index_in_buffer: int) -> None:
+    """Enqueue the expected next item after an update, even if its buffered index is stale."""
     controller = PlayerQueuesController.__new__(PlayerQueuesController)
     controller.logger = MagicMock()
 
@@ -43,23 +49,25 @@ async def test_enqueue_next_item_waits_for_playing_player_update() -> None:
     mass.players.enqueue_next_media = AsyncMock()
     controller.mass = mass
 
-    current_item = _make_queue_item("q1", "current")
-    next_item = _make_queue_item("q1", "next")
+    current_item = _make_queue_item("q1", "nerin")
+    next_item = _make_queue_item("q1", "another-love")
+    future_item = _make_queue_item("q1", "future-track")
+    queue_items = [current_item, next_item, future_item]
     queue = PlayerQueue(
         queue_id="q1",
         active=True,
         display_name="Q1",
         available=True,
-        items=2,
+        items=len(queue_items),
         state=PlaybackState.IDLE,
         current_index=0,
-        index_in_buffer=0,
+        index_in_buffer=index_in_buffer,
         current_item=current_item,
     )
     controller._queue_data = {
         "q1": PlayerQueueData(
             queue=queue,
-            items=[current_item, next_item],
+            items=queue_items,
             session_id="session-1",
         )
     }
@@ -83,8 +91,11 @@ async def test_enqueue_next_item_waits_for_playing_player_update() -> None:
     )
     mass.players.enqueue_next_media.assert_awaited_once()
     assert mass.players.enqueue_next_media.await_args.kwargs["player_id"] == "q1"
-    assert mass.players.enqueue_next_media.await_args.kwargs["media"].queue_item_id == "next"
-    assert controller._queue_data["q1"].next_item_id_enqueued == "next"
+    assert (
+        mass.players.enqueue_next_media.await_args.kwargs["media"].queue_item_id
+        == next_item.queue_item_id
+    )
+    assert controller._queue_data["q1"].next_item_id_enqueued == next_item.queue_item_id
 
 
 def _make_queue_item(queue_id: str, item_id: str) -> QueueItem:


### PR DESCRIPTION
# What does this implement/fix?

Dynamic queues can shift items while a track is buffered, leaving the numeric buffer index stale. The enqueue callback now resolves the expected next item from the stable current item ID so valid next tracks are not rejected.

- Resolve the next item from the current queue item ID.
- Cover aligned and stale buffer indexes with regression tests.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project AI Policy for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.