### PR TITLE
AirPlay: use one clock identity for multi-room timing

### DIFF
--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -646,7 +646,10 @@ class AirPlayProvider(PlayerProvider):
                 err,
             )
             return
-        args = [cli_binary, "--ptp-daemon"]
+        # Advertise the same grandmaster identity as the per-stream sessions
+        # (which derive their PTP clock id from --dacp), so receivers see one
+        # consistent clock whether the daemon or an in-process engine serves it.
+        args = [cli_binary, "--ptp-daemon", "--dacp", self.dacp_id]
         bind_ip = str(self.mass.streams.bind_ip)
         if bind_ip not in ("0.0.0.0", "::", ""):
             args += ["--if", bind_ip]

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -202,6 +202,38 @@ def _live_ptp_daemon() -> MagicMock:
     return daemon
 
 
+async def test_ptp_daemon_spawn_advertises_dacp_identity() -> None:
+    """The spawned PTP daemon is handed the provider's DACP id as its clock identity."""
+    prov = _ptp_provider()
+    prov.dacp_id = "AABBCCDD11223344"
+    prov.mass = MagicMock()
+    prov.mass.streams.bind_ip = "0.0.0.0"
+
+    def _consume_task(coro: object) -> MagicMock:
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        return MagicMock()
+
+    prov.mass.create_task.side_effect = _consume_task
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.provider.get_cli_binary",
+            AsyncMock(return_value="/bin/cliairplay"),
+        ),
+        patch("music_assistant.providers.airplay.provider.AsyncProcess") as process_cls,
+    ):
+        process_cls.return_value.start = AsyncMock()
+        await prov._start_ptp_daemon()
+
+    assert process_cls.call_args.args[0] == [
+        "/bin/cliairplay",
+        "--ptp-daemon",
+        "--dacp",
+        "AABBCCDD11223344",
+    ]
+
+
 def test_ptp_daemon_ready_event_set_on_daemon_up_line() -> None:
     """The readiness event is set when the daemon prints its 'daemon up' line."""
     prov = _ptp_provider()


### PR DESCRIPTION
# What does this implement/fix?

AirPlay streams derive their timing (PTP) clock identity from the provider's DACP id, but the shared multi-room timing daemon advertised its own default identity. This passes the same identity to the daemon, so receivers see one consistent clock whether timing comes from the daemon or from a single stream's in-process engine.

Pairs with music-assistant/airplay-cli#7 (which teaches the daemon the flag); older cliairplay binaries simply ignore it, so this is safe to merge independently.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.