### PR TITLE
Add announcement support for ESPHome-based Sendspin players

### DIFF
--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -13,7 +13,7 @@ import asyncio
 import logging
 import os
 from functools import partial
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, TypedDict, cast
 
 import shortuuid
 from aiohttp import ClientError
@@ -47,6 +47,7 @@ from music_assistant_models.streamdetails import StreamDetails
 from music_assistant.constants import MASS_LOGO_ONLINE, VERBOSE_LOG_LEVEL
 from music_assistant.helpers.auth import AuthenticationHelper
 from music_assistant.helpers.json import SerializableType
+from music_assistant.helpers.tags import async_parse_tags
 from music_assistant.helpers.util import try_parse_int
 from music_assistant.models.plugin import PluginProvider
 
@@ -81,6 +82,15 @@ STATE_FETCH_CONCURRENCY = 8
 CONTROL_DOMAINS = ("media_player", "switch", "input_boolean", "number", "input_number")
 # Home Assistant entity domains that back the TTS and AI Task features.
 FEATURE_DOMAINS = ("tts", "ai_task")
+
+
+class DeviceMediaPlayerInfo(TypedDict):
+    """Home Assistant correlation info for a device that is natively connected elsewhere."""
+
+    # user-facing device name in HA (name_by_user or name)
+    name: str | None
+    # first enabled media_player entity of the device that supports announcements
+    announce_entity_id: str | None
 
 
 async def setup(
@@ -426,6 +436,85 @@ class HomeAssistantProvider(PluginProvider):
                     return device
         return None
 
+    async def get_media_player_device_infos(
+        self,
+        mac_addresses: Collection[str],
+        platform: str,
+    ) -> dict[str, DeviceMediaPlayerInfo]:
+        """
+        Correlate devices (by MAC address) to their HA name and media_player entity.
+
+        Used for devices that are natively connected to Music Assistant but also
+        present in Home Assistant, to pick up their HA device name and their
+        (announcement-capable) media_player entity.
+
+        :param mac_addresses: Device MAC addresses to look up (case-insensitive).
+        :param platform: The HA integration domain the media_player entities must belong to.
+        :return: Correlation info keyed by lowercased MAC address; devices unknown
+            to Home Assistant are absent from the result.
+        """
+        wanted_macs = {mac.lower() for mac in mac_addresses}
+        if not wanted_macs:
+            return {}
+        device_registry = await self.hass.get_device_registry()
+        device_by_mac: dict[str, Device] = {
+            connection[1].lower(): device
+            for device in device_registry
+            for connection in device.get("connections", [])
+            if len(connection) == 2
+            and connection[0] == "mac"
+            and connection[1].lower() in wanted_macs
+        }
+        if not device_by_mac:
+            return {}
+        media_players_by_device: dict[str, list[str]] = {}
+        for entry in await self.hass.get_entity_registry():
+            if (
+                entry["platform"] == platform
+                and entry["entity_id"].startswith("media_player.")
+                and entry.get("disabled_by") is None
+            ):
+                media_players_by_device.setdefault(entry["device_id"], []).append(
+                    entry["entity_id"]
+                )
+        candidates_by_mac = {
+            mac: media_players_by_device.get(device["id"], [])
+            for mac, device in device_by_mac.items()
+        }
+        states = {
+            state["entity_id"]: state
+            for state in await self.get_states(
+                entity_ids=[
+                    entity_id
+                    for entity_ids in candidates_by_mac.values()
+                    for entity_id in entity_ids
+                ]
+            )
+        }
+
+        def _supports_announce(entity_id: str) -> bool:
+            if (state := states.get(entity_id)) is None:
+                return False
+            supported_features = MediaPlayerEntityFeature(
+                state["attributes"].get("supported_features") or 0
+            )
+            return MediaPlayerEntityFeature.MEDIA_ANNOUNCE in supported_features
+
+        return {
+            mac: DeviceMediaPlayerInfo(
+                name=device["name_by_user"] or device["name"],
+                announce_entity_id=next(
+                    (
+                        entity_id
+                        for entity_id in candidates_by_mac[mac]
+                        if _supports_announce(entity_id)
+                    ),
+                    None,
+                ),
+            )
+            for mac, device in device_by_mac.items()
+        }
+
     async def get_user_details(self, ha_user_id: str) -> tuple[str | None, str | None, str | None]:
         """
         Get user username, display name and avatar URL from Home Assistant.
@@ -580,6 +669,32 @@ class HomeAssistantProvider(PluginProvider):
             msg = f"AI Task returned no data in response: {result}"
             raise MusicAssistantError(msg)
         return str(data)
+
+    async def play_announcement_on_entity(self, entity_id: str, announcement_url: str) -> None:
+        """
+        Play an announcement on a Home Assistant media_player entity.
+
+        Uses Home Assistant's announce feature, so the entity's integration ducks
+        or pauses any running playback and resumes it afterwards. Returns once the
+        announcement has finished playing (approximated by its duration).
+
+        :param entity_id: The media_player entity to play the announcement on.
+        :param announcement_url: URL of the announcement audio to play.
+        """
+        await self.hass.call_service(
+            domain="media_player",
+            service="play_media",
+            service_data={
+                "media_content_id": announcement_url,
+                "media_content_type": "music",
+                "announce": True,
+            },
+            target={"entity_id": entity_id},
+        )
+        # Wait until the announcement is finished playing so callers can play
+        # announcements in a sequence; HA gives no completion signal for announcements.
+        media_info = await async_parse_tags(announcement_url, require_duration=True)
+        await asyncio.sleep(media_info.duration or 5)
 
     async def get_tts_message(self, message: str, language: str | None = None) -> StreamDetails:
         """Handle text-to-speech via Home Assistant's REST API."""

--- a/music_assistant/providers/hass_players/player.py
+++ b/music_assistant/providers/hass_players/player.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import time
 from typing import TYPE_CHECKING, Any, cast
 
@@ -24,7 +23,6 @@ from music_assistant.constants import (
     create_output_codec_config_entry,
 )
 from music_assistant.helpers.datetime import from_iso_string
-from music_assistant.helpers.tags import async_parse_tags
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia, PlayerSource
 from music_assistant.models.player_provider import PlayerProvider
 from music_assistant.providers.hass.constants import (
@@ -314,21 +312,8 @@ class HomeAssistantPlayer(Player):
                 "Announcement volume level is not supported for player %s",
                 self.display_name,
             )
-        await self.hass.call_service(
-            domain="media_player",
-            service="play_media",
-            service_data={
-                "media_content_id": announcement.uri,
-                "media_content_type": "music",
-                "announce": True,
-            },
-            target={"entity_id": self.player_id},
-        )
-        # Wait until the announcement is finished playing
-        # This is helpful for people who want to play announcements in a sequence
-        media_info = await async_parse_tags(announcement.uri, require_duration=True)
-        duration = media_info.duration or 5
-        await asyncio.sleep(duration)
+        hass_prov = cast("HomeAssistantPlayerProvider", self.provider).hass_prov
+        await hass_prov.play_announcement_on_entity(self.player_id, announcement.uri)
         self.logger.debug(
             "Playing announcement on %s completed",
             self.display_name,

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -70,6 +70,7 @@ from music_assistant_models.media_items import Album, Artist, is_track
 from music_assistant_models.player import DeviceInfo
 from PIL import Image
 
+from music_assistant.constants import HIDDEN_ANNOUNCE_VOLUME_CONFIG_ENTRIES
 from music_assistant.controllers.streams.audio_analysis import SMART_FADES_ANALYSIS_DOMAIN
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import Player, PlayerMedia
@@ -213,6 +214,7 @@ if TYPE_CHECKING:
 
     from music_assistant.controllers.player_queues.state import PlayerQueueData
     from music_assistant.providers.chromecast.sendspin_bridge import SendspinBridgeManager
+    from music_assistant.providers.hass import HomeAssistantProvider
 
     from .provider import PinPairingSession, SendspinProvider
 
@@ -856,6 +858,8 @@ class SendspinPlayer(SendspinBasePlayer):
     _beat_retry_queue_item_id: str | None = None
     playback_session: SendspinPlaybackSession
     static_delay_default_ms: int = DEFAULT_SENDSPIN_STATIC_DELAY
+    # HA media_player entity announcements are relayed to (ESPHome-backed devices)
+    _hass_announce_entity_id: str | None = None
 
     @property
     def requires_flow_mode(self) -> bool:
@@ -904,6 +908,44 @@ class SendspinPlayer(SendspinBasePlayer):
                 self._attr_supported_features.add(feature)
             else:
                 self._attr_supported_features.discard(feature)
+
+    def set_hass_announce_entity(self, entity_id: str | None) -> None:
+        """
+        Set or clear the Home Assistant entity used to relay announcements.
+
+        ESPHome devices support announcements natively (ducking any running
+        playback), but that capability is only reachable through their Home
+        Assistant media_player entity; the PLAY_ANNOUNCEMENT feature follows it.
+
+        :param entity_id: The HA media_player entity id, or None to clear.
+        """
+        self._hass_announce_entity_id = entity_id
+        if entity_id is not None:
+            self._attr_supported_features.add(PlayerFeature.PLAY_ANNOUNCEMENT)
+        else:
+            self._attr_supported_features.discard(PlayerFeature.PLAY_ANNOUNCEMENT)
+
+    async def play_announcement(
+        self, announcement: PlayerMedia, volume_level: int | None = None
+    ) -> None:
+        """Handle (provider native) playback of an announcement on given player."""
+        entity_id = self._hass_announce_entity_id
+        hass = cast("HomeAssistantProvider | None", self.mass.get_provider("hass"))
+        if entity_id is None or hass is None or not hass.available:
+            raise PlayerCommandFailed(
+                f"Announcement relay via Home Assistant is not available for {self.display_name}"
+            )
+        self.logger.info(
+            "Playing announcement %s on %s (via Home Assistant)",
+            announcement.uri,
+            self.display_name,
+        )
+        if volume_level is not None:
+            # the device's announcement pipeline plays at its own volume;
+            # the announce volume config entries are hidden for this player
+            self.logger.debug("Ignoring announcement volume level for player %s", self.display_name)
+        await hass.play_announcement_on_entity(entity_id, announcement.uri)
+        self.logger.debug("Playing announcement on %s completed", self.display_name)
 
     def restore_bridge_identity(
         self, previous_device_info: DeviceInfo, previous_type: PlayerType
@@ -1796,6 +1838,11 @@ class SendspinPlayer(SendspinBasePlayer):
                     advanced=False,
                 )
             )
+
+        if self._hass_announce_entity_id is not None:
+            # announcements are relayed to the device via Home Assistant,
+            # which has no volume control for announcements
+            entries.extend(HIDDEN_ANNOUNCE_VOLUME_CONFIG_ENTRIES)
 
         return entries
 

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -321,6 +321,9 @@ class SendspinProvider(PlayerProvider):
             self.server_api.add_event_listener(self.event_cb),
             self.mass.subscribe(self._on_providers_updated, EventType.PROVIDERS_UPDATED),
         ]
+        # seed the hass availability snapshot so the first (un)load is seen as a change
+        hass = self.mass.get_provider("hass")
+        self._hass_available = hass is not None and hass.available
 
     def event_cb(self, server: SendspinServer, event: SendspinEvent) -> None:
         """Event callback registered to the sendspin server."""

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -90,7 +90,7 @@ from music_assistant.providers.sendspin.security import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Sequence
 
     from aiosendspin.models.core import PairMethodDescriptor
     from aiosendspin.models.management import (
@@ -241,6 +241,7 @@ class SendspinProvider(PlayerProvider):
     _manual_ip_config: tuple[str, ...]
     _virtual_players: dict[str, str]
     _unloading: bool
+    _hass_available: bool
 
     def __init__(
         self, mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
@@ -265,6 +266,7 @@ class SendspinProvider(PlayerProvider):
             str, tuple[SendspinConnection, ManagementResultData]
         ] = {}
         self._unloading = False
+        self._hass_available = False
         self.unregister_cbs = []
 
     async def handle_async_init(self) -> None:
@@ -843,15 +845,56 @@ class SendspinProvider(PlayerProvider):
         """Return True if the event version is still the latest for the client."""
         return self._client_event_versions.get(client_id) == event_version
 
-    async def _apply_hass_name_override(self, player: SendspinBasePlayer, client_id: str) -> None:
-        """Apply Home Assistant display name for ESPHome-backed Sendspin players."""
-        if player.device_info.manufacturer != "ESPHome":
+    async def _apply_hass_esphome_enrichment(self, players: Sequence[SendspinBasePlayer]) -> None:
+        """
+        Apply Home Assistant-sourced enrichment to ESPHome-backed Sendspin players.
+
+        Applies the HA display name and resolves the HA media_player entity that
+        announcements are relayed to: ESPHome devices support announcements
+        natively, but that capability is only reachable through the HA API.
+        Players are correlated by MAC address (the Sendspin client id).
+        """
+        esphome_players = [
+            player for player in players if player.device_info.manufacturer == "ESPHome"
+        ]
+        if not esphome_players:
             return
-        if not (hass := self.mass.get_provider("hass")):
+        hass = cast("HomeAssistantProvider | None", self.mass.get_provider("hass"))
+        if hass is None or not hass.available:
+            for player in esphome_players:
+                if isinstance(player, SendspinPlayer):
+                    player.set_hass_announce_entity(None)
             return
-        hass = cast("HomeAssistantProvider", hass)
-        if hass_device := await hass.get_device_by_connection(client_id):
-            player._attr_name = hass_device["name_by_user"] or hass_device["name"] or player.name
+        try:
+            device_infos = await hass.get_media_player_device_infos(
+                [player.player_id for player in esphome_players], platform="esphome"
+            )
+        except Exception as err:
+            self.logger.warning("Failed to apply Home Assistant enrichment: %s", err)
+            return
+        for player in esphome_players:
+            device_info = device_infos.get(player.player_id.lower())
+            if device_info is not None and device_info["name"]:
+                player._attr_name = device_info["name"]
+            if isinstance(player, SendspinPlayer):
+                player.set_hass_announce_entity(
+                    device_info["announce_entity_id"] if device_info is not None else None
+                )
+
+    async def _refresh_hass_esphome_enrichment(self) -> None:
+        """Re-apply the HA enrichment to all registered ESPHome players (in place)."""
+        players = [
+            player
+            for player in self.players
+            if isinstance(player, SendspinBasePlayer)
+            and player.device_info.manufacturer == "ESPHome"
+        ]
+        if not players:
+            return
+        await self._apply_hass_esphome_enrichment(players)
+        for player in players:
+            if player.initialized.is_set():
+                player.update_state()
 
     def _create_player(
         self,
@@ -1141,9 +1184,9 @@ class SendspinProvider(PlayerProvider):
             for id_type, id_value in preserved_identifiers.items():
                 player.device_info.add_identifier(id_type, id_value)
             self.logger.debug("Client %s connected", client_id)
-            await self._apply_hass_name_override(player, client_id)
+            await self._apply_hass_esphome_enrichment([player])
             if not self._is_current_client_event(client_id, event_version):
-                self.logger.debug("Skipping stale add event for %s after name override", client_id)
+                self.logger.debug("Skipping stale add event for %s after HA enrichment", client_id)
                 player._unsubscribe_client_callbacks()
                 return
             try:
@@ -1200,7 +1243,7 @@ class SendspinProvider(PlayerProvider):
             existing_player._refresh_client_info(sendspin_client)
             if isinstance(existing_player, SendspinPlayer):
                 existing_player.restore_bridge_identity(previous_device_info, previous_type)
-            await self._apply_hass_name_override(existing_player, client_id)
+            await self._apply_hass_esphome_enrichment([existing_player])
             if not self._is_current_client_event(client_id, event_version):
                 self.logger.debug("Skipping stale update event for %s after refresh", client_id)
                 return
@@ -1302,11 +1345,12 @@ class SendspinProvider(PlayerProvider):
         """Accept stream start requests for virtual players (nothing to connect)."""
 
     async def _on_providers_updated(self, event: MassEvent) -> None:
-        """Remove virtual players whose owning provider is no longer loaded."""
+        """Handle a change in the loaded providers."""
         # during (server) shutdown all providers unload; the startup sweep
         # takes care of configs whose owner is really gone
         if self._unloading or self.mass.closing:
             return
+        # remove virtual players whose owning provider is no longer loaded
         for player_id, owner_instance_id in list(self._virtual_players.items()):
             if self.mass.get_provider(owner_instance_id) is not None:
                 continue
@@ -1314,6 +1358,12 @@ class SendspinProvider(PlayerProvider):
                 "Removing virtual player %s: owner %s unloaded", player_id, owner_instance_id
             )
             await self.remove_virtual_player(player_id)
+        # (re)apply the HA-backed enrichment when the hass plugin (un)loads
+        hass = self.mass.get_provider("hass")
+        hass_available = hass is not None and hass.available
+        if hass_available != self._hass_available:
+            self._hass_available = hass_available
+            await self._refresh_hass_esphome_enrichment()
 
     def _remove_orphan_virtual_player_configs(self) -> None:
         """Delete stored configs of virtual players whose owner provider is gone."""

--- a/tests/providers/hass/test_device_correlation.py
+++ b/tests/providers/hass/test_device_correlation.py
@@ -1,0 +1,128 @@
+"""Tests for correlating natively connected devices to their Home Assistant representation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from music_assistant.providers.hass import HomeAssistantProvider
+
+MEDIA_ANNOUNCE = 1048576
+MAC = "aa:bb:cc:dd:ee:ff"
+
+
+def _provider(
+    devices: list[dict[str, Any]],
+    entities: list[dict[str, Any]],
+    states: list[dict[str, Any]],
+) -> HomeAssistantProvider:
+    provider = HomeAssistantProvider.__new__(HomeAssistantProvider)
+    provider.hass = SimpleNamespace(
+        get_device_registry=AsyncMock(return_value=devices),
+        get_entity_registry=AsyncMock(return_value=entities),
+    )
+    provider.get_states = AsyncMock(return_value=states)  # type: ignore[method-assign]
+    return provider
+
+
+def _device(device_id: str = "dev1", name_by_user: str | None = None) -> dict[str, Any]:
+    return {
+        "id": device_id,
+        "name": "Kitchen Speaker",
+        "name_by_user": name_by_user,
+        "connections": [["mac", MAC.upper()]],
+    }
+
+
+def _entity(
+    entity_id: str,
+    device_id: str = "dev1",
+    platform: str = "esphome",
+    disabled_by: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "entity_id": entity_id,
+        "platform": platform,
+        "device_id": device_id,
+        "disabled_by": disabled_by,
+    }
+
+
+def _state(entity_id: str, supported_features: int) -> dict[str, Any]:
+    return {"entity_id": entity_id, "attributes": {"supported_features": supported_features}}
+
+
+async def test_correlates_name_and_announce_entity() -> None:
+    """A device is matched case-insensitively on MAC with its announce-capable entity."""
+    provider = _provider(
+        [_device(name_by_user="Kitchen")],
+        [_entity("media_player.kitchen")],
+        [_state("media_player.kitchen", MEDIA_ANNOUNCE)],
+    )
+    result = await provider.get_media_player_device_infos([MAC.upper()], platform="esphome")
+    assert result == {MAC: {"name": "Kitchen", "announce_entity_id": "media_player.kitchen"}}
+
+
+async def test_entity_without_announce_support() -> None:
+    """A matched device without an announce-capable entity still yields its name."""
+    provider = _provider(
+        [_device()],
+        [_entity("media_player.kitchen")],
+        [_state("media_player.kitchen", 0)],
+    )
+    result = await provider.get_media_player_device_infos([MAC], platform="esphome")
+    assert result == {MAC: {"name": "Kitchen Speaker", "announce_entity_id": None}}
+
+
+async def test_ignores_disabled_and_foreign_entities() -> None:
+    """Disabled entities and entities of other integrations are not considered."""
+    provider = _provider(
+        [_device()],
+        [
+            _entity("media_player.disabled", disabled_by="user"),
+            _entity("media_player.other", platform="cast"),
+            _entity("sensor.kitchen_temperature"),
+        ],
+        [],
+    )
+    result = await provider.get_media_player_device_infos([MAC], platform="esphome")
+    assert result == {MAC: {"name": "Kitchen Speaker", "announce_entity_id": None}}
+
+
+async def test_unknown_devices_are_absent() -> None:
+    """Devices unknown to Home Assistant are absent from the result."""
+    provider = _provider([_device()], [], [])
+    result = await provider.get_media_player_device_infos(["11:22:33:44:55:66"], platform="esphome")
+    assert result == {}
+
+
+async def test_empty_input_skips_registry_fetch() -> None:
+    """An empty lookup does not hit the Home Assistant registries."""
+    provider = _provider([], [], [])
+    assert await provider.get_media_player_device_infos([], platform="esphome") == {}
+    provider.hass.get_device_registry.assert_not_awaited()
+
+
+async def test_play_announcement_on_entity() -> None:
+    """An announcement is played via HA's announce feature and awaited for its duration."""
+    provider = HomeAssistantProvider.__new__(HomeAssistantProvider)
+    provider.hass = SimpleNamespace(call_service=AsyncMock())
+    with patch(
+        "music_assistant.providers.hass.async_parse_tags",
+        AsyncMock(return_value=SimpleNamespace(duration=0.01)),
+    ) as parse_tags:
+        await provider.play_announcement_on_entity(
+            "media_player.kitchen", "http://mass.local/announcement.mp3"
+        )
+    provider.hass.call_service.assert_awaited_once_with(
+        domain="media_player",
+        service="play_media",
+        service_data={
+            "media_content_id": "http://mass.local/announcement.mp3",
+            "media_content_type": "music",
+            "announce": True,
+        },
+        target={"entity_id": "media_player.kitchen"},
+    )
+    parse_tags.assert_awaited_once_with("http://mass.local/announcement.mp3", require_duration=True)

--- a/tests/providers/sendspin/test_hass_announce.py
+++ b/tests/providers/sendspin/test_hass_announce.py
@@ -1,0 +1,157 @@
+"""Tests for the announcement relay via Home Assistant on ESPHome-backed Sendspin players."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from music_assistant_models.enums import PlayerFeature
+from music_assistant_models.errors import PlayerCommandFailed
+from music_assistant_models.player import DeviceInfo, PlayerMedia
+
+from music_assistant.providers.sendspin.player import SendspinPlayer
+from music_assistant.providers.sendspin.provider import SendspinProvider
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import PlayerConfig
+
+    from music_assistant.mass import MusicAssistant
+
+MAC = "aa:bb:cc:dd:ee:ff"
+ENTITY_ID = "media_player.kitchen_speaker"
+
+
+def _player(*, manufacturer: str = "ESPHome", player_id: str = MAC) -> SendspinPlayer:
+    player = SendspinPlayer.__new__(SendspinPlayer)
+    player._player_id = player_id
+    player._cache = {}
+    player._attr_supported_features = set()
+    player._attr_device_info = DeviceInfo(manufacturer=manufacturer)
+    player._attr_name = "hello name"
+    player._config = cast("PlayerConfig", SimpleNamespace(name=None, default_name=None))
+    player.logger = Mock()
+    return player
+
+
+def _provider(hass_provider: object | None) -> SendspinProvider:
+    provider = SendspinProvider.__new__(SendspinProvider)
+    provider.mass = cast(
+        "MusicAssistant", SimpleNamespace(get_provider=lambda _domain: hass_provider)
+    )
+    provider.logger = Mock()
+    return provider
+
+
+def _hass_provider(device_infos: dict[str, dict[str, str | None]]) -> SimpleNamespace:
+    return SimpleNamespace(
+        available=True,
+        get_media_player_device_infos=AsyncMock(return_value=device_infos),
+        play_announcement_on_entity=AsyncMock(),
+    )
+
+
+def test_set_hass_announce_entity_adds_feature() -> None:
+    """Setting the HA announce entity adds the PLAY_ANNOUNCEMENT feature."""
+    player = _player()
+    player.set_hass_announce_entity(ENTITY_ID)
+    assert player._hass_announce_entity_id == ENTITY_ID
+    assert PlayerFeature.PLAY_ANNOUNCEMENT in player.supported_features
+
+
+def test_clear_hass_announce_entity_removes_feature() -> None:
+    """Clearing the HA announce entity removes the PLAY_ANNOUNCEMENT feature."""
+    player = _player()
+    player.set_hass_announce_entity(ENTITY_ID)
+    player.set_hass_announce_entity(None)
+    assert player._hass_announce_entity_id is None
+    assert PlayerFeature.PLAY_ANNOUNCEMENT not in player.supported_features
+
+
+async def test_enrichment_applies_name_and_announce_entity() -> None:
+    """An ESPHome player picks up its HA name and announce entity."""
+    hass = _hass_provider({MAC: {"name": "Kitchen Speaker", "announce_entity_id": ENTITY_ID}})
+    player = _player()
+    await _provider(hass)._apply_hass_esphome_enrichment([player])
+    assert player._attr_name == "Kitchen Speaker"
+    assert player._hass_announce_entity_id == ENTITY_ID
+    assert PlayerFeature.PLAY_ANNOUNCEMENT in player.supported_features
+    hass.get_media_player_device_infos.assert_awaited_once_with([MAC], platform="esphome")
+
+
+async def test_enrichment_ignores_non_esphome_players() -> None:
+    """Players not backed by ESPHome are left alone entirely."""
+    hass = _hass_provider({})
+    player = _player(manufacturer="Music Assistant")
+    await _provider(hass)._apply_hass_esphome_enrichment([player])
+    hass.get_media_player_device_infos.assert_not_awaited()
+    assert player._attr_name == "hello name"
+
+
+@pytest.mark.parametrize("hass_provider", [None, SimpleNamespace(available=False)])
+async def test_enrichment_clears_announce_entity_without_hass(hass_provider: object) -> None:
+    """The announce relay is dropped when the hass plugin is not available."""
+    player = _player()
+    player.set_hass_announce_entity(ENTITY_ID)
+    await _provider(hass_provider)._apply_hass_esphome_enrichment([player])
+    assert player._hass_announce_entity_id is None
+    assert PlayerFeature.PLAY_ANNOUNCEMENT not in player.supported_features
+
+
+async def test_enrichment_clears_announce_entity_for_unknown_device() -> None:
+    """A device no longer known to HA loses the announce relay but keeps its name."""
+    player = _player()
+    player.set_hass_announce_entity(ENTITY_ID)
+    await _provider(_hass_provider({}))._apply_hass_esphome_enrichment([player])
+    assert player._hass_announce_entity_id is None
+    assert player._attr_name == "hello name"
+
+
+async def test_enrichment_keeps_state_on_hass_error() -> None:
+    """A transient HA failure keeps the current enrichment instead of dropping it."""
+    hass = SimpleNamespace(
+        available=True,
+        get_media_player_device_infos=AsyncMock(side_effect=RuntimeError("connection lost")),
+    )
+    player = _player()
+    player.set_hass_announce_entity(ENTITY_ID)
+    provider = _provider(hass)
+    await provider._apply_hass_esphome_enrichment([player])
+    assert player._hass_announce_entity_id == ENTITY_ID
+    cast("Mock", provider.logger).warning.assert_called_once()
+
+
+async def test_play_announcement_relays_via_hass() -> None:
+    """An announcement is relayed to the HA entity, ignoring the volume level."""
+    hass = _hass_provider({})
+    player = _player()
+    player.mass = cast("MusicAssistant", SimpleNamespace(get_provider=lambda _domain: hass))
+    player.set_hass_announce_entity(ENTITY_ID)
+    announcement = PlayerMedia(uri="http://mass.local/announcement.mp3")
+    await player.play_announcement(announcement, volume_level=50)
+    hass.play_announcement_on_entity.assert_awaited_once_with(
+        ENTITY_ID, "http://mass.local/announcement.mp3"
+    )
+
+
+@pytest.mark.parametrize("hass_provider", [None, SimpleNamespace(available=False)])
+async def test_play_announcement_requires_hass(hass_provider: object) -> None:
+    """An announcement fails cleanly when the hass plugin is gone."""
+    player = _player()
+    player.mass = cast(
+        "MusicAssistant", SimpleNamespace(get_provider=lambda _domain: hass_provider)
+    )
+    player.set_hass_announce_entity(ENTITY_ID)
+    with pytest.raises(PlayerCommandFailed):
+        await player.play_announcement(PlayerMedia(uri="http://mass.local/announcement.mp3"))
+
+
+async def test_play_announcement_requires_resolved_entity() -> None:
+    """An announcement fails cleanly when no HA entity was resolved."""
+    player = _player()
+    player.mass = cast(
+        "MusicAssistant", SimpleNamespace(get_provider=lambda _domain: _hass_provider({}))
+    )
+    with pytest.raises(PlayerCommandFailed):
+        await player.play_announcement(PlayerMedia(uri="http://mass.local/announcement.mp3"))


### PR DESCRIPTION
# What does this implement/fix?

ESPHome devices nowadays connect to Music Assistant directly via Sendspin, without the detour through Home Assistant. That detour however provided the announcement feature: ESPHome devices can natively duck running playback, play an announcement and resume — but that capability is only reachable through the Home Assistant API. Announcements on Sendspin players therefore fell back to the generic (interrupting) flow: ungroup, stop the stream, play the announcement, restore.

With this change, Sendspin players backed by an ESPHome device automatically pick up their Home Assistant media_player entity (when the Home Assistant plugin is set up) and relay announcements through it, so the device's own announcement pipeline does the mixing and the music keeps playing.

- ESPHome-based Sendspin players now advertise announcement support when their Home Assistant entity supports it
- Announcements are relayed through Home Assistant's announce feature — music playback is no longer interrupted
- The Home Assistant device name and announce capability now also refresh when the Home Assistant plugin (un)loads
- Announcement volume settings are hidden for these players (the device itself controls the announcement volume)
- The announce relay logic is shared between the Home Assistant plugin and the Home Assistant player provider

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's AI Policy for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
