### PR TITLE
Prevent importing Home Assistant players that are natively supported

### DIFF
--- a/music_assistant/providers/hass_players/__init__.py
+++ b/music_assistant/providers/hass_players/__init__.py
@@ -15,11 +15,18 @@ from music_assistant_models.errors import SetupFailedError
 
 from music_assistant.providers.hass import DOMAIN as HASS_DOMAIN
 
-from .constants import CONF_PLAYERS
-from .helpers import get_hass_media_players
+from .constants import (
+    CONF_PLAYERS,
+    DISABLED_REASON_NATIVE_DUPLICATE,
+    DISABLED_REASON_NATIVE_INTEGRATION,
+    NATIVE_SUPPORTED_HASS_INTEGRATIONS,
+)
+from .helpers import get_hass_media_players, native_player_macs, normalized_mac
 from .provider import HomeAssistantPlayerProvider
 
 if TYPE_CHECKING:
+    from hass_client.models import Device as HassDevice
+    from hass_client.models import Entity as HassEntity
     from music_assistant_models.config_entries import ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
@@ -42,9 +49,9 @@ async def setup(
 
 async def get_config_entries(
     mass: MusicAssistant,
-    instance_id: str | None = None,  # noqa: ARG001
+    instance_id: str | None = None,
     action: str | None = None,  # noqa: ARG001
-    values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
     """
     Return Config entries to setup this provider.
@@ -56,9 +63,27 @@ async def get_config_entries(
     hass_prov = cast("HomeAssistantProvider|None", mass.get_provider(HASS_DOMAIN))
     player_entities: list[ConfigValueOption] = []
     if hass_prov and hass_prov.hass.connected:
-        async for state in get_hass_media_players(hass_prov):
-            name = f"{state['attributes']['friendly_name']} ({state['entity_id']})"
-            player_entities.append(ConfigValueOption(state["entity_id"], title=name))
+        # entities that are already imported must stay selectable,
+        # so editing the provider config never drops them
+        selected_players = _selected_players(mass, instance_id, values)
+        device_registry = {x["id"]: x for x in await hass_prov.hass.get_device_registry()}
+        native_macs = native_player_macs(mass)
+        async for state, entity_registry_entry in get_hass_media_players(hass_prov):
+            entity_id = state["entity_id"]
+            name = f"{state['attributes']['friendly_name']} ({entity_id})"
+            disabled_reason: str | None = None
+            if entity_id not in selected_players:
+                disabled_reason = _native_support_reason(
+                    entity_registry_entry, device_registry, native_macs
+                )
+            player_entities.append(
+                ConfigValueOption(
+                    entity_id,
+                    title=name,
+                    disabled=disabled_reason is not None,
+                    disabled_reason=disabled_reason,
+                )
+            )
     return (
         ConfigEntry(
             key=CONF_PLAYERS,
@@ -68,3 +93,40 @@ async def get_config_entries(
             options=player_entities,
         ),
     )
+
+
+def _selected_players(
+    mass: MusicAssistant,
+    instance_id: str | None,
+    values: dict[str, ConfigValueType] | None,
+) -> set[str]:
+    """Return the entity ids currently selected as players (stored and in-flight)."""
+    selected: set[str] = set()
+    if values and isinstance(players_value := values.get(CONF_PLAYERS), list):
+        selected.update(cast("list[str]", players_value))
+    if instance_id and isinstance(
+        stored_players := mass.config.get_raw_provider_config_value(instance_id, CONF_PLAYERS),
+        list,
+    ):
+        selected.update(cast("list[str]", stored_players))
+    return selected
+
+
+def _native_support_reason(
+    entity_registry_entry: HassEntity | None,
+    device_registry: dict[str, HassDevice],
+    native_macs: set[str],
+) -> str | None:
+    """Return why the entity can not be imported (natively supported), or None if it can."""
+    if entity_registry_entry is None:
+        return None
+    if entity_registry_entry["platform"] in NATIVE_SUPPORTED_HASS_INTEGRATIONS:
+        return DISABLED_REASON_NATIVE_INTEGRATION
+    device = device_registry.get(entity_registry_entry["device_id"] or "")
+    if device is not None and any(
+        normalized_mac(connection[1]) in native_macs
+        for connection in device.get("connections", [])
+        if len(connection) == 2 and connection[0] == "mac"
+    ):
+        return DISABLED_REASON_NATIVE_DUPLICATE
+    return None

--- a/music_assistant/providers/hass_players/constants.py
+++ b/music_assistant/providers/hass_players/constants.py
@@ -5,11 +5,35 @@ from __future__ import annotations
 from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import ConfigEntryType
 
+DOMAIN = "hass_players"
+
 CONF_PLAYERS = "players"
 
+# HA integrations that are known to not work (correctly) at all through this provider.
 BLOCKLISTED_HASS_INTEGRATIONS = ("alexa_media", "apple_tv")
-WARN_HASS_INTEGRATIONS = ("cast", "dlna_dmr", "fully_kiosk", "sonos", "snapcast")
+# HA integrations whose players are fully supported by a native Music Assistant
+# player provider: importing them here is blocked (use the native provider instead).
+NATIVE_SUPPORTED_HASS_INTEGRATIONS = (
+    "bluesound",
+    "cast",
+    "dlna_dmr",
+    "fully_kiosk",
+    "heos",
+    "linkplay",
+    "mpd",
+    "snapcast",
+    "sonos",
+    "squeezebox",
+    "yamaha_musiccast",
+)
 
+DISABLED_REASON_NATIVE_INTEGRATION = (
+    "Music Assistant has native support for this player type - "
+    "set up the native player provider instead."
+)
+DISABLED_REASON_NATIVE_DUPLICATE = (
+    "This device is already available in Music Assistant as a native player."
+)
 
 CONF_ENTRY_WARN_HASS_INTEGRATION = ConfigEntry(
     key="warn_hass_integration",

--- a/music_assistant/providers/hass_players/helpers.py
+++ b/music_assistant/providers/hass_players/helpers.py
@@ -6,24 +6,27 @@ import logging
 import os
 from typing import TYPE_CHECKING, TypedDict, cast
 
+from music_assistant_models.enums import IdentifierType
 from music_assistant_models.errors import InvalidDataError, LoginFailed
 
 from music_assistant.providers.hass.constants import MediaPlayerEntityFeature
 
-from .constants import BLOCKLISTED_HASS_INTEGRATIONS
+from .constants import BLOCKLISTED_HASS_INTEGRATIONS, DOMAIN
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
+    from hass_client.models import Entity as HassEntity
     from hass_client.models import State as HassState
 
+    from music_assistant.mass import MusicAssistant
     from music_assistant.providers.hass import HomeAssistantProvider
 
 
 async def get_hass_media_players(
     hass_prov: HomeAssistantProvider,
-) -> AsyncGenerator[HassState]:
-    """Return all HA state objects for (valid) media_player entities."""
+) -> AsyncGenerator[tuple[HassState, HassEntity | None]]:
+    """Return all HA state objects (with registry entry) for (valid) media_player entities."""
     entity_registry = {x["entity_id"]: x for x in await hass_prov.hass.get_entity_registry()}
     # discover via the registry instead of a full state dump; entities without a
     # unique_id are not registered and are therefore not discovered here
@@ -40,11 +43,33 @@ async def get_hass_media_players(
         supported_features = MediaPlayerEntityFeature(state["attributes"]["supported_features"])
         if MediaPlayerEntityFeature.PLAY_MEDIA not in supported_features:
             continue
-        if entity_registry_entry := entity_registry.get(state["entity_id"]):
+        entity_registry_entry = entity_registry.get(state["entity_id"])
+        if entity_registry_entry is not None:
             hass_domain = entity_registry_entry["platform"]
             if hass_domain in BLOCKLISTED_HASS_INTEGRATIONS:
                 continue
-        yield state
+        yield state, entity_registry_entry
+
+
+def normalized_mac(mac: str) -> str:
+    """Normalize a MAC address for comparison (lowercase, no separators)."""
+    return mac.replace(":", "").replace("-", "").lower()
+
+
+def native_player_macs(mass: MusicAssistant) -> set[str]:
+    """
+    Collect the normalized MAC addresses of all natively registered players.
+
+    Used to detect HA entities that point to a device that is already available
+    as a native Music Assistant player (e.g. an ESPHome device using Sendspin).
+    """
+    macs: set[str] = set()
+    for player in mass.players:
+        if player.provider.domain == DOMAIN:
+            continue
+        if mac := player.device_info.identifiers.get(IdentifierType.MAC_ADDRESS):
+            macs.add(normalized_mac(mac))
+    return macs
 
 
 class ESPHomeSupportedAudioFormat(TypedDict):

--- a/music_assistant/providers/hass_players/player.py
+++ b/music_assistant/providers/hass_players/player.py
@@ -34,8 +34,8 @@ from music_assistant.providers.hass.constants import (
     StateMap,
 )
 
-from .constants import CONF_ENTRY_WARN_HASS_INTEGRATION, WARN_HASS_INTEGRATIONS
-from .helpers import ESPHomeSupportedAudioFormat
+from .constants import CONF_ENTRY_WARN_HASS_INTEGRATION, NATIVE_SUPPORTED_HASS_INTEGRATIONS
+from .helpers import ESPHomeSupportedAudioFormat, native_player_macs, normalized_mac
 
 if TYPE_CHECKING:
     from hass_client import HomeAssistantClient
@@ -143,6 +143,12 @@ class HomeAssistantPlayer(Player):
     ) -> list[ConfigEntry]:
         """Return all (provider/player specific) Config Entries for the player."""
         base_entries = [*DEFAULT_PLAYER_CONFIG_ENTRIES]
+        # add alert if the player (type) is also supported by a native MA provider
+        if (
+            self.extra_data.get("hass_domain") in NATIVE_SUPPORTED_HASS_INTEGRATIONS
+            or self._has_native_duplicate()
+        ):
+            base_entries = [CONF_ENTRY_WARN_HASS_INTEGRATION, *base_entries]
         supported_formats: list[ESPHomeSupportedAudioFormat] | None = self.extra_data.get(
             "esphome_supported_audio_formats"
         )
@@ -172,10 +178,6 @@ class HomeAssistantPlayer(Player):
             )
 
             return config_entries
-
-        # add alert if player is a known player type that has a native provider in MA
-        if self.extra_data.get("hass_domain") in WARN_HASS_INTEGRATIONS:
-            base_entries = [CONF_ENTRY_WARN_HASS_INTEGRATION, *base_entries]
 
         return base_entries
 
@@ -501,3 +503,9 @@ class HomeAssistantPlayer(Player):
             )
             return self.mass.metadata.get_image_url(image)
         return None
+
+    def _has_native_duplicate(self) -> bool:
+        """Whether this device is also registered as a native Music Assistant player."""
+        if not (mac := self.device_info.identifiers.get(IdentifierType.MAC_ADDRESS)):
+            return False
+        return normalized_mac(mac) in native_player_macs(self.mass)

--- a/music_assistant/providers/hass_players/provider.py
+++ b/music_assistant/providers/hass_players/provider.py
@@ -58,7 +58,7 @@ class HomeAssistantPlayerProvider(PlayerProvider):
             x["entity_id"]: x for x in await self.hass_prov.hass.get_entity_registry()
         }
         # setup players from hass entities
-        async for state in get_hass_media_players(self.hass_prov):
+        async for state, _ in get_hass_media_players(self.hass_prov):
             if state["entity_id"] not in player_ids:
                 continue
             await self._setup_player(state, entity_registry, device_registry)
@@ -183,7 +183,7 @@ class HomeAssistantPlayerProvider(PlayerProvider):
         entity_registry = {
             x["entity_id"]: x for x in await self.hass_prov.hass.get_entity_registry()
         }
-        async for state in get_hass_media_players(self.hass_prov):
+        async for state, _ in get_hass_media_players(self.hass_prov):
             if state["entity_id"] != entity_id:
                 continue
             await self._setup_player(state, entity_registry, device_registry)

--- a/tests/providers/hass_players/__init__.py
+++ b/tests/providers/hass_players/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Home Assistant Player provider."""

--- a/tests/providers/hass_players/test_native_import_guard.py
+++ b/tests/providers/hass_players/test_native_import_guard.py
@@ -1,0 +1,149 @@
+"""Tests for blocking the import of HA players that are natively supported in MA."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock
+
+from music_assistant_models.enums import IdentifierType
+
+from music_assistant.providers.hass_players import get_config_entries
+from music_assistant.providers.hass_players.constants import (
+    DISABLED_REASON_NATIVE_DUPLICATE,
+    DISABLED_REASON_NATIVE_INTEGRATION,
+)
+from music_assistant.providers.hass_players.helpers import native_player_macs, normalized_mac
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ConfigValueOption
+
+    from music_assistant.mass import MusicAssistant
+
+PLAY_MEDIA = 512
+MAC = "aa:bb:cc:dd:ee:ff"
+
+
+def _state(entity_id: str) -> dict[str, Any]:
+    return {
+        "entity_id": entity_id,
+        "state": "idle",
+        "attributes": {"friendly_name": entity_id, "supported_features": PLAY_MEDIA},
+    }
+
+
+def _entity(entity_id: str, platform: str, device_id: str | None = None) -> dict[str, Any]:
+    return {"entity_id": entity_id, "platform": platform, "device_id": device_id}
+
+
+def _native_player(mac: str | None = MAC, provider_domain: str = "sendspin") -> SimpleNamespace:
+    identifiers = {IdentifierType.MAC_ADDRESS: mac} if mac else {}
+    return SimpleNamespace(
+        provider=SimpleNamespace(domain=provider_domain),
+        device_info=SimpleNamespace(identifiers=identifiers),
+    )
+
+
+def _mass(
+    entities: list[dict[str, Any]],
+    devices: list[dict[str, Any]] | None = None,
+    native_players: list[SimpleNamespace] | None = None,
+    stored_players: list[str] | None = None,
+) -> MusicAssistant:
+    hass_prov = SimpleNamespace(
+        hass=SimpleNamespace(
+            connected=True,
+            get_entity_registry=AsyncMock(return_value=entities),
+            get_device_registry=AsyncMock(return_value=devices or []),
+        ),
+        get_states=AsyncMock(return_value=[_state(entity["entity_id"]) for entity in entities]),
+    )
+    return cast(
+        "MusicAssistant",
+        SimpleNamespace(
+            get_provider=lambda _domain: hass_prov,
+            players=native_players or [],
+            config=SimpleNamespace(
+                get_raw_provider_config_value=lambda *_args, **_kwargs: stored_players
+            ),
+        ),
+    )
+
+
+async def _picker_options(
+    mass: MusicAssistant, instance_id: str | None = None
+) -> list[ConfigValueOption]:
+    entries = await get_config_entries(mass, instance_id=instance_id)
+    return entries[0].options
+
+
+async def test_native_integration_entity_is_disabled() -> None:
+    """An entity of an integration with a native MA provider can not be newly imported."""
+    mass = _mass([_entity("media_player.living_room_tv", "cast")])
+    (option,) = await _picker_options(mass)
+    assert option.disabled is True
+    assert option.disabled_reason == DISABLED_REASON_NATIVE_INTEGRATION
+
+
+async def test_native_duplicate_device_is_disabled() -> None:
+    """An entity whose device is already a native MA player can not be newly imported."""
+    mass = _mass(
+        [_entity("media_player.kitchen_speaker", "esphome", device_id="dev1")],
+        devices=[{"id": "dev1", "connections": [["mac", MAC.upper()]]}],
+        native_players=[_native_player()],
+    )
+    (option,) = await _picker_options(mass)
+    assert option.disabled is True
+    assert option.disabled_reason == DISABLED_REASON_NATIVE_DUPLICATE
+
+
+async def test_esphome_entity_without_native_player_is_selectable() -> None:
+    """An ESPHome device without a native MA player (no Sendspin) can still be imported."""
+    mass = _mass(
+        [_entity("media_player.diy_speaker", "esphome", device_id="dev1")],
+        devices=[{"id": "dev1", "connections": [["mac", "11:22:33:44:55:66"]]}],
+        native_players=[_native_player()],
+    )
+    (option,) = await _picker_options(mass)
+    assert option.disabled is False
+    assert option.disabled_reason is None
+
+
+async def test_already_imported_entity_stays_selectable() -> None:
+    """An already imported entity stays selectable so a config edit never drops it."""
+    mass = _mass(
+        [_entity("media_player.living_room_tv", "cast")],
+        stored_players=["media_player.living_room_tv"],
+    )
+    (option,) = await _picker_options(mass, instance_id="hass_players--test")
+    assert option.disabled is False
+    assert option.disabled_reason is None
+
+
+async def test_regular_entity_is_selectable() -> None:
+    """An entity without native MA support is offered as before."""
+    mass = _mass([_entity("media_player.kodi_bedroom", "kodi")])
+    (option,) = await _picker_options(mass)
+    assert option.disabled is False
+    assert option.disabled_reason is None
+
+
+def test_native_player_macs_excludes_own_players() -> None:
+    """MACs of players imported through this provider itself are not counted."""
+    mass = cast(
+        "MusicAssistant",
+        SimpleNamespace(
+            players=[
+                _native_player(),
+                _native_player(mac="11:22:33:44:55:66", provider_domain="hass_players"),
+                _native_player(mac=None),
+            ]
+        ),
+    )
+    assert native_player_macs(mass) == {normalized_mac(MAC)}
+
+
+def test_normalized_mac() -> None:
+    """MAC addresses normalize regardless of separators and casing."""
+    assert normalized_mac("AA:BB:CC:DD:EE:FF") == "aabbccddeeff"
+    assert normalized_mac("aa-bb-cc-dd-ee-ff") == "aabbccddeeff"


### PR DESCRIPTION
# What does this implement/fix?

Importing players through the Home Assistant provider while Music Assistant already supports them natively (Chromecast, Sonos, ESPHome via Sendspin, etc.) results in duplicate players and a worse experience than the native provider offers. Until now this was only a warning, shown after the player was already imported.

- Entities from integrations with a native Music Assistant player provider are now shown greyed-out (with the reason) in the player selection and can no longer be newly imported
- Entities pointing to a device that is already available as a native player (e.g. an ESPHome device connected via Sendspin) are also greyed-out
- ESPHome devices without Sendspin can still be imported — Home Assistant is their only route
- Already imported players are untouched: they stay selectable and keep working, with the existing warning shown in their settings

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's AI Policy for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
