### PR TITLE
Keep player settings when a universal player is replaced by a native player

### DIFF
--- a/music_assistant/controllers/players/README.md
+++ b/music_assistant/controllers/players/README.md
@@ -307,7 +307,8 @@ Key scenarios to test:
 1. **Single protocol device** - Should create Universal Player
 2. **Multi-protocol device** - All protocols linked to one Universal Player
 3. **Late protocol discovery** - New protocol added to existing Universal Player
-4. **Native player appears** - Universal Player replaced by native
+4. **Native player appears** - Universal Player replaced by native; its user
+   settings (name, config values, DSP and queue settings) carry over
 5. **Permanent parent removal** - Protocol links reset and discovery is re-scheduled
 6. **Protocol disappears** - Handle graceful degradation
 

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from copy import deepcopy
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.enums import (
+    EventType,
     IdentifierType,
     PlaybackState,
     PlayerFeature,
@@ -25,10 +27,15 @@ from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.player import OutputProtocol
 
 from music_assistant.constants import (
+    CONF_CACHED_ARP_MAC,
     CONF_LINKED_PROTOCOL_IDS,
+    CONF_PLAYER_DSP,
+    CONF_PLAYER_QUEUES,
     CONF_PLAYERS,
     CONF_PREFERRED_OUTPUT_PROTOCOL,
+    CONF_PROTOCOL_KEY_SPLITTER,
     CONF_PROTOCOL_PARENT_ID,
+    CONF_REPORTED_MAC,
     CONF_UNDERLYING_PLAYER_ID,
     PROTOCOL_PRIORITY,
     VERBOSE_LOG_LEVEL,
@@ -40,12 +47,29 @@ from music_assistant.helpers.util import (
 )
 from music_assistant.models.player import Player
 from music_assistant.providers.universal_player import UniversalPlayer, UniversalPlayerProvider
+from music_assistant.providers.universal_player.constants import (
+    CONF_DEVICE_IDENTIFIERS,
+    CONF_DEVICE_INFO,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
     from typing import Any
 
     from music_assistant import MusicAssistant
+
+# Config value keys that are bookkeeping of the universal player wrapper itself
+# (protocol links and device-identity caches) and must never be carried over
+# when a native player replaces a universal player.
+UNIVERSAL_PLAYER_INTERNAL_CONF_KEYS = (
+    CONF_LINKED_PROTOCOL_IDS,
+    CONF_PROTOCOL_PARENT_ID,
+    CONF_UNDERLYING_PLAYER_ID,
+    CONF_DEVICE_IDENTIFIERS,
+    CONF_DEVICE_INFO,
+    CONF_CACHED_ARP_MAC,
+    CONF_REPORTED_MAC,
+)
 
 
 class ProtocolLinkingMixin:
@@ -1002,8 +1026,122 @@ class ProtocolLinkingMixin:
             )
             native_player.refresh_state()
 
+            # Carry over the user's configuration before the permanent removal
+            # below deletes the universal player's config
+            self._migrate_universal_player_config(player, native_player)
+
             # Remove the now-obsolete universal player
             self.mass.create_task(self.unregister(player.player_id, permanent=True))
+
+    def _migrate_universal_player_config(
+        self, universal_player: Player, native_player: Player
+    ) -> None:
+        """
+        Carry over user-set configuration from a replaced universal player.
+
+        Copies the custom display name, player config values, DSP settings and
+        per-queue settings of the (obsolete) universal player onto the native
+        player that replaces it, without overwriting values explicitly set on
+        the native player itself. Must be called before the universal player is
+        permanently unregistered, as that deletes its config.
+
+        :param universal_player: The obsolete universal player being replaced.
+        :param native_player: The native player that replaces it.
+        """
+        universal_id = universal_player.player_id
+        native_id = native_player.player_id
+        source_raw = self.mass.config.get(f"{CONF_PLAYERS}/{universal_id}")
+        source_raw = source_raw if isinstance(source_raw, dict) else {}
+        target_key = f"{CONF_PLAYERS}/{native_id}"
+        target_raw = self.mass.config.get(target_key)
+        target_raw = target_raw if isinstance(target_raw, dict) else {}
+        player_config_changed = False
+
+        # only carry an actual user rename, not the auto-generated default name
+        custom_name = source_raw.get("name")
+        if (
+            custom_name
+            and custom_name != source_raw.get("default_name")
+            and not target_raw.get("name")
+        ):
+            self.mass.config.set(f"{target_key}/name", custom_name)
+            player_config_changed = True
+
+        source_values = source_raw.get("values")
+        source_values = source_values if isinstance(source_values, dict) else {}
+        target_values = target_raw.get("values")
+        target_values = target_values if isinstance(target_values, dict) else {}
+        for key, value in source_values.items():
+            if key in UNIVERSAL_PLAYER_INTERNAL_CONF_KEYS:
+                continue
+            if CONF_PROTOCOL_KEY_SPLITTER in key:
+                # stale virtual mirror of a protocol player's own config
+                continue
+            if key in target_values:
+                continue
+            self.mass.config.set(f"{target_key}/values/{key}", deepcopy(value))
+            player_config_changed = True
+
+        # DSP settings follow wholesale, unless the native player has its own
+        dsp_changed = False
+        source_dsp = self.mass.config.get(f"{CONF_PLAYER_DSP}/{universal_id}")
+        if source_dsp and not self.mass.config.get(f"{CONF_PLAYER_DSP}/{native_id}"):
+            self.mass.config.set(f"{CONF_PLAYER_DSP}/{native_id}", deepcopy(source_dsp))
+            dsp_changed = True
+
+        queue_changed = self._migrate_universal_queue_config(universal_id, native_id)
+
+        if not (player_config_changed or dsp_changed or queue_changed):
+            return
+        self.logger.info(
+            "Carried over configuration of universal player %s to %s", universal_id, native_id
+        )
+        if player_config_changed:
+            # the native player's in-place config was loaded before the carry-over,
+            # so reload it to make the migrated values (e.g. custom name) effective
+            self.mass.create_task(self._reapply_player_config(native_id))
+
+    def _migrate_universal_queue_config(self, universal_id: str, native_id: str) -> bool:
+        """
+        Move the per-queue settings of a replaced universal player to its replacement.
+
+        Queue ids equal player ids. The queue config is not covered by the
+        permanent unregister cleanup, so the source entry is removed here.
+
+        :param universal_id: Player id of the obsolete universal player.
+        :param native_id: Player id of the native player that replaces it.
+        :return: True if any queue setting was carried over.
+        """
+        queue_changed = False
+        source_queue_raw = self.mass.config.get(f"{CONF_PLAYER_QUEUES}/{universal_id}")
+        source_queue_raw = source_queue_raw if isinstance(source_queue_raw, dict) else None
+        if source_queue_values := (source_queue_raw or {}).get("values"):
+            target_queue_key = f"{CONF_PLAYER_QUEUES}/{native_id}"
+            target_queue_raw = self.mass.config.get(target_queue_key)
+            target_queue_raw = (
+                deepcopy(target_queue_raw) if isinstance(target_queue_raw, dict) else {}
+            )
+            target_queue_values = target_queue_raw.setdefault("values", {})
+            for key, value in source_queue_values.items():
+                if key in target_queue_values:
+                    continue
+                target_queue_values[key] = deepcopy(value)
+                queue_changed = True
+            if queue_changed:
+                target_queue_raw["queue_id"] = native_id
+                self.mass.config.set(target_queue_key, target_queue_raw)
+        if source_queue_raw is not None:
+            self.mass.config.remove(f"{CONF_PLAYER_QUEUES}/{universal_id}")
+        return queue_changed
+
+    async def _reapply_player_config(self, player_id: str) -> None:
+        """Reload the stored config onto a registered player and refresh its state."""
+        if not (player := self.get_player(player_id)):
+            return
+        config = await self.mass.config.get_player_config(player_id)
+        player.set_config(config)
+        player.update_state()
+        self.mass.signal_event(EventType.PLAYER_CONFIG_UPDATED, object_id=player_id, data=config)
 
     def _parent_has_active_protocol_from_domain(
         self, parent: Player, domain: str, exclude_player_id: str | None = None

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1057,12 +1057,16 @@ class ProtocolLinkingMixin:
         target_raw = target_raw if isinstance(target_raw, dict) else {}
         player_config_changed = False
 
-        # only carry an actual user rename, not the auto-generated default name
+        # only carry an actual user rename, not the auto-generated default name;
+        # likewise a name on the native player only counts as a user override when
+        # it differs from the default name (fresh configs store name == default_name)
         custom_name = source_raw.get("name")
+        target_name = target_raw.get("name")
+        target_has_custom_name = bool(target_name) and target_name != target_raw.get("default_name")
         if (
             custom_name
             and custom_name != source_raw.get("default_name")
-            and not target_raw.get("name")
+            and not target_has_custom_name
         ):
             self.mass.config.set(f"{target_key}/name", custom_name)
             player_config_changed = True

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -5658,7 +5658,14 @@ class TestUniversalPlayerReplacement:
     async def test_replace_carries_over_universal_config(self, mock_mass: MagicMock) -> None:
         """Replacement migrates name, values, DSP and queue settings to the native player."""
         config_store: dict[str, Any] = {
-            "players/cast_1": {"enabled": True, "values": {"volume_control": "native"}},
+            # fresh native configs store name == default_name; that must not
+            # count as a user override blocking the name carry-over
+            "players/cast_1": {
+                "enabled": True,
+                "name": "Soundbar",
+                "default_name": "Soundbar",
+                "values": {"volume_control": "native"},
+            },
             "players/up_old": {
                 "enabled": True,
                 "name": "Living Room",
@@ -5742,7 +5749,7 @@ class TestUniversalPlayerReplacement:
     def test_replace_keeps_native_name_dsp_and_queue_values(self, mock_mass: MagicMock) -> None:
         """Values explicitly set on the native player win over the universal player's."""
         config_store: dict[str, Any] = {
-            "players/cast_1": {"enabled": True, "name": "Kitchen"},
+            "players/cast_1": {"enabled": True, "name": "Kitchen", "default_name": "Soundbar"},
             "players/up_old": {
                 "enabled": True,
                 "name": "Living Room",

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -6,7 +6,14 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import IdentifierType, PlaybackState, PlayerFeature, PlayerType
+from music_assistant_models.config_entries import PlayerConfig
+from music_assistant_models.enums import (
+    EventType,
+    IdentifierType,
+    PlaybackState,
+    PlayerFeature,
+    PlayerType,
+)
 from music_assistant_models.player import OutputProtocol, PlayerMedia
 
 from music_assistant.constants import (
@@ -5576,6 +5583,228 @@ class TestUniversalPlayerReplacement:
         assert all(
             link.output_protocol_id != "ap_old" for link in universal.linked_output_protocols
         )
+
+    @staticmethod
+    def _setup_carry_over_scenario(
+        mock_mass: MagicMock, config_store: dict[str, Any]
+    ) -> tuple[PlayerController, MockPlayer, list[Awaitable[object]]]:
+        """
+        Wire a replacement scenario for the config carry-over tests.
+
+        Universal player 'up_old' (holding protocol player 'ap_live') is
+        replaceable by native player 'cast_1'.
+        """
+        controller = PlayerController(mock_mass)
+        up_provider = create_mock_universal_provider(mock_mass)
+
+        def config_get(key: str, default: object = None) -> object:
+            return config_store.get(key, default)
+
+        def config_set(key: str, value: object) -> None:
+            config_store[key] = value
+
+        def config_remove(key: str) -> None:
+            config_store.pop(key, None)
+
+        scheduled_tasks: list[Awaitable[object]] = []
+
+        def capture_task(task: Awaitable[object], *_args: Any, **_kwargs: Any) -> None:
+            scheduled_tasks.append(task)
+
+        mock_mass.config.get = MagicMock(side_effect=config_get)
+        mock_mass.config.set = MagicMock(side_effect=config_set)
+        mock_mass.config.remove = MagicMock(side_effect=config_remove)
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        mock_mass.call_later = MagicMock()
+        mock_mass.loop = MagicMock()
+        mock_mass.create_task = MagicMock(side_effect=capture_task)
+
+        universal = UniversalPlayer(
+            provider=up_provider,
+            player_id="up_old",
+            name="Soundbar (Universal)",
+            device_info=DeviceInfo(model="Test", manufacturer="Test"),
+            protocol_player_ids=["ap_live"],
+        )
+        universal._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, "AA:BB:CC:DD:EE:FF")
+        universal._cache.clear()
+        universal.update_state(signal_event=False)
+        universal.set_initialized()
+
+        cast_provider = MockProvider("cast", mass=mock_mass)
+        native = MockPlayer(
+            cast_provider,
+            "cast_1",
+            "Soundbar",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        native.set_initialized()
+
+        airplay_provider = MockProvider("airplay", mass=mock_mass)
+        ap_live = MockPlayer(
+            airplay_provider,
+            "ap_live",
+            "Soundbar (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        ap_live.set_initialized()
+
+        controller._players = {"up_old": universal, "cast_1": native, "ap_live": ap_live}
+        controller._add_protocol_link(universal, ap_live, "airplay")
+        return controller, native, scheduled_tasks
+
+    async def test_replace_carries_over_universal_config(self, mock_mass: MagicMock) -> None:
+        """Replacement migrates name, values, DSP and queue settings to the native player."""
+        config_store: dict[str, Any] = {
+            "players/cast_1": {"enabled": True, "values": {"volume_control": "native"}},
+            "players/up_old": {
+                "enabled": True,
+                "name": "Living Room",
+                "default_name": "Soundbar (Universal)",
+                "values": {
+                    "hide_in_ui": True,
+                    "volume_control": "up_volume_control",
+                    "linked_protocol_ids": ["ap_live", "ghost_proto"],
+                    "device_identifiers": {"mac_address": "AA:BB:CC:DD:EE:FF"},
+                    "device_info": {"model": "Test", "manufacturer": "Test"},
+                    "ap_live||protocol||output_codec": "flac",
+                },
+            },
+            "players/ap_live": {"enabled": True},
+            "player_dsp/up_old": {"enabled": True, "filters": []},
+            "player_queues/up_old": {"queue_id": "up_old", "values": {"crossfade_duration": 5}},
+        }
+        controller, native, scheduled_tasks = self._setup_carry_over_scenario(
+            mock_mass, config_store
+        )
+
+        controller._check_replace_universal_player(native)
+
+        # the custom display name and user-set values moved onto the native player
+        assert config_store["players/cast_1/name"] == "Living Room"
+        assert config_store["players/cast_1/values/hide_in_ui"] is True
+        # values the native player has explicitly set are not overwritten
+        assert "players/cast_1/values/volume_control" not in config_store
+        # wrapper bookkeeping and protocol-mirror values are not carried over
+        assert "players/cast_1/values/device_identifiers" not in config_store
+        assert "players/cast_1/values/device_info" not in config_store
+        assert "players/cast_1/values/ap_live||protocol||output_codec" not in config_store
+        # linked ids come from the protocol move machinery, not the universal's raw list
+        assert config_store["players/cast_1/values/linked_protocol_ids"] == ["ap_live"]
+        # DSP settings moved wholesale
+        assert config_store["player_dsp/cast_1"] == {"enabled": True, "filters": []}
+        # queue settings moved and re-keyed onto the native player's queue
+        assert config_store["player_queues/cast_1"] == {
+            "queue_id": "cast_1",
+            "values": {"crossfade_duration": 5},
+        }
+        assert "player_queues/up_old" not in config_store
+        # the native player's in-place config gets reloaded to apply the new values
+        assert any("_reapply_player_config" in repr(t) for t in scheduled_tasks)
+
+        # and the universal player is still permanently removed
+        unregister_tasks = [t for t in scheduled_tasks if "unregister" in repr(t)]
+        assert len(unregister_tasks) == 1
+        await unregister_tasks[0]
+        assert "up_old" not in controller._players
+        # migrated values survive the permanent cleanup of the universal player
+        assert config_store["players/cast_1/name"] == "Living Room"
+        assert "players/up_old" not in config_store
+        assert "player_dsp/up_old" not in config_store
+
+    def test_replace_carries_over_nothing_without_user_config(self, mock_mass: MagicMock) -> None:
+        """A non-customized universal player migrates nothing (no default-name carry)."""
+        config_store: dict[str, Any] = {
+            "players/cast_1": {"enabled": True},
+            "players/up_old": {
+                "enabled": True,
+                "name": "Soundbar (Universal)",
+                "default_name": "Soundbar (Universal)",
+                "values": {"linked_protocol_ids": ["ap_live"]},
+            },
+            "players/ap_live": {"enabled": True},
+        }
+        controller, native, scheduled_tasks = self._setup_carry_over_scenario(
+            mock_mass, config_store
+        )
+
+        controller._check_replace_universal_player(native)
+
+        assert "players/cast_1/name" not in config_store
+        assert "player_dsp/cast_1" not in config_store
+        assert "player_queues/cast_1" not in config_store
+        # nothing migrated, so no config reload is scheduled
+        assert not any("_reapply_player_config" in repr(t) for t in scheduled_tasks)
+        assert any("unregister" in repr(t) for t in scheduled_tasks)
+
+    def test_replace_keeps_native_name_dsp_and_queue_values(self, mock_mass: MagicMock) -> None:
+        """Values explicitly set on the native player win over the universal player's."""
+        config_store: dict[str, Any] = {
+            "players/cast_1": {"enabled": True, "name": "Kitchen"},
+            "players/up_old": {
+                "enabled": True,
+                "name": "Living Room",
+                "default_name": "Soundbar (Universal)",
+                "values": {"hide_in_ui": True},
+            },
+            "players/ap_live": {"enabled": True},
+            "player_dsp/cast_1": {"enabled": False, "filters": ["native"]},
+            "player_dsp/up_old": {"enabled": True, "filters": ["universal"]},
+            "player_queues/cast_1": {"queue_id": "cast_1", "values": {"crossfade_duration": 2}},
+            "player_queues/up_old": {
+                "queue_id": "up_old",
+                "values": {"crossfade_duration": 8, "autoplay_mode": "smart"},
+            },
+        }
+        controller, native, _ = self._setup_carry_over_scenario(mock_mass, config_store)
+
+        controller._check_replace_universal_player(native)
+
+        # the native player's own custom name and DSP config win
+        assert "players/cast_1/name" not in config_store
+        assert config_store["players/cast_1"]["name"] == "Kitchen"
+        assert config_store["player_dsp/cast_1"] == {"enabled": False, "filters": ["native"]}
+        # queue values merge without overwriting the native queue's own values
+        assert config_store["player_queues/cast_1"] == {
+            "queue_id": "cast_1",
+            "values": {"crossfade_duration": 2, "autoplay_mode": "smart"},
+        }
+        assert "player_queues/up_old" not in config_store
+        # non-conflicting values still migrate
+        assert config_store["players/cast_1/values/hide_in_ui"] is True
+
+    async def test_reapply_player_config_refreshes_native_player(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Reloading the config applies a migrated custom name to the live player."""
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        mock_mass.call_later = MagicMock()
+        provider = MockProvider("cast", mass=mock_mass)
+        native = MockPlayer(provider, "cast_1", "Soundbar")
+        native.set_initialized()
+        controller._players = {"cast_1": native}
+
+        new_config = PlayerConfig.parse(
+            [],
+            {
+                "player_id": "cast_1",
+                "provider": "cast",
+                "name": "Living Room",
+                "default_name": "Soundbar",
+            },
+        )
+        mock_mass.config.get_player_config = AsyncMock(return_value=new_config)
+
+        await controller._reapply_player_config("cast_1")
+
+        assert native.config is new_config
+        assert native.display_name == "Living Room"
+        signaled_events = [call.args[0] for call in mock_mass.signal_event.call_args_list]
+        assert EventType.PLAYER_CONFIG_UPDATED in signaled_events
 
 
 class TestEndToEndDuplicateProtocol:


### PR DESCRIPTION
# What does this implement/fix?

When a device that was handled by a Universal Player gets replaced by a native player (for example after enabling a native provider for it, or when a device changes type such as with the recent squeezelite update), the Universal Player is removed - and all of the user's settings on it were lost: the custom name, player settings, DSP configuration and queue settings.

This change carries those settings over to the native player during the replacement:

- Custom display name, player settings, DSP configuration and queue settings now move onto the replacing native player
- Settings the native player already has explicitly set are never overwritten
- Internal bookkeeping of the Universal Player (protocol links, device identifiers) is not carried over
- The queue settings of the removed Universal Player are now cleaned up as well (previously left behind)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
