### PR TITLE
ariacast_receiver: Add configurable Device Name

### DIFF
--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -9,7 +9,7 @@ import socket
 import time
 from collections.abc import AsyncGenerator
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
 from aiohttp import ClientTimeout, web
@@ -46,6 +46,8 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 CONF_MASS_PLAYER_ID = "mass_player_id"
+CONF_ARIACAST_NAME = "ariacast_name"
+DEFAULT_ARIACAST_NAME = "Music Assistant"
 PLAYER_ID_AUTO = "__auto__"
 SUPPORTED_FEATURES = {ProviderFeature.AUDIO_SOURCE}
 AUDIO_SOURCE_ID = "main"
@@ -94,6 +96,9 @@ class AriaCastReceiver(PluginProvider):
         super().__init__(mass, manifest, config, SUPPORTED_FEATURES)
         # Avoid str(None), which would bypass automatic player selection.
         self._default_player_id = str(self.get_setup_value(CONF_MASS_PLAYER_ID) or PLAYER_ID_AUTO)
+        self._ariacast_name = (
+            cast("str", self.get_setup_value(CONF_ARIACAST_NAME)) or DEFAULT_ARIACAST_NAME
+        )
 
         # Audio pipeline: one asyncio.Queue, drained per stream (VBAN pattern)
         self._audio_queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=100)
@@ -181,7 +186,9 @@ class AriaCastReceiver(PluginProvider):
                 f"Cannot bind AriaCast server on port {ARIACAST_PORT}: {err}"
             ) from err
 
-        self.logger.info("AriaCast server listening on port %d", ARIACAST_PORT)
+        self.logger.info(
+            "AriaCast server '%s' listening on port %d", self._ariacast_name, ARIACAST_PORT
+        )
         self.mass.create_task(self._run_udp_discovery())
         self._stats_task = self.mass.create_task(self._run_stats_broadcast())
 
@@ -832,7 +839,7 @@ class AriaCastReceiver(PluginProvider):
 
         response_payload = json.dumps(
             {
-                "server_name": "MusicAssistant AriaCast Receiver",
+                "server_name": self._ariacast_name,
                 "ip": local_ip,
                 "port": ARIACAST_PORT,
                 "samplerate": 48000,

--- a/music_assistant/providers/ariacast_receiver/setup_flow.py
+++ b/music_assistant/providers/ariacast_receiver/setup_flow.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
 
 from music_assistant.constants import CONF_ENTRY_WARN_PREVIEW
 from music_assistant.helpers.config_entries import create_player_selector
 from music_assistant.models.setup_flow import SetupFlowError
 
-from . import CONF_MASS_PLAYER_ID, PLAYER_ID_AUTO
+from . import (
+    CONF_ARIACAST_NAME,
+    CONF_MASS_PLAYER_ID,
+    DEFAULT_ARIACAST_NAME,
+    PLAYER_ID_AUTO,
+)
 
 if TYPE_CHECKING:
     from music_assistant.models.setup_flow import SetupSession
@@ -23,7 +31,9 @@ async def run_setup(session: SetupSession) -> None:
     setup_data = dict(session.context.setup_data)
     errors: dict[str, str] | None = None
     while True:
-        prefill = {**session.context.values, **setup_data}
+        prefill: dict[str, Any] = {**session.context.values, **setup_data}
+        ariacast_name = str(prefill.get(CONF_ARIACAST_NAME) or DEFAULT_ARIACAST_NAME)
+
         values = await session.form(
             [
                 CONF_ENTRY_WARN_PREVIEW,
@@ -32,6 +42,13 @@ async def run_setup(session: SetupSession) -> None:
                     CONF_MASS_PLAYER_ID,
                     prefill.get(CONF_MASS_PLAYER_ID),
                     PLAYER_ID_AUTO,
+                ),
+                ConfigEntry(
+                    key=CONF_ARIACAST_NAME,
+                    type=ConfigEntryType.STRING,
+                    required=True,
+                    default_value=ariacast_name,
+                    value=ariacast_name,
                 ),
             ],
             step_id="user",

--- a/music_assistant/providers/ariacast_receiver/strings.json
+++ b/music_assistant/providers/ariacast_receiver/strings.json
@@ -6,6 +6,10 @@
       "options": {
         "__auto__": "Auto (prefer playing player)"
       }
+    },
+    "ariacast_name": {
+      "label": "AriaCast Device Name",
+      "description": "The name shown to AriaCast senders when they discover this receiver on the network."
     }
   },
   "setup_flow": {

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -896,6 +896,8 @@
   "provider.ard_audiothek.config_entries.token_expiry.label": "token_expiry",
   "provider.ard_audiothek.config_entries.user_id.label": "uid",
   "provider.ard_audiothek.manifest.description": "Stream radio shows, news, and podcasts from ARD’s Audiothek (Germany’s public broadcaster).",
+  "provider.ariacast_receiver.config_entries.ariacast_name.description": "The name shown to AriaCast senders when they discover this receiver on the network.",
+  "provider.ariacast_receiver.config_entries.ariacast_name.label": "AriaCast Device Name",
   "provider.ariacast_receiver.config_entries.mass_player_id.description": "The player to route AriaCast audio to.",
   "provider.ariacast_receiver.config_entries.mass_player_id.label": "Connected Music Assistant Player",
   "provider.ariacast_receiver.config_entries.mass_player_id.options.__auto__": "Auto (prefer playing player)",

--- a/tests/providers/receiver_setup_flows/test_receiver_setup_flows.py
+++ b/tests/providers/receiver_setup_flows/test_receiver_setup_flows.py
@@ -20,7 +20,7 @@ from music_assistant.providers.airplay_receiver import (
 )
 from music_assistant.providers.airplay_receiver import setup_flow as airplay_flow
 from music_assistant.providers.ariacast_receiver import (
-    CONF_MASS_PLAYER_ID as ARIACAST_PLAYER_ID,
+    CONF_ARIACAST_NAME,
 )
 from music_assistant.providers.ariacast_receiver import setup_flow as ariacast_flow
 from music_assistant.providers.spotify_connect import (
@@ -122,7 +122,10 @@ async def _wait_finished(session: SetupSession) -> None:
         (
             "ariacast_receiver",
             ariacast_flow,
-            {ARIACAST_PLAYER_ID: "kitchen"},
+            {
+                AIRPLAY_PLAYER_ID: "kitchen",
+                CONF_ARIACAST_NAME: "Kitchen AriaCast",
+            },
         ),
     ],
 )


### PR DESCRIPTION
- New 'Device Name' ConfigEntry (CONF_DEVICE_NAME), following the pattern of airplay_receiver's CONF_AIRPLAY_NAME: falls back to the provider instance name when unset, default value 'Music Assistant'.
- The configured name now drives the 'server_name' field in the UDP discovery response, replacing the hardcoded 'MusicAssistant AriaCast Receiver' string.
- strings.json updated with a device_name entry

# What does this implement/fix?

Adds a configurable 'Device Name" option, the device name is shown to AriaCast senders when they discover the receiver on the network.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
