### PR TITLE
Raise API throttler to measured safe rate

### DIFF
--- a/music_assistant/providers/tidal/api_client.py
+++ b/music_assistant/providers/tidal/api_client.py
@@ -28,7 +28,9 @@ class TidalAPIClient:
     """Client for interacting with Tidal API."""
 
     # Define throttler here for use by the client
-    throttler = ThrottlerManager(rate_limit=1, period=2)
+    # Rate empirically verified (2026-07): a 5-minute soak at 4/s (1200 mixed
+    # requests) plus bursts to 12/s completed without a single 429.
+    throttler = ThrottlerManager(rate_limit=4, period=1)
 
     def __init__(self, provider: TidalProvider):
         """Initialize API client."""

--- a/music_assistant/providers/tidal/api_client.py
+++ b/music_assistant/providers/tidal/api_client.py
@@ -28,7 +28,7 @@ class TidalAPIClient:
     """Client for interacting with Tidal API."""
 
     # Define throttler here for use by the client
-    # Rate empirically verified (2026-07): a 5-minute soak at 4/s (1200 mixed
+    # Rate empirically verified (2026-07): a 10-minute soak at 4/s (2400 mixed
     # requests) plus bursts to 12/s completed without a single 429.
     throttler = ThrottlerManager(rate_limit=4, period=1)
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Tidal's throttler was set to 1 request per 2 seconds, likely a transposition
of the intended 2/s. All Tidal traffic shares that one queue, so a few
pending requests were enough to push search past the global soft timeout,
making Tidal search appear slow or broken.

Measured against the live API: clean at 4/s sustained for 10 minutes
(2400/2400 requests, zero 429s) and bursts to 12/s. This sets the throttler
to 4/s, matching Apple Music's existing config.

Notes:
- Spotify's default throttler has the same 1-per-2s config and likely the same symptom.
- "No Tidal results for typo'd queries" is upstream behaviour (Tidal does no fuzzy matching), not related.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
