### PR TITLE
Smart fades: stop stranding the listener in silence on energy-drop transitions

### DIFF
--- a/music_assistant/controllers/streams/smart_fades/planner/policies.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/policies.py
@@ -161,9 +161,12 @@ class DeadAirPolicy(Policy):
         if peak <= 0.0:
             return False
         bin_seconds = duration / len(rms)
-        fade_start = ctx.buffer_offset + plan.fade_out_window - plan.crossfade_duration
-        low = max(0, int((fade_start - self.lookback_seconds) / bin_seconds))
-        high = max(low + 1, min(len(rms), int(fade_start / bin_seconds)))
+        # sample the source RMS over the last lookback window ending at the cut
+        # anchor; the stored energy is unfaded, so this reads the outgoing's own
+        # level right before the cut with no crossfade-ramp or tempo-stretch mixed in
+        anchor = ctx.buffer_offset + plan.fade_out_window
+        low = max(0, int((anchor - self.lookback_seconds) / bin_seconds))
+        high = max(low + 1, min(len(rms), int(anchor / bin_seconds)))
         window = rms[low:high]
         return sum(window) / len(window) >= peak * self.hot_outgoing_floor
 

--- a/music_assistant/controllers/streams/smart_fades/planner/policies.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/policies.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
-from music_assistant.controllers.streams.smart_fades.models import TransitionTier
+from music_assistant.controllers.streams.smart_fades.models import TransitionPlan, TransitionTier
 from music_assistant.controllers.streams.smart_fades.vocal import (
     COLLISION_SECONDS_LIMIT,
     SHORT_FADE_SECONDS,
@@ -125,6 +125,49 @@ class AudibleTrimPolicy(Policy):
         return Verdict.ok(trim * self.trim_penalty_per_second)
 
 
+class DeadAirPolicy(Policy):
+    """Penalize a handover that strands the listener in silence before B's groove entry."""
+
+    grace_seconds: float = 4.0
+    dead_air_penalty_per_second: float = 1.0
+    # pre-fade outgoing level (relative to its own track peak) below which the
+    # outgoing is already a whisper and a slow incoming intro is welcome
+    hot_outgoing_floor: float = 0.178  # -15 dB
+    lookback_seconds: float = 8.0
+
+    def evaluate(self, candidate: Candidate, ctx: TransitionContext) -> Verdict:
+        """Judge one candidate against the shared per-transition context."""
+        plan = candidate.plan
+        gap = (
+            ctx.natural_entry
+            - (plan.fadein_trim_start or 0.0)
+            - plan.crossfade_duration
+            - self.grace_seconds
+        )
+        if gap <= 0.0 or not self._outgoing_is_hot(plan, ctx):
+            return Verdict.ok()
+        return Verdict.ok(gap * self.dead_air_penalty_per_second)
+
+    def _outgoing_is_hot(self, plan: TransitionPlan, ctx: TransitionContext) -> bool:
+        """Whether the outgoing still plays at level just before the candidate's fade."""
+        analysis = ctx.outgoing.analysis
+        rms = analysis.rms_energy
+        duration = analysis.duration
+        if rms is None or len(rms) == 0 or not duration:
+            # without energy data the gate cannot clear the penalty; dead air
+            # after an unknown outgoing is worse than a trimmed intro
+            return True
+        peak = max(rms)
+        if peak <= 0.0:
+            return False
+        bin_seconds = duration / len(rms)
+        fade_start = ctx.buffer_offset + plan.fade_out_window - plan.crossfade_duration
+        low = max(0, int((fade_start - self.lookback_seconds) / bin_seconds))
+        high = max(low + 1, min(len(rms), int(fade_start / bin_seconds)))
+        window = rms[low:high]
+        return sum(window) / len(window) >= peak * self.hot_outgoing_floor
+
+
 class OverlapPreferencePolicy(Policy):
     """Prefer the tier's top rung, the context's chosen tier, and two-sided vocal relief."""
 
@@ -172,6 +215,7 @@ def default_policies() -> tuple[Policy, ...]:
         VocalCollisionPolicy(),
         VocalTruncationPolicy(),
         AudibleTrimPolicy(),
+        DeadAirPolicy(),
         OverlapPreferencePolicy(),
         AnchorAlignmentPolicy(),
     )

--- a/tests/controllers/streams/smart_fades/conftest.py
+++ b/tests/controllers/streams/smart_fades/conftest.py
@@ -18,7 +18,7 @@ from music_assistant.controllers.streams.smart_fades.planner.candidates import (
 from music_assistant.models.audio_analysis import AudioAnalysisData
 
 
-def build_test_candidate(
+def build_test_candidate(  # noqa: PLR0913
     *,
     bars: int = 8,
     ideal: int = 8,
@@ -30,12 +30,19 @@ def build_test_candidate(
     duration: float = 20.0,
     one_sided: str | None = None,
     tier: TransitionTier = TransitionTier.FULL_BLEND,
+    fadein_trim: float | None = None,
+    fade_end: float | None = None,
 ) -> Candidate:
     """Build a minimal ``Candidate`` with only the fields a policy under test reads."""
     spec = CandidateSpec(
         tier=tier, bars=bars, anchor_s=None, entry_s=None, one_sided_vocal=one_sided
     )
-    plan = TransitionPlan(tier=tier, fade_out_window=duration, crossfade_duration=duration)
+    plan = TransitionPlan(
+        tier=tier,
+        fade_out_window=fade_end if fade_end is not None else duration,
+        crossfade_duration=duration,
+        fadein_trim_start=fadein_trim,
+    )
     metrics = PlanMetrics(
         audible_outgoing_trim=trim,
         outgoing_vocal_fade_seconds=vocal_fade,

--- a/tests/controllers/streams/smart_fades/test_policies.py
+++ b/tests/controllers/streams/smart_fades/test_policies.py
@@ -17,6 +17,7 @@ from music_assistant.controllers.streams.smart_fades.planner.context import (
 from music_assistant.controllers.streams.smart_fades.planner.policies import (
     AnchorAlignmentPolicy,
     AudibleTrimPolicy,
+    DeadAirPolicy,
     OverlapPreferencePolicy,
     Verdict,
     VocalCollisionPolicy,
@@ -38,6 +39,9 @@ def _ctx(
     tier: TransitionTier = TransitionTier.FULL_BLEND,
     vocal_out_scoring: VocalMask | None = None,
     vocal_in_scoring: VocalMask | None = None,
+    natural_entry: float = 0.0,
+    outgoing_analysis: AudioAnalysisData | None = None,
+    buffer_offset: float = 0.0,
 ) -> TransitionContext:
     deck = Deck(
         analysis=AudioAnalysisData(),
@@ -45,13 +49,14 @@ def _ctx(
         beats=np.array([], dtype=np.float32),
         downbeats=np.array([], dtype=np.float32),
     )
+    outgoing = dataclasses.replace(deck, analysis=outgoing_analysis) if outgoing_analysis else deck
     return TransitionContext(
-        outgoing=deck,
+        outgoing=outgoing,
         incoming=deck,
         outgoing_profile=None,
         incoming_profile=None,
         buffer_duration=45.0,
-        buffer_offset=0.0,
+        buffer_offset=buffer_offset,
         audio_end=45.0,
         default_anchor=45.0,
         mix_out_anchor=None,
@@ -65,7 +70,7 @@ def _ctx(
         vocal_in_placement=None,
         vocal_out_scoring=vocal_out_scoring,
         vocal_in_scoring=vocal_in_scoring,
-        natural_entry=0.0,
+        natural_entry=natural_entry,
         protective_downbeats=(),
     )
 
@@ -380,14 +385,66 @@ class TestAnchorAlignmentPolicy:
         assert self.policy.evaluate(candidate, ctx).penalty == pytest.approx(6.0)
 
 
-def test_default_policies_returns_the_five_standard_policies() -> None:
-    """The standard policy tuple contains one instance of each of the five policies."""
+def test_default_policies_returns_the_six_standard_policies() -> None:
+    """The standard policy tuple contains one instance of each of the six policies."""
     policies = default_policies()
 
     assert [type(p) for p in policies] == [
         VocalCollisionPolicy,
         VocalTruncationPolicy,
         AudibleTrimPolicy,
+        DeadAirPolicy,
         OverlapPreferencePolicy,
         AnchorAlignmentPolicy,
     ]
+
+
+class TestDeadAirPolicy:
+    """Penalize a handover that strands the listener before B's groove entry."""
+
+    def _hot_outgoing(self, tail_level: float = 0.9) -> AudioAnalysisData:
+        # peak mid-track; the tail level decides whether the pre-fade window is hot
+        rms = [0.9] * 1500 + [tail_level] * 300
+        return AudioAnalysisData(duration=220.0, rms_energy=rms)
+
+    def test_dead_air_beyond_grace_is_penalized_per_second(self) -> None:
+        """A hot outgoing into a late groove entry pays for every second past the grace."""
+        ctx = _ctx(natural_entry=19.2, outgoing_analysis=self._hot_outgoing(), buffer_offset=175.0)
+        candidate = _candidate(duration=2.0, fade_end=42.0)
+
+        verdict = DeadAirPolicy().evaluate(candidate, ctx)
+
+        assert verdict.penalty == pytest.approx(19.2 - 2.0 - 4.0)
+        assert not verdict.rejected
+
+    def test_trimming_to_the_groove_entry_clears_the_penalty(self) -> None:
+        """A candidate that enters at B's groove has no dead air to pay for."""
+        ctx = _ctx(natural_entry=19.2, outgoing_analysis=self._hot_outgoing(), buffer_offset=175.0)
+        candidate = _candidate(duration=2.0, fade_end=42.0, fadein_trim=19.2)
+
+        assert DeadAirPolicy().evaluate(candidate, ctx).penalty == 0.0
+
+    def test_gap_within_grace_is_free(self) -> None:
+        """Short breathing room after the fade stays unpenalized."""
+        ctx = _ctx(natural_entry=5.5, outgoing_analysis=self._hot_outgoing(), buffer_offset=175.0)
+        candidate = _candidate(duration=2.0, fade_end=42.0)
+
+        assert DeadAirPolicy().evaluate(candidate, ctx).penalty == 0.0
+
+    def test_quiet_outgoing_keeps_the_incoming_intro(self) -> None:
+        """An outgoing already faded to a whisper welcomes a slow ambient intro."""
+        ctx = _ctx(
+            natural_entry=19.2,
+            outgoing_analysis=self._hot_outgoing(tail_level=0.02),
+            buffer_offset=175.0,
+        )
+        candidate = _candidate(duration=2.0, fade_end=42.0)
+
+        assert DeadAirPolicy().evaluate(candidate, ctx).penalty == 0.0
+
+    def test_missing_outgoing_rms_still_penalizes(self) -> None:
+        """Without RMS data the hot-outgoing gate cannot clear the penalty."""
+        ctx = _ctx(natural_entry=19.2, outgoing_analysis=AudioAnalysisData(), buffer_offset=175.0)
+        candidate = _candidate(duration=2.0, fade_end=42.0)
+
+        assert DeadAirPolicy().evaluate(candidate, ctx).penalty > 0.0


### PR DESCRIPTION
# What does this implement/fix?

Smart crossfades sometimes strand the listener in silence: a full-energy outgoing track fades out, then the incoming track's long quiet intro plays for 15–20s before its groove arrives. It reads as "the outgoing track was cut off early," even though almost nothing was trimmed.

The scorer measured seconds of *outgoing* music lost, but nothing charged for seconds of *dead air* after the handover. So a candidate that keeps the incoming's silent intro (cheap on every existing policy) beat one that trims to the groove (which pays a small alignment penalty).

This adds `DeadAirPolicy`: it charges ~1 point per second of gap between the fade end and the incoming's groove entry (`natural_entry`), beyond a short grace window. The existing groove-entry trim candidates now win, so the incoming's music lands right after the fade instead of 15–20s later.

Guarded to fire only where it should:
- **Grace window (4s):** short breathing room after a fade stays free.
- **Hot-outgoing gate:** the penalty only applies when the outgoing was still playing at level (RMS above −15 dB rel peak just before the fade). Ambient-into-ambient handovers keep their slow intros untouched.

Verified against two real transitions reported from listening sessions (Le Youth – Paradise → a vow; Jody Wisternoff – Citadel → Michael FK – Go Back): both flip from keeping the ~15–19s silent intro to trimming to the groove, with the outgoing fade unchanged. Plan-level corpus A/B: 0 of the existing pairs change (full-data and stale-vocal), so the policy is inert everywhere except the dead-air pattern it targets.

**Related issue (if applicable):**

- related issue N/A (reported directly from listening sessions)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
