### PR TITLE
Fix spontaneous pairing prompts on Apple TVs

### DIFF
--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -635,7 +635,7 @@ class AirPlayControlPlayer(AirPlayPlayer):
     def _is_apple_tv_device(self) -> bool:
         """Return whether the underlying device identifies itself as an Apple TV."""
         if self.airplay_discovery_info and (
-            model := self.airplay_discovery_info.decoded_properties.get("model")
+            model := get_decoded_property(self.airplay_discovery_info, "model")
         ):
             return model.startswith("AppleTV")
         return "apple tv" in self.device_info.model.lower()

--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -65,6 +65,7 @@ from .constants import (
     FALLBACK_VOLUME,
 )
 from .helpers import (
+    get_decoded_property,
     supports_companion_pairing,
     supports_mrp_service,
     supports_mrp_tunnel,
@@ -164,18 +165,6 @@ class AirPlayControlPlayer(AirPlayPlayer):
         return supports_companion_pairing(self.companion_discovery_info)
 
     @property
-    def needs_setup(self) -> bool:
-        """Return whether streaming or control features still require pairing."""
-        return (
-            super().needs_setup
-            or (
-                self.companion_pairing_supported
-                and not self.config.get_value(CONF_COMPANION_CREDENTIALS)
-            )
-            or (self.mrp_pairing_supported and not self._mrp_credentials)
-        )
-
-    @property
     def mrp_pairing_supported(self) -> bool:
         """Return whether MRP playback monitoring can be paired."""
         endpoint = self._mrp_endpoint
@@ -183,11 +172,7 @@ class AirPlayControlPlayer(AirPlayPlayer):
             return False
         discovery_info, protocol = endpoint
         if protocol == Protocol.MRP:
-            allow_pairing = (
-                discovery_info.decoded_properties.get("AllowPairing")
-                or discovery_info.decoded_properties.get("allowpairing")
-                or "no"
-            )
+            allow_pairing = get_decoded_property(discovery_info, "AllowPairing") or "no"
             return allow_pairing.lower() == "yes"
         return bool(
             not self._uses_transient_mrp
@@ -204,9 +189,11 @@ class AirPlayControlPlayer(AirPlayPlayer):
             FeatureName.Previous
         ):
             features.add(PlayerFeature.NEXT_PREVIOUS)
+        # POWER is advertised only when it can actually be served: a connected
+        # control channel exposing power commands, or stored Companion
+        # credentials (so the feature does not flap while (re)connecting).
         if (
-            self.companion_pairing_supported
-            or self.config.get_value(CONF_COMPANION_CREDENTIALS)
+            self.config.get_value(CONF_COMPANION_CREDENTIALS)
             or self._device_for_feature(FeatureName.TurnOn)
             or self._device_for_feature(FeatureName.TurnOff)
         ):
@@ -634,9 +621,24 @@ class AirPlayControlPlayer(AirPlayPlayer):
     @property
     def _uses_transient_mrp(self) -> bool:
         """Return whether playback monitoring uses transient AirPlay credentials."""
-        return not self.companion_pairing_supported and supports_transient_mrp(
-            self.airplay_discovery_info
-        )
+        # Mirrors pyatv's device rules: Apple TVs only accept real (paired) HAP
+        # credentials on the MRP tunnel and answer a transient pair-setup by
+        # showing the on-screen AirPlay pairing dialog, so they must never take
+        # this path - not even while the Companion record is still undiscovered.
+        # HomePods (and tunnel-capable third-party receivers) accept the
+        # transient handshake silently.
+        if self._is_apple_tv_device:
+            return False
+        return supports_transient_mrp(self.airplay_discovery_info)
+
+    @property
+    def _is_apple_tv_device(self) -> bool:
+        """Return whether the underlying device identifies itself as an Apple TV."""
+        if self.airplay_discovery_info and (
+            model := self.airplay_discovery_info.decoded_properties.get("model")
+        ):
+            return model.startswith("AppleTV")
+        return "apple tv" in self.device_info.model.lower()
 
     def _device_for_feature(self, feature: FeatureName) -> AppleTV | None:
         """Return the preferred connected device facade for a feature."""

--- a/music_assistant/providers/airplay/helpers.py
+++ b/music_assistant/providers/airplay/helpers.py
@@ -167,11 +167,32 @@ def is_apple_device(manufacturer: str, model: str) -> bool:
     )
 
 
+def get_decoded_property(discovery_info: AsyncServiceInfo, key: str) -> str | None:
+    """
+    Return an mDNS TXT property value by case-insensitive key.
+
+    TXT record keys are case-insensitive (RFC 6763) and zeroconf preserves the
+    casing as advertised on the wire, which differs per device (e.g. Companion
+    services advertise ``rpFl``, MRP services ``SystemBuildVersion``).
+
+    :param discovery_info: The mDNS service info to read the property from.
+    :param key: The TXT record key to look up (any casing).
+    """
+    decoded_properties = discovery_info.decoded_properties
+    if (value := decoded_properties.get(key)) is not None:
+        return value
+    folded_key = key.casefold()
+    for prop_key, prop_value in decoded_properties.items():
+        if prop_key.casefold() == folded_key:
+            return prop_value
+    return None
+
+
 def supports_companion_pairing(discovery_info: AsyncServiceInfo | None) -> bool:
     """Return whether a Companion service supports PIN pairing."""
     if discovery_info is None:
         return False
-    raw_flags = discovery_info.decoded_properties.get("rpfl")
+    raw_flags = get_decoded_property(discovery_info, "rpFl")
     if raw_flags is None:
         return False
     try:
@@ -210,11 +231,7 @@ def supports_mrp_service(discovery_info: AsyncServiceInfo | None) -> bool:
     """Return whether a native MRP service is usable."""
     if discovery_info is None or discovery_info.port is None:
         return False
-    build = (
-        discovery_info.decoded_properties.get("SystemBuildVersion")
-        or discovery_info.decoded_properties.get("systembuildversion")
-        or ""
-    )
+    build = get_decoded_property(discovery_info, "SystemBuildVersion") or ""
     match = re.match(r"^(\d+)[A-Z]", build)
     return match is None or int(match.group(1)) < 19
 

--- a/tests/providers/airplay/test_control_player.py
+++ b/tests/providers/airplay/test_control_player.py
@@ -84,10 +84,12 @@ def _make_control_player(
     config.update.side_effect = values.update
     provider.mass.config.get_base_player_config.return_value = config
     provider.mass.config.save_player_config = AsyncMock()
+    # Real Companion services advertise the flags under the mixed-case key
+    # "rpFl"; zeroconf preserves TXT key casing as sent on the wire.
     companion_info = (
         _service_info(
             COMPANION_DISCOVERY_TYPE,
-            properties={"rpfl": companion_flags},
+            properties={"rpFl": companion_flags},
         )
         if companion_flags is not None
         else None
@@ -148,8 +150,22 @@ def test_companion_pairing_follows_advertised_flags(flags: str, supported: bool)
     player = _make_control_player(companion_flags=flags)
 
     assert player.companion_pairing_supported is supported
-    assert (PlayerFeature.POWER in player.supported_features) is supported
+    # Pairability alone never advertises POWER: without stored credentials or a
+    # connected control channel the command could not be served.
+    assert PlayerFeature.POWER not in player.supported_features
     assert PlayerFeature.NEXT_PREVIOUS not in player.supported_features
+
+
+def test_power_feature_requires_credentials_or_connection() -> None:
+    """POWER is advertised for stored Companion credentials or a live channel."""
+    paired = _make_control_player(config_values={CONF_COMPANION_CREDENTIALS: "companion-creds"})
+    assert PlayerFeature.POWER in paired.supported_features
+
+    connected = _make_control_player()
+    device = MagicMock(spec=AppleTV)
+    device.features.in_state.side_effect = lambda _state, feature: feature == FeatureName.TurnOn
+    connected._companion_device = device
+    assert PlayerFeature.POWER in connected.supported_features
 
 
 def test_native_transport_features_follow_live_capabilities() -> None:
@@ -247,28 +263,36 @@ def test_duplicate_native_volume_update_is_ignored() -> None:
     update_state.assert_not_called()
 
 
-def test_pairable_companion_service_requires_setup_until_paired() -> None:
-    """Companion and MRP pairing contribute to the player's setup state."""
+def test_control_pairing_is_optional_and_never_requires_setup() -> None:
+    """Optional control pairing never marks the player as requiring setup."""
+    # needs_setup makes a player unavailable for playback, so it must only
+    # reflect the streaming requirements: an Apple TV streams fine without
+    # Companion/MRP credentials and pairing is offered in its settings instead.
     player = _make_control_player()
-    assert player.needs_setup is True
-
-    paired_player = _make_control_player(
-        config_values={CONF_COMPANION_CREDENTIALS: "companion-creds"}
-    )
-    assert paired_player.needs_setup is True
-
-    fully_paired_player = _make_control_player(
-        config_values={
-            CONF_COMPANION_CREDENTIALS: "companion-creds",
-            CONF_MRP_CREDENTIALS: "mrp-creds",
-        }
-    )
-    assert fully_paired_player.needs_setup is False
+    assert player.companion_pairing_supported is True
+    assert player.mrp_pairing_supported is True
+    assert player.needs_setup is False
 
     homepod = _make_control_player(model="HomePod Mini", companion_flags="0x62792")
     assert homepod.companion_pairing_supported is False
     assert homepod.mrp_pairing_supported is False
     assert homepod.needs_setup is False
+
+
+async def test_unpaired_apple_tv_never_attempts_control_connection() -> None:
+    """An Apple TV without stored credentials is never connected (or paired)."""
+    # An unsolicited connect would run pyatv's transient pair-setup, which makes
+    # an Apple TV display the AirPlay pairing dialog. Regression test for the
+    # spontaneous pairing popups: no credentials means no connection attempt,
+    # also while the Companion record is still undiscovered.
+    for companion_flags in ("0x367A2", None):
+        player = _make_control_player(companion_flags=companion_flags)
+        with patch(
+            "music_assistant.providers.airplay.control_player.pyatv.connect",
+        ) as connect:
+            assert await player._connect_companion() is False
+            assert await player._connect_mrp() is False
+        connect.assert_not_awaited()
 
 
 async def test_play_media_wakes_device_before_starting_stream() -> None:
@@ -633,7 +657,7 @@ async def test_provider_selects_player_model_from_device_identity(
     provider._companion_info_by_address = {
         "192.168.1.10": _service_info(
             COMPANION_DISCOVERY_TYPE,
-            properties={"rpfl": "0x367A2"},
+            properties={"rpFl": "0x367A2"},
         )
     }
     provider._mrp_info_by_address = {}
@@ -677,7 +701,7 @@ async def test_apple_device_setup_attaches_discovered_companion_service() -> Non
     provider._mrp_info_by_address = {}
     companion_info = _service_info(
         COMPANION_DISCOVERY_TYPE,
-        properties={"rpfl": "0x367A2"},
+        properties={"rpFl": "0x367A2"},
     )
 
     async def _find_service(
@@ -818,7 +842,7 @@ async def test_late_companion_discovery_never_changes_player_model() -> None:
     provider.mass.players.register = AsyncMock()
     info = _service_info(
         COMPANION_DISCOVERY_TYPE,
-        properties={"rpfl": "0x367A2"},
+        properties={"rpFl": "0x367A2"},
     )
 
     await provider._handle_companion_service_state_change(

--- a/tests/providers/airplay/test_control_player.py
+++ b/tests/providers/airplay/test_control_player.py
@@ -294,6 +294,17 @@ async def test_unpaired_apple_tv_never_attempts_control_connection() -> None:
             assert await player._connect_mrp() is False
         connect.assert_not_awaited()
 
+    # Apple TV detection reads the TXT model key case-insensitively as well.
+    player = _make_control_player(companion_flags=None)
+    assert player.airplay_discovery_info is not None
+    properties = player.airplay_discovery_info.decoded_properties
+    properties["Model"] = properties.pop("model")
+    with patch(
+        "music_assistant.providers.airplay.control_player.pyatv.connect",
+    ) as connect:
+        assert await player._connect_mrp() is False
+    connect.assert_not_awaited()
+
 
 async def test_play_media_wakes_device_before_starting_stream() -> None:
     """A sleeping controlled device receives wake before the AirPlay stream starts."""

--- a/tests/providers/airplay/test_helpers.py
+++ b/tests/providers/airplay/test_helpers.py
@@ -6,9 +6,47 @@ import pytest
 
 from music_assistant.providers.airplay.helpers import (
     get_cli_binary,
+    get_decoded_property,
     serialize_txt_records,
     supports_airplay2,
+    supports_companion_pairing,
 )
+
+
+def test_get_decoded_property_matches_case_insensitively() -> None:
+    """TXT record keys resolve regardless of the casing advertised on the wire."""
+    discovery_info = MagicMock()
+    discovery_info.decoded_properties = {"rpFl": "0x367A2", "SystemBuildVersion": "21K69"}
+
+    assert get_decoded_property(discovery_info, "rpFl") == "0x367A2"
+    assert get_decoded_property(discovery_info, "rpfl") == "0x367A2"
+    assert get_decoded_property(discovery_info, "systembuildversion") == "21K69"
+    assert get_decoded_property(discovery_info, "missing") is None
+
+
+@pytest.mark.parametrize(
+    ("properties", "expected"),
+    [
+        # Apple TV advertises its flags under the mixed-case wire key "rpFl"
+        ({"rpFl": "0x367A2"}, True),
+        # HomePod: PIN pairing not supported
+        ({"rpFl": "0x62792"}, False),
+        # pairing explicitly disabled
+        ({"rpFl": "0x367A6"}, False),
+        ({"rpFl": "invalid"}, False),
+        ({}, False),
+    ],
+)
+def test_supports_companion_pairing(properties: dict[str, str], expected: bool) -> None:
+    """Companion PIN pairing support is read from the wire-cased rpFl flags."""
+    discovery_info = MagicMock()
+    discovery_info.decoded_properties = properties
+    assert supports_companion_pairing(discovery_info) is expected
+
+
+def test_supports_companion_pairing_without_service() -> None:
+    """A device without a Companion service is never pairable."""
+    assert supports_companion_pairing(None) is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
After #4882, Apple TVs could spontaneously show the AirPlay pairing dialog with a code, without anyone starting a pairing from the settings.

Root cause: the Companion service advertises its capability flags under the mixed-case TXT key `rpFl`, while detection read the lowercase `rpfl` (zeroconf preserves TXT key casing as sent on the wire). Companion pairing support was therefore never detected for Apple TVs, which routed them onto the transient MRP monitoring path meant for HomePods. That handshake starts with `POST /pair-pin-start` - the request that makes the device display the pairing code - then fails because Apple TVs only accept real (paired) HAP credentials, and was retried every 30 seconds, so the dialog kept reappearing on every Apple TV.

Fixes:
- Read mDNS TXT properties case-insensitively (RFC 6763) via a new `get_decoded_property` helper, fixing Companion pairing detection.
- Never select the transient MRP handshake for Apple TVs, regardless of discovery state (mirrors pyatv's own device rules). Without stored credentials there is no connection attempt at all: pairing only ever starts from the player settings.
- Optional control pairing no longer marks the player as `needs_setup` (that would have made every unpaired Apple TV unavailable for playback) and POWER is only advertised when it can actually be served (stored credentials or a live control channel).