### PR TITLE
Fix player settings being ignored when audio plays via a linked protocol

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1079,6 +1079,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 announcement_url=url,
                 pre_announce=bool(pre_announce),
                 pre_announce_url=pre_announce_url,
+                announce_player_id=(announce_player.player_id if native_announce_support else None),
             )
             announcement = PlayerMedia(
                 uri=self.mass.streams.get_announcement_url(player_id, announce_data=announce_data),

--- a/music_assistant/controllers/players/helpers.py
+++ b/music_assistant/controllers/players/helpers.py
@@ -33,6 +33,9 @@ class AnnounceData(TypedDict):
     announcement_url: str
     pre_announce: bool
     pre_announce_url: str
+    # player that fetches the announcement stream when it is not the
+    # visible player itself (e.g. a linked protocol player)
+    announce_player_id: str | None
 
 
 @overload

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1187,9 +1187,7 @@ class StreamsAudio:
             if dsp.output_gain != 0:
                 filter_params.append(f"volume={dsp.output_gain}dB")
 
-        channel_value = self.mass.config.get_raw_player_config_value(
-            destination_player_id, CONF_OUTPUT_CHANNELS, "stereo"
-        )
+        channel_value = self._get_output_channels(player, player_id)
         source_channel = None
         if channel_value == "left":
             source_channel = AudioChannel.FL
@@ -1266,11 +1264,7 @@ class StreamsAudio:
         if output_format_str == "pcm":
             content_type = ContentType.from_bit_depth(output_bit_depth)
 
-        output_channels_str = self.mass.config.get_raw_player_config_value(
-            player.protocol_parent_id or player.player_id,
-            CONF_OUTPUT_CHANNELS,
-            "stereo",
-        )
+        output_channels_str = self._get_output_channels(player, player.player_id)
         fmt = AudioFormat(
             content_type=content_type,
             sample_rate=output_sample_rate,
@@ -3044,6 +3038,22 @@ class StreamsAudio:
             assert child_player is not None
             dsp_player_id = child_player.player_id
         return dsp_player_id
+
+    def _get_output_channels(self, player: Player | None, player_id: str) -> str:
+        """
+        Return the configured output channels for the rendering player.
+
+        The value may be stored on the rendering player(protocol) itself (the
+        protocol section of the config UI) or on its visible parent player (the
+        native section); the rendering player's own stored value wins.
+        """
+        parent_id = player.protocol_parent_id if player and player.protocol_parent_id else player_id
+        parent_value = self.mass.config.get_raw_player_config_value(
+            parent_id, CONF_OUTPUT_CHANNELS, "stereo"
+        )
+        return self.mass.config.get_raw_player_config_value(
+            player.player_id if player else player_id, CONF_OUTPUT_CHANNELS, parent_value
+        )
 
     def _pick_pcm_bit_depth(
         self,

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1090,10 +1090,7 @@ class StreamsController(CoreController):
         fmt = request.match_info["fmt"]
         audio_format = AudioFormat(content_type=ContentType.try_parse(fmt))
 
-        mass_player = self.mass.players.get_player(player_id)
-        http_profile = (
-            mass_player.get_config_value(CONF_HTTP_PROFILE, "default") if mass_player else "default"
-        )
+        http_profile = self._get_announcement_http_profile(player_id, announce_data)
         if http_profile == "forced_content_length":
             # given the fact that an announcement is just a short audio clip,
             # just send it over completely at once so we have a fixed content length
@@ -1583,6 +1580,23 @@ class StreamsController(CoreController):
             ),
             alters_audio=queue_item.streamdetails.fade_in,
         )
+
+    def _get_announcement_http_profile(self, player_id: str, announce_data: AnnounceData) -> str:
+        """
+        Resolve the http profile for serving an announcement stream.
+
+        Announcement urls are registered under the visible player's id, but the
+        stream may be fetched by a linked protocol player; the profile must come
+        from the player that actually performs the fetch.
+        """
+        announce_player = None
+        if announce_player_id := announce_data.get("announce_player_id"):
+            announce_player = self.mass.players.get_player(announce_player_id)
+        if announce_player is None:
+            announce_player = self.mass.players.get_player(player_id)
+        if announce_player is None:
+            return "default"
+        return announce_player.get_output_config_value(CONF_HTTP_PROFILE, "default")
 
     def _log_request(self, request: web.Request) -> None:
         """Log request."""

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -910,6 +910,69 @@ class Player(ABC):
         """
         return self.config.get_value(key, default)
 
+    @final
+    def resolve_output_player(self) -> Player:
+        """
+        Return the player that actually renders this player's audio output.
+
+        For a player playing via one of its linked output protocols this is the
+        active protocol player; in all other cases (native output, protocol
+        players themselves, group players serving their own stream) it is the
+        player itself.
+        """
+        active_protocol = self.active_output_protocol
+        if (
+            active_protocol
+            and active_protocol != "native"
+            and (protocol_player := self.mass.players.get_player(active_protocol))
+        ):
+            return protocol_player
+        return self
+
+    @overload
+    def get_output_config_value(
+        self, key: str, default: _ConfigValueT, *, return_type: builtins.type[_ConfigValueT] = ...
+    ) -> _ConfigValueT: ...
+
+    @overload
+    def get_output_config_value(
+        self, key: str, default: ConfigValueType = ..., *, return_type: builtins.type[_ConfigValueT]
+    ) -> _ConfigValueT: ...
+
+    @overload
+    def get_output_config_value(
+        self, key: str, default: ConfigValueType = ..., *, return_type: None = ...
+    ) -> ConfigValueType: ...
+
+    def get_output_config_value(
+        self,
+        key: str,
+        default: ConfigValueType = None,
+        *,
+        return_type: builtins.type[_ConfigValueT | ConfigValueType] | None = None,
+    ) -> _ConfigValueT | ConfigValueType:
+        """
+        Return a config value resolved on the player that renders the audio output.
+
+        Audio/output related settings (output codec, http profile, output channels,
+        sample rates) live on the player(protocol) that actually renders the audio:
+        the active linked protocol player when outputting via a protocol, otherwise
+        this player itself. The output player's value (or its provider's entry
+        default) takes precedence; this player's own value is the fallback for keys
+        the output player has no entry for.
+
+        :param key: The config key to retrieve.
+        :param default: Value to return when the key is not present in any config.
+        :param return_type: Optional type hint for type inference (e.g., str, int, bool).
+            Note: This parameter is used purely for static type checking and does not
+            perform runtime type validation. Callers are responsible for ensuring the
+            specified type matches the actual config value type.
+        """
+        output_player = self.resolve_output_player()
+        if output_player is not self and key in output_player.config.values:
+            return output_player.config.get_value(key, default)
+        return self.get_config_value(key, default)
+
     async def on_config_updated(self) -> None:
         """
         Handle logic when the player is loaded or updated.

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -595,10 +595,11 @@ class UniversalGroupPlayer(Player):
         }
         resp = web.StreamResponse(status=200, reason="OK", headers=headers)
         http_profile = self.get_config_value(CONF_HTTP_PROFILE, "chunked")
-        # prefer the child (protocol) player configuration
-        # (child player_id may be stale/invalid; fall back to the group profile)
+        # prefer the configuration of the player that actually renders the audio
+        # (the member's active protocol player when it outputs via a protocol);
+        # child player_id may be stale/invalid, then fall back to the group profile
         if child_player_id and (child_player := self.mass.players.get_player(child_player_id)):
-            http_profile = child_player.get_config_value(CONF_HTTP_PROFILE, http_profile)
+            http_profile = child_player.get_output_config_value(CONF_HTTP_PROFILE, http_profile)
         if http_profile == "chunked" and request.version < HttpVersion11:
             # chunked encoding is not allowed on HTTP/1.0; fall back to
             # connection-close streaming to avoid raising in resp.prepare()

--- a/tests/controllers/streams/test_announcement_stream.py
+++ b/tests/controllers/streams/test_announcement_stream.py
@@ -12,6 +12,7 @@ import pytest
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 
+from music_assistant.controllers.players.helpers import AnnounceData
 from music_assistant.controllers.streams.controller import StreamsController
 
 PCM_FORMAT = AudioFormat(
@@ -69,3 +70,40 @@ async def test_fetch_task_cancelled_when_consumer_abandons() -> None:
     await asyncio.wait_for(ffmpeg_stream_closed.wait(), timeout=1)
     with pytest.raises(asyncio.CancelledError):
         await fetch_tasks[0]
+
+
+def _announce_data(announce_player_id: str | None) -> AnnounceData:
+    return AnnounceData(
+        announcement_url="http://test/announcement.mp3",
+        pre_announce=False,
+        pre_announce_url="",
+        announce_player_id=announce_player_id,
+    )
+
+
+def test_announcement_http_profile_prefers_fetching_player() -> None:
+    """The http profile comes from the player that actually fetches the announcement."""
+    controller = StreamsController.__new__(StreamsController)
+    controller.mass = mass = MagicMock()
+    fetcher = MagicMock()
+    fetcher.get_output_config_value.return_value = "forced_content_length"
+    parent = MagicMock()
+    parent.get_output_config_value.return_value = "chunked"
+    players = {"fetcher": fetcher, "parent": parent}
+    mass.players.get_player = MagicMock(side_effect=lambda pid: players.get(pid))
+
+    # a known fetcher (e.g. a linked protocol player) provides the profile
+    profile = controller._get_announcement_http_profile("parent", _announce_data("fetcher"))
+    assert profile == "forced_content_length"
+
+    # without a recorded fetcher, resolve against the visible player's output path
+    profile = controller._get_announcement_http_profile("parent", _announce_data(None))
+    assert profile == "chunked"
+
+    # a dangling fetcher id falls back to the visible player
+    profile = controller._get_announcement_http_profile("parent", _announce_data("ghost"))
+    assert profile == "chunked"
+
+    # unknown player resolves to the safe default
+    profile = controller._get_announcement_http_profile("unknown", _announce_data(None))
+    assert profile == "default"

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -516,6 +516,51 @@ def test_player_output_plan_excludes_neutral_filters() -> None:
     assert not any(param.startswith("equalizer=") for param in plan.filter_params)
 
 
+def test_player_output_plan_prefers_rendering_player_channels() -> None:
+    """Output channels stored on the rendering player win over the parent's value."""
+    mass = MagicMock()
+    player = MagicMock(player_id="child-1", protocol_parent_id="parent-1")
+    player.state.active_group = None
+    player.state.synced_to = None
+    mass.players.get_player.return_value = player
+    mass.config.get_player_dsp_config.return_value = DSPConfig(enabled=False)
+    mass.config.get_raw_player_config_value.side_effect = lambda player_id, _key, default: (
+        "left" if player_id == "child-1" else default
+    )
+    audio = StreamsAudio(cast("Any", mass))
+    audio_format = _format(ContentType.PCM_F32LE, 48000, 32)
+
+    plan = audio.get_player_output_plan(
+        "child-1",
+        audio_format,
+        audio_format,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+
+    assert plan.output_details.source_channel == AudioChannel.FL
+    assert "pan=mono|c0=FL" in plan.filter_params
+    # processing attribution still points at the visible parent player
+    assert mass.streams.audio_processing.update_output.call_args.args[0] == "parent-1"
+
+
+@pytest.mark.asyncio
+async def test_output_format_prefers_rendering_player_channels() -> None:
+    """The output format channel count follows the rendering player's own stored value."""
+    mass = MagicMock()
+    player = MagicMock(player_id="child-1", protocol_parent_id="parent-1")
+    player.get_supported_sample_rates.return_value = [(48000, 24)]
+    mass.config.get_raw_player_config_value.side_effect = lambda player_id, _key, default: (
+        "left" if player_id == "child-1" else default
+    )
+    audio = StreamsAudio(cast("Any", mass))
+
+    fmt = await audio.get_output_format("flac", player, 48000, 24, MediaType.TRACK)
+
+    assert fmt.channels == 1
+
+
 @pytest.mark.asyncio
 async def test_single_stream_handler_shares_native_group_members(
     monkeypatch: pytest.MonkeyPatch,
@@ -582,8 +627,11 @@ def test_protocol_output_uses_parent_settings(monkeypatch: pytest.MonkeyPatch) -
     assert plan.output_details.dsp.preset_id == "parent-preset"
     assert plan.dsp_config_id == "player-1"
     assert plan.output_details.source_channel == AudioChannel.FR
+    # the output channels are looked up on the rendering player first (no value
+    # stored there in this scenario), then resolved from the user-facing parent
     assert {call.args[0] for call in mass.config.get_raw_player_config_value.call_args_list} == {
-        "player-1"
+        "player-1",
+        "protocol-1",
     }
     mass.streams.audio_processing.update_output.assert_called_once_with(
         "player-1",

--- a/tests/models/test_player_output_config.py
+++ b/tests/models/test_player_output_config.py
@@ -1,0 +1,153 @@
+"""Tests for config resolution against the player's active audio output path."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.config_entries import ConfigEntry, PlayerConfig
+from music_assistant_models.enums import ConfigEntryType, PlayerType
+
+from music_assistant.constants import CONF_HTTP_PROFILE
+from tests.common import MockPlayer, MockProvider
+
+
+@pytest.fixture
+def mock_mass() -> MagicMock:
+    """Create a mock MusicAssistant instance."""
+    mass = MagicMock()
+    mass.closing = False
+    mass.config.get = MagicMock(return_value=[])
+    mass.config.get_raw_player_config_value = MagicMock(return_value=None)
+    mass.config.get_raw_core_config_value = MagicMock(return_value="GLOBAL")
+    mass.config.set = MagicMock()
+    return mass
+
+
+def _http_profile_entry(default_value: str) -> ConfigEntry:
+    return ConfigEntry(
+        key=CONF_HTTP_PROFILE,
+        type=ConfigEntryType.STRING,
+        default_value=default_value,
+    )
+
+
+def _player_config(
+    player_id: str,
+    entries: list[ConfigEntry] | None = None,
+    values: dict[str, Any] | None = None,
+) -> PlayerConfig:
+    raw: dict[str, Any] = {"player_id": player_id, "provider": "test"}
+    if values:
+        raw["values"] = values
+    return cast("PlayerConfig", PlayerConfig.parse(entries or [], raw))
+
+
+def _make_parent_and_child(mock_mass: MagicMock) -> tuple[MockPlayer, MockPlayer]:
+    """Create a parent player and a protocol child wired into mass.players."""
+    provider = MockProvider("test", mass=mock_mass)
+    parent = MockPlayer(provider, "parent", "Parent")
+    child = MockPlayer(provider, "child", "Child", player_type=PlayerType.PROTOCOL)
+    players = {"parent": parent, "child": child}
+    mock_mass.players.get_player = MagicMock(side_effect=lambda pid: players.get(pid))
+    return parent, child
+
+
+class TestResolveOutputPlayer:
+    """Tests for Player.resolve_output_player."""
+
+    def test_returns_active_protocol_player(self, mock_mass: MagicMock) -> None:
+        """An active (non-native) output protocol resolves to the protocol player."""
+        parent, child = _make_parent_and_child(mock_mass)
+        parent.set_active_output_protocol("child")
+        assert parent.resolve_output_player() is child
+
+    def test_returns_self_for_native_output(self, mock_mass: MagicMock) -> None:
+        """Native output resolves to the player itself."""
+        parent, _child = _make_parent_and_child(mock_mass)
+        parent.set_active_output_protocol("native")
+        assert parent.resolve_output_player() is parent
+
+    def test_returns_self_without_active_protocol(self, mock_mass: MagicMock) -> None:
+        """No active output protocol resolves to the player itself."""
+        parent, _child = _make_parent_and_child(mock_mass)
+        assert parent.resolve_output_player() is parent
+
+    def test_returns_self_when_protocol_player_missing(self, mock_mass: MagicMock) -> None:
+        """A dangling active protocol id falls back to the player itself."""
+        parent, _child = _make_parent_and_child(mock_mass)
+        parent.set_active_output_protocol("ghost")
+        assert parent.resolve_output_player() is parent
+
+
+class TestGetOutputConfigValue:
+    """Tests for Player.get_output_config_value."""
+
+    def test_protocol_entry_default_beats_parent_value(self, mock_mass: MagicMock) -> None:
+        """The output player's provider entry default wins over the parent's stored value."""
+        parent, child = _make_parent_and_child(mock_mass)
+        parent.set_config(
+            _player_config(
+                "parent",
+                [_http_profile_entry("default")],
+                {CONF_HTTP_PROFILE: "chunked"},
+            )
+        )
+        child.set_config(_player_config("child", [_http_profile_entry("forced_content_length")]))
+        parent.set_active_output_protocol("child")
+
+        assert parent.get_output_config_value(CONF_HTTP_PROFILE, "default") == (
+            "forced_content_length"
+        )
+
+    def test_protocol_stored_value_wins(self, mock_mass: MagicMock) -> None:
+        """A value stored on the output player wins over its entry default."""
+        parent, child = _make_parent_and_child(mock_mass)
+        child.set_config(
+            _player_config(
+                "child",
+                [_http_profile_entry("forced_content_length")],
+                {CONF_HTTP_PROFILE: "no_content_length"},
+            )
+        )
+        parent.set_active_output_protocol("child")
+
+        assert parent.get_output_config_value(CONF_HTTP_PROFILE, "default") == "no_content_length"
+
+    def test_own_value_used_without_active_protocol(self, mock_mass: MagicMock) -> None:
+        """Without an active output protocol the player's own value applies."""
+        parent, _child = _make_parent_and_child(mock_mass)
+        parent.set_config(
+            _player_config(
+                "parent",
+                [_http_profile_entry("default")],
+                {CONF_HTTP_PROFILE: "chunked"},
+            )
+        )
+
+        assert parent.get_output_config_value(CONF_HTTP_PROFILE, "default") == "chunked"
+
+    def test_falls_back_to_own_value_when_protocol_lacks_entry(self, mock_mass: MagicMock) -> None:
+        """A key the output player has no entry for falls back to the player's own value."""
+        parent, child = _make_parent_and_child(mock_mass)
+        parent.set_config(
+            _player_config(
+                "parent",
+                [_http_profile_entry("default")],
+                {CONF_HTTP_PROFILE: "chunked"},
+            )
+        )
+        child.set_config(_player_config("child"))
+        parent.set_active_output_protocol("child")
+
+        assert parent.get_output_config_value(CONF_HTTP_PROFILE, "default") == "chunked"
+
+    def test_default_for_unknown_key(self, mock_mass: MagicMock) -> None:
+        """A key present on neither player resolves to the given default."""
+        parent, child = _make_parent_and_child(mock_mass)
+        parent.set_config(_player_config("parent"))
+        child.set_config(_player_config("child"))
+        parent.set_active_output_protocol("child")
+
+        assert parent.get_output_config_value(CONF_HTTP_PROFILE, "default") == "default"


### PR DESCRIPTION
# What does this implement/fix?

Several audio output settings were read from the wrong player when a device plays through a linked protocol or is wrapped by a universal player. Those settings live on the (hidden) protocol player's config, so reading them from the visible player silently returned defaults.

- New `resolve_output_player()` / `get_output_config_value()` helpers on the Player model resolve a setting against the active audio output path
- The left/right output channel setting is applied again (regression from #4793): it is now read from the rendering player first, with the visible player as fallback
- Announcements now use the http profile of the player that actually fetches the announcement stream (fixes announcements on e.g. a universal player wrapping a Chromecast)
- Universal Group streams now use the http profile of the member's active protocol player instead of the (wrapper) member itself

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
