### PR TITLE
Keep settings and group memberships when universal players merge or get replaced

### DIFF
--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -453,7 +453,7 @@ def _absorb_universal_player_config(
         other_values = other_cfg.get("values")
         if not isinstance(other_values, dict):
             continue
-        for key in ("group_members", "dynamic_group_members", "allowed_members"):
+        for key in ("group_members", "allowed_members"):
             members = other_values.get(key)
             if isinstance(members, list) and universal_id in members:
                 other_values[key] = [player_id if pid == universal_id else pid for pid in members]

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from contextlib import suppress
 from copy import deepcopy
 from typing import TYPE_CHECKING, cast
 
@@ -23,11 +24,12 @@ from music_assistant_models.enums import (
     PlayerType,
     ProviderType,
 )
-from music_assistant_models.errors import PlayerCommandFailed
+from music_assistant_models.errors import PlayerCommandFailed, PlayerUnavailableError
 from music_assistant_models.player import OutputProtocol
 
 from music_assistant.constants import (
     CONF_CACHED_ARP_MAC,
+    CONF_GROUP_MEMBERS,
     CONF_LINKED_PROTOCOL_IDS,
     CONF_PLAYER_DSP,
     CONF_PLAYER_QUEUES,
@@ -46,6 +48,7 @@ from music_assistant.helpers.util import (
     normalize_mac_for_matching,
 )
 from music_assistant.models.player import Player
+from music_assistant.providers.sync_group.constants import CONF_ALLOWED_MEMBERS
 from music_assistant.providers.universal_player import UniversalPlayer, UniversalPlayerProvider
 from music_assistant.providers.universal_player.constants import (
     CONF_DEVICE_IDENTIFIERS,
@@ -824,9 +827,16 @@ class ProtocolLinkingMixin:
                 keep.device_info.add_identifier(conn_type, value)
             keep.refresh_state()
 
-            # Persist updated data and remove the obsolete player
+            # Persist updated data before the obsolete player is removed
             self._save_universal_player_data(keep)
-            self.mass.create_task(self.unregister(remove.player_id, permanent=True))
+
+            # Carry over the user's configuration and re-point group memberships
+            # before the permanent removal below deletes the losing wrapper's config
+            self._migrate_universal_player_config(remove, keep)
+            self._repoint_group_memberships(remove.player_id, keep.player_id)
+
+            # Stop playback and remove the obsolete player
+            self.mass.create_task(self._stop_and_unregister(remove))
 
             # Only merge one at a time (re-evaluation will catch cascading merges)
             break
@@ -1026,12 +1036,13 @@ class ProtocolLinkingMixin:
             )
             native_player.refresh_state()
 
-            # Carry over the user's configuration before the permanent removal
-            # below deletes the universal player's config
+            # Carry over the user's configuration and re-point group memberships
+            # before the permanent removal below deletes the universal player's config
             self._migrate_universal_player_config(player, native_player)
+            self._repoint_group_memberships(player.player_id, native_player.player_id)
 
-            # Remove the now-obsolete universal player
-            self.mass.create_task(self.unregister(player.player_id, permanent=True))
+            # Stop playback and remove the now-obsolete universal player
+            self.mass.create_task(self._stop_and_unregister(player))
 
     def _migrate_universal_player_config(
         self, universal_player: Player, native_player: Player
@@ -1146,6 +1157,60 @@ class ProtocolLinkingMixin:
         player.set_config(config)
         player.update_state()
         self.mass.signal_event(EventType.PLAYER_CONFIG_UPDATED, object_id=player_id, data=config)
+
+    def _repoint_group_memberships(self, old_player_id: str, new_player_id: str) -> None:
+        """
+        Re-point group memberships from a removed player to its successor.
+
+        When a universal player is replaced by a native player or merged into
+        another universal player, other players that list the removed player as
+        a group member (or allowed member) must follow its successor so those
+        memberships are not silently lost. Updates the persisted config and keeps
+        any registered player whose membership changed in sync.
+
+        :param old_player_id: Player id that is being removed.
+        :param new_player_id: Player id that replaces it.
+        """
+        all_player_configs = self.mass.config.get(CONF_PLAYERS, {})
+        if not isinstance(all_player_configs, dict):
+            return
+        for other_id, other_cfg in all_player_configs.items():
+            if not isinstance(other_cfg, dict):
+                continue
+            other_values = other_cfg.get("values")
+            if not isinstance(other_values, dict):
+                continue
+            for key in (CONF_GROUP_MEMBERS, CONF_ALLOWED_MEMBERS):
+                members = other_values.get(key)
+                if not isinstance(members, list) or old_player_id not in members:
+                    continue
+                new_members: list[str] = []
+                for member_id in members:
+                    resolved = new_player_id if member_id == old_player_id else member_id
+                    if resolved not in new_members:
+                        new_members.append(resolved)
+                self.mass.config.set(f"{CONF_PLAYERS}/{other_id}/values/{key}", new_members)
+                # keep a registered player's in-place config copy and state in sync
+                if other_player := self.get_player(other_id):
+                    if entry := other_player.config.values.get(key):
+                        entry.value = new_members
+                    other_player.refresh_state()
+
+    async def _stop_and_unregister(self, player: Player) -> None:
+        """
+        Stop active playback on a player and then permanently unregister it.
+
+        Used when an obsolete universal player is replaced or merged away: while
+        it is not idle its protocol child keeps playing the dead queue's stream
+        until the buffer drains, so playback is stopped first. Queue ownership is
+        intentionally not transferred.
+
+        :param player: The obsolete player to stop and permanently remove.
+        """
+        if player.playback_state != PlaybackState.IDLE:
+            with suppress(PlayerCommandFailed, PlayerUnavailableError):
+                await self.mass.player_queues.stop(player.player_id)
+        await self.unregister(player.player_id, permanent=True)
 
     def _parent_has_active_protocol_from_domain(
         self, parent: Player, domain: str, exclude_player_id: str | None = None

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -5253,6 +5253,277 @@ class TestUniversalPlayerMerging:
                 f"but has {len(up.linked_output_protocols)}"
             )
 
+    @staticmethod
+    def _setup_merge_scenario(
+        mock_mass: MagicMock, config_store: dict[str, Any]
+    ) -> tuple[PlayerController, UniversalPlayer, list[Awaitable[object]]]:
+        """
+        Wire a merge scenario for the config carry-over tests.
+
+        Universal players 'up_keep' and 'up_remove' share a MAC; with equal
+        link counts the deterministic tiebreaker keeps 'up_keep' and removes
+        'up_remove', so 'up_remove' is the loser whose config is carried over.
+        """
+        controller = PlayerController(mock_mass)
+        up_provider = create_mock_universal_provider(mock_mass)
+
+        def config_get(key: str, default: object = None) -> object:
+            return config_store.get(key, default)
+
+        def config_set(key: str, value: object) -> None:
+            config_store[key] = value
+
+        def config_remove(key: str) -> None:
+            config_store.pop(key, None)
+
+        scheduled_tasks: list[Awaitable[object]] = []
+
+        def capture_task(task: Awaitable[object], *_args: Any, **_kwargs: Any) -> None:
+            scheduled_tasks.append(task)
+
+        mock_mass.config.get = MagicMock(side_effect=config_get)
+        mock_mass.config.set = MagicMock(side_effect=config_set)
+        mock_mass.config.remove = MagicMock(side_effect=config_remove)
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        mock_mass.call_later = MagicMock()
+        mock_mass.loop = MagicMock()
+        mock_mass.create_task = MagicMock(side_effect=capture_task)
+
+        keep = UniversalPlayer(
+            provider=up_provider,
+            player_id="up_keep",
+            name="Keep (Universal)",
+            device_info=DeviceInfo(model="Test", manufacturer="Test"),
+            protocol_player_ids=["ap_keep"],
+        )
+        keep._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, "AA:BB:CC:DD:EE:FF")
+        keep._cache.clear()
+        keep.update_state(signal_event=False)
+        keep.set_initialized()
+
+        remove = UniversalPlayer(
+            provider=up_provider,
+            player_id="up_remove",
+            name="Remove (Universal)",
+            device_info=DeviceInfo(model="Test", manufacturer="Test"),
+            protocol_player_ids=["dlna_live"],
+        )
+        remove._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, "AA:BB:CC:DD:EE:FF")
+        remove._cache.clear()
+        remove.update_state(signal_event=False)
+        remove.set_initialized()
+
+        ap_keep = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "ap_keep",
+            "AirPlay",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        ap_keep.set_initialized()
+
+        dlna_live = MockPlayer(
+            MockProvider("dlna", mass=mock_mass),
+            "dlna_live",
+            "DLNA",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        dlna_live.set_initialized()
+
+        controller._players = {
+            "up_keep": keep,
+            "up_remove": remove,
+            "ap_keep": ap_keep,
+            "dlna_live": dlna_live,
+        }
+        controller._add_protocol_link(keep, ap_keep, "airplay")
+        controller._add_protocol_link(remove, dlna_live, "dlna")
+        return controller, keep, scheduled_tasks
+
+    async def test_merge_carries_over_universal_config(self, mock_mass: MagicMock) -> None:
+        """Merge migrates name, values, DSP and queue settings from loser to keeper."""
+        config_store: dict[str, Any] = {
+            "players/up_keep": {
+                "enabled": True,
+                "name": "Keep (Universal)",
+                "default_name": "Keep (Universal)",
+                "values": {"volume_control": "keep_ctrl"},
+            },
+            "players/up_remove": {
+                "enabled": True,
+                "name": "Living Room",
+                "default_name": "Remove (Universal)",
+                "values": {
+                    "hide_in_ui": True,
+                    "volume_control": "remove_ctrl",
+                    "device_info": {"model": "Test", "manufacturer": "Test"},
+                },
+            },
+            "players/ap_keep": {"enabled": True},
+            "players/dlna_live": {"enabled": True},
+            "player_dsp/up_remove": {"enabled": True, "filters": []},
+            "player_queues/up_remove": {
+                "queue_id": "up_remove",
+                "values": {"crossfade_duration": 5},
+            },
+        }
+        controller, keep, scheduled_tasks = self._setup_merge_scenario(mock_mass, config_store)
+
+        with patch.object(controller, "_save_universal_player_data"):
+            controller._check_merge_universal_players(keep)
+
+        # the custom display name and non-conflicting values moved onto the keeper
+        assert config_store["players/up_keep/name"] == "Living Room"
+        assert config_store["players/up_keep/values/hide_in_ui"] is True
+        # values the keeper has explicitly set are not overwritten
+        assert "players/up_keep/values/volume_control" not in config_store
+        # wrapper bookkeeping is not carried over
+        assert "players/up_keep/values/device_info" not in config_store
+        # DSP moved wholesale and queue settings moved and re-keyed onto the keeper
+        assert config_store["player_dsp/up_keep"] == {"enabled": True, "filters": []}
+        assert config_store["player_queues/up_keep"] == {
+            "queue_id": "up_keep",
+            "values": {"crossfade_duration": 5},
+        }
+        assert "player_queues/up_remove" not in config_store
+        # the keeper's in-place config gets reloaded to apply the migrated values
+        assert any("_reapply_player_config" in repr(t) for t in scheduled_tasks)
+
+        # and the losing universal player is still permanently removed
+        unregister_tasks = [t for t in scheduled_tasks if "unregister" in repr(t)]
+        assert len(unregister_tasks) == 1
+        await unregister_tasks[0]
+        assert "up_remove" not in controller._players
+
+    def test_merge_keeps_keeper_explicit_values(self, mock_mass: MagicMock) -> None:
+        """Values explicitly set on the keeper win over the losing player's."""
+        config_store: dict[str, Any] = {
+            "players/up_keep": {
+                "enabled": True,
+                "name": "Kitchen",
+                "default_name": "Keep (Universal)",
+                "values": {"hide_in_ui": False},
+            },
+            "players/up_remove": {
+                "enabled": True,
+                "name": "Living Room",
+                "default_name": "Remove (Universal)",
+                "values": {"hide_in_ui": True, "flow_mode": True},
+            },
+            "players/ap_keep": {"enabled": True},
+            "players/dlna_live": {"enabled": True},
+            "player_dsp/up_keep": {"enabled": False, "filters": ["keep"]},
+            "player_dsp/up_remove": {"enabled": True, "filters": ["remove"]},
+        }
+        controller, keep, _ = self._setup_merge_scenario(mock_mass, config_store)
+
+        with patch.object(controller, "_save_universal_player_data"):
+            controller._check_merge_universal_players(keep)
+
+        # the keeper's own custom name and DSP config win
+        assert "players/up_keep/name" not in config_store
+        assert config_store["players/up_keep"]["name"] == "Kitchen"
+        assert config_store["player_dsp/up_keep"] == {"enabled": False, "filters": ["keep"]}
+        # the keeper's explicit value is not overwritten
+        assert "players/up_keep/values/hide_in_ui" not in config_store
+        # non-conflicting values still migrate
+        assert config_store["players/up_keep/values/flow_mode"] is True
+
+    def test_merge_repoints_group_memberships(self, mock_mass: MagicMock) -> None:
+        """Merge re-points group memberships from the removed wrapper to the keeper."""
+        config_store: dict[str, Any] = {
+            "players/up_keep": {
+                "enabled": True,
+                "name": "Keep (Universal)",
+                "default_name": "Keep (Universal)",
+                "values": {},
+            },
+            "players/up_remove": {
+                "enabled": True,
+                "name": "Remove (Universal)",
+                "default_name": "Remove (Universal)",
+                "values": {},
+            },
+            "players/ap_keep": {"enabled": True},
+            "players/dlna_live": {"enabled": True},
+            # nested players dict scanned by _repoint_group_memberships
+            "players": {
+                "group_1": {
+                    "enabled": True,
+                    "values": {
+                        "group_members": ["up_remove", "other"],
+                        "allowed_members": ["up_remove"],
+                    },
+                },
+                "group_2": {
+                    "enabled": True,
+                    # keeper already listed -> no duplicate after re-point
+                    "values": {"group_members": ["up_keep", "up_remove"]},
+                },
+            },
+        }
+        controller, keep, _ = self._setup_merge_scenario(mock_mass, config_store)
+
+        with patch.object(controller, "_save_universal_player_data"):
+            controller._check_merge_universal_players(keep)
+
+        assert config_store["players/group_1/values/group_members"] == ["up_keep", "other"]
+        assert config_store["players/group_1/values/allowed_members"] == ["up_keep"]
+        # no duplicate when the keeper is already a member
+        assert config_store["players/group_2/values/group_members"] == ["up_keep"]
+
+    async def test_merge_stops_playing_loser_before_unregister(self, mock_mass: MagicMock) -> None:
+        """A playing losing wrapper is stopped before it is permanently removed."""
+        config_store: dict[str, Any] = {
+            "players/up_keep": {"enabled": True},
+            "players/up_remove": {"enabled": True},
+            "players/ap_keep": {"enabled": True},
+            "players/dlna_live": {"enabled": True},
+        }
+        controller, keep, scheduled_tasks = self._setup_merge_scenario(mock_mass, config_store)
+        controller._players["up_remove"]._attr_playback_state = PlaybackState.PLAYING
+
+        call_order: list[str] = []
+        mock_mass.player_queues.stop = AsyncMock(
+            side_effect=lambda *_a, **_k: call_order.append("stop")
+        )
+
+        with patch.object(controller, "_save_universal_player_data"):
+            controller._check_merge_universal_players(keep)
+
+        task = next(t for t in scheduled_tasks if "unregister" in repr(t))
+
+        def _record_unregister(*_a: Any, **_k: Any) -> None:
+            call_order.append("unregister")
+
+        with patch.object(controller, "unregister", new=AsyncMock(side_effect=_record_unregister)):
+            await task
+
+        assert call_order == ["stop", "unregister"]
+        mock_mass.player_queues.stop.assert_awaited_once_with("up_remove")
+
+    async def test_merge_idle_loser_not_stopped(self, mock_mass: MagicMock) -> None:
+        """An idle losing wrapper is removed without a stop command."""
+        config_store: dict[str, Any] = {
+            "players/up_keep": {"enabled": True},
+            "players/up_remove": {"enabled": True},
+            "players/ap_keep": {"enabled": True},
+            "players/dlna_live": {"enabled": True},
+        }
+        controller, keep, scheduled_tasks = self._setup_merge_scenario(mock_mass, config_store)
+        mock_mass.player_queues.stop = AsyncMock()
+
+        with patch.object(controller, "_save_universal_player_data"):
+            controller._check_merge_universal_players(keep)
+
+        task = next(t for t in scheduled_tasks if "unregister" in repr(t))
+        await task
+
+        mock_mass.player_queues.stop.assert_not_awaited()
+        assert "up_remove" not in controller._players
+
 
 class TestUniversalPlayerReplacement:
     """Tests for replacing a universal player with a native player."""
@@ -5812,6 +6083,109 @@ class TestUniversalPlayerReplacement:
         assert native.display_name == "Living Room"
         signaled_events = [call.args[0] for call in mock_mass.signal_event.call_args_list]
         assert EventType.PLAYER_CONFIG_UPDATED in signaled_events
+
+    def test_replace_repoints_group_memberships(self, mock_mass: MagicMock) -> None:
+        """Replacement re-points group memberships from the wrapper to the native player."""
+        config_store: dict[str, Any] = {
+            "players/cast_1": {"enabled": True},
+            "players/up_old": {
+                "enabled": True,
+                "name": "Soundbar (Universal)",
+                "default_name": "Soundbar (Universal)",
+                "values": {"linked_protocol_ids": ["ap_live"]},
+            },
+            "players/ap_live": {"enabled": True},
+            # nested players dict scanned by _repoint_group_memberships
+            "players": {
+                "group_1": {
+                    "enabled": True,
+                    "values": {
+                        "group_members": ["up_old", "other"],
+                        "allowed_members": ["up_old"],
+                    },
+                },
+                "group_2": {
+                    "enabled": True,
+                    # native id already listed -> no duplicate after re-point
+                    "values": {"group_members": ["up_old", "cast_1", "extra"]},
+                },
+            },
+        }
+        controller, native, _ = self._setup_carry_over_scenario(mock_mass, config_store)
+        group_1 = MockPlayer(MockProvider("player_group", mass=mock_mass), "group_1", "Group")
+        group_1.set_initialized()
+        controller._players["group_1"] = group_1
+
+        with patch.object(group_1, "refresh_state") as mock_refresh:
+            controller._check_replace_universal_player(native)
+
+        # the wrapper id is replaced by the native id on both membership keys
+        assert config_store["players/group_1/values/group_members"] == ["cast_1", "other"]
+        assert config_store["players/group_1/values/allowed_members"] == ["cast_1"]
+        # no duplicate when the native id is already a member
+        assert config_store["players/group_2/values/group_members"] == ["cast_1", "extra"]
+        # a registered player whose membership changed is refreshed
+        mock_refresh.assert_called()
+
+    async def test_replace_stops_playing_universal_before_unregister(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A playing universal player is stopped before it is permanently removed."""
+        config_store: dict[str, Any] = {
+            "players/cast_1": {"enabled": True},
+            "players/up_old": {
+                "enabled": True,
+                "name": "Soundbar (Universal)",
+                "default_name": "Soundbar (Universal)",
+                "values": {"linked_protocol_ids": ["ap_live"]},
+            },
+            "players/ap_live": {"enabled": True},
+        }
+        controller, native, scheduled_tasks = self._setup_carry_over_scenario(
+            mock_mass, config_store
+        )
+        controller._players["up_old"]._attr_playback_state = PlaybackState.PLAYING
+
+        call_order: list[str] = []
+        mock_mass.player_queues.stop = AsyncMock(
+            side_effect=lambda *_a, **_k: call_order.append("stop")
+        )
+
+        controller._check_replace_universal_player(native)
+        task = next(t for t in scheduled_tasks if "unregister" in repr(t))
+
+        def _record_unregister(*_a: Any, **_k: Any) -> None:
+            call_order.append("unregister")
+
+        with patch.object(controller, "unregister", new=AsyncMock(side_effect=_record_unregister)):
+            await task
+
+        assert call_order == ["stop", "unregister"]
+        mock_mass.player_queues.stop.assert_awaited_once_with("up_old")
+
+    async def test_replace_idle_universal_not_stopped(self, mock_mass: MagicMock) -> None:
+        """An idle universal player is removed without a stop command."""
+        config_store: dict[str, Any] = {
+            "players/cast_1": {"enabled": True},
+            "players/up_old": {
+                "enabled": True,
+                "name": "Soundbar (Universal)",
+                "default_name": "Soundbar (Universal)",
+                "values": {"linked_protocol_ids": ["ap_live"]},
+            },
+            "players/ap_live": {"enabled": True},
+        }
+        controller, native, scheduled_tasks = self._setup_carry_over_scenario(
+            mock_mass, config_store
+        )
+        mock_mass.player_queues.stop = AsyncMock()
+
+        controller._check_replace_universal_player(native)
+        task = next(t for t in scheduled_tasks if "unregister" in repr(t))
+        await task
+
+        mock_mass.player_queues.stop.assert_not_awaited()
+        assert "up_old" not in controller._players
 
 
 class TestEndToEndDuplicateProtocol:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #4921: two more paths still lost user configuration around universal players, and a removed wrapper could leave things behind in a bad state.

- When two universal players merge (e.g. a device first seen via one protocol gains a second identifier), the losing wrapper's settings were deleted - its custom name, player settings, DSP and queue settings now carry over to the surviving player, without overwriting anything set on it
- When a universal player is replaced or merged away, sync group / universal group memberships that referenced it are now re-pointed to its successor instead of silently dropping the device from the group
- If the wrapper was still playing at that moment, playback is now stopped cleanly first (previously the stream kept playing until the buffer drained)
- Removed a dead key from the config migration's membership re-pointing

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
