### PR TITLE
Remote access: migrate WebRTC backend to libdatachannel (aiolibdatachannel)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -174,6 +174,8 @@ repos:
         language: system
         types: [text]
         entry: uv run detect-private-key
+        # frozen throwaway fixture key guarding Remote ID stability
+        exclude: ^tests/helpers/test_webrtc_certificate\.py$
 
       - id: end-of-file-fixer
         name: ⮐ Fix End of Files

--- a/music_assistant/controllers/webserver/remote_access/__init__.py
+++ b/music_assistant/controllers/webserver/remote_access/__init__.py
@@ -22,11 +22,10 @@ from music_assistant.constants import CONF_CORE
 from music_assistant.helpers.util import format_ip_for_url
 from music_assistant.helpers.webrtc_certificate import (
     get_or_create_remote_id,
-    get_or_create_webrtc_certificate,
+    get_or_create_webrtc_certificate_pems,
 )
 
 if TYPE_CHECKING:
-    from aiortc.rtcdtlstransport import RTCCertificate
     from music_assistant_models.event import MassEvent
 
     from music_assistant.controllers.webserver import WebserverController
@@ -66,7 +65,8 @@ class RemoteAccessManager:
         self.gateway: WebRTCGateway | None = None
         self._gateway_lock = asyncio.Lock()
         self._remote_id: str
-        self._certificate: RTCCertificate
+        self._cert_pem: str
+        self._key_pem: str
         self._enabled: bool = False
         self._using_ha_cloud: bool = False
         self._target_using_ha_cloud: bool = False
@@ -74,8 +74,8 @@ class RemoteAccessManager:
 
     async def setup(self) -> None:
         """Initialize the remote access manager."""
-        # derive the Remote ID without importing aiortc, so a disabled instance keeps
-        # aiortc/PyAV (~51MB) out of memory while the remote_access/info endpoint still works
+        # derive the Remote ID without importing aiolibdatachannel, so a disabled instance
+        # never spins up the native lib's thread pool while remote_access/info still works
         self._remote_id = get_or_create_remote_id(self.mass.storage_path)
 
         enabled_value = self.mass.config.get(f"{CONF_CORE}/{CONF_KEY_MAIN}/{CONF_ENABLED}", False)
@@ -142,11 +142,6 @@ class RemoteAccessManager:
         """Return the current Remote ID."""
         return self._remote_id
 
-    @property
-    def certificate(self) -> RTCCertificate:
-        """Return the persistent WebRTC DTLS certificate."""
-        return self._certificate
-
     def _schedule_start(self) -> None:
         """Schedule a debounced gateway restart."""
         self.mass.cancel_timer(TASK_ID_START_GATEWAY)
@@ -191,13 +186,15 @@ class RemoteAccessManager:
         if self.gateway is not None:
             await self._stop_gateway_locked()
 
-        # imported here (and the certificate built here) so aiortc/PyAV is only
-        # loaded when remote access is actually enabled, never at idle
+        # imported here so the native WebRTC lib (and its thread pool) is only loaded
+        # when remote access is actually enabled, never at idle
         from music_assistant.controllers.webserver.remote_access.gateway import (  # noqa: PLC0415
             WebRTCGateway,
         )
 
-        self._certificate = get_or_create_webrtc_certificate(self.mass.storage_path)
+        self._cert_pem, self._key_pem = get_or_create_webrtc_certificate_pems(
+            self.mass.storage_path
+        )
 
         base_url = self.mass.webserver.base_url
         local_ws_url = base_url.replace("http", "ws")
@@ -220,7 +217,8 @@ class RemoteAccessManager:
         gateway = WebRTCGateway(
             http_session=self.mass.http_session,
             remote_id=self._remote_id,
-            certificate=self._certificate,
+            cert_pem=self._cert_pem,
+            key_pem=self._key_pem,
             signaling_url=SIGNALING_SERVER_URL,
             local_ws_url=local_ws_url,
             sendspin_url=sendspin_url,

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -9,6 +9,7 @@ bridging them to the local WebSocket API.
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import json
 import logging
@@ -23,6 +24,7 @@ from aiolibdatachannel import (
     IceServer,
     PeerConnection,
     RTCConfiguration,
+    RTCError,
     RTCState,
     StateChangeEvent,
     install_python_logger,
@@ -39,8 +41,8 @@ LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.remote_access")
 # data channel stays bounded and never blocks the API message pump (see #4889).
 HTTP_PROXY_CONCURRENCY = 6
 
-# Chunk proxied bodies larger than this; libdatachannel caps data-channel messages at 256 KiB.
-HTTP_PROXY_CHUNK_SIZE = 64 * 1024
+# Chunk ma-api messages larger than this; libdatachannel caps data-channel messages at 256 KiB.
+MA_API_CHUNK_SIZE = 64 * 1024
 
 
 @dataclass
@@ -134,6 +136,7 @@ class WebRTCGateway:
         self._connecting = False
         # gateway-wide by design: normally a single remote client is connected
         self._http_proxy_semaphore = asyncio.Semaphore(HTTP_PROXY_CONCURRENCY)
+        self._chunk_group_seq = 0
 
     @property
     def is_running(self) -> bool:
@@ -507,53 +510,46 @@ class WebRTCGateway:
         headers: dict[str, str],
         body: bytes,
     ) -> None:
-        """Send an HTTP-proxy response over the data channel, chunking large bodies."""
-        channel = session.data_channel
-        # Small bodies fit a single message; keep the legacy format so clients that
-        # don't understand chunking still work for everything but large images.
-        if len(body) <= HTTP_PROXY_CHUNK_SIZE:
-            await self._send_on_channel(
-                channel,
-                json.dumps(
-                    {
-                        "type": "http-proxy-response",
-                        "id": request_id,
-                        "status": status,
-                        "headers": headers,
-                        "body": body.hex(),
-                    }
-                ),
-            )
-            return
-
-        # Announce the chunked response, then stream fixed-size hex chunks the client
-        # reassembles by request ID.
-        chunk_count = (len(body) + HTTP_PROXY_CHUNK_SIZE - 1) // HTTP_PROXY_CHUNK_SIZE
-        await self._send_on_channel(
-            channel,
+        """Send an HTTP-proxy response over the ma-api channel."""
+        await self._send_ma_api(
+            session.data_channel,
             json.dumps(
                 {
-                    "type": "http-proxy-response-start",
+                    "type": "http-proxy-response",
                     "id": request_id,
                     "status": status,
                     "headers": headers,
-                    "chunks": chunk_count,
+                    "body": body.hex(),
                 }
             ),
         )
-        for index in range(chunk_count):
+
+    async def _send_ma_api(self, channel: DataChannel | None, text: str) -> None:
+        """Send a text message on the ma-api channel, chunking it if it exceeds the size limit."""
+        data = text.encode()
+        if len(data) <= MA_API_CHUNK_SIZE:
+            await self._send_on_channel(channel, text)
+            return
+
+        # libdatachannel enforces the 256 KiB message limit, so oversized messages are split
+        # into base64 frames the client reassembles by group id (base64 keeps each frame's size
+        # predictable regardless of JSON escaping / unicode).
+        self._chunk_group_seq += 1
+        group_id = self._chunk_group_seq
+        count = (len(data) + MA_API_CHUNK_SIZE - 1) // MA_API_CHUNK_SIZE
+        for seq in range(count):
             if channel is None or not channel.is_open:
                 return
-            offset = index * HTTP_PROXY_CHUNK_SIZE
-            chunk = body[offset : offset + HTTP_PROXY_CHUNK_SIZE]
+            piece = data[seq * MA_API_CHUNK_SIZE : (seq + 1) * MA_API_CHUNK_SIZE]
             await self._send_on_channel(
                 channel,
                 json.dumps(
                     {
-                        "type": "http-proxy-response-chunk",
-                        "id": request_id,
-                        "index": index,
-                        "body": chunk.hex(),
+                        "type": "__chunk__",
+                        "id": group_id,
+                        "seq": seq,
+                        "count": count,
+                        "b64": base64.b64encode(piece).decode(),
                     }
                 ),
             )
@@ -615,6 +611,13 @@ class WebRTCGateway:
 
     async def _bridge_ma_api(self, session: WebRTCSession, channel: DataChannel) -> None:
         """Bridge the ma-api data channel to the local WebSocket API."""
+        # wait for the channel to open first, so the local WS's initial server_info (sent
+        # immediately on connect) isn't dropped by _send_on_channel while it's still opening
+        try:
+            await channel.wait_open()
+        except RTCError:
+            self._schedule_close(session.session_id)
+            return
         try:
             # Include session_id in URL so server can track WebRTC sessions
             ws_url = f"{self.local_ws_url}?webrtc_session_id={session.session_id}"
@@ -673,13 +676,16 @@ class WebRTCGateway:
         try:
             async for msg in local_ws:
                 if msg.type == aiohttp.WSMsgType.TEXT:
-                    await self._send_on_channel(channel, msg.data)
+                    await self._send_ma_api(channel, msg.data)
                 elif msg.type in (aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSED):
                     break
         except asyncio.CancelledError:
             raise
         except Exception:
             self.logger.exception("Error forwarding from local WebSocket")
+        # the local WS closed: the ma-api session is unusable, so tear it down instead of
+        # leaving the client an open channel that silently drops messages
+        self._schedule_close(session.session_id)
 
     async def _bridge_sendspin(self, session: WebRTCSession, channel: DataChannel) -> None:
         """Bridge the sendspin data channel to the internal sendspin server."""
@@ -738,6 +744,8 @@ class WebRTCGateway:
             raise
         except Exception:
             self.logger.exception("Error forwarding sendspin from local")
+        # the internal sendspin WS closed: close only this bridge, leaving the ma-api session up
+        await self._close_sendspin_bridge(session)
 
     async def _close_sendspin_bridge(self, session: WebRTCSession) -> None:
         """Close the internal Sendspin bridge for a WebRTC session."""
@@ -780,8 +788,13 @@ class WebRTCGateway:
         """Send data on a data channel if it is currently open."""
         if channel is None or not channel.is_open:
             return
-        with contextlib.suppress(ConnectionClosedError):
+        try:
             await channel.send(data)
+        except ConnectionClosedError:
+            pass
+        except RTCError as err:
+            # a single failed send (e.g. an over-limit message) must not tear down the pump
+            self.logger.warning("Dropping %d-byte data channel message: %s", len(data), err)
 
     def _try_extract_sendspin_client_id(self, session: WebRTCSession, message: str) -> None:
         """Try to extract client_id from sendspin auth message and set on websocket client."""

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -30,6 +30,13 @@ LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.remote_access")
 # data channel stays bounded and never blocks the API message pump (see #4889).
 HTTP_PROXY_CONCURRENCY = 6
 
+# Large proxied bodies (album art) are split into chunks before sending: libdatachannel
+# enforces the negotiated 256 KiB data-channel message limit, whereas aiortc silently
+# fragmented any size. 64 KiB raw -> ~128 KiB hex per message stays well under the limit,
+# and keeps messages small enough that API traffic can interleave between image chunks
+# (browsers don't implement SCTP message interleaving, RFC 8260).
+HTTP_PROXY_CHUNK_SIZE = 64 * 1024
+
 
 @dataclass
 class WebRTCSession:
@@ -524,32 +531,82 @@ class WebRTCGateway:
                 async with self.http_session.request(
                     method, local_http_url, headers=headers
                 ) as response:
-                    # Read response body
                     body = await response.read()
-
-                    # Prepare response data
-                    response_data = {
-                        "type": "http-proxy-response",
-                        "id": request_id,
-                        "status": response.status,
-                        "headers": dict(response.headers),
-                        "body": body.hex(),  # Send as hex string to avoid encoding issues
-                    }
-
-                    # Send response back through data channel
-                    await self._send_on_channel(session.data_channel, json.dumps(response_data))
-
+                    await self._send_http_proxy_response(
+                        session, request_id, response.status, dict(response.headers), body
+                    )
             except Exception as err:
                 self.logger.exception("Error handling HTTP proxy request")
-                # Send error response
-                error_response = {
-                    "type": "http-proxy-response",
+                await self._send_http_proxy_response(
+                    session, request_id, 500, {"Content-Type": "text/plain"}, str(err).encode()
+                )
+
+    async def _send_http_proxy_response(
+        self,
+        session: WebRTCSession,
+        request_id: str | None,
+        status: int,
+        headers: dict[str, str],
+        body: bytes,
+    ) -> None:
+        """
+        Send an HTTP-proxy response over the data channel, chunking large bodies.
+
+        :param session: The WebRTC session.
+        :param request_id: The originating request ID.
+        :param status: The HTTP status code.
+        :param headers: The HTTP response headers.
+        :param body: The raw response body.
+        """
+        channel = session.data_channel
+        # Small bodies fit a single message; keep the legacy format so clients that
+        # don't understand chunking still work for everything but large images.
+        if len(body) <= HTTP_PROXY_CHUNK_SIZE:
+            await self._send_on_channel(
+                channel,
+                json.dumps(
+                    {
+                        "type": "http-proxy-response",
+                        "id": request_id,
+                        "status": status,
+                        "headers": headers,
+                        "body": body.hex(),
+                    }
+                ),
+            )
+            return
+
+        # Announce the chunked response, then stream fixed-size hex chunks the client
+        # reassembles by request ID.
+        chunk_count = (len(body) + HTTP_PROXY_CHUNK_SIZE - 1) // HTTP_PROXY_CHUNK_SIZE
+        await self._send_on_channel(
+            channel,
+            json.dumps(
+                {
+                    "type": "http-proxy-response-start",
                     "id": request_id,
-                    "status": 500,
-                    "headers": {"Content-Type": "text/plain"},
-                    "body": str(err).encode().hex(),
+                    "status": status,
+                    "headers": headers,
+                    "chunks": chunk_count,
                 }
-                await self._send_on_channel(session.data_channel, json.dumps(error_response))
+            ),
+        )
+        for index in range(chunk_count):
+            if channel is None or not channel.is_open:
+                return
+            offset = index * HTTP_PROXY_CHUNK_SIZE
+            chunk = body[offset : offset + HTTP_PROXY_CHUNK_SIZE]
+            await self._send_on_channel(
+                channel,
+                json.dumps(
+                    {
+                        "type": "http-proxy-response-chunk",
+                        "id": request_id,
+                        "index": index,
+                        "body": chunk.hex(),
+                    }
+                ),
+            )
 
     async def _close_session(self, session_id: str) -> None:
         """

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -411,6 +411,7 @@ class WebRTCGateway:
         # PC-owned tasks are cancelled and awaited by pc.aclose() during teardown
         pc.spawn_task(self._monitor_state(session))
         pc.spawn_task(self._accept_channels(session))
+        pc.spawn_task(self._forward_local_candidates(session))
 
     async def _handle_offer(self, session_id: str, offer: dict[str, Any]) -> None:
         """
@@ -434,14 +435,16 @@ class WebRTCGateway:
             return
 
         try:
-            # create_answer waits for ICE gathering-complete and inlines candidates,
-            # so the answer we send already carries our local candidates (non-trickle)
             await pc.set_remote_description(str(sdp), "offer")
 
             if session_id not in self.sessions or pc.closed:
                 return
 
-            answer = await pc.create_answer()
+            # Trickle ICE: set_local_description returns as soon as the SDP is ready
+            # (candidate-less), so we answer immediately instead of blocking on
+            # create_answer() until ICE gathering completes (~20s+ with slow STUN/TURN).
+            # Local candidates are streamed separately by _forward_local_candidates.
+            answer = await pc.set_local_description("answer")
 
             if session_id not in self.sessions or pc.closed:
                 return
@@ -584,6 +587,27 @@ class WebRTCGateway:
             if isinstance(event, StateChangeEvent) and event.state == RTCState.FAILED:
                 self._schedule_close(session.session_id)
                 return
+
+    async def _forward_local_candidates(self, session: WebRTCSession) -> None:
+        """
+        Stream locally-gathered ICE candidates to the remote client (trickle ICE).
+
+        :param session: The WebRTC session.
+        """
+        # The iterator ends on gathering-complete or when the PC closes.
+        async for candidate in session.pc.ice_candidates():
+            if session.session_id not in self.sessions or not self._signaling_ws:
+                return
+            await self._signaling_ws.send_json(
+                {
+                    "type": "ice-candidate",
+                    "sessionId": session.session_id,
+                    "data": {
+                        "candidate": candidate.candidate,
+                        "sdpMid": candidate.mid,
+                    },
+                }
+            )
 
     async def _accept_channels(self, session: WebRTCSession) -> None:
         """

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -13,27 +13,21 @@ import contextlib
 import json
 import logging
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import urlparse
 
 import aiohttp
-from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection, RTCSessionDescription
-from aiortc.sdp import candidate_from_sdp
 
 from music_assistant.constants import MASS_LOGGER_NAME, VERBOSE_LOG_LEVEL
-from music_assistant.helpers.webrtc_certificate import create_peer_connection_with_certificate
 
 if TYPE_CHECKING:
-    from aiortc.rtcdtlstransport import RTCCertificate
+    from aiolibdatachannel import DataChannel, PeerConnection
 
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.remote_access")
 
-# Reduce verbose logging from aiortc/aioice
-logging.getLogger("aioice").setLevel(logging.WARNING)
-logging.getLogger("aiortc").setLevel(logging.WARNING)
-
-# Max concurrent proxied fetches, so a burst of album-art requests stays bounded
+# Max concurrent proxied (image) fetches, so a burst of album-art requests over the
+# data channel stays bounded and never blocks the API message pump (see #4889).
 HTTP_PROXY_CONCURRENCY = 6
 
 
@@ -42,25 +36,14 @@ class WebRTCSession:
     """Represents an active WebRTC session with a remote client."""
 
     session_id: str
-    peer_connection: RTCPeerConnection
+    pc: PeerConnection
     # Main API channel (ma-api) - bridges to local MA WebSocket API
-    data_channel: Any = None
-    local_ws: Any = None
-    message_queue: asyncio.Queue[str] = field(default_factory=asyncio.Queue)
-    data_channel_setup_task: asyncio.Task[None] | None = None
-    forward_to_local_task: asyncio.Task[None] | None = None
-    forward_from_local_task: asyncio.Task[None] | None = None
-    proxy_tasks: set[asyncio.Task[None]] = field(default_factory=set)
-    data_channel_active: bool = False
+    data_channel: DataChannel | None = None
+    local_ws: aiohttp.ClientWebSocketResponse | None = None
     # Sendspin channel - bridges to internal sendspin server
-    sendspin_channel: Any = None
-    sendspin_ws: Any = None
-    sendspin_queue: asyncio.Queue[str | bytes] = field(default_factory=asyncio.Queue)
+    sendspin_channel: DataChannel | None = None
+    sendspin_ws: aiohttp.ClientWebSocketResponse | None = None
     sendspin_player_id: str | None = None  # Extracted from first sendspin auth message
-    sendspin_setup_task: asyncio.Task[None] | None = None
-    sendspin_to_local_task: asyncio.Task[None] | None = None
-    sendspin_from_local_task: asyncio.Task[None] | None = None
-    sendspin_channel_active: bool = False
 
 
 class WebRTCGateway:
@@ -90,7 +73,8 @@ class WebRTCGateway:
         self,
         http_session: aiohttp.ClientSession,
         remote_id: str,
-        certificate: RTCCertificate,
+        cert_pem: str,
+        key_pem: str,
         signaling_url: str = "wss://signaling.music-assistant.io/ws",
         local_ws_url: str = "ws://localhost:8095/ws",
         sendspin_url: str = "ws://localhost:8927/sendspin",
@@ -103,7 +87,8 @@ class WebRTCGateway:
 
         :param http_session: Shared aiohttp ClientSession for HTTP/WebSocket connections.
         :param remote_id: Remote ID for this server instance.
-        :param certificate: Persistent RTCCertificate for DTLS, enabling client-side pinning.
+        :param cert_pem: Persistent DTLS certificate (PEM), enabling client-side pinning.
+        :param key_pem: Private key (PEM) matching the DTLS certificate.
         :param signaling_url: WebSocket URL of the signaling server.
         :param local_ws_url: Local WebSocket URL to bridge to.
         :param sendspin_url: Internal Sendspin WebSocket URL to bridge to.
@@ -116,7 +101,8 @@ class WebRTCGateway:
         self.local_ws_url = local_ws_url
         self.sendspin_url = sendspin_url
         self._remote_id = remote_id
-        self._certificate = certificate
+        self._cert_pem = cert_pem
+        self._key_pem = key_pem
         self.logger = LOGGER
         self._ice_servers_callback = ice_servers_callback
         self._set_sendspin_player_callback = set_sendspin_player_callback
@@ -126,8 +112,6 @@ class WebRTCGateway:
 
         self.sessions: dict[str, WebRTCSession] = {}
         self._background_tasks: set[asyncio.Task[None]] = set()
-        # gateway-wide by design: normally a single remote client is connected
-        self._http_proxy_semaphore = asyncio.Semaphore(HTTP_PROXY_CONCURRENCY)
         self._signaling_ws: aiohttp.ClientWebSocketResponse | None = None
         self._running = False
         self._reconnect_delay = 10  # Wait 10 seconds before reconnecting
@@ -136,6 +120,8 @@ class WebRTCGateway:
         self._run_task: asyncio.Task[None] | None = None
         self._is_connected = False
         self._connecting = False
+        # gateway-wide by design: normally a single remote client is connected
+        self._http_proxy_semaphore = asyncio.Semaphore(HTTP_PROXY_CONCURRENCY)
 
     @property
     def is_running(self) -> bool:
@@ -152,6 +138,11 @@ class WebRTCGateway:
         if self._running:
             self.logger.warning("WebRTC Gateway already running, skipping start")
             return
+        # imported here (never at module import) because the native lib spins up its
+        # thread pool on first use; only the (rarely-used) WebRTC paths need it
+        from aiolibdatachannel import install_python_logger  # noqa: PLC0415
+
+        install_python_logger(self.logger)
         self.logger.info("Starting WebRTC Gateway")
         self.logger.debug("Signaling URL: %s", self.signaling_url)
         self.logger.debug("Local WS URL: %s", self.local_ws_url)
@@ -403,62 +394,23 @@ class WebRTCGateway:
 
         :param session_id: The session ID.
         """
+        # imported here (never at module import) because the native lib spins up its
+        # thread pool on first use; only the (rarely-used) WebRTC paths need it
+        from aiolibdatachannel import PeerConnection, RTCConfiguration  # noqa: PLC0415
+
         session_ice_servers = await self._get_fresh_ice_servers()
         config = RTCConfiguration(
-            iceServers=[RTCIceServer(**server) for server in session_ice_servers]
+            ice_servers=self._build_ice_servers(session_ice_servers),
+            certificate_pem=self._cert_pem,
+            key_pem=self._key_pem,
         )
-        pc = create_peer_connection_with_certificate(self._certificate, configuration=config)
-        session = WebRTCSession(session_id=session_id, peer_connection=pc)
+        pc = PeerConnection(config)
+        session = WebRTCSession(session_id=session_id, pc=pc)
         self.sessions[session_id] = session
 
-        @pc.on("datachannel")
-        def on_datachannel(channel: Any) -> None:
-            if channel.label == "sendspin":
-                session.sendspin_channel = channel
-                session.sendspin_channel_active = True
-                self._register_sendspin_channel_handlers(session)
-                task = asyncio.create_task(self._setup_sendspin_channel(session))
-                session.sendspin_setup_task = task
-
-                def clear_setup_task(completed_task: asyncio.Task[None]) -> None:
-                    if session.sendspin_setup_task is completed_task:
-                        session.sendspin_setup_task = None
-
-                task.add_done_callback(clear_setup_task)
-            else:
-                session.data_channel = channel
-                session.data_channel_active = True
-                self._register_data_channel_handlers(session)
-                task = asyncio.create_task(self._setup_data_channel(session))
-                session.data_channel_setup_task = task
-
-                def clear_data_setup_task(completed_task: asyncio.Task[None]) -> None:
-                    if session.data_channel_setup_task is completed_task:
-                        session.data_channel_setup_task = None
-
-                task.add_done_callback(clear_data_setup_task)
-            self._background_tasks.add(task)
-            task.add_done_callback(self._background_tasks.discard)
-
-        @pc.on("icecandidate")
-        async def on_icecandidate(candidate: Any) -> None:
-            if candidate and self._signaling_ws:
-                await self._signaling_ws.send_json(
-                    {
-                        "type": "ice-candidate",
-                        "sessionId": session_id,
-                        "data": {
-                            "candidate": candidate.candidate,
-                            "sdpMid": candidate.sdpMid,
-                            "sdpMLineIndex": candidate.sdpMLineIndex,
-                        },
-                    }
-                )
-
-        @pc.on("connectionstatechange")
-        async def on_connectionstatechange() -> None:
-            if pc.connectionState == "failed":
-                await self._close_session(session_id)
+        # PC-owned tasks are cancelled and awaited by pc.aclose() during teardown
+        pc.spawn_task(self._monitor_state(session))
+        pc.spawn_task(self._accept_channels(session))
 
     async def _handle_offer(self, session_id: str, offer: dict[str, Any]) -> None:
         """
@@ -470,9 +422,9 @@ class WebRTCGateway:
         session = self.sessions.get(session_id)
         if not session:
             return
-        pc = session.peer_connection
+        pc = session.pc
 
-        if pc.connectionState in ("closed", "failed"):
+        if pc.closed:
             return
 
         sdp = offer.get("sdp")
@@ -482,36 +434,16 @@ class WebRTCGateway:
             return
 
         try:
-            await pc.setRemoteDescription(
-                RTCSessionDescription(
-                    sdp=str(sdp),
-                    type=str(sdp_type),
-                )
-            )
+            # create_answer waits for ICE gathering-complete and inlines candidates,
+            # so the answer we send already carries our local candidates (non-trickle)
+            await pc.set_remote_description(str(sdp), "offer")
 
-            if session_id not in self.sessions or pc.connectionState in ("closed", "failed"):
+            if session_id not in self.sessions or pc.closed:
                 return
 
-            answer = await pc.createAnswer()
+            answer = await pc.create_answer()
 
-            if session_id not in self.sessions or pc.connectionState in ("closed", "failed"):
-                return
-
-            await pc.setLocalDescription(answer)
-
-            # Wait for ICE gathering to complete before sending the answer
-            # aiortc doesn't support trickle ICE, candidates are embedded in SDP after gathering
-            gather_timeout = 30
-            gather_start = asyncio.get_event_loop().time()
-            while pc.iceGatheringState != "complete":
-                if session_id not in self.sessions or pc.connectionState in ("closed", "failed"):
-                    return
-                if asyncio.get_event_loop().time() - gather_start > gather_timeout:
-                    self.logger.warning("Session %s ICE gathering timeout", session_id)
-                    break
-                await asyncio.sleep(0.1)
-
-            if session_id not in self.sessions or pc.connectionState in ("closed", "failed"):
+            if session_id not in self.sessions or pc.closed:
                 return
 
             if self._signaling_ws:
@@ -520,8 +452,8 @@ class WebRTCGateway:
                         "type": "answer",
                         "sessionId": session_id,
                         "data": {
-                            "sdp": pc.localDescription.sdp,
-                            "type": pc.localDescription.type,
+                            "sdp": answer.sdp,
+                            "type": answer.type,
                         },
                     }
                 )
@@ -541,189 +473,24 @@ class WebRTCGateway:
         if not session or not candidate:
             return
 
-        pc = session.peer_connection
-        if pc.connectionState in ("closed", "failed"):
+        pc = session.pc
+        if pc.closed:
             return
 
         candidate_str = candidate.get("candidate")
         sdp_mid = candidate.get("sdpMid")
-        sdp_mline_index = candidate.get("sdpMLineIndex")
 
         if not candidate_str:
             return
 
+        # libdatachannel accepts both the browser's "candidate:..."-prefixed form and the
+        # bare form, so the string is forwarded as-is. add_remote_candidate buffers the
+        # candidate internally until the remote description is set.
+        mid = str(sdp_mid) if sdp_mid else ""
         try:
-            # Parse ICE candidate - browser sends "candidate:..." format
-            if candidate_str.startswith("candidate:"):
-                sdp_candidate_str = candidate_str[len("candidate:") :]
-            else:
-                sdp_candidate_str = candidate_str
-
-            ice_candidate = candidate_from_sdp(sdp_candidate_str)
-            ice_candidate.sdpMid = str(sdp_mid) if sdp_mid else None
-            ice_candidate.sdpMLineIndex = (
-                int(sdp_mline_index) if sdp_mline_index is not None else None
-            )
-
-            if session_id not in self.sessions or pc.connectionState in ("closed", "failed"):
-                return
-
-            await session.peer_connection.addIceCandidate(ice_candidate)
+            await pc.add_remote_candidate(candidate_str, mid)
         except Exception:
             self.logger.exception("Failed to add ICE candidate for session %s", session_id)
-
-    async def _setup_data_channel(self, session: WebRTCSession) -> None:
-        """
-        Set up data channel and bridge to local WebSocket.
-
-        :param session: The WebRTC session.
-        """
-        channel = session.data_channel
-        if not channel:
-            return
-        try:
-            # Include session_id in URL so server can track WebRTC sessions
-            ws_url = f"{self.local_ws_url}?webrtc_session_id={session.session_id}"
-            session.local_ws = await self.http_session.ws_connect(ws_url)
-            if not session.data_channel_active:
-                await self._close_data_channel_bridge(session)
-                return
-
-            # Store task references for proper cleanup
-            session.forward_to_local_task = asyncio.create_task(self._forward_to_local(session))
-            session.forward_from_local_task = asyncio.create_task(self._forward_from_local(session))
-        except Exception:
-            self.logger.exception("Failed to connect to local WebSocket")
-            await self._close_data_channel_bridge(session)
-            channel.close()
-
-    def _register_data_channel_handlers(self, session: WebRTCSession) -> None:
-        """
-        Register API handlers before the remote peer can send its first message.
-
-        :param session: The WebRTC session.
-        """
-        channel = session.data_channel
-        if channel is None:
-            return
-        loop = asyncio.get_running_loop()
-
-        @channel.on("message")  # type: ignore[untyped-decorator]
-        def on_message(message: str) -> None:
-            def enqueue_message() -> None:
-                if not session.data_channel_active:
-                    return
-                if (
-                    session.forward_to_local_task is None
-                    or not session.forward_to_local_task.done()
-                ):
-                    session.message_queue.put_nowait(message)
-
-            loop.call_soon_threadsafe(enqueue_message)
-
-        @channel.on("close")  # type: ignore[untyped-decorator]
-        def on_close() -> None:
-            session.data_channel_active = False
-
-            def schedule_close() -> None:
-                if session.session_id not in self.sessions:
-                    return
-                task = asyncio.create_task(self._close_session(session.session_id))
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
-
-            loop.call_soon_threadsafe(schedule_close)
-
-    async def _close_data_channel_bridge(self, session: WebRTCSession) -> None:
-        """
-        Close the local API bridge for a WebRTC session.
-
-        :param session: The WebRTC session.
-        """
-        session.data_channel_active = False
-        current_task = asyncio.current_task()
-        tasks = [
-            task
-            for task in (
-                session.data_channel_setup_task,
-                session.forward_to_local_task,
-                session.forward_from_local_task,
-            )
-            if task is not None and task is not current_task
-        ]
-        tasks += [task for task in session.proxy_tasks if task is not current_task]
-        local_ws = session.local_ws
-        session.data_channel_setup_task = None
-        session.forward_to_local_task = None
-        session.forward_from_local_task = None
-        session.proxy_tasks = set()
-        session.local_ws = None
-        session.message_queue = asyncio.Queue()
-
-        for task in tasks:
-            if not task.done():
-                task.cancel()
-        for task in tasks:
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-        if local_ws and not local_ws.closed:
-            await local_ws.close()
-
-    async def _forward_to_local(self, session: WebRTCSession) -> None:
-        """
-        Forward messages from WebRTC DataChannel to local WebSocket.
-
-        :param session: The WebRTC session.
-        """
-        try:
-            while session.local_ws and not session.local_ws.closed:
-                message = await session.message_queue.get()
-
-                # Check if this is an HTTP proxy request
-                try:
-                    msg_data = json.loads(message)
-                    if isinstance(msg_data, dict) and msg_data.get("type") == "http-proxy-request":
-                        # handle off the receive loop so a slow fetch never blocks API traffic
-                        task = asyncio.create_task(
-                            self._handle_http_proxy_request(session, msg_data)
-                        )
-                        session.proxy_tasks.add(task)
-                        task.add_done_callback(session.proxy_tasks.discard)
-                        continue
-                except json.JSONDecodeError, ValueError:
-                    pass
-
-                # Regular WebSocket message
-                if session.local_ws and not session.local_ws.closed:
-                    await session.local_ws.send_str(message)
-        except asyncio.CancelledError:
-            # Task was cancelled during cleanup, this is expected
-            self.logger.debug("Forward to local task cancelled for session %s", session.session_id)
-            raise
-        except Exception:
-            self.logger.exception("Error forwarding to local WebSocket")
-
-    async def _forward_from_local(self, session: WebRTCSession) -> None:
-        """
-        Forward messages from local WebSocket to WebRTC DataChannel.
-
-        :param session: The WebRTC session.
-        """
-        try:
-            async for msg in session.local_ws:
-                if msg.type == aiohttp.WSMsgType.TEXT:
-                    if session.data_channel and session.data_channel.readyState == "open":
-                        session.data_channel.send(msg.data)
-                elif msg.type in (aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSED):
-                    break
-        except asyncio.CancelledError:
-            # Task was cancelled during cleanup, this is expected
-            self.logger.debug(
-                "Forward from local task cancelled for session %s", session.session_id
-            )
-            raise
-        except Exception:
-            self.logger.exception("Error forwarding from local WebSocket")
 
     async def _handle_http_proxy_request(
         self, session: WebRTCSession, request_data: dict[str, Any]
@@ -767,8 +534,7 @@ class WebRTCGateway:
                     }
 
                     # Send response back through data channel
-                    if session.data_channel and session.data_channel.readyState == "open":
-                        session.data_channel.send(json.dumps(response_data))
+                    await self._send_on_channel(session.data_channel, json.dumps(response_data))
 
             except Exception as err:
                 self.logger.exception("Error handling HTTP proxy request")
@@ -780,8 +546,7 @@ class WebRTCGateway:
                     "headers": {"Content-Type": "text/plain"},
                     "body": str(err).encode().hex(),
                 }
-                if session.data_channel and session.data_channel.readyState == "open":
-                    session.data_channel.send(json.dumps(error_response))
+                await self._send_on_channel(session.data_channel, json.dumps(error_response))
 
     async def _close_session(self, session_id: str) -> None:
         """
@@ -793,130 +558,169 @@ class WebRTCGateway:
         if not session:
             return
 
-        await self._close_data_channel_bridge(session)
-        await self._close_sendspin_bridge(session)
+        # Close the local bridges first so no more data is fed through the channels
+        for local_ws in (session.local_ws, session.sendspin_ws):
+            if local_ws is not None and not local_ws.closed:
+                with contextlib.suppress(Exception):
+                    await local_ws.close()
+        session.local_ws = None
+        session.sendspin_ws = None
 
-        # Close connections
-        if session.data_channel:
-            session.data_channel.close()
-        if session.sendspin_channel:
-            session.sendspin_channel.close()
-        await session.peer_connection.close()
+        # aclose tears down all PC-owned pumps and every data channel; safe here because
+        # _close_session is never invoked from within a PC-owned task
+        await session.pc.aclose()
 
-    async def _setup_sendspin_channel(self, session: WebRTCSession) -> None:
+    # ---- Session pumps (PC-owned tasks) --------------------------------------
+
+    async def _monitor_state(self, session: WebRTCSession) -> None:
         """
-        Set up sendspin data channel and bridge to internal sendspin server.
+        Close the session when its PeerConnection reports a failed state.
 
         :param session: The WebRTC session.
         """
-        channel = session.sendspin_channel
-        if not channel:
+        from aiolibdatachannel import RTCState, StateChangeEvent  # noqa: PLC0415
+
+        async for event in session.pc.events():
+            if isinstance(event, StateChangeEvent) and event.state == RTCState.FAILED:
+                self._schedule_close(session.session_id)
+                return
+
+    async def _accept_channels(self, session: WebRTCSession) -> None:
+        """
+        Accept incoming data channels and start their bridges.
+
+        :param session: The WebRTC session.
+        """
+        async for channel in session.pc.incoming_data_channels():
+            # The browser opens "ma-api" (default) and "sendspin" (by label); route each
+            if channel.label == "sendspin":
+                session.sendspin_channel = channel
+                session.pc.spawn_task(self._bridge_sendspin(session, channel))
+            else:
+                session.data_channel = channel
+                session.pc.spawn_task(self._bridge_ma_api(session, channel))
+
+    async def _bridge_ma_api(self, session: WebRTCSession, channel: DataChannel) -> None:
+        """
+        Bridge the ma-api data channel to the local WebSocket API.
+
+        :param session: The WebRTC session.
+        :param channel: The ma-api data channel.
+        """
+        try:
+            # Include session_id in URL so server can track WebRTC sessions
+            ws_url = f"{self.local_ws_url}?webrtc_session_id={session.session_id}"
+            session.local_ws = await self.http_session.ws_connect(ws_url)
+        except Exception:
+            self.logger.exception("Failed to connect to local WebSocket")
+            channel.close()
+            self._schedule_close(session.session_id)
             return
 
+        # from_local runs as its own PC-owned pump; this task drives channel -> local
+        session.pc.spawn_task(self._ma_api_from_local(session, channel))
+        await self._ma_api_to_local(session, channel)
+        # channel -> local loop ended (remote channel closed): tear down the session
+        self._schedule_close(session.session_id)
+
+    async def _ma_api_to_local(self, session: WebRTCSession, channel: DataChannel) -> None:
+        """
+        Forward messages from the ma-api data channel to the local WebSocket.
+
+        :param session: The WebRTC session.
+        :param channel: The ma-api data channel.
+        """
+        from aiolibdatachannel import ConnectionClosedError  # noqa: PLC0415
+
+        try:
+            async for message in channel:
+                if isinstance(message, str):
+                    # Check if this is an HTTP proxy request
+                    try:
+                        msg_data = json.loads(message)
+                        if (
+                            isinstance(msg_data, dict)
+                            and msg_data.get("type") == "http-proxy-request"
+                        ):
+                            # Handle off the receive loop so a slow image fetch never
+                            # blocks API messages or the next image (bounded by the
+                            # gateway-wide semaphore; see #4889).
+                            session.pc.spawn_task(
+                                self._handle_http_proxy_request(session, msg_data)
+                            )
+                            continue
+                    except json.JSONDecodeError, ValueError:
+                        pass
+
+                if session.local_ws and not session.local_ws.closed:
+                    if isinstance(message, bytes):
+                        await session.local_ws.send_bytes(message)
+                    else:
+                        await session.local_ws.send_str(message)
+        except ConnectionClosedError:
+            self.logger.debug("ma-api channel closed for session %s", session.session_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger.exception("Error forwarding to local WebSocket")
+
+    async def _ma_api_from_local(self, session: WebRTCSession, channel: DataChannel) -> None:
+        """
+        Forward messages from the local WebSocket to the ma-api data channel.
+
+        :param session: The WebRTC session.
+        :param channel: The ma-api data channel.
+        """
+        local_ws = session.local_ws
+        if local_ws is None:
+            return
+        try:
+            async for msg in local_ws:
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    await self._send_on_channel(channel, msg.data)
+                elif msg.type in (aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSED):
+                    break
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger.exception("Error forwarding from local WebSocket")
+
+    async def _bridge_sendspin(self, session: WebRTCSession, channel: DataChannel) -> None:
+        """
+        Bridge the sendspin data channel to the internal sendspin server.
+
+        :param session: The WebRTC session.
+        :param channel: The sendspin data channel.
+        """
         try:
             session.sendspin_ws = await self.http_session.ws_connect(self.sendspin_url)
             self.logger.debug("Sendspin channel connected for session %s", session.session_id)
-            if not session.sendspin_channel_active:
-                await self._close_sendspin_bridge(session)
-                return
-
-            # Start forwarding tasks - queued messages will be processed
-            session.sendspin_to_local_task = asyncio.create_task(
-                self._forward_sendspin_to_local(session)
-            )
-            session.sendspin_from_local_task = asyncio.create_task(
-                self._forward_sendspin_from_local(session)
-            )
-
         except Exception:
             self.logger.exception(
                 "Failed to connect sendspin channel to internal server for session %s",
                 session.session_id,
             )
-            await self._close_sendspin_bridge(session)
             channel.close()
-
-    def _register_sendspin_channel_handlers(self, session: WebRTCSession) -> None:
-        """
-        Register Sendspin handlers before the remote peer can send its first message.
-
-        :param session: The WebRTC session.
-        """
-        channel = session.sendspin_channel
-        if channel is None:
             return
-        loop = asyncio.get_running_loop()
 
-        @channel.on("message")  # type: ignore[untyped-decorator]
-        def on_message(message: str | bytes) -> None:
-            def enqueue_message() -> None:
-                if not session.sendspin_channel_active:
-                    return
-                if (
-                    session.sendspin_to_local_task is None
-                    or not session.sendspin_to_local_task.done()
-                ):
-                    session.sendspin_queue.put_nowait(message)
+        # from_local runs as its own PC-owned pump; this task drives channel -> internal
+        session.pc.spawn_task(self._sendspin_from_local(session, channel))
+        await self._sendspin_to_local(session, channel)
+        # channel -> internal loop ended (remote channel closed): tear down only this bridge
+        await self._close_sendspin_bridge(session)
 
-            loop.call_soon_threadsafe(enqueue_message)
-
-        @channel.on("close")  # type: ignore[untyped-decorator]
-        def on_close() -> None:
-            session.sendspin_channel_active = False
-
-            def schedule_cleanup() -> None:
-                if session.session_id not in self.sessions:
-                    return
-                task = asyncio.create_task(self._close_sendspin_bridge(session))
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
-
-            loop.call_soon_threadsafe(schedule_cleanup)
-
-    async def _close_sendspin_bridge(self, session: WebRTCSession) -> None:
+    async def _sendspin_to_local(self, session: WebRTCSession, channel: DataChannel) -> None:
         """
-        Close the internal Sendspin bridge for a WebRTC session.
+        Forward messages from the sendspin data channel to the internal sendspin server.
 
         :param session: The WebRTC session.
+        :param channel: The sendspin data channel.
         """
-        session.sendspin_channel_active = False
-        current_task = asyncio.current_task()
-        tasks = [
-            task
-            for task in (
-                session.sendspin_setup_task,
-                session.sendspin_to_local_task,
-                session.sendspin_from_local_task,
-            )
-            if task is not None and task is not current_task
-        ]
-        sendspin_ws = session.sendspin_ws
-        session.sendspin_setup_task = None
-        session.sendspin_to_local_task = None
-        session.sendspin_from_local_task = None
-        session.sendspin_ws = None
-        session.sendspin_queue = asyncio.Queue()
+        from aiolibdatachannel import ConnectionClosedError  # noqa: PLC0415
 
-        for task in tasks:
-            if not task.done():
-                task.cancel()
-        for task in tasks:
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-        if sendspin_ws and not sendspin_ws.closed:
-            await sendspin_ws.close()
-
-    async def _forward_sendspin_to_local(self, session: WebRTCSession) -> None:
-        """
-        Forward messages from sendspin DataChannel to internal sendspin server.
-
-        :param session: The WebRTC session.
-        """
         first_message = True
         try:
-            while session.sendspin_ws and not session.sendspin_ws.closed:
-                message = await session.sendspin_queue.get()
-
+            async for message in channel:
                 # Check only the first message for client_id extraction
                 if first_message:
                     first_message = False
@@ -928,14 +732,99 @@ class WebRTCGateway:
                         await session.sendspin_ws.send_bytes(message)
                     else:
                         await session.sendspin_ws.send_str(message)
+        except ConnectionClosedError:
+            self.logger.debug("Sendspin channel closed for session %s", session.session_id)
         except asyncio.CancelledError:
-            self.logger.debug(
-                "Sendspin forward to local task cancelled for session %s",
-                session.session_id,
-            )
             raise
         except Exception:
             self.logger.exception("Error forwarding sendspin to local")
+
+    async def _sendspin_from_local(self, session: WebRTCSession, channel: DataChannel) -> None:
+        """
+        Forward messages from the internal sendspin server to the sendspin data channel.
+
+        :param session: The WebRTC session.
+        :param channel: The sendspin data channel.
+        """
+        sendspin_ws = session.sendspin_ws
+        if sendspin_ws is None:
+            return
+        try:
+            async for msg in sendspin_ws:
+                if msg.type in {aiohttp.WSMsgType.TEXT, aiohttp.WSMsgType.BINARY}:
+                    await self._send_on_channel(channel, msg.data)
+                elif msg.type in (aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSED):
+                    break
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger.exception("Error forwarding sendspin from local")
+
+    async def _close_sendspin_bridge(self, session: WebRTCSession) -> None:
+        """
+        Close the internal Sendspin bridge for a WebRTC session.
+
+        :param session: The WebRTC session.
+        """
+        sendspin_ws = session.sendspin_ws
+        session.sendspin_ws = None
+        if sendspin_ws is not None and not sendspin_ws.closed:
+            with contextlib.suppress(Exception):
+                await sendspin_ws.close()
+        channel = session.sendspin_channel
+        session.sendspin_channel = None
+        if channel is not None and not channel.closed:
+            with contextlib.suppress(Exception):
+                await channel.aclose()
+
+    # ---- Helpers -------------------------------------------------------------
+
+    def _build_ice_servers(self, servers: list[dict[str, Any]]) -> list[Any]:
+        """
+        Build IceServer entries (one per url) from ICE server config dicts.
+
+        :param servers: ICE server dicts ({"urls": str|list, "username"?, "credential"?}).
+        :return: List of IceServer instances for RTCConfiguration.
+        """
+        from aiolibdatachannel import IceServer  # noqa: PLC0415
+
+        ice_servers: list[Any] = []
+        for server in servers:
+            urls = server.get("urls")
+            username = server.get("username")
+            credential = server.get("credential")
+            url_list = [urls] if isinstance(urls, str) else (urls or [])
+            for url in url_list:
+                ice_servers.append(IceServer(url=url, username=username, credential=credential))
+        return ice_servers
+
+    def _schedule_close(self, session_id: str) -> None:
+        """
+        Schedule session teardown on a gateway-owned task.
+
+        :param session_id: The session ID.
+        """
+        # Run outside the PC-owned pump that triggered it so pc.aclose() (which the pump
+        # is awaited by) does not deadlock on itself
+        if session_id not in self.sessions:
+            return
+        task = asyncio.create_task(self._close_session(session_id))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    async def _send_on_channel(self, channel: DataChannel | None, data: str | bytes) -> None:
+        """
+        Send data on a data channel if it is currently open.
+
+        :param channel: The data channel (or None).
+        :param data: The str or bytes payload to send.
+        """
+        from aiolibdatachannel import ConnectionClosedError  # noqa: PLC0415
+
+        if channel is None or not channel.is_open:
+            return
+        with contextlib.suppress(ConnectionClosedError):
+            await channel.send(data)
 
     def _try_extract_sendspin_client_id(self, session: WebRTCSession, message: str) -> None:
         """
@@ -962,28 +851,3 @@ class WebRTCGateway:
                     self._set_sendspin_player_callback(session.session_id, client_id)
         except json.JSONDecodeError, TypeError:
             pass  # Not valid JSON, ignore
-
-    async def _forward_sendspin_from_local(self, session: WebRTCSession) -> None:
-        """
-        Forward messages from internal sendspin server to sendspin DataChannel.
-
-        :param session: The WebRTC session.
-        """
-        if not session.sendspin_ws or session.sendspin_ws.closed:
-            return
-
-        try:
-            async for msg in session.sendspin_ws:
-                if msg.type in {aiohttp.WSMsgType.TEXT, aiohttp.WSMsgType.BINARY}:
-                    if session.sendspin_channel and session.sendspin_channel.readyState == "open":
-                        session.sendspin_channel.send(msg.data)
-                elif msg.type in (aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSED):
-                    break
-        except asyncio.CancelledError:
-            self.logger.debug(
-                "Sendspin forward from local task cancelled for session %s",
-                session.session_id,
-            )
-            raise
-        except Exception:
-            self.logger.exception("Error forwarding sendspin from local")

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -762,9 +762,9 @@ class WebRTCGateway:
 
     # ---- Helpers -------------------------------------------------------------
 
-    def _build_ice_servers(self, servers: list[dict[str, Any]]) -> list[Any]:
+    def _build_ice_servers(self, servers: list[dict[str, Any]]) -> list[IceServer]:
         """Build IceServer entries (one per url) from ICE server config dicts."""
-        ice_servers: list[Any] = []
+        ice_servers: list[IceServer] = []
         for server in servers:
             urls = server.get("urls")
             username = server.get("username")

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -18,11 +18,20 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import urlparse
 
 import aiohttp
+from aiolibdatachannel import (
+    ConnectionClosedError,
+    IceServer,
+    PeerConnection,
+    RTCConfiguration,
+    RTCState,
+    StateChangeEvent,
+    install_python_logger,
+)
 
 from music_assistant.constants import MASS_LOGGER_NAME, VERBOSE_LOG_LEVEL
 
 if TYPE_CHECKING:
-    from aiolibdatachannel import DataChannel, PeerConnection
+    from aiolibdatachannel import DataChannel
 
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.remote_access")
 
@@ -30,11 +39,7 @@ LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.remote_access")
 # data channel stays bounded and never blocks the API message pump (see #4889).
 HTTP_PROXY_CONCURRENCY = 6
 
-# Large proxied bodies (album art) are split into chunks before sending: libdatachannel
-# enforces the negotiated 256 KiB data-channel message limit, whereas aiortc silently
-# fragmented any size. 64 KiB raw -> ~128 KiB hex per message stays well under the limit,
-# and keeps messages small enough that API traffic can interleave between image chunks
-# (browsers don't implement SCTP message interleaving, RFC 8260).
+# Chunk proxied bodies larger than this; libdatachannel caps data-channel messages at 256 KiB.
 HTTP_PROXY_CHUNK_SIZE = 64 * 1024
 
 
@@ -145,10 +150,6 @@ class WebRTCGateway:
         if self._running:
             self.logger.warning("WebRTC Gateway already running, skipping start")
             return
-        # imported here (never at module import) because the native lib spins up its
-        # thread pool on first use; only the (rarely-used) WebRTC paths need it
-        from aiolibdatachannel import install_python_logger  # noqa: PLC0415
-
         install_python_logger(self.logger)
         self.logger.info("Starting WebRTC Gateway")
         self.logger.debug("Signaling URL: %s", self.signaling_url)
@@ -187,14 +188,7 @@ class WebRTCGateway:
         self._connecting = False
 
     async def _get_fresh_ice_servers(self) -> list[dict[str, Any]]:
-        """
-        Get fresh ICE servers for a new WebRTC session.
-
-        If an ice_servers_callback was provided, it will be called to get fresh
-        TURN credentials. Otherwise, returns the static ice_servers.
-
-        :return: List of ICE server configurations with fresh credentials.
-        """
+        """Get fresh ICE servers for a new WebRTC session."""
         if self._ice_servers_callback:
             try:
                 fresh_servers = await self._ice_servers_callback()
@@ -240,11 +234,7 @@ class WebRTCGateway:
                 break
 
     async def _connect_to_signaling(self) -> bool:
-        """
-        Connect to the signaling server.
-
-        :return: True if reconnection should be attempted, False if connection was replaced.
-        """
+        """Connect to the signaling server."""
         if self._connecting:
             self.logger.warning("Already connecting to signaling server, skipping")
             return False  # Don't trigger another reconnect cycle
@@ -301,12 +291,7 @@ class WebRTCGateway:
         return True
 
     async def _signaling_message_loop(self, ws: aiohttp.ClientWebSocketResponse) -> int | None:
-        """
-        Process messages from the signaling WebSocket.
-
-        :param ws: The WebSocket connection to process messages from.
-        :return: Close code if connection was closed with a code, None otherwise.
-        """
+        """Process messages from the signaling WebSocket."""
         close_code: int | None = None
         self.logger.debug("Entering message loop")
         async for msg in ws:
@@ -349,11 +334,7 @@ class WebRTCGateway:
             )
 
     async def _handle_signaling_message(self, message: dict[str, Any]) -> None:
-        """
-        Handle incoming signaling messages.
-
-        :param message: The signaling message.
-        """
+        """Handle incoming signaling messages."""
         msg_type = message.get("type")
 
         if msg_type in ("ping", "pong"):
@@ -396,15 +377,7 @@ class WebRTCGateway:
                 await self._handle_ice_candidate(session_id, candidate_data)
 
     async def _create_session(self, session_id: str) -> None:
-        """
-        Create a new WebRTC session.
-
-        :param session_id: The session ID.
-        """
-        # imported here (never at module import) because the native lib spins up its
-        # thread pool on first use; only the (rarely-used) WebRTC paths need it
-        from aiolibdatachannel import PeerConnection, RTCConfiguration  # noqa: PLC0415
-
+        """Create a new WebRTC session."""
         session_ice_servers = await self._get_fresh_ice_servers()
         config = RTCConfiguration(
             ice_servers=self._build_ice_servers(session_ice_servers),
@@ -421,12 +394,7 @@ class WebRTCGateway:
         pc.spawn_task(self._forward_local_candidates(session))
 
     async def _handle_offer(self, session_id: str, offer: dict[str, Any]) -> None:
-        """
-        Handle incoming WebRTC offer.
-
-        :param session_id: The session ID.
-        :param offer: The offer data.
-        """
+        """Handle incoming WebRTC offer."""
         session = self.sessions.get(session_id)
         if not session:
             return
@@ -473,12 +441,7 @@ class WebRTCGateway:
             await self._close_session(session_id)
 
     async def _handle_ice_candidate(self, session_id: str, candidate: dict[str, Any]) -> None:
-        """
-        Handle incoming ICE candidate.
-
-        :param session_id: The session ID.
-        :param candidate: The ICE candidate data.
-        """
+        """Handle incoming ICE candidate."""
         session = self.sessions.get(session_id)
         if not session or not candidate:
             return
@@ -505,12 +468,7 @@ class WebRTCGateway:
     async def _handle_http_proxy_request(
         self, session: WebRTCSession, request_data: dict[str, Any]
     ) -> None:
-        """
-        Handle HTTP proxy request from remote client.
-
-        :param session: The WebRTC session.
-        :param request_data: The HTTP proxy request data.
-        """
+        """Handle HTTP proxy request from remote client."""
         request_id = request_data.get("id")
         method = request_data.get("method", "GET")
         path = request_data.get("path", "/")
@@ -549,15 +507,7 @@ class WebRTCGateway:
         headers: dict[str, str],
         body: bytes,
     ) -> None:
-        """
-        Send an HTTP-proxy response over the data channel, chunking large bodies.
-
-        :param session: The WebRTC session.
-        :param request_id: The originating request ID.
-        :param status: The HTTP status code.
-        :param headers: The HTTP response headers.
-        :param body: The raw response body.
-        """
+        """Send an HTTP-proxy response over the data channel, chunking large bodies."""
         channel = session.data_channel
         # Small bodies fit a single message; keep the legacy format so clients that
         # don't understand chunking still work for everything but large images.
@@ -609,11 +559,7 @@ class WebRTCGateway:
             )
 
     async def _close_session(self, session_id: str) -> None:
-        """
-        Close a WebRTC session.
-
-        :param session_id: The session ID.
-        """
+        """Close a WebRTC session."""
         session = self.sessions.pop(session_id, None)
         if not session:
             return
@@ -633,24 +579,14 @@ class WebRTCGateway:
     # ---- Session pumps (PC-owned tasks) --------------------------------------
 
     async def _monitor_state(self, session: WebRTCSession) -> None:
-        """
-        Close the session when its PeerConnection reports a failed state.
-
-        :param session: The WebRTC session.
-        """
-        from aiolibdatachannel import RTCState, StateChangeEvent  # noqa: PLC0415
-
+        """Close the session when its PeerConnection reports a failed state."""
         async for event in session.pc.events():
             if isinstance(event, StateChangeEvent) and event.state == RTCState.FAILED:
                 self._schedule_close(session.session_id)
                 return
 
     async def _forward_local_candidates(self, session: WebRTCSession) -> None:
-        """
-        Stream locally-gathered ICE candidates to the remote client (trickle ICE).
-
-        :param session: The WebRTC session.
-        """
+        """Stream locally-gathered ICE candidates to the remote client (trickle ICE)."""
         # The iterator ends on gathering-complete or when the PC closes.
         async for candidate in session.pc.ice_candidates():
             if session.session_id not in self.sessions or not self._signaling_ws:
@@ -667,11 +603,7 @@ class WebRTCGateway:
             )
 
     async def _accept_channels(self, session: WebRTCSession) -> None:
-        """
-        Accept incoming data channels and start their bridges.
-
-        :param session: The WebRTC session.
-        """
+        """Accept incoming data channels and start their bridges."""
         async for channel in session.pc.incoming_data_channels():
             # The browser opens "ma-api" (default) and "sendspin" (by label); route each
             if channel.label == "sendspin":
@@ -682,12 +614,7 @@ class WebRTCGateway:
                 session.pc.spawn_task(self._bridge_ma_api(session, channel))
 
     async def _bridge_ma_api(self, session: WebRTCSession, channel: DataChannel) -> None:
-        """
-        Bridge the ma-api data channel to the local WebSocket API.
-
-        :param session: The WebRTC session.
-        :param channel: The ma-api data channel.
-        """
+        """Bridge the ma-api data channel to the local WebSocket API."""
         try:
             # Include session_id in URL so server can track WebRTC sessions
             ws_url = f"{self.local_ws_url}?webrtc_session_id={session.session_id}"
@@ -705,14 +632,7 @@ class WebRTCGateway:
         self._schedule_close(session.session_id)
 
     async def _ma_api_to_local(self, session: WebRTCSession, channel: DataChannel) -> None:
-        """
-        Forward messages from the ma-api data channel to the local WebSocket.
-
-        :param session: The WebRTC session.
-        :param channel: The ma-api data channel.
-        """
-        from aiolibdatachannel import ConnectionClosedError  # noqa: PLC0415
-
+        """Forward messages from the ma-api data channel to the local WebSocket."""
         try:
             async for message in channel:
                 if isinstance(message, str):
@@ -746,12 +666,7 @@ class WebRTCGateway:
             self.logger.exception("Error forwarding to local WebSocket")
 
     async def _ma_api_from_local(self, session: WebRTCSession, channel: DataChannel) -> None:
-        """
-        Forward messages from the local WebSocket to the ma-api data channel.
-
-        :param session: The WebRTC session.
-        :param channel: The ma-api data channel.
-        """
+        """Forward messages from the local WebSocket to the ma-api data channel."""
         local_ws = session.local_ws
         if local_ws is None:
             return
@@ -767,12 +682,7 @@ class WebRTCGateway:
             self.logger.exception("Error forwarding from local WebSocket")
 
     async def _bridge_sendspin(self, session: WebRTCSession, channel: DataChannel) -> None:
-        """
-        Bridge the sendspin data channel to the internal sendspin server.
-
-        :param session: The WebRTC session.
-        :param channel: The sendspin data channel.
-        """
+        """Bridge the sendspin data channel to the internal sendspin server."""
         try:
             session.sendspin_ws = await self.http_session.ws_connect(self.sendspin_url)
             self.logger.debug("Sendspin channel connected for session %s", session.session_id)
@@ -791,14 +701,7 @@ class WebRTCGateway:
         await self._close_sendspin_bridge(session)
 
     async def _sendspin_to_local(self, session: WebRTCSession, channel: DataChannel) -> None:
-        """
-        Forward messages from the sendspin data channel to the internal sendspin server.
-
-        :param session: The WebRTC session.
-        :param channel: The sendspin data channel.
-        """
-        from aiolibdatachannel import ConnectionClosedError  # noqa: PLC0415
-
+        """Forward messages from the sendspin data channel to the internal sendspin server."""
         first_message = True
         try:
             async for message in channel:
@@ -821,12 +724,7 @@ class WebRTCGateway:
             self.logger.exception("Error forwarding sendspin to local")
 
     async def _sendspin_from_local(self, session: WebRTCSession, channel: DataChannel) -> None:
-        """
-        Forward messages from the internal sendspin server to the sendspin data channel.
-
-        :param session: The WebRTC session.
-        :param channel: The sendspin data channel.
-        """
+        """Forward messages from the internal sendspin server to the sendspin data channel."""
         sendspin_ws = session.sendspin_ws
         if sendspin_ws is None:
             return
@@ -842,11 +740,7 @@ class WebRTCGateway:
             self.logger.exception("Error forwarding sendspin from local")
 
     async def _close_sendspin_bridge(self, session: WebRTCSession) -> None:
-        """
-        Close the internal Sendspin bridge for a WebRTC session.
-
-        :param session: The WebRTC session.
-        """
+        """Close the internal Sendspin bridge for a WebRTC session."""
         sendspin_ws = session.sendspin_ws
         session.sendspin_ws = None
         if sendspin_ws is not None and not sendspin_ws.closed:
@@ -861,14 +755,7 @@ class WebRTCGateway:
     # ---- Helpers -------------------------------------------------------------
 
     def _build_ice_servers(self, servers: list[dict[str, Any]]) -> list[Any]:
-        """
-        Build IceServer entries (one per url) from ICE server config dicts.
-
-        :param servers: ICE server dicts ({"urls": str|list, "username"?, "credential"?}).
-        :return: List of IceServer instances for RTCConfiguration.
-        """
-        from aiolibdatachannel import IceServer  # noqa: PLC0415
-
+        """Build IceServer entries (one per url) from ICE server config dicts."""
         ice_servers: list[Any] = []
         for server in servers:
             urls = server.get("urls")
@@ -880,11 +767,7 @@ class WebRTCGateway:
         return ice_servers
 
     def _schedule_close(self, session_id: str) -> None:
-        """
-        Schedule session teardown on a gateway-owned task.
-
-        :param session_id: The session ID.
-        """
+        """Schedule session teardown on a gateway-owned task."""
         # Run outside the PC-owned pump that triggered it so pc.aclose() (which the pump
         # is awaited by) does not deadlock on itself
         if session_id not in self.sessions:
@@ -894,26 +777,14 @@ class WebRTCGateway:
         task.add_done_callback(self._background_tasks.discard)
 
     async def _send_on_channel(self, channel: DataChannel | None, data: str | bytes) -> None:
-        """
-        Send data on a data channel if it is currently open.
-
-        :param channel: The data channel (or None).
-        :param data: The str or bytes payload to send.
-        """
-        from aiolibdatachannel import ConnectionClosedError  # noqa: PLC0415
-
+        """Send data on a data channel if it is currently open."""
         if channel is None or not channel.is_open:
             return
         with contextlib.suppress(ConnectionClosedError):
             await channel.send(data)
 
     def _try_extract_sendspin_client_id(self, session: WebRTCSession, message: str) -> None:
-        """
-        Try to extract client_id from sendspin auth message and set on websocket client.
-
-        :param session: The WebRTC session.
-        :param message: The first sendspin message (expected to be auth).
-        """
+        """Try to extract client_id from sendspin auth message and set on websocket client."""
         try:
             data = json.loads(message)
             if data.get("type") != "auth":

--- a/music_assistant/helpers/webrtc_certificate.py
+++ b/music_assistant/helpers/webrtc_certificate.py
@@ -14,7 +14,6 @@ import os
 import stat
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -22,10 +21,6 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.x509.oid import NameOID
 
 from music_assistant.helpers.datetime import utc
-
-if TYPE_CHECKING:
-    from aiortc import RTCConfiguration, RTCPeerConnection
-    from aiortc.rtcdtlstransport import RTCCertificate
 
 LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +38,7 @@ def _generate_certificate() -> tuple[ec.EllipticCurvePrivateKey, x509.Certificat
 
     :return: Tuple of (private_key, certificate).
     """
-    # Generate ECDSA key (SECP256R1 - same as aiortc default)
+    # Generate ECDSA key (SECP256R1 - the standard WebRTC DTLS curve)
     private_key = ec.generate_private_key(ec.SECP256R1())
 
     now = utc()
@@ -186,37 +181,19 @@ def _remote_id_from_certificate(cert: x509.Certificate) -> str:
     :return: Custom base32-encoded (with 9s instead of 2s) Remote ID string
         (26 characters, uppercase, no-padding).
     """
-    # SHA-256 over the DER certificate, matching aiortc's certificate_digest; take the
-    # first 128 bits and base32-encode (with 9s instead of 2s) without padding.
+    # SHA-256 over the DER certificate, matching the DTLS certificate digest so Remote IDs
+    # stay stable; take the first 128 bits and base32-encode (with 9s instead of 2s), no padding.
     digest = cert.fingerprint(hashes.SHA256())
     return base64.b32encode(digest[:16]).decode("ascii").rstrip("=").replace("2", "9")
 
 
-def get_or_create_webrtc_certificate(storage_path: str) -> RTCCertificate:
-    """
-    Get or create a persistent WebRTC DTLS certificate.
-
-    Loads an existing certificate from disk if available and valid, otherwise
-    generates a new certificate and saves it.
-
-    :param storage_path: Directory to store/load the certificate files.
-    :return: RTCCertificate instance for use with WebRTC.
-    """
-    # imported here so importing this module never pulls in aiortc/PyAV (~51MB);
-    # only the (rarely-used) WebRTC paths actually need it
-    from aiortc.rtcdtlstransport import RTCCertificate  # noqa: PLC0415
-
-    private_key, cert = _get_or_create_certificate(storage_path)
-    return RTCCertificate(key=private_key, cert=cert)
-
-
 def get_or_create_remote_id(storage_path: str) -> str:
     """
-    Return the stable Remote ID for this instance without importing aiortc.
+    Return the stable Remote ID for this instance without loading the WebRTC lib.
 
     Loads (or creates and persists) the WebRTC DTLS certificate and derives the
     Remote ID from it, so the always-on remote_access/info endpoint can report the
-    Remote ID even when remote access is disabled and aiortc was never loaded.
+    Remote ID even when remote access is disabled and the native lib was never loaded.
 
     :param storage_path: Directory to store/load the certificate files.
     :return: The Remote ID derived from the persistent certificate.
@@ -225,21 +202,18 @@ def get_or_create_remote_id(storage_path: str) -> str:
     return _remote_id_from_certificate(cert)
 
 
-def create_peer_connection_with_certificate(
-    certificate: RTCCertificate,
-    configuration: RTCConfiguration | None = None,
-) -> RTCPeerConnection:
+def get_or_create_webrtc_certificate_pems(storage_path: str) -> tuple[str, str]:
     """
-    Create an RTCPeerConnection with a custom persistent certificate.
+    Get or create the persistent WebRTC DTLS certificate as PEM strings.
 
-    :param certificate: The RTCCertificate to use for DTLS.
-    :param configuration: Optional RTCConfiguration with ICE servers.
-    :return: RTCPeerConnection configured with the provided certificate.
+    :param storage_path: Directory to store/load the certificate files.
+    :return: Tuple of (certificate_pem, private_key_pem).
     """
-    from aiortc import RTCPeerConnection  # noqa: PLC0415
-
-    pc = RTCPeerConnection(configuration=configuration)
-    # Replace the auto-generated certificate with our persistent one
-    # Uses name-mangled private attribute access
-    pc._RTCPeerConnection__certificates = [certificate]  # type: ignore[attr-defined]
-    return pc
+    private_key, cert = _get_or_create_certificate(storage_path)
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    return cert_pem, key_pem

--- a/music_assistant/providers/sendspin/README.md
+++ b/music_assistant/providers/sendspin/README.md
@@ -205,7 +205,7 @@ Sendspin players support:
 ## Dependencies
 
 - `aiosendspin` - Async Sendspin protocol implementation
-- `aiortc` - WebRTC implementation for Python (used for WebRTC bridging)
+- `aiolibdatachannel` - WebRTC implementation for Python (used for WebRTC bridging)
 - `PIL/Pillow` - Image processing for artwork
 
 ## External Players (Protocol Bridges)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ dependencies = [
   "torch==2.13.0",
   "torchaudio==2.11.0",
   "gql[all]==4.0.0",
-  "aiortc>=1.6.0",
+  # TEMPORARY test-drive pin — replace with PyPI release before merge (see webrtc_aiolibdatachannel_plan.md Phase C)
+  "aiolibdatachannel @ git+https://github.com/music-assistant/aiolibdatachannel@feat/certpem-testdrive",
   "pyjwt[crypto]>=2.10.1",
 ]
 description = "Music Assistant"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -11,8 +11,8 @@ aiohttp_asyncmdnsresolver==0.2.0
 aiohttp-fast-zlib==0.3.0
 aiohttp-socks==0.11.0
 aiojellyfin==0.14.1
+aiolibdatachannel @ git+https://github.com/music-assistant/aiolibdatachannel@feat/certpem-testdrive
 aiomusiccast==0.15.0
-aiortc>=1.6.0
 aiosendspin[server]==7.0.0
 aioslimproto==3.1.9
 aiosonos==0.1.12

--- a/tests/helpers/test_webrtc_certificate.py
+++ b/tests/helpers/test_webrtc_certificate.py
@@ -12,10 +12,35 @@ from music_assistant.helpers.webrtc_certificate import (
     CERT_FILENAME,
     KEY_FILENAME,
     _get_or_create_certificate,
+    get_or_create_remote_id,
+    get_or_create_webrtc_certificate_pems,
 )
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+# Frozen fixtures derived from _generate_certificate()/_remote_id_from_certificate(),
+# pinned as literals so these tests keep guarding the derivation even if the
+# implementation changes later.
+FIXTURE_CERT_PEM = (
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIBQTCB6KADAgECAhRuYKuRIszhzAOCq29MyuvEOzJ9EDAKBggqhkjOPQQDAjAh\n"
+    "MR8wHQYDVQQDDBZNdXNpYyBBc3Npc3RhbnQgV2ViUlRDMB4XDTI2MDcxOTEwMjIw\n"
+    "OFoXDTM2MDcxNzEwMjIwOFowITEfMB0GA1UEAwwWTXVzaWMgQXNzaXN0YW50IFdl\n"
+    "YlJUQzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAU/5JpGlyTQ2pexaev5083F\n"
+    "1/dkvNKxCCRWQbfZOvk1vRhJP4jsT710Un7jzfMx25rtMVsv1lzvCmerRFCsacsw\n"
+    "CgYIKoZIzj0EAwIDSAAwRQIgOTVzTaqOXVyaD2NDNIVjXlX3hDOxEgbacy7Q7Lfj\n"
+    "61QCIQCq3RN0iyR9qfuo28VjkWceEcHkDwynS1vFKr2oqffO6g==\n"
+    "-----END CERTIFICATE-----\n"
+)
+FIXTURE_KEY_PEM = (
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgrrFr6dcpp+Sr1j+e\n"
+    "dY0oUp/WYDjh/xpceu3sIxmldUWhRANCAAQFP+SaRpck0NqXsWnr+dPNxdf3ZLzS\n"
+    "sQgkVkG32Tr5Nb0YST+I7E+9dFJ+483zMdua7TFbL9Zc7wpnq0RQrGnL\n"
+    "-----END PRIVATE KEY-----\n"
+)
+FIXTURE_REMOTE_ID = "QCPJJTJMI3IDBNURU6XJJENRYU"
 
 
 def test_certificate_is_persistent(tmp_path: Path) -> None:
@@ -66,3 +91,23 @@ def test_private_key_permissions_tightened_on_load(tmp_path: Path) -> None:
     _, cert2 = _get_or_create_certificate(str(tmp_path))
     assert cert2 == cert
     assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+
+def test_remote_id_and_pems_stable_across_frozen_fixture(tmp_path: Path) -> None:
+    """A pre-existing certificate pair yields the frozen Remote ID and is returned as-is."""
+    (tmp_path / CERT_FILENAME).write_text(FIXTURE_CERT_PEM)
+    (tmp_path / KEY_FILENAME).write_text(FIXTURE_KEY_PEM)
+
+    assert get_or_create_remote_id(str(tmp_path)) == FIXTURE_REMOTE_ID
+    assert get_or_create_webrtc_certificate_pems(str(tmp_path)) == (
+        FIXTURE_CERT_PEM,
+        FIXTURE_KEY_PEM,
+    )
+
+
+def test_get_or_create_webrtc_certificate_pems_persists(tmp_path: Path) -> None:
+    """A fresh call creates the certificate files and a second call returns the same PEMs."""
+    cert_pem, key_pem = get_or_create_webrtc_certificate_pems(str(tmp_path))
+    cert_pem2, key_pem2 = get_or_create_webrtc_certificate_pems(str(tmp_path))
+    assert cert_pem2 == cert_pem
+    assert key_pem2 == key_pem

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -2,16 +2,17 @@
 
 import asyncio
 import base64
-import contextlib
-import json
-from collections.abc import Callable
-from typing import cast
+import hashlib
+from collections.abc import AsyncIterator, Callable
+from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 from urllib.parse import urlparse
 
+import aiohttp
 import pytest
-from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection
-from aiortc.rtcdtlstransport import RTCCertificate
+from aiolibdatachannel import DataChannel, IceServer, PeerConnection, RTCConfiguration
+from cryptography.hazmat.primitives import serialization
 
 from music_assistant.controllers.webserver.remote_access import (
     STARTUP_DELAY,
@@ -26,7 +27,6 @@ from music_assistant.controllers.webserver.remote_access.gateway import (
 from music_assistant.helpers.webrtc_certificate import (
     _generate_certificate,
     _remote_id_from_certificate,
-    create_peer_connection_with_certificate,
 )
 
 
@@ -867,128 +867,246 @@ async def test_http_proxy_request_cannot_change_host(
     assert "evil.com" not in (parsed.netloc or "")
 
 
-async def test_http_proxy_request_does_not_block_receive_loop(mock_certificate: Mock) -> None:
-    """A slow proxied image fetch must not stall API messages behind it in the receive loop."""
-    mock_session = Mock()
-    release = asyncio.Event()
+# ---- aiolibdatachannel loopback tests --------------------------------------
+#
+# These exercise the migrated gateway against real loopback PeerConnections
+# (offerer = browser role, answerer = gateway role) rather than mocking the
+# WebRTC layer. ICE servers are stubbed to [] so gathering completes on host
+# candidates only (fast, offline).
 
-    def fake_request(_method: str, _url: str, **_kwargs: object) -> AsyncMock:
-        response = AsyncMock()
-        response.status = 200
-        response.headers = {}
-        response.read = AsyncMock(return_value=b"")
 
-        async def blocking_aenter(*_args: object) -> AsyncMock:
-            await release.wait()
-            return response
+@pytest.fixture(scope="session")
+def cert_pems() -> tuple[str, str]:
+    """Generate a throwaway DTLS cert/key as PEM strings for the gateway."""
+    private_key, cert = _generate_certificate()
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    return cert_pem, key_pem
 
-        ctx = AsyncMock()
-        ctx.__aenter__ = blocking_aenter
-        ctx.__aexit__ = AsyncMock(return_value=False)
-        return ctx
 
-    mock_session.request = fake_request
+def _sha256_fingerprint(cert_pem: str) -> str:
+    """Compute the uppercase colon-separated SHA-256 fingerprint of a PEM certificate."""
+    body = "".join(line for line in cert_pem.splitlines() if line and not line.startswith("-----"))
+    der = base64.b64decode(body)
+    digest = hashlib.sha256(der).hexdigest().upper()
+    return ":".join(digest[i : i + 2] for i in range(0, len(digest), 2))
 
+
+class _FakeSignaling:
+    """Signaling WebSocket stand-in that captures outbound JSON messages."""
+
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+
+    async def send_json(self, data: dict[str, Any]) -> None:
+        self.messages.append(data)
+
+    @property
+    def answers(self) -> list[dict[str, Any]]:
+        return [m for m in self.messages if m.get("type") == "answer"]
+
+
+class _FakeLocalWS:
+    """Minimal aiohttp WebSocket stand-in for channel-bridging tests."""
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.sent: list[str | bytes] = []
+        self._incoming: asyncio.Queue[SimpleNamespace | None] = asyncio.Queue()
+
+    async def send_str(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.sent.append(data)
+
+    async def close(self) -> None:
+        self.closed = True
+        self._incoming.put_nowait(None)
+
+    def feed_text(self, data: str) -> None:
+        """Queue a text message as if the local server sent it."""
+        self._incoming.put_nowait(SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data=data))
+
+    def __aiter__(self) -> AsyncIterator[SimpleNamespace]:
+        return self
+
+    async def __anext__(self) -> SimpleNamespace:
+        msg = await self._incoming.get()
+        if msg is None:
+            raise StopAsyncIteration
+        return msg
+
+
+async def _wait_for(predicate: Callable[[], bool], timeout: float = 15.0) -> None:
+    """Poll ``predicate`` until it is true or the timeout elapses."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("condition not met within timeout")
+
+
+async def _connect_gateway_session(
+    gateway: WebRTCGateway, session_id: str
+) -> tuple[PeerConnection, DataChannel]:
+    """
+    Drive a browser-role offerer through the gateway until the ma-api channel opens.
+
+    :return: Tuple of (offerer PeerConnection, opened ma-api DataChannel).
+    """
+    signaling = _FakeSignaling()
+    gateway._signaling_ws = cast("aiohttp.ClientWebSocketResponse", signaling)
+    offerer = PeerConnection(RTCConfiguration())
+    dc = await offerer.create_data_channel("ma-api")
+    offer = await offerer.create_offer()
+    await gateway._create_session(session_id)
+    await asyncio.wait_for(
+        gateway._handle_offer(session_id, {"sdp": offer.sdp, "type": "offer"}), timeout=15
+    )
+    answer = signaling.answers[-1]
+    await offerer.set_remote_description(answer["data"]["sdp"], "answer")
+    await asyncio.wait_for(dc.wait_open(), timeout=15)
+    return offerer, dc
+
+
+async def test_handle_offer_answers_with_pinned_fingerprint(cert_pems: tuple[str, str]) -> None:
+    """The answer SDP carries the DTLS fingerprint of the configured certificate (pinning)."""
+    cert_pem, key_pem = cert_pems
     gateway = WebRTCGateway(
-        http_session=mock_session,
+        http_session=Mock(),
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
-        local_ws_url="ws://localhost:8095/ws",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
     )
-    session = WebRTCSession(session_id="s1", peer_connection=Mock())
-    session.local_ws = Mock()
-    session.local_ws.closed = False
-    session.local_ws.send_str = AsyncMock()
-    session.data_channel = Mock()
-    session.data_channel.readyState = "open"
-    session.data_channel.send = Mock()
-
-    proxy_message = json.dumps(
-        {"type": "http-proxy-request", "id": "1", "method": "GET", "path": "/imageproxy/x"}
-    )
-    api_message = '{"command": "ping"}'
-    session.message_queue.put_nowait(proxy_message)
-    session.message_queue.put_nowait(api_message)
-
-    forward_task = asyncio.create_task(gateway._forward_to_local(session))
-
+    signaling = _FakeSignaling()
+    gateway._signaling_ws = cast("aiohttp.ClientWebSocketResponse", signaling)
+    offerer = PeerConnection(RTCConfiguration())
+    session_id = "fingerprint-session"
     try:
-        # The API message must get through while the proxy fetch is still blocked.
-        for _ in range(20):
-            if session.local_ws.send_str.await_args_list:
-                break
-            await asyncio.sleep(0.05)
-        assert not release.is_set()
-        session.local_ws.send_str.assert_awaited_with(api_message)
+        await offerer.create_data_channel("ma-api")
+        offer = await offerer.create_offer()
+        with patch.object(gateway, "_get_fresh_ice_servers", AsyncMock(return_value=[])):
+            await gateway._create_session(session_id)
+            await asyncio.wait_for(
+                gateway._handle_offer(session_id, {"sdp": offer.sdp, "type": "offer"}),
+                timeout=15,
+            )
 
-        release.set()
-
-        for _ in range(20):
-            if session.data_channel.send.call_args_list:
-                break
-            await asyncio.sleep(0.05)
-        assert session.data_channel.send.call_args is not None
-        response_data = json.loads(session.data_channel.send.call_args[0][0])
-        assert response_data["id"] == "1"
+        assert len(signaling.answers) == 1
+        answer = signaling.answers[0]
+        assert answer["sessionId"] == session_id
+        assert answer["data"]["type"] == "answer"
+        fingerprint_line = next(
+            line
+            for line in answer["data"]["sdp"].splitlines()
+            if line.startswith("a=fingerprint:")
+        )
+        assert _sha256_fingerprint(cert_pem) in fingerprint_line
     finally:
-        # Unblock a still-pending fetch so cleanup can't hang on assertion failure
-        release.set()
-        session.local_ws.closed = True
-        forward_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await forward_task
-        for task in list(session.proxy_tasks):
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
+        await gateway._close_session(session_id)
+        await offerer.aclose()
 
 
-async def test_close_data_channel_bridge_cancels_pending_proxy_tasks(
-    mock_certificate: Mock,
-) -> None:
-    """Closing a session's bridge must cancel its still-running proxy fetches."""
-    mock_session = Mock()
-    release = asyncio.Event()
-
-    def fake_request(_method: str, _url: str, **_kwargs: object) -> AsyncMock:
-        async def blocking_aenter(*_args: object) -> AsyncMock:
-            await release.wait()
-            return AsyncMock()
-
-        ctx = AsyncMock()
-        ctx.__aenter__ = blocking_aenter
-        ctx.__aexit__ = AsyncMock(return_value=False)
-        return ctx
-
-    mock_session.request = fake_request
-
+async def test_ma_api_channel_bridges_to_local_ws(cert_pems: tuple[str, str]) -> None:
+    """Messages flow both ways across the ma-api data channel and the local WebSocket."""
+    cert_pem, key_pem = cert_pems
+    fake_ws = _FakeLocalWS()
+    local_ws = cast("aiohttp.ClientWebSocketResponse", fake_ws)
+    http_session = Mock()
+    http_session.ws_connect = AsyncMock(return_value=local_ws)
     gateway = WebRTCGateway(
-        http_session=mock_session,
+        http_session=http_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
-        local_ws_url="ws://localhost:8095/ws",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
     )
-    session = WebRTCSession(session_id="s1", peer_connection=Mock())
-    session.local_ws = Mock()
-    session.local_ws.closed = False
-    session.local_ws.close = AsyncMock()
-    session.data_channel = Mock()
-    session.data_channel.readyState = "open"
-
-    session.message_queue.put_nowait(
-        json.dumps({"type": "http-proxy-request", "id": "1", "method": "GET", "path": "/img"})
-    )
-    session.forward_to_local_task = asyncio.create_task(gateway._forward_to_local(session))
-
+    session_id = "bridge-session"
+    with patch.object(gateway, "_get_fresh_ice_servers", AsyncMock(return_value=[])):
+        offerer, dc = await _connect_gateway_session(gateway, session_id)
     try:
-        for _ in range(20):
-            if session.proxy_tasks:
-                break
-            await asyncio.sleep(0.05)
-        proxy_task = next(iter(session.proxy_tasks))
+        await _wait_for(lambda: gateway.sessions[session_id].local_ws is local_ws)
 
-        await gateway._close_data_channel_bridge(session)
+        # browser -> local WebSocket
+        await dc.send("from browser")
+        await _wait_for(lambda: fake_ws.sent == ["from browser"])
 
-        assert proxy_task.cancelled()
-        assert not session.proxy_tasks
+        # local WebSocket -> browser
+        fake_ws.feed_text("from local")
+        msg = await asyncio.wait_for(dc.recv(), timeout=15)
+        assert msg == "from local"
     finally:
-        release.set()
+        await gateway._close_session(session_id)
+        await offerer.aclose()
+
+
+def test_build_ice_servers_maps_dicts() -> None:
+    """ICE server dicts map to one IceServer per url, preserving TURN credentials."""
+    gateway = WebRTCGateway(
+        http_session=Mock(),
+        remote_id="TEST-REMOTE-ID",
+        cert_pem="cert",
+        key_pem="key",
+    )
+    servers: list[dict[str, Any]] = [
+        {"urls": "stun:stun.example.com:3478"},
+        {"urls": "turn:turn.example.com:3478", "username": "user", "credential": "pass"},
+        {
+            "urls": ["stun:a.example.com:3478", "turn:b.example.com:3478"],
+            "username": "u2",
+            "credential": "c2",
+        },
+    ]
+
+    result = gateway._build_ice_servers(servers)
+
+    assert all(isinstance(server, IceServer) for server in result)
+    # the two-url entry fans out, so 1 + 1 + 2 = 4 IceServers
+    assert len(result) == 4
+    assert result[0] == IceServer(url="stun:stun.example.com:3478")
+    assert result[1] == IceServer(
+        url="turn:turn.example.com:3478", username="user", credential="pass"
+    )
+    # to_url() inlines the TURN credentials for libdatachannel
+    assert result[1].to_url() == "turn:user:pass@turn.example.com:3478"
+    # list urls share the entry's credentials
+    assert result[2] == IceServer(url="stun:a.example.com:3478", username="u2", credential="c2")
+    assert result[3] == IceServer(url="turn:b.example.com:3478", username="u2", credential="c2")
+
+
+async def test_session_closes_when_ma_api_channel_closes(cert_pems: tuple[str, str]) -> None:
+    """Closing the browser ma-api channel tears down the whole gateway session."""
+    cert_pem, key_pem = cert_pems
+    fake_ws = _FakeLocalWS()
+    local_ws = cast("aiohttp.ClientWebSocketResponse", fake_ws)
+    http_session = Mock()
+    http_session.ws_connect = AsyncMock(return_value=local_ws)
+    gateway = WebRTCGateway(
+        http_session=http_session,
+        remote_id="TEST-REMOTE-ID",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+    )
+    session_id = "channel-close-session"
+    with patch.object(gateway, "_get_fresh_ice_servers", AsyncMock(return_value=[])):
+        offerer, dc = await _connect_gateway_session(gateway, session_id)
+    try:
+        await _wait_for(
+            lambda: gateway.sessions.get(session_id) is not None
+            and gateway.sessions[session_id].local_ws is local_ws
+        )
+
+        await dc.aclose()
+
+        await _wait_for(lambda: session_id not in gateway.sessions)
+        assert session_id not in gateway.sessions
+    finally:
+        await gateway._close_session(session_id)
+        await offerer.aclose()
+

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -32,20 +32,6 @@ from music_assistant.helpers.webrtc_certificate import (
 )
 
 
-@pytest.fixture
-def mock_certificate() -> Mock:
-    """Create a mock RTCCertificate for testing."""
-    cert = Mock()
-    mock_fingerprint = Mock()
-    mock_fingerprint.algorithm = "sha-256"
-    mock_fingerprint.value = (
-        "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:"
-        "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99"
-    )
-    cert.getFingerprints.return_value = [mock_fingerprint]
-    return cert
-
-
 async def test_remote_id_from_certificate() -> None:
     """Test deterministic remote ID generation from a certificate."""
     _, cert = _generate_certificate()
@@ -58,20 +44,6 @@ async def test_remote_id_from_certificate() -> None:
     assert len(remote_id) == 26
     # deterministic: the same certificate always yields the same id
     assert _remote_id_from_certificate(cert) == remote_id
-
-
-async def test_remote_id_matches_aiortc_fingerprint() -> None:
-    """The aiortc-free remote ID must match aiortc's own certificate fingerprint derivation."""
-    private_key, cert = _generate_certificate()
-    rtc_cert = RTCCertificate(key=private_key, cert=cert)
-    fingerprint = next(fp.value for fp in rtc_cert.getFingerprints() if fp.algorithm == "sha-256")
-    expected = (
-        base64.b32encode(bytes.fromhex(fingerprint.replace(":", ""))[:16])
-        .decode("ascii")
-        .rstrip("=")
-        .replace("2", "9")
-    )
-    assert _remote_id_from_certificate(cert) == expected
 
 
 async def test_remote_access_info_dataclass() -> None:
@@ -215,13 +187,15 @@ async def test_remote_access_skips_restart_after_mode_flap_settles() -> None:
     assert manager._target_using_ha_cloud is False
 
 
-async def test_webrtc_gateway_initialization(mock_certificate: Mock) -> None:
+async def test_webrtc_gateway_initialization(cert_pems: tuple[str, str]) -> None:
     """Test WebRTCGateway initializes correctly."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
         signaling_url="wss://test.example.com/ws",
         local_ws_url="ws://localhost:8095/ws",
     )
@@ -234,8 +208,9 @@ async def test_webrtc_gateway_initialization(mock_certificate: Mock) -> None:
     assert len(gateway.ice_servers) > 0
 
 
-async def test_webrtc_gateway_custom_ice_servers(mock_certificate: Mock) -> None:
+async def test_webrtc_gateway_custom_ice_servers(cert_pems: tuple[str, str]) -> None:
     """Test WebRTCGateway accepts custom ICE servers."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     custom_ice_servers = [
         {"urls": "stun:custom.stun.server:3478"},
@@ -245,20 +220,23 @@ async def test_webrtc_gateway_custom_ice_servers(mock_certificate: Mock) -> None
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
         ice_servers=custom_ice_servers,
     )
 
     assert gateway.ice_servers == custom_ice_servers
 
 
-async def test_webrtc_gateway_start_stop(mock_certificate: Mock) -> None:
+async def test_webrtc_gateway_start_stop(cert_pems: tuple[str, str]) -> None:
     """Test WebRTCGateway start and stop."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
     )
 
     # Mock the _run method to avoid actual connection
@@ -271,13 +249,15 @@ async def test_webrtc_gateway_start_stop(mock_certificate: Mock) -> None:
         assert gateway.is_running is False
 
 
-async def test_webrtc_gateway_handle_registration_message(mock_certificate: Mock) -> None:
+async def test_webrtc_gateway_handle_registration_message(cert_pems: tuple[str, str]) -> None:
     """Test WebRTCGateway handles registration confirmation."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
     )
 
     # Mock signaling WebSocket
@@ -289,13 +269,15 @@ async def test_webrtc_gateway_handle_registration_message(mock_certificate: Mock
     # Should log but not crash
 
 
-async def test_webrtc_gateway_handle_error_message(mock_certificate: Mock) -> None:
+async def test_webrtc_gateway_handle_error_message(cert_pems: tuple[str, str]) -> None:
     """Test WebRTCGateway handles error messages."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
     )
 
     message = {"type": "error", "message": "Test error"}
@@ -303,63 +285,73 @@ async def test_webrtc_gateway_handle_error_message(mock_certificate: Mock) -> No
     await gateway._handle_signaling_message(message)
 
 
-async def test_webrtc_gateway_create_session(mock_certificate: Mock) -> None:
+async def test_webrtc_gateway_create_session(cert_pems: tuple[str, str]) -> None:
     """Test WebRTCGateway creates sessions for clients."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
     )
 
     session_id = "test-session-123"
-    await gateway._create_session(session_id)
+    with patch.object(gateway, "_get_fresh_ice_servers", AsyncMock(return_value=[])):
+        await gateway._create_session(session_id)
 
-    assert session_id in gateway.sessions
-    assert gateway.sessions[session_id].session_id == session_id
-    assert gateway.sessions[session_id].peer_connection is not None
+        assert session_id in gateway.sessions
+        assert gateway.sessions[session_id].session_id == session_id
+        assert gateway.sessions[session_id].pc is not None
 
-    # Cleanup
-    await gateway._close_session(session_id)
+        # Cleanup
+        await gateway._close_session(session_id)
 
 
-async def test_webrtc_gateway_close_session(mock_certificate: Mock) -> None:
+async def test_webrtc_gateway_close_session(cert_pems: tuple[str, str]) -> None:
     """Test WebRTCGateway closes sessions properly."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
     )
 
     session_id = "test-session-456"
-    await gateway._create_session(session_id)
-    assert session_id in gateway.sessions
+    with patch.object(gateway, "_get_fresh_ice_servers", AsyncMock(return_value=[])):
+        await gateway._create_session(session_id)
+        assert session_id in gateway.sessions
 
-    await gateway._close_session(session_id)
-    assert session_id not in gateway.sessions
+        await gateway._close_session(session_id)
+        assert session_id not in gateway.sessions
 
 
-async def test_webrtc_gateway_close_nonexistent_session(mock_certificate: Mock) -> None:
+async def test_webrtc_gateway_close_nonexistent_session(cert_pems: tuple[str, str]) -> None:
     """Test WebRTCGateway handles closing non-existent session gracefully."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
     )
 
     # Should not raise an error
     await gateway._close_session("nonexistent-session")
 
 
-async def test_webrtc_gateway_default_ice_servers(mock_certificate: Mock) -> None:
+async def test_webrtc_gateway_default_ice_servers(cert_pems: tuple[str, str]) -> None:
     """Test WebRTCGateway uses default ICE servers."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
     )
 
     assert len(gateway.ice_servers) > 0
@@ -367,352 +359,62 @@ async def test_webrtc_gateway_default_ice_servers(mock_certificate: Mock) -> Non
     assert any("stun:" in server["urls"] for server in gateway.ice_servers)
 
 
-async def test_webrtc_gateway_handle_client_connected(mock_certificate: Mock) -> None:
+async def test_webrtc_gateway_handle_client_connected(cert_pems: tuple[str, str]) -> None:
     """Test WebRTCGateway handles client-connected message."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
     )
 
-    message = {"type": "client-connected", "sessionId": "test-session"}
-    await gateway._handle_signaling_message(message)
+    with patch.object(gateway, "_get_fresh_ice_servers", AsyncMock(return_value=[])):
+        message = {"type": "client-connected", "sessionId": "test-session"}
+        await gateway._handle_signaling_message(message)
 
-    # Session should be created
-    assert "test-session" in gateway.sessions
+        # Session should be created
+        assert "test-session" in gateway.sessions
 
-    # Cleanup
-    await gateway._close_session("test-session")
+        # Cleanup
+        await gateway._close_session("test-session")
 
 
-async def test_webrtc_gateway_handle_client_disconnected(mock_certificate: Mock) -> None:
+async def test_webrtc_gateway_handle_client_disconnected(cert_pems: tuple[str, str]) -> None:
     """Test WebRTCGateway handles client-disconnected message."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
     )
 
-    # Create a session first
-    session_id = "test-disconnect-session"
-    await gateway._create_session(session_id)
-    assert session_id in gateway.sessions
+    with patch.object(gateway, "_get_fresh_ice_servers", AsyncMock(return_value=[])):
+        # Create a session first
+        session_id = "test-disconnect-session"
+        await gateway._create_session(session_id)
+        assert session_id in gateway.sessions
 
-    # Handle disconnect
-    message = {"type": "client-disconnected", "sessionId": session_id}
-    await gateway._handle_signaling_message(message)
+        # Handle disconnect
+        message = {"type": "client-disconnected", "sessionId": session_id}
+        await gateway._handle_signaling_message(message)
 
-    # Session should be removed
-    assert session_id not in gateway.sessions
-
-
-async def test_sendspin_handler_queues_message_before_setup_runs(
-    mock_certificate: Mock,
-) -> None:
-    """Queue the first Sendspin message as soon as its data channel is announced."""
-    gateway = WebRTCGateway(
-        http_session=Mock(),
-        remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
-    )
-    session_id = "sendspin-session"
-    await gateway._create_session(session_id)
-    session = gateway.sessions[session_id]
-    callbacks: dict[str, Callable[..., None]] = {}
-    channel = Mock()
-    channel.label = "sendspin"
-
-    def register_callback(
-        event: str,
-    ) -> Callable[[Callable[..., None]], Callable[..., None]]:
-        def decorator(callback: Callable[..., None]) -> Callable[..., None]:
-            callbacks[event] = callback
-            return callback
-
-        return decorator
-
-    channel.on.side_effect = register_callback
-
-    try:
-        with patch.object(gateway, "_setup_sendspin_channel", new=AsyncMock()):
-            session.peer_connection.emit("datachannel", channel)
-            message = '{"type":"auth","client_id":"web-player"}'
-            callbacks["message"](message)
-            await asyncio.sleep(0)
-            assert session.sendspin_queue.get_nowait() == message
-    finally:
-        await gateway._close_session(session_id)
+        # Session should be removed
+        assert session_id not in gateway.sessions
 
 
-async def test_api_handler_queues_message_before_setup_runs(
-    mock_certificate: Mock,
-) -> None:
-    """Queue the first API message as soon as its data channel is announced."""
-    gateway = WebRTCGateway(
-        http_session=Mock(),
-        remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
-    )
-    session_id = "api-session"
-    await gateway._create_session(session_id)
-    session = gateway.sessions[session_id]
-    callbacks: dict[str, Callable[..., None]] = {}
-    channel = Mock()
-    channel.label = "ma-api"
-
-    def register_callback(
-        event: str,
-    ) -> Callable[[Callable[..., None]], Callable[..., None]]:
-        def decorator(callback: Callable[..., None]) -> Callable[..., None]:
-            callbacks[event] = callback
-            return callback
-
-        return decorator
-
-    channel.on.side_effect = register_callback
-
-    try:
-        with patch.object(gateway, "_setup_data_channel", new=AsyncMock()):
-            session.peer_connection.emit("datachannel", channel)
-            message = '{"command":"server/info"}'
-            callbacks["message"](message)
-            await asyncio.sleep(0)
-            assert session.message_queue.get_nowait() == message
-    finally:
-        await gateway._close_session(session_id)
-
-
-async def test_sendspin_setup_failure_stops_accepting_messages(
-    mock_certificate: Mock,
-) -> None:
-    """Drop queued and future messages when the internal audio bridge cannot connect."""
-    http_session = Mock()
-    http_session.ws_connect = AsyncMock(side_effect=RuntimeError("connection failed"))
-    gateway = WebRTCGateway(
-        http_session=http_session,
-        remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
-    )
-    session = WebRTCSession(session_id="sendspin-session", peer_connection=Mock())
-    callbacks: dict[str, Callable[..., None]] = {}
-    channel = Mock()
-    session.sendspin_channel = channel
-    session.sendspin_channel_active = True
-
-    def register_callback(
-        event: str,
-    ) -> Callable[[Callable[..., None]], Callable[..., None]]:
-        def decorator(callback: Callable[..., None]) -> Callable[..., None]:
-            callbacks[event] = callback
-            return callback
-
-        return decorator
-
-    channel.on.side_effect = register_callback
-    gateway._register_sendspin_channel_handlers(session)
-    callbacks["message"]("queued before setup")
-    await asyncio.sleep(0)
-    assert session.sendspin_queue.qsize() == 1
-
-    await gateway._setup_sendspin_channel(session)
-    callbacks["message"]("sent after failure")
-    await asyncio.sleep(0)
-
-    assert session.sendspin_channel_active is False
-    assert session.sendspin_queue.empty()
-    channel.close.assert_called_once_with()
-
-
-async def test_sendspin_close_during_setup_closes_internal_bridge(
-    mock_certificate: Mock,
-) -> None:
-    """Close a late internal bridge when its remote data channel is already gone."""
-    connect_started = asyncio.Event()
-    allow_connect = asyncio.Event()
-    internal_ws = AsyncMock()
-    internal_ws.closed = False
-
-    async def connect_internal(_url: str) -> AsyncMock:
-        connect_started.set()
-        await allow_connect.wait()
-        return internal_ws
-
-    http_session = Mock()
-    http_session.ws_connect = AsyncMock(side_effect=connect_internal)
-    gateway = WebRTCGateway(
-        http_session=http_session,
-        remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
-    )
-    session = WebRTCSession(session_id="sendspin-session", peer_connection=Mock())
-    callbacks: dict[str, Callable[..., None]] = {}
-    channel = Mock()
-    session.sendspin_channel = channel
-    session.sendspin_channel_active = True
-
-    def register_callback(
-        event: str,
-    ) -> Callable[[Callable[..., None]], Callable[..., None]]:
-        def decorator(callback: Callable[..., None]) -> Callable[..., None]:
-            callbacks[event] = callback
-            return callback
-
-        return decorator
-
-    channel.on.side_effect = register_callback
-    gateway._register_sendspin_channel_handlers(session)
-
-    setup_task = asyncio.create_task(gateway._setup_sendspin_channel(session))
-    await connect_started.wait()
-    callbacks["close"]()
-    allow_connect.set()
-    await setup_task
-
-    internal_ws.close.assert_awaited_once_with()
-    assert session.sendspin_ws is None
-    assert session.sendspin_to_local_task is None
-    assert session.sendspin_from_local_task is None
-
-
-async def test_sendspin_channel_close_cleans_forwarding_tasks(
-    mock_certificate: Mock,
-) -> None:
-    """Cancel forwarding tasks when the remote audio data channel closes."""
-    gateway = WebRTCGateway(
-        http_session=Mock(),
-        remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
-    )
-    session = WebRTCSession(session_id="sendspin-session", peer_connection=Mock())
-    gateway.sessions[session.session_id] = session
-    callbacks: dict[str, Callable[..., None]] = {}
-    channel = Mock()
-    session.sendspin_channel = channel
-    session.sendspin_channel_active = True
-    sendspin_ws = AsyncMock()
-    sendspin_ws.closed = False
-    session.sendspin_ws = sendspin_ws
-
-    async def wait_forever() -> None:
-        await asyncio.Event().wait()
-
-    to_local = asyncio.create_task(wait_forever())
-    from_local = asyncio.create_task(wait_forever())
-    session.sendspin_to_local_task = to_local
-    session.sendspin_from_local_task = from_local
-
-    def register_callback(
-        event: str,
-    ) -> Callable[[Callable[..., None]], Callable[..., None]]:
-        def decorator(callback: Callable[..., None]) -> Callable[..., None]:
-            callbacks[event] = callback
-            return callback
-
-        return decorator
-
-    channel.on.side_effect = register_callback
-    gateway._register_sendspin_channel_handlers(session)
-    callbacks["close"]()
-    for _ in range(20):
-        await asyncio.sleep(0)
-        if to_local.done() and from_local.done() and not gateway._background_tasks:
-            break
-
-    assert session.sendspin_channel_active is False
-    assert to_local.cancelled()
-    assert from_local.cancelled()
-    assert vars(session)["sendspin_to_local_task"] is None
-    assert vars(session)["sendspin_from_local_task"] is None
-    assert session.sendspin_ws is None
-    sendspin_ws.close.assert_awaited_once_with()
-    gateway.sessions.pop(session.session_id)
-
-
-async def test_sendspin_session_close_cancels_inflight_setup(
-    mock_certificate: Mock,
-) -> None:
-    """Cancel a pending internal audio connection before closing its WebRTC session."""
-    connect_started = asyncio.Event()
-
-    async def connect_internal(_url: str) -> None:
-        connect_started.set()
-        await asyncio.Event().wait()
-
-    http_session = Mock()
-    http_session.ws_connect = AsyncMock(side_effect=connect_internal)
-    gateway = WebRTCGateway(
-        http_session=http_session,
-        remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
-    )
-    peer_connection = Mock()
-    peer_connection.close = AsyncMock()
-    session = WebRTCSession(
-        session_id="sendspin-session",
-        peer_connection=peer_connection,
-    )
-    session.sendspin_channel = Mock()
-    session.sendspin_channel_active = True
-    setup_task = asyncio.create_task(gateway._setup_sendspin_channel(session))
-    session.sendspin_setup_task = setup_task
-    gateway.sessions[session.session_id] = session
-    await connect_started.wait()
-
-    await gateway._close_session(session.session_id)
-
-    assert setup_task.cancelled()
-    assert vars(session)["sendspin_setup_task"] is None
-    assert session.session_id not in vars(gateway)["sessions"]
-    peer_connection.close.assert_awaited_once_with()
-
-
-async def test_api_session_close_cancels_inflight_setup(
-    mock_certificate: Mock,
-) -> None:
-    """Cancel a pending local API connection before closing its WebRTC session."""
-    connect_started = asyncio.Event()
-
-    async def connect_local(_url: str) -> None:
-        connect_started.set()
-        await asyncio.Event().wait()
-
-    http_session = Mock()
-    http_session.ws_connect = AsyncMock(side_effect=connect_local)
-    gateway = WebRTCGateway(
-        http_session=http_session,
-        remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
-    )
-    peer_connection = Mock()
-    peer_connection.close = AsyncMock()
-    session = WebRTCSession(
-        session_id="api-session",
-        peer_connection=peer_connection,
-    )
-    session.data_channel = Mock()
-    session.data_channel_active = True
-    setup_task = asyncio.create_task(gateway._setup_data_channel(session))
-    session.data_channel_setup_task = setup_task
-    gateway.sessions[session.session_id] = session
-    await connect_started.wait()
-
-    await gateway._close_session(session.session_id)
-
-    assert setup_task.cancelled()
-    assert vars(session)["data_channel_setup_task"] is None
-    assert session.session_id not in vars(gateway)["sessions"]
-    peer_connection.close.assert_awaited_once_with()
-
-
-async def test_webrtc_gateway_reconnection_logic(mock_certificate: Mock) -> None:
+async def test_webrtc_gateway_reconnection_logic(cert_pems: tuple[str, str]) -> None:
     """Test WebRTCGateway has proper reconnection backoff."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
     )
 
     # Check initial reconnect delay
@@ -735,32 +437,15 @@ async def test_webrtc_gateway_reconnection_logic(mock_certificate: Mock) -> None
     assert gateway._current_reconnect_delay <= gateway._max_reconnect_delay
 
 
-async def test_webrtc_gateway_session_data_structures() -> None:
-    """Test WebRTCSession data structure."""
-    config = RTCConfiguration()
-    pc = RTCPeerConnection(configuration=config)
-
-    session = WebRTCSession(session_id="test-123", peer_connection=pc)
-
-    assert session.session_id == "test-123"
-    assert session.peer_connection is pc
-    assert session.data_channel is None
-    assert session.local_ws is None
-    assert session.message_queue is not None
-    assert session.forward_to_local_task is None
-    assert session.forward_from_local_task is None
-
-    # Cleanup
-    await pc.close()
-
-
-async def test_webrtc_gateway_handle_offer_without_session(mock_certificate: Mock) -> None:
+async def test_webrtc_gateway_handle_offer_without_session(cert_pems: tuple[str, str]) -> None:
     """Test WebRTCGateway handles offer for non-existent session gracefully."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
     )
 
     # Try to handle offer for non-existent session
@@ -770,13 +455,17 @@ async def test_webrtc_gateway_handle_offer_without_session(mock_certificate: Moc
     # Should not crash
 
 
-async def test_webrtc_gateway_handle_ice_candidate_without_session(mock_certificate: Mock) -> None:
+async def test_webrtc_gateway_handle_ice_candidate_without_session(
+    cert_pems: tuple[str, str],
+) -> None:
     """Test WebRTCGateway handles ICE candidate for non-existent session gracefully."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
     )
 
     # Try to handle ICE candidate for non-existent session
@@ -790,37 +479,6 @@ async def test_webrtc_gateway_handle_ice_candidate_without_session(mock_certific
     # Should not crash
 
 
-async def test_create_peer_connection_with_certificate() -> None:
-    """
-    Test that create_peer_connection_with_certificate correctly sets the custom certificate.
-
-    This verifies the fragile name-mangled private attribute access works correctly
-    and that our custom certificate fully replaces the auto-generated one, which is
-    critical for DTLS pinning.
-    """
-    # First verify the name-mangled attribute exists on RTCPeerConnection.
-    # If aiortc changes its internals, this will fail and alert us to update our code.
-    pc = RTCPeerConnection()
-    try:
-        assert hasattr(pc, "_RTCPeerConnection__certificates")
-    finally:
-        await pc.close()
-
-    # Now test our function correctly sets the certificate
-    private_key, cert = _generate_certificate()
-    certificate = RTCCertificate(key=private_key, cert=cert)
-    config = RTCConfiguration(iceServers=[RTCIceServer(urls="stun:stun.example.com:3478")])
-
-    pc = create_peer_connection_with_certificate(certificate, configuration=config)
-
-    try:
-        certificates = pc._RTCPeerConnection__certificates  # type: ignore[attr-defined]
-        assert len(certificates) == 1
-        assert certificates[0] is certificate
-    finally:
-        await pc.close()
-
-
 @pytest.mark.parametrize(
     "malicious_path",
     [
@@ -831,9 +489,10 @@ async def test_create_peer_connection_with_certificate() -> None:
     ],
 )
 async def test_http_proxy_request_cannot_change_host(
-    mock_certificate: Mock, malicious_path: str
+    cert_pems: tuple[str, str], malicious_path: str
 ) -> None:
     """An attacker-controlled proxy path must never change the target host (SSRF guard)."""
+    cert_pem, key_pem = cert_pems
     mock_session = Mock()
     captured_url: dict[str, str] = {}
 
@@ -853,10 +512,11 @@ async def test_http_proxy_request_cannot_change_host(
     gateway = WebRTCGateway(
         http_session=mock_session,
         remote_id="TEST-REMOTE-ID",
-        certificate=mock_certificate,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
         local_ws_url="ws://localhost:8095/ws",
     )
-    session = WebRTCSession(session_id="s1", peer_connection=Mock())
+    session = WebRTCSession(session_id="s1", pc=Mock())
 
     await gateway._handle_http_proxy_request(
         session, {"id": "1", "method": "GET", "path": malicious_path}
@@ -1006,9 +666,7 @@ async def test_handle_offer_answers_with_pinned_fingerprint(cert_pems: tuple[str
         assert answer["sessionId"] == session_id
         assert answer["data"]["type"] == "answer"
         fingerprint_line = next(
-            line
-            for line in answer["data"]["sdp"].splitlines()
-            if line.startswith("a=fingerprint:")
+            line for line in answer["data"]["sdp"].splitlines() if line.startswith("a=fingerprint:")
         )
         assert _sha256_fingerprint(cert_pem) in fingerprint_line
     finally:
@@ -1100,8 +758,10 @@ async def test_session_closes_when_ma_api_channel_closes(cert_pems: tuple[str, s
         offerer, dc = await _connect_gateway_session(gateway, session_id)
     try:
         await _wait_for(
-            lambda: gateway.sessions.get(session_id) is not None
-            and gateway.sessions[session_id].local_ws is local_ws
+            lambda: (
+                gateway.sessions.get(session_id) is not None
+                and gateway.sessions[session_id].local_ws is local_ws
+            )
         )
 
         await dc.aclose()
@@ -1226,4 +886,3 @@ async def test_http_proxy_response_chunks_survive_real_data_channel(
     finally:
         await gateway._close_session(session_id)
         await offerer.aclose()
-

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import hashlib
+import json
 from collections.abc import AsyncIterator, Callable
 from types import SimpleNamespace
 from typing import Any, cast
@@ -21,6 +22,7 @@ from music_assistant.controllers.webserver.remote_access import (
     RemoteAccessManager,
 )
 from music_assistant.controllers.webserver.remote_access.gateway import (
+    HTTP_PROXY_CHUNK_SIZE,
     WebRTCGateway,
     WebRTCSession,
 )
@@ -1106,6 +1108,121 @@ async def test_session_closes_when_ma_api_channel_closes(cert_pems: tuple[str, s
 
         await _wait_for(lambda: session_id not in gateway.sessions)
         assert session_id not in gateway.sessions
+    finally:
+        await gateway._close_session(session_id)
+        await offerer.aclose()
+
+
+class _FakeDataChannel:
+    """Data channel stand-in that captures outbound messages for proxy tests."""
+
+    def __init__(self) -> None:
+        self.is_open = True
+        self.sent: list[str] = []
+
+    async def send(self, data: str) -> None:
+        self.sent.append(data)
+
+
+def _proxy_gateway(cert_pems: tuple[str, str]) -> WebRTCGateway:
+    cert_pem, key_pem = cert_pems
+    return WebRTCGateway(
+        http_session=Mock(),
+        remote_id="TEST-REMOTE-ID",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+    )
+
+
+async def test_http_proxy_response_small_body_single_message(
+    cert_pems: tuple[str, str],
+) -> None:
+    """A body within the chunk size is sent as one legacy http-proxy-response message."""
+    gateway = _proxy_gateway(cert_pems)
+    channel = _FakeDataChannel()
+    session = cast("WebRTCSession", SimpleNamespace(data_channel=channel))
+    body = b"\x00\x01\x02small-body"
+
+    await gateway._send_http_proxy_response(session, "req-small", 200, {"X-Test": "y"}, body)
+
+    assert len(channel.sent) == 1
+    msg = json.loads(channel.sent[0])
+    assert msg["type"] == "http-proxy-response"
+    assert msg["id"] == "req-small"
+    assert msg["status"] == 200
+    assert msg["headers"] == {"X-Test": "y"}
+    assert bytes.fromhex(msg["body"]) == body
+
+
+async def test_http_proxy_response_large_body_chunked(cert_pems: tuple[str, str]) -> None:
+    """A body over the chunk size is announced then streamed as reassemblable chunks."""
+    gateway = _proxy_gateway(cert_pems)
+    channel = _FakeDataChannel()
+    session = cast("WebRTCSession", SimpleNamespace(data_channel=channel))
+    # 2.5 chunks worth of data so the final chunk is a partial one.
+    body = bytes(range(256)) * ((HTTP_PROXY_CHUNK_SIZE * 5) // 512)
+    assert len(body) > HTTP_PROXY_CHUNK_SIZE
+
+    await gateway._send_http_proxy_response(session, "req-big", 200, {}, body)
+
+    expected_chunks = -(-len(body) // HTTP_PROXY_CHUNK_SIZE)
+    start = json.loads(channel.sent[0])
+    assert start["type"] == "http-proxy-response-start"
+    assert start["id"] == "req-big"
+    assert start["status"] == 200
+    assert start["chunks"] == expected_chunks
+    assert len(channel.sent) == expected_chunks + 1
+
+    chunks = [json.loads(m) for m in channel.sent[1:]]
+    assert [c["index"] for c in chunks] == list(range(expected_chunks))
+    assert all(c["type"] == "http-proxy-response-chunk" for c in chunks)
+    # Every serialized message must stay under the negotiated 256 KiB data-channel limit.
+    assert all(len(m.encode()) < 256 * 1024 for m in channel.sent)
+
+    reassembled = b"".join(bytes.fromhex(c["body"]) for c in chunks)
+    assert reassembled == body
+
+
+async def test_http_proxy_response_chunks_survive_real_data_channel(
+    cert_pems: tuple[str, str],
+) -> None:
+    """A body too large for one message is chunked over a real libdatachannel session."""
+    cert_pem, key_pem = cert_pems
+    fake_ws = _FakeLocalWS()
+    http_session = Mock()
+    http_session.ws_connect = AsyncMock(
+        return_value=cast("aiohttp.ClientWebSocketResponse", fake_ws)
+    )
+    gateway = WebRTCGateway(
+        http_session=http_session,
+        remote_id="TEST-REMOTE-ID",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+    )
+    session_id = "chunk-wire-session"
+    with patch.object(gateway, "_get_fresh_ice_servers", AsyncMock(return_value=[])):
+        offerer, dc = await _connect_gateway_session(gateway, session_id)
+    try:
+        # ~293 KiB: as a single hex message this is ~586 KiB, well over the 256 KiB
+        # data-channel limit, so it only arrives at all if chunking works.
+        body = bytes((i * 7) % 256 for i in range(300_000))
+        session = gateway.sessions[session_id]
+        await gateway._send_http_proxy_response(
+            session, "wire-req", 200, {"content-type": "image/jpeg"}, body
+        )
+
+        start = json.loads(await asyncio.wait_for(dc.recv(), timeout=15))
+        assert start["type"] == "http-proxy-response-start"
+        assert start["id"] == "wire-req"
+        assert start["chunks"] > 1
+
+        parts: list[str] = [""] * start["chunks"]
+        for _ in range(start["chunks"]):
+            chunk = json.loads(await asyncio.wait_for(dc.recv(), timeout=15))
+            assert chunk["type"] == "http-proxy-response-chunk"
+            parts[chunk["index"]] = chunk["body"]
+
+        assert bytes.fromhex("".join(parts)) == body
     finally:
         await gateway._close_session(session_id)
         await offerer.aclose()

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -22,7 +22,7 @@ from music_assistant.controllers.webserver.remote_access import (
     RemoteAccessManager,
 )
 from music_assistant.controllers.webserver.remote_access.gateway import (
-    HTTP_PROXY_CHUNK_SIZE,
+    MA_API_CHUNK_SIZE,
     WebRTCGateway,
     WebRTCSession,
 )
@@ -794,6 +794,18 @@ def _proxy_gateway(cert_pems: tuple[str, str]) -> WebRTCGateway:
     )
 
 
+def _reassemble_chunks(frames: list[str]) -> str:
+    """Reassemble __chunk__ frames back into the original text (base64 -> bytes -> utf-8)."""
+    parsed = [json.loads(f) for f in frames]
+    assert all(f["type"] == "__chunk__" for f in parsed)
+    assert len({f["id"] for f in parsed}) == 1
+    count = parsed[0]["count"]
+    parts: list[bytes] = [b""] * count
+    for frame in parsed:
+        parts[frame["seq"]] = base64.b64decode(frame["b64"])
+    return b"".join(parts).decode()
+
+
 async def test_http_proxy_response_small_body_single_message(
     cert_pems: tuple[str, str],
 ) -> None:
@@ -815,38 +827,50 @@ async def test_http_proxy_response_small_body_single_message(
 
 
 async def test_http_proxy_response_large_body_chunked(cert_pems: tuple[str, str]) -> None:
-    """A body over the chunk size is announced then streamed as reassemblable chunks."""
+    """A large HTTP-proxy response is split into base64 chunk frames the client reassembles."""
     gateway = _proxy_gateway(cert_pems)
     channel = _FakeDataChannel()
     session = cast("WebRTCSession", SimpleNamespace(data_channel=channel))
-    # 2.5 chunks worth of data so the final chunk is a partial one.
-    body = bytes(range(256)) * ((HTTP_PROXY_CHUNK_SIZE * 5) // 512)
-    assert len(body) > HTTP_PROXY_CHUNK_SIZE
+    body = bytes(range(256)) * ((MA_API_CHUNK_SIZE * 5) // 512)  # big body -> big JSON message
 
     await gateway._send_http_proxy_response(session, "req-big", 200, {}, body)
 
-    expected_chunks = -(-len(body) // HTTP_PROXY_CHUNK_SIZE)
-    start = json.loads(channel.sent[0])
-    assert start["type"] == "http-proxy-response-start"
-    assert start["id"] == "req-big"
-    assert start["status"] == 200
-    assert start["chunks"] == expected_chunks
-    assert len(channel.sent) == expected_chunks + 1
-
-    chunks = [json.loads(m) for m in channel.sent[1:]]
-    assert [c["index"] for c in chunks] == list(range(expected_chunks))
-    assert all(c["type"] == "http-proxy-response-chunk" for c in chunks)
-    # Every serialized message must stay under the negotiated 256 KiB data-channel limit.
+    assert len(channel.sent) > 1
+    assert all(json.loads(m)["type"] == "__chunk__" for m in channel.sent)
+    # every serialized frame must stay under the negotiated 256 KiB data-channel limit
     assert all(len(m.encode()) < 256 * 1024 for m in channel.sent)
 
-    reassembled = b"".join(bytes.fromhex(c["body"]) for c in chunks)
-    assert reassembled == body
+    reassembled = json.loads(_reassemble_chunks(channel.sent))
+    assert reassembled["type"] == "http-proxy-response"
+    assert reassembled["id"] == "req-big"
+    assert reassembled["status"] == 200
+    assert bytes.fromhex(reassembled["body"]) == body
 
 
-async def test_http_proxy_response_chunks_survive_real_data_channel(
-    cert_pems: tuple[str, str],
-) -> None:
-    """A body too large for one message is chunked over a real libdatachannel session."""
+async def test_send_ma_api_small_message_passthrough(cert_pems: tuple[str, str]) -> None:
+    """A ma-api message within the limit is sent verbatim, not chunked."""
+    gateway = _proxy_gateway(cert_pems)
+    channel = _FakeDataChannel()
+    await gateway._send_ma_api(channel, '{"event":"player_updated"}')
+    assert channel.sent == ['{"event":"player_updated"}']
+
+
+async def test_send_ma_api_large_message_chunked(cert_pems: tuple[str, str]) -> None:
+    """A large ma-api message is chunked and reassembles byte-identically (multibyte-safe)."""
+    gateway = _proxy_gateway(cert_pems)
+    channel = _FakeDataChannel()
+    # multibyte payload so chunk boundaries fall mid-character, exercising the byte-level split
+    text = '{"data":"' + "音楽" * MA_API_CHUNK_SIZE + '"}'
+
+    await gateway._send_ma_api(channel, text)
+
+    assert len(channel.sent) > 1
+    assert all(len(m.encode()) < 256 * 1024 for m in channel.sent)
+    assert _reassemble_chunks(channel.sent) == text
+
+
+async def test_ma_api_chunks_survive_real_data_channel(cert_pems: tuple[str, str]) -> None:
+    """A body too large for one message round-trips as chunks over a real libdatachannel session."""
     cert_pem, key_pem = cert_pems
     fake_ws = _FakeLocalWS()
     http_session = Mock()
@@ -863,26 +887,23 @@ async def test_http_proxy_response_chunks_survive_real_data_channel(
     with patch.object(gateway, "_get_fresh_ice_servers", AsyncMock(return_value=[])):
         offerer, dc = await _connect_gateway_session(gateway, session_id)
     try:
-        # ~293 KiB: as a single hex message this is ~586 KiB, well over the 256 KiB
-        # data-channel limit, so it only arrives at all if chunking works.
+        # ~293 KiB body -> ~586 KiB hex JSON, well over the 256 KiB limit: only arrives chunked
         body = bytes((i * 7) % 256 for i in range(300_000))
         session = gateway.sessions[session_id]
         await gateway._send_http_proxy_response(
             session, "wire-req", 200, {"content-type": "image/jpeg"}, body
         )
 
-        start = json.loads(await asyncio.wait_for(dc.recv(), timeout=15))
-        assert start["type"] == "http-proxy-response-start"
-        assert start["id"] == "wire-req"
-        assert start["chunks"] > 1
+        first = await asyncio.wait_for(dc.recv(), timeout=15)
+        count = json.loads(first)["count"]
+        assert count > 1
+        frames = [first]
+        for _ in range(count - 1):
+            frames.append(await asyncio.wait_for(dc.recv(), timeout=15))
 
-        parts: list[str] = [""] * start["chunks"]
-        for _ in range(start["chunks"]):
-            chunk = json.loads(await asyncio.wait_for(dc.recv(), timeout=15))
-            assert chunk["type"] == "http-proxy-response-chunk"
-            parts[chunk["index"]] = chunk["body"]
-
-        assert bytes.fromhex("".join(parts)) == body
+        reassembled = json.loads(_reassemble_chunks(frames))
+        assert reassembled["id"] == "wire-req"
+        assert bytes.fromhex(reassembled["body"]) == body
     finally:
         await gateway._close_session(session_id)
         await offerer.aclose()

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -851,7 +851,7 @@ async def test_send_ma_api_small_message_passthrough(cert_pems: tuple[str, str])
     """A ma-api message within the limit is sent verbatim, not chunked."""
     gateway = _proxy_gateway(cert_pems)
     channel = _FakeDataChannel()
-    await gateway._send_ma_api(channel, '{"event":"player_updated"}')
+    await gateway._send_ma_api(cast("DataChannel", channel), '{"event":"player_updated"}')
     assert channel.sent == ['{"event":"player_updated"}']
 
 
@@ -862,7 +862,7 @@ async def test_send_ma_api_large_message_chunked(cert_pems: tuple[str, str]) -> 
     # multibyte payload so chunk boundaries fall mid-character, exercising the byte-level split
     text = '{"data":"' + "音楽" * MA_API_CHUNK_SIZE + '"}'
 
-    await gateway._send_ma_api(channel, text)
+    await gateway._send_ma_api(cast("DataChannel", channel), text)
 
     assert len(channel.sent) > 1
     assert all(len(m.encode()) < 256 * 1024 for m in channel.sent)
@@ -901,7 +901,7 @@ async def test_ma_api_chunks_survive_real_data_channel(cert_pems: tuple[str, str
         for _ in range(count - 1):
             frames.append(await asyncio.wait_for(dc.recv(), timeout=15))
 
-        reassembled = json.loads(_reassemble_chunks(frames))
+        reassembled = json.loads(_reassemble_chunks(cast("list[str]", frames)))
         assert reassembled["id"] == "wire-req"
         assert bytes.fromhex(reassembled["body"]) == body
     finally:


### PR DESCRIPTION
# What does this implement/fix?

Migrates Music Assistant remote access from `aiortc` to `aiolibdatachannel` (libdatachannel-based) to improve WebRTC connection quality and reliability, plus two improvements the new backend enables:

- **Migration** — `gateway.py` rewritten against aiolibdatachannel; DTLS certificate handled as PEM (the persistent Remote ID is preserved); async-native pumps replace the aiortc thread/queue bridging.
- **Trickle ICE** — the answer is returned immediately (candidate-less) and local ICE candidates are streamed separately, cutting connection setup from ~20 s+ to ~100 ms.
- **Chunking** — large proxied responses (album art) are split below libdatachannel's negotiated 256 KiB data-channel message limit. aiortc fragmented silently; libdatachannel enforces the limit. Bodies ≤ 64 KiB keep the single-message format, so it stays backward compatible.

Verified end-to-end over a live remote connection: connect in ~110 ms, and 82 real album-art responses proxied with correct chunk splitting at 64 KiB and zero send failures.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

---

**Companion PR:** music-assistant/frontend#2183 (client-side chunk reassembly).

**Notes (draft — not ready for review yet):**
- Depends on a temporary git pin `music-assistant/aiolibdatachannel@feat/certpem-testdrive` (adds the cert-PEM C-API bindings + a GIL-release fix for a callback-registration deadlock). To be swapped to a PyPI release before merge, once libdatachannel v0.25 ships the cert-PEM C-API and aiolibdatachannel cuts a release carrying the GIL fix (PR opened upstream).
- Branch is behind `dev` and needs a rebase before ready.
- The existing `tests/test_remote_access.py` cases still construct the gateway with the old `certificate=` API and need updating to `cert_pem`/`key_pem`.
