### PR TITLE
Clean up leftover universal player settings after a native player takes over

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -209,9 +209,9 @@ class ProtocolLinkingMixin:
             if protocol_player.protocol_parent_id:
                 protocol_player.refresh_state()
                 parent_player.refresh_state()
-                # Copy identifiers from protocol player to universal player on restore.
-                # Restored universal players start with empty identifiers which must be
-                # repopulated from their protocol players so that new protocol players
+                # Merge the protocol player's identifiers into the universal player
+                # so identifiers discovered since the last persist (e.g. an
+                # ARP-resolved MAC) are included and new protocol players
                 # (like Sendspin bridges) can match via identifiers.
                 if parent_player.provider.domain == "universal_player" and isinstance(
                     parent_player, UniversalPlayer
@@ -264,9 +264,8 @@ class ProtocolLinkingMixin:
                         # duplicate domain)
                         if not protocol_player.protocol_parent_id:
                             continue
-                        # Copy identifiers from protocol player to universal player
-                        # This is important for restored universal players which start
-                        # with empty identifiers
+                        # Merge the protocol player's identifiers into the universal
+                        # player so newly discovered identifiers are included as well
                         for conn_type, value in protocol_player.device_info.identifiers.items():
                             native_player.device_info.add_identifier(conn_type, value)
                         # Update model/manufacturer if universal player has generic values
@@ -598,11 +597,12 @@ class ProtocolLinkingMixin:
         """
         Update universal player's device info from protocol player if needed.
 
-        When a universal player is restored from config, it has generic device info
-        (model="Universal Player", manufacturer="Music Assistant"). This method
-        updates those values from a protocol player that has real device info.
+        A universal player carries generic placeholder device info
+        (model="Universal Player", manufacturer="Music Assistant") when no real
+        values are known for it (yet). This method updates those values from a
+        protocol player that has real device info.
         """
-        # Check if universal player has generic device info (from restore)
+        # Check if universal player has generic placeholder device info
         device_info = universal_player.device_info
         protocol_info = protocol_player.device_info
 
@@ -832,7 +832,7 @@ class ProtocolLinkingMixin:
 
             # Carry over the user's configuration and re-point group memberships
             # before the permanent removal below deletes the losing wrapper's config
-            self._migrate_universal_player_config(remove, keep)
+            self._migrate_universal_player_config(remove.player_id, keep.player_id)
             self._repoint_group_memberships(remove.player_id, keep.player_id)
 
             # Stop playback and remove the obsolete player
@@ -1038,29 +1038,25 @@ class ProtocolLinkingMixin:
 
             # Carry over the user's configuration and re-point group memberships
             # before the permanent removal below deletes the universal player's config
-            self._migrate_universal_player_config(player, native_player)
+            self._migrate_universal_player_config(player.player_id, native_player.player_id)
             self._repoint_group_memberships(player.player_id, native_player.player_id)
 
             # Stop playback and remove the now-obsolete universal player
             self.mass.create_task(self._stop_and_unregister(player))
 
-    def _migrate_universal_player_config(
-        self, universal_player: Player, native_player: Player
-    ) -> None:
+    def _migrate_universal_player_config(self, universal_id: str, native_id: str) -> None:
         """
         Carry over user-set configuration from a replaced universal player.
 
         Copies the custom display name, player config values, DSP settings and
         per-queue settings of the (obsolete) universal player onto the native
         player that replaces it, without overwriting values explicitly set on
-        the native player itself. Must be called before the universal player is
-        permanently unregistered, as that deletes its config.
+        the native player itself. Must be called while the universal player's
+        config still exists, as the permanent removal deletes it.
 
-        :param universal_player: The obsolete universal player being replaced.
-        :param native_player: The native player that replaces it.
+        :param universal_id: Player id of the obsolete universal player being replaced.
+        :param native_id: Player id of the native player that replaces it.
         """
-        universal_id = universal_player.player_id
-        native_id = native_player.player_id
         source_raw = self.mass.config.get(f"{CONF_PLAYERS}/{universal_id}")
         source_raw = source_raw if isinstance(source_raw, dict) else {}
         target_key = f"{CONF_PLAYERS}/{native_id}"

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -292,10 +292,10 @@ class UniversalPlayerProvider(PlayerProvider):
         all_player_configs = self.mass.config.get(CONF_PLAYERS, {})
         valid_protocol_ids = self._resolve_stored_protocol_ids(player_id, all_player_configs)
 
-        # Never delete the stored config of a universal player from the restore
-        # path - it holds user customizations. If nothing links to it (anymore),
-        # simply skip restoring it: the config is picked up again when protocol
-        # players return, as universal player ids are derived from the device.
+        # When nothing links to the stored universal player config (anymore),
+        # keep it - it holds user customizations - and simply skip restoring:
+        # the config is picked up again when protocol players return, as
+        # universal player ids are derived from the device.
         if not valid_protocol_ids:
             self.logger.debug(
                 "Not restoring universal player %s - no linked protocol players remain",
@@ -305,7 +305,8 @@ class UniversalPlayerProvider(PlayerProvider):
 
         # Protocols that (also) belong to a native player mean this universal
         # player is a leftover wrapper: repair the protocol links to point at
-        # the rightful native parent and skip restoring the wrapper.
+        # the rightful native parent and replace the wrapper by that native
+        # player instead of restoring it.
         native_claims: dict[str, str] = {}
         for protocol_id in valid_protocol_ids:
             for other_player_id, other_config in all_player_configs.items():
@@ -335,6 +336,22 @@ class UniversalPlayerProvider(PlayerProvider):
                     native_id,
                 )
                 await self._reparent_protocols_to_native(native_id, protocol_ids)
+            # Mirror the runtime replacement by a native player: carry the
+            # wrapper's user settings and group memberships over to the native
+            # player and delete the wrapper's now-obsolete config, so it doesn't
+            # linger as a permanently unavailable entry in the settings UI.
+            # Skipped while the wrapper is still registered - the runtime
+            # replacement flow owns that transition.
+            if not self.mass.players.get_player(player_id):
+                self.logger.info(
+                    "Removing stored config of universal player %s - replaced by %s",
+                    player_id,
+                    default_parent,
+                )
+                self.mass.players._migrate_universal_player_config(player_id, default_parent)
+                self.mass.players._repoint_group_memberships(player_id, default_parent)
+                self.mass.players.delete_player_config(player_id)
+                self.mass.player_queues.on_player_remove(player_id, permanent=True)
             return
 
         stored_protocol_ids = valid_protocol_ids

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -7765,6 +7765,39 @@ class TestUniversalPlayerRestoreOrphanCleanup:
 
         mock_mass.config.get.side_effect = _get
 
+    @staticmethod
+    def _wire_nested_config(mock_mass: MagicMock, store: dict[str, Any]) -> None:
+        """Wire mass.config get/set/remove to a nested, path-addressable store."""
+
+        def _get(key: str, default: object = None) -> object:
+            node: Any = store
+            for part in key.split("/"):
+                if not isinstance(node, dict) or part not in node:
+                    return default
+                node = node[part]
+            return node
+
+        def _set(key: str, value: object) -> None:
+            parts = key.split("/")
+            node: dict[str, Any] = store
+            for part in parts[:-1]:
+                node = node.setdefault(part, {})
+            node[parts[-1]] = value
+
+        def _remove(key: str) -> None:
+            parts = key.split("/")
+            node: Any = store
+            for part in parts[:-1]:
+                node = node.get(part) if isinstance(node, dict) else None
+                if node is None:
+                    return
+            if isinstance(node, dict):
+                node.pop(parts[-1], None)
+
+        mock_mass.config.get = MagicMock(side_effect=_get)
+        mock_mass.config.set = MagicMock(side_effect=_set)
+        mock_mass.config.remove = MagicMock(side_effect=_remove)
+
     @pytest.mark.asyncio
     async def test_orphan_protocol_dropped_but_configs_kept(self, mock_mass: MagicMock) -> None:
         """Orphan protocol is dropped from membership without deleting any config."""
@@ -7975,10 +8008,10 @@ class TestUniversalPlayerRestoreOrphanCleanup:
         """
         Self-heal: stale UP whose protocols belong to a disabled native parent.
 
-        Restoring such a UP should skip the wrapper (keeping its config), restore
-        each protocol's parent_id back to the rightful (disabled) native parent, and
-        cascade-disable each protocol so the next registration cycle doesn't rebuild
-        the wrapper.
+        Restoring such a UP should skip the wrapper, restore each protocol's
+        parent_id back to the rightful (disabled) native parent, cascade-disable
+        each protocol so the next registration cycle doesn't rebuild the wrapper,
+        and hand the wrapper's config over to the native parent before deleting it.
         """
         provider = create_mock_universal_provider(mock_mass)
         universal_id = "up_test"
@@ -8029,8 +8062,18 @@ class TestUniversalPlayerRestoreOrphanCleanup:
 
         await provider._restore_player(universal_id)
 
-        # The wrapper is skipped but its config is kept
-        mock_mass.config.remove_player_config.assert_not_awaited()
+        # The wrapper is not restored; its settings are handed over to the
+        # native parent and its now-obsolete config is deleted
+        mock_mass.players._migrate_universal_player_config.assert_called_once_with(
+            universal_id, native_parent_id
+        )
+        mock_mass.players._repoint_group_memberships.assert_called_once_with(
+            universal_id, native_parent_id
+        )
+        mock_mass.players.delete_player_config.assert_called_once_with(universal_id)
+        mock_mass.player_queues.on_player_remove.assert_called_once_with(
+            universal_id, permanent=True
+        )
 
         # Each protocol's parent_id is restored to the disabled native parent
         parent_restorations = {
@@ -8116,6 +8159,246 @@ class TestUniversalPlayerRestoreOrphanCleanup:
         }
         for call in mock_mass.config.save_player_config.await_args_list:
             assert call.args[1] == {ATTR_ENABLED: False}
+        # The wrapper's settings are handed to the first claimer, then its
+        # config is deleted
+        mock_mass.players._migrate_universal_player_config.assert_called_once_with(
+            universal_id, "native_a"
+        )
+        mock_mass.players._repoint_group_memberships.assert_called_once_with(
+            universal_id, "native_a"
+        )
+        mock_mass.players.delete_player_config.assert_called_once_with(universal_id)
+        mock_mass.player_queues.on_player_remove.assert_called_once_with(
+            universal_id, permanent=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_restore_native_claims_carries_config_and_deletes_wrapper(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """The wrapper's user settings move to the native claimer and its config is deleted."""
+        universal_id = "up_old"
+        native_id = "cast_1"
+        ap_id = "ap_1"
+        store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                universal_id: {
+                    "provider": "universal_player",
+                    "enabled": True,
+                    "name": "Living Room",
+                    "default_name": "Soundbar (Universal)",
+                    "values": {
+                        "hide_in_ui": True,
+                        "volume_control": "up_volume_control",
+                        "linked_protocol_ids": [ap_id],
+                        "device_identifiers": {"mac_address": "AA:BB:CC:DD:EE:FF"},
+                        "device_info": {"model": "Test", "manufacturer": "Test"},
+                    },
+                },
+                native_id: {
+                    "provider": "cast",
+                    "enabled": True,
+                    "name": "Soundbar",
+                    "default_name": "Soundbar",
+                    "values": {
+                        "volume_control": "native",
+                        "linked_protocol_ids": [ap_id],
+                    },
+                },
+                ap_id: {
+                    "player_type": "protocol",
+                    "enabled": True,
+                    "values": {"protocol_parent_id": universal_id},
+                },
+                "group_1": {
+                    "provider": "sync_group",
+                    "enabled": True,
+                    "values": {
+                        "group_members": [universal_id, "other"],
+                        "allowed_members": [universal_id],
+                    },
+                },
+            },
+            CONF_PLAYER_DSP: {universal_id: {"enabled": True, "filters": []}},
+            CONF_PLAYER_QUEUES: {
+                universal_id: {"queue_id": universal_id, "values": {"crossfade_duration": 5}}
+            },
+        }
+        self._wire_nested_config(mock_mass, store)
+        mock_mass.config.save_player_config = AsyncMock()
+        scheduled_tasks: list[Awaitable[object]] = []
+        mock_mass.create_task = MagicMock(
+            side_effect=lambda task, *_a, **_kw: scheduled_tasks.append(task)
+        )
+        controller = PlayerController(mock_mass)
+        controller._players = {}
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        provider = create_mock_universal_provider(mock_mass)
+
+        await provider._restore_player(universal_id)
+
+        players_tree = store[CONF_PLAYERS]
+        # the protocol player is reparented to the native claimer
+        assert players_tree[ap_id]["values"]["protocol_parent_id"] == native_id
+        # the custom display name and user-set values moved onto the native player
+        assert players_tree[native_id]["name"] == "Living Room"
+        assert players_tree[native_id]["values"]["hide_in_ui"] is True
+        # values the native player has explicitly set are not overwritten
+        assert players_tree[native_id]["values"]["volume_control"] == "native"
+        # wrapper bookkeeping values are not carried over
+        assert "device_identifiers" not in players_tree[native_id]["values"]
+        assert "device_info" not in players_tree[native_id]["values"]
+        # DSP and queue settings moved onto the native player
+        assert store[CONF_PLAYER_DSP] == {native_id: {"enabled": True, "filters": []}}
+        assert store[CONF_PLAYER_QUEUES] == {
+            native_id: {"queue_id": native_id, "values": {"crossfade_duration": 5}}
+        }
+        # group memberships that referenced the wrapper now point at the native player
+        assert players_tree["group_1"]["values"]["group_members"] == [native_id, "other"]
+        assert players_tree["group_1"]["values"]["allowed_members"] == [native_id]
+        # the wrapper's own config entries are all gone
+        assert universal_id not in players_tree
+        # cached queue state of the wrapper is purged as well
+        mock_mass.player_queues.on_player_remove.assert_called_once_with(
+            universal_id, permanent=True
+        )
+        # the wrapper itself is not registered as a player
+        assert universal_id not in controller._players
+        for task in scheduled_tasks:
+            await task
+
+    @pytest.mark.asyncio
+    async def test_restore_native_claims_keeps_native_name_dsp_and_queue_values(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Values explicitly set on the native player win over the wrapper's on restore."""
+        universal_id = "up_old"
+        native_id = "cast_1"
+        ap_id = "ap_1"
+        store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                universal_id: {
+                    "provider": "universal_player",
+                    "enabled": True,
+                    "name": "Living Room",
+                    "default_name": "Soundbar (Universal)",
+                    "values": {"hide_in_ui": True, "linked_protocol_ids": [ap_id]},
+                },
+                native_id: {
+                    "provider": "cast",
+                    "enabled": True,
+                    "name": "Kitchen",
+                    "default_name": "Soundbar",
+                    "values": {"linked_protocol_ids": [ap_id]},
+                },
+                ap_id: {
+                    "player_type": "protocol",
+                    "enabled": True,
+                    "values": {"protocol_parent_id": universal_id},
+                },
+            },
+            CONF_PLAYER_DSP: {
+                universal_id: {"enabled": True, "filters": ["universal"]},
+                native_id: {"enabled": False, "filters": ["native"]},
+            },
+            CONF_PLAYER_QUEUES: {
+                universal_id: {
+                    "queue_id": universal_id,
+                    "values": {"crossfade_duration": 8, "autoplay_mode": "smart"},
+                },
+                native_id: {"queue_id": native_id, "values": {"crossfade_duration": 2}},
+            },
+        }
+        self._wire_nested_config(mock_mass, store)
+        mock_mass.config.save_player_config = AsyncMock()
+        scheduled_tasks: list[Awaitable[object]] = []
+        mock_mass.create_task = MagicMock(
+            side_effect=lambda task, *_a, **_kw: scheduled_tasks.append(task)
+        )
+        controller = PlayerController(mock_mass)
+        controller._players = {}
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        provider = create_mock_universal_provider(mock_mass)
+
+        await provider._restore_player(universal_id)
+
+        players_tree = store[CONF_PLAYERS]
+        # the native player's own custom name and DSP config win
+        assert players_tree[native_id]["name"] == "Kitchen"
+        assert store[CONF_PLAYER_DSP] == {native_id: {"enabled": False, "filters": ["native"]}}
+        # queue values merge without overwriting the native queue's own values
+        assert store[CONF_PLAYER_QUEUES] == {
+            native_id: {
+                "queue_id": native_id,
+                "values": {"crossfade_duration": 2, "autoplay_mode": "smart"},
+            }
+        }
+        # non-conflicting values still migrate and the wrapper config is gone
+        assert players_tree[native_id]["values"]["hide_in_ui"] is True
+        assert universal_id not in players_tree
+        for task in scheduled_tasks:
+            await task
+
+    @pytest.mark.asyncio
+    async def test_restore_native_claims_keeps_config_while_wrapper_registered(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """No config carry-over/deletion while the wrapper is still registered."""
+        provider = create_mock_universal_provider(mock_mass)
+        universal_id = "up_test"
+        ap_id = "airplay_1"
+
+        all_configs = {
+            universal_id: {
+                "values": {
+                    "linked_protocol_ids": [ap_id],
+                    "device_identifiers": {},
+                    "device_info": {},
+                },
+                "name": "Test UP",
+            },
+            "native_a": {
+                "provider": "dlna",
+                "values": {"linked_protocol_ids": [ap_id]},
+            },
+            ap_id: {
+                "player_type": "protocol",
+                "values": {"protocol_parent_id": universal_id},
+            },
+        }
+
+        def _config_get(key: str, default: object = None) -> object:
+            if key == CONF_PLAYERS:
+                return all_configs
+            if key.startswith(f"{CONF_PLAYERS}/"):
+                pid = key.split("/", 1)[1]
+                return all_configs.get(pid, default)
+            return default
+
+        mock_mass.config.get.side_effect = _config_get
+        mock_mass.config.set = MagicMock()
+        mock_mass.config.save_player_config = AsyncMock()
+        mock_mass.players = MagicMock()
+        mock_mass.players.get_player = MagicMock(return_value=MagicMock())
+
+        await provider._restore_player(universal_id)
+
+        # the protocol link repair still runs
+        parent_restorations = {
+            call.args[0]: call.args[1]
+            for call in mock_mass.config.set.call_args_list
+            if "protocol_parent_id" in call.args[0]
+        }
+        assert parent_restorations == {
+            f"{CONF_PLAYERS}/{ap_id}/values/protocol_parent_id": "native_a",
+        }
+        # but the registered wrapper keeps its config and group memberships
+        mock_mass.players._migrate_universal_player_config.assert_not_called()
+        mock_mass.players._repoint_group_memberships.assert_not_called()
+        mock_mass.players.delete_player_config.assert_not_called()
+        mock_mass.player_queues.on_player_remove.assert_not_called()
 
 
 class TestParentDisableCascade:


### PR DESCRIPTION
# What does this implement/fix?

When a device that was wrapped in an (auto-created) universal player gets taken over by a native player while Music Assistant is restarting - instead of while it is running - the startup restore repaired the protocol links but left the universal player's settings entry behind. That entry showed up in the player settings as a permanently unavailable player that could only be removed by hand, and any customizations made on it were lost.

- On startup, when a universal player's linked protocol players turn out to belong to a native player, the user's settings (custom name, player settings, DSP and queue settings) now carry over to that native player - just like the runtime replacement already does - without overwriting anything set on the native player itself.
- The universal player's leftover settings entry (including DSP, queue settings and saved queue state) is cleaned up afterwards, so it no longer lingers in the player settings.
- Reworded a few outdated code comments that claimed restored universal players start without device identifiers.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
