### PR TITLE
Add start_from_beginning option for podcast playback

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -479,6 +479,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         radio_mode: bool = False,
         start_item: PlayableMediaItemType | str | None = None,
         sort_by: str | None = None,
+        start_from_beginning: bool = False,
     ) -> None:
         """
         Play media item(s) on the given queue.
@@ -490,12 +491,16 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             prefer enqueuing that URI directly.
         :param start_item: Optional item to start the playlist or album from.
         :param sort_by: Optional sort key to order tracks before applying start_item.
+        :param start_from_beginning: Start a podcast episode at position 0, ignoring any
+            saved resume position. The stored progress itself is left untouched.
         """
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
         # Lock is acquired by the @handle_play_action decorator on the internal handler
-        await self._handle_play_media(queue_id, media, option, radio_mode, start_item, sort_by)
+        await self._handle_play_media(
+            queue_id, media, option, radio_mode, start_item, sort_by, start_from_beginning
+        )
 
     @api_command("player_queues/move_item", required_scope=Scope.QUEUES_CONTROL)
     def move_item(self, queue_id: str, queue_item_id: str, pos_shift: int = 1) -> None:

--- a/music_assistant/controllers/player_queues/media_resolver.py
+++ b/music_assistant/controllers/player_queues/media_resolver.py
@@ -291,25 +291,6 @@ class MediaResolver:
         )
         return 0 if full_played else resume_position_ms
 
-    async def _set_episode_resume_point(
-        self, episode: PodcastEpisode, userid: str | None, start_from_beginning: bool
-    ) -> None:
-        """
-        Apply the resume point to a resolved podcast episode.
-
-        When start_from_beginning is set the episode starts at position 0 and the resume
-        lookup is skipped; the stored progress itself is left untouched.
-        """
-        if start_from_beginning:
-            episode.fully_played = False
-            episode.resume_position_ms = 0
-            return
-        fully_played, resume_position_ms = await self.mass.music.get_resume_position(
-            episode, userid=userid
-        )
-        episode.fully_played = fully_played
-        episode.resume_position_ms = 0 if fully_played else resume_position_ms
-
     async def get_next_podcast_episodes(
         self,
         podcast: Podcast | None,
@@ -413,6 +394,25 @@ class MediaResolver:
         episode_index = all_episodes.index(resolved_episode)
         # return the (remaining) episode(s) to play
         return UniqueList(all_episodes[episode_index:])
+
+    async def _set_episode_resume_point(
+        self, episode: PodcastEpisode, userid: str | None, start_from_beginning: bool
+    ) -> None:
+        """
+        Apply the resume point to a resolved podcast episode.
+
+        When start_from_beginning is set the episode starts at position 0 and the resume
+        lookup is skipped; the stored progress itself is left untouched.
+        """
+        if start_from_beginning:
+            episode.fully_played = False
+            episode.resume_position_ms = 0
+            return
+        fully_played, resume_position_ms = await self.mass.music.get_resume_position(
+            episode, userid=userid
+        )
+        episode.fully_played = fully_played
+        episode.resume_position_ms = 0 if fully_played else resume_position_ms
 
     async def _resolve_library_artist(self, artist: Artist) -> Artist | None:
         """

--- a/music_assistant/controllers/player_queues/media_resolver.py
+++ b/music_assistant/controllers/player_queues/media_resolver.py
@@ -291,11 +291,31 @@ class MediaResolver:
         )
         return 0 if full_played else resume_position_ms
 
+    async def _set_episode_resume_point(
+        self, episode: PodcastEpisode, userid: str | None, start_from_beginning: bool
+    ) -> None:
+        """
+        Apply the resume point to a resolved podcast episode.
+
+        When start_from_beginning is set the episode starts at position 0 and the resume
+        lookup is skipped; the stored progress itself is left untouched.
+        """
+        if start_from_beginning:
+            episode.fully_played = False
+            episode.resume_position_ms = 0
+            return
+        fully_played, resume_position_ms = await self.mass.music.get_resume_position(
+            episode, userid=userid
+        )
+        episode.fully_played = fully_played
+        episode.resume_position_ms = 0 if fully_played else resume_position_ms
+
     async def get_next_podcast_episodes(
         self,
         podcast: Podcast | None,
         episode: PodcastEpisode | str | None,
         userid: str | None = None,
+        start_from_beginning: bool = False,
     ) -> UniqueList[PodcastEpisode]:
         """
         Return the next episode(s) and resume point for the given podcast.
@@ -306,6 +326,8 @@ class MediaResolver:
             a case-insensitive substring of an episode name, or one of the
             reserved lowercase keywords `"latest"` / `"newest"`.
         :param userid: User whose resume position should be applied.
+        :param start_from_beginning: When True, the resolved episode starts at position 0,
+            ignoring any saved resume position. The stored progress itself is left untouched.
         """
         if podcast is None and isinstance(episode, str | NoneType):
             raise InvalidDataError("Either podcast or episode must be provided")
@@ -316,12 +338,7 @@ class MediaResolver:
                 "Fetching resume point to play for Podcast episode %s",
                 episode.name,
             )
-            (
-                fully_played,
-                resume_position_ms,
-            ) = await self.mass.music.get_resume_position(episode, userid=userid)
-            episode.fully_played = fully_played
-            episode.resume_position_ms = 0 if fully_played else resume_position_ms
+            await self._set_episode_resume_point(episode, userid, start_from_beginning)
             return UniqueList([episode])
         # podcast with optional start episode requested
         self.logger.debug(
@@ -339,12 +356,7 @@ class MediaResolver:
                 raise InvalidDataError(
                     f"Unable to resolve episode to play for Podcast {podcast.name}"
                 )
-            (
-                fully_played,
-                resume_position_ms,
-            ) = await self.mass.music.get_resume_position(latest, userid=userid)
-            latest.fully_played = fully_played
-            latest.resume_position_ms = 0 if fully_played else resume_position_ms
+            await self._set_episode_resume_point(latest, userid, start_from_beginning)
             return UniqueList([latest])
         all_episodes = [
             x async for x in self.mass.music.podcasts.episodes(podcast.item_id, podcast.provider)
@@ -393,6 +405,10 @@ class MediaResolver:
                 resolved_episode = next((x for x in all_episodes), None)
         if resolved_episode is None:
             raise InvalidDataError(f"Unable to resolve episode to play for Podcast {podcast.name}")
+        if start_from_beginning:
+            # play the resolved episode from position 0 without touching stored progress
+            resolved_episode.fully_played = False
+            resolved_episode.resume_position_ms = 0
         # get the index of the episode
         episode_index = all_episodes.index(resolved_episode)
         # return the (remaining) episode(s) to play
@@ -443,6 +459,7 @@ class MediaResolver:
         userid: str | None = None,
         queue_id: str | None = None,
         sort_by: str | None = None,
+        start_from_beginning: bool = False,
     ) -> list[MediaItemType]:
         """Resolve/unwrap media items to enqueue."""
         # resolve Itemmapping to full media item
@@ -491,10 +508,18 @@ class MediaResolver:
                     media_item, userid=userid, queue_id=queue_id, user_initiated=True
                 )
             )
-            return list(await self.get_next_podcast_episodes(media_item, start_item, userid=userid))
+            return list(
+                await self.get_next_podcast_episodes(
+                    media_item, start_item, userid=userid, start_from_beginning=start_from_beginning
+                )
+            )
         if media_item.media_type == MediaType.PODCAST_EPISODE:
             media_item = cast("PodcastEpisode", media_item)
-            return list(await self.get_next_podcast_episodes(None, media_item, userid=userid))
+            return list(
+                await self.get_next_podcast_episodes(
+                    None, media_item, userid=userid, start_from_beginning=start_from_beginning
+                )
+            )
         if media_item.media_type == MediaType.FOLDER:
             media_item = cast("BrowseFolder", media_item)
             return list(await self._get_folder_tracks(media_item))

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -493,6 +493,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         radio_mode: bool = False,
         start_item: PlayableMediaItemType | str | None = None,
         sort_by: str | None = None,
+        start_from_beginning: bool = False,
     ) -> None:
         """Handle play media without acquiring the queue lock."""
         # cancel any pending play_index calls for this queue to prevent conflicts
@@ -659,6 +660,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                         userid=queue_data.userid,
                         queue_id=queue_id,
                         sort_by=sort_by,
+                        start_from_beginning=start_from_beginning,
                     )
 
             except MusicAssistantError as err:

--- a/tests/controllers/player_queues/test_podcast_start_from_beginning.py
+++ b/tests/controllers/player_queues/test_podcast_start_from_beginning.py
@@ -1,0 +1,86 @@
+"""
+Tests for the ``start_from_beginning`` podcast playback option.
+
+The option lets an episode start at absolute position 0 while leaving the
+user's saved progress in the playlog untouched (a non-destructive counterpart
+to ``music/mark_unplayed``). See discussion music-assistant/discussions#4191.
+
+These integration tests use the ``mass`` fixture from ``tests/conftest.py``
+which creates a full MusicAssistant instance with a real SQLite database.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import Podcast, PodcastEpisode, ProviderMapping
+
+from music_assistant.constants import DB_TABLE_PLAYLOG
+from music_assistant.mass import MusicAssistant
+
+
+def _provider_mapping(provider: str = "test_podcast_prov") -> set[ProviderMapping]:
+    """Create a single provider mapping with a unique item id."""
+    return {
+        ProviderMapping(
+            item_id=uuid4().hex,
+            provider_domain=provider,
+            provider_instance=provider,
+        )
+    }
+
+
+async def test_start_from_beginning_ignores_saved_resume(mass: MusicAssistant) -> None:
+    """start_from_beginning forces resume_position_ms=0 without wiping saved progress."""
+    user = await mass.webserver.auth.create_user("podcaststartfrombeginning")
+
+    podcast = Podcast(
+        item_id="show-sfb-001",
+        provider="test_podcast_prov",
+        name="Start From Beginning Show",
+        provider_mappings=_provider_mapping(),
+    )
+    episode = PodcastEpisode(
+        item_id="ep-sfb-001",
+        provider="test_podcast_prov",
+        name="Episode 1",
+        provider_mappings=_provider_mapping(),
+        position=1,
+        podcast=podcast,
+    )
+
+    # seed 120 seconds of saved progress for this episode
+    await mass.music.mark_item_played(
+        episode,
+        fully_played=False,
+        seconds_played=120,
+        user_initiated=True,
+        userid=user.user_id,
+    )
+
+    resolver = mass.player_queues._media_resolver
+
+    # sanity: without the flag, the saved 120s resume position is applied
+    normal = await resolver.get_next_podcast_episodes(None, episode, userid=user.user_id)
+    assert normal[0].resume_position_ms == 120_000
+
+    # with the flag, the episode starts at absolute 0
+    from_start = await resolver.get_next_podcast_episodes(
+        None, episode, userid=user.user_id, start_from_beginning=True
+    )
+    assert from_start[0].resume_position_ms == 0
+    assert from_start[0].fully_played is False
+
+    # the saved progress row must be left untouched (non-destructive)
+    row = await mass.music.database.get_row(
+        DB_TABLE_PLAYLOG,
+        {
+            "media_type": MediaType.PODCAST_EPISODE.value,
+            "item_id": episode.item_id,
+            "provider": episode.provider,
+            "userid": user.user_id,
+        },
+    )
+    assert row is not None, "start_from_beginning must not delete the saved progress row"
+    assert row["seconds_played"] == 120


### PR DESCRIPTION
# What does this implement/fix?

Adds a `start_from_beginning` option to the `player_queues/play_media` command. When set, a podcast episode starts at position 0, ignoring any saved resume position; the stored progress in the playlog is left untouched (unlike `mark_unplayed`, which clears it). This gives a non-destructive way to replay an episode from the start, e.g. from automations.

**Related issue (if applicable):**

- related discussion: https://github.com/orgs/music-assistant/discussions/4191
- frontend: https://github.com/music-assistant/frontend/pull/2184 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
