### PR TITLE
Fix ghost players created by the server's own AirPlay receivers

### DIFF
--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -156,6 +156,12 @@ async def migrate(data: dict[str, Any]) -> bool:  # noqa: PLR0915
     if _migrate_local_audio_attribution_stubs(data):
         changed = True
 
+    # Drop ghost players that were discovered from this server's own AirPlay Receiver
+    # (shairport-sync) advertisements before discovery learned to filter them out.
+    # TODO: remove after 2.11 release
+    if _migrate_airplay_receiver_ghost_players(data):
+        changed = True
+
     # Drop the stored value of the removed output limiter player setting; clipping protection
     # is now an explicit Safety Limiter DSP filter instead of a fixed output stage.
     # TODO: remove after 2.10 release
@@ -574,6 +580,91 @@ def _migrate_fully_kiosk_multi_instance(data: dict[str, Any]) -> bool:
         "Devices and their passwords have been preserved, but any Fully Kiosk player "
         "that was part of a universal group will need to be re-added to it. ",
         len(legacy_ids),
+    )
+    return True
+
+
+def _migrate_airplay_receiver_ghost_players(data: dict[str, Any]) -> bool:
+    """
+    Remove ghost players left behind by this server's own AirPlay Receiver instances.
+
+    The AirPlay provider could discover the server's own AirPlay Receiver
+    (shairport-sync) advertisements as regular AirPlay players. shairport-sync
+    derives its device id from the receiver name plus a host interface MAC, which
+    can change per boot (e.g. virtual interface MACs), so every restart could mint
+    a new player id: the previous ids linger as permanently unavailable players and
+    universal player wrappers. Discovery now filters these advertisements out; this
+    migration drops the leftovers.
+    """
+    all_provider_configs = data.get(CONF_PROVIDERS, {})
+    all_player_configs = data.get(CONF_PLAYERS, {})
+    if not isinstance(all_provider_configs, dict) or not isinstance(all_player_configs, dict):
+        return False
+    # the advertised name of every configured receiver instance
+    # (key and default mirror the airplay_receiver provider's config entry)
+    receiver_names: set[str] = set()
+    for provider_cfg in all_provider_configs.values():
+        if not isinstance(provider_cfg, dict) or provider_cfg.get("domain") != "airplay_receiver":
+            continue
+        provider_values = provider_cfg.get("values")
+        airplay_name = (
+            provider_values.get("airplay_name") if isinstance(provider_values, dict) else None
+        )
+        receiver_names.add(str(airplay_name) if airplay_name else "Music Assistant")
+    if not receiver_names:
+        return False
+    # the Sendspin bridge of such a ghost registered under "<name> (AirPlay)"
+    bridge_names = {f"{name} (AirPlay)" for name in receiver_names}
+
+    ghost_ids: set[str] = set()
+    for player_id, player_cfg in all_player_configs.items():
+        if not isinstance(player_cfg, dict):
+            continue
+        default_name = player_cfg.get("default_name")
+        provider = player_cfg.get("provider")
+        if (
+            player_id.startswith("ap") and provider == "airplay" and default_name in receiver_names
+        ) or (
+            player_id.startswith("spb_") and provider == "sendspin" and default_name in bridge_names
+        ):
+            ghost_ids.add(player_id)
+        elif (
+            player_id.startswith("up")
+            and provider == "universal_player"
+            and default_name in receiver_names | bridge_names
+        ):
+            values = player_cfg.get("values")
+            linked = values.get(CONF_LINKED_PROTOCOL_IDS) if isinstance(values, dict) else None
+            # only remove wrappers that exclusively wrap such ghost endpoints
+            if not isinstance(linked, list) or all(
+                isinstance(pid, str) and pid.startswith(("ap", "spb_")) for pid in linked
+            ):
+                ghost_ids.add(player_id)
+    if not ghost_ids:
+        return False
+
+    for player_id in ghost_ids:
+        del all_player_configs[player_id]
+        # drop dead per-queue and DSP state along with the player config
+        for tree_key in (CONF_PLAYER_QUEUES, CONF_PLAYER_DSP):
+            tree = data.get(tree_key)
+            if isinstance(tree, dict):
+                tree.pop(player_id, None)
+    # strip dangling references to the removed ghosts from group configurations
+    for player_cfg in all_player_configs.values():
+        if not isinstance(player_cfg, dict):
+            continue
+        values = player_cfg.get("values")
+        if not isinstance(values, dict):
+            continue
+        for key in ("group_members", "allowed_members"):
+            members = values.get(key)
+            if isinstance(members, list) and any(pid in ghost_ids for pid in members):
+                values[key] = [pid for pid in members if pid not in ghost_ids]
+    LOGGER.info(
+        "Removed %d ghost player config(s) left behind by this server's own "
+        "AirPlay Receiver instances",
+        len(ghost_ids),
     )
     return True
 

--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -158,7 +158,7 @@ async def migrate(data: dict[str, Any]) -> bool:  # noqa: PLR0915
 
     # Drop ghost players that were discovered from this server's own AirPlay Receiver
     # (shairport-sync) advertisements before discovery learned to filter them out.
-    # TODO: remove after 2.11 release
+    # TODO: remove after 2.10 release
     if _migrate_airplay_receiver_ghost_players(data):
         changed = True
 

--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -616,7 +616,9 @@ def _migrate_airplay_receiver_ghost_players(data: dict[str, Any]) -> bool:
     # the Sendspin bridge of such a ghost registered under "<name> (AirPlay)"
     bridge_names = {f"{name} (AirPlay)" for name in receiver_names}
 
-    ghost_ids: set[str] = set()
+    # First identify the ghost protocol endpoints: the discovered AirPlay player and
+    # its Sendspin bridge, each matched by its own advertised (receiver) name.
+    endpoint_ghost_ids: set[str] = set()
     for player_id, player_cfg in all_player_configs.items():
         if not isinstance(player_cfg, dict):
             continue
@@ -627,19 +629,26 @@ def _migrate_airplay_receiver_ghost_players(data: dict[str, Any]) -> bool:
         ) or (
             player_id.startswith("spb_") and provider == "sendspin" and default_name in bridge_names
         ):
-            ghost_ids.add(player_id)
-        elif (
+            endpoint_ghost_ids.add(player_id)
+
+    # Then add the universal player wrappers that exclusively wrap those endpoints.
+    # A wrapper is only removed when it links at least one confirmed ghost endpoint
+    # and nothing else, so a real player that merely shares the receiver name (with
+    # no or different linked protocols) is never deleted.
+    ghost_ids = set(endpoint_ghost_ids)
+    for player_id, player_cfg in all_player_configs.items():
+        if not isinstance(player_cfg, dict):
+            continue
+        if not (
             player_id.startswith("up")
-            and provider == "universal_player"
-            and default_name in receiver_names | bridge_names
+            and player_cfg.get("provider") == "universal_player"
+            and player_cfg.get("default_name") in receiver_names | bridge_names
         ):
-            values = player_cfg.get("values")
-            linked = values.get(CONF_LINKED_PROTOCOL_IDS) if isinstance(values, dict) else None
-            # only remove wrappers that exclusively wrap such ghost endpoints
-            if not isinstance(linked, list) or all(
-                isinstance(pid, str) and pid.startswith(("ap", "spb_")) for pid in linked
-            ):
-                ghost_ids.add(player_id)
+            continue
+        values = player_cfg.get("values")
+        linked = values.get(CONF_LINKED_PROTOCOL_IDS) if isinstance(values, dict) else None
+        if isinstance(linked, list) and linked and all(pid in endpoint_ghost_ids for pid in linked):
+            ghost_ids.add(player_id)
     if not ghost_ids:
         return False
 

--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -600,11 +600,16 @@ def _migrate_airplay_receiver_ghost_players(data: dict[str, Any]) -> bool:
     all_player_configs = data.get(CONF_PLAYERS, {})
     if not isinstance(all_provider_configs, dict) or not isinstance(all_player_configs, dict):
         return False
-    # the advertised name of every configured receiver instance
-    # (key and default mirror the airplay_receiver provider's config entry)
+    # the advertised name of every enabled receiver instance
+    # (key and default mirror the airplay_receiver provider's config entry).
+    # Disabled instances are skipped, consistent with the discovery filter: they
+    # run no daemon and cannot have produced the ghosts, so their name is too weak
+    # a signal to delete a config on (it could be a legitimate same-named device).
     receiver_names: set[str] = set()
     for provider_cfg in all_provider_configs.values():
         if not isinstance(provider_cfg, dict) or provider_cfg.get("domain") != "airplay_receiver":
+            continue
+        if not provider_cfg.get("enabled", True):
             continue
         provider_values = provider_cfg.get("values")
         airplay_name = (

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -8,18 +8,24 @@ import json
 import socket
 import time
 from contextlib import suppress
-from ipaddress import ip_address
+from ipaddress import IPv4Address, IPv6Address, ip_address
 from typing import Final, cast
 
 from music_assistant_models.enums import PlaybackState
 from zeroconf import ServiceStateChange
 from zeroconf.asyncio import AsyncServiceInfo
 
-from music_assistant.constants import CONF_PLAYERS, CONF_SYNC_ADJUST, VERBOSE_LOG_LEVEL
+from music_assistant.constants import (
+    CONF_PLAYERS,
+    CONF_PROVIDERS,
+    CONF_SYNC_ADJUST,
+    VERBOSE_LOG_LEVEL,
+)
 from music_assistant.helpers.datetime import utc
 from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.process import AsyncProcess
 from music_assistant.helpers.util import (
+    get_ip_addresses,
     get_ip_pton,
     get_primary_ip_address_from_zeroconf,
     select_free_port,
@@ -302,6 +308,14 @@ class AirPlayProvider(PlayerProvider):
         if not self.mass.config.get_raw_player_config_value(player_id, "enabled", True):
             self.logger.debug("Ignoring %s in discovery as it is disabled.", display_name)
             return
+        # Filter out this server's own AirPlay Receiver (shairport-sync) instances
+        # before anything else: they must never register as AirPlay players.
+        if await self._is_own_airplay_receiver(display_name, discovery_info):
+            self.logger.debug(
+                "Ignoring %s in discovery: it is an AirPlay Receiver instance of this server",
+                display_name,
+            )
+            return
         raop_discovery_info: AsyncServiceInfo | None = None
         airplay_discovery_info: AsyncServiceInfo | None = None
         if discovery_info.type == RAOP_DISCOVERY_TYPE:
@@ -331,24 +345,6 @@ class AirPlayProvider(PlayerProvider):
         address = get_primary_ip_address_from_zeroconf(discovery_info, prefer_ipv6=prefer_ipv6)
         if not address:
             return  # should not happen, but guard just in case
-
-        # Filter out shairport-sync instances running on THIS Music Assistant server
-        # These are managed by the AirPlay Receiver provider, not the AirPlay provider
-        # We check both model name AND that it's a local address to avoid filtering
-        # shairport-sync instances running on other machines
-        if model == "ShairportSync":
-            # Check if this is a local address (loopback or matches our server's IP)
-            if ip_address(address).is_loopback or address == self.mass.streams.publish_ip:
-                # Only filter if the port matches one of MA's own AirPlay Receiver instances.
-                # This allows user-configured shairport-sync instances on the same machine
-                # to be used as AirPlay players (e.g., multiple audio outputs via shairport-sync).
-                receiver_ports = {
-                    port
-                    for prov in self.mass.get_provider_instances("airplay_receiver")
-                    if (port := getattr(prov, "airplay_port", None)) is not None
-                }
-                if discovery_info.port in receiver_ports:
-                    return
 
         # if we reach this point, all preflights are ok and we can create the player
         self.logger.debug("Discovered AirPlay device %s on %s", display_name, address)
@@ -437,6 +433,69 @@ class AirPlayProvider(PlayerProvider):
 
         # Set up Sendspin bridge for protocol linking (if Sendspin provider is available)
         await self._bridge_manager.evaluate_bridge(player)
+
+    async def _is_own_airplay_receiver(
+        self, display_name: str, discovery_info: AsyncServiceInfo
+    ) -> bool:
+        """
+        Return whether a discovered service is an AirPlay Receiver instance of this server.
+
+        :param display_name: The advertised device name (mdns name without any id prefix).
+        :param discovery_info: The mdns service info that triggered the discovery.
+        """
+        from music_assistant.providers.airplay_receiver import (  # noqa: PLC0415
+            CONF_AIRPLAY_NAME,
+            DEFAULT_AIRPLAY_NAME,
+            airplay_receiver_port,
+        )
+
+        # Collect the advertised names and ports of all configured AirPlay Receiver
+        # instances from raw config storage: this works regardless of provider load
+        # order at boot, when the receiver instances may not be running yet.
+        receiver_names: set[str] = set()
+        receiver_ports: set[int] = set()
+        for instance_id, raw_conf in self.mass.config.get(CONF_PROVIDERS, {}).items():
+            if not isinstance(raw_conf, dict) or raw_conf.get("domain") != "airplay_receiver":
+                continue
+            if not raw_conf.get("enabled", True):
+                continue
+            values = raw_conf.get("values")
+            airplay_name = values.get(CONF_AIRPLAY_NAME) if isinstance(values, dict) else None
+            receiver_names.add(str(airplay_name) if airplay_name else DEFAULT_AIRPLAY_NAME)
+            receiver_ports.add(airplay_receiver_port(str(instance_id)))
+        # running instances are authoritative for the actual daemon ports
+        for prov in self.mass.get_provider_instances("airplay_receiver"):
+            if (port := getattr(prov, "airplay_port", None)) is not None:
+                receiver_ports.add(port)
+        if not receiver_names and not receiver_ports:
+            return False
+
+        # The advertisement must originate from this host. shairport-sync's embedded
+        # mDNS responder announces address records for every host interface and which
+        # one resolves (first) is undefined, so match the full advertised address set
+        # against all of this host's addresses instead of a single picked address.
+        advertised_ips: set[IPv4Address | IPv6Address] = set()
+        for value in discovery_info.parsed_addresses():
+            with suppress(ValueError):
+                advertised_ips.add(ip_address(value))
+        if not advertised_ips:
+            return False
+        if not any(advertised_ip.is_loopback for advertised_ip in advertised_ips):
+            host_ips: set[IPv4Address | IPv6Address] = set()
+            for value in await get_ip_addresses(include_ipv6=True):
+                with suppress(ValueError):
+                    host_ips.add(ip_address(value))
+            if advertised_ips.isdisjoint(host_ips):
+                return False
+
+        # Match by advertised name (robust even when the TXT record did not resolve).
+        if display_name in receiver_names:
+            return True
+        # Match by port, gated on the shairport-sync model so user-run AirPlay
+        # receivers on this machine (e.g. the macOS built-in receiver, which also
+        # listens on port 7000) remain usable as players when their name differs.
+        _, model = get_model_info(discovery_info)
+        return model == "ShairportSync" and discovery_info.port in receiver_ports
 
     async def _handle_companion_service_state_change(
         self,

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
 
 CONF_MASS_PLAYER_ID = "mass_player_id"
 CONF_AIRPLAY_NAME = "airplay_name"
+DEFAULT_AIRPLAY_NAME = "Music Assistant"
 
 # Special value for auto player selection
 PLAYER_ID_AUTO = "__auto__"
@@ -70,6 +71,19 @@ SUPPORTED_FEATURES = {ProviderFeature.AUDIO_SOURCE}
 # stable id for the single AudioSource this provider exposes;
 # combined with the provider instance_id this forms the persistent uri
 AUDIO_SOURCE_ID = "main"
+
+
+def airplay_receiver_port(instance_id: str) -> int:
+    """
+    Return the AirPlay port used by a receiver instance.
+
+    Deterministically derived from the instance id, so it stays the same across
+    server restarts (Python's built-in ``hash()`` is salted per process).
+
+    :param instance_id: The provider instance id of the AirPlay receiver.
+    """
+    digest = hashlib.md5(instance_id.encode(), usedforsecurity=False).hexdigest()
+    return 7000 + int(digest, 16) % 1000
 
 
 async def setup(
@@ -113,7 +127,7 @@ async def get_config_entries(
         ConfigEntry(
             key=CONF_AIRPLAY_NAME,
             type=ConfigEntryType.STRING,
-            default_value="Music Assistant",
+            default_value=DEFAULT_AIRPLAY_NAME,
         ),
     )
 
@@ -143,9 +157,10 @@ class AirPlayReceiverProvider(PluginProvider):
         self.audio_pipe = AsyncNamedPipeWriter(audio_pipe_path)
         self.metadata_pipe = AsyncNamedPipeWriter(metadata_pipe_path)
         self.config_file = f"/tmp/ma_shairport_sync_{self.instance_id}.conf"  # noqa: S108
-        # Use port 7000+ for AirPlay 2 compatibility
-        # Each instance gets a unique port: 7000, 7001, 7002, etc.
-        self.airplay_port = 7000 + (hash(self.instance_id) % 1000)
+        # Use port 7000+ for AirPlay 2 compatibility, one unique port per instance.
+        # The port must be stable across restarts: the AirPlay provider uses it to
+        # recognize (and ignore) our own shairport-sync advertisement in discovery.
+        self.airplay_port = airplay_receiver_port(self.instance_id)
         airplay_name = cast("str", self.config.get_value(CONF_AIRPLAY_NAME)) or self.name
         # _audio_format describes the original AirPlay source (ALAC at 44.1/16,
         # the protocol-native format AirPlay senders use) and is what we

--- a/tests/controllers/config/test_migrations.py
+++ b/tests/controllers/config/test_migrations.py
@@ -2,7 +2,10 @@
 
 from typing import Any
 
-from music_assistant.controllers.config.migrations import _migrate_output_limiter
+from music_assistant.controllers.config.migrations import (
+    _migrate_airplay_receiver_ghost_players,
+    _migrate_output_limiter,
+)
 
 
 def test_migrate_output_limiter_drops_stored_values() -> None:
@@ -24,3 +27,123 @@ def test_migrate_output_limiter_noop_when_absent() -> None:
     """Migration reports no change when no player stored the setting."""
     data: dict[str, Any] = {"players": {"p1": {"player_id": "p1", "values": {"flow_mode": True}}}}
     assert _migrate_output_limiter(data) is False
+
+
+def _airplay_receiver_ghost_data() -> dict[str, Any]:
+    """Build a config store with AirPlay Receiver ghost players next to real players."""
+    return {
+        "providers": {
+            "airplay_receiver--abc1": {
+                "domain": "airplay_receiver",
+                "instance_id": "airplay_receiver--abc1",
+                "values": {"airplay_name": "Garage [AirPlay]"},
+            },
+            "airplay": {"domain": "airplay", "instance_id": "airplay", "values": {}},
+        },
+        "players": {
+            # ghosts of the receiver: airplay player + sendspin bridge + universal wrapper
+            "ap41cf0e23916f": {
+                "player_id": "ap41cf0e23916f",
+                "provider": "airplay",
+                "default_name": "Garage [AirPlay]",
+                "values": {},
+            },
+            "spb_41cf0e23916f": {
+                "player_id": "spb_41cf0e23916f",
+                "provider": "sendspin",
+                "default_name": "Garage [AirPlay] (AirPlay)",
+                "values": {},
+            },
+            "up41cf0e23916f": {
+                "player_id": "up41cf0e23916f",
+                "provider": "universal_player",
+                "default_name": "Garage [AirPlay]",
+                "values": {"linked_protocol_ids": ["ap41cf0e23916f", "spb_41cf0e23916f"]},
+            },
+            # a real airplay player with another name must be kept
+            "apaabbccddeeff": {
+                "player_id": "apaabbccddeeff",
+                "provider": "airplay",
+                "default_name": "Kitchen",
+                "values": {},
+            },
+            # a universal player with a matching name wrapping a native (non-ghost)
+            # protocol player must be kept
+            "up10b41dc887f8": {
+                "player_id": "up10b41dc887f8",
+                "provider": "universal_player",
+                "default_name": "Garage [AirPlay]",
+                "values": {"linked_protocol_ids": ["10:B4:1D:C8:87:F8", "spb_10b41dc887f8"]},
+            },
+            # a group referencing a ghost keeps its other members
+            "syncgroup1": {
+                "player_id": "syncgroup1",
+                "provider": "sync_group",
+                "default_name": "All Speakers",
+                "values": {"group_members": ["up41cf0e23916f", "apaabbccddeeff"]},
+            },
+        },
+        "player_queues": {"up41cf0e23916f": {"queue_id": "up41cf0e23916f"}},
+        "player_dsp": {"up41cf0e23916f": {"enabled": True}},
+    }
+
+
+def test_migrate_airplay_receiver_ghosts_removes_matching_players() -> None:
+    """Ghost ap/spb/up players of an own receiver are removed with their leftover state."""
+    data = _airplay_receiver_ghost_data()
+
+    assert _migrate_airplay_receiver_ghost_players(data) is True
+
+    players = data["players"]
+    assert "ap41cf0e23916f" not in players
+    assert "spb_41cf0e23916f" not in players
+    assert "up41cf0e23916f" not in players
+    # real players survive, including the same-name wrapper of a native player
+    assert "apaabbccddeeff" in players
+    assert "up10b41dc887f8" in players
+    # ghost references are stripped from group membership and per-player state trees
+    assert players["syncgroup1"]["values"]["group_members"] == ["apaabbccddeeff"]
+    assert data["player_queues"] == {}
+    assert data["player_dsp"] == {}
+
+
+def test_migrate_airplay_receiver_ghosts_uses_default_name() -> None:
+    """A receiver without an explicit airplay_name matches ghosts of the default name."""
+    data: dict[str, Any] = {
+        "providers": {
+            "airplay_receiver--abc1": {
+                "domain": "airplay_receiver",
+                "instance_id": "airplay_receiver--abc1",
+                "values": {},
+            },
+        },
+        "players": {
+            "apdb1ff0aae80e": {
+                "player_id": "apdb1ff0aae80e",
+                "provider": "airplay",
+                "default_name": "Music Assistant",
+                "values": {},
+            },
+        },
+    }
+
+    assert _migrate_airplay_receiver_ghost_players(data) is True
+    assert data["players"] == {}
+
+
+def test_migrate_airplay_receiver_ghosts_noop_without_receivers() -> None:
+    """Without configured receiver instances no player config is touched."""
+    data: dict[str, Any] = {
+        "providers": {"airplay": {"domain": "airplay", "instance_id": "airplay", "values": {}}},
+        "players": {
+            "apdb1ff0aae80e": {
+                "player_id": "apdb1ff0aae80e",
+                "provider": "airplay",
+                "default_name": "Music Assistant",
+                "values": {},
+            },
+        },
+    }
+
+    assert _migrate_airplay_receiver_ghost_players(data) is False
+    assert "apdb1ff0aae80e" in data["players"]

--- a/tests/controllers/config/test_migrations.py
+++ b/tests/controllers/config/test_migrations.py
@@ -131,6 +131,45 @@ def test_migrate_airplay_receiver_ghosts_uses_default_name() -> None:
     assert data["players"] == {}
 
 
+def test_migrate_airplay_receiver_ghosts_keeps_same_name_wrapper_without_ghost_links() -> None:
+    """A wrapper sharing the receiver name is kept unless it links only ghost endpoints."""
+    data: dict[str, Any] = {
+        "providers": {
+            "airplay_receiver--abc1": {
+                "domain": "airplay_receiver",
+                "instance_id": "airplay_receiver--abc1",
+                "values": {"airplay_name": "Garage [AirPlay]"},
+            },
+        },
+        "players": {
+            # empty linked list: must NOT be deleted (all([]) is True)
+            "upemptylinks": {
+                "player_id": "upemptylinks",
+                "provider": "universal_player",
+                "default_name": "Garage [AirPlay]",
+                "values": {"linked_protocol_ids": []},
+            },
+            # no linked_protocol_ids at all: must NOT be deleted
+            "upnolinks": {
+                "player_id": "upnolinks",
+                "provider": "universal_player",
+                "default_name": "Garage [AirPlay]",
+                "values": {},
+            },
+            # links a native (non-ghost) protocol player: must NOT be deleted
+            "upnative": {
+                "player_id": "upnative",
+                "provider": "universal_player",
+                "default_name": "Garage [AirPlay]",
+                "values": {"linked_protocol_ids": ["spb_10b41dc887f8"]},
+            },
+        },
+    }
+
+    assert _migrate_airplay_receiver_ghost_players(data) is False
+    assert set(data["players"]) == {"upemptylinks", "upnolinks", "upnative"}
+
+
 def test_migrate_airplay_receiver_ghosts_noop_without_receivers() -> None:
     """Without configured receiver instances no player config is touched."""
     data: dict[str, Any] = {

--- a/tests/controllers/config/test_migrations.py
+++ b/tests/controllers/config/test_migrations.py
@@ -170,6 +170,31 @@ def test_migrate_airplay_receiver_ghosts_keeps_same_name_wrapper_without_ghost_l
     assert set(data["players"]) == {"upemptylinks", "upnolinks", "upnative"}
 
 
+def test_migrate_airplay_receiver_ghosts_ignores_disabled_receiver() -> None:
+    """A disabled receiver's name is not used, so same-named players are kept."""
+    data: dict[str, Any] = {
+        "providers": {
+            "airplay_receiver--abc1": {
+                "domain": "airplay_receiver",
+                "instance_id": "airplay_receiver--abc1",
+                "enabled": False,
+                "values": {"airplay_name": "Garage [AirPlay]"},
+            },
+        },
+        "players": {
+            "ap41cf0e23916f": {
+                "player_id": "ap41cf0e23916f",
+                "provider": "airplay",
+                "default_name": "Garage [AirPlay]",
+                "values": {},
+            },
+        },
+    }
+
+    assert _migrate_airplay_receiver_ghost_players(data) is False
+    assert "ap41cf0e23916f" in data["players"]
+
+
 def test_migrate_airplay_receiver_ghosts_noop_without_receivers() -> None:
     """Without configured receiver instances no player config is touched."""
     data: dict[str, Any] = {

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import time
+from contextlib import AbstractContextManager
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
@@ -19,6 +20,7 @@ from music_assistant.providers.airplay.player import AirPlayPlayer
 from music_assistant.providers.airplay.provider import AirPlayProvider
 from music_assistant.providers.airplay.stream import AirPlayStream
 from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
+from music_assistant.providers.airplay_receiver import airplay_receiver_port
 
 INSTANCE_ID = "airplay"
 START_UNIX_MS = 1_750_000_000_000
@@ -593,3 +595,175 @@ async def test_build_cli_args_none_falls_back_to_daemon_liveness() -> None:
     assert "--ptp-shared" not in await _build_args(
         _stream_player(ptp_daemon_running=False), use_shared_ptp=None
     )
+
+
+# --- Own AirPlay Receiver filtering in discovery -------------------------------
+
+RECEIVER_INSTANCE_ID = "airplay_receiver--test1234"
+HOST_IPS = ("192.168.1.10", "172.30.32.1")
+
+
+def _receiver_filter_provider(
+    provider_configs: dict[str, dict[str, object]],
+    receiver_instances: tuple[MagicMock, ...] = (),
+) -> AirPlayProvider:
+    """Build a bare provider wired to raw provider configs and running receiver instances."""
+    prov = AirPlayProvider.__new__(AirPlayProvider)
+    prov.mass = MagicMock()
+    prov.logger = logging.getLogger("test.airplay.provider")
+    prov.mass.config.get.return_value = provider_configs
+    prov.mass.get_provider_instances.return_value = list(receiver_instances)
+    return prov
+
+
+def _receiver_config(
+    airplay_name: str | None = "Garage [AirPlay]", enabled: bool = True
+) -> dict[str, dict[str, object]]:
+    """Build the raw provider config store with a single AirPlay Receiver instance."""
+    values: dict[str, object] = {"airplay_name": airplay_name} if airplay_name else {}
+    return {
+        RECEIVER_INSTANCE_ID: {
+            "domain": "airplay_receiver",
+            "instance_id": RECEIVER_INSTANCE_ID,
+            "enabled": enabled,
+            "values": values,
+        },
+        "spotify": {"domain": "spotify", "instance_id": "spotify", "values": {}},
+    }
+
+
+def _discovery_info(
+    addresses: list[str],
+    port: int | None = 7123,
+    properties: dict[str, str] | None = None,
+) -> MagicMock:
+    """Build a minimal mdns service info stand-in for the receiver filter."""
+    info = MagicMock()
+    info.parsed_addresses.return_value = addresses
+    info.port = port
+    info.decoded_properties = properties or {}
+    return info
+
+
+def _patch_host_ips() -> AbstractContextManager[AsyncMock]:
+    """Patch the host IP enumeration used by the receiver filter."""
+    return patch(
+        "music_assistant.providers.airplay.provider.get_ip_addresses",
+        AsyncMock(return_value=HOST_IPS),
+    )
+
+
+async def test_own_receiver_filtered_by_name_without_txt_record() -> None:
+    """A host-local advertisement matching a receiver name is ours, even without TXT data."""
+    prov = _receiver_filter_provider(_receiver_config())
+    # advertised via a secondary host interface (e.g. a docker bridge) and
+    # with an unresolved TXT record - both must not defeat the filter
+    info = _discovery_info(["172.30.32.1"], port=9999)
+
+    with _patch_host_ips():
+        assert await prov._is_own_airplay_receiver("Garage [AirPlay]", info) is True
+
+
+async def test_own_receiver_filtered_with_default_name() -> None:
+    """A receiver instance without an explicit name advertises the default name."""
+    prov = _receiver_filter_provider(_receiver_config(airplay_name=None))
+    info = _discovery_info(["192.168.1.10"])
+
+    with _patch_host_ips():
+        assert await prov._is_own_airplay_receiver("Music Assistant", info) is True
+
+
+async def test_own_receiver_filtered_on_loopback() -> None:
+    """A loopback advertisement matching a receiver name is filtered without host IP probing."""
+    prov = _receiver_filter_provider(_receiver_config())
+    info = _discovery_info(["127.0.0.1"])
+
+    assert await prov._is_own_airplay_receiver("Garage [AirPlay]", info) is True
+
+
+async def test_own_receiver_filtered_by_port_and_model() -> None:
+    """A host-local ShairportSync advertisement on a receiver port is ours, any name."""
+    prov = _receiver_filter_provider(_receiver_config())
+    info = _discovery_info(
+        ["192.168.1.10"],
+        port=airplay_receiver_port(RECEIVER_INSTANCE_ID),
+        properties={"am": "ShairportSync"},
+    )
+
+    with _patch_host_ips():
+        assert await prov._is_own_airplay_receiver("Renamed Receiver", info) is True
+
+
+async def test_own_receiver_filtered_by_running_instance_port() -> None:
+    """The port of a running receiver instance is honoured next to the derived ports."""
+    receiver = MagicMock()
+    receiver.airplay_port = 7555
+    prov = _receiver_filter_provider(_receiver_config(), receiver_instances=(receiver,))
+    info = _discovery_info(["192.168.1.10"], port=7555, properties={"am": "ShairportSync"})
+
+    with _patch_host_ips():
+        assert await prov._is_own_airplay_receiver("Renamed Receiver", info) is True
+
+
+async def test_same_name_receiver_on_other_host_not_filtered() -> None:
+    """A device with a matching name on another host must not be filtered."""
+    prov = _receiver_filter_provider(_receiver_config())
+    info = _discovery_info(["192.168.1.55"], properties={"am": "ShairportSync"})
+
+    with _patch_host_ips():
+        assert await prov._is_own_airplay_receiver("Garage [AirPlay]", info) is False
+
+
+async def test_user_shairport_on_same_host_not_filtered() -> None:
+    """A user-run shairport-sync on this host with its own name and port stays usable."""
+    prov = _receiver_filter_provider(_receiver_config())
+    info = _discovery_info(["192.168.1.10"], port=5000, properties={"am": "ShairportSync"})
+
+    with _patch_host_ips():
+        assert await prov._is_own_airplay_receiver("My Shairport", info) is False
+
+
+async def test_local_receiver_with_other_model_not_filtered_on_port_collision() -> None:
+    """A non-shairport local receiver is kept even when its port collides (e.g. macOS on 7000)."""
+    receiver = MagicMock()
+    receiver.airplay_port = 7000
+    prov = _receiver_filter_provider(_receiver_config(), receiver_instances=(receiver,))
+    info = _discovery_info(["192.168.1.10"], port=7000, properties={"am": "MacBookAir10,1"})
+
+    with _patch_host_ips():
+        assert await prov._is_own_airplay_receiver("Marcel's MacBook Air", info) is False
+
+
+async def test_disabled_receiver_config_not_filtered() -> None:
+    """A disabled receiver instance cannot be advertising, so its identity is ignored."""
+    prov = _receiver_filter_provider(_receiver_config(enabled=False))
+    info = _discovery_info(["192.168.1.10"])
+
+    with _patch_host_ips():
+        assert await prov._is_own_airplay_receiver("Garage [AirPlay]", info) is False
+
+
+async def test_no_receiver_configs_never_filters() -> None:
+    """Without any configured receiver instance the filter is a no-op."""
+    prov = _receiver_filter_provider(
+        {"spotify": {"domain": "spotify", "instance_id": "spotify", "values": {}}}
+    )
+    info = _discovery_info(["192.168.1.10"], properties={"am": "ShairportSync"})
+
+    assert await prov._is_own_airplay_receiver("Garage [AirPlay]", info) is False
+
+
+async def test_setup_player_skips_own_receiver_before_service_lookup() -> None:
+    """Discovery setup bails out on own receivers before any counterpart service lookup."""
+    prov = AirPlayProvider.__new__(AirPlayProvider)
+    prov.mass = MagicMock()
+    prov.logger = logging.getLogger("test.airplay.provider")
+    prov.mass.config.get_raw_player_config_value.return_value = True
+    prov._is_own_airplay_receiver = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    info = _discovery_info(["192.168.1.10"])
+    info.type = "_raop._tcp.local."
+
+    await prov._setup_player("apdb1ff0aae80e", "Garage [AirPlay]", info)
+
+    prov.mass.discovery.async_find_mdns_service.assert_not_called()
+    prov.mass.players.register.assert_not_called()

--- a/tests/providers/airplay_receiver/test_provider.py
+++ b/tests/providers/airplay_receiver/test_provider.py
@@ -1,0 +1,18 @@
+"""Unit tests for the AirPlay Receiver provider (deterministic AirPlay port)."""
+
+from music_assistant.providers.airplay_receiver import airplay_receiver_port
+
+
+def test_airplay_receiver_port_is_deterministic() -> None:
+    """The port derivation must be stable across processes/restarts (unlike ``hash()``)."""
+    # pinned expectations guard against accidental changes to the derivation:
+    # the AirPlay provider relies on reproducing these ports from config alone
+    assert airplay_receiver_port("airplay_receiver--test1234") == 7745
+    assert airplay_receiver_port("airplay_receiver--aabbccdd") == 7038
+
+
+def test_airplay_receiver_port_stays_in_expected_range() -> None:
+    """Derived ports stay within the 7000-7999 AirPlay range for any instance id."""
+    for index in range(50):
+        port = airplay_receiver_port(f"airplay_receiver--instance{index}")
+        assert 7000 <= port <= 7999


### PR DESCRIPTION
# What does this implement/fix?

Music Assistant could discover its own AirPlay Receiver instances as regular AirPlay players. Because the receiver announces itself with a new device id on (almost) every restart, each restart could add another permanently unavailable duplicate player - leaving users with a growing pile of "ghost" players.

- Discovery now reliably recognizes the server's own AirPlay receivers (by their configured name and port, on this host's addresses) and skips them
- The receiver's AirPlay port is now stable across restarts
- A config migration cleans up the ghost players (and their leftover settings) created by earlier versions
- shairport-sync instances the user runs themselves, on this or another machine, remain usable as players

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5771

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
