### PR TITLE
Release the active output protocol when a wrapped player's session ends

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -127,6 +127,7 @@ if TYPE_CHECKING:
         CoreConfig,
         PlayerConfig,
     )
+    from music_assistant_models.player import OutputProtocol
     from music_assistant_models.player_queue import PlayerQueue
 
     from music_assistant import MusicAssistant
@@ -3891,12 +3892,18 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             player.set_active_mass_source(media.source_id)
 
         # Determine output protocol to use:
-        # If player already has an active protocol set, prefer that.
-        # Otherwise, select best protocol based on current state.
+        # While a session is active (playing/paused), keep using the already active
+        # protocol so mid-session commands stay on the same output.
+        # On a fresh start always (re)select: a leftover active protocol from a
+        # previous session must not overrule user preference, a grouped protocol
+        # or native playback (and it may point at a player that is gone by now).
+        target_player: Player | None = None
+        output_protocol: OutputProtocol | None = None
         if (
-            player.active_output_protocol
+            player.state.playback_state in (PlaybackState.PLAYING, PlaybackState.PAUSED)
+            and player.active_output_protocol
             and player.active_output_protocol != "native"
-            and (target_player := self.get_player(player.active_output_protocol))
+            and (protocol_player := self.get_player(player.active_output_protocol))
         ):
             # Use the already-set protocol directly
             output_protocol = next(
@@ -3907,7 +3914,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 ),
                 None,
             )
-        else:
+            if output_protocol is not None:
+                target_player = protocol_player
+        if target_player is None:
             target_player, output_protocol = self._select_best_output_protocol(player)
 
         if target_player.player_id != player.player_id:
@@ -4046,16 +4055,25 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         """
         player = self.get_player(player_id, raise_unavailable=True)
         assert player is not None
+        protocol_player: Player | None = None
+        if player.active_output_protocol and player.active_output_protocol != "native":
+            protocol_player = self.get_player(player.active_output_protocol)
         if player.state.playback_state == PlaybackState.IDLE:
+            # The player already reports idle but an output protocol is still marked
+            # active: the protocol player may never have received a stop at all
+            # (e.g. the source stream ended on its own before this stop command
+            # arrived). Forward an (idempotent) stop and schedule the protocol clear
+            # so no stale session lingers on the device and the next playback
+            # (re)selects the output protocol.
+            if protocol_player is not None:
+                await protocol_player.stop()
+                if len(protocol_player.group_members) <= 1:
+                    self.schedule_active_output_protocol_clear(player)
             return
         player.mark_stop_called()
         # Delegate to active protocol player if one is active
         target_player = player
-        if (
-            player.active_output_protocol
-            and player.active_output_protocol != "native"
-            and (protocol_player := self.get_player(player.active_output_protocol))
-        ):
+        if protocol_player is not None:
             target_player = protocol_player
             if PlayerFeature.POWER in target_player.supported_features:
                 # if protocol player supports/requires power,

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -33,7 +33,6 @@ from music_assistant_models.enums import (
 from music_assistant_models.errors import (
     AudioError,
     MediaNotFoundError,
-    PlayerCommandFailed,
     UnsupportedFeaturedException,
 )
 from music_assistant_models.media_items import (
@@ -729,12 +728,20 @@ class AirPlayReceiverProvider(PluginProvider):
 
     async def _start_playback(self, target_player_id: str) -> None:
         """Start playback after any pending stop completes."""
-        if self._pending_stop_task and not self._pending_stop_task.done():
+        pending_stop_task = self._pending_stop_task
+        if pending_stop_task is not None:
+            # Await (even if already done) so a failed stop's exception is retrieved,
+            # and continue regardless of how it failed: a stop that can't complete must
+            # not keep the next session from starting. The reference is cleared only
+            # after the await so concurrent starts (rapid "playing" events before the
+            # stream is claimed) all await the same stop instead of racing past it.
             try:
-                await self._pending_stop_task
-            except PlayerCommandFailed as err:
+                await pending_stop_task
+            except Exception as err:
                 self.logger.warning("Failed to stop previous AirPlay playback: %s", err)
-        self._pending_stop_task = None
+            # Don't clear a newer stop that replaced ours while we were awaiting.
+            if self._pending_stop_task is pending_stop_task:
+                self._pending_stop_task = None
         await self.mass.player_queues.play_media(target_player_id, str(self._audio_source.uri))
 
     def _handle_volume_change(self, volume: int) -> None:

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -1053,8 +1053,21 @@ class SendspinPlayer(SendspinBasePlayer):
 
     def _on_group_stopped(self) -> None:
         """Cancel playback session when group stops and we are the leader."""
-        if self.synced_to is None:
-            self.mass.create_task(self.playback_session.cancel("group stopped"))
+        if self.synced_to is not None:
+            return
+        # Bind the cancel to the session task that is live right now: by the time
+        # the deferred task below runs, play_media may already have started a fresh
+        # session, which must not be torn down by this stale group-stopped event.
+        stale_task = self.playback_session.playback_task
+        if stale_task is None or stale_task.done():
+            return
+        self.mass.create_task(self._cancel_stale_playback_session(stale_task))
+
+    async def _cancel_stale_playback_session(self, task: asyncio.Task[None]) -> None:
+        """Cancel the playback session only if the given task is still the active one."""
+        if self.playback_session.playback_task is not task:
+            return
+        await self.playback_session.cancel("group stopped")
 
     def group_event_cb(self, group: SendspinGroup, event: GroupEvent) -> None:
         """Event callback registered to the sendspin group this player belongs to."""

--- a/tests/controllers/players/test_active_protocol_lifecycle.py
+++ b/tests/controllers/players/test_active_protocol_lifecycle.py
@@ -1,0 +1,265 @@
+"""
+Tests for the active output protocol lifecycle in play/stop command handling.
+
+Covers two regressions from support#5771:
+- a leftover ``active_output_protocol`` from a previous session must not be
+  reused on a fresh playback start (it bypassed protocol selection entirely,
+  e.g. a Sonos kept playing via AirPlay after leaving a sync group);
+- a stop command arriving when the player already reports IDLE must still
+  forward the stop to the pinned protocol player and schedule the protocol
+  clear (previously it returned early, leaving a stale session on the device
+  and the protocol pinned forever).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
+from music_assistant_models.player import OutputProtocol, PlayerMedia
+
+from music_assistant.controllers.players import PlayerController
+from tests.common import MockPlayer, MockProvider
+
+
+class PlayableMockPlayer(MockPlayer):
+    """MockPlayer that records play_media calls."""
+
+    def __init__(
+        self,
+        provider: MockProvider,
+        player_id: str,
+        name: str,
+        player_type: PlayerType = PlayerType.PLAYER,
+    ) -> None:
+        """Initialize the mock player with play_media call recording."""
+        super().__init__(provider, player_id, name, player_type=player_type)
+        self.play_media_calls: list[PlayerMedia] = []
+
+    async def play_media(self, media: PlayerMedia) -> None:
+        """Record the play_media call."""
+        self.play_media_calls.append(media)
+
+
+@pytest.fixture
+def mock_mass() -> MagicMock:
+    """Create a mock MusicAssistant instance."""
+    mass = MagicMock()
+    mass.closing = False
+    mass.config = MagicMock()
+    mass.config.get = MagicMock(return_value=[])
+
+    def _get_raw_player_config_value(
+        _player_id: str, key: str, default: str | int | None = None
+    ) -> str | int | None:
+        if key == "min_volume":
+            return 0
+        if key == "max_volume":
+            return 100
+        return default if default is not None else "auto"
+
+    mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw_player_config_value)
+    mass.config.get_raw_core_config_value = MagicMock(return_value="GLOBAL")
+    mass.config.set = MagicMock()
+    mass.signal_event = MagicMock()
+    mass.get_providers = MagicMock(return_value=[])
+    mass.player_queues = MagicMock()
+    mass.player_queues.get = MagicMock(return_value=None)
+    return mass
+
+
+@pytest.fixture
+def controller(mock_mass: MagicMock) -> PlayerController:
+    """Create a PlayerController instance."""
+    ctrl = PlayerController(mock_mass)
+    mock_mass.players = ctrl
+    return ctrl
+
+
+def _make_player_with_protocol(
+    mock_mass: MagicMock,
+    controller: PlayerController,
+    protocol_state: PlaybackState,
+    native_play_media: bool = True,
+) -> tuple[PlayableMockPlayer, PlayableMockPlayer]:
+    """Create a native player with one linked sendspin protocol player."""
+    native_provider = MockProvider("sonos", mass=mock_mass)
+    player = PlayableMockPlayer(native_provider, "player_1", "Test Player")
+    if native_play_media:
+        player._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+
+    protocol_provider = MockProvider("sendspin", mass=mock_mass)
+    protocol_player = PlayableMockPlayer(
+        protocol_provider, "proto_1", "Test Protocol", player_type=PlayerType.PROTOCOL
+    )
+    protocol_player._attr_playback_state = protocol_state
+
+    controller._players = {"player_1": player, "proto_1": protocol_player}
+    player.set_linked_output_protocols(
+        [
+            OutputProtocol(
+                output_protocol_id="proto_1",
+                name="Sendspin",
+                protocol_domain="sendspin",
+                priority=40,
+            )
+        ]
+    )
+    player.set_active_output_protocol("proto_1")
+    protocol_player.update_state(signal_event=False)
+    player.refresh_state(signal_event=False)
+    return player, protocol_player
+
+
+class TestPlayMediaProtocolSelection:
+    """A fresh playback start must re-select instead of reusing a stale protocol."""
+
+    async def test_idle_player_reselects_instead_of_stale_protocol(
+        self, mock_mass: MagicMock, controller: PlayerController
+    ) -> None:
+        """
+        An idle player with a leftover active protocol re-runs selection.
+
+        Regression: a Sonos grouped via AirPlay kept the AirPlay protocol pinned
+        after leaving the group, so the next standalone playback used AirPlay
+        instead of native playback.
+        """
+        player, protocol_player = _make_player_with_protocol(
+            mock_mass, controller, PlaybackState.IDLE
+        )
+        media = PlayerMedia(uri="http://test/stream")
+
+        await controller._handle_play_media("player_1", media)
+
+        assert player.play_media_calls == [media]
+        assert protocol_player.play_media_calls == []
+        assert player.active_output_protocol == "native"
+
+    async def test_playing_player_keeps_active_protocol(
+        self, mock_mass: MagicMock, controller: PlayerController
+    ) -> None:
+        """While a session is active the already-set protocol stays in use."""
+        player, protocol_player = _make_player_with_protocol(
+            mock_mass, controller, PlaybackState.PLAYING
+        )
+        media = PlayerMedia(uri="http://test/stream")
+
+        await controller._handle_play_media("player_1", media)
+
+        assert protocol_player.play_media_calls == [media]
+        assert player.play_media_calls == []
+        assert player.active_output_protocol == "proto_1"
+
+    async def test_unlinked_active_protocol_falls_back_to_selection(
+        self, mock_mass: MagicMock, controller: PlayerController
+    ) -> None:
+        """An active protocol that is no longer linked falls back to selection."""
+        player, protocol_player = _make_player_with_protocol(
+            mock_mass, controller, PlaybackState.PLAYING
+        )
+        # simulate the protocol link being removed while the id stays pinned
+        player.set_linked_output_protocols([])
+        player.refresh_state(signal_event=False)
+        media = PlayerMedia(uri="http://test/stream")
+
+        await controller._handle_play_media("player_1", media)
+
+        assert player.play_media_calls == [media]
+        assert protocol_player.play_media_calls == []
+        assert player.active_output_protocol == "native"
+
+    async def test_idle_player_reselects_best_protocol_without_native(
+        self, mock_mass: MagicMock, controller: PlayerController
+    ) -> None:
+        """Without native playback, re-selection picks the best protocol again."""
+        player, protocol_player = _make_player_with_protocol(
+            mock_mass, controller, PlaybackState.IDLE, native_play_media=False
+        )
+        media = PlayerMedia(uri="http://test/stream")
+
+        await controller._handle_play_media("player_1", media)
+
+        assert protocol_player.play_media_calls == [media]
+        assert player.play_media_calls == []
+        assert player.active_output_protocol == "proto_1"
+
+
+class TestCmdStopWithPinnedProtocol:
+    """Stop on an already-idle player must still release the pinned protocol."""
+
+    async def test_idle_stop_forwards_to_pinned_protocol(
+        self, mock_mass: MagicMock, controller: PlayerController
+    ) -> None:
+        """
+        Stop on an idle player with a pinned protocol stops the protocol player.
+
+        Regression: when the source stream ended on its own before the stop
+        command arrived, the early idle-return skipped the protocol stop, so the
+        device kept a stale session (reported "playing" while silent) and the
+        protocol stayed pinned forever.
+        """
+        player, protocol_player = _make_player_with_protocol(
+            mock_mass, controller, PlaybackState.IDLE
+        )
+        protocol_player.stop = AsyncMock()  # type: ignore[method-assign]
+        player.stop = AsyncMock()  # type: ignore[method-assign]
+        controller.schedule_active_output_protocol_clear = MagicMock()  # type: ignore[method-assign]
+
+        await controller._handle_cmd_stop("player_1")
+
+        protocol_player.stop.assert_awaited_once()
+        player.stop.assert_not_awaited()
+        controller.schedule_active_output_protocol_clear.assert_called_once_with(player)
+
+    async def test_idle_stop_without_pinned_protocol_is_noop(
+        self, mock_mass: MagicMock, controller: PlayerController
+    ) -> None:
+        """Stop on an idle player without an active protocol does nothing."""
+        player, protocol_player = _make_player_with_protocol(
+            mock_mass, controller, PlaybackState.IDLE
+        )
+        player.set_active_output_protocol(None)
+        player.refresh_state(signal_event=False)
+        protocol_player.stop = AsyncMock()  # type: ignore[method-assign]
+        player.stop = AsyncMock()  # type: ignore[method-assign]
+        controller.schedule_active_output_protocol_clear = MagicMock()  # type: ignore[method-assign]
+
+        await controller._handle_cmd_stop("player_1")
+
+        protocol_player.stop.assert_not_awaited()
+        player.stop.assert_not_awaited()
+        controller.schedule_active_output_protocol_clear.assert_not_called()
+
+    async def test_idle_stop_grouped_protocol_keeps_pin(
+        self, mock_mass: MagicMock, controller: PlayerController
+    ) -> None:
+        """A protocol player that still has group members keeps the pin."""
+        _player, protocol_player = _make_player_with_protocol(
+            mock_mass, controller, PlaybackState.IDLE
+        )
+        protocol_player._attr_group_members = ["proto_1", "proto_2"]
+        protocol_player.stop = AsyncMock()  # type: ignore[method-assign]
+        controller.schedule_active_output_protocol_clear = MagicMock()  # type: ignore[method-assign]
+
+        await controller._handle_cmd_stop("player_1")
+
+        protocol_player.stop.assert_awaited_once()
+        controller.schedule_active_output_protocol_clear.assert_not_called()
+
+    async def test_playing_stop_delegates_and_schedules_clear(
+        self, mock_mass: MagicMock, controller: PlayerController
+    ) -> None:
+        """The regular stop path (player playing) is unchanged."""
+        player, protocol_player = _make_player_with_protocol(
+            mock_mass, controller, PlaybackState.PLAYING
+        )
+        protocol_player.stop = AsyncMock()  # type: ignore[method-assign]
+        player.stop = AsyncMock()  # type: ignore[method-assign]
+        controller.schedule_active_output_protocol_clear = MagicMock()  # type: ignore[method-assign]
+
+        await controller._handle_cmd_stop("player_1")
+
+        protocol_player.stop.assert_awaited_once()
+        player.stop.assert_not_awaited()
+        controller.schedule_active_output_protocol_clear.assert_called_once_with(player)

--- a/tests/providers/airplay_receiver/test_stop_play_race.py
+++ b/tests/providers/airplay_receiver/test_stop_play_race.py
@@ -18,7 +18,9 @@ def provider() -> MagicMock:
     mock = MagicMock()
     mock.logger = MagicMock()
     mock._first_volume_event_received = False
-    mock._in_use_by_queue = "queue1"
+    # queue_id == player_id in MA: the stop and the follow-up play target the same
+    # player, which is the same-player reconnect scenario the race can actually break.
+    mock._in_use_by_queue = "player1"
     mock._active_player_id = "player1"
     mock._active_session_id = "session1"
     mock._pending_stop_task = None
@@ -98,3 +100,49 @@ async def test_play_proceeds_when_stop_fails(provider: MagicMock) -> None:
     await asyncio.sleep(0.01)
 
     provider.mass.player_queues.play_media.assert_awaited_once_with("player1", "airplay://source")
+
+
+async def test_play_proceeds_when_stop_fails_unexpectedly(provider: MagicMock) -> None:
+    """An unexpected (non-PlayerCommandFailed) stop error must not abort the new session."""
+    provider.mass.players.cmd_stop = AsyncMock(side_effect=RuntimeError("kaboom"))
+    provider.mass.player_queues.play_media = AsyncMock()
+
+    _handle(provider, "stopped")
+    _handle(provider, "playing")
+    await asyncio.sleep(0.01)
+
+    provider.mass.player_queues.play_media.assert_awaited_once_with("player1", "airplay://source")
+    assert provider._pending_stop_task is None
+
+
+async def test_concurrent_starts_all_wait_for_pending_stop(provider: MagicMock) -> None:
+    """Rapid duplicate starts must all await the pending stop, none racing past it."""
+    events: list[str] = []
+    stop_release = asyncio.Event()
+
+    async def slow_stop() -> None:
+        await stop_release.wait()
+        events.append("stop_done")
+
+    async def play_media(_player_id: str, _media: str) -> None:
+        events.append("play")
+
+    provider._pending_stop_task = asyncio.get_event_loop().create_task(slow_stop())
+    provider.mass.player_queues.play_media = play_media
+
+    # two starts before on_source_selected claims _in_use_by_queue
+    starts = [
+        asyncio.ensure_future(AirPlayReceiverProvider._start_playback(provider, "player1"))
+        for _ in range(2)
+    ]
+    for _ in range(5):
+        await asyncio.sleep(0)
+    # neither start may play until the pending stop has finished
+    assert events == []
+
+    stop_release.set()
+    await asyncio.gather(*starts)
+
+    assert events[0] == "stop_done"
+    assert events.count("play") == 2
+    assert provider._pending_stop_task is None

--- a/tests/providers/sendspin/test_stale_group_stop_cancel.py
+++ b/tests/providers/sendspin/test_stale_group_stop_cancel.py
@@ -1,0 +1,92 @@
+"""
+Tests for the deferred group-stopped cancel guard (support#5771).
+
+The group-stopped event schedules a deferred cancel of the playback session.
+When a new play_media starts a fresh session before that deferred task runs,
+the stale cancel must not tear down the new session — doing so left the client
+stranded in "playing" state with no audio stream.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant.providers.sendspin.player import SendspinPlayer
+
+
+def _make_player_mock() -> MagicMock:
+    """Create a mock with the real methods under test bound to it."""
+    mock = MagicMock()
+    mock.synced_to = None
+    mock.playback_session.cancel = AsyncMock()
+    return mock
+
+
+def test_group_stopped_binds_cancel_to_current_task() -> None:
+    """The deferred cancel is bound to the session task live at event time."""
+    mock = _make_player_mock()
+    task = MagicMock()
+    task.done.return_value = False
+    mock.playback_session.playback_task = task
+
+    SendspinPlayer._on_group_stopped(mock)
+
+    mock._cancel_stale_playback_session.assert_called_once_with(task)
+    mock.mass.create_task.assert_called_once()
+
+
+def test_group_stopped_without_session_schedules_nothing() -> None:
+    """No live session task means nothing to cancel."""
+    mock = _make_player_mock()
+    mock.playback_session.playback_task = None
+
+    SendspinPlayer._on_group_stopped(mock)
+
+    mock.mass.create_task.assert_not_called()
+
+
+def test_group_stopped_with_finished_session_schedules_nothing() -> None:
+    """A finished session task means nothing to cancel."""
+    mock = _make_player_mock()
+    task = MagicMock()
+    task.done.return_value = True
+    mock.playback_session.playback_task = task
+
+    SendspinPlayer._on_group_stopped(mock)
+
+    mock.mass.create_task.assert_not_called()
+
+
+def test_group_stopped_as_synced_follower_schedules_nothing() -> None:
+    """Synced followers do not own the playback session."""
+    mock = _make_player_mock()
+    mock.synced_to = "leader_id"
+    task = MagicMock()
+    task.done.return_value = False
+    mock.playback_session.playback_task = task
+
+    SendspinPlayer._on_group_stopped(mock)
+
+    mock.mass.create_task.assert_not_called()
+
+
+async def test_stale_cancel_skips_newer_session() -> None:
+    """A cancel bound to a superseded task must not touch the new session."""
+    mock = _make_player_mock()
+    stale_task = MagicMock()
+    mock.playback_session.playback_task = MagicMock()  # a newer session task
+
+    await SendspinPlayer._cancel_stale_playback_session(mock, stale_task)
+
+    mock.playback_session.cancel.assert_not_awaited()
+
+
+async def test_stale_cancel_cancels_still_active_session() -> None:
+    """A cancel bound to the still-active task cancels the session."""
+    mock = _make_player_mock()
+    task = MagicMock()
+    mock.playback_session.playback_task = task
+
+    await SendspinPlayer._cancel_stale_playback_session(mock, task)
+
+    mock.playback_session.cancel.assert_awaited_once_with("group stopped")


### PR DESCRIPTION
# What does this implement/fix?

A player that outputs through a linked protocol (a Sendspin or AirPlay device wrapped by a universal/native player) could get pinned to a stale output protocol and go silent on the next session.

The active output protocol was only ever cleared by a stop that arrived while the player was still playing. When the source stream ended on its own first — an AirPlay-receiver session ending, a queue running out — `_handle_cmd_stop` hit its idle early-return and skipped both the stop forwarded to the protocol player and the protocol clear. The device kept a dead session (reporting "playing" while silent) and the protocol stayed pinned, so every later start reused it and bypassed protocol selection.

- **Idle stop now releases the protocol**: when the player already reports idle but an output protocol is still active, forward an idempotent stop to the protocol player and schedule the protocol clear (group-members guard preserved).
- **Fresh starts re-select**: the active protocol is only reused while a session is live (playing/paused); a fresh start re-runs selection so user preference, grouping and native output are honoured again. Also stops asserting when the pinned id is no longer linked.
- **Sendspin**: bind the deferred group-stopped cancel to the session task that was live, so a stale group-stopped event can't tear down a newer session and strand the client "playing" with no audio.
- **AirPlay receiver** (follow-up to #4785): always await the pending stop and continue on any failure, so a stop that can't complete never blocks the next session and a completed stop's exception is always retrieved.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

Related issue: music-assistant/support#5771
