### PR TITLE
Instant AirPlay seek, next-track and resume

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -316,6 +316,14 @@ class AirPlayPlayer(Player):
 
     async def play(self) -> None:
         """Send PLAY (unpause) command to player."""
+        if self.group_members or self.synced_to:
+            # Grouped pause parks the whole session (standby); unpausing one
+            # member cannot restart the group in sync. Resume via the queue
+            # instead: play_media commits a fresh generation to every parked
+            # member at one shared instant.
+            queue_id = self.synced_to or self.player_id
+            await self.mass.player_queues.resume(queue_id, fade_in=False)
+            return
         async with self._lock:
             if self.stream and self.stream.running:
                 await self.stream.send_cli_command("ACTION=PLAY")
@@ -323,12 +331,21 @@ class AirPlayPlayer(Player):
     async def pause(self) -> None:
         """Send PAUSE command to player."""
         if self.group_members or self.synced_to:
-            # Each member of a sync group is an independent cliairplay process anchored
-            # to a shared start instant; a broadcast pause/resume cannot keep the members
-            # sample-aligned on resume. So grouped/synced playback is paused by stopping
-            # the whole session and letting the queue controller resume it from the saved
-            # position with a fresh shared anchor.
-            self.logger.debug("Player is part of a sync group, using STOP instead of PAUSE")
+            # A broadcast pause cannot keep independent member processes
+            # sample-aligned on resume. Instead the session is parked: every
+            # member stalls but keeps its connection (and remote control), and
+            # the queue's resume commits a new generation over the live
+            # connections — the same coordinated warm restart as seek/next.
+            if (
+                self.stream
+                and self.stream.running
+                and self.stream.session
+                and await self.stream.session.standby()
+            ):
+                return
+            # some member cannot be parked (e.g. RAOP legacy): full stop and
+            # let the queue controller resume from the saved position
+            self.logger.debug("Sync group cannot be parked, using STOP instead of PAUSE")
             await self.stop()
             return
 
@@ -362,6 +379,16 @@ class AirPlayPlayer(Player):
                 )
                 if await self.stream.session.replace(audio_source, media):
                     self._transitioning = False
+                    # A seek changes no media identity, so the identity-driven
+                    # metadata callback stays silent and receivers would show
+                    # a stale Now Playing position; nudge every member once
+                    # the queue position has settled.
+                    for member in self.stream.session.sync_clients:
+                        self.mass.call_later(
+                            1,
+                            member._on_player_media_updated,
+                            task_id=f"player_media_updated_{member.player_id}",
+                        )
                     return
                 # warm replacement failed; fall through to a cold restart
 

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -345,7 +345,27 @@ class AirPlayPlayer(Player):
                 raise RuntimeError("Player is synced")
             self._attr_current_media = media
 
-            # Always stop any existing stream
+            sync_clients = self._get_sync_clients()
+            session_pcm_format = self._get_session_pcm_format(sync_clients, media)
+
+            # Warm path: a live, compatible session absorbs the new media as
+            # its next generation (seek/next never pays the reconnect cost).
+            if (
+                self.stream
+                and self.stream.running
+                and self.stream.session
+                and self.stream.session.can_replace(sync_clients, session_pcm_format)
+            ):
+                self._transitioning = True
+                audio_source = self.mass.streams.get_stream(
+                    media, session_pcm_format, self.player_id, use_flow_stream_buffering=True
+                )
+                if await self.stream.session.replace(audio_source, media):
+                    self._transitioning = False
+                    return
+                # warm replacement failed; fall through to a cold restart
+
+            # Cold path: stop any existing stream and set up from scratch
             if self.stream and self.stream.running and self.stream.session:
                 # Set transitioning flag to ignore stale DACP messages (like prevent-playback)
                 self._transitioning = True
@@ -353,8 +373,6 @@ class AirPlayPlayer(Player):
                 self.stream = None
 
             # select audio source
-            sync_clients = self._get_sync_clients()
-            session_pcm_format = self._get_session_pcm_format(sync_clients, media)
             audio_source = self.mass.streams.get_stream(
                 media, session_pcm_format, self.player_id, use_flow_stream_buffering=True
             )

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import logging
 import socket
 import time
 from contextlib import suppress
@@ -653,6 +654,12 @@ class AirPlayProvider(PlayerProvider):
         bind_ip = str(self.mass.streams.bind_ip)
         if bind_ip not in ("0.0.0.0", "::", ""):
             args += ["--if", bind_ip]
+        # Mirror the per-stream debug level so the daemon's receive side
+        # (peer Announce/Sync/Delay_Req traffic) is visible in the log.
+        if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+            args += ["--debug", "10"]
+        elif self.logger.isEnabledFor(logging.DEBUG):
+            args += ["--debug", "5"]
         daemon = AsyncProcess(args, stdout=True, stderr=True, name="cliairplay-ptp-daemon")
         # (Re)gate readiness for this daemon instance: not ready until a reader
         # sees the "daemon up" line (a restart clears any previous readiness).

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-import logging
 import socket
 import time
 from contextlib import suppress
@@ -654,12 +653,11 @@ class AirPlayProvider(PlayerProvider):
         bind_ip = str(self.mass.streams.bind_ip)
         if bind_ip not in ("0.0.0.0", "::", ""):
             args += ["--if", bind_ip]
-        # Mirror the per-stream debug level so the daemon's receive side
-        # (peer Announce/Sync/Delay_Req traffic) is visible in the log.
+        # The daemon runs quiet by default; only a verbose session turns on its
+        # per-packet PTP tracing (Announce/Sync/Delay_Req), so a normal debug
+        # session does not flood the log with timing chatter.
         if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
             args += ["--debug", "10"]
-        elif self.logger.isEnabledFor(logging.DEBUG):
-            args += ["--debug", "5"]
         daemon = AsyncProcess(args, stdout=True, stderr=True, name="cliairplay-ptp-daemon")
         # (Re)gate readiness for this daemon instance: not ready until a reader
         # sees the "daemon up" line (a restart clears any previous readiness).
@@ -690,8 +688,16 @@ class AirPlayProvider(PlayerProvider):
                     self._handle_ptp_daemon_line(line)
 
     def _handle_ptp_daemon_line(self, line: str) -> None:
-        """Debug-log a PTP daemon output line and detect its readiness signal."""
-        self.logger.debug("PTP daemon: %s", line)
+        """Log a PTP daemon output line and detect its readiness signal."""
+        # Routine daemon output is verbose-only so it never floods a user's log
+        # (the per-packet timing trace only runs at verbose in the first place).
+        # The daemon tags no log levels, so a genuine problem is recognised by
+        # keyword and promoted to a warning that stays visible at normal levels.
+        lowered = line.lower()
+        if any(marker in lowered for marker in ("error", "cannot", "failed", "unable")):
+            self.logger.warning("PTP daemon: %s", line)
+        else:
+            self.logger.log(VERBOSE_LOG_LEVEL, "PTP daemon: %s", line)
         # The readiness marker is matched on either pipe: the daemon's diagnostic
         # output is not contractually stdout-vs-stderr, so both readers feed this
         # handler and setting the event is idempotent.

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -64,6 +64,12 @@ if TYPE_CHECKING:
 # prefill need (~wait_start + its ~2 s buffer) yet far below a whole-track backlog.
 MAX_DEVICE_BUFFER_SECONDS: float = 8.0
 
+# How long to keep a connected CLI alive after a sendspin stream ends, waiting
+# for the next stream (seek/next) to reuse it warm. A real stop tears down after
+# this window. Comfortably longer than a sendspin stream restart, short enough
+# that a genuine stop stops the device promptly.
+BRIDGE_WARM_GRACE_SECONDS: float = 4.0
+
 
 def get_bridge_client_id(airplay_player: AirPlayPlayer) -> str | None:
     """
@@ -182,6 +188,11 @@ class SendspinAirPlayBridge:
         self._airplay_stream_start_task: asyncio.Task[None] | None = None
         self._airplay_stream_ready = asyncio.Event()
         self._cleanup_task: asyncio.Task[None] | None = None
+        # Timer id for the deferred teardown on stream end. A seek/next ends the
+        # sendspin stream and immediately starts a new one; deferring the CLI
+        # teardown across that gap lets the next stream reuse the connected
+        # binary as a warm generation instead of a cold reconnect.
+        self._teardown_timer_id = f"bridge_teardown_{airplay_player.player_id}"
         self._lock = asyncio.Lock()
 
     @property
@@ -269,6 +280,7 @@ class SendspinAirPlayBridge:
 
     async def stop(self) -> None:
         """Stop and unregister the Sendspin bridge."""
+        self.mass.cancel_timer(self._teardown_timer_id)
         async with self._lock:
             await self._stop_streaming()
             if self._sendspin_client and self._bridge_client_id:
@@ -328,6 +340,10 @@ class SendspinAirPlayBridge:
                 self.airplay_player.display_name,
             )
             return
+        # A new stream arrived within the grace window: cancel the deferred
+        # teardown so the previous stream's still-connected CLI survives to be
+        # reused as a warm generation instead of cold-restarting.
+        self.mass.cancel_timer(self._teardown_timer_id)
         # Bridge outlives config changes, so re-read the current timing values.
         self._refresh_bridge_timing()
         # Capture and detach old stream resources before scheduling their cleanup.
@@ -594,16 +610,20 @@ class SendspinAirPlayBridge:
 
     def _on_bridge_stream_end(self) -> None:
         """
-        Stop the AirPlay protocol immediately when the stream ends.
+        Handle the sendspin stream ending: defer the CLI teardown briefly.
 
-        Rather than just sending EOF (which lets the CLI play out its buffer),
-        we schedule a full cleanup that kills the CLI process immediately.
+        A seek or next-track ends the stream and immediately starts a new one.
+        Tearing the CLI down here would force every such switch through a cold
+        reconnect; instead we keep the connected binary alive for a short grace
+        window so the next stream can reuse it as a warm generation. If no new
+        stream arrives within the window (a real stop), the deferred cleanup
+        kills the CLI so AirPlay stops instead of draining its buffer.
         """
         self._is_streaming = False
         self._next_expected_timestamp_us = None
-        # Schedule full streaming cleanup - this kills the CLI process immediately
-        # so AirPlay stops playing instead of draining its 30s buffer.
-        self._schedule_cleanup()
+        self.mass.call_later(
+            BRIDGE_WARM_GRACE_SECONDS, self._schedule_cleanup, task_id=self._teardown_timer_id
+        )
 
     def _schedule_cleanup(self) -> None:
         """

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -552,11 +552,13 @@ class SendspinAirPlayBridge:
                 return False
             if asyncio.current_task() is not self._airplay_stream_start_task:
                 # A newer stream start already owns the bridge; abandon this
-                # generation without touching state it may already have claimed.
+                # generation. Do NOT close fifo_fd here: it was published as
+                # self._sink_fd above, so it is either still the writer's active
+                # sink (closing it would break the writer with EBADF) or already
+                # closed/replaced by the newer task's _set_sink_fd. The sink fd's
+                # lifecycle is owned by _set_sink_fd / teardown, not this task.
                 # The binary safely collapses a superseded staged generation on
                 # its next PREPARE.
-                with suppress(OSError):
-                    await asyncio.to_thread(os.close, fifo_fd)
                 return False
             await stream.start_generation(gen, 0, start_unix_ms)
             self.logger.info(

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -18,6 +18,7 @@ Sendspin PushStream → BridgePlayerRole.on_audio_chunk → AirPlay CLI process
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from contextlib import suppress
 from typing import TYPE_CHECKING, cast
@@ -174,6 +175,9 @@ class SendspinAirPlayBridge:
         # Used to pace writes so the device buffer stays bounded (see _cli_writer).
         self._start_unix_ms: int = 0
         self._write_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+        # Raw-fd sink for a warm generation's fifo (None = write to the CLI's
+        # stdin via self._airplay_stream.write_audio, i.e. generation 0).
+        self._sink_fd: int | None = None
         self._writer_task: asyncio.Task[None] | None = None
         self._airplay_stream_start_task: asyncio.Task[None] | None = None
         self._airplay_stream_ready = asyncio.Event()
@@ -289,6 +293,22 @@ class SendspinAirPlayBridge:
             min_buffer_ms=0,
         )
 
+    def _stream_is_warm_eligible(self) -> bool:
+        """
+        Return whether the current AirPlayStream can absorb a new stream as a generation.
+
+        A kept stream must still be running, already connected, and on an
+        AirPlay 2 route -- RAOP and a not-yet-connected AirPlay 2 stream have
+        no persistent-generation support, so those always pay a cold restart.
+        """
+        stream = self._airplay_stream
+        return (
+            stream is not None
+            and stream.running
+            and stream.connected
+            and stream.active_route.startswith("AirPlay 2")
+        )
+
     def _on_stream_start(self, request: ExternalStreamStartRequest) -> None:
         """
         Handle stream start request from Sendspin server.
@@ -312,15 +332,19 @@ class SendspinAirPlayBridge:
         self._refresh_bridge_timing()
         # Capture and detach old stream resources before scheduling their cleanup.
         # This prevents the async cleanup from accidentally destroying the new
-        # stream's resources, which reuse the same instance variables.
-        old_stream = self._airplay_stream
+        # stream's resources, which reuse the same instance variables. A warm-
+        # eligible stream is kept out of the snapshot entirely so it survives
+        # into the new stream instead of being torn down.
+        keep_stream = self._stream_is_warm_eligible()
+        old_stream = None if keep_stream else self._airplay_stream
         old_writer_task = self._writer_task
         old_stream_start_task = self._airplay_stream_start_task
 
-        self._airplay_stream = None
+        if not keep_stream:
+            self._airplay_stream = None
+            self.airplay_player.stream = None
         self._writer_task = None
         self._airplay_stream_start_task = None
-        self.airplay_player.stream = None
         self._airplay_stream_ready.clear()
 
         if old_stream or old_writer_task or old_stream_start_task:
@@ -344,15 +368,19 @@ class SendspinAirPlayBridge:
         Called via the BridgePlayerRole.on_stream_start callback when the
         PushStream begins delivering audio chunks.
         """
-        # The stream might not yet be cleaned up completely (on rapid skips for example)
-        old_stream = self._airplay_stream
+        # The stream might not yet be cleaned up completely (on rapid skips for example).
+        # A warm-eligible stream is kept out of the snapshot so it survives into the
+        # new stream instead of being torn down (see _stream_is_warm_eligible).
+        keep_stream = self._stream_is_warm_eligible()
+        old_stream = None if keep_stream else self._airplay_stream
         old_writer_task = self._writer_task
         old_stream_start_task = self._airplay_stream_start_task
 
-        self._airplay_stream = None
+        if not keep_stream:
+            self._airplay_stream = None
+            self.airplay_player.stream = None
         self._writer_task = None
         self._airplay_stream_start_task = None
-        self.airplay_player.stream = None
 
         if old_stream or old_writer_task or old_stream_start_task:
             prev_cleanup = self._cleanup_task
@@ -415,6 +443,20 @@ class SendspinAirPlayBridge:
             # Publish the audible anchor so the writer can pace against it.
             self._start_unix_ms = start_unix_ms
 
+            # A kept, still-connected AirPlay 2 stream (see _stream_is_warm_eligible,
+            # checked by the stream-start callbacks) absorbs the new media as a warm
+            # generation instead of paying a cold reconnect.
+            kept_stream = self._airplay_stream
+            if kept_stream is not None:
+                if await self._start_warm_generation(kept_stream, start_unix_ms):
+                    return
+                # Warm handover failed - tear down the kept stream and fall through
+                # to the cold path below, which spawns a fresh process.
+                with suppress(Exception):
+                    await kept_stream.stop(force=True)
+                self._airplay_stream = None
+                self.airplay_player.stream = None
+
             # On a rapid skip, _on_bridge_stream_start snapshots self._airplay_stream
             # for cleanup. If we assigned it earlier, the new stream would be missed
             # and leaked. Only publish once start() succeeds and this task is current.
@@ -449,6 +491,82 @@ class SendspinAirPlayBridge:
             self._is_streaming = False
             self._airplay_stream_ready.set()
             self._schedule_cleanup()
+
+    async def _start_warm_generation(self, stream: AirPlayStream, start_unix_ms: int) -> bool:
+        """
+        Stage and commit a new media generation on a kept, still-connected stream.
+
+        The new generation is staged on a fresh fifo while ``stream`` keeps playing
+        its current one, then committed with a single START once primed. Returns
+        True once the switch is committed. Any failure (staging, a prime timeout,
+        or this task being superseded before commit) reverts the writer to the
+        stdin sink and returns False so the caller falls back to a cold restart of
+        the kept stream; the fifo node is never left behind.
+
+        :param stream: The kept AirPlayStream to stage the new generation on.
+        :param start_unix_ms: The audible-start instant to commit the generation at.
+        """
+        gen = stream.next_generation()
+        fifo = f"/tmp/ma-bridge-{self.airplay_player.player_id}-{gen}.pcm"  # noqa: S108
+        opened = False
+        try:
+            with suppress(FileNotFoundError):
+                await asyncio.to_thread(os.unlink, fifo)
+            await asyncio.to_thread(os.mkfifo, fifo)
+            await stream.prepare_generation(gen, fifo, 0)
+            fifo_fd = await asyncio.wait_for(
+                asyncio.to_thread(os.open, fifo, os.O_WRONLY), timeout=5
+            )
+            opened = True
+            # Both ends now hold the fifo open; drop the directory entry right away
+            # so no stale pipe nodes accumulate even if a later step fails.
+            with suppress(OSError):
+                await asyncio.to_thread(os.unlink, fifo)
+            await self._set_sink_fd(fifo_fd)
+            # Unblocks the writer task, which was waiting on this event; it can
+            # now prefill the pipe while the generation primes.
+            self._airplay_stream_ready.set()
+            if not await stream.wait_generation_primed(gen):
+                self.logger.warning(
+                    "Generation prime timed out for %s, falling back to a cold restart",
+                    self.airplay_player.display_name,
+                )
+                with suppress(Exception):
+                    await self._set_sink_fd(None)
+                return False
+            if asyncio.current_task() is not self._airplay_stream_start_task:
+                # A newer stream start already owns the bridge; abandon this
+                # generation without touching state it may already have claimed.
+                # The binary safely collapses a superseded staged generation on
+                # its next PREPARE.
+                with suppress(OSError):
+                    await asyncio.to_thread(os.close, fifo_fd)
+                return False
+            await stream.start_generation(gen, 0, start_unix_ms)
+            self.logger.info(
+                "Bridge warm handover for %s (generation=%d, start_unix_ms=%d)",
+                self.airplay_player.display_name,
+                gen,
+                start_unix_ms,
+            )
+        except Exception as err:
+            self.logger.warning(
+                "Warm handover failed for %s (%r), falling back to a cold restart",
+                self.airplay_player.display_name,
+                err,
+            )
+            with suppress(Exception):
+                await self._set_sink_fd(None)
+            return False
+        finally:
+            if not opened:
+                # Unblock a writer-open still pending on a failed pipe by briefly
+                # opening the read side, then remove the pipe node either way.
+                with suppress(OSError):
+                    os.close(os.open(fifo, os.O_RDONLY | os.O_NONBLOCK))
+                with suppress(OSError):
+                    await asyncio.to_thread(os.unlink, fifo)
+        return True
 
     async def _wait_for_airplay_connection(self) -> None:
         """Wait for AirPlay connection in the background and log the result."""
@@ -642,14 +760,46 @@ class SendspinAirPlayBridge:
         self._write_queue.put_nowait(chunk.data)
         return True
 
+    async def _set_sink_fd(self, fd: int | None) -> None:
+        """
+        Swap the writer's raw-fd sink, closing whatever fd it replaces.
+
+        :param fd: The new warm-generation fifo fd to write to, or None to
+            switch the writer back to the CLI's stdin (cold/generation 0).
+        """
+        old_fd = self._sink_fd
+        self._sink_fd = fd
+        if old_fd is not None:
+            with suppress(OSError):
+                await asyncio.to_thread(os.close, old_fd)
+
+    async def _write_to_sink(self, fd: int, data: bytes) -> None:
+        """
+        Write raw audio bytes to a warm-generation fifo fd, off the event loop.
+
+        :param fd: The fifo fd to write to (a snapshot of self._sink_fd).
+        :param data: Raw audio bytes to write.
+        """
+
+        def _write() -> None:
+            view = memoryview(data)
+            while view:
+                view = view[os.write(fd, view) :]
+
+        await asyncio.to_thread(_write)
+
     async def _cli_writer(self) -> None:
         """
-        Write queued audio data to the CLI process stdin.
+        Write queued audio data to the CLI's stdin, or a warm generation's fifo.
 
         Waits for any pending cleanup and then for the new protocol to be
         ready before writing. Runs as a single task so writes are serialised
         and ordered. A None sentinel signals end-of-stream: write EOF to
         stdin and exit.
+
+        Writes go to self._sink_fd (a warm generation's fifo) when set, else
+        to the CLI's stdin via self._airplay_stream.write_audio -- see
+        _start_warm_generation, which is the only place that sets the sink.
 
         Writes are paced against the audible anchor so the device is never
         buffered more than ``MAX_DEVICE_BUFFER_SECONDS`` ahead of real time.
@@ -698,12 +848,18 @@ class SendspinAirPlayBridge:
                     if ahead > MAX_DEVICE_BUFFER_SECONDS:
                         await asyncio.sleep(ahead - MAX_DEVICE_BUFFER_SECONDS)
                 with suppress(Exception):
-                    await self._airplay_stream.write_audio(data)
+                    if (sink_fd := self._sink_fd) is not None:
+                        await self._write_to_sink(sink_fd, data)
+                    else:
+                        await self._airplay_stream.write_audio(data)
                     bytes_written += len(data)
         finally:
             # Only clear if this writer is still the active one.
             if self._writer_task is asyncio.current_task():
                 self._writer_task = None
+            # Release whatever fifo fd this writer was using, if any.
+            with suppress(Exception):
+                await self._set_sink_fd(None)
 
     async def _stop_streaming(self) -> None:
         """Stop streaming (internal, called with lock held)."""
@@ -726,6 +882,10 @@ class SendspinAirPlayBridge:
             await self._airplay_stream.stop(force=True)
             self._airplay_stream = None
             self.airplay_player.stream = None
+        # Belt-and-suspenders: the writer task closes its own sink fd on exit,
+        # but guard against a leak if it never ran.
+        with suppress(Exception):
+            await self._set_sink_fd(None)
 
 
 class SendspinBridgeManager(SendspinBridgeManagerBase[SendspinAirPlayBridge]):

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -657,40 +657,9 @@ class AirPlayStream:
         async for line in self._cli_proc.iter_stderr():
             if self._stopped:
                 break
-
-            if "[STATUS] connected" in line:
-                self._connected.set()
-            elif "[STATUS] playing elapsed_ms=" in line:
-                try:
-                    millis = int(line.split("elapsed_ms=")[1])
-                except ValueError, IndexError:
-                    pass
-                else:
-                    self._update_elapsed(millis / 1000)
-            elif "[STATUS] paused" in line:
-                player.set_state_from_stream(state=PlaybackState.PAUSED, stream=self)
-            elif "[STATUS] ready generation=" in line:
-                if (event := self._gen_ready.get(self._parse_generation(line))) is not None:
-                    event.set()
-            elif "[STATUS] primed generation=" in line:
-                if (event := self._gen_primed.get(self._parse_generation(line))) is not None:
-                    event.set()
-            elif "[STATUS] input_eof generation=" in line:
-                logger.debug("cliairplay: %s", line.strip())
-            elif "[STATUS] eof generation=" in line:
-                # A generation's input finished. Only the ACTIVE generation
-                # ending matters; a retired generation's eof is just noise.
-                # The plain "[STATUS] eof" line that follows drives the
-                # end-of-stream path for the final generation.
-                if self._parse_generation(line) != self._generation:
-                    logger.debug("stale generation eof ignored: %s", line.strip())
-            elif "[STATUS] eof" in line:
-                logger.debug("End of stream reached")
+            if self._handle_status_line(line):
                 expected_eof = True
                 break
-            elif "[ERROR]" in line:
-                logger.error("cliairplay: %s", line.strip())
-
             logger.log(VERBOSE_LOG_LEVEL, line)
             await asyncio.sleep(0)
 
@@ -714,6 +683,47 @@ class AirPlayStream:
                 player.set_state_from_stream(state=PlaybackState.IDLE, elapsed_time=0, stream=self)
             finally:
                 await self.commands_pipe.remove()
+
+    def _handle_status_line(self, line: str) -> bool:
+        """Dispatch one cliairplay status line; True ends the stderr loop."""
+        player = self.player
+        if "[STATUS] connected" in line:
+            self._connected.set()
+        elif "[STATUS] playing elapsed_ms=" in line:
+            try:
+                millis = int(line.split("elapsed_ms=")[1])
+            except ValueError, IndexError:
+                pass
+            else:
+                self._update_elapsed(millis / 1000)
+        elif "[STATUS] paused" in line:
+            player.set_state_from_stream(state=PlaybackState.PAUSED, stream=self)
+        elif "[STATUS] ready generation=" in line:
+            if (event := self._gen_ready.get(self._parse_generation(line))) is not None:
+                event.set()
+        elif "[STATUS] primed generation=" in line:
+            if (event := self._gen_primed.get(self._parse_generation(line))) is not None:
+                event.set()
+        elif "[STATUS] input_eof generation=" in line:
+            player.logger.debug("cliairplay: %s", line.strip())
+        elif "[STATUS] eof generation=" in line:
+            # A generation's input finished. Only the ACTIVE generation
+            # ending matters; a retired generation's eof is just noise.
+            # The plain "[STATUS] eof" line that follows drives the
+            # end-of-stream path for the final generation.
+            if self._parse_generation(line) != self._generation:
+                player.logger.debug("stale generation eof ignored: %s", line.strip())
+        elif "[STATUS] idle_timeout" in line:
+            # a parked (paused) session outlived the binary's idle cap;
+            # treat it as a normal end of stream
+            player.logger.debug("cliairplay idle timeout reached")
+            return True
+        elif "[STATUS] eof" in line:
+            player.logger.debug("End of stream reached")
+            return True
+        elif "[ERROR]" in line:
+            player.logger.error("cliairplay: %s", line.strip())
+        return False
 
     @staticmethod
     def _parse_generation(line: str) -> int:

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -92,7 +92,12 @@ class AirPlayStream:
         # Persistent generations: the binary keeps one connection alive and
         # plays numbered media generations over it (seek/next = new generation
         # on a fresh pipe instead of a reconnect).
+        # _generation is the latest ALLOCATED id (bumped at PREPARE, while the
+        # previous generation is still playing); _active_generation is the one
+        # actually playing (only advances at START). Elapsed/EOF handling keys
+        # off the active id so a staged generation never skews them mid-handover.
         self._generation = 0
+        self._active_generation = 0
         self._generation_position: float = 0.0
         self._gen_ready: dict[int, asyncio.Event] = {}
         self._gen_primed: dict[int, asyncio.Event] = {}
@@ -284,6 +289,7 @@ class AirPlayStream:
         primed member.
         """
         self._generation_position = position_ms / 1000
+        self._active_generation = generation
         # Stamp the player's elapsed onto the new generation's base right away:
         # until the binary's first status arrives, interpolation would otherwise
         # keep extending the SUPERSEDED generation's clock, which briefly maps
@@ -711,7 +717,7 @@ class AirPlayStream:
             # ending matters; a retired generation's eof is just noise.
             # The plain "[STATUS] eof" line that follows drives the
             # end-of-stream path for the final generation.
-            if self._parse_generation(line) != self._generation:
+            if self._parse_generation(line) != self._active_generation:
                 player.logger.debug("stale generation eof ignored: %s", line.strip())
         elif "[STATUS] idle_timeout" in line:
             # a parked (paused) session outlived the binary's idle cap;
@@ -735,12 +741,12 @@ class AirPlayStream:
 
     def _update_elapsed(self, elapsed_time: float) -> None:
         """Update elapsed time with session offset compensation."""
-        if self._generation > 0:
+        if self._active_generation > 0:
             # elapsed restarts per generation; report against its media base
             elapsed_time += self._generation_position
         elif self._elapsed_time_offset is None and self.session:
             self._elapsed_time_offset = max(0, time.time() - self.session.start_time - elapsed_time)
-        if self._generation == 0 and self._elapsed_time_offset:
+        if self._active_generation == 0 and self._elapsed_time_offset:
             elapsed_time += self._elapsed_time_offset
         # The binary only emits this status while actually playing, so it is
         # also the signal that drives the player into the PLAYING state.

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -284,6 +284,11 @@ class AirPlayStream:
         primed member.
         """
         self._generation_position = position_ms / 1000
+        # Stamp the player's elapsed onto the new generation's base right away:
+        # until the binary's first status arrives, interpolation would otherwise
+        # keep extending the SUPERSEDED generation's clock, which briefly maps
+        # onto the new stream log as a bogus position.
+        self.player.set_state_from_stream(elapsed_time=self._generation_position, stream=self)
         await self._write_cli_command(
             f"GENERATION={generation}\nSTART_UNIX_MS={start_unix_ms}\nACTION=START"
         )

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -89,6 +89,13 @@ class AirPlayStream:
         self._artwork_render_generations: set[int] = set()
         self._last_progress_sent: int = -1
         self._elapsed_time_offset: float | None = None
+        # Persistent generations: the binary keeps one connection alive and
+        # plays numbered media generations over it (seek/next = new generation
+        # on a fresh pipe instead of a reconnect).
+        self._generation = 0
+        self._generation_position: float = 0.0
+        self._gen_ready: dict[int, asyncio.Event] = {}
+        self._gen_primed: dict[int, asyncio.Event] = {}
         self._stdout_reader_task: asyncio.Task[None] | None = None
         # Device latency info reported by the binary after connect (0 = unreported)
         self.latency_lead_ms: int = 0
@@ -234,6 +241,57 @@ class AirPlayStream:
         if self._stopped or self._stopping:
             return
         await self._write_cli_command(command)
+
+    def next_generation(self) -> int:
+        """Allocate the next media generation number and its status events."""
+        self._generation += 1
+        self._gen_ready[self._generation] = asyncio.Event()
+        self._gen_primed[self._generation] = asyncio.Event()
+        return self._generation
+
+    async def prepare_generation(self, generation: int, audio_path: str, position_ms: int) -> None:
+        """
+        Stage the next media generation on the running binary.
+
+        The binary opens the given FIFO and prefills from it while the current
+        generation keeps playing; `primed` is reported once enough audio is
+        buffered for an underrun-free start.
+        """
+        await self._write_cli_command(
+            f"GENERATION={generation}\nAUDIO={audio_path}\n"
+            f"POSITION_MS={position_ms}\nACTION=PREPARE"
+        )
+
+    async def wait_generation_primed(self, generation: int, timeout: float = 8.0) -> bool:
+        """Wait until the staged generation has buffered enough to start."""
+        event = self._gen_primed.get(generation)
+        if event is None:
+            return False
+        try:
+            await asyncio.wait_for(event.wait(), timeout)
+        except TimeoutError:
+            return False
+        return True
+
+    async def start_generation(
+        self, generation: int, position_ms: int, start_unix_ms: int = 0
+    ) -> None:
+        """
+        Commit the staged generation: warm-flush and start it.
+
+        start_unix_ms 0 means as soon as possible (the binary clamps to its
+        minimum warm lead); a group start passes the same instant to every
+        primed member.
+        """
+        self._generation_position = position_ms / 1000
+        await self._write_cli_command(
+            f"GENERATION={generation}\nSTART_UNIX_MS={start_unix_ms}\nACTION=START"
+        )
+        # drop event bookkeeping for superseded generations
+        for gen in list(self._gen_ready):
+            if gen < generation:
+                self._gen_ready.pop(gen, None)
+                self._gen_primed.pop(gen, None)
 
     async def send_metadata(
         self,
@@ -606,6 +664,21 @@ class AirPlayStream:
                     self._update_elapsed(millis / 1000)
             elif "[STATUS] paused" in line:
                 player.set_state_from_stream(state=PlaybackState.PAUSED, stream=self)
+            elif "[STATUS] ready generation=" in line:
+                if (event := self._gen_ready.get(self._parse_generation(line))) is not None:
+                    event.set()
+            elif "[STATUS] primed generation=" in line:
+                if (event := self._gen_primed.get(self._parse_generation(line))) is not None:
+                    event.set()
+            elif "[STATUS] input_eof generation=" in line:
+                logger.debug("cliairplay: %s", line.strip())
+            elif "[STATUS] eof generation=" in line:
+                # A generation's input finished. Only the ACTIVE generation
+                # ending matters; a retired generation's eof is just noise.
+                # The plain "[STATUS] eof" line that follows drives the
+                # end-of-stream path for the final generation.
+                if self._parse_generation(line) != self._generation:
+                    logger.debug("stale generation eof ignored: %s", line.strip())
             elif "[STATUS] eof" in line:
                 logger.debug("End of stream reached")
                 expected_eof = True
@@ -637,11 +710,22 @@ class AirPlayStream:
             finally:
                 await self.commands_pipe.remove()
 
+    @staticmethod
+    def _parse_generation(line: str) -> int:
+        """Extract the generation number from a generation-tagged status line."""
+        try:
+            return int(line.split("generation=")[1].split(maxsplit=1)[0])
+        except ValueError, IndexError:
+            return -1
+
     def _update_elapsed(self, elapsed_time: float) -> None:
         """Update elapsed time with session offset compensation."""
-        if self._elapsed_time_offset is None and self.session:
+        if self._generation > 0:
+            # elapsed restarts per generation; report against its media base
+            elapsed_time += self._generation_position
+        elif self._elapsed_time_offset is None and self.session:
             self._elapsed_time_offset = max(0, time.time() - self.session.start_time - elapsed_time)
-        if self._elapsed_time_offset:
+        if self._generation == 0 and self._elapsed_time_offset:
             elapsed_time += self._elapsed_time_offset
         # The binary only emits this status while actually playing, so it is
         # also the signal that drives the player into the PLAYING state.

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -218,6 +218,36 @@ class AirPlayStreamSession:
                     await asyncio.to_thread(os.unlink, fifo)
         return True
 
+    async def standby(self) -> bool:
+        """
+        Park the session: stall every member but keep the connections alive.
+
+        The next play_media (resume or seek) commits a new generation over the
+        live connections — the same coordinated warm restart as seek/next.
+        Returns False when any member lacks a running AirPlay 2 stream (RAOP
+        cannot be parked), so the caller can fall back to a full stop.
+        """
+        if not all(
+            p.stream is not None and p.stream.running and p.protocol == StreamingProtocol.AIRPLAY2
+            for p in self.sync_clients
+        ):
+            return False
+        if self._audio_source_task and not self._audio_source_task.done():
+            self._audio_source_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._audio_source_task
+        for player in self.sync_clients:
+            if ffmpeg := self._player_ffmpeg.pop(player.player_id, None):
+                await ffmpeg.kill()
+            stream = player.stream
+            assert stream
+            await stream.send_cli_command("ACTION=STANDBY")
+            player.set_state_from_stream(state=PlaybackState.PAUSED, stream=stream)
+        # a parked session has no live timeline; the resume re-anchors it
+        self.seconds_streamed = 0
+        self._pcm_buffer.clear()
+        return True
+
     async def stop(self) -> None:
         """Stop playback and cleanup."""
         if self._audio_source_task and not self._audio_source_task.done():

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -653,7 +653,11 @@ class AirPlayStreamSession:
         The open pairs with the read side the binary opened at PREPARE.
         """
         if ffmpeg := self._player_ffmpeg.pop(player.player_id, None):
-            await ffmpeg.close()
+            # Kill, not close: a graceful close waits for the old ffmpeg to
+            # drain its buffered audio into the binary at playback speed
+            # (seconds), and that audio is superseded anyway. The binary keeps
+            # playing the old generation from its own ring until START lands.
+            await ffmpeg.kill()
         stream = player.stream
         assert stream
         handoff_format = stream.pcm_format

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -164,28 +164,7 @@ class AirPlayStreamSession:
                 with suppress(asyncio.CancelledError):
                     await self._audio_source_task
             for player in self.sync_clients:
-                if ffmpeg := self._player_ffmpeg.pop(player.player_id, None):
-                    await ffmpeg.close()
-                stream = player.stream
-                assert stream
-                handoff_format = stream.pcm_format
-                output_plan = self.mass.streams.audio.get_player_output_plan(
-                    player.player_id,
-                    input_format=self.pcm_format,
-                    output_format=get_final_output_format(handoff_format, player),
-                    handoff_format=handoff_format,
-                    queue_id=media.source_id,
-                    session_id=get_media_session_id(media),
-                )
-                ffmpeg = FFMpeg(
-                    audio_input="-",
-                    input_format=self.pcm_format,
-                    output_format=handoff_format,
-                    filter_params=output_plan.filter_params,
-                    audio_output=fifos[player.player_id],
-                )
-                await ffmpeg.start()
-                self._player_ffmpeg[player.player_id] = ffmpeg
+                await self._start_generation_ffmpeg(player, fifos[player.player_id], media)
             self.media = media
             self.seconds_streamed = 0
             self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
@@ -219,6 +198,10 @@ class AirPlayStreamSession:
             return False
         finally:
             for fifo in fifos.values():
+                # Unblock any writer-open still pending on a failed pipe by
+                # briefly opening the read side, then remove the pipe node.
+                with suppress(OSError):
+                    os.close(os.open(fifo, os.O_RDONLY | os.O_NONBLOCK))
                 with suppress(OSError):
                     await asyncio.to_thread(os.unlink, fifo)
         return True
@@ -656,3 +639,44 @@ class AirPlayStreamSession:
         )
         await ffmpeg.start()
         self._player_ffmpeg[airplay_player.player_id] = ffmpeg
+
+    async def _start_generation_ffmpeg(
+        self, player: AirPlayPlayer, fifo: str, media: PlayerMedia
+    ) -> None:
+        """
+        Start the per-player DSP ffmpeg for a staged generation.
+
+        Retires the player's previous ffmpeg and spawns a fresh one writing
+        into the generation's pipe. The pipe's write side is opened here and
+        handed to ffmpeg as an inherited descriptor (like the stdin case in
+        ``_start_client``) because ffmpeg refuses to open an existing path.
+        The open pairs with the read side the binary opened at PREPARE.
+        """
+        if ffmpeg := self._player_ffmpeg.pop(player.player_id, None):
+            await ffmpeg.close()
+        stream = player.stream
+        assert stream
+        handoff_format = stream.pcm_format
+        output_plan = self.mass.streams.audio.get_player_output_plan(
+            player.player_id,
+            input_format=self.pcm_format,
+            output_format=get_final_output_format(handoff_format, player),
+            handoff_format=handoff_format,
+            queue_id=media.source_id,
+            session_id=get_media_session_id(media),
+        )
+        fifo_fd = await asyncio.wait_for(asyncio.to_thread(os.open, fifo, os.O_WRONLY), timeout=5)
+        try:
+            ffmpeg = FFMpeg(
+                audio_input="-",
+                input_format=self.pcm_format,
+                output_format=handoff_format,
+                filter_params=output_plan.filter_params,
+                audio_output=fifo_fd,
+            )
+            await ffmpeg.start()
+        finally:
+            # the ffmpeg child inherited the descriptor; drop our copy so the
+            # pipe sees EOF when ffmpeg exits
+            os.close(fifo_fd)
+        self._player_ffmpeg[player.player_id] = ffmpeg

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from collections.abc import AsyncGenerator
 from contextlib import suppress
@@ -108,6 +109,119 @@ class AirPlayStreamSession:
             # playback failed to start, cleanup
             await self.stop()
             raise PlayerCommandFailed("Playback failed to start") from err
+
+    def can_replace(self, sync_clients: list[AirPlayPlayer], pcm_format: AudioFormat) -> bool:
+        """
+        Return whether this live session can absorb a new play_media warm.
+
+        A warm replacement needs the same member set, the same session PCM
+        format and running AirPlay 2 streams on every member; anything else
+        takes the cold path.
+        """
+        if {p.player_id for p in sync_clients} != {p.player_id for p in self.sync_clients}:
+            return False
+        if (
+            pcm_format.sample_rate != self.pcm_format.sample_rate
+            or pcm_format.bit_depth != self.pcm_format.bit_depth
+        ):
+            return False
+        return all(
+            p.stream is not None and p.stream.running and p.protocol == StreamingProtocol.AIRPLAY2
+            for p in self.sync_clients
+        )
+
+    async def replace(self, audio_source: AsyncGenerator[bytes], media: PlayerMedia) -> bool:
+        """
+        Warm-replace the playing media with a new source (seek/next-track).
+
+        Each member stages the new source as its next generation on a fresh
+        pipe while the old audio keeps playing; once every member reports
+        primed, one shared START commits the switch (warm flush + re-anchor)
+        a few hundred milliseconds later. Returns False when anything fails,
+        so the caller can fall back to the cold path.
+        """
+        position_ms = int((media.elapsed_time or 0) * 1000)
+        generations: dict[str, int] = {}
+        fifos: dict[str, str] = {}
+        try:
+            # stage the new generation on every member (old audio unaffected)
+            for player in self.sync_clients:
+                stream = player.stream
+                assert stream
+                gen = stream.next_generation()
+                fifo = f"/tmp/ma-gen-{player.player_id}-{gen}.pcm"  # noqa: S108
+                with suppress(FileNotFoundError):
+                    await asyncio.to_thread(os.unlink, fifo)
+                await asyncio.to_thread(os.mkfifo, fifo)
+                generations[player.player_id] = gen
+                fifos[player.player_id] = fifo
+                await stream.prepare_generation(gen, fifo, position_ms)
+
+            # swap the source: retire the old flow + per-player DSP ffmpegs,
+            # spawn fresh ones writing into the generation pipes
+            if self._audio_source_task and not self._audio_source_task.done():
+                self._audio_source_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await self._audio_source_task
+            for player in self.sync_clients:
+                if ffmpeg := self._player_ffmpeg.pop(player.player_id, None):
+                    await ffmpeg.close()
+                stream = player.stream
+                assert stream
+                handoff_format = stream.pcm_format
+                output_plan = self.mass.streams.audio.get_player_output_plan(
+                    player.player_id,
+                    input_format=self.pcm_format,
+                    output_format=get_final_output_format(handoff_format, player),
+                    handoff_format=handoff_format,
+                    queue_id=media.source_id,
+                    session_id=get_media_session_id(media),
+                )
+                ffmpeg = FFMpeg(
+                    audio_input="-",
+                    input_format=self.pcm_format,
+                    output_format=handoff_format,
+                    filter_params=output_plan.filter_params,
+                    audio_output=fifos[player.player_id],
+                )
+                await ffmpeg.start()
+                self._player_ffmpeg[player.player_id] = ffmpeg
+            self.media = media
+            self.seconds_streamed = 0
+            self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
+
+            # commit once every member is primed: same instant for the group,
+            # ASAP (binary-clamped warm lead) for a standalone player
+            primed = await asyncio.gather(
+                *[
+                    p.stream.wait_generation_primed(generations[p.player_id])
+                    for p in self.sync_clients
+                    if p.stream
+                ]
+            )
+            if not all(primed):
+                raise PlayerCommandFailed("generation prime timeout")
+            start_unix_ms = 0 if len(self.sync_clients) == 1 else int(time.time() * 1000) + 750
+            for player in self.sync_clients:
+                member_start = start_unix_ms
+                sync_adjust = player.config.get_value(CONF_SYNC_ADJUST, 0)
+                if start_unix_ms and isinstance(sync_adjust, int) and sync_adjust:
+                    member_start += sync_adjust
+                stream = player.stream
+                assert stream
+                await stream.start_generation(
+                    generations[player.player_id], position_ms, member_start
+                )
+        except Exception as err:
+            self.prov.logger.warning(
+                "Warm replacement failed (%s); falling back to a cold restart", err
+            )
+            return False
+        finally:
+            for fifo in fifos.values():
+                with suppress(OSError):
+                    await asyncio.to_thread(os.unlink, fifo)
+        return True
 
     async def stop(self) -> None:
         """Stop playback and cleanup."""

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -166,7 +166,11 @@ class AirPlayStreamSession:
             for player in self.sync_clients:
                 await self._start_generation_ffmpeg(player, fifos[player.player_id], media)
             self.media = media
+            # The stream position counter and the late-join prime buffer both
+            # describe the OLD generation's timeline; restart them before the
+            # new source starts pumping.
             self.seconds_streamed = 0
+            self._pcm_buffer.clear()
             self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
 
             # commit once every member is primed: same instant for the group,
@@ -180,20 +184,28 @@ class AirPlayStreamSession:
             )
             if not all(primed):
                 raise PlayerCommandFailed("generation prime timeout")
-            start_unix_ms = 0 if len(self.sync_clients) == 1 else int(time.time() * 1000) + 750
+            # Commit at an explicit shared instant: a lone player gets a hair
+            # above the binary's minimum warm lead, a group extra headroom.
+            warm_lead_ms = 400 if len(self.sync_clients) == 1 else 750
+            start_unix_ms = int(time.time() * 1000) + warm_lead_ms
             for player in self.sync_clients:
                 member_start = start_unix_ms
                 sync_adjust = player.config.get_value(CONF_SYNC_ADJUST, 0)
-                if start_unix_ms and isinstance(sync_adjust, int) and sync_adjust:
+                if isinstance(sync_adjust, int) and sync_adjust:
                     member_start += sync_adjust
                 stream = player.stream
                 assert stream
                 await stream.start_generation(
                     generations[player.player_id], position_ms, member_start
                 )
+            # Re-anchor the session on the new generation's timeline so late
+            # joiners map buffered samples to the correct wall-clock instant
+            # (the old anchor died with the warm flush).
+            self.start_unix_ms = start_unix_ms
+            self.start_time = start_unix_ms / 1000
         except Exception as err:
             self.prov.logger.warning(
-                "Warm replacement failed (%s); falling back to a cold restart", err
+                "Warm replacement failed (%r); falling back to a cold restart", err
             )
             return False
         finally:

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -812,10 +812,30 @@ async def test_single_player_pause_sends_action_pause(airplay_player: AirPlayPla
 
 
 @pytest.mark.asyncio
-async def test_grouped_leader_pause_stops_session(airplay_player: AirPlayPlayer) -> None:
-    """A sync leader pauses by stopping the whole session, never sending ACTION=PAUSE."""
+async def test_grouped_leader_pause_parks_session(airplay_player: AirPlayPlayer) -> None:
+    """A sync leader pauses by parking the session (standby), never sending ACTION=PAUSE."""
     airplay_player._attr_group_members = ["test_player", "child"]
     send_cmd = _setup_running_stream(airplay_player)
+    assert airplay_player.stream is not None
+    session = cast("MagicMock", airplay_player.stream.session)
+    session.standby = AsyncMock(return_value=True)
+
+    with patch.object(AirPlayPlayer, "stop", new=AsyncMock()) as mock_stop:
+        await airplay_player.pause()
+
+    session.standby.assert_awaited_once()
+    mock_stop.assert_not_called()
+    send_cmd.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_grouped_pause_falls_back_to_stop(airplay_player: AirPlayPlayer) -> None:
+    """When a member cannot be parked (e.g. RAOP), grouped pause stops the session."""
+    airplay_player._attr_group_members = ["test_player", "child"]
+    send_cmd = _setup_running_stream(airplay_player)
+    assert airplay_player.stream is not None
+    session = cast("MagicMock", airplay_player.stream.session)
+    session.standby = AsyncMock(return_value=False)
 
     with patch.object(AirPlayPlayer, "stop", new=AsyncMock()) as mock_stop:
         await airplay_player.pause()
@@ -825,10 +845,13 @@ async def test_grouped_leader_pause_stops_session(airplay_player: AirPlayPlayer)
 
 
 @pytest.mark.asyncio
-async def test_synced_child_pause_stops_session(airplay_player: AirPlayPlayer) -> None:
-    """A synced child also pauses by stopping the shared session, never ACTION=PAUSE."""
+async def test_synced_child_pause_parks_session(airplay_player: AirPlayPlayer) -> None:
+    """A synced child also pauses by parking the shared session, never ACTION=PAUSE."""
     airplay_player._attr_group_members = []
     send_cmd = _setup_running_stream(airplay_player)
+    assert airplay_player.stream is not None
+    session = cast("MagicMock", airplay_player.stream.session)
+    session.standby = AsyncMock(return_value=True)
 
     with (
         patch.object(AirPlayPlayer, "synced_to", new_callable=PropertyMock, return_value="parent"),
@@ -836,5 +859,6 @@ async def test_synced_child_pause_stops_session(airplay_player: AirPlayPlayer) -
     ):
         await airplay_player.pause()
 
-    mock_stop.assert_called_once()
+    session.standby.assert_awaited_once()
+    mock_stop.assert_not_called()
     send_cmd.assert_not_called()

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -208,6 +208,10 @@ async def test_ptp_daemon_spawn_advertises_dacp_identity() -> None:
     prov.dacp_id = "AABBCCDD11223344"
     prov.mass = MagicMock()
     prov.mass.streams.bind_ip = "0.0.0.0"
+    # The spawn mirrors the live logger level into --debug flags; pin the
+    # level so suite ordering (other tests raising verbosity) cannot leak
+    # extra args into this assertion.
+    prov.logger.setLevel(logging.INFO)
 
     def _consume_task(coro: object) -> MagicMock:
         if asyncio.iscoroutine(coro):
@@ -232,6 +236,34 @@ async def test_ptp_daemon_spawn_advertises_dacp_identity() -> None:
         "--dacp",
         "AABBCCDD11223344",
     ]
+
+
+async def test_ptp_daemon_spawn_mirrors_debug_level() -> None:
+    """A debug-level provider logger passes a debug flag through to the daemon."""
+    prov = _ptp_provider()
+    prov.dacp_id = "AABBCCDD11223344"
+    prov.mass = MagicMock()
+    prov.mass.streams.bind_ip = "0.0.0.0"
+    prov.logger.setLevel(logging.DEBUG)
+
+    def _consume_task(coro: object) -> MagicMock:
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        return MagicMock()
+
+    prov.mass.create_task.side_effect = _consume_task
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.provider.get_cli_binary",
+            AsyncMock(return_value="/bin/cliairplay"),
+        ),
+        patch("music_assistant.providers.airplay.provider.AsyncProcess") as process_cls,
+    ):
+        process_cls.return_value.start = AsyncMock()
+        await prov._start_ptp_daemon()
+
+    assert process_cls.call_args.args[0][-2:] == ["--debug", "5"]
 
 
 def test_ptp_daemon_ready_event_set_on_daemon_up_line() -> None:

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -6,7 +6,7 @@ import time
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
-from music_assistant.constants import CONF_SYNC_ADJUST
+from music_assistant.constants import CONF_SYNC_ADJUST, VERBOSE_LOG_LEVEL
 from music_assistant.providers.airplay.constants import (
     CONF_FORCE_RAOP,
     CONF_LEGACY_AIRPLAY_PROTOCOL,
@@ -238,8 +238,8 @@ async def test_ptp_daemon_spawn_advertises_dacp_identity() -> None:
     ]
 
 
-async def test_ptp_daemon_spawn_mirrors_debug_level() -> None:
-    """A debug-level provider logger passes a debug flag through to the daemon."""
+async def test_ptp_daemon_spawn_quiet_at_debug_level() -> None:
+    """A normal debug session keeps the daemon quiet (no per-packet tracing)."""
     prov = _ptp_provider()
     prov.dacp_id = "AABBCCDD11223344"
     prov.mass = MagicMock()
@@ -263,7 +263,35 @@ async def test_ptp_daemon_spawn_mirrors_debug_level() -> None:
         process_cls.return_value.start = AsyncMock()
         await prov._start_ptp_daemon()
 
-    assert process_cls.call_args.args[0][-2:] == ["--debug", "5"]
+    assert "--debug" not in process_cls.call_args.args[0]
+
+
+async def test_ptp_daemon_spawn_traces_at_verbose_level() -> None:
+    """A verbose session turns on the daemon's per-packet timing trace."""
+    prov = _ptp_provider()
+    prov.dacp_id = "AABBCCDD11223344"
+    prov.mass = MagicMock()
+    prov.mass.streams.bind_ip = "0.0.0.0"
+    prov.logger.setLevel(VERBOSE_LOG_LEVEL)
+
+    def _consume_task(coro: object) -> MagicMock:
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        return MagicMock()
+
+    prov.mass.create_task.side_effect = _consume_task
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.provider.get_cli_binary",
+            AsyncMock(return_value="/bin/cliairplay"),
+        ),
+        patch("music_assistant.providers.airplay.provider.AsyncProcess") as process_cls,
+    ):
+        process_cls.return_value.start = AsyncMock()
+        await prov._start_ptp_daemon()
+
+    assert process_cls.call_args.args[0][-2:] == ["--debug", "10"]
 
 
 def test_ptp_daemon_ready_event_set_on_daemon_up_line() -> None:

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -1,7 +1,7 @@
 """
 Unit tests for the Sendspin -> AirPlay bridge timing.
 
-Cover three things, with the Sendspin clock mocked via ``ManualClock`` so the
+Cover four things, with the Sendspin clock mocked via ``ManualClock`` so the
 tests are deterministic and independent of the host wall-clock:
 
 * the clock-domain conversion turning a Sendspin audible instant (Sendspin's own
@@ -9,9 +9,13 @@ tests are deterministic and independent of the host wall-clock:
 * the start anchor: byte 0 is anchored to the first chunk Sendspin delivers, so a
   fresh track keeps position 0 and a late joiner lands at the group's live position;
 * the write pacing that keeps the device buffered a bounded amount ahead of real
-  time so a late-join catch-up backlog is not dumped into the CLI.
+  time so a late-join catch-up backlog is not dumped into the CLI;
+* the warm handover: a running, connected AirPlay 2 stream is kept (not torn down)
+  across a new Sendspin stream, and stages/commits a new generation on itself
+  instead of a cold reconnect -- with prime-timeout and superseded-task fallback.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiosendspin.clock import ManualClock
@@ -266,3 +270,139 @@ async def test_failed_cli_write_does_not_advance_pacing_cursor() -> None:
 
     assert [call.args[1] for call in buffer_ahead.call_args_list] == [0, 0]
     assert stream.write_audio.await_count == 2
+
+
+# --- Warm handover: a kept stream survives a new stream start and absorbs a generation ---
+
+
+def _make_kept_stream(
+    *, route: str = "AirPlay 2 (realtime, PTP)", running: bool = True, connected: bool = True
+) -> MagicMock:
+    """Build a mock AirPlayStream reporting the given running/connected/route state."""
+    stream = MagicMock()
+    stream.running = running
+    stream.connected = connected
+    stream.active_route = route
+    return stream
+
+
+def test_on_bridge_stream_start_keeps_warm_eligible_stream() -> None:
+    """A running, connected AirPlay 2 stream survives a new Sendspin stream start."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    kept_stream = _make_kept_stream()
+    bridge._airplay_stream = kept_stream
+    bridge.airplay_player.stream = kept_stream
+
+    bridge._on_bridge_stream_start()
+
+    assert bridge._airplay_stream is kept_stream
+    assert bridge.airplay_player.stream is kept_stream
+
+
+def test_on_bridge_stream_start_replaces_non_eligible_stream() -> None:
+    """A RAOP stream is cleared on a new Sendspin stream start so a fresh one is built."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    old_stream = _make_kept_stream(route="RAOP")
+    bridge._airplay_stream = old_stream
+    bridge.airplay_player.stream = old_stream
+
+    bridge._on_bridge_stream_start()
+
+    assert bridge._airplay_stream is None
+    # mypy narrows this attribute to MagicMock from the assignment above and doesn't
+    # know _on_bridge_stream_start() resets it, so it (wrongly) considers this unreachable.
+    assert bridge.airplay_player.stream is None  # type: ignore[unreachable]
+
+
+def test_on_stream_start_keeps_warm_eligible_stream() -> None:
+    """The Sendspin-server-side stream-start callback also keeps a warm-eligible stream."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    kept_stream = _make_kept_stream()
+    bridge._airplay_stream = kept_stream
+    bridge.airplay_player.stream = kept_stream
+
+    bridge._on_stream_start(MagicMock())
+
+    assert bridge._airplay_stream is kept_stream
+    assert bridge.airplay_player.stream is kept_stream
+
+
+async def test_warm_generation_commits_on_kept_stream_instance() -> None:
+    """A warm handover stages and commits a new generation on the same stream instance."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    kept_stream = MagicMock()
+    kept_stream.next_generation = MagicMock(return_value=3)
+    kept_stream.prepare_generation = AsyncMock()
+    kept_stream.wait_generation_primed = AsyncMock(return_value=True)
+    kept_stream.start_generation = AsyncMock()
+    bridge._airplay_stream = kept_stream
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    expected_fifo = f"/tmp/ma-bridge-{bridge.airplay_player.player_id}-3.pcm"  # noqa: S108
+
+    with (
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=99),
+    ):
+        committed = await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
+
+    assert committed is True
+    assert bridge._airplay_stream is kept_stream  # no new instance was built
+    kept_stream.prepare_generation.assert_awaited_once_with(3, expected_fifo, 0)
+    kept_stream.wait_generation_primed.assert_awaited_once_with(3)
+    kept_stream.start_generation.assert_awaited_once_with(3, 0, 1_784_000_000_000)
+    assert bridge._sink_fd == 99
+    assert bridge._airplay_stream_ready.is_set()
+
+
+async def test_warm_generation_prime_timeout_falls_back_to_cold_restart() -> None:
+    """A prime timeout never commits and reverts the writer to the stdin sink."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    kept_stream = MagicMock()
+    kept_stream.next_generation = MagicMock(return_value=1)
+    kept_stream.prepare_generation = AsyncMock()
+    kept_stream.wait_generation_primed = AsyncMock(return_value=False)
+    kept_stream.start_generation = AsyncMock()
+    bridge._airplay_stream = kept_stream
+    bridge._airplay_stream_start_task = asyncio.current_task()
+
+    with (
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=55),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as mock_close,
+    ):
+        committed = await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
+
+    assert committed is False
+    kept_stream.start_generation.assert_not_awaited()
+    assert bridge._sink_fd is None  # reverted so the cold-path writer uses stdin again
+    mock_close.assert_any_call(55)
+
+
+async def test_warm_generation_superseded_before_commit_does_not_start() -> None:
+    """If a newer stream start already owns the bridge, the stale attempt never commits."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    kept_stream = MagicMock()
+    kept_stream.next_generation = MagicMock(return_value=2)
+    kept_stream.prepare_generation = AsyncMock()
+    kept_stream.wait_generation_primed = AsyncMock(return_value=True)
+    kept_stream.start_generation = AsyncMock()
+    bridge._airplay_stream = kept_stream
+    # Simulate a newer stream start having already replaced the tracked task.
+    bridge._airplay_stream_start_task = MagicMock()
+
+    with (
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=77),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as mock_close,
+    ):
+        committed = await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
+
+    assert committed is False
+    kept_stream.start_generation.assert_not_awaited()
+    mock_close.assert_any_call(77)
+    # Left pointing at the now-closed fd rather than touched further: a newer task may
+    # already be relying on self._sink_fd, so the stale attempt only cleans up its own copy.
+    assert bridge._sink_fd == 77

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -402,7 +402,8 @@ async def test_warm_generation_superseded_before_commit_does_not_start() -> None
 
     assert committed is False
     kept_stream.start_generation.assert_not_awaited()
-    mock_close.assert_any_call(77)
-    # Left pointing at the now-closed fd rather than touched further: a newer task may
-    # already be relying on self._sink_fd, so the stale attempt only cleans up its own copy.
+    # The stale attempt must NOT close the fd: it was published as self._sink_fd,
+    # so closing it here would break the writer (EBADF) or double-close a fd a
+    # newer task already replaced. Its lifecycle is owned by _set_sink_fd/teardown.
+    assert all(call.args[0] != 77 for call in mock_close.call_args_list)
     assert bridge._sink_fd == 77


### PR DESCRIPTION
# What does this implement/fix?

Seeking, skipping to the next track and resuming on AirPlay used to tear down the connection to the speaker and build a new one from scratch, which is why those actions took several seconds.

This keeps the connection alive and swaps the audio underneath it, so seek and next-track land in about a second instead of four or five. The audio for the new position is prepared while the current track is still playing, then every speaker in a group switches over at the same instant so they stay in sync.

Pausing a group now keeps the speakers connected instead of stopping them, so playback resumes together and the remote on the device keeps working. Players driven through the Sendspin bridge get the same fast seeking and track changes. Natural track-to-track playback is unchanged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
