### PR TITLE
Release the active output protocol when a wrapped player's session ends

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -126,6 +126,7 @@ if TYPE_CHECKING:
         CoreConfig,
         PlayerConfig,
     )
+    from music_assistant_models.player import OutputProtocol
     from music_assistant_models.player_queue import PlayerQueue
 
     from music_assistant import MusicAssistant
@@ -3555,12 +3556,18 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             player.set_active_mass_source(media.source_id)
 
         # Determine output protocol to use:
-        # If player already has an active protocol set, prefer that.
-        # Otherwise, select best protocol based on current state.
+        # While a session is active (playing/paused), keep using the already active
+        # protocol so mid-session commands stay on the same output.
+        # On a fresh start always (re)select: a leftover active protocol from a
+        # previous session must not overrule user preference, a grouped protocol
+        # or native playback (and it may point at a player that is gone by now).
+        target_player: Player | None = None
+        output_protocol: OutputProtocol | None = None
         if (
-            player.active_output_protocol
+            player.state.playback_state in (PlaybackState.PLAYING, PlaybackState.PAUSED)
+            and player.active_output_protocol
             and player.active_output_protocol != "native"
-            and (target_player := self.get_player(player.active_output_protocol))
+            and (protocol_player := self.get_player(player.active_output_protocol))
         ):
             # Use the already-set protocol directly
             output_protocol = next(
@@ -3571,7 +3578,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 ),
                 None,
             )
-        else:
+            if output_protocol is not None:
+                target_player = protocol_player
+        if target_player is None:
             target_player, output_protocol = self._select_best_output_protocol(player)
 
         if target_player.player_id != player.player_id:
@@ -3710,16 +3719,30 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         """
         player = self.get_player(player_id, raise_unavailable=True)
         assert player is not None
+        protocol_player: Player | None = None
+        if player.active_output_protocol and player.active_output_protocol != "native":
+            protocol_player = self.get_player(player.active_output_protocol)
         if player.state.playback_state == PlaybackState.IDLE:
+            # The player already reports idle but an output protocol is still marked
+            # active: the protocol player may never have received a stop at all
+            # (e.g. the source stream ended on its own before this stop command
+            # arrived). Forward an (idempotent) stop and schedule the protocol clear
+            # so no stale session lingers on the device and the next playback
+            # (re)selects the output protocol.
+            if protocol_player is not None:
+                await protocol_player.stop()
+                if len(protocol_player.group_members) <= 1:
+                    self.mass.call_later(
+                        5,
+                        player.set_active_output_protocol,
+                        None,
+                        task_id=f"clear_active_protocol_{player_id}",
+                    )
             return
         player.mark_stop_called()
         # Delegate to active protocol player if one is active
         target_player = player
-        if (
-            player.active_output_protocol
-            and player.active_output_protocol != "native"
-            and (protocol_player := self.get_player(player.active_output_protocol))
-        ):
+        if protocol_player is not None:
             target_player = protocol_player
             if PlayerFeature.POWER in target_player.supported_features:
                 # if protocol player supports/requires power,

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -580,8 +580,21 @@ class SendspinPlayer(SendspinBasePlayer):
 
     def _on_group_stopped(self) -> None:
         """Cancel playback session when group stops and we are the leader."""
-        if self.synced_to is None:
-            self.mass.create_task(self.playback_session.cancel("group stopped"))
+        if self.synced_to is not None:
+            return
+        # Bind the cancel to the session task that is live right now: by the time
+        # the deferred task below runs, play_media may already have started a fresh
+        # session, which must not be torn down by this stale group-stopped event.
+        stale_task = self.playback_session.playback_task
+        if stale_task is None or stale_task.done():
+            return
+        self.mass.create_task(self._cancel_stale_playback_session(stale_task))
+
+    async def _cancel_stale_playback_session(self, task: asyncio.Task[None]) -> None:
+        """Cancel the playback session only if the given task is still the active one."""
+        if self.playback_session.playback_task is not task:
+            return
+        await self.playback_session.cancel("group stopped")
 
     def group_event_cb(self, group: SendspinGroup, event: GroupEvent) -> None:
         """Event callback registered to the sendspin group this player belongs to."""


### PR DESCRIPTION
Backport of #4937 to stable.

A player that outputs through a linked protocol (a Sendspin or AirPlay device wrapped by a universal/native player) could get pinned to a stale output protocol and go silent on the next session: the active protocol was only ever cleared by a stop that arrived while the player was still playing, so when the source stream ended on its own first, the idle early-return skipped both the protocol-player stop and the protocol clear.

- idle-stop now forwards an idempotent stop to the protocol player and schedules the protocol clear
- a fresh start re-selects the output protocol instead of reusing a stale one
- sendspin: the deferred group-stopped cancel is bound to the session that was live, so it can't tear down a newer one

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

Related issue: music-assistant/support#5771
