### PR TITLE
Start AirPlay groups after all players are ready

### DIFF
--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -225,13 +225,15 @@ Apple TV and Mac devices require pairing before they can be used for streaming.
 The `AirPlayStreamSession` class in [stream_session.py](stream_session.py) manages streaming to one or more synchronized players:
 
 1. **Initialization** (`start()` method)
-   - Calculates the audible start instant (`now + setup lead`) as unix epoch milliseconds
-   - Every member receives the exact same start value (`--start-unix-ms`)
+   - Connects every member before preparing playback
+   - Prepares generation 0 on every connected CLI and starts feeding audio
+   - Waits until every member reports the generation primed
+   - Sends one shared audible start instant to every member
 
 2. **Client Setup** (per player, `_start_client()` method)
    - Creates an `AirPlayStream` instance with the player's PCM format
      (16-bit default, 24-bit s32le when hi-res is enabled)
-   - Starts the CLI process with the shared start instant
+   - Starts the CLI process and connects to the receiver without starting playback
    - Configures FFmpeg for audio format conversion and optional DSP filters
    - Pipes FFmpeg output to CLI process stdin
 
@@ -242,7 +244,7 @@ The `AirPlayStreamSession` class in [stream_session.py](stream_session.py) manag
    - Handles silence padding if audio source is slow (watchdog mechanism)
 
 4. **Connection Monitoring**
-   - Waits for all devices to connect before starting playback
+   - Waits for all devices to connect and prime before starting playback
    - Monitors CLI stderr for connection status and errors
    - Removes players that fail to keep up (write timeouts)
 
@@ -402,24 +404,23 @@ The provider monitors stderr in a separate task (`_stderr_reader()` in [stream.p
 
 ## Start Timing and Synchronization
 
-The provider never handles NTP fixed-point formats: the group start is passed
-to the binary as plain unix epoch milliseconds (`--start-unix-ms`), meaning
-"**the first sample is audible exactly at this instant**" on every protocol
-path (RAOP, AirPlay 2 RAOP-compat and native).
+The provider never handles NTP fixed-point formats: every media generation is
+prepared and started over the command pipe. `START_UNIX_MS` is a plain unix
+epoch millisecond meaning "**the first sample is audible exactly at this
+instant**" on every protocol path (RAOP, AirPlay 2 RAOP-compat and native).
 
-1. Calculate the start instant: `now + wait_start`, a fixed per-protocol lead
-   (`AIRPLAY_RAOP_SETUP_LEAD_MS` / `AIRPLAY_AP2_SETUP_LEAD_MS`) covering process
-   spawn + connect + session setup + receiver pre-fill; native AirPlay 2 uses
-   the larger budget as its pre-fill is paced
-2. Pass the **same** value to every member of a sync group — the group takes
-   the largest member lead, so mixed RAOP + AirPlay 2 groups align by
-   construction
-3. The binary owns all lead/buffer handling from there: it fills the
-   receiver's buffer ahead of the audible start (clamped to the buffering
-   window the device reports), so the start cannot underrun
-4. Audio may be written to the binary's stdin as soon as it is available -
-   byte 0 of stdin maps to the sample audible at the start instant
-5. Per-player `sync_adjust` config allows fine-tuning (+/- milliseconds)
+1. Start every CLI and wait until every group member reports connected
+2. Send `PREPARE` for generation 0 to every member, begin feeding PCM, and wait
+   until every member reports primed
+3. Calculate one explicit start instant with a short post-prime lead and send
+   the same value in `START` to every member
+4. The binary owns receiver-buffer handling from there, so the commanded start
+   cannot race connection or pre-fill
+5. Warm seek, next-track and resume use the same PREPARE/prime/START barrier for
+   later generations
+6. Sendspin starts preserve its externally supplied audible instant after the
+   same connection and prime gates
+7. Per-player `sync_adjust` config allows fine-tuning (+/- milliseconds)
 
 ### Shared PTP Clock Daemon
 

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -51,14 +51,10 @@ MRP_DISCOVERY_TYPE: Final[str] = "_mediaremotetv._tcp.local."
 RAOP_DISCOVERY_TYPE: Final[str] = "_raop._tcp.local."
 DACP_DISCOVERY_TYPE: Final[str] = "_dacp._tcp.local."
 
-# Fixed lead (ms) between starting the stream and the audible group start
-# (--start-unix-ms means "the first sample is audible exactly at this instant"
-# on every protocol path). Covers process spawn + connect/session setup plus
-# the receiver-buffer pre-fill the binary does ahead of the audible start.
-# The effective pre-fill is roughly lead - connect_time; the native AirPlay 2
-# path needs a larger budget than RAOP because its pre-fill is paced (RAOP
-# bursts its backlog and fills faster), so too short a lead intermittently
-# clips the first fraction of a second on native receivers such as Sonos.
+# Setup lead (ms) advertised to externally timed sources such as Sendspin.
+# It covers process spawn, connect/session setup and receiver pre-fill before
+# the commanded audible instant. Native AirPlay 2 needs a larger budget than
+# RAOP because its pre-fill is paced.
 AIRPLAY_RAOP_SETUP_LEAD_MS: Final[int] = 1500
 AIRPLAY_AP2_SETUP_LEAD_MS: Final[int] = 2500
 # Late joiners keep a more conservative headroom: besides connecting, their

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -204,11 +204,7 @@ class AirPlayPlayer(Player):
 
     @property
     def wait_start(self) -> int:
-        """Get the lead time in ms between starting the stream and the audible start."""
-        # the binary owns all lead/buffer handling from the chosen start instant;
-        # MA only budgets a fixed setup lead for spawn + connect + session setup
-        # + receiver pre-fill. Native AirPlay 2 needs a larger budget than RAOP
-        # (its pre-fill is paced), otherwise the start clips intermittently.
+        """Get the setup lead required by an externally timed audio source."""
         if self.protocol == StreamingProtocol.RAOP:
             return AIRPLAY_RAOP_SETUP_LEAD_MS
         return AIRPLAY_AP2_SETUP_LEAD_MS

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -96,7 +96,7 @@ def sendspin_audible_instant_to_unix_ms(
     Map an audible instant on the Sendspin clock to a unix epoch millisecond.
 
     Sendspin schedules playback on its own monotonic clock (``server.clock.now_us()``)
-    whereas the AirPlay binary's ``--start-unix-ms`` contract is unix wall-clock.
+    whereas the AirPlay generation START command uses unix wall-clock.
     The two clocks share no epoch, so only the *offset from now* transfers between
     them: this takes how far ``audible_instant_us`` sits in the future on the
     Sendspin clock and applies that same offset to a unix reading captured at the
@@ -187,6 +187,7 @@ class SendspinAirPlayBridge:
         self._writer_task: asyncio.Task[None] | None = None
         self._airplay_stream_start_task: asyncio.Task[None] | None = None
         self._airplay_stream_ready = asyncio.Event()
+        self._generation_started = False
         self._cleanup_task: asyncio.Task[None] | None = None
         # Timer id for the deferred teardown on stream end. A seek/next ends the
         # sendspin stream and immediately starts a new one; deferring the CLI
@@ -318,6 +319,7 @@ class SendspinAirPlayBridge:
             stream is not None
             and stream.running
             and stream.connected
+            and self._generation_started
             and stream.active_route.startswith("AirPlay 2")
         )
 
@@ -376,6 +378,7 @@ class SendspinAirPlayBridge:
         self._drop_until_us = 0
         self._start_aligned = False
         self._start_unix_ms = 0
+        self._generation_started = False
 
     def _on_bridge_stream_start(self) -> None:
         """
@@ -412,6 +415,7 @@ class SendspinAirPlayBridge:
         self._drop_until_us = 0
         self._start_aligned = False
         self._start_unix_ms = 0
+        self._generation_started = False
         # Drain stale audio data from the previous stream
         while not self._write_queue.empty():
             self._write_queue.get_nowait()
@@ -435,7 +439,7 @@ class SendspinAirPlayBridge:
             # Derive the audible start instant from _drop_until_us (set on first
             # chunk arrival) so the CLI has enough lead to connect and establish
             # the session. _drop_until_us is on the Sendspin (monotonic) clock;
-            # map it to the unix epoch ms the binary's --start-unix-ms expects.
+            # map it to the unix epoch ms used by the generation START command.
             sendspin_clock_now_us = self.sendspin_server.clock.now_us()
             unix_clock_now = time.time()
             start_unix_ms = sendspin_audible_instant_to_unix_ms(
@@ -478,25 +482,32 @@ class SendspinAirPlayBridge:
             # and leaked. Only publish once start() succeeds and this task is current.
             new_stream = AirPlayStream(self.airplay_player)
             try:
-                await new_stream.start(start_unix_ms)
+                await new_stream.start()
+                await new_stream.wait_for_connection()
+                if asyncio.current_task() is not self._airplay_stream_start_task:
+                    await new_stream.stop(force=True)
+                    return
+                self._airplay_stream = new_stream
+                self.airplay_player.stream = new_stream
+                await new_stream.prepare_generation(0, "-", 0)
+                self._airplay_stream_ready.set()
+                if not await new_stream.wait_generation_primed(0):
+                    raise RuntimeError("generation 0 prime timed out")
+                if asyncio.current_task() is not self._airplay_stream_start_task:
+                    await new_stream.stop(force=True)
+                    return
+                await new_stream.start_generation(0, 0, start_unix_ms)
+                self._generation_started = True
             except BaseException:
                 with suppress(Exception):
                     await new_stream.stop(force=True)
                 raise
-            if asyncio.current_task() is not self._airplay_stream_start_task:
-                with suppress(Exception):
-                    await new_stream.stop(force=True)
-                return
-            self._airplay_stream = new_stream
-            self.airplay_player.stream = new_stream
-            self._airplay_stream_ready.set()
             self.logger.info(
                 "Bridge protocol started for %s (start_unix_ms=%s, lookahead=%.0fms)",
                 self.airplay_player.display_name,
                 start_unix_ms,
                 lead_us / 1000,
             )
-            self.mass.create_task(self._wait_for_airplay_connection())
         except Exception as err:
             self.logger.error(
                 "Failed to start AirPlay protocol for %s: %s",
@@ -561,6 +572,7 @@ class SendspinAirPlayBridge:
                 # its next PREPARE.
                 return False
             await stream.start_generation(gen, 0, start_unix_ms)
+            self._generation_started = True
             self.logger.info(
                 "Bridge warm handover for %s (generation=%d, start_unix_ms=%d)",
                 self.airplay_player.display_name,
@@ -585,22 +597,6 @@ class SendspinAirPlayBridge:
                 with suppress(OSError):
                     await asyncio.to_thread(os.unlink, fifo)
         return True
-
-    async def _wait_for_airplay_connection(self) -> None:
-        """Wait for AirPlay connection in the background and log the result."""
-        if not self._airplay_stream:
-            return
-        try:
-            await self._airplay_stream.wait_for_connection()
-            self.logger.info(
-                "AirPlay connection established for %s", self.airplay_player.display_name
-            )
-        except Exception as err:
-            self.logger.warning(
-                "AirPlay connection failed for %s: %s",
-                self.airplay_player.display_name,
-                err,
-            )
 
     def _on_volume_change(self, volume: int) -> None:
         """Forward volume changes to the AirPlay player."""
@@ -888,6 +884,7 @@ class SendspinAirPlayBridge:
         self._is_streaming = False
         self._next_expected_timestamp_us = None
         self._airplay_stream_ready.clear()
+        self._generation_started = False
         if self._airplay_stream_start_task:
             self._airplay_stream_start_task.cancel()
             with suppress(asyncio.CancelledError, Exception):

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -88,7 +88,6 @@ class AirPlayStream:
         self._metadata_lock = asyncio.Lock()
         self._artwork_render_generations: set[int] = set()
         self._last_progress_sent: int = -1
-        self._elapsed_time_offset: float | None = None
         # Persistent generations: the binary keeps one connection alive and
         # plays numbered media generations over it (seek/next = new generation
         # on a fresh pipe instead of a reconnect).
@@ -127,16 +126,12 @@ class AirPlayStream:
 
     async def start(
         self,
-        start_unix_ms: int,
         use_shared_ptp: bool | None = None,
         ptp_follow: bool = False,
     ) -> None:
         """
-        Start cliairplay process.
+        Start cliairplay and connect to the receiver.
 
-        :param start_unix_ms: The instant the first sample must be audible,
-            as unix epoch milliseconds. All members of a sync group must
-            receive the same value.
         :param use_shared_ptp: Session-wide decision on whether native AirPlay 2
             members attach to the shared PTP clock daemon. The stream session
             passes the same value to every member so a group never mixes PTP and
@@ -147,7 +142,7 @@ class AirPlayStream:
             (Samsung renders only on its own clock). Never combined with the
             shared daemon.
         """
-        args = await self._build_cli_args(start_unix_ms, use_shared_ptp, ptp_follow)
+        args = await self._build_cli_args(use_shared_ptp, ptp_follow)
         self.player.logger.debug("Starting cliairplay for player %s", self.player.player_id)
         self._cli_proc = AsyncProcess(args, stdin=True, stdout=True, stderr=True, name="cliairplay")
         try:
@@ -171,7 +166,7 @@ class AirPlayStream:
     async def wait_for_connection(self) -> None:
         """Wait for device connection to be established."""
         if not self._cli_proc:
-            return
+            raise RuntimeError("cliairplay process is not running")
         await asyncio.wait_for(self._connected.wait(), timeout=10)
         # Send the mute-aware volume right away — audio can start within a
         # second now that metadata goes out immediately — and repeat it after
@@ -184,12 +179,9 @@ class AirPlayStream:
         self._metadata_text_checksum = ""
         self._pending_metadata_checksum = ""
         self._metadata_generation += 1
-        # Push track metadata immediately on connect. Some receivers (notably
-        # Sonos) hold back audio rendering until they receive track metadata
-        # anchored to the stream timeline; the binary anchors that timeline the
-        # instant it reports connected, so a metadata command issued now lands
-        # with a valid anchor. Deferring it kept those devices silent past the
-        # scheduled start, clipping the first seconds of the stream.
+        # Push track metadata before PREPARE/START. Some receivers (notably
+        # Sonos) hold back audio rendering until they receive track metadata;
+        # deferring it can keep them silent past the commanded start.
         self.player._on_player_media_updated()
 
     async def stop(self, force: bool = False) -> None:
@@ -265,12 +257,16 @@ class AirPlayStream:
 
     async def prepare_generation(self, generation: int, audio_path: str, position_ms: int) -> None:
         """
-        Stage the next media generation on the running binary.
+        Stage a media generation on the connected binary.
 
         The binary opens the given FIFO and prefills from it while the current
         generation keeps playing; `primed` is reported once enough audio is
         buffered for an underrun-free start.
         """
+        if not self.running or not self.connected:
+            raise RuntimeError("Cannot prepare a generation without a connected cliairplay process")
+        self._gen_ready.setdefault(generation, asyncio.Event())
+        self._gen_primed.setdefault(generation, asyncio.Event())
         await self._write_cli_command(
             f"GENERATION={generation}\nAUDIO={audio_path}\n"
             f"POSITION_MS={position_ms}\nACTION=PREPARE"
@@ -297,6 +293,11 @@ class AirPlayStream:
         minimum warm lead); a group start passes the same instant to every
         primed member.
         """
+        if not self.running or not self.connected:
+            raise RuntimeError("Cannot start a generation without a connected cliairplay process")
+        primed = self._gen_primed.get(generation)
+        if primed is None or not primed.is_set():
+            raise RuntimeError(f"Cannot start generation {generation} before it is primed")
         self._generation_position = position_ms / 1000
         self._active_generation = generation
         # Stamp the player's elapsed onto the new generation's base right away:
@@ -416,18 +417,18 @@ class AirPlayStream:
 
     async def _build_cli_args(  # noqa: PLR0915
         self,
-        start_unix_ms: int,
         use_shared_ptp: bool | None = None,
         ptp_follow: bool = False,
     ) -> list[str]:
         """
         Assemble the cliairplay argument list for this stream.
 
-        :param start_unix_ms: The audible-start instant in unix epoch ms.
         :param use_shared_ptp: Whether a native AirPlay 2 stream attaches to the
             shared PTP clock daemon. The stream session passes an explicit
             group-wide decision so members never mix PTP and NTP timing; None
             (single-stream callers) falls back to the daemon's live state.
+        :param ptp_follow: Whether a solo native AirPlay 2 stream may follow
+            the receiver's PTP clock.
         """
         cli_binary = await get_cli_binary()
         prov = cast("AirPlayProvider", self.prov)
@@ -455,8 +456,6 @@ class AirPlayStream:
             self.active_remote_id,
             "--cmdpipe",
             self.commands_pipe.path,
-            "--start-unix-ms",
-            str(start_unix_ms),
             "--samplerate",
             str(self.pcm_format.sample_rate),
             "--bitdepth",
@@ -757,14 +756,9 @@ class AirPlayStream:
             return -1
 
     def _update_elapsed(self, elapsed_time: float) -> None:
-        """Update elapsed time with session offset compensation."""
-        if self._active_generation > 0:
-            # elapsed restarts per generation; report against its media base
-            elapsed_time += self._generation_position
-        elif self._elapsed_time_offset is None and self.session:
-            self._elapsed_time_offset = max(0, time.time() - self.session.start_time - elapsed_time)
-        if self._active_generation == 0 and self._elapsed_time_offset:
-            elapsed_time += self._elapsed_time_offset
+        """Update elapsed time against the active generation's media position."""
+        # elapsed restarts per generation; report against its media base
+        elapsed_time += self._generation_position
         # The binary only emits this status while actually playing, so it is
         # also the signal that drives the player into the PLAYING state.
         self.player.set_state_from_stream(

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -125,7 +125,12 @@ class AirPlayStream:
         """Return boolean if the device connection has been established."""
         return self._connected.is_set()
 
-    async def start(self, start_unix_ms: int, use_shared_ptp: bool | None = None) -> None:
+    async def start(
+        self,
+        start_unix_ms: int,
+        use_shared_ptp: bool | None = None,
+        ptp_follow: bool = False,
+    ) -> None:
         """
         Start cliairplay process.
 
@@ -137,8 +142,12 @@ class AirPlayStream:
             passes the same value to every member so a group never mixes PTP and
             NTP timing. None (single-stream callers) falls back to the daemon's
             live state.
+        :param ptp_follow: Solo-session clock negotiation: the binary may yield
+            the timeline to a receiver that announces itself as a master
+            (Samsung renders only on its own clock). Never combined with the
+            shared daemon.
         """
-        args = await self._build_cli_args(start_unix_ms, use_shared_ptp)
+        args = await self._build_cli_args(start_unix_ms, use_shared_ptp, ptp_follow)
         self.player.logger.debug("Starting cliairplay for player %s", self.player.player_id)
         self._cli_proc = AsyncProcess(args, stdin=True, stdout=True, stderr=True, name="cliairplay")
         try:
@@ -406,7 +415,10 @@ class AirPlayStream:
                     self._metadata_checksum = metadata_checksum
 
     async def _build_cli_args(  # noqa: PLR0915
-        self, start_unix_ms: int, use_shared_ptp: bool | None = None
+        self,
+        start_unix_ms: int,
+        use_shared_ptp: bool | None = None,
+        ptp_follow: bool = False,
     ) -> list[str]:
         """
         Assemble the cliairplay argument list for this stream.
@@ -518,7 +530,12 @@ class AirPlayStream:
         # daemon's live state.
         if target_protocol == StreamingProtocol.AIRPLAY2:
             shared_ptp = prov.ptp_daemon_running if use_shared_ptp is None else use_shared_ptp
-            if shared_ptp:
+            if ptp_follow:
+                # Solo session: negotiate the clock honestly and yield to a
+                # master-or-mute receiver (Samsung); never via the shared
+                # daemon, which always holds grandmaster.
+                args += ["--ptp-follow"]
+            elif shared_ptp:
                 args += ["--ptp-shared"]
 
         # Local interface binding

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -430,6 +430,8 @@ class AirPlayStream:
         :param ptp_follow: Whether a solo native AirPlay 2 stream may follow
             the receiver's PTP clock.
         """
+        if use_shared_ptp and ptp_follow:
+            raise ValueError("Shared PTP and receiver clock-follow are mutually exclusive")
         cli_binary = await get_cli_binary()
         prov = cast("AirPlayProvider", self.prov)
         airplay_info = self.player.airplay_discovery_info

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -66,6 +66,10 @@ class AirPlayStreamSession:
         # sync group can never mix shared-PTP and NTP members.
         self.use_shared_ptp: bool = False
         self._shared_ptp_resolved = False
+        # A lone native AirPlay 2 player negotiates the clock honestly and may
+        # yield the timeline to a master-or-mute receiver (Samsung); groups
+        # keep the sender-owned shared timeline.
+        self._ptp_follow = False
         self._ptp_degraded_warning_logged = False
         # Raw PCM ring buffer for late joiners. When a late joiner arrives we
         # send this buffer to prime its pipeline so it starts playing quickly
@@ -79,7 +83,8 @@ class AirPlayStreamSession:
     async def start(self, audio_source: AsyncGenerator[bytes]) -> None:
         """Initialize stream session for all players."""
         ap2_members = sum(1 for p in self.sync_clients if p.protocol == StreamingProtocol.AIRPLAY2)
-        if ap2_members:
+        self._ptp_follow = ap2_members == 1 and len(self.sync_clients) == 1
+        if ap2_members and not self._ptp_follow:
             # Resolve the timing source before calculating the audible anchor so
             # a bounded daemon-readiness wait cannot consume the setup lead.
             self.use_shared_ptp = await self._resolve_shared_ptp(ap2_members)
@@ -322,6 +327,11 @@ class AirPlayStreamSession:
            to prime the pipe while cliairplay is still connecting, then add to
            sync_clients so the audio streamer continues seamlessly.
         """
+        if self._ptp_follow:
+            # A group needs the sender-owned timeline; the solo session
+            # yielded its clock to the receiver, so restart as a group.
+            await self._regroup_from_follow()
+            return
         await self._resolve_late_joiner_ptp(airplay_player)
         async with self._lock:
             if not self.sync_clients:
@@ -497,6 +507,20 @@ class AirPlayStreamSession:
             ap2_members,
         )
 
+    async def _regroup_from_follow(self) -> None:
+        """
+        Restart a yielded (receiver-clocked) solo session as a proper group.
+
+        The late joiner is already in the leader's group_members, so the
+        queue's resume rebuilds playback as a sender-clocked group including
+        it. The resume runs as a task because the caller holds the leader's
+        lock (resume ends in play_media, which takes the same lock).
+        """
+        queue_id = self.media.source_id
+        await self.stop()
+        if queue_id:
+            self.mass.create_task(self.mass.player_queues.resume(queue_id, fade_in=False))
+
     async def _cleanup_after_removal(
         self, airplay_player: AirPlayPlayer, reason: str = "client removed"
     ) -> None:
@@ -653,7 +677,9 @@ class AirPlayStreamSession:
         assert isinstance(sync_adjust, int)
         if sync_adjust != 0:
             start_unix_ms += sync_adjust
-        await airplay_player.stream.start(start_unix_ms, use_shared_ptp)
+        await airplay_player.stream.start(
+            start_unix_ms, use_shared_ptp, ptp_follow=self._ptp_follow
+        )
         # Start ffmpeg to feed audio to CLI stdin
         if ffmpeg := self._player_ffmpeg.pop(airplay_player.player_id, None):
             await ffmpeg.close()

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -89,24 +89,28 @@ class AirPlayStreamSession:
             # a bounded daemon-readiness wait cannot consume the setup lead.
             self.use_shared_ptp = await self._resolve_shared_ptp(ap2_members)
             self._shared_ptp_resolved = True
-        cur_time = time.time()
-        wait_start = max(p.wait_start for p in self.sync_clients)
-        wait_start_seconds = wait_start / 1000
-        self.wait_start = wait_start_seconds
-        self.start_time = cur_time + wait_start_seconds
-        # group start as plain unix epoch milliseconds: every member of the
-        # sync group receives the exact same value (--start-unix-ms)
-        self.start_unix_ms = int(self.start_time * 1000)
+        self.wait_start = max(p.wait_start for p in self.sync_clients) / 1000
+        position_ms = int((self.media.elapsed_time or 0) * 1000)
+        generations = {player.player_id: 0 for player in self.sync_clients}
         try:
             async with asyncio.TaskGroup() as task_group:
                 for player in self.sync_clients:
-                    task_group.create_task(
-                        self._start_client(player, self.start_unix_ms, self.use_shared_ptp)
-                    )
-            self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
+                    task_group.create_task(self._start_client(player, self.use_shared_ptp))
             await asyncio.gather(
                 *[p.stream.wait_for_connection() for p in self.sync_clients if p.stream]
             )
+            async with asyncio.TaskGroup() as task_group:
+                for player in self.sync_clients:
+                    stream = player.stream
+                    assert stream
+                    task_group.create_task(stream.prepare_generation(0, "-", position_ms))
+            self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
+            primed = await asyncio.gather(
+                *[p.stream.wait_generation_primed(0) for p in self.sync_clients if p.stream]
+            )
+            if not all(primed):
+                raise PlayerCommandFailed("generation prime timeout")
+            await self._commit_generations(generations, position_ms)
         except asyncio.CancelledError:
             await self.stop()
             raise
@@ -178,8 +182,6 @@ class AirPlayStreamSession:
             self._pcm_buffer.clear()
             self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
 
-            # commit once every member is primed: same instant for the group,
-            # ASAP (binary-clamped warm lead) for a standalone player
             primed = await asyncio.gather(
                 *[
                     p.stream.wait_generation_primed(generations[p.player_id])
@@ -189,25 +191,7 @@ class AirPlayStreamSession:
             )
             if not all(primed):
                 raise PlayerCommandFailed("generation prime timeout")
-            # Commit at an explicit shared instant: a lone player gets a hair
-            # above the binary's minimum warm lead, a group extra headroom.
-            warm_lead_ms = 400 if len(self.sync_clients) == 1 else 750
-            start_unix_ms = int(time.time() * 1000) + warm_lead_ms
-            for player in self.sync_clients:
-                member_start = start_unix_ms
-                sync_adjust = player.config.get_value(CONF_SYNC_ADJUST, 0)
-                if isinstance(sync_adjust, int) and sync_adjust:
-                    member_start += sync_adjust
-                stream = player.stream
-                assert stream
-                await stream.start_generation(
-                    generations[player.player_id], position_ms, member_start
-                )
-            # Re-anchor the session on the new generation's timeline so late
-            # joiners map buffered samples to the correct wall-clock instant
-            # (the old anchor died with the warm flush).
-            self.start_unix_ms = start_unix_ms
-            self.start_time = start_unix_ms / 1000
+            await self._commit_generations(generations, position_ms)
         except Exception as err:
             self.prov.logger.warning(
                 "Warm replacement failed (%r); falling back to a cold restart", err
@@ -301,7 +285,7 @@ class AirPlayStreamSession:
         if airplay_player.stream and airplay_player.stream.session == self:
             await airplay_player.stream.stop(force=True)
 
-    async def add_client(self, airplay_player: AirPlayPlayer) -> None:
+    async def add_client(self, airplay_player: AirPlayPlayer) -> None:  # noqa: PLR0915
         """
         Add a sync client to the session as a late joiner.
 
@@ -318,14 +302,15 @@ class AirPlayStreamSession:
         buffered PCM, so the first sample we send maps to the correct future
         stream position.
 
-        1. Snapshot the ring buffer and calculate how many seconds it holds.
-        2. Map the buffer's first byte to its stream position; if the
+        1. Connect the new client without starting playback.
+        2. Snapshot the ring buffer and map its first byte to its stream
+           position; if the
            resulting start anchor is in the past, shift it forward to
            ``now + min_headroom`` and trim that many seconds from the buffer
            head so timing stays aligned with the rest of the group.
-        3. Start ffmpeg+CLI, write the (possibly trimmed) buffer into ffmpeg
-           to prime the pipe while cliairplay is still connecting, then add to
-           sync_clients so the audio streamer continues seamlessly.
+        3. Prepare generation 0, write the (possibly trimmed) buffer, and add
+           the client so the live stream continues priming it.
+        4. Start generation 0 only after the client reports primed.
         """
         if self._ptp_follow:
             # A group needs the sender-owned timeline; the solo session
@@ -339,6 +324,31 @@ class AirPlayStreamSession:
             first_client = self.sync_clients[0]
             if not first_client.stream or not first_client.stream.running:
                 return
+        try:
+            await self._start_client(airplay_player, self.use_shared_ptp)
+            stream = airplay_player.stream
+            assert stream
+            await stream.wait_for_connection()
+        except asyncio.CancelledError:
+            await self.stop_client(airplay_player, reason="late joiner start cancelled")
+            raise
+        except Exception as err:
+            self.prov.logger.warning(
+                "Late joiner %s: failed to connect pipeline: %s",
+                airplay_player.player_id,
+                err,
+            )
+            await self.stop_client(airplay_player, reason="late joiner connection failed")
+            return
+
+        async with self._lock:
+            if not self.sync_clients:
+                await self.stop_client(airplay_player, reason="session ended during late join")
+                return
+            first_client = self.sync_clients[0]
+            if not first_client.stream or not first_client.stream.running:
+                await self.stop_client(airplay_player, reason="session ended during late join")
+                return
             now = time.time()
             pcm_sample_size = self.pcm_format.pcm_sample_size
             frame_size = (self.pcm_format.bit_depth // 8) * self.pcm_format.channels
@@ -347,6 +357,7 @@ class AirPlayStreamSession:
             buffer_seconds = len(buffered_pcm) / pcm_sample_size
             # The first byte in the buffer corresponds to this stream position
             first_byte_pos = self.seconds_streamed - buffer_seconds
+            first_sample_pos = first_byte_pos
             start_at = self.start_time + first_byte_pos
 
             # The audio we hand to ffmpeg → cliairplay must be bit-aligned with
@@ -377,17 +388,21 @@ class AirPlayStreamSession:
                     # the clamp below may still move it later to preserve
                     # the required headroom.
                     buffered_pcm = b""
+                    first_sample_pos = self.seconds_streamed
                     start_at = self.start_time + self.seconds_streamed
                 else:
                     buffered_pcm = buffered_pcm[trim_bytes:]
                     # Advance start_at by exactly the trimmed duration so the
                     # NTP anchor matches the first sample we actually send.
-                    start_at += trim_bytes / pcm_sample_size
+                    trimmed_seconds = trim_bytes / pcm_sample_size
+                    first_sample_pos += trimmed_seconds
+                    start_at += trimmed_seconds
                 # Make sure start_at still leaves enough lead time for slow
                 # connections / very-far-behind joiners.
                 start_at = max(start_at, target_start_at)
 
             start_unix_ms = int(start_at * 1000)
+            position_ms = int(((self.media.elapsed_time or 0) + first_sample_pos) * 1000)
 
             self.prov.logger.debug(
                 "Late joiner %s: sending %.2fs of buffered audio, "
@@ -402,15 +417,13 @@ class AirPlayStreamSession:
                 trim_seconds,
             )
 
-            # Start ffmpeg+CLI and immediately write the buffered PCM.
-            # ffmpeg accepts data on stdin right away; it queues in the pipe
-            # while cliairplay is still connecting to the device.
             try:
-                # A late joiner must use the SAME timing source the group
-                # committed to at session start, else it would drift against it.
-                await self._start_client(airplay_player, start_unix_ms, self.use_shared_ptp)
+                await stream.prepare_generation(0, "-", position_ms)
                 if buffered_pcm:
                     await self._write_chunk_to_player(airplay_player, buffered_pcm)
+            except asyncio.CancelledError:
+                await self.stop_client(airplay_player, reason="late joiner prepare cancelled")
+                raise
             except Exception as err:
                 self.prov.logger.warning(
                     "Late joiner %s: failed to start/prime pipeline: %s",
@@ -420,8 +433,6 @@ class AirPlayStreamSession:
                 await self.stop_client(airplay_player, reason="late joiner start/prime failed")
                 return
 
-            # Now add to sync_clients — the audio streamer's next chunk
-            # continues exactly from seconds_streamed where the buffer ended.
             if airplay_player not in self.sync_clients:
                 self.sync_clients.append(airplay_player)
             if airplay_player.protocol == StreamingProtocol.AIRPLAY2 and not self.use_shared_ptp:
@@ -432,22 +443,31 @@ class AirPlayStreamSession:
                 )
                 self._warn_degraded_shared_ptp(ap2_members)
 
-        # Wait for device connection outside the lock.
-        if airplay_player.stream:
-            try:
-                await airplay_player.stream.wait_for_connection()
-                self.prov.logger.debug(
-                    "Late joiner %s: device connected after %.2fs",
-                    airplay_player.player_id,
-                    time.time() - now,
-                )
-            except TimeoutError:
-                self.prov.logger.warning(
-                    "Late joiner %s: device connection timed out after %.2fs",
-                    airplay_player.player_id,
-                    time.time() - now,
-                )
-                await self.remove_client(airplay_player, reason="late joiner connection timeout")
+        try:
+            if not await stream.wait_generation_primed(0):
+                raise PlayerCommandFailed("generation prime timeout")
+            await self._commit_generations(
+                {airplay_player.player_id: 0},
+                position_ms,
+                start_unix_ms,
+                reanchor_session=False,
+            )
+        except asyncio.CancelledError:
+            await self.remove_client(airplay_player, reason="late joiner prime cancelled")
+            raise
+        except Exception as err:
+            self.prov.logger.warning(
+                "Late joiner %s: failed to prime generation: %s",
+                airplay_player.player_id,
+                err,
+            )
+            await self.remove_client(airplay_player, reason="late joiner prime failed")
+            return
+        self.prov.logger.debug(
+            "Late joiner %s: device primed after %.2fs",
+            airplay_player.player_id,
+            time.time() - now,
+        )
 
     async def _resolve_shared_ptp(self, ap2_members: int | None = None) -> bool:
         """
@@ -655,14 +675,11 @@ class AirPlayStreamSession:
             if airplay_player.stream:
                 await airplay_player.stream.write_audio_eof()
 
-    async def _start_client(
-        self, airplay_player: AirPlayPlayer, start_unix_ms: int, use_shared_ptp: bool
-    ) -> None:
+    async def _start_client(self, airplay_player: AirPlayPlayer, use_shared_ptp: bool) -> None:
         """
-        Start CLI process and ffmpeg for a single client.
+        Connect a CLI process and start ffmpeg for a single client.
 
         :param airplay_player: The player to start streaming to.
-        :param start_unix_ms: The audible-start instant in unix epoch ms.
         :param use_shared_ptp: The session-wide shared-PTP decision applied to
             this member so the whole group shares one timing source.
         """
@@ -673,13 +690,7 @@ class AirPlayStreamSession:
         stream_pcm_format = airplay_player.get_stream_pcm_format(self.pcm_format)
         airplay_player.stream = AirPlayStream(airplay_player, pcm_format=stream_pcm_format)
         airplay_player.stream.session = self
-        sync_adjust = airplay_player.config.get_value(CONF_SYNC_ADJUST, 0)
-        assert isinstance(sync_adjust, int)
-        if sync_adjust != 0:
-            start_unix_ms += sync_adjust
-        await airplay_player.stream.start(
-            start_unix_ms, use_shared_ptp, ptp_follow=self._ptp_follow
-        )
+        await airplay_player.stream.start(use_shared_ptp, ptp_follow=self._ptp_follow)
         # Start ffmpeg to feed audio to CLI stdin
         if ffmpeg := self._player_ffmpeg.pop(airplay_player.player_id, None):
             await ffmpeg.close()
@@ -707,6 +718,43 @@ class AirPlayStreamSession:
         )
         await ffmpeg.start()
         self._player_ffmpeg[airplay_player.player_id] = ffmpeg
+
+    async def _commit_generations(
+        self,
+        generations: dict[str, int],
+        position_ms: int,
+        start_unix_ms: int | None = None,
+        *,
+        reanchor_session: bool = True,
+    ) -> None:
+        """
+        Start prepared member generations at one audible instant.
+
+        :param generations: Generation number keyed by player ID.
+        :param position_ms: Media position represented by each generation's first sample.
+        :param start_unix_ms: Optional audible-start instant in unix epoch milliseconds.
+        :param reanchor_session: Whether this generation becomes the session timeline anchor.
+        """
+        if start_unix_ms is None:
+            start_lead_ms = 400 if len(generations) == 1 else 750
+            start_unix_ms = int(time.time() * 1000) + start_lead_ms
+        async with asyncio.TaskGroup() as task_group:
+            for player in self.sync_clients:
+                generation = generations.get(player.player_id)
+                if generation is None:
+                    continue
+                member_start = start_unix_ms
+                sync_adjust = player.config.get_value(CONF_SYNC_ADJUST, 0)
+                if isinstance(sync_adjust, int):
+                    member_start += sync_adjust
+                stream = player.stream
+                assert stream
+                task_group.create_task(
+                    stream.start_generation(generation, position_ms, member_start)
+                )
+        if reanchor_session:
+            self.start_unix_ms = start_unix_ms
+            self.start_time = start_unix_ms / 1000
 
     async def _start_generation_ffmpeg(
         self, player: AirPlayPlayer, fifo: str, media: PlayerMedia

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -520,7 +520,17 @@ async def test_raop_session_resolves_ptp_for_first_ap2_late_joiner() -> None:
         return True
 
     prov.wait_ptp_daemon_ready = AsyncMock(side_effect=_wait_ptp_daemon_ready)
-    with patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start:
+
+    async def _start_client(player: MagicMock, _use_shared_ptp: bool) -> None:
+        player.stream = MagicMock(running=True)
+        player.stream.wait_for_connection = AsyncMock()
+        player.stream.prepare_generation = AsyncMock()
+        player.stream.wait_generation_primed = AsyncMock(return_value=True)
+        player.stream.start_generation = AsyncMock()
+
+    with patch.object(
+        session, "_start_client", new_callable=AsyncMock, side_effect=_start_client
+    ) as mock_start:
         await session.add_client(cast("AirPlayPlayer", ap2_player))
 
     prov.wait_ptp_daemon_ready.assert_awaited_once()
@@ -528,7 +538,7 @@ async def test_raop_session_resolves_ptp_for_first_ap2_late_joiner() -> None:
     assert session._shared_ptp_resolved is True
     await_args = mock_start.await_args
     assert await_args is not None
-    assert await_args.args[2] is True
+    assert await_args.args[1] is True
 
 
 async def test_session_start_applies_uniform_ptp_decision_to_all_members() -> None:
@@ -539,6 +549,9 @@ async def test_session_start_applies_uniform_ptp_decision_to_all_members() -> No
     for player in players:
         player.stream = MagicMock()
         player.stream.wait_for_connection = AsyncMock()
+        player.stream.prepare_generation = AsyncMock()
+        player.stream.wait_generation_primed = AsyncMock(return_value=True)
+        player.stream.start_generation = AsyncMock()
     session = _make_ptp_session(prov, players)
 
     with (
@@ -549,7 +562,7 @@ async def test_session_start_applies_uniform_ptp_decision_to_all_members() -> No
 
     # One start per member, and every member received the same resolved decision.
     assert mock_start.call_count == len(players)
-    ptp_decisions = {call.args[2] for call in mock_start.call_args_list}
+    ptp_decisions = {call.args[1] for call in mock_start.call_args_list}
     assert ptp_decisions == {True}
     assert session.use_shared_ptp is True
 
@@ -561,6 +574,9 @@ async def test_session_start_calculates_anchor_after_ptp_resolution() -> None:
     for player in players:
         player.stream = MagicMock()
         player.stream.wait_for_connection = AsyncMock()
+        player.stream.prepare_generation = AsyncMock()
+        player.stream.wait_generation_primed = AsyncMock(return_value=True)
+        player.stream.start_generation = AsyncMock()
     session = _make_ptp_session(prov, players)
     now = 100.0
 
@@ -575,13 +591,15 @@ async def test_session_start_calculates_anchor_after_ptp_resolution() -> None:
             "music_assistant.providers.airplay.stream_session.time.time",
             side_effect=lambda: now,
         ),
-        patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start,
+        patch.object(session, "_start_client", new_callable=AsyncMock),
         patch.object(session, "_audio_streamer", new_callable=AsyncMock),
     ):
         await session.start(MagicMock())
 
-    assert session.start_unix_ms == 105_500
-    assert {call.args[1] for call in mock_start.call_args_list} == {105_500}
+    assert session.start_unix_ms == 103_750
+    for player in players:
+        player.stream.start_generation.assert_awaited_once()
+        assert player.stream.start_generation.await_args.args[2] == 103_750
 
 
 # --- Session decision reaches the CLI args (overrides bare liveness) ------------
@@ -626,7 +644,7 @@ async def _build_args(player: MagicMock, use_shared_ptp: bool | None) -> list[st
             return_value="192.168.1.5",
         ),
     ):
-        return await stream._build_cli_args(START_UNIX_MS, use_shared_ptp)
+        return await stream._build_cli_args(use_shared_ptp)
 
 
 async def test_build_cli_args_explicit_shared_ptp_overrides_dead_daemon() -> None:

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -5,7 +5,7 @@ Cover four things, with the Sendspin clock mocked via ``ManualClock`` so the
 tests are deterministic and independent of the host wall-clock:
 
 * the clock-domain conversion turning a Sendspin audible instant (Sendspin's own
-  monotonic clock) into the unix epoch ms the binary expects (``--start-unix-ms``);
+  monotonic clock) into the unix epoch ms used by the generation START command;
 * the start anchor: byte 0 is anchored to the first chunk Sendspin delivers, so a
   fresh track keeps position 0 and a late joiner lands at the group's live position;
 * the write pacing that keeps the device buffered a bounded amount ahead of real
@@ -272,6 +272,43 @@ async def test_failed_cli_write_does_not_advance_pacing_cursor() -> None:
     assert stream.write_audio.await_count == 2
 
 
+# --- Commanded cold start and warm handover ------------------------------------
+
+
+async def test_cold_start_connects_then_prepares_and_starts_generation_zero() -> None:
+    """A fresh bridge stream commands generation 0 only after the CLI connects."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + AP2_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    stream = MagicMock()
+    stream.start = AsyncMock()
+    stream.wait_for_connection = AsyncMock()
+    stream.prepare_generation = AsyncMock()
+    stream.wait_generation_primed = AsyncMock(return_value=True)
+    stream.start_generation = AsyncMock()
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=stream,
+        ),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.time",
+            return_value=UNIX_NOW_S,
+        ),
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    stream.start.assert_awaited_once_with()
+    stream.wait_for_connection.assert_awaited_once_with()
+    stream.prepare_generation.assert_awaited_once_with(0, "-", 0)
+    stream.wait_generation_primed.assert_awaited_once_with(0)
+    stream.start_generation.assert_awaited_once_with(0, 0, int(UNIX_NOW_S * 1000) + AP2_LEAD_MS)
+    assert bridge._airplay_stream is stream
+    assert bridge.airplay_player.stream is stream
+    assert bridge._generation_started is True
+
+
 # --- Warm handover: a kept stream survives a new stream start and absorbs a generation ---
 
 
@@ -292,6 +329,7 @@ def test_on_bridge_stream_start_keeps_warm_eligible_stream() -> None:
     kept_stream = _make_kept_stream()
     bridge._airplay_stream = kept_stream
     bridge.airplay_player.stream = kept_stream
+    bridge._generation_started = True
 
     bridge._on_bridge_stream_start()
 
@@ -314,12 +352,26 @@ def test_on_bridge_stream_start_replaces_non_eligible_stream() -> None:
     assert bridge.airplay_player.stream is None  # type: ignore[unreachable]
 
 
+def test_on_bridge_stream_start_replaces_uncommitted_stream() -> None:
+    """A connected stream cannot be retained before generation 0 has started."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    old_stream = _make_kept_stream()
+    bridge._airplay_stream = old_stream
+    bridge.airplay_player.stream = old_stream
+
+    bridge._on_bridge_stream_start()
+
+    assert bridge._airplay_stream is None
+    assert bridge.airplay_player.stream is None  # type: ignore[unreachable]
+
+
 def test_on_stream_start_keeps_warm_eligible_stream() -> None:
     """The Sendspin-server-side stream-start callback also keeps a warm-eligible stream."""
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     kept_stream = _make_kept_stream()
     bridge._airplay_stream = kept_stream
     bridge.airplay_player.stream = kept_stream
+    bridge._generation_started = True
 
     bridge._on_stream_start(MagicMock())
 

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -160,6 +160,15 @@ async def test_cli_args_no_ptp_shared_without_daemon() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cli_args_reject_shared_ptp_with_clock_follow() -> None:
+    """Shared PTP and receiver clock-follow cannot be requested together."""
+    stream = AirPlayStream(_make_player())
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        await stream._build_cli_args(use_shared_ptp=True, ptp_follow=True)
+
+
+@pytest.mark.asyncio
 async def test_cli_args_no_latency_override() -> None:
     """The playback lead/buffer is binary-managed; MA never passes --latency."""
     player = _make_player()

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -75,7 +75,7 @@ async def _build_args(player: MagicMock) -> list[str]:
             return_value="192.168.1.5",
         ),
     ):
-        return await stream._build_cli_args(START_UNIX_MS)
+        return await stream._build_cli_args()
 
 
 def _arg_value(args: list[str], flag: str) -> Any:
@@ -90,7 +90,7 @@ async def test_cli_args_default_auto() -> None:
     args = await _build_args(player)
 
     assert _arg_value(args, "--protocol") == "auto"
-    assert _arg_value(args, "--start-unix-ms") == str(START_UNIX_MS)
+    assert "--start-unix-ms" not in args
     # legacy timing args are gone
     assert "--ntpstart" not in args
     assert "--wait" not in args
@@ -183,7 +183,7 @@ async def test_cli_args_hires_pcm_format() -> None:
             return_value="192.168.1.5",
         ),
     ):
-        args = await stream._build_cli_args(START_UNIX_MS)
+        args = await stream._build_cli_args()
 
     assert _arg_value(args, "--samplerate") == "48000"
     assert _arg_value(args, "--bitdepth") == "24"
@@ -353,7 +353,7 @@ async def test_start_queues_text_metadata_before_connection() -> None:
         patch.object(stream.commands_pipe, "create", side_effect=create_pipe),
         patch.object(stream, "send_metadata", side_effect=send_metadata) as send_metadata_mock,
     ):
-        await stream.start(START_UNIX_MS)
+        await stream.start()
 
     assert operation_order == ["pipe", "process", "metadata"]
     send_metadata_mock.assert_awaited_once_with(12, metadata, send_artwork=False)
@@ -393,12 +393,80 @@ async def test_start_failure_cleans_up_process_and_pipe() -> None:
         ),
         pytest.raises(OSError, match="metadata write failed"),
     ):
-        await stream.start(START_UNIX_MS)
+        await stream.start()
 
     process.kill.assert_awaited_once()
     remove_pipe.assert_awaited_once()
     assert stream._cli_proc is None
     assert stream._cleanup_complete is True
+
+
+@pytest.mark.asyncio
+async def test_generation_zero_uses_prepare_and_start_commands() -> None:
+    """The first generation is prepared, primed, and started over the command pipe."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+
+    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command:
+        await stream.prepare_generation(0, "-", 12_000)
+        assert stream._handle_status_line("[STATUS] primed generation=0") is False
+        assert await stream.wait_generation_primed(0)
+        await stream.start_generation(0, 12_000, START_UNIX_MS)
+
+    assert [call.args[0] for call in write_command.await_args_list] == [
+        "GENERATION=0\nAUDIO=-\nPOSITION_MS=12000\nACTION=PREPARE",
+        f"GENERATION=0\nSTART_UNIX_MS={START_UNIX_MS}\nACTION=START",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_generation_cannot_start_before_primed() -> None:
+    """A START command is rejected until that generation has reported primed."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+
+    with (
+        patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command,
+        pytest.raises(RuntimeError, match="before it is primed"),
+    ):
+        await stream.start_generation(0, 0, START_UNIX_MS)
+
+    write_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_generation_cannot_start_after_process_exit() -> None:
+    """A primed generation is not started after its CLI process exits."""
+    stream = AirPlayStream(_make_player())
+    process = MagicMock(closed=False)
+    stream._cli_proc = process
+    stream._connected.set()
+
+    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command:
+        await stream.prepare_generation(0, "-", 0)
+        stream._handle_status_line("[STATUS] primed generation=0")
+        process.closed = True
+        with pytest.raises(RuntimeError, match="without a connected cliairplay process"):
+            await stream.start_generation(0, 0, START_UNIX_MS)
+
+    write_command.assert_awaited_once_with("GENERATION=0\nAUDIO=-\nPOSITION_MS=0\nACTION=PREPARE")
+
+
+def test_generation_zero_elapsed_includes_position_once() -> None:
+    """Generation-0 progress is based on its media position without session offset."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    stream._generation_position = 12.0
+
+    stream._update_elapsed(1.5)
+
+    player.set_state_from_stream.assert_called_once_with(
+        state=PlaybackState.PLAYING,
+        elapsed_time=13.5,
+        stream=stream,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -36,7 +36,7 @@ def _make_session(
     leader.stream = MagicMock()
     leader.stream.running = True
 
-    session = AirPlayStreamSession(prov, [leader], pcm_format, MagicMock())
+    session = AirPlayStreamSession(prov, [leader], pcm_format, MagicMock(elapsed_time=0))
     session.start_time = start_time
     session.seconds_streamed = seconds_streamed
     session.start_unix_ms = 1  # dummy
@@ -63,13 +63,16 @@ def _setup_stream(player: MagicMock) -> Any:
         player.stream = MagicMock()
         player.stream.running = True
         player.stream.wait_for_connection = AsyncMock()
+        player.stream.prepare_generation = AsyncMock()
+        player.stream.wait_generation_primed = AsyncMock(return_value=True)
+        player.stream.start_generation = AsyncMock()
 
     return _side_effect
 
 
-def _captured_start_at(mock_start: AsyncMock) -> float:
-    """Return the start time (unix seconds) passed to the patched _start_client."""
-    start_unix_ms = mock_start.call_args[0][1]
+def _captured_start_at(player: MagicMock) -> float:
+    """Return the start time passed to the player's generation-0 START."""
+    start_unix_ms = player.stream.start_generation.call_args[0][2]
     assert isinstance(start_unix_ms, int)
     return start_unix_ms / 1000
 
@@ -116,6 +119,156 @@ async def test_initial_client_failure_stops_started_clients() -> None:
 
 
 @pytest.mark.asyncio
+async def test_initial_group_waits_for_every_member_before_shared_start() -> None:
+    """Generation 0 starts at one instant only after every member connects and primes."""
+    session = _make_session(0, 0)
+    first_player: Any = session.sync_clients[0]
+    first_player.player_id = "first"
+    first_player.wait_start = 2500
+    first_player.config.get_value = MagicMock(return_value=0)
+    second_player = MagicMock(player_id="second", wait_start=2500)
+    second_player.config.get_value = MagicMock(return_value=0)
+    session.sync_clients.append(second_player)
+    session.media.elapsed_time = 12
+    operations: list[str] = []
+
+    async def start_client(player: MagicMock, _use_shared_ptp: bool) -> None:
+        stream = MagicMock(running=True)
+
+        async def wait_for_connection() -> None:
+            operations.append(f"connected:{player.player_id}")
+
+        async def prepare_generation(generation: int, audio_path: str, position_ms: int) -> None:
+            assert (generation, audio_path, position_ms) == (0, "-", 12_000)
+            operations.append(f"prepared:{player.player_id}")
+
+        async def wait_generation_primed(_generation: int) -> bool:
+            operations.append(f"primed:{player.player_id}")
+            return True
+
+        async def start_generation(_generation: int, _position_ms: int, start_unix_ms: int) -> None:
+            operations.append(f"started:{player.player_id}:{start_unix_ms}")
+
+        stream.wait_for_connection = AsyncMock(side_effect=wait_for_connection)
+        stream.prepare_generation = AsyncMock(side_effect=prepare_generation)
+        stream.wait_generation_primed = AsyncMock(side_effect=wait_generation_primed)
+        stream.start_generation = AsyncMock(side_effect=start_generation)
+        player.stream = stream
+
+    with (
+        patch.object(session, "_start_client", side_effect=start_client),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0),
+    ):
+        await session.start(MagicMock())
+
+    first_prepare = min(i for i, op in enumerate(operations) if op.startswith("prepared:"))
+    last_connected = max(i for i, op in enumerate(operations) if op.startswith("connected:"))
+    first_start = min(i for i, op in enumerate(operations) if op.startswith("started:"))
+    last_primed = max(i for i, op in enumerate(operations) if op.startswith("primed:"))
+    assert last_connected < first_prepare
+    assert last_primed < first_start
+    starts = {int(op.rsplit(":", 1)[1]) for op in operations if op.startswith("started:")}
+    assert starts == {100_750}
+
+
+@pytest.mark.asyncio
+async def test_initial_single_player_uses_commanded_generation_zero() -> None:
+    """A standalone player follows the same generation-0 flow with the solo lead."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.player_id = "solo"
+    player.wait_start = 2500
+    player.config.get_value = MagicMock(return_value=0)
+    stream = MagicMock(running=True)
+    stream.wait_for_connection = AsyncMock()
+    stream.prepare_generation = AsyncMock()
+    stream.wait_generation_primed = AsyncMock(return_value=True)
+    stream.start_generation = AsyncMock()
+
+    async def start_client(_player: MagicMock, _use_shared_ptp: bool) -> None:
+        player.stream = stream
+
+    with (
+        patch.object(session, "_start_client", side_effect=start_client),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=200.0),
+    ):
+        await session.start(MagicMock())
+
+    stream.prepare_generation.assert_awaited_once_with(0, "-", 0)
+    stream.wait_generation_primed.assert_awaited_once_with(0)
+    stream.start_generation.assert_awaited_once_with(0, 0, 200_400)
+
+
+@pytest.mark.asyncio
+async def test_initial_prime_timeout_never_starts_partial_group() -> None:
+    """If any member fails to prime, no member receives START and the group is stopped."""
+    session = _make_session(0, 0)
+    first_player: Any = session.sync_clients[0]
+    first_player.wait_start = 2500
+    second_player = MagicMock(player_id="second", wait_start=2500)
+    session.sync_clients.append(second_player)
+
+    async def start_client(player: MagicMock, _use_shared_ptp: bool) -> None:
+        stream = MagicMock(running=True)
+        stream.wait_for_connection = AsyncMock()
+        stream.prepare_generation = AsyncMock()
+        stream.wait_generation_primed = AsyncMock(return_value=player is not second_player)
+        stream.start_generation = AsyncMock()
+        player.stream = stream
+
+    with (
+        patch.object(session, "_start_client", side_effect=start_client),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch.object(session, "stop", new_callable=AsyncMock) as stop_session,
+        pytest.raises(PlayerCommandFailed, match="Playback failed to start"),
+    ):
+        await session.start(MagicMock())
+
+    for player in session.sync_clients:
+        stream: Any = player.stream
+        stream.start_generation.assert_not_awaited()
+    stop_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_initial_connection_cancellation_never_prepares_group() -> None:
+    """Cancellation while connecting cleans up without preparing or starting."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.player_id = "solo"
+    player.wait_start = 2500
+    connection_waiting = asyncio.Event()
+    stream = MagicMock(running=True)
+
+    async def wait_for_connection() -> None:
+        connection_waiting.set()
+        await asyncio.Event().wait()
+
+    stream.wait_for_connection = AsyncMock(side_effect=wait_for_connection)
+    stream.prepare_generation = AsyncMock()
+    stream.start_generation = AsyncMock()
+
+    async def start_client(_player: MagicMock, _use_shared_ptp: bool) -> None:
+        player.stream = stream
+
+    with (
+        patch.object(session, "_start_client", side_effect=start_client),
+        patch.object(session, "stop", new_callable=AsyncMock) as stop_session,
+    ):
+        start_task = asyncio.create_task(session.start(MagicMock()))
+        await connection_waiting.wait()
+        start_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await start_task
+
+    stream.prepare_generation.assert_not_awaited()
+    stream.start_generation.assert_not_awaited()
+    stop_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_late_join_empty_buffer() -> None:
     """Test that with an empty buffer, start_at = start_time + seconds_streamed."""
     now = time.time()
@@ -130,7 +283,7 @@ async def test_late_join_empty_buffer() -> None:
 
     assert mock_start.called, "_start_client was never called"
     expected = start_time + seconds_streamed
-    assert abs(_captured_start_at(mock_start) - expected) < 0.1
+    assert abs(_captured_start_at(player) - expected) < 0.1
 
 
 @pytest.mark.asyncio
@@ -156,7 +309,7 @@ async def test_late_join_with_buffered_pcm_in_future() -> None:
     assert mock_start.called, "_start_client was never called"
     # start_at should remain at start_time + (seconds_streamed - 3.0) — already in future
     expected = start_time + (seconds_streamed - 3.0)
-    captured = _captured_start_at(mock_start)
+    captured = _captured_start_at(player)
     assert abs(captured - expected) < 0.1, (
         f"start_at should match buffer position, expected {expected}, got {captured}"
     )
@@ -220,9 +373,9 @@ async def test_late_join_trims_and_shifts_when_start_at_in_past() -> None:
 
     # start_at should be pushed to now + min_headroom (session.wait_start = 2.0)
     assert mock_start.called, "_start_client was never called"
-    assert _captured_start_at(mock_start) - now == pytest.approx(2.0, abs=0.01), (
+    assert _captured_start_at(player) - now == pytest.approx(2.0, abs=0.01), (
         f"start_at should be at now + min_headroom, "
-        f"got offset {_captured_start_at(mock_start) - now:.4f}s"
+        f"got offset {_captured_start_at(player) - now:.4f}s"
     )
 
     # Buffer should have been trimmed: 2.5s out of 5s (start_at shifted from -0.5 to +2.0)
@@ -264,7 +417,7 @@ async def test_late_join_drops_buffer_when_trim_exceeds_buffer() -> None:
     assert written_chunks == [], "Buffer should have been dropped entirely"
     # start_at should be exactly now + min_headroom (since the next-chunk anchor would
     # have landed at now - 1.0, which is below the target).
-    assert _captured_start_at(mock_start) - now == pytest.approx(2.0, abs=0.01)
+    assert _captured_start_at(player) - now == pytest.approx(2.0, abs=0.01)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

AirPlay playback now connects and primes every player before sending one commanded start time, preventing cold group members from starting before the whole group is ready.

This PR includes the prerequisite solo clock-negotiation commit because that follow-up was not part of the merged warm-start PR.

- Removes command-line start timing and uses command-pipe PREPARE/START for generation 0
- Gates group starts on every member being connected and primed
- Preserves commanded starts for standalone, late-join, and Sendspin playback
- Adds targeted failure, cancellation, timing, and group-readiness coverage

Validation: 107 targeted AirPlay tests pass. The full local suite cannot collect without the native `libchromaprint` library.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.