### PR TITLE
Add High/Low-pass DSP filter

### DIFF
--- a/music_assistant/helpers/dsp.py
+++ b/music_assistant/helpers/dsp.py
@@ -9,6 +9,8 @@ from music_assistant_models.dsp import (
     BalanceFilter,
     DSPFilter,
     GainFilter,
+    HighLowPassFilter,
+    HighLowPassMode,
     ParametricEQBandType,
     ParametricEQFilter,
     ToneControlFilter,
@@ -127,26 +129,12 @@ def filter_to_ffmpeg_params(dsp_filter: DSPFilter, input_format: AudioFormat) ->
                     f"biquad=b0={b0}:b1={b1}:b2={b2}:a0={a0}:a1={a1}:a2={a2}{channels}"
                 )
             elif b.type == ParametricEQBandType.HIGH_PASS:
-                b0 = (1 + math.cos(w_0)) / 2
-                b1 = -(1 + math.cos(w_0))
-                b2 = (1 + math.cos(w_0)) / 2
-                a0 = 1 + alpha
-                a1 = -2 * math.cos(w_0)
-                a2 = 1 - alpha
-
                 filter_params.append(
-                    f"biquad=b0={b0}:b1={b1}:b2={b2}:a0={a0}:a1={a1}:a2={a2}{channels}"
+                    _pass_biquad_params(high_pass=True, w_0=w_0, alpha=alpha, channels=channels)
                 )
             elif b.type == ParametricEQBandType.LOW_PASS:
-                b0 = (1 - math.cos(w_0)) / 2
-                b1 = 1 - math.cos(w_0)
-                b2 = (1 - math.cos(w_0)) / 2
-                a0 = 1 + alpha
-                a1 = -2 * math.cos(w_0)
-                a2 = 1 - alpha
-
                 filter_params.append(
-                    f"biquad=b0={b0}:b1={b1}:b2={b2}:a0={a0}:a1={a1}:a2={a2}{channels}"
+                    _pass_biquad_params(high_pass=False, w_0=w_0, alpha=alpha, channels=channels)
                 )
             elif b.type == ParametricEQBandType.NOTCH:
                 b0 = 1
@@ -187,4 +175,42 @@ def filter_to_ffmpeg_params(dsp_filter: DSPFilter, input_format: AudioFormat) ->
             else:
                 filter_params.append(f"pan=stereo|FL=FL|FR={attenuation}*FR")
 
+    if isinstance(dsp_filter, HighLowPassFilter):
+        # A high/low-pass of a given slope is a cascade of second-order Butterworth
+        # sections, each adding 12 dB/octave, at the same cutoff but different Q.
+        # slope is validated to 12, 24 or 48 dB/octave, so order is 2, 4 or 8.
+        high_pass = dsp_filter.mode == HighLowPassMode.HIGH_PASS
+        order = dsp_filter.slope // 6
+        w_0 = 2 * math.pi * dsp_filter.frequency / input_format.sample_rate
+        sin_w0 = math.sin(w_0)
+        for section in range(order // 2):
+            # Butterworth pole Q for this section
+            q = 1 / (2 * math.cos(math.pi * (2 * section + 1) / (2 * order)))
+            alpha = sin_w0 / (2 * q)
+            filter_params.append(_pass_biquad_params(high_pass=high_pass, w_0=w_0, alpha=alpha))
+
     return filter_params
+
+
+def _pass_biquad_params(*, high_pass: bool, w_0: float, alpha: float, channels: str = "") -> str:
+    """
+    Build the FFmpeg biquad parameters for one high-pass or low-pass section.
+
+    :param high_pass: True for a high-pass section, False for a low-pass section.
+    :param w_0: Normalised angular cutoff frequency, 2*pi*frequency/sample_rate.
+    :param alpha: Cookbook alpha term, sin(w_0)/(2*Q).
+    :param channels: Optional FFmpeg channel selector suffix, e.g. ":c=FL".
+    """
+    cos_w0 = math.cos(w_0)
+    if high_pass:
+        b0 = (1 + cos_w0) / 2
+        b1 = -(1 + cos_w0)
+        b2 = (1 + cos_w0) / 2
+    else:
+        b0 = (1 - cos_w0) / 2
+        b1 = 1 - cos_w0
+        b2 = (1 - cos_w0) / 2
+    a0 = 1 + alpha
+    a1 = -2 * cos_w0
+    a2 = 1 - alpha
+    return f"biquad=b0={b0}:b1={b1}:b2={b2}:a0={a0}:a1={a1}:a2={a2}{channels}"

--- a/tests/helpers/test_dsp.py
+++ b/tests/helpers/test_dsp.py
@@ -6,6 +6,9 @@ from music_assistant_models.dsp import (
     AudioChannel,
     BalanceFilter,
     GainFilter,
+    HighLowPassFilter,
+    HighLowPassMode,
+    HighLowPassSlope,
     ParametricEQBand,
     ParametricEQBandType,
     ParametricEQFilter,
@@ -129,3 +132,64 @@ def test_parametric_eq_disabled_band_skipped() -> None:
     band = ParametricEQBand(enabled=False, gain=6.0)
     dsp_filter = ParametricEQFilter(enabled=True, per_channel_preamp={}, bands=[band])
     assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == []
+
+
+def _expected_pass_section(mode: HighLowPassMode, frequency: float, q: float) -> str:
+    """Build the expected cookbook biquad string for one high/low-pass section."""
+    w_0 = 2 * math.pi * frequency / INPUT_FORMAT.sample_rate
+    alpha = math.sin(w_0) / (2 * q)
+    if mode == HighLowPassMode.HIGH_PASS:
+        b0 = (1 + math.cos(w_0)) / 2
+        b1 = -(1 + math.cos(w_0))
+        b2 = (1 + math.cos(w_0)) / 2
+    else:
+        b0 = (1 - math.cos(w_0)) / 2
+        b1 = 1 - math.cos(w_0)
+        b2 = (1 - math.cos(w_0)) / 2
+    a0 = 1 + alpha
+    a1 = -2 * math.cos(w_0)
+    a2 = 1 - alpha
+    return f"biquad=b0={b0}:b1={b1}:b2={b2}:a0={a0}:a1={a1}:a2={a2}"
+
+
+def test_high_low_pass_12db_single_section() -> None:
+    """Test that a 12 dB/octave high-pass is a single Butterworth biquad at Q=1/sqrt(2)."""
+    dsp_filter = HighLowPassFilter(
+        enabled=True, mode=HighLowPassMode.HIGH_PASS, frequency=100.0, slope=HighLowPassSlope.DB12
+    )
+    q = 1 / (2 * math.cos(math.pi / 4))
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == [
+        _expected_pass_section(HighLowPassMode.HIGH_PASS, 100.0, q)
+    ]
+
+
+def test_high_low_pass_24db_two_sections() -> None:
+    """Test that a 24 dB/octave low-pass is two sections with the 4th-order Butterworth Qs."""
+    dsp_filter = HighLowPassFilter(
+        enabled=True, mode=HighLowPassMode.LOW_PASS, frequency=8000.0, slope=HighLowPassSlope.DB24
+    )
+    qs = [1 / (2 * math.cos(math.pi * (2 * k + 1) / 8)) for k in range(2)]
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == [
+        _expected_pass_section(HighLowPassMode.LOW_PASS, 8000.0, q) for q in qs
+    ]
+
+
+def test_high_low_pass_48db_has_four_sections() -> None:
+    """Test that a 48 dB/octave filter is a cascade of four biquad sections."""
+    dsp_filter = HighLowPassFilter(
+        enabled=True, mode=HighLowPassMode.HIGH_PASS, frequency=40.0, slope=HighLowPassSlope.DB48
+    )
+    params = filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT)
+    assert len(params) == 4
+    assert all(p.startswith("biquad=") for p in params)
+
+
+def test_high_low_pass_mode_changes_coefficients() -> None:
+    """Test that high-pass and low-pass at identical settings produce different coefficients."""
+    high = HighLowPassFilter(
+        enabled=True, mode=HighLowPassMode.HIGH_PASS, frequency=1000.0, slope=HighLowPassSlope.DB12
+    )
+    low = HighLowPassFilter(
+        enabled=True, mode=HighLowPassMode.LOW_PASS, frequency=1000.0, slope=HighLowPassSlope.DB12
+    )
+    assert filter_to_ffmpeg_params(high, INPUT_FORMAT) != filter_to_ffmpeg_params(low, INPUT_FORMAT)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Render a HighLowPassFilter, giving a selectable cutoff and a 12, 24 or 48 dB/octave slope. The high-pass/low-pass cookbook coefficients, previously duplicated in the parametric EQ band loop, are factored into a shared helper.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
