### PR TITLE
Support commanded AirPlay starts

### DIFF
--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -235,7 +235,7 @@ The `AirPlayStreamSession` class in [stream_session.py](stream_session.py) manag
      (16-bit default, 24-bit s32le when hi-res is enabled)
    - Starts the CLI process and connects to the receiver without starting playback
    - Configures FFmpeg for audio format conversion and optional DSP filters
-   - Pipes FFmpeg output to CLI process stdin
+   - Keeps process stdin connected so generation 0 can select it with `AUDIO=-`
 
 3. **Audio Streaming** (`_audio_streamer()` method)
    - Receives PCM audio chunks from Music Assistant core
@@ -378,13 +378,16 @@ and verify it against that release's `SHA256SUMS`. For local source development,
 ### Binary Communication
 
 **Input** (stdin):
-- PCM audio data piped from FFmpeg: s16le for 16-bit, raw s32le for 24-bit
+- Generation 0 PCM selected by command-pipe `PREPARE` with `AUDIO=-`: s16le
+  for 16-bit, raw s32le for 24-bit
   (the binary truncates 32→24 internally when `--bitdepth 24` is passed)
 - May be written eagerly, ahead of the scheduled start; byte 0 maps to the
   sample audible at the start instant
 
 **Commands** (named pipe):
 - Interactive commands sent via `AsyncNamedPipeWriter`
+- Required for every streaming protocol; audio sources are supplied only by
+  generation `PREPARE` (`AUDIO=-` for stdin or `AUDIO=<fifo path>`)
 - Examples: `ACTION=PLAY`, `ACTION=PAUSE`, `VOLUME=50`, `TITLE=Song Name`
 - MA creates the pipe and sends text metadata immediately after process start;
   timeline-anchored metadata and artwork are refreshed once the receiver connects
@@ -416,8 +419,8 @@ instant**" on every protocol path (RAOP, AirPlay 2 RAOP-compat and native).
    the same value in `START` to every member
 4. The binary owns receiver-buffer handling from there, so the commanded start
    cannot race connection or pre-fill
-5. Warm seek, next-track and resume use the same PREPARE/prime/START barrier for
-   later generations
+5. Warm seek and next-track use the same PREPARE/prime/START barrier for later
+   generations on legacy RAOP, RAOP-compatible AirPlay 2 and native AirPlay 2
 6. Sendspin starts preserve its externally supplied audible instant after the
    same connection and prime gates
 7. Per-player `sync_adjust` config allows fine-tuning (+/- milliseconds)

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -310,17 +310,13 @@ class SendspinAirPlayBridge:
         """
         Return whether the current AirPlayStream can absorb a new stream as a generation.
 
-        A kept stream must still be running, already connected, and on an
-        AirPlay 2 route -- RAOP and a not-yet-connected AirPlay 2 stream have
-        no persistent-generation support, so those always pay a cold restart.
+        A kept stream must still be running, already connected, and have a
+        committed generation. Every streaming route supports persistent
+        generations.
         """
         stream = self._airplay_stream
         return (
-            stream is not None
-            and stream.running
-            and stream.connected
-            and self._generation_started
-            and stream.active_route.startswith("AirPlay 2")
+            stream is not None and stream.running and stream.connected and self._generation_started
         )
 
     def _on_stream_start(self, request: ExternalStreamStartRequest) -> None:
@@ -378,7 +374,7 @@ class SendspinAirPlayBridge:
         self._drop_until_us = 0
         self._start_aligned = False
         self._start_unix_ms = 0
-        self._generation_started = False
+        self._generation_started = keep_stream
 
     def _on_bridge_stream_start(self) -> None:
         """
@@ -415,7 +411,7 @@ class SendspinAirPlayBridge:
         self._drop_until_us = 0
         self._start_aligned = False
         self._start_unix_ms = 0
-        self._generation_started = False
+        self._generation_started = keep_stream
         # Drain stale audio data from the previous stream
         while not self._write_queue.empty():
             self._write_queue.get_nowait()
@@ -463,9 +459,9 @@ class SendspinAirPlayBridge:
             # Publish the audible anchor so the writer can pace against it.
             self._start_unix_ms = start_unix_ms
 
-            # A kept, still-connected AirPlay 2 stream (see _stream_is_warm_eligible,
-            # checked by the stream-start callbacks) absorbs the new media as a warm
-            # generation instead of paying a cold reconnect.
+            # A kept, still-connected stream (see _stream_is_warm_eligible,
+            # checked by the stream-start callbacks) absorbs the new media as a
+            # warm generation instead of paying a cold reconnect.
             kept_stream = self._airplay_stream
             if kept_stream is not None:
                 if await self._start_warm_generation(kept_stream, start_unix_ms):

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -259,9 +259,9 @@ class AirPlayStream:
         """
         Stage a media generation on the connected binary.
 
-        The binary opens the given FIFO and prefills from it while the current
-        generation keeps playing; `primed` is reported once enough audio is
-        buffered for an underrun-free start.
+        The binary opens the given audio source and prefills from it while the
+        current generation keeps playing; `primed` is reported once enough
+        audio is buffered for an underrun-free start.
         """
         if not self.running or not self.connected:
             raise RuntimeError("Cannot prepare a generation without a connected cliairplay process")
@@ -571,8 +571,9 @@ class AirPlayStream:
         elif self.prov.logger.isEnabledFor(logging.DEBUG):
             args += ["--debug", "5"]
 
-        # Positional args: device address + stdin for audio
-        args += [self.player.address, "-"]
+        # Audio is supplied only by command-pipe PREPARE. Keep process stdin
+        # connected because AUDIO=- selects it for generation 0.
+        args.append(self.player.address)
         return args
 
     async def _stdout_reader(self) -> None:

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -124,8 +124,8 @@ class AirPlayStreamSession:
         Return whether this live session can absorb a new play_media warm.
 
         A warm replacement needs the same member set, the same session PCM
-        format and running AirPlay 2 streams on every member; anything else
-        takes the cold path.
+        format and a connected stream on every member; anything else takes the
+        cold path.
         """
         if {p.player_id for p in sync_clients} != {p.player_id for p in self.sync_clients}:
             return False
@@ -135,7 +135,7 @@ class AirPlayStreamSession:
         ):
             return False
         return all(
-            p.stream is not None and p.stream.running and p.protocol == StreamingProtocol.AIRPLAY2
+            p.stream is not None and p.stream.running and p.stream.connected
             for p in self.sync_clients
         )
 

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -10,8 +10,8 @@ tests are deterministic and independent of the host wall-clock:
   fresh track keeps position 0 and a late joiner lands at the group's live position;
 * the write pacing that keeps the device buffered a bounded amount ahead of real
   time so a late-join catch-up backlog is not dumped into the CLI;
-* the warm handover: a running, connected AirPlay 2 stream is kept (not torn down)
-  across a new Sendspin stream, and stages/commits a new generation on itself
+* the warm handover: a running, connected stream is kept (not torn down) across
+  a new Sendspin stream, and stages/commits a new generation on itself
   instead of a cold reconnect -- with prime-timeout and superseded-task fallback.
 """
 
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from aiosendspin.clock import ManualClock
 from aiosendspin.server.roles import AudioChunk
 
+from music_assistant.providers.airplay.constants import StreamingProtocol
 from music_assistant.providers.airplay.sendspin_bridge import (
     MAX_DEVICE_BUFFER_SECONDS,
     SendspinAirPlayBridge,
@@ -153,7 +154,11 @@ def test_anchor_already_in_the_past_maps_to_a_past_unix_instant() -> None:
 # --- Start anchor: fresh keeps position 0, late join lands at live position ---
 
 
-def _make_bridge(clock_now_us: int, wait_start_ms: int = AP2_LEAD_MS) -> SendspinAirPlayBridge:
+def _make_bridge(
+    clock_now_us: int,
+    wait_start_ms: int = AP2_LEAD_MS,
+    protocol: StreamingProtocol = StreamingProtocol.AIRPLAY2,
+) -> SendspinAirPlayBridge:
     """Build a bridge with mocked provider/player/server and a ManualClock."""
     provider = MagicMock()
     provider.mass = MagicMock()
@@ -161,6 +166,7 @@ def _make_bridge(clock_now_us: int, wait_start_ms: int = AP2_LEAD_MS) -> Sendspi
     airplay_player.player_id = "apc43875e9e53a"
     airplay_player.display_name = "Test Player"
     airplay_player.wait_start = wait_start_ms
+    airplay_player.protocol = protocol
     sendspin_server = MagicMock()
     sendspin_server.clock = ManualClock(now_us_value=clock_now_us)
     bridge = SendspinAirPlayBridge(provider, airplay_player, sendspin_server)
@@ -312,14 +318,11 @@ async def test_cold_start_connects_then_prepares_and_starts_generation_zero() ->
 # --- Warm handover: a kept stream survives a new stream start and absorbs a generation ---
 
 
-def _make_kept_stream(
-    *, route: str = "AirPlay 2 (realtime, PTP)", running: bool = True, connected: bool = True
-) -> MagicMock:
-    """Build a mock AirPlayStream reporting the given running/connected/route state."""
+def _make_kept_stream(*, running: bool = True, connected: bool = True) -> MagicMock:
+    """Build a mock AirPlayStream reporting the given running/connected state."""
     stream = MagicMock()
     stream.running = running
     stream.connected = connected
-    stream.active_route = route
     return stream
 
 
@@ -335,21 +338,44 @@ def test_on_bridge_stream_start_keeps_warm_eligible_stream() -> None:
 
     assert bridge._airplay_stream is kept_stream
     assert bridge.airplay_player.stream is kept_stream
+    assert bridge._stream_is_warm_eligible()
 
 
-def test_on_bridge_stream_start_replaces_non_eligible_stream() -> None:
-    """A RAOP stream is cleared on a new Sendspin stream start so a fresh one is built."""
-    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    old_stream = _make_kept_stream(route="RAOP")
+def test_on_bridge_stream_start_keeps_raop_stream() -> None:
+    """A committed legacy RAOP stream is eligible for warm Sendspin generations."""
+    bridge = _make_bridge(
+        clock_now_us=SENDSPIN_EPOCH_US,
+        wait_start_ms=RAOP_LEAD_MS,
+        protocol=StreamingProtocol.RAOP,
+    )
+    old_stream = _make_kept_stream()
     bridge._airplay_stream = old_stream
     bridge.airplay_player.stream = old_stream
+    bridge._generation_started = True
 
     bridge._on_bridge_stream_start()
 
-    assert bridge._airplay_stream is None
-    # mypy narrows this attribute to MagicMock from the assignment above and doesn't
-    # know _on_bridge_stream_start() resets it, so it (wrongly) considers this unreachable.
-    assert bridge.airplay_player.stream is None  # type: ignore[unreachable]
+    assert bridge._airplay_stream is old_stream
+    assert bridge.airplay_player.stream is old_stream
+
+
+def test_sendspin_callbacks_keep_raop_stream_until_warm_handover() -> None:
+    """Both Sendspin start callbacks preserve a reusable legacy RAOP session."""
+    bridge = _make_bridge(
+        clock_now_us=SENDSPIN_EPOCH_US,
+        wait_start_ms=RAOP_LEAD_MS,
+        protocol=StreamingProtocol.RAOP,
+    )
+    kept_stream = _make_kept_stream()
+    bridge._airplay_stream = kept_stream
+    bridge.airplay_player.stream = kept_stream
+    bridge._generation_started = True
+
+    bridge._on_stream_start(MagicMock())
+    bridge._on_bridge_stream_start()
+
+    assert bridge._airplay_stream is kept_stream
+    assert bridge.airplay_player.stream is kept_stream
 
 
 def test_on_bridge_stream_start_replaces_uncommitted_stream() -> None:

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -117,8 +117,10 @@ async def test_cli_args_default_auto() -> None:
     # networking
     assert _arg_value(args, "--if") == "192.168.1.5"
     assert _arg_value(args, "--publish-ip") == "192.168.1.99"
-    # positional args: device address + stdin
-    assert args[-2:] == ["192.168.1.50", "-"]
+    # the target is the only positional argument; PREPARE selects stdin
+    assert args[-1] == "192.168.1.50"
+    assert "-" not in args
+    assert "--cmdpipe" in args
 
 
 @pytest.mark.asyncio
@@ -202,7 +204,7 @@ async def test_cli_args_hires_pcm_format() -> None:
 
 @pytest.mark.asyncio
 async def test_cli_args_raop_only_device() -> None:
-    """A device without an _airplay._tcp service targets the RAOP service, no --txt."""
+    """True legacy RAOP uses the command pipe and has no positional audio source."""
     player = _make_player()
     player.airplay_discovery_info = None
     player.protocol = StreamingProtocol.RAOP
@@ -213,6 +215,9 @@ async def test_cli_args_raop_only_device() -> None:
     assert "--txt" not in args
     assert "--name" not in args
     assert "--encrypt" in args
+    assert "--cmdpipe" in args
+    assert args[-1] == "192.168.1.50"
+    assert "-" not in args
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from music_assistant_models.errors import PlayerCommandFailed
 
+from music_assistant.providers.airplay.constants import StreamingProtocol
 from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
 
 PCM_SAMPLE_SIZE = 176400  # 44.1kHz / 16-bit / 2ch
@@ -33,8 +34,12 @@ def _make_session(
     pcm_format.channels = 2
 
     leader = MagicMock()
+    leader.player_id = "leader"
+    leader.protocol = StreamingProtocol.RAOP
     leader.stream = MagicMock()
     leader.stream.running = True
+    leader.stream.connected = True
+    leader.config.get_value = MagicMock(return_value=0)
 
     session = AirPlayStreamSession(prov, [leader], pcm_format, MagicMock(elapsed_time=0))
     session.start_time = start_time
@@ -49,6 +54,7 @@ def _make_late_joiner(wait_start_ms: int = 2000) -> MagicMock:
     """Create a mock AirPlay player for late-join testing."""
     player = MagicMock()
     player.player_id = "late_joiner"
+    player.protocol = StreamingProtocol.RAOP
     player.wait_start = wait_start_ms
     player.stream = None
     player.config = MagicMock()
@@ -119,14 +125,27 @@ async def test_initial_client_failure_stops_started_clients() -> None:
 
 
 @pytest.mark.asyncio
-async def test_initial_group_waits_for_every_member_before_shared_start() -> None:
+@pytest.mark.parametrize(
+    ("first_protocol", "second_protocol"),
+    [
+        (StreamingProtocol.RAOP, StreamingProtocol.RAOP),
+        (StreamingProtocol.AIRPLAY2, StreamingProtocol.AIRPLAY2),
+        (StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2),
+    ],
+)
+async def test_initial_group_waits_for_every_member_before_shared_start(
+    first_protocol: StreamingProtocol,
+    second_protocol: StreamingProtocol,
+) -> None:
     """Generation 0 starts at one instant only after every member connects and primes."""
     session = _make_session(0, 0)
     first_player: Any = session.sync_clients[0]
     first_player.player_id = "first"
+    first_player.protocol = first_protocol
     first_player.wait_start = 2500
     first_player.config.get_value = MagicMock(return_value=0)
     second_player = MagicMock(player_id="second", wait_start=2500)
+    second_player.protocol = second_protocol
     second_player.config.get_value = MagicMock(return_value=0)
     session.sync_clients.append(second_player)
     session.media.elapsed_time = 12
@@ -158,6 +177,7 @@ async def test_initial_group_waits_for_every_member_before_shared_start() -> Non
     with (
         patch.object(session, "_start_client", side_effect=start_client),
         patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch.object(session, "_resolve_shared_ptp", new_callable=AsyncMock, return_value=False),
         patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0),
     ):
         await session.start(MagicMock())
@@ -173,11 +193,18 @@ async def test_initial_group_waits_for_every_member_before_shared_start() -> Non
 
 
 @pytest.mark.asyncio
-async def test_initial_single_player_uses_commanded_generation_zero() -> None:
+@pytest.mark.parametrize(
+    "protocol",
+    [StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2],
+)
+async def test_initial_single_player_uses_commanded_generation_zero(
+    protocol: StreamingProtocol,
+) -> None:
     """A standalone player follows the same generation-0 flow with the solo lead."""
     session = _make_session(0, 0)
     player: Any = session.sync_clients[0]
     player.player_id = "solo"
+    player.protocol = protocol
     player.wait_start = 2500
     player.config.get_value = MagicMock(return_value=0)
     stream = MagicMock(running=True)
@@ -206,8 +233,10 @@ async def test_initial_prime_timeout_never_starts_partial_group() -> None:
     """If any member fails to prime, no member receives START and the group is stopped."""
     session = _make_session(0, 0)
     first_player: Any = session.sync_clients[0]
+    first_player.protocol = StreamingProtocol.RAOP
     first_player.wait_start = 2500
     second_player = MagicMock(player_id="second", wait_start=2500)
+    second_player.protocol = StreamingProtocol.RAOP
     session.sync_clients.append(second_player)
 
     async def start_client(player: MagicMock, _use_shared_ptp: bool) -> None:
@@ -238,6 +267,7 @@ async def test_initial_connection_cancellation_never_prepares_group() -> None:
     session = _make_session(0, 0)
     player: Any = session.sync_clients[0]
     player.player_id = "solo"
+    player.protocol = StreamingProtocol.RAOP
     player.wait_start = 2500
     connection_waiting = asyncio.Event()
     stream = MagicMock(running=True)
@@ -266,6 +296,31 @@ async def test_initial_connection_cancellation_never_prepares_group() -> None:
     stream.prepare_generation.assert_not_awaited()
     stream.start_generation.assert_not_awaited()
     stop_session.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "protocols",
+    [
+        (StreamingProtocol.RAOP,),
+        (StreamingProtocol.AIRPLAY2,),
+        (StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2),
+    ],
+)
+def test_warm_replace_supports_every_streaming_protocol(
+    protocols: tuple[StreamingProtocol, ...],
+) -> None:
+    """Connected legacy RAOP, AirPlay 2 and mixed sessions can replace warm."""
+    session = _make_session(0, 0)
+    players: Any = []
+    for index, protocol in enumerate(protocols):
+        player = MagicMock()
+        player.player_id = f"player-{index}"
+        player.protocol = protocol
+        player.stream = MagicMock(running=True, connected=True)
+        players.append(player)
+    session.sync_clients = players
+
+    assert session.can_replace(players, session.pcm_format)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

AirPlay streams now use the command pipe for every protocol from the first generation onward.

- Removes the positional audio source from cliairplay startup
- Enables warm seek, next-track, and Sendspin handovers for legacy RAOP and mixed groups
- Keeps synchronized starts behind the shared connect, prepare, and prime barrier

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.