### PR TITLE
Fix controls for bridged AirPlay groups

### DIFF
--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -151,7 +151,9 @@ class AirPlayProvider(PlayerProvider):
 
     def handle_remote_command(self, player: AirPlayPlayer, command: AirPlayRemoteCommand) -> None:
         """Dispatch a transport command received from an AirPlay receiver."""
-        player_id = player.player_id
+        player_id = (
+            self.bridge_manager.get_transport_command_target(player.player_id) or player.player_id
+        )
         match command:
             case AirPlayRemoteCommand.PLAY:
                 # Some receivers echo play as confirmation of a command from MA.

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -200,6 +200,18 @@ class SendspinAirPlayBridge:
         """Return whether the bridge is registered with Sendspin."""
         return self._sendspin_client is not None
 
+    @property
+    def bridge_client_id(self) -> str | None:
+        """Return the Sendspin player ID registered for this bridge."""
+        return self._bridge_client_id
+
+    @property
+    def owns_airplay_stream(self) -> bool:
+        """Return whether this bridge owns the AirPlay player's current stream."""
+        return (
+            self._airplay_stream is not None and self.airplay_player.stream is self._airplay_stream
+        )
+
     async def start(self) -> None:
         """Register the AirPlay player as an external Sendspin client."""
         self._bridge_client_id = get_bridge_client_id(self.airplay_player)
@@ -912,6 +924,30 @@ class SendspinAirPlayBridge:
 
 class SendspinBridgeManager(SendspinBridgeManagerBase[SendspinAirPlayBridge]):
     """Manages Sendspin bridges for all AirPlay players."""
+
+    def get_transport_command_target(self, airplay_player_id: str) -> str | None:
+        """
+        Return the visible Sendspin session player controlling an AirPlay bridge.
+
+        :param airplay_player_id: The AirPlay player reporting the command.
+        :return: The owning Sendspin session player ID, or None when Sendspin does
+            not currently control the AirPlay player.
+        """
+        if not (bridge := self._bridges.get(airplay_player_id)):
+            return None
+        if not bridge.owns_airplay_stream:
+            return None
+        if not (bridge_client_id := bridge.bridge_client_id):
+            return None
+        if not (bridge_player := self.mass.players.get_player(bridge_client_id)):
+            return None
+
+        sync_leader_id = bridge_player.synced_to
+        if sync_leader_id:
+            if sync_leader := self.mass.players.get_player(sync_leader_id):
+                return sync_leader.protocol_parent_id or sync_leader.player_id
+            return sync_leader_id
+        return bridge_player.protocol_parent_id or bridge_player.player_id
 
     def stop_streaming(self, airplay_player_id: str) -> bool:
         """

--- a/scripts/fetch_airplay_cli.py
+++ b/scripts/fetch_airplay_cli.py
@@ -6,6 +6,7 @@ import hashlib
 import platform
 import re
 import stat
+import subprocess
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -20,7 +21,7 @@ BINARY_DIR = Path("music_assistant/providers/airplay/bin")
 
 def fetch_airplay_cli(root: Path) -> Path | None:
     """
-    Download the container-pinned cliairplay binary when it is not present.
+    Install the container-pinned cliairplay binary when missing or outdated.
 
     :param root: Music Assistant server repository root.
     :return: Local binary path, or None when the current platform is unsupported.
@@ -39,11 +40,15 @@ def fetch_airplay_cli(root: Path) -> Path | None:
         if not destination.is_file():
             msg = f"cliairplay destination is not a file: {destination}"
             raise RuntimeError(msg)
-        print(f"Using existing AirPlay development binary: {destination}")
-        return destination
 
     dockerfile = root / "Dockerfile"
     version = _read_docker_arg(dockerfile, "CLIAIRPLAY_VERSION")
+    if destination.exists():
+        if not _binary_is_outdated(destination, version):
+            print(f"Using existing AirPlay development binary: {destination}")
+            return destination
+        print(f"Updating AirPlay development binary to {version}: {destination}")
+
     manifest_digest = _read_docker_arg(dockerfile, "CLIAIRPLAY_CHECKSUMS_SHA256")
     release_url = f"{RELEASE_BASE_URL}/{version}"
 
@@ -116,6 +121,56 @@ def _read_docker_arg(dockerfile: Path, name: str) -> str:
         msg = f"Unable to find {name} in {dockerfile}"
         raise RuntimeError(msg)
     return match.group(1)
+
+
+def _binary_is_outdated(binary_path: Path, pinned_version: str) -> bool:
+    """
+    Return whether an existing release binary predates the Docker pin.
+
+    Unknown versions are treated as local development builds and preserved.
+
+    :param binary_path: Existing cliairplay executable.
+    :param pinned_version: Release version configured in the Dockerfile.
+    """
+    current = _read_binary_version(binary_path)
+    pinned = _parse_release_version(pinned_version)
+    return current is not None and pinned is not None and current < pinned
+
+
+def _read_binary_version(binary_path: Path) -> tuple[int, int, int] | None:
+    """
+    Return the semantic version reported by a cliairplay executable.
+
+    :param binary_path: cliairplay executable to inspect.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603
+            [binary_path, "--check"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+    except OSError, subprocess.TimeoutExpired:
+        return None
+    if result.returncode != 0:
+        return None
+    match = re.search(r"\bcliairplay\s+(v?\d+\.\d+\.\d+)\s+check\b", result.stdout)
+    if match is None:
+        return None
+    return _parse_release_version(match.group(1))
+
+
+def _parse_release_version(value: str) -> tuple[int, int, int] | None:
+    """
+    Parse a three-part cliairplay release version.
+
+    :param value: Version with an optional ``v`` prefix.
+    """
+    match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", value.strip())
+    if match is None:
+        return None
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
 
 
 def _binary_digest(manifest: bytes, asset_name: str) -> str:

--- a/tests/providers/airplay/dacp/conftest.py
+++ b/tests/providers/airplay/dacp/conftest.py
@@ -69,7 +69,10 @@ def airplay_provider(
     handle_async_init (DACP server / zeroconf) is intentionally not called; only the
     request handler is exercised. The default logger level keeps VERBOSE capture off.
     """
-    return AirPlayProvider(mock_mass, manifest_mock, config_mock)
+    provider = AirPlayProvider(mock_mass, manifest_mock, config_mock)
+    provider._bridge_manager = MagicMock()
+    provider._bridge_manager.get_transport_command_target.return_value = None
+    return provider
 
 
 def make_player(  # noqa: PLR0913

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -7,6 +7,8 @@ from contextlib import AbstractContextManager
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+from music_assistant_models.enums import PlaybackState
+
 from music_assistant.constants import CONF_SYNC_ADJUST, VERBOSE_LOG_LEVEL
 from music_assistant.providers.airplay.constants import (
     CONF_FORCE_RAOP,
@@ -14,10 +16,15 @@ from music_assistant.providers.airplay.constants import (
     CONF_LEGACY_FORCE_RAOP,
     CONF_PROTOCOL_MIGRATION_MARKER,
     CONF_SYNC_ADJUST_RESET_MARKER,
+    AirPlayRemoteCommand,
     StreamingProtocol,
 )
 from music_assistant.providers.airplay.player import AirPlayPlayer
 from music_assistant.providers.airplay.provider import AirPlayProvider
+from music_assistant.providers.airplay.sendspin_bridge import (
+    SendspinAirPlayBridge,
+    SendspinBridgeManager,
+)
 from music_assistant.providers.airplay.stream import AirPlayStream
 from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
 from music_assistant.providers.airplay_receiver import airplay_receiver_port
@@ -151,6 +158,60 @@ def test_protocol_migration_runs_only_once() -> None:
 
     cast("MagicMock", prov.mass.config).set_raw_player_config_value.assert_not_called()
     cast("MagicMock", prov.mass.config).set_raw_provider_config_value.assert_not_called()
+
+
+def test_remote_pause_routes_to_sendspin_session() -> None:
+    """A bridged device pause targets the owning Sendspin session."""
+    prov = _make_provider(False, {}, {})
+    players = cast("MagicMock", prov.mass.players)
+    manager = SendspinBridgeManager(prov)
+    prov._bridge_manager = manager
+
+    airplay_player = MagicMock()
+    airplay_player.player_id = "apc43875e9e53a"
+    airplay_player.playback_state = PlaybackState.PLAYING
+
+    bridge = SendspinAirPlayBridge(prov, airplay_player, MagicMock())
+    bridge._bridge_client_id = "sendspin-bridge"
+    bridge._airplay_stream = airplay_player.stream = MagicMock()
+    manager._bridges[airplay_player.player_id] = bridge
+
+    bridge_player = MagicMock()
+    bridge_player.synced_to = "sendspin-leader"
+    bridge_player.protocol_parent_id = airplay_player.player_id
+    bridge_player.player_id = "sendspin-bridge"
+
+    sync_leader = MagicMock()
+    sync_leader.protocol_parent_id = "sendspin-session"
+    sync_leader.player_id = "sendspin-leader"
+    players.get_player.side_effect = {
+        "sendspin-bridge": bridge_player,
+        "sendspin-leader": sync_leader,
+    }.get
+
+    prov.handle_remote_command(airplay_player, AirPlayRemoteCommand.PAUSE)
+
+    players.cmd_pause.assert_called_once_with("sendspin-session")
+
+
+def test_remote_pause_keeps_normal_airplay_routing() -> None:
+    """An inactive bridge does not change normal AirPlay pause routing."""
+    prov = _make_provider(False, {}, {})
+    players = cast("MagicMock", prov.mass.players)
+    manager = SendspinBridgeManager(prov)
+    prov._bridge_manager = manager
+    airplay_player = MagicMock()
+    airplay_player.player_id = "apc43875e9e53a"
+    airplay_player.playback_state = PlaybackState.PLAYING
+    airplay_player.stream = MagicMock()
+
+    bridge = SendspinAirPlayBridge(prov, airplay_player, MagicMock())
+    bridge._bridge_client_id = "sendspin-bridge"
+    manager._bridges[airplay_player.player_id] = bridge
+
+    prov.handle_remote_command(airplay_player, AirPlayRemoteCommand.PAUSE)
+
+    players.cmd_pause.assert_called_once_with(airplay_player.player_id)
 
 
 async def test_unload_awaits_cancelled_ptp_stdout_reader() -> None:

--- a/tests/scripts/test_fetch_airplay_cli.py
+++ b/tests/scripts/test_fetch_airplay_cli.py
@@ -56,8 +56,10 @@ def test_fetch_airplay_cli_preserves_existing_binary(
     destination = tmp_path / fetch_airplay_cli.BINARY_DIR / "cliairplay-linux-x86_64"
     destination.parent.mkdir(parents=True)
     destination.write_bytes(b"local build")
+    _write_dockerfile(tmp_path, b"unused manifest")
     monkeypatch.setattr("scripts.fetch_airplay_cli.platform.system", lambda: "Linux")
     monkeypatch.setattr("scripts.fetch_airplay_cli.platform.machine", lambda: "x86_64")
+    monkeypatch.setattr(fetch_airplay_cli, "_read_binary_version", lambda _path: None)
     monkeypatch.setattr(
         fetch_airplay_cli,
         "_download",
@@ -66,6 +68,36 @@ def test_fetch_airplay_cli_preserves_existing_binary(
 
     assert fetch_airplay_cli.fetch_airplay_cli(tmp_path) == destination
     assert destination.read_bytes() == b"local build"
+
+
+def test_fetch_airplay_cli_replaces_older_release_binary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Replace a recognized older release binary with the pinned release."""
+    binary = b"new release"
+    asset_name = "cliairplay-macos-arm64"
+    manifest = f"{hashlib.sha256(binary).hexdigest()}  {asset_name}\n".encode()
+    _write_dockerfile(tmp_path, manifest)
+    destination = tmp_path / fetch_airplay_cli.BINARY_DIR / asset_name
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"old release")
+    downloads: list[str] = []
+
+    def download(url: str) -> bytes:
+        downloads.append(url)
+        return manifest if url.endswith("/SHA256SUMS") else binary
+
+    monkeypatch.setattr("scripts.fetch_airplay_cli.platform.system", lambda: "Darwin")
+    monkeypatch.setattr("scripts.fetch_airplay_cli.platform.machine", lambda: "arm64")
+    monkeypatch.setattr(fetch_airplay_cli, "_read_binary_version", lambda _path: (0, 0, 9))
+    monkeypatch.setattr(fetch_airplay_cli, "_download", download)
+
+    assert fetch_airplay_cli.fetch_airplay_cli(tmp_path) == destination
+    assert destination.read_bytes() == binary
+    assert downloads == [
+        f"{fetch_airplay_cli.RELEASE_BASE_URL}/v0.1.0/SHA256SUMS",
+        f"{fetch_airplay_cli.RELEASE_BASE_URL}/v0.1.0/{asset_name}",
+    ]
 
 
 def test_fetch_airplay_cli_rejects_checksum_mismatch(
@@ -156,6 +188,43 @@ def test_main_reports_filesystem_error(
 def test_asset_name(system: str, machine: str, expected: str | None) -> None:
     """Map supported development platforms to their release asset."""
     assert fetch_airplay_cli._asset_name(system, machine) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("v0.3.0", (0, 3, 0)),
+        ("1.2.3", (1, 2, 3)),
+        ("0.3", None),
+        ("development", None),
+    ],
+)
+def test_parse_release_version(value: str, expected: tuple[int, int, int] | None) -> None:
+    """Parse supported release versions without treating local labels as releases."""
+    assert fetch_airplay_cli._parse_release_version(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("current", "pinned", "expected"),
+    [
+        ((0, 2, 0), "v0.3.0", True),
+        ((0, 3, 0), "v0.3.0", False),
+        ((0, 3, 1), "v0.3.0", False),
+        (None, "v0.3.0", False),
+    ],
+)
+def test_binary_is_outdated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    current: tuple[int, int, int] | None,
+    pinned: str,
+    expected: bool,
+) -> None:
+    """Only older recognized releases are replaced."""
+    binary_path = tmp_path / "cliairplay"
+    monkeypatch.setattr(fetch_airplay_cli, "_read_binary_version", lambda _path: current)
+
+    assert fetch_airplay_cli._binary_is_outdated(binary_path, pinned) is expected
 
 
 def _write_dockerfile(root: Path, manifest: bytes, *, manifest_digest: str | None = None) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Physical controls on an AirPlay speaker could affect only that speaker while playback was owned by a Sendspin group.

- Route playback controls to the active Sendspin group.
- Keep normal AirPlay control behavior unchanged.
- Refresh outdated local AirPlay binaries after version updates.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
