### PR TITLE
Keep all AirPlay groups connected while paused

### DIFF
--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -419,8 +419,9 @@ instant**" on every protocol path (RAOP, AirPlay 2 RAOP-compat and native).
    the same value in `START` to every member
 4. The binary owns receiver-buffer handling from there, so the commanded start
    cannot race connection or pre-fill
-5. Warm seek and next-track use the same PREPARE/prime/START barrier for later
-   generations on legacy RAOP, RAOP-compatible AirPlay 2 and native AirPlay 2
+5. Warm seek, next-track and grouped resume use the same PREPARE/prime/START
+   barrier for later generations on legacy RAOP, RAOP-compatible AirPlay 2 and
+   native AirPlay 2; standby keeps each protocol connection alive
 6. Sendspin starts preserve its externally supplied audible instant after the
    same connection and prime gates
 7. Per-player `sync_adjust` config allows fine-tuning (+/- milliseconds)

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -339,8 +339,8 @@ class AirPlayPlayer(Player):
                 and await self.stream.session.standby()
             ):
                 return
-            # some member cannot be parked (e.g. RAOP legacy): full stop and
-            # let the queue controller resume from the saved position
+            # Some member no longer has a live connection: full stop and let
+            # the queue controller resume from the saved position.
             self.logger.debug("Sync group cannot be parked, using STOP instead of PAUSE")
             await self.stop()
             return

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -213,11 +213,11 @@ class AirPlayStreamSession:
 
         The next play_media (resume or seek) commits a new generation over the
         live connections — the same coordinated warm restart as seek/next.
-        Returns False when any member lacks a running AirPlay 2 stream (RAOP
-        cannot be parked), so the caller can fall back to a full stop.
+        Returns False when any member lacks a running, connected stream so the
+        caller can fall back to a full stop.
         """
         if not all(
-            p.stream is not None and p.stream.running and p.protocol == StreamingProtocol.AIRPLAY2
+            p.stream is not None and p.stream.running and p.stream.connected
             for p in self.sync_clients
         ):
             return False

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -830,7 +830,7 @@ async def test_grouped_leader_pause_parks_session(airplay_player: AirPlayPlayer)
 
 @pytest.mark.asyncio
 async def test_grouped_pause_falls_back_to_stop(airplay_player: AirPlayPlayer) -> None:
-    """When a member cannot be parked (e.g. RAOP), grouped pause stops the session."""
+    """When a member cannot be parked, grouped pause stops the session."""
     airplay_player._attr_group_members = ["test_player", "child"]
     send_cmd = _setup_running_stream(airplay_player)
     assert airplay_player.stream is not None

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -354,6 +354,62 @@ async def test_standby_supports_every_connected_streaming_protocol(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "protocols",
+    [
+        (StreamingProtocol.RAOP, StreamingProtocol.RAOP),
+        (StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2),
+    ],
+)
+async def test_standby_resumes_next_generation_on_existing_streams(
+    protocols: tuple[StreamingProtocol, StreamingProtocol],
+) -> None:
+    """All-RAOP and mixed sessions resume warm on their parked streams."""
+    session = _make_session(0, 0)
+    players: Any = []
+    original_streams: dict[str, MagicMock] = {}
+    for index, protocol in enumerate(protocols):
+        player = MagicMock()
+        player.player_id = f"player-{index}"
+        player.protocol = protocol
+        player.config.get_value = MagicMock(return_value=0)
+        player.stream = MagicMock(running=True, connected=True)
+        player.stream.send_cli_command = AsyncMock()
+        player.stream.next_generation = MagicMock(return_value=1)
+        player.stream.prepare_generation = AsyncMock()
+        player.stream.wait_generation_primed = AsyncMock(return_value=True)
+        player.stream.start_generation = AsyncMock()
+        players.append(player)
+        original_streams[player.player_id] = player.stream
+    session.sync_clients = players
+
+    assert await session.standby()
+    assert session.can_replace(players, session.pcm_format)
+    media = MagicMock(elapsed_time=10)
+    with (
+        patch.object(session, "_start_generation_ffmpeg", new_callable=AsyncMock),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0),
+        patch("music_assistant.providers.airplay.stream_session.os.unlink"),
+        patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
+        patch("music_assistant.providers.airplay.stream_session.os.open", return_value=99),
+        patch("music_assistant.providers.airplay.stream_session.os.close"),
+    ):
+        assert await session.replace(MagicMock(), media)
+
+    for player in players:
+        stream = original_streams[player.player_id]
+        assert player.stream is stream
+        stream.prepare_generation.assert_awaited_once_with(
+            1,
+            f"/tmp/ma-gen-{player.player_id}-1.pcm",  # noqa: S108
+            10_000,
+        )
+        stream.wait_generation_primed.assert_awaited_once_with(1)
+        stream.start_generation.assert_awaited_once_with(1, 10_000, 100_750)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("stream_state", ["missing", "stopped", "disconnected"])
 async def test_standby_requires_every_member_running_and_connected(stream_state: str) -> None:
     """Standby is unavailable when any member lacks a reusable generation session."""
@@ -373,6 +429,7 @@ async def test_standby_requires_every_member_running_and_connected(stream_state:
     session.sync_clients = players
 
     assert await session.standby() is False
+    assert session.can_replace(players, session.pcm_format) is False
     ready_player.stream.send_cli_command.assert_not_awaited()
     ready_player.set_state_from_stream.assert_not_called()
     if unavailable_player.stream:

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -324,6 +324,41 @@ def test_warm_replace_supports_every_streaming_protocol(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("protocols", "standby_supported"),
+    [
+        ((StreamingProtocol.AIRPLAY2,), True),
+        ((StreamingProtocol.RAOP,), False),
+        ((StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2), False),
+    ],
+)
+async def test_standby_requires_every_member_to_support_airplay2(
+    protocols: tuple[StreamingProtocol, ...],
+    standby_supported: bool,
+) -> None:
+    """Generation support does not imply legacy RAOP standby support."""
+    session = _make_session(0, 0)
+    players: Any = []
+    for index, protocol in enumerate(protocols):
+        player = MagicMock()
+        player.player_id = f"player-{index}"
+        player.protocol = protocol
+        player.stream = MagicMock(running=True)
+        player.stream.send_cli_command = AsyncMock()
+        players.append(player)
+    session.sync_clients = players
+
+    assert await session.standby() is standby_supported
+    for player in players:
+        if standby_supported:
+            player.stream.send_cli_command.assert_awaited_once_with("ACTION=STANDBY")
+            player.set_state_from_stream.assert_called_once()
+        else:
+            player.stream.send_cli_command.assert_not_awaited()
+            player.set_state_from_stream.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_late_join_empty_buffer() -> None:
     """Test that with an empty buffer, start_at = start_time + seconds_streamed."""
     now = time.time()

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -325,37 +325,59 @@ def test_warm_replace_supports_every_streaming_protocol(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("protocols", "standby_supported"),
+    "protocols",
     [
-        ((StreamingProtocol.AIRPLAY2,), True),
-        ((StreamingProtocol.RAOP,), False),
-        ((StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2), False),
+        (StreamingProtocol.AIRPLAY2,),
+        (StreamingProtocol.RAOP,),
+        (StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2),
     ],
 )
-async def test_standby_requires_every_member_to_support_airplay2(
+async def test_standby_supports_every_connected_streaming_protocol(
     protocols: tuple[StreamingProtocol, ...],
-    standby_supported: bool,
 ) -> None:
-    """Generation support does not imply legacy RAOP standby support."""
+    """Connected legacy RAOP, AirPlay 2 and mixed sessions can enter standby."""
     session = _make_session(0, 0)
     players: Any = []
     for index, protocol in enumerate(protocols):
         player = MagicMock()
         player.player_id = f"player-{index}"
         player.protocol = protocol
-        player.stream = MagicMock(running=True)
+        player.stream = MagicMock(running=True, connected=True)
         player.stream.send_cli_command = AsyncMock()
         players.append(player)
     session.sync_clients = players
 
-    assert await session.standby() is standby_supported
+    assert await session.standby()
     for player in players:
-        if standby_supported:
-            player.stream.send_cli_command.assert_awaited_once_with("ACTION=STANDBY")
-            player.set_state_from_stream.assert_called_once()
-        else:
-            player.stream.send_cli_command.assert_not_awaited()
-            player.set_state_from_stream.assert_not_called()
+        player.stream.send_cli_command.assert_awaited_once_with("ACTION=STANDBY")
+        player.set_state_from_stream.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream_state", ["missing", "stopped", "disconnected"])
+async def test_standby_requires_every_member_running_and_connected(stream_state: str) -> None:
+    """Standby is unavailable when any member lacks a reusable generation session."""
+    session = _make_session(0, 0)
+    ready_player = MagicMock(player_id="ready", protocol=StreamingProtocol.AIRPLAY2)
+    ready_player.stream = MagicMock(running=True, connected=True)
+    ready_player.stream.send_cli_command = AsyncMock()
+    unavailable_player = MagicMock(player_id="unavailable", protocol=StreamingProtocol.RAOP)
+    unavailable_player.stream = None
+    if stream_state != "missing":
+        unavailable_player.stream = MagicMock(
+            running=stream_state != "stopped",
+            connected=stream_state != "disconnected",
+        )
+        unavailable_player.stream.send_cli_command = AsyncMock()
+    players: Any = [ready_player, unavailable_player]
+    session.sync_clients = players
+
+    assert await session.standby() is False
+    ready_player.stream.send_cli_command.assert_not_awaited()
+    ready_player.set_state_from_stream.assert_not_called()
+    if unavailable_player.stream:
+        unavailable_player.stream.send_cli_command.assert_not_awaited()
+        unavailable_player.set_state_from_stream.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

AirPlay groups can now pause without disconnecting, regardless of the cliairplay route in use.

- Enables standby for legacy RAOP, RAOP-compatible AirPlay 2, native AirPlay 2, and mixed groups
- Requires every member to retain a running, connected generation session
- Preserves existing PAUSE/PLAY and AirPlay 2-only timing behavior

**Related issue (if applicable):**

- music-assistant/airplay-cli#12

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.