### PR TITLE
Add setup flow engine for interactive provider and player setup

### DIFF
--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -26,6 +26,7 @@ from music_assistant.constants import (
 from music_assistant.controllers.config.constants import DEFAULT_SAVE_DELAY
 from music_assistant.controllers.config.core import CoreConfigMixin
 from music_assistant.controllers.config.dsp import DSPConfigMixin
+from music_assistant.controllers.config.flows import SetupFlowMixin
 from music_assistant.controllers.config.migrations import migrate
 from music_assistant.controllers.config.players import PlayerConfigMixin
 from music_assistant.controllers.config.providers import ProviderConfigMixin
@@ -49,6 +50,7 @@ class ConfigController(
     PlayerQueueConfigMixin,
     DSPConfigMixin,
     CoreConfigMixin,
+    SetupFlowMixin,
 ):
     """Controller that handles storage of persistent configuration settings."""
 

--- a/music_assistant/controllers/config/flows.py
+++ b/music_assistant/controllers/config/flows.py
@@ -404,9 +404,17 @@ class SetupFlowMixin:
         raw_conf = self.get(conf_key)
         if not raw_conf:
             raise SetupFlowError(f"No config found for player {player_id}")
-        existing_setup_data = dict(raw_conf.get("setup_data") or {})
-        self.set(f"{conf_key}/setup_data", {**existing_setup_data, **self._encrypt_values(values)})
-        config = await self.get_player_config(player_id)
+        snapshot = dict(raw_conf.get("setup_data") or {})
+        self.set(f"{conf_key}/setup_data", {**snapshot, **self._encrypt_values(values)})
+        try:
+            config = await self.get_player_config(player_id)
+        except asyncio.CancelledError:
+            self.set(f"{conf_key}/setup_data", snapshot)
+            raise
+        except Exception as err:
+            # reading back the just-updated config failed: restore the previous setup_data
+            self.set(f"{conf_key}/setup_data", snapshot)
+            raise SetupFlowError(str(err) or err.__class__.__name__) from err
         self.mass.signal_event(EventType.PLAYER_CONFIG_UPDATED, object_id=player_id, data=config)
         return {"player_id": player_id}
 

--- a/music_assistant/controllers/config/flows.py
+++ b/music_assistant/controllers/config/flows.py
@@ -1,0 +1,522 @@
+"""Setup flow engine: registry and API commands for interactive provider/player setup."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from music_assistant_models.auth import Scope
+from music_assistant_models.enums import EventType, FlowStepType
+from music_assistant_models.errors import (
+    ActionUnavailable,
+    InsufficientPermissions,
+    SetupFailedError,
+)
+from music_assistant_models.setup_flow import SetupFlowStep
+
+from music_assistant.constants import CONF_PLAYERS, CONF_PROVIDERS
+from music_assistant.controllers.config.helpers import _AUTH_ERROR_CODES
+from music_assistant.helpers.api import api_command
+from music_assistant.helpers.util import load_provider_module
+from music_assistant.models.player import Player
+from music_assistant.models.setup_flow import (
+    AbortFlow,
+    FlowReason,
+    SetupFlowContext,
+    SetupFlowError,
+    SetupSession,
+    StepExpiredError,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from music_assistant_models.config_entries import ConfigValueType, ProviderConfig
+    from music_assistant_models.provider import ProviderManifest
+
+    from music_assistant import MusicAssistant
+
+LOGGER = logging.getLogger(__name__)
+
+# a flow with no client interaction or step changes for this long is garbage collected
+IDLE_FLOW_TTL = 15 * 60
+FLOW_SWEEP_INTERVAL = 60
+# how long start/submit wait for the flow coroutine to produce the (next) step;
+# generous because finish() may install requirements and load the provider
+NEXT_STEP_TIMEOUT = 120
+
+
+@dataclass
+class ActiveSetupFlow:
+    """Registry record for a running setup flow."""
+
+    session: SetupSession
+    # target_key: identifies what the flow is (re)configuring; one flow per target
+    target_key: str
+    # required_scope: the scope the starting command required; re-checked on
+    # every flows/* continuation command
+    required_scope: Scope
+    task: asyncio.Task[None] | None = None
+
+
+class SetupFlowMixin:
+    """Mixin providing the setup flow engine for the ConfigController."""
+
+    # registry of running flows, keyed by flow_id (lazily created per instance)
+    _flows: dict[str, ActiveSetupFlow] | None = None
+    _flow_sweep_handle: asyncio.TimerHandle | None = None
+
+    # Type hints for attributes/methods provided by the class this mixin is used with
+    if TYPE_CHECKING:
+        mass: MusicAssistant
+
+        @property
+        def onboard_done(self) -> bool: ...  # noqa: D102
+
+        def get(self, key: str, default: Any = None) -> Any: ...  # noqa: D102
+
+        def set(self, key: str, value: Any, immediate: bool = False) -> None: ...  # noqa: D102
+
+        def encrypt_string(self, str_value: str) -> str: ...  # noqa: D102
+
+        def decrypt_string(self, encrypted_str: str) -> str: ...  # noqa: D102
+
+        async def get_provider_configs(  # noqa: D102
+            self, provider_type: Any = None, provider_domain: str | None = None
+        ) -> list[ProviderConfig]: ...
+
+        async def get_provider_config(self, instance_id: str) -> ProviderConfig: ...  # noqa: D102
+
+        def update_provider_last_error(self, instance_id: str, error: Any) -> None: ...  # noqa: D102
+
+        async def get_player_config(self, player_id: str) -> Any: ...  # noqa: D102
+
+        async def _create_provider_instance(
+            self,
+            provider_domain: str,
+            values: dict[str, ConfigValueType],
+            setup_data: dict[str, Any] | None = None,
+        ) -> ProviderConfig: ...
+
+    @api_command("config/providers/setup", required_scope=Scope.CONFIG_PROVIDERS_WRITE)
+    async def setup_provider(self, provider_domain: str) -> SetupFlowStep:
+        """
+        Start the setup flow to add a new instance of the given provider.
+
+        For a provider without a setup flow (no user input needed) the instance is
+        created right away and a FINISH step is returned, so the add-provider path
+        is uniform for all providers.
+
+        :param provider_domain: Domain of the provider to add an instance of.
+        """
+        for manifest in self.mass.get_provider_manifests():
+            if manifest.domain == provider_domain:
+                break
+        else:
+            msg = f"Unknown provider domain: {provider_domain}"
+            raise KeyError(msg)
+        owner = f"provider.{provider_domain}"
+        # fail fast on conditions that would otherwise only surface at save
+        existing = await self.get_provider_configs(provider_domain=provider_domain)
+        if existing and not manifest.multi_instance:
+            return self._synthesized_step(FlowStepType.ABORT, owner, reason="already_configured")
+        if manifest.depends_on:
+            dep_configs = await self.get_provider_configs(provider_domain=manifest.depends_on)
+            if not any(dep_conf.enabled for dep_conf in dep_configs):
+                return self._synthesized_step(
+                    FlowStepType.ABORT, owner, reason="missing_dependency"
+                )
+        flow_module = await self._get_setup_flow_module(manifest)
+        if flow_module is None:
+            # zero-input provider: create the instance immediately and report it
+            # as an (already) finished flow
+            config = await self._create_provider_instance(provider_domain, {})
+            return self._synthesized_step(
+                FlowStepType.FINISH, owner, result={"instance_id": config.instance_id}
+            )
+        context = SetupFlowContext(kind="setup", reason="user", domain=provider_domain)
+        return await self._start_flow(
+            flow_coro=flow_module.run_setup,
+            context=context,
+            target_key=f"provider_setup:{provider_domain}",
+            required_scope=Scope.CONFIG_PROVIDERS_WRITE,
+            finish_handler=self._finish_provider_setup,
+        )
+
+    @api_command("config/providers/reconfigure", required_scope=Scope.CONFIG_PROVIDERS_WRITE)
+    async def reconfigure_provider(self, instance_id: str) -> SetupFlowStep:
+        """
+        Start the reconfigure flow on an existing provider instance (covers reauth).
+
+        :param instance_id: The provider instance to reconfigure.
+        """
+        raw_conf = self.get(f"{CONF_PROVIDERS}/{instance_id}")
+        if not raw_conf:
+            msg = f"No config found for provider id {instance_id}"
+            raise KeyError(msg)
+        domain: str = raw_conf["domain"]
+        manifest = self.mass.get_provider_manifest(domain)
+        owner = f"provider.{domain}"
+        flow_module = await self._get_setup_flow_module(manifest)
+        if flow_module is None:
+            # flow-less providers have nothing to reconfigure;
+            # their failures are environmental (reload/retry covers them)
+            return self._synthesized_step(FlowStepType.ABORT, owner, reason="nothing_to_configure")
+        context = SetupFlowContext(
+            kind="reconfigure",
+            reason=self._reconfigure_reason(raw_conf.get("last_error")),
+            domain=domain,
+            instance_id=instance_id,
+            setup_data=self._decrypt_values(raw_conf.get("setup_data") or {}),
+            values=self._decrypt_values(raw_conf.get("values") or {}),
+        )
+        return await self._start_flow(
+            flow_coro=flow_module.run_setup,
+            context=context,
+            target_key=f"provider_reconfigure:{instance_id}",
+            required_scope=Scope.CONFIG_PROVIDERS_WRITE,
+            finish_handler=self._finish_provider_reconfigure,
+        )
+
+    @api_command("config/players/setup", required_scope=Scope.CONFIG_PLAYERS_WRITE)
+    async def setup_player(self, player_id: str) -> SetupFlowStep:
+        """
+        Start the setup flow for a player (e.g. pairing).
+
+        :param player_id: The player to set up.
+        """
+        # deliberately no raise_unavailable: a player that needs setup is serialized
+        # as unavailable, and that is exactly the player this command targets
+        player = self.mass.players.get_player(player_id)
+        if player is None:
+            msg = f"Player {player_id} not found"
+            raise KeyError(msg)
+        owner = f"provider.{player.provider.domain}"
+        if type(player).run_setup_flow is Player.run_setup_flow:
+            # the player (provider) implements no setup flow
+            return self._synthesized_step(FlowStepType.ABORT, owner, reason="nothing_to_configure")
+        raw_conf = self.get(f"{CONF_PLAYERS}/{player_id}") or {}
+        context = SetupFlowContext(
+            kind="setup",
+            reason="user",
+            domain=player.provider.domain,
+            instance_id=player.provider.instance_id,
+            player_id=player_id,
+            setup_data=self._decrypt_values(raw_conf.get("setup_data") or {}),
+            values=self._decrypt_values(raw_conf.get("values") or {}),
+        )
+        return await self._start_flow(
+            flow_coro=player.run_setup_flow,
+            context=context,
+            target_key=f"player_setup:{player_id}",
+            required_scope=Scope.CONFIG_PLAYERS_WRITE,
+            finish_handler=self._finish_player_setup,
+        )
+
+    @api_command("config/flows/submit")
+    async def submit_setup_flow(
+        self, flow_id: str, values: dict[str, ConfigValueType]
+    ) -> SetupFlowStep:
+        """
+        Submit the user's values for the flow's pending FORM step.
+
+        Returns the flow's next step, or the same FORM step (with per-field errors
+        set) when validation failed.
+
+        :param flow_id: The id of the running flow.
+        :param values: The raw values for the form's config entries.
+        """
+        flow = self._get_flow(flow_id)
+        self._check_flow_permission(flow)
+        if (error_step := flow.session.handle_submit(values)) is not None:
+            return error_step
+        # wait (bounded) for the coroutine to produce the next step; on the rare
+        # timeout the stored step is returned as-is and the client picks up the real
+        # next step from the SETUP_FLOW_UPDATED push event
+        await flow.session.wait_for_step_change(NEXT_STEP_TIMEOUT)
+        step = flow.session.current_step
+        assert step is not None  # an accepted submit implies a published FORM step
+        return step
+
+    @api_command("config/flows/get")
+    async def get_setup_flow(self, flow_id: str) -> SetupFlowStep:
+        """
+        Return the current step of a running flow (idempotent re-render, never advances).
+
+        :param flow_id: The id of the running flow.
+        """
+        flow = self._get_flow(flow_id)
+        self._check_flow_permission(flow)
+        flow.session.last_activity = time.monotonic()
+        if (step := flow.session.current_step) is None:
+            raise ActionUnavailable("The setup flow has not produced a step yet")
+        return step
+
+    @api_command("config/flows/abort")
+    async def abort_setup_flow(self, flow_id: str) -> None:
+        """
+        Abort a running flow (user cancelled).
+
+        :param flow_id: The id of the running flow.
+        """
+        flow = self._get_flow(flow_id)
+        self._check_flow_permission(flow)
+        await self._abort_flow(flow, reason="aborted")
+
+    async def _start_flow(
+        self,
+        *,
+        flow_coro: Callable[[SetupSession], Awaitable[Any]],
+        context: SetupFlowContext,
+        target_key: str,
+        required_scope: Scope,
+        finish_handler: Callable[
+            [SetupSession, dict[str, ConfigValueType]], Awaitable[dict[str, str]]
+        ],
+    ) -> SetupFlowStep:
+        """Register and start a new flow, returning its first published step."""
+        # one flow per target: starting anew replaces (aborts) a lingering previous flow
+        for existing_flow in list(self._setup_flows.values()):
+            if existing_flow.target_key == target_key:
+                await self._abort_flow(existing_flow, reason="replaced")
+        flow_id = uuid4().hex
+        session = SetupSession(self.mass, flow_id, context, finish_handler)
+        flow = ActiveSetupFlow(
+            session=session, target_key=target_key, required_scope=required_scope
+        )
+        self._setup_flows[flow_id] = flow
+        flow.task = self.mass.create_task(self._run_flow(flow, flow_coro))
+        self._schedule_flow_sweep()
+        if session.current_step is None:
+            await session.wait_for_step_change(NEXT_STEP_TIMEOUT)
+        if (step := session.current_step) is None:
+            await self._abort_flow(flow, reason="internal_error")
+            raise SetupFailedError("Setup flow did not produce a first step")
+        return step
+
+    async def _run_flow(
+        self, flow: ActiveSetupFlow, flow_coro: Callable[[SetupSession], Awaitable[Any]]
+    ) -> None:
+        """Drive the flow coroutine and convert its outcome into a terminal step."""
+        session = flow.session
+        try:
+            await flow_coro(session)
+        except AbortFlow as err:
+            session.publish_abort(err.reason)
+        except StepExpiredError:
+            session.publish_abort("timed_out")
+        except SetupFlowError as err:
+            # the author did not catch a finish failure: end with the failure message
+            session.publish_abort(str(err) or "internal_error")
+        except asyncio.CancelledError:
+            # abort/replace/shutdown: the author's cleanup (finally blocks) has run;
+            # the canceller publishes the ABORT step. Never swallow the cancellation.
+            raise
+        except Exception:
+            LOGGER.exception("Unhandled error in setup flow for %s", session.context.domain)
+            session.publish_abort("internal_error")
+        else:
+            if not session.finished:
+                LOGGER.error(
+                    "Setup flow for %s returned without calling finish()", session.context.domain
+                )
+                session.publish_abort("internal_error")
+        finally:
+            session.close()
+            self._setup_flows.pop(session.flow_id, None)
+
+    async def _abort_flow(self, flow: ActiveSetupFlow, reason: str) -> None:
+        """
+        Abort the given flow with the given reason and clean it up.
+
+        Cancelling raises CancelledError inside the flow coroutine so the author's
+        cleanup (try/finally around pairing sessions etc.) runs before the terminal
+        ABORT step goes out.
+        """
+        if flow.task is not None and not flow.task.done():
+            flow.task.cancel()
+            # wait() shields us from the task's CancelledError without
+            # masking a cancellation of the caller itself
+            await asyncio.wait([flow.task])
+        self._setup_flows.pop(flow.session.flow_id, None)
+        current_step = flow.session.current_step
+        if current_step is None or current_step.type not in (
+            FlowStepType.FINISH,
+            FlowStepType.ABORT,
+        ):
+            flow.session.publish_abort(reason)
+
+    async def _finish_provider_setup(
+        self, session: SetupSession, values: dict[str, ConfigValueType]
+    ) -> dict[str, str]:
+        """Finish handler for provider setup flows: create, persist and load the instance."""
+        try:
+            config = await self._create_provider_instance(
+                session.context.domain, {}, setup_data=self._encrypt_values(values)
+            )
+        except Exception as err:
+            raise SetupFlowError(
+                str(err) or err.__class__.__name__,
+                translation_key=getattr(err, "translation_key", None),
+            ) from err
+        return {"instance_id": config.instance_id}
+
+    async def _finish_provider_reconfigure(
+        self, session: SetupSession, values: dict[str, ConfigValueType]
+    ) -> dict[str, str]:
+        """Finish handler for provider reconfigure flows: merge setup_data and reload."""
+        instance_id = session.context.instance_id
+        assert instance_id is not None  # always set for reconfigure flows
+        conf_key = f"{CONF_PROVIDERS}/{instance_id}"
+        raw_conf = self.get(conf_key)
+        if not raw_conf:
+            raise SetupFlowError(f"Provider {instance_id} no longer exists")
+        snapshot = dict(raw_conf.get("setup_data") or {})
+        self.set(f"{conf_key}/setup_data", {**snapshot, **self._encrypt_values(values)})
+        try:
+            config = await self.get_provider_config(instance_id)
+            await self.mass.load_provider_config(config)
+        except asyncio.CancelledError:
+            self.set(f"{conf_key}/setup_data", snapshot)
+            raise
+        except Exception as err:
+            # reloading with the new values failed: restore the previous setup_data
+            self.set(f"{conf_key}/setup_data", snapshot)
+            raise SetupFlowError(
+                str(err) or err.__class__.__name__,
+                translation_key=getattr(err, "translation_key", None),
+            ) from err
+        self.update_provider_last_error(instance_id, None)
+        return {"instance_id": instance_id}
+
+    async def _finish_player_setup(
+        self, session: SetupSession, values: dict[str, ConfigValueType]
+    ) -> dict[str, str]:
+        """Finish handler for player setup flows: persist setup_data on the player config."""
+        player_id = session.context.player_id
+        assert player_id is not None  # always set for player flows
+        conf_key = f"{CONF_PLAYERS}/{player_id}"
+        raw_conf = self.get(conf_key)
+        if not raw_conf:
+            raise SetupFlowError(f"No config found for player {player_id}")
+        existing_setup_data = dict(raw_conf.get("setup_data") or {})
+        self.set(f"{conf_key}/setup_data", {**existing_setup_data, **self._encrypt_values(values)})
+        config = await self.get_player_config(player_id)
+        self.mass.signal_event(EventType.PLAYER_CONFIG_UPDATED, object_id=player_id, data=config)
+        return {"player_id": player_id}
+
+    async def _get_setup_flow_module(self, manifest: ProviderManifest) -> Any | None:
+        """
+        Import (lazily) the provider's setup_flow module, or None when it has none.
+
+        A provider without a setup_flow module needs no setup input at all.
+        """
+        # ensure the provider's requirements are installed and its package imports
+        # cleanly first: the setup_flow submodule may rely on those requirements
+        await load_provider_module(manifest.domain, manifest.requirements)
+        module_path = f"music_assistant.providers.{manifest.domain}.setup_flow"
+        try:
+            return await asyncio.to_thread(importlib.import_module, module_path)
+        except ModuleNotFoundError as err:
+            if err.name == module_path:
+                # the provider ships no setup_flow module: it needs no setup input
+                return None
+            # an import *inside* setup_flow.py failed: an actual bug, surface it
+            raise
+
+    @property
+    def _setup_flows(self) -> dict[str, ActiveSetupFlow]:
+        """Return the registry of running flows (created lazily)."""
+        if self._flows is None:
+            self._flows = {}
+        return self._flows
+
+    def _get_flow(self, flow_id: str) -> ActiveSetupFlow:
+        """Return the running flow for the given id."""
+        if flow := self._setup_flows.get(flow_id):
+            return flow
+        msg = f"Unknown (or finished) setup flow: {flow_id}"
+        raise KeyError(msg)
+
+    def _check_flow_permission(self, flow: ActiveSetupFlow) -> None:
+        """Verify the calling user holds the scope the flow's start command required."""
+        # imported here: the webserver helpers pull in the full auth stack,
+        # which must not be imported with the config controller at startup
+        from music_assistant.controllers.webserver.helpers.auth_middleware import (  # noqa: PLC0415
+            get_current_user,
+            has_scope,
+        )
+
+        user = get_current_user()
+        # no user context means an internal (server-side) caller, which is trusted
+        if user is not None and not has_scope(user, flow.required_scope):
+            raise InsufficientPermissions(
+                f"This action requires the {flow.required_scope.value} scope"
+            )
+
+    def _synthesized_step(
+        self,
+        step_type: FlowStepType,
+        translation_owner: str,
+        *,
+        result: dict[str, str] | None = None,
+        reason: str | None = None,
+    ) -> SetupFlowStep:
+        """Return a terminal step for a flow that ended before a session was needed."""
+        return SetupFlowStep(
+            flow_id=uuid4().hex,
+            step_id="finish" if step_type == FlowStepType.FINISH else "abort",
+            type=step_type,
+            result=result,
+            reason=reason,
+            translation_owner=translation_owner,
+        )
+
+    def _reconfigure_reason(self, last_error: Any) -> FlowReason:
+        """Derive the reconfigure flow reason from the provider's stored last_error."""
+        if not last_error:
+            return "user"
+        # legacy settings may still hold a plain string last_error
+        error_code = last_error.get("error_code") if isinstance(last_error, dict) else None
+        if error_code in _AUTH_ERROR_CODES:
+            return "auth"
+        return "error"
+
+    def _encrypt_values(self, values: dict[str, ConfigValueType]) -> dict[str, Any]:
+        """Return a copy of the values with all string values encrypted (at-rest form)."""
+        return {
+            key: self.encrypt_string(value) if isinstance(value, str) else value
+            for key, value in values.items()
+        }
+
+    def _decrypt_values(self, values: dict[str, Any]) -> dict[str, Any]:
+        """Return a copy of the values with all (encrypted) string values decrypted."""
+        return {
+            key: self.decrypt_string(value) if isinstance(value, str) else value
+            for key, value in values.items()
+        }
+
+    def _schedule_flow_sweep(self) -> None:
+        """Arm the periodic idle-flow sweeper (idempotent)."""
+        if self._flow_sweep_handle is not None:
+            return
+        self._flow_sweep_handle = self.mass.loop.call_later(
+            FLOW_SWEEP_INTERVAL, self._sweep_idle_flows
+        )
+
+    def _sweep_idle_flows(self) -> None:
+        """Abort flows that have been idle for longer than the TTL."""
+        self._flow_sweep_handle = None
+        if self.mass.closing:
+            return
+        now = time.monotonic()
+        for flow in list(self._setup_flows.values()):
+            if now - flow.session.last_activity >= IDLE_FLOW_TTL:
+                self.mass.create_task(self._abort_flow(flow, "timed_out"))
+        if self._setup_flows:
+            self._schedule_flow_sweep()

--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -532,8 +532,8 @@ class ProviderConfigMixin:
         """
         Create, persist and load a new provider instance.
 
-        Shared creation tail used by both the (legacy) provider config save path and
-        the setup flow finish path. The created config is removed again when loading
+        Shared creation tail used by both the provider config save path and the
+        setup flow finish path. The created config is removed again when loading
         the provider with it fails.
 
         :param provider_domain: Domain of the provider to create an instance of.

--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import builtins
 import logging
 from typing import TYPE_CHECKING, Any, cast, overload
@@ -454,6 +455,16 @@ class ProviderConfigMixin:
         # provider wants to manipulate the config during load
         conf_key = f"{CONF_PROVIDERS}/{config.instance_id}"
         raw_conf = config.to_raw()
+        # Preserve stored values that don't have config entries in the current context
+        # (e.g. values written by a provider at runtime while its declared entries
+        # changed) - to_raw() only rebuilds the values from the declared entries.
+        existing_values = (self.get(conf_key) or {}).get("values", {})
+        new_values = raw_conf.get("values", {})
+        config_entry_keys = set(config.values.keys())
+        for key, value in existing_values.items():
+            if key not in new_values and key not in config_entry_keys:
+                new_values[key] = value
+        raw_conf["values"] = new_values
         self.set(conf_key, raw_conf)
         if config.enabled and prov_instance and available:
             # update config for existing/loaded provider instance
@@ -510,6 +521,32 @@ class ProviderConfigMixin:
             if not any(dep_conf.enabled for dep_conf in dep_configs):
                 msg = f"Provider {manifest.name} depends on {prov.depends_on}"
                 raise ValueError(msg)
+        return await self._create_provider_instance(provider_domain, values)
+
+    async def _create_provider_instance(
+        self,
+        provider_domain: str,
+        values: dict[str, ConfigValueType],
+        setup_data: dict[str, Any] | None = None,
+    ) -> ProviderConfig:
+        """
+        Create, persist and load a new provider instance.
+
+        Shared creation tail used by both the (legacy) provider config save path and
+        the setup flow finish path. The created config is removed again when loading
+        the provider with it fails.
+
+        :param provider_domain: Domain of the provider to create an instance of.
+        :param values: The raw values for the (options) config entries.
+        :param setup_data: Optional setup flow data (pre-encrypted) to store on the config.
+        """
+        for prov in self.mass.get_provider_manifests():
+            if prov.domain == provider_domain:
+                manifest = prov
+                break
+        else:
+            msg = f"Unknown provider domain: {provider_domain}"
+            raise KeyError(msg)
         # create new provider config with given values
         existing = {
             x.instance_id for x in await self.get_provider_configs(provider_domain=provider_domain)
@@ -536,6 +573,7 @@ class ProviderConfigMixin:
                     "instance_id": instance_id,
                     "default_name": manifest.name,
                     "values": values,
+                    "setup_data": setup_data or {},
                 },
             ),
         )
@@ -548,6 +586,11 @@ class ProviderConfigMixin:
         # try to load the provider
         try:
             await self.mass.load_provider_config(config)
+        except asyncio.CancelledError:
+            # a cancelled load (e.g. an aborted setup flow) must not leave a
+            # half-created config behind either
+            self.remove(conf_key)
+            raise
         except Exception:
             # loading failed, remove config
             self.remove(conf_key)

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -71,6 +71,7 @@ if TYPE_CHECKING:
     from music_assistant_models.player_queue import PlayerQueue
 
     from .player_provider import PlayerProvider
+    from .setup_flow import SetupSession
 
 # TypeVar for config value type inference
 _ConfigValueT = TypeVar("_ConfigValueT", bound=ConfigValueType)
@@ -872,6 +873,17 @@ class Player(ABC):
         # To override the default config entries, simply define an entry with the same key
         # and it will be used instead of the default one.
         return []
+
+    async def run_setup_flow(self, session: SetupSession) -> None:
+        """
+        Run the interactive setup flow for this player (e.g. pairing).
+
+        Override in player implementations that require user interaction to become
+        usable; players without an override report that there is nothing to set up.
+
+        :param session: The setup flow session used to interact with the user.
+        """
+        raise NotImplementedError
 
     @overload
     def get_config_value(

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -11,7 +11,7 @@ from music_assistant_models.config_entries import ConfigValueType
 from music_assistant_models.enums import ConfigEntryType, EventType
 from music_assistant_models.errors import UnsupportedFeaturedException
 
-from music_assistant.constants import CONF_LOG_LEVEL, MASS_LOGGER_NAME
+from music_assistant.constants import CONF_LOG_LEVEL, CONF_PROVIDERS, MASS_LOGGER_NAME
 
 if TYPE_CHECKING:
     from async_upnp_client.utils import CaseInsensitiveDict
@@ -275,6 +275,49 @@ class Provider:
             assert isinstance(value, str)
             return self.mass.config.decrypt_string(value)
         return value
+
+    def get_setup_value(self, key: str, default: ConfigValueType = None) -> ConfigValueType:
+        """
+        Return a value collected by this provider's setup flow (from setup_data).
+
+        Encrypted (string) values are decrypted transparently. Falls back to the
+        legacy config values for installs that were configured before setup flows
+        existed, so no data migration is needed.
+
+        :param key: The setup data key to retrieve.
+        :param default: Value to return when the key is not present anywhere.
+        """
+        setup_data = self.mass.config.get(f"{CONF_PROVIDERS}/{self.instance_id}/setup_data") or {}
+        if key in setup_data:
+            value = setup_data[key]
+            return self.mass.config.decrypt_string(value) if isinstance(value, str) else value
+        # read-through to the legacy (pre-setup-flow) config values, no migration
+        value = self.mass.config.get_raw_provider_config_value(self.instance_id, key)
+        if value is None:
+            return self.get_config_value(key, default)
+        return self.mass.config.decrypt_string(value) if isinstance(value, str) else value
+
+    def _update_setup_data(self, key: str, value: ConfigValueType, immediate: bool = True) -> None:
+        """
+        Update a single setup_data value for this provider (e.g. a rotated auth token).
+
+        :param key: The setup data key to update.
+        :param value: The new value; strings are encrypted at rest.
+        :param immediate: Persist to disk right away (the default) instead of on the
+            debounced save timer, so a critical value survives a crash.
+        """
+        if not self.mass.config.get(f"{CONF_PROVIDERS}/{self.instance_id}"):
+            # only allow setting setup data if the main config entry exists
+            msg = f"Invalid provider instance: {self.instance_id}"
+            raise KeyError(msg)
+        stored_value = self.mass.config.encrypt_string(value) if isinstance(value, str) else value
+        self.mass.config.set(
+            f"{CONF_PROVIDERS}/{self.instance_id}/setup_data/{key}",
+            stored_value,
+            immediate=immediate,
+        )
+        # keep the in-memory config copy in sync with storage
+        self.config.setup_data[key] = stored_value
 
     def _update_config_value(
         self, key: str, value: ConfigValueType, encrypted: bool = False, immediate: bool = False

--- a/music_assistant/models/setup_flow.py
+++ b/music_assistant/models/setup_flow.py
@@ -1,0 +1,479 @@
+"""
+Session model and exceptions for interactive setup flows.
+
+A setup flow is the interactive, multi-step process (credentials, OAuth, pairing, ...)
+that creates or reconfigures a provider or player. A flow is authored as one plain
+coroutine that awaits the user through a SetupSession:
+
+    # music_assistant/providers/<domain>/setup_flow.py
+    async def run_setup(session: SetupSession) -> None:
+        values = await session.form([...])
+        await session.finish(values)
+
+The engine (config controller's SetupFlowMixin) owns the session lifecycle: it stores
+the current step, pushes SETUP_FLOW_UPDATED events, feeds submitted values/callback
+params back into the awaiting coroutine and persists the collected values on finish.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
+
+from aiohttp.web import Request, Response
+from music_assistant_models.config_entries import UI_ONLY, ConfigEntry, ConfigValueType
+from music_assistant_models.enums import ConfigEntryType, EventType, FlowStepType
+from music_assistant_models.errors import ActionUnavailable
+from music_assistant_models.setup_flow import SetupFlowStep
+
+from music_assistant.helpers.json import json_loads
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from music_assistant.mass import MusicAssistant
+
+LOGGER = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+FlowKind = Literal["setup", "reconfigure"]
+FlowReason = Literal["user", "auth", "error"]
+
+CALLBACK_RESPONSE_HTML = """
+<html>
+<body onload="window.close();">
+    Authentication completed, you may now close this window.
+</body>
+</html>
+"""
+
+
+class SetupFlowError(Exception):
+    """
+    Error raised into the flow coroutine when session.finish() failed.
+
+    The author may catch it to re-render a form with the error message and retry,
+    or let it propagate so the engine aborts the flow with the failure message.
+    """
+
+    def __init__(self, message: str, translation_key: str | None = None) -> None:
+        """
+        Initialize the error.
+
+        :param message: Human readable (English) description of the failure.
+        :param translation_key: Optional (bare) translation slug of the underlying error,
+            usable by flow authors as a localizable form error.
+        """
+        super().__init__(message)
+        self.translation_key = translation_key
+
+
+class StepExpiredError(Exception):
+    """
+    Raised into the flow coroutine when the active step's deadline passed.
+
+    The author may catch it to refresh the step (e.g. a new QR code or pairing
+    session) or let it propagate so the engine aborts the flow as timed out.
+    """
+
+
+class AbortFlow(Exception):
+    """
+    Raise anywhere inside a flow coroutine to cleanly abort the flow.
+
+    :param reason: Slug describing why the flow was aborted; resolved from the
+        translations (setup_flow.abort.<reason>) when the ABORT step is served.
+    """
+
+    def __init__(self, reason: str = "aborted") -> None:
+        """Initialize with the abort reason slug."""
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(kw_only=True)
+class SetupFlowContext:
+    """Static context describing what a running setup flow is (re)configuring."""
+
+    # kind: whether this flow sets up a new target or reconfigures an existing one
+    kind: FlowKind
+    # reason: what triggered the flow (user initiated, auth failure or another error)
+    reason: FlowReason
+    # domain: the provider domain the flow belongs to (for players: the player's provider)
+    domain: str
+    # instance_id: the existing provider instance (reconfigure/player flows)
+    instance_id: str | None = None
+    # player_id: the player being set up (player flows only)
+    player_id: str | None = None
+    # setup_data: decrypted values collected by an earlier flow run, for prefill
+    setup_data: dict[str, Any] = field(default_factory=dict)
+    # values: the target's existing (options) config values, for prefill
+    values: dict[str, ConfigValueType] = field(default_factory=dict)
+
+
+class SetupSession:
+    """
+    Coroutine-facing session handle for a running setup flow.
+
+    Handed to the flow coroutine (``run_setup(session)``); the form/external/progress
+    methods each publish a step to the client(s) and - where applicable - suspend the
+    coroutine until the engine feeds the user's response back in.
+    """
+
+    def __init__(
+        self,
+        mass: MusicAssistant,
+        flow_id: str,
+        context: SetupFlowContext,
+        finish_handler: Callable[
+            [SetupSession, dict[str, ConfigValueType]], Awaitable[dict[str, str]]
+        ],
+    ) -> None:
+        """
+        Initialize the session (done by the flow engine, never by flow authors).
+
+        :param mass: The MusicAssistant instance.
+        :param flow_id: Unique id of this flow.
+        :param context: Static context describing the flow's target.
+        :param finish_handler: Engine callback that persists the collected values
+            and creates/reloads the target when the flow finishes.
+        """
+        self.mass = mass
+        self.flow_id = flow_id
+        self.context = context
+        self.current_step: SetupFlowStep | None = None
+        self.finished = False
+        self.last_activity = time.monotonic()
+        self._finish_handler = finish_handler
+        self._translation_owner = f"provider.{context.domain}"
+        self._callback_path = f"/setup_flow/callback/{flow_id}"
+        self._input_future: asyncio.Future[dict[str, ConfigValueType]] | None = None
+        self._callback_future: asyncio.Future[dict[str, str]] | None = None
+        self._step_changed = asyncio.Event()
+        self._unregister_callback_route: Callable[[], None] | None = None
+
+    @property
+    def callback_url(self) -> str:
+        """Return the public callback URL that resumes this flow's external step."""
+        self._ensure_callback_route()
+        return f"{self.mass.webserver.base_url}{self._callback_path}"
+
+    async def form(
+        self,
+        entries: list[ConfigEntry],
+        step_id: str = "user",
+        errors: dict[str, str] | None = None,
+        last_step: bool | None = None,
+        expires_in: float | None = None,
+    ) -> dict[str, ConfigValueType]:
+        """
+        Show a form to the user and wait for the submitted (validated) values.
+
+        :param entries: The config entries that make up the form fields.
+        :param step_id: Stable slug identifying this step (also the i18n key segment).
+        :param errors: Optional field-key (or "base") -> error slug to display.
+        :param last_step: Optional hint that this is the flow's final form.
+        :param expires_in: Optional deadline in seconds; when it passes,
+            StepExpiredError is raised here (and the client countdown runs out).
+        """
+        step = self._build_step(
+            FlowStepType.FORM,
+            step_id,
+            entries=self._prepare_entries(entries),
+            errors=dict(errors) if errors else {},
+            last_step=last_step,
+            expires_in=expires_in,
+        )
+        self._input_future = asyncio.get_running_loop().create_future()
+        self._publish_step(step)
+        try:
+            return await self._await_with_deadline(self._input_future, expires_in)
+        finally:
+            self._input_future = None
+
+    async def external(
+        self,
+        url: str,
+        step_id: str = "auth",
+        expires_in: float | None = None,
+    ) -> dict[str, str]:
+        """
+        Send the user to an external URL (e.g. OAuth) and wait for the callback params.
+
+        The flow resumes when the external party (or a bounce page) hits this flow's
+        ``callback_url``; GET query and POST body parameters are merged and returned.
+
+        :param url: The URL the user must open.
+        :param step_id: Stable slug identifying this step (also the i18n key segment).
+        :param expires_in: Optional deadline in seconds; when it passes,
+            StepExpiredError is raised here (and the client countdown runs out).
+        """
+        self._ensure_callback_route()
+        step = self._build_step(FlowStepType.EXTERNAL, step_id, url=url, expires_in=expires_in)
+        self._callback_future = asyncio.get_running_loop().create_future()
+        self._publish_step(step)
+        try:
+            return await self._await_with_deadline(self._callback_future, expires_in)
+        finally:
+            self._callback_future = None
+
+    def progress(
+        self,
+        step_id: str,
+        text: str | None = None,
+        pct: float | None = None,
+        image: str | None = None,
+    ) -> None:
+        """
+        Publish a display-only progress step (fire-and-forget, re-emittable).
+
+        :param step_id: Stable slug identifying this step (also the i18n key segment).
+        :param text: Optional progress text (slug, resolved from the translations).
+        :param pct: Optional completion fraction between 0 and 1.
+        :param image: Optional data-URI illustration (e.g. a pairing QR code).
+        """
+        step = self._build_step(
+            FlowStepType.PROGRESS, step_id, progress_text=text, progress=pct, image=image
+        )
+        self._publish_step(step)
+
+    async def progress_until(
+        self,
+        awaitable: Awaitable[_T],
+        step_id: str,
+        text: str | None = None,
+        image: str | None = None,
+        expires_in: float | None = None,
+    ) -> _T:
+        """
+        Publish a progress step and wait for the given awaitable, deadline-enforced.
+
+        Display and enforcement come from the single ``expires_in`` declaration: the
+        step's countdown and the engine deadline cannot drift. On the deadline the
+        awaitable is cancelled and StepExpiredError is raised here.
+
+        :param awaitable: The work/wait to perform while the progress step shows.
+        :param step_id: Stable slug identifying this step (also the i18n key segment).
+        :param text: Optional progress text (slug, resolved from the translations).
+        :param image: Optional data-URI illustration (e.g. a pairing QR code).
+        :param expires_in: Optional deadline in seconds.
+        """
+        step = self._build_step(
+            FlowStepType.PROGRESS, step_id, progress_text=text, image=image, expires_in=expires_in
+        )
+        self._publish_step(step)
+        return await self._await_with_deadline(awaitable, expires_in)
+
+    async def finish(self, values: dict[str, ConfigValueType]) -> dict[str, str]:
+        """
+        Complete the flow: persist the collected values and create/reload the target.
+
+        Raises SetupFlowError when applying the values failed (e.g. the provider
+        does not load with them); the author may catch it and loop back to a form.
+        On success the FINISH step is published and the result reference
+        (e.g. ``{"instance_id": ...}``) is returned.
+
+        :param values: The values to persist as the target's setup_data.
+        """
+        result = await self._finish_handler(self, values)
+        self.finished = True
+        step = self._build_step(FlowStepType.FINISH, "finish", result=result)
+        self._publish_step(step)
+        return result
+
+    # ------------------------------------------------------------------------------
+    # Engine-facing methods below: called by the SetupFlowMixin, never by flow authors
+    # ------------------------------------------------------------------------------
+
+    def handle_submit(self, values: dict[str, ConfigValueType]) -> SetupFlowStep | None:
+        """
+        Validate submitted form values and hand them to the awaiting flow coroutine.
+
+        Returns the updated FORM step when validation failed (the coroutine is not
+        woken), or None when the values were accepted and the coroutine will resume.
+
+        :param values: The raw values as submitted by the client.
+        """
+        step = self.current_step
+        if (
+            step is None
+            or step.type != FlowStepType.FORM
+            or self._input_future is None
+            or self._input_future.done()
+        ):
+            raise ActionUnavailable("The setup flow is not awaiting form input")
+        self.last_activity = time.monotonic()
+        errors: dict[str, str] = {}
+        parsed: dict[str, ConfigValueType] = {}
+        for entry in step.entries:
+            if entry.type in UI_ONLY:
+                continue
+            raw_value = values.get(entry.key, entry.value)
+            try:
+                # parse_value also runs the entry's optional validate callback and
+                # stores the parsed value on the entry (echoed on a re-render)
+                parsed[entry.key] = entry.parse_value(raw_value, allow_none=False)
+            except TypeError, ValueError:
+                errors[entry.key] = "required" if raw_value in (None, "") else "invalid_value"
+                if not isinstance(raw_value, list):
+                    entry.value = raw_value
+            if entry.type == ConfigEntryType.SECURE_STRING:
+                # secure values are only handed to the flow coroutine; they are never
+                # kept on (or echoed back with) the stored step
+                entry.value = None
+        if errors:
+            step.errors = errors
+            self._publish_step(step)
+            return step
+        step.errors = {}
+        # clear the step-changed marker before waking the coroutine, so the submit
+        # caller can await the *next* published step without racing the coroutine
+        self._step_changed.clear()
+        self._input_future.set_result(parsed)
+        return None
+
+    async def handle_callback(self, request: Request) -> Response:
+        """
+        Handle an incoming request on this flow's external-step callback route.
+
+        :param request: The incoming (GET or POST) request; query parameters and any
+            POST body (JSON or form encoded) are merged into the callback params.
+        """
+        params: dict[str, str] = dict(request.query)
+        if request.method == "POST" and request.can_read_body:
+            try:
+                if request.content_type == "application/json":
+                    params.update(json_loads(await request.read()))
+                else:
+                    params.update({key: str(val) for key, val in (await request.post()).items()})
+            except Exception as err:
+                LOGGER.error("Failed to parse setup flow callback body: %s", err)
+        self.last_activity = time.monotonic()
+        if self._callback_future is not None and not self._callback_future.done():
+            self._callback_future.set_result(params)
+        else:
+            LOGGER.debug(
+                "Received setup flow callback for %s while no external step is pending",
+                self.flow_id,
+            )
+        return Response(body=CALLBACK_RESPONSE_HTML, headers={"content-type": "text/html"})
+
+    async def wait_for_step_change(self, timeout: float) -> None:
+        """
+        Wait (bounded) until the flow publishes a step, returning silently on timeout.
+
+        :param timeout: Maximum time in seconds to wait.
+        """
+        try:
+            async with asyncio.timeout(timeout):
+                await self._step_changed.wait()
+        except TimeoutError:
+            return
+
+    def publish_abort(self, reason: str) -> None:
+        """
+        Publish the terminal ABORT step for this flow.
+
+        :param reason: Slug describing why the flow was aborted; resolved from the
+            translations (setup_flow.abort.<reason>) when the step is served.
+        """
+        step = self._build_step(FlowStepType.ABORT, "abort", reason=reason)
+        self._publish_step(step)
+
+    def close(self) -> None:
+        """Release the session's engine resources (callback route); called on flow end."""
+        if self._unregister_callback_route is not None:
+            self._unregister_callback_route()
+            self._unregister_callback_route = None
+
+    async def _await_with_deadline(self, awaitable: Awaitable[_T], expires_in: float | None) -> _T:
+        """
+        Await the given awaitable, converting the step deadline into StepExpiredError.
+
+        asyncio.timeout cancels the inner await at the deadline and raises TimeoutError
+        in *this* (the flow's) coroutine - exactly the required inject-into-the-author
+        semantic: catch it right at the awaiting call to refresh the step, or let it
+        propagate so the engine converts it into a timed_out ABORT.
+        """
+        if expires_in is None:
+            return await awaitable
+        try:
+            async with asyncio.timeout(expires_in):
+                return await awaitable
+        except TimeoutError as err:
+            raise StepExpiredError from err
+
+    def _build_step(  # noqa: PLR0913 - mirrors the step model's fields
+        self,
+        step_type: FlowStepType,
+        step_id: str,
+        *,
+        entries: list[ConfigEntry] | None = None,
+        errors: dict[str, str] | None = None,
+        last_step: bool | None = None,
+        url: str | None = None,
+        progress_text: str | None = None,
+        progress: float | None = None,
+        image: str | None = None,
+        result: dict[str, str] | None = None,
+        reason: str | None = None,
+        expires_in: float | None = None,
+    ) -> SetupFlowStep:
+        """Build a SetupFlowStep for this flow, stamping owner and absolute deadline."""
+        return SetupFlowStep(
+            flow_id=self.flow_id,
+            step_id=step_id,
+            type=step_type,
+            entries=entries or [],
+            errors=errors or {},
+            last_step=last_step,
+            url=url,
+            progress_text=progress_text,
+            progress=progress,
+            image=image,
+            # absolute epoch deadline so the remaining time survives a client re-fetch
+            expires_at=time.time() + expires_in if expires_in is not None else None,
+            result=result,
+            reason=reason,
+            translation_owner=self._translation_owner,
+        )
+
+    def _prepare_entries(self, entries: list[ConfigEntry]) -> list[ConfigEntry]:
+        """Return copies of the form entries, validated and stamped for this flow."""
+        prepared: list[ConfigEntry] = []
+        for entry in entries:
+            if entry.action:
+                # actions are the pseudo-flow mechanism of the options surface;
+                # inside real flows they are structurally banned
+                msg = f"Config entry {entry.key} carries an action, not allowed in setup flows"
+                raise ValueError(msg)
+            # replace() returns a copy so the (often module-level) entry definitions
+            # are never mutated by submit-side value/owner stamping
+            copied = replace(
+                entry, translation_owner=entry.translation_owner or self._translation_owner
+            )
+            if copied.type == ConfigEntryType.SECURE_STRING:
+                # secrets never leave the server: a (prefilled) secure value is
+                # stripped from the step; the user always (re)types it
+                copied.value = None
+            prepared.append(copied)
+        return prepared
+
+    def _publish_step(self, step: SetupFlowStep) -> None:
+        """Store the step as current, mark activity and push it to subscribers."""
+        self.current_step = step
+        self.last_activity = time.monotonic()
+        self._step_changed.set()
+        self.mass.signal_event(EventType.SETUP_FLOW_UPDATED, object_id=self.flow_id, data=step)
+
+    def _ensure_callback_route(self) -> None:
+        """Register the flow's dynamic callback route (idempotent)."""
+        if self._unregister_callback_route is not None:
+            return
+        self._unregister_callback_route = self.mass.webserver.register_dynamic_route(
+            self._callback_path, self.handle_callback
+        )

--- a/tests/controllers/config/test_provider_config_load.py
+++ b/tests/controllers/config/test_provider_config_load.py
@@ -13,11 +13,12 @@ Covers three fixes for the Spotify auth failures caused by refresh-token rotatio
 
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.config_entries import ProviderConfig, ProviderError
-from music_assistant_models.enums import ProviderStatus, ProviderType
+from music_assistant_models.config_entries import ConfigEntry, ProviderConfig, ProviderError
+from music_assistant_models.enums import ConfigEntryType, ProviderStatus, ProviderType
 from music_assistant_models.errors import LoginFailed
 
 from music_assistant.constants import CONF_PROVIDERS
@@ -71,6 +72,38 @@ async def test_failed_reload_records_auth_error(mass_minimal: MusicAssistant) ->
     prov_conf = _prov_conf(instance)
     prov_conf.last_error = ProviderError.from_dict(stored)
     assert _provider_status(prov_conf, is_loaded=False) == ProviderStatus.AUTH_REQUIRED
+
+
+async def test_save_preserves_unknown_stored_values(mass_minimal: MusicAssistant) -> None:
+    """Stored values without config entries in the current save context survive a save."""
+    config = mass_minimal.config
+    instance = "spotify--test"
+    conf_key = f"{CONF_PROVIDERS}/{instance}"
+    config.set(
+        conf_key,
+        {
+            "domain": "spotify",
+            "type": "music",
+            "instance_id": instance,
+            "enabled": True,
+            "values": {"legacy_token": "keep-me"},
+            "setup_data": {"token": "abc"},
+        },
+    )
+    entry = ConfigEntry(key="region", type=ConfigEntryType.STRING, required=False)
+    prov_conf = cast("ProviderConfig", ProviderConfig.parse([entry], config.get(conf_key)))
+    with (
+        patch.object(config, "get_provider_config", AsyncMock(return_value=prov_conf)),
+        patch.object(mass_minimal, "load_provider_config", AsyncMock()),
+    ):
+        await config._update_provider_config(instance, {"region": "eu"})
+    stored = config.get(conf_key)
+    assert stored["values"]["region"] == "eu"
+    # a value written outside the declared entries (e.g. by a provider at runtime)
+    # is preserved instead of being dropped by the save rebuild
+    assert stored["values"]["legacy_token"] == "keep-me"
+    # setup_data travels along untouched
+    assert stored["setup_data"] == {"token": "abc"}
 
 
 async def test_immediate_flush_for_rotated_token(mass_minimal: MusicAssistant) -> None:

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -1,0 +1,697 @@
+"""Tests for the setup flow engine (SetupFlowMixin + SetupSession)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+from music_assistant_models.config_entries import ConfigEntry, PlayerConfig
+from music_assistant_models.enums import ConfigEntryType, EventType, FlowStepType, ProviderType
+from music_assistant_models.errors import ActionUnavailable, LoginFailed, PlayerUnavailableError
+from music_assistant_models.provider import ProviderManifest
+
+from music_assistant.constants import CONF_PLAYERS, CONF_PROVIDERS, ENCRYPT_SUFFIX
+from music_assistant.mass import MusicAssistant
+from music_assistant.models.player import Player
+from music_assistant.models.setup_flow import AbortFlow, SetupSession, StepExpiredError
+from tests.common import MockPlayer, MockProvider
+
+if TYPE_CHECKING:
+    from music_assistant_models.event import MassEvent
+    from music_assistant_models.setup_flow import SetupFlowStep
+
+FAKE_DOMAIN = "_setup_flow_test"
+
+USERNAME_ENTRY = ConfigEntry(key="username", type=ConfigEntryType.STRING, required=True)
+PORT_ENTRY = ConfigEntry(key="port", type=ConfigEntryType.INTEGER, required=False, default_value=80)
+PASSWORD_ENTRY = ConfigEntry(key="password", type=ConfigEntryType.SECURE_STRING, required=True)
+
+
+@pytest.fixture
+async def flow_mass(mass_minimal: MusicAssistant) -> AsyncGenerator[MusicAssistant]:
+    """
+    Provide a minimal server with a fake (flow-capable) provider manifest injected.
+
+    Builds on mass_minimal (no webserver/ports bound) and stubs the narrow surface
+    the flow engine touches: the dynamic-route webserver API and the players/music
+    controllers.
+    """
+    manifest = ProviderManifest(
+        type=ProviderType.MUSIC,
+        domain=FAKE_DOMAIN,
+        name="Setup Flow Test Provider",
+        description="Fake provider for setup flow tests",
+        codeowners=[],
+    )
+    mass_minimal._provider_manifests[FAKE_DOMAIN] = manifest
+    # stub the dynamic-route surface so external-step tests need no bound port
+    routes: dict[str, Any] = {}
+
+    def register_dynamic_route(path: str, handler: Any, _method: str = "*") -> Any:
+        routes[path] = handler
+        return lambda: routes.pop(path, None)
+
+    mass_minimal.webserver = SimpleNamespace(  # type: ignore[assignment]
+        base_url="http://test.local:8095",
+        register_dynamic_route=register_dynamic_route,
+        unregister_dynamic_route=lambda path, _method="*": routes.pop(path, None),
+        routes=routes,
+    )
+    mass_minimal.music = MagicMock()
+    mass_minimal.players = MagicMock()
+    try:
+        yield mass_minimal
+    finally:
+        # abort any flow a test left behind so no tasks outlive the loop
+        for flow in list(mass_minimal.config._setup_flows.values()):
+            await mass_minimal.config._abort_flow(flow, reason="aborted")
+        if (sweep_handle := mass_minimal.config._flow_sweep_handle) is not None:
+            sweep_handle.cancel()
+        mass_minimal._provider_manifests.pop(FAKE_DOMAIN, None)
+
+
+@pytest.fixture
+def flow_events(flow_mass: MusicAssistant) -> list[MassEvent]:
+    """Capture all SETUP_FLOW_UPDATED events emitted during the test."""
+    events: list[MassEvent] = []
+    flow_mass.subscribe(events.append, EventType.SETUP_FLOW_UPDATED)
+    return events
+
+
+def _use_flow(mass: MusicAssistant, flow: Callable[[SetupSession], Awaitable[Any]]) -> Any:
+    """Patch the engine's flow module loader to serve the given run_setup coroutine."""
+    return patch.object(
+        mass.config,
+        "_get_setup_flow_module",
+        AsyncMock(return_value=SimpleNamespace(run_setup=flow)),
+    )
+
+
+async def _wait_for(predicate: Callable[[], Any], timeout: float = 5.0) -> Any:
+    """Wait until the predicate returns a truthy value (or fail the test)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if result := predicate():
+            return result
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition not met within timeout")
+
+
+def _abort_events(events: list[MassEvent]) -> list[SetupFlowStep]:
+    return [event.data for event in events if event.data.type == FlowStepType.ABORT]
+
+
+async def test_zero_input_provider_immediate_finish(flow_mass: MusicAssistant) -> None:
+    """A provider without a setup_flow module is created right away with a FINISH step."""
+    no_module = AsyncMock(return_value=None)
+    with (
+        patch.object(flow_mass.config, "_get_setup_flow_module", no_module),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()) as mock_load,
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+    assert step.type == FlowStepType.FINISH
+    assert step.result == {"instance_id": FAKE_DOMAIN}
+    mock_load.assert_awaited_once()
+    # the config was created and persisted (with empty values/setup_data)
+    raw_conf = flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}")
+    assert raw_conf["domain"] == FAKE_DOMAIN
+    assert raw_conf["setup_data"] == {}
+    # no flow session was registered for the synthesized step
+    assert not flow_mass.config._setup_flows
+
+
+async def test_form_flow_finish_success(
+    flow_mass: MusicAssistant, flow_events: list[MassEvent]
+) -> None:
+    """A form flow persists its (encrypted) values as setup_data and loads the provider."""
+
+    async def run_setup(session: SetupSession) -> None:
+        values = await session.form([USERNAME_ENTRY, PASSWORD_ENTRY], step_id="credentials")
+        await session.finish(values)
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()) as mock_load,
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        assert step.type == FlowStepType.FORM
+        assert step.step_id == "credentials"
+        # entries are stamped with the provider's translation owner
+        assert all(x.translation_owner == f"provider.{FAKE_DOMAIN}" for x in step.entries)
+        finish_step = await flow_mass.config.submit_setup_flow(
+            step.flow_id, {"username": "marcel", "password": "secret"}
+        )
+    assert finish_step.type == FlowStepType.FINISH
+    assert finish_step.result == {"instance_id": FAKE_DOMAIN}
+    mock_load.assert_awaited_once()
+    # values are stored in setup_data with strings encrypted at rest
+    raw_conf = flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}")
+    assert raw_conf["setup_data"]["username"].startswith(ENCRYPT_SUFFIX)
+    assert flow_mass.config.decrypt_string(raw_conf["setup_data"]["username"]) == "marcel"
+    assert flow_mass.config.decrypt_string(raw_conf["setup_data"]["password"]) == "secret"
+    # the flow is cleaned up after finishing
+    assert step.flow_id not in flow_mass.config._setup_flows
+    # both steps were pushed as events
+    await _wait_for(lambda: len(flow_events) >= 2)
+    assert [event.data.type for event in flow_events[:2]] == [
+        FlowStepType.FORM,
+        FlowStepType.FINISH,
+    ]
+    assert all(event.object_id == step.flow_id for event in flow_events)
+
+
+async def test_form_validation_errors(flow_mass: MusicAssistant) -> None:
+    """Invalid submitted values return the FORM step with errors, without advancing the flow."""
+    advanced = asyncio.Event()
+
+    async def run_setup(session: SetupSession) -> None:
+        values = await session.form([USERNAME_ENTRY, PORT_ENTRY])
+        advanced.set()
+        await session.finish(values)
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        # missing required value + unparsable integer
+        error_step = await flow_mass.config.submit_setup_flow(
+            step.flow_id, {"port": "not-a-number"}
+        )
+        assert error_step.type == FlowStepType.FORM
+        assert error_step.errors == {"username": "required", "port": "invalid_value"}
+        assert not advanced.is_set()
+        assert step.flow_id in flow_mass.config._setup_flows
+        # a valid re-submit picks up where the form left off
+        finish_step = await flow_mass.config.submit_setup_flow(
+            step.flow_id, {"username": "marcel", "port": 8095}
+        )
+    assert advanced.is_set()
+    assert finish_step.type == FlowStepType.FINISH
+    raw_conf = flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}")
+    assert raw_conf["setup_data"]["port"] == 8095
+
+
+async def test_submit_returns_next_form_step(flow_mass: MusicAssistant) -> None:
+    """Submitting a multi-step flow returns the next FORM step."""
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.form([USERNAME_ENTRY], step_id="first")
+        values = await session.form([PORT_ENTRY], step_id="second", last_step=True)
+        await session.finish(values)
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        assert step.step_id == "first"
+        second_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"username": "marcel"})
+        assert second_step.type == FlowStepType.FORM
+        assert second_step.step_id == "second"
+        assert second_step.last_step is True
+        finish_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"port": 1234})
+        assert finish_step.type == FlowStepType.FINISH
+
+
+@pytest.mark.usefixtures("flow_events")
+async def test_finish_failure_rolls_back_provider_config(flow_mass: MusicAssistant) -> None:
+    """A failing provider load on finish removes the created config again."""
+
+    async def run_setup(session: SetupSession) -> None:
+        values = await session.form([USERNAME_ENTRY])
+        # SetupFlowError deliberately not caught: flow ends with the failure message
+        await session.finish(values)
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(
+            flow_mass, "load_provider_config", AsyncMock(side_effect=LoginFailed("bad creds"))
+        ),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        abort_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"username": "x"})
+    assert abort_step.type == FlowStepType.ABORT
+    assert abort_step.reason == "bad creds"
+    # the config created during finish was removed again
+    assert flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}") is None
+    assert step.flow_id not in flow_mass.config._setup_flows
+
+
+async def test_finish_failure_author_retry_loop(flow_mass: MusicAssistant) -> None:
+    """An author can catch SetupFlowError and re-render the form with the error."""
+
+    async def run_setup(session: SetupSession) -> None:
+        values = await session.form([USERNAME_ENTRY])
+        while True:
+            try:
+                await session.finish(values)
+                return
+            except Exception as err:
+                values = await session.form([USERNAME_ENTRY], errors={"base": str(err)})
+
+    load_mock = AsyncMock(side_effect=[LoginFailed("bad creds"), None])
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", load_mock),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        retry_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"username": "x"})
+        assert retry_step.type == FlowStepType.FORM
+        assert retry_step.errors == {"base": "bad creds"}
+        finish_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"username": "y"})
+    assert finish_step.type == FlowStepType.FINISH
+    assert flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}") is not None
+
+
+async def test_external_step_callback_roundtrip(flow_mass: MusicAssistant) -> None:
+    """An external step resumes the flow with the merged callback (query) params."""
+    received: dict[str, str] = {}
+
+    async def run_setup(session: SetupSession) -> None:
+        assert session.callback_url.endswith(f"/setup_flow/callback/{session.flow_id}")
+        received.update(await session.external("https://example.com/authorize"))
+        await session.finish({"token": received["code"]})
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        assert step.type == FlowStepType.EXTERNAL
+        assert step.url == "https://example.com/authorize"
+        session = flow_mass.config._setup_flows[step.flow_id].session
+        # the callback route was registered on the webserver (stub) for this flow
+        registered_routes = cast("Any", flow_mass.webserver).routes
+        callback_path = f"/setup_flow/callback/{step.flow_id}"
+        handler = registered_routes[callback_path]
+        request = make_mocked_request("GET", f"{callback_path}?code=abc&state=xyz")
+        response = await handler(request)
+        assert response.status == 200
+        await _wait_for(lambda: session.finished)
+    assert received == {"code": "abc", "state": "xyz"}
+    raw_conf = flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}")
+    assert flow_mass.config.decrypt_string(raw_conf["setup_data"]["token"]) == "abc"
+    # the route is released again when the flow ends
+    await _wait_for(lambda: callback_path not in registered_routes)
+
+
+async def test_form_expiry_aborts_flow(
+    flow_mass: MusicAssistant, flow_events: list[MassEvent]
+) -> None:
+    """An uncaught form deadline converts into a timed_out ABORT."""
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.form([USERNAME_ENTRY], expires_in=0.05)
+        await session.finish({})
+
+    with _use_flow(flow_mass, run_setup):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        assert step.expires_at is not None
+        abort_step = await _wait_for(
+            lambda: next(iter(_abort_events(flow_events)), None), timeout=2
+        )
+    assert abort_step.reason == "timed_out"
+    assert step.flow_id not in flow_mass.config._setup_flows
+
+
+async def test_form_expiry_author_refresh(flow_mass: MusicAssistant) -> None:
+    """An author can catch StepExpiredError and refresh the step in place."""
+
+    async def run_setup(session: SetupSession) -> None:
+        try:
+            await session.form([USERNAME_ENTRY], step_id="short_lived", expires_in=0.05)
+        except StepExpiredError:
+            await session.form([USERNAME_ENTRY], step_id="refreshed")
+        await session.finish({})
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        assert step.step_id == "short_lived"
+        flow = flow_mass.config._setup_flows[step.flow_id]
+        await _wait_for(
+            lambda: flow.session.current_step and flow.session.current_step.step_id == "refreshed",
+            timeout=2,
+        )
+        # the refreshed step accepts input as usual
+        finish_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"username": "x"})
+        assert finish_step.type == FlowStepType.FINISH
+
+
+async def test_progress_until_expiry(
+    flow_mass: MusicAssistant, flow_events: list[MassEvent]
+) -> None:
+    """progress_until enforces its deadline by raising StepExpiredError into the flow."""
+
+    async def run_setup(session: SetupSession) -> None:
+        try:
+            await session.progress_until(
+                asyncio.sleep(30), "waiting_for_device", text="press_button", expires_in=0.05
+            )
+        except StepExpiredError:
+            raise AbortFlow("pairing_window_closed") from None
+
+    with _use_flow(flow_mass, run_setup):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        assert step.type == FlowStepType.PROGRESS
+        assert step.progress_text == "press_button"
+        assert step.expires_at is not None
+        abort_step = await _wait_for(
+            lambda: next(iter(_abort_events(flow_events)), None), timeout=2
+        )
+    assert abort_step.reason == "pairing_window_closed"
+
+
+async def test_abort_runs_author_cleanup(
+    flow_mass: MusicAssistant, flow_events: list[MassEvent]
+) -> None:
+    """Aborting a flow cancels the coroutine so the author's finally cleanup runs."""
+    cleanup_ran = asyncio.Event()
+
+    async def run_setup(session: SetupSession) -> None:
+        try:
+            await session.form([USERNAME_ENTRY])
+        finally:
+            cleanup_ran.set()
+
+    with _use_flow(flow_mass, run_setup):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        await flow_mass.config.abort_setup_flow(step.flow_id)
+    assert cleanup_ran.is_set()
+    assert step.flow_id not in flow_mass.config._setup_flows
+    abort_step = await _wait_for(lambda: next(iter(_abort_events(flow_events)), None))
+    assert abort_step.reason == "aborted"
+    # continuing an aborted flow is rejected
+    with pytest.raises(KeyError):
+        await flow_mass.config.get_setup_flow(step.flow_id)
+
+
+async def test_idle_flow_ttl_sweep(flow_mass: MusicAssistant, flow_events: list[MassEvent]) -> None:
+    """The periodic sweeper aborts flows that have been idle for longer than the TTL."""
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.form([USERNAME_ENTRY])
+        await session.finish({})
+
+    with _use_flow(flow_mass, run_setup):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        flow = flow_mass.config._setup_flows[step.flow_id]
+        flow.session.last_activity = time.monotonic() - 16 * 60
+        flow_mass.config._sweep_idle_flows()
+        await _wait_for(lambda: step.flow_id not in flow_mass.config._setup_flows)
+    abort_step = await _wait_for(lambda: next(iter(_abort_events(flow_events)), None))
+    assert abort_step.reason == "timed_out"
+
+
+async def test_one_flow_per_target_replaces(
+    flow_mass: MusicAssistant, flow_events: list[MassEvent]
+) -> None:
+    """Starting a flow for a target that already has one aborts the old flow."""
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.form([USERNAME_ENTRY])
+        await session.finish({})
+
+    with _use_flow(flow_mass, run_setup):
+        first_step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        second_step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+    assert first_step.flow_id != second_step.flow_id
+    assert first_step.flow_id not in flow_mass.config._setup_flows
+    assert second_step.flow_id in flow_mass.config._setup_flows
+    replaced = await _wait_for(lambda: next(iter(_abort_events(flow_events)), None))
+    assert replaced.flow_id == first_step.flow_id
+    assert replaced.reason == "replaced"
+
+
+async def test_get_flow_is_idempotent(flow_mass: MusicAssistant) -> None:
+    """config/flows/get re-renders the current step without ever advancing the flow."""
+
+    async def run_setup(session: SetupSession) -> None:
+        values = await session.form([USERNAME_ENTRY])
+        await session.finish(values)
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        for _ in range(3):
+            fetched = await flow_mass.config.get_setup_flow(step.flow_id)
+            assert fetched.type == FlowStepType.FORM
+            assert fetched.step_id == step.step_id
+            assert fetched.flow_id == step.flow_id
+        # the flow still accepts input afterwards
+        finish_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"username": "x"})
+        assert finish_step.type == FlowStepType.FINISH
+
+
+async def test_submit_without_pending_form(flow_mass: MusicAssistant) -> None:
+    """Submitting while no FORM step is pending is rejected."""
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.external("https://example.com/authorize")
+        await session.finish({})
+
+    with _use_flow(flow_mass, run_setup):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        assert step.type == FlowStepType.EXTERNAL
+        with pytest.raises(ActionUnavailable):
+            await flow_mass.config.submit_setup_flow(step.flow_id, {"username": "x"})
+        await flow_mass.config.abort_setup_flow(step.flow_id)
+
+
+@pytest.mark.usefixtures("flow_events")
+async def test_form_entries_with_action_rejected(flow_mass: MusicAssistant) -> None:
+    """The engine rejects FORM entries that carry an action (banned inside flows)."""
+    action_entry = ConfigEntry(
+        key="authenticate", type=ConfigEntryType.STRING, action="auth", required=False
+    )
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.form([action_entry])
+        await session.finish({})
+
+    with _use_flow(flow_mass, run_setup):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+    # the ValueError ends the flow as an internal error
+    assert step.type == FlowStepType.ABORT
+    assert step.reason == "internal_error"
+
+
+async def test_reconfigure_prefill_and_success(flow_mass: MusicAssistant) -> None:
+    """Reconfigure decrypts setup_data for prefill and merges the new values on finish."""
+    instance_id = FAKE_DOMAIN
+    flow_mass.config.set(
+        f"{CONF_PROVIDERS}/{instance_id}",
+        {
+            "type": "music",
+            "domain": FAKE_DOMAIN,
+            "instance_id": instance_id,
+            "enabled": True,
+            "values": {"region": "eu"},
+            "setup_data": {
+                "token": flow_mass.config.encrypt_string("old-secret"),
+                "device_id": flow_mass.config.encrypt_string("device-1"),
+            },
+            "last_error": {"error_code": LoginFailed.error_code, "message": "expired"},
+        },
+    )
+    contexts: list[Any] = []
+
+    async def run_setup(session: SetupSession) -> None:
+        contexts.append(session.context)
+        values = await session.form([ConfigEntry(key="token", type=ConfigEntryType.STRING)])
+        await session.finish(values)
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()) as mock_load,
+    ):
+        step = await flow_mass.config.reconfigure_provider(instance_id)
+        assert step.type == FlowStepType.FORM
+        context = contexts[0]
+        assert context.kind == "reconfigure"
+        assert context.reason == "auth"
+        assert context.instance_id == instance_id
+        assert context.setup_data == {"token": "old-secret", "device_id": "device-1"}
+        assert context.values == {"region": "eu"}
+        finish_step = await flow_mass.config.submit_setup_flow(
+            step.flow_id, {"token": "new-secret"}
+        )
+    assert finish_step.type == FlowStepType.FINISH
+    assert finish_step.result == {"instance_id": instance_id}
+    mock_load.assert_awaited_once()
+    raw_conf = flow_mass.config.get(f"{CONF_PROVIDERS}/{instance_id}")
+    # new value merged in (encrypted), untouched keys preserved, last_error cleared
+    assert flow_mass.config.decrypt_string(raw_conf["setup_data"]["token"]) == "new-secret"
+    assert flow_mass.config.decrypt_string(raw_conf["setup_data"]["device_id"]) == "device-1"
+    assert raw_conf["last_error"] is None
+
+
+async def test_reconfigure_failure_restores_setup_data(flow_mass: MusicAssistant) -> None:
+    """A failing reload on reconfigure finish restores the previous setup_data."""
+    instance_id = FAKE_DOMAIN
+    original_setup_data = {"token": flow_mass.config.encrypt_string("old-secret")}
+    flow_mass.config.set(
+        f"{CONF_PROVIDERS}/{instance_id}",
+        {
+            "type": "music",
+            "domain": FAKE_DOMAIN,
+            "instance_id": instance_id,
+            "enabled": True,
+            "values": {},
+            "setup_data": dict(original_setup_data),
+        },
+    )
+
+    async def run_setup(session: SetupSession) -> None:
+        values = await session.form([ConfigEntry(key="token", type=ConfigEntryType.STRING)])
+        await session.finish(values)
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(
+            flow_mass, "load_provider_config", AsyncMock(side_effect=LoginFailed("still bad"))
+        ),
+    ):
+        step = await flow_mass.config.reconfigure_provider(instance_id)
+        abort_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"token": "bogus"})
+    assert abort_step.type == FlowStepType.ABORT
+    assert abort_step.reason == "still bad"
+    raw_conf = flow_mass.config.get(f"{CONF_PROVIDERS}/{instance_id}")
+    assert raw_conf["setup_data"] == original_setup_data
+
+
+async def test_reconfigure_without_flow_module_aborts(flow_mass: MusicAssistant) -> None:
+    """Reconfigure on a flow-less provider returns a nothing_to_configure ABORT."""
+    instance_id = FAKE_DOMAIN
+    flow_mass.config.set(
+        f"{CONF_PROVIDERS}/{instance_id}",
+        {"type": "music", "domain": FAKE_DOMAIN, "instance_id": instance_id, "enabled": True},
+    )
+    with patch.object(flow_mass.config, "_get_setup_flow_module", AsyncMock(return_value=None)):
+        step = await flow_mass.config.reconfigure_provider(instance_id)
+    assert step.type == FlowStepType.ABORT
+    assert step.reason == "nothing_to_configure"
+    assert not flow_mass.config._setup_flows
+
+
+async def test_setup_provider_single_instance_guard(flow_mass: MusicAssistant) -> None:
+    """Setting up a non-multi-instance provider that already exists aborts fast."""
+    flow_mass.config.set(
+        f"{CONF_PROVIDERS}/{FAKE_DOMAIN}",
+        {"type": "music", "domain": FAKE_DOMAIN, "instance_id": FAKE_DOMAIN, "enabled": True},
+    )
+    step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+    assert step.type == FlowStepType.ABORT
+    assert step.reason == "already_configured"
+
+
+async def test_setup_unknown_provider_domain(flow_mass: MusicAssistant) -> None:
+    """Setting up an unknown provider domain raises."""
+    with pytest.raises(KeyError):
+        await flow_mass.config.setup_provider("_no_such_provider")
+
+
+class _FlowPlayer(MockPlayer):
+    """Mock player that implements a setup (pairing) flow."""
+
+    async def run_setup_flow(self, session: SetupSession) -> None:
+        """Run a minimal pairing flow."""
+        values = await session.form([ConfigEntry(key="pin", type=ConfigEntryType.STRING)])
+        await session.finish(values)
+
+
+async def test_player_setup_without_flow_aborts(flow_mass: MusicAssistant) -> None:
+    """Player setup for a player without a run_setup_flow override aborts."""
+    provider = MockProvider("test_players", instance_id="test_players--1")
+    player = MockPlayer(provider, "test_player_1", "Player One")
+    assert type(player).run_setup_flow is Player.run_setup_flow
+    with patch.object(flow_mass.players, "get_player", return_value=player):
+        step = await flow_mass.config.setup_player("test_player_1")
+    assert step.type == FlowStepType.ABORT
+    assert step.reason == "nothing_to_configure"
+
+
+async def test_player_setup_reaches_unavailable_player(flow_mass: MusicAssistant) -> None:
+    """
+    Player setup must not gate on player availability.
+
+    A player that needs setup is serialized as unavailable (available folds in
+    needs_setup), so requesting availability here would lock out exactly the
+    players this command exists for.
+    """
+    provider = MockProvider("test_players", instance_id="test_players--1")
+    player = MockPlayer(provider, "test_player_1", "Player One")
+
+    def get_player_needs_setup(player_id: str, raise_unavailable: bool = False) -> MockPlayer:
+        # mimic the real controller for a needs_setup player: state.available is
+        # False, so raise_unavailable=True would raise PlayerUnavailableError
+        if raise_unavailable:
+            raise PlayerUnavailableError(f"Player {player_id} is not available")
+        return player
+
+    with patch.object(flow_mass.players, "get_player", side_effect=get_player_needs_setup):
+        step = await flow_mass.config.setup_player("test_player_1")
+    assert step.type == FlowStepType.ABORT
+    assert step.reason == "nothing_to_configure"
+
+
+async def test_player_setup_flow_finish(flow_mass: MusicAssistant) -> None:
+    """A player flow persists (encrypted) setup_data on the player config."""
+    events: list[MassEvent] = []
+    flow_mass.subscribe(events.append, EventType.PLAYER_CONFIG_UPDATED)
+    player_id = "test_player_1"
+    provider = MockProvider("test_players", instance_id="test_players--1")
+    player = _FlowPlayer(provider, player_id, "Player One")
+    flow_mass.config.set(
+        f"{CONF_PLAYERS}/{player_id}",
+        {"player_id": player_id, "provider": provider.instance_id, "enabled": True},
+    )
+    player_config = PlayerConfig(values={}, provider=provider.instance_id, player_id=player_id)
+    with (
+        patch.object(flow_mass.players, "get_player", return_value=player),
+        patch.object(flow_mass.config, "get_player_config", AsyncMock(return_value=player_config)),
+    ):
+        step = await flow_mass.config.setup_player(player_id)
+        assert step.type == FlowStepType.FORM
+        finish_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"pin": "1234"})
+    assert finish_step.type == FlowStepType.FINISH
+    assert finish_step.result == {"player_id": player_id}
+    raw_conf = flow_mass.config.get(f"{CONF_PLAYERS}/{player_id}")
+    assert flow_mass.config.decrypt_string(raw_conf["setup_data"]["pin"]) == "1234"
+    config_event = await _wait_for(lambda: next(iter(events), None))
+    assert config_event.object_id == player_id
+
+
+async def test_secure_values_never_echoed_on_step(flow_mass: MusicAssistant) -> None:
+    """Submitted SECURE_STRING values are handed to the flow but never kept on the step."""
+    received: dict[str, Any] = {}
+
+    async def run_setup(session: SetupSession) -> None:
+        received.update(await session.form([USERNAME_ENTRY, PASSWORD_ENTRY]))
+        # keep the flow alive on a second form so the stored step can be inspected
+        await session.form([USERNAME_ENTRY], step_id="second")
+        await session.finish({})
+
+    with _use_flow(flow_mass, run_setup):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        # validation failure path: the password must not be echoed back
+        error_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"password": "sssh"})
+        password_entry = next(x for x in error_step.entries if x.key == "password")
+        assert password_entry.value is None
+        # success path: the flow receives the value, the stored step does not keep it
+        await flow_mass.config.submit_setup_flow(
+            step.flow_id, {"username": "marcel", "password": "sssh"}
+        )
+        assert received["password"] == "sssh"
+        await flow_mass.config.abort_setup_flow(step.flow_id)

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -622,6 +622,47 @@ async def test_player_setup_without_flow_aborts(flow_mass: MusicAssistant) -> No
     assert step.reason == "nothing_to_configure"
 
 
+async def test_player_setup_abort_mid_finish_restores_setup_data(
+    flow_mass: MusicAssistant,
+) -> None:
+    """Aborting a player flow while finish() is in flight restores the previous setup_data."""
+    player_id = "test_player_1"
+    provider = MockProvider("test_players", instance_id="test_players--1")
+    player = _FlowPlayer(provider, player_id, "Player One")
+    original_setup_data = {"pin": flow_mass.config.encrypt_string("0000")}
+    flow_mass.config.set(
+        f"{CONF_PLAYERS}/{player_id}",
+        {
+            "player_id": player_id,
+            "provider": provider.instance_id,
+            "enabled": True,
+            "setup_data": dict(original_setup_data),
+        },
+    )
+    finish_reached = asyncio.Event()
+
+    async def hanging_get_player_config(_player_id: str) -> Any:
+        finish_reached.set()
+        await asyncio.sleep(3600)
+
+    with (
+        patch.object(flow_mass.players, "get_player", return_value=player),
+        patch.object(flow_mass.config, "get_player_config", hanging_get_player_config),
+    ):
+        step = await flow_mass.config.setup_player(player_id)
+        assert step.type == FlowStepType.FORM
+        submit_task = asyncio.create_task(
+            flow_mass.config.submit_setup_flow(step.flow_id, {"pin": "1234"})
+        )
+        await asyncio.wait_for(finish_reached.wait(), timeout=5)
+        await flow_mass.config.abort_setup_flow(step.flow_id)
+        submit_step = await submit_task
+    # the abort interrupted finish(): the previous setup_data was restored
+    raw_conf = flow_mass.config.get(f"{CONF_PLAYERS}/{player_id}")
+    assert raw_conf["setup_data"] == original_setup_data
+    assert submit_step.type == FlowStepType.ABORT
+
+
 async def test_player_setup_reaches_unavailable_player(flow_mass: MusicAssistant) -> None:
     """
     Player setup must not gate on player availability.


### PR DESCRIPTION
# What does this implement/fix?

Groundwork for the new interactive setup flows: a server-driven flow engine that replaces the action-based config-entry workarounds for provider/player setup (credentials, OAuth, pairing) — with a clear begin and end, multiple steps, progress and proper cancellation. Purely additive: nothing changes yet for existing providers or clients.

- New `SetupSession`: a provider authors its setup as one plain coroutine (`run_setup(session)` in `providers/<domain>/setup_flow.py`) using awaitable `form()` / `external()` / `progress_until()` steps, optional step deadlines and clean abort/cleanup semantics
- New api commands: `config/providers/setup`, `config/providers/reconfigure` (also covers re-authentication) and `config/players/setup`, plus `config/flows/submit|get|abort`; step changes are pushed via the new `SETUP_FLOW_UPDATED` event
- Providers that need no setup input are created immediately, so the add-provider path is uniform for all providers
- Values collected by flows land in the new `setup_data` config section: encrypted at rest and never exposed over the API
- Options saves no longer drop stored values that have no config entry (ports the player-config preservation guard to provider configs)

**Related:** music-assistant/models#324 (shipped in models 1.1.169)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
