### PR TITLE
Improve grouped AirPlay pause fallback

### DIFF
--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -47,7 +47,14 @@ class AsyncNamedPipeWriter:
         await asyncio.to_thread(_create)
 
     async def write(self, data: bytes) -> bool:
-        """Write data to the named pipe."""
+        """
+        Write data to the named pipe.
+
+        :param data: Data to write.
+        :return: True for a complete write, False when no reader is available,
+            the reader closes, or the write is incomplete.
+        :raises OSError: If writing fails for another reason.
+        """
 
         def _write() -> bool:
             if not self._ensure_write_fd():

--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -29,6 +29,7 @@ class AsyncNamedPipeWriter:
         self._pipe_path = pipe_path
         self._owner_id = owner_id
         self._write_fd: int | None = None
+        self._write_lock = asyncio.Lock()
 
     @property
     def path(self) -> str:
@@ -52,7 +53,7 @@ class AsyncNamedPipeWriter:
 
         :param data: Data to write.
         :return: True for a complete write, False when no reader is available,
-            the reader closes, or the write is incomplete.
+            the reader closes, or the write cannot make progress.
         :raises OSError: If writing fails for another reason.
         """
 
@@ -65,18 +66,23 @@ class AsyncNamedPipeWriter:
                     len(data),
                 )
                 return False
+            data_view = memoryview(data)
+            total_bytes_written = 0
             try:
                 assert self._write_fd is not None
-                bytes_written = os.write(self._write_fd, data)
-                if bytes_written != len(data):
-                    _LOGGER.debug(
-                        "Named pipe write incomplete on %s (owner=%s, %d of %d bytes written)",
-                        self._pipe_path,
-                        self._log_owner,
-                        bytes_written,
-                        len(data),
-                    )
-                    return False
+                while total_bytes_written < len(data_view):
+                    bytes_written = os.write(self._write_fd, data_view[total_bytes_written:])
+                    if bytes_written == 0:
+                        _LOGGER.debug(
+                            "Named pipe write made no progress on %s "
+                            "(owner=%s, %d of %d bytes written)",
+                            self._pipe_path,
+                            self._log_owner,
+                            total_bytes_written,
+                            len(data),
+                        )
+                        return False
+                    total_bytes_written += bytes_written
                 return True
             except OSError as e:
                 if e.errno == errno_module.EPIPE:
@@ -86,15 +92,18 @@ class AsyncNamedPipeWriter:
                             os.close(self._write_fd)
                         self._write_fd = None
                     _LOGGER.debug(
-                        "Named pipe write failed (EPIPE) on %s (owner=%s, %d bytes dropped): reader closed",
+                        "Named pipe write failed (EPIPE) on %s "
+                        "(owner=%s, %d of %d bytes written): reader closed",
                         self._pipe_path,
                         self._log_owner,
+                        total_bytes_written,
                         len(data),
                     )
                     return False
                 raise
 
-        return await asyncio.to_thread(_write)
+        async with self._write_lock:
+            return await asyncio.to_thread(_write)
 
     async def remove(self) -> None:
         """Close write fd and remove the pipe."""

--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -60,7 +60,16 @@ class AsyncNamedPipeWriter:
                 return False
             try:
                 assert self._write_fd is not None
-                os.write(self._write_fd, data)
+                bytes_written = os.write(self._write_fd, data)
+                if bytes_written != len(data):
+                    _LOGGER.debug(
+                        "Named pipe write incomplete on %s (owner=%s, %d of %d bytes written)",
+                        self._pipe_path,
+                        self._log_owner,
+                        bytes_written,
+                        len(data),
+                    )
+                    return False
                 return True
             except OSError as e:
                 if e.errno == errno_module.EPIPE:

--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -46,10 +46,10 @@ class AsyncNamedPipeWriter:
 
         await asyncio.to_thread(_create)
 
-    async def write(self, data: bytes) -> None:
+    async def write(self, data: bytes) -> bool:
         """Write data to the named pipe."""
 
-        def _write() -> None:
+        def _write() -> bool:
             if not self._ensure_write_fd():
                 _LOGGER.debug(
                     "Named pipe write failed: no writable fd for pipe %s (owner=%s, %d bytes dropped)",
@@ -57,10 +57,11 @@ class AsyncNamedPipeWriter:
                     self._log_owner,
                     len(data),
                 )
-                return
+                return False
             try:
                 assert self._write_fd is not None
                 os.write(self._write_fd, data)
+                return True
             except OSError as e:
                 if e.errno == errno_module.EPIPE:
                     # Reader closed, reset fd for next attempt
@@ -74,10 +75,10 @@ class AsyncNamedPipeWriter:
                         self._log_owner,
                         len(data),
                     )
-                else:
-                    raise
+                    return False
+                raise
 
-        await asyncio.to_thread(_write)
+        return await asyncio.to_thread(_write)
 
     async def remove(self) -> None:
         """Close write fd and remove the pipe."""

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -242,11 +242,11 @@ class AirPlayStream:
             return
         await self._cli_proc.write_eof()
 
-    async def send_cli_command(self, command: str) -> None:
+    async def send_cli_command(self, command: str) -> bool:
         """Send an interactive command to the running CLI binary."""
         if self._stopped or self._stopping:
-            return
-        await self._write_cli_command(command)
+            return False
+        return await self._write_cli_command(command)
 
     def next_generation(self) -> int:
         """Allocate the next media generation number and its status events."""
@@ -813,11 +813,11 @@ class AirPlayStream:
             self._cleanup_complete = True
             self._cli_proc = None
 
-    async def _write_cli_command(self, command: str) -> None:
+    async def _write_cli_command(self, command: str) -> bool:
         """Write an interactive command regardless of stream teardown state."""
         if not self._cli_proc or self._cli_proc.closed:
-            return
+            return False
         self.player.last_command_sent = time.time()
         if not command.endswith("\n"):
             command += "\n"
-        await self.commands_pipe.write(command.encode("utf-8"))
+        return await self.commands_pipe.write(command.encode("utf-8"))

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -243,7 +243,13 @@ class AirPlayStream:
         await self._cli_proc.write_eof()
 
     async def send_cli_command(self, command: str) -> bool:
-        """Send an interactive command to the running CLI binary."""
+        """
+        Send an interactive command to the running CLI binary.
+
+        :param command: Command to send.
+        :return: True when the complete command is delivered, False when the
+            command is ignored, the CLI is unavailable, or the write is dropped.
+        """
         if self._stopped or self._stopping:
             return False
         return await self._write_cli_command(command)

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -823,7 +823,9 @@ class AirPlayStream:
         """Write an interactive command regardless of stream teardown state."""
         if not self._cli_proc or self._cli_proc.closed:
             return False
-        self.player.last_command_sent = time.time()
         if not command.endswith("\n"):
             command += "\n"
-        return await self.commands_pipe.write(command.encode("utf-8"))
+        command_delivered = await self.commands_pipe.write(command.encode("utf-8"))
+        if command_delivered:
+            self.player.last_command_sent = time.time()
+        return command_delivered

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -230,7 +230,19 @@ class AirPlayStreamSession:
                 await ffmpeg.kill()
             stream = player.stream
             assert stream
-            await stream.send_cli_command("ACTION=STANDBY")
+            try:
+                command_delivered = await stream.send_cli_command("ACTION=STANDBY")
+            except Exception as err:
+                self.prov.logger.warning(
+                    "Could not park AirPlay player %s: %s", player.player_id, err
+                )
+                return False
+            if not command_delivered:
+                self.prov.logger.warning(
+                    "Could not park AirPlay player %s: standby command was not delivered",
+                    player.player_id,
+                )
+                return False
             player.set_state_from_stream(state=PlaybackState.PAUSED, stream=stream)
         # a parked session has no live timeline; the resume re-anchors it
         self.seconds_streamed = 0

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -213,8 +213,9 @@ class AirPlayStreamSession:
 
         The next play_media (resume or seek) commits a new generation over the
         live connections — the same coordinated warm restart as seek/next.
-        Returns False when any member lacks a running, connected stream so the
-        caller can fall back to a full stop.
+        Returns False when any member lacks a running, connected stream or its
+        standby command cannot be delivered so the caller can fall back to a
+        full stop.
         """
         if not all(
             p.stream is not None and p.stream.running and p.stream.connected

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -346,6 +346,30 @@ async def test_command_pipe_write_returns_false_without_reader(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
+async def test_command_pipe_write_returns_true_for_complete_write() -> None:
+    """A complete command pipe write reports successful delivery."""
+    data = b"ACTION=STANDBY\n"
+    writer = AsyncNamedPipeWriter("/tmp/commands")  # noqa: S108
+    writer._write_fd = 42
+
+    with patch("music_assistant.helpers.named_pipe.os.write", return_value=len(data)) as write:
+        assert await writer.write(data) is True
+
+    write.assert_called_once_with(42, data)
+
+
+@pytest.mark.asyncio
+async def test_command_pipe_write_returns_false_for_short_write() -> None:
+    """An incomplete command pipe write reports failed delivery."""
+    data = b"ACTION=STANDBY\n"
+    writer = AsyncNamedPipeWriter("/tmp/commands")  # noqa: S108
+    writer._write_fd = 42
+
+    with patch("music_assistant.helpers.named_pipe.os.write", return_value=len(data) - 1):
+        assert await writer.write(data) is False
+
+
+@pytest.mark.asyncio
 async def test_command_pipe_write_returns_false_and_resets_fd_on_epipe() -> None:
     """A closed command pipe reader resets the writer for a later retry."""
     writer = AsyncNamedPipeWriter("/tmp/commands")  # noqa: S108
@@ -362,6 +386,22 @@ async def test_command_pipe_write_returns_false_and_resets_fd_on_epipe() -> None
 
     close_fd.assert_called_once_with(42)
     assert writer._write_fd is None
+
+
+@pytest.mark.asyncio
+async def test_command_pipe_write_propagates_non_epipe_errors() -> None:
+    """An unexpected command pipe write error remains visible to the caller."""
+    writer = AsyncNamedPipeWriter("/tmp/commands")  # noqa: S108
+    writer._write_fd = 42
+
+    with (
+        patch(
+            "music_assistant.helpers.named_pipe.os.write",
+            side_effect=OSError(errno.EBADF, "bad file descriptor"),
+        ),
+        pytest.raises(OSError, match="bad file descriptor"),
+    ):
+        await writer.write(b"ACTION=STANDBY\n")
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -4,6 +4,7 @@ import asyncio
 import errno
 import logging
 import os
+import threading
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any
@@ -359,14 +360,19 @@ async def test_command_pipe_write_returns_true_for_complete_write() -> None:
 
 
 @pytest.mark.asyncio
-async def test_command_pipe_write_returns_false_for_short_write() -> None:
-    """An incomplete command pipe write reports failed delivery."""
+async def test_command_pipe_write_completes_short_write() -> None:
+    """A short command pipe write continues with the remaining data."""
     data = b"ACTION=STANDBY\n"
     writer = AsyncNamedPipeWriter("/tmp/commands")  # noqa: S108
     writer._write_fd = 42
 
-    with patch("music_assistant.helpers.named_pipe.os.write", return_value=len(data) - 1):
-        assert await writer.write(data) is False
+    with patch(
+        "music_assistant.helpers.named_pipe.os.write",
+        side_effect=[5, len(data) - 5],
+    ) as write:
+        assert await writer.write(data) is True
+
+    assert write.call_args_list == [call(42, memoryview(data)), call(42, memoryview(data)[5:])]
 
 
 @pytest.mark.asyncio
@@ -389,6 +395,57 @@ async def test_command_pipe_write_returns_false_and_resets_fd_on_epipe() -> None
 
 
 @pytest.mark.asyncio
+async def test_command_pipe_write_resets_fd_when_epipe_follows_partial_write() -> None:
+    """An EPIPE after a short write reports failure and resets the writer."""
+    data = b"ACTION=STANDBY\n"
+    writer = AsyncNamedPipeWriter("/tmp/commands")  # noqa: S108
+    writer._write_fd = 42
+
+    with (
+        patch(
+            "music_assistant.helpers.named_pipe.os.write",
+            side_effect=[5, OSError(errno.EPIPE, "reader closed")],
+        ) as write,
+        patch("music_assistant.helpers.named_pipe.os.close") as close_fd,
+    ):
+        assert await writer.write(data) is False
+
+    assert write.call_args_list == [call(42, memoryview(data)), call(42, memoryview(data)[5:])]
+    close_fd.assert_called_once_with(42)
+    assert writer._write_fd is None
+
+
+@pytest.mark.asyncio
+async def test_command_pipe_writes_are_serialized() -> None:
+    """Concurrent command writes cannot interleave after a short write."""
+    writer = AsyncNamedPipeWriter("/tmp/commands")  # noqa: S108
+    writer._write_fd = 42
+    written_chunks: list[bytes] = []
+    first_chunk_written = threading.Event()
+    release_first_write = threading.Event()
+
+    def write_chunk(_fd: int, data: memoryview) -> int:
+        chunk = bytes(data)
+        if not written_chunks:
+            written_chunks.append(chunk[:2])
+            first_chunk_written.set()
+            assert release_first_write.wait(timeout=1)
+            return 2
+        written_chunks.append(chunk)
+        return len(chunk)
+
+    with patch("music_assistant.helpers.named_pipe.os.write", side_effect=write_chunk):
+        first_write = asyncio.create_task(writer.write(b"FIRST\n"))
+        assert await asyncio.to_thread(first_chunk_written.wait, 1)
+        second_write = asyncio.create_task(writer.write(b"SECOND\n"))
+        await asyncio.sleep(0)
+        release_first_write.set()
+        assert all(await asyncio.gather(first_write, second_write))
+
+    assert b"".join(written_chunks) == b"FIRST\nSECOND\n"
+
+
+@pytest.mark.asyncio
 async def test_command_pipe_write_propagates_non_epipe_errors() -> None:
     """An unexpected command pipe write error remains visible to the caller."""
     writer = AsyncNamedPipeWriter("/tmp/commands")  # noqa: S108
@@ -402,6 +459,58 @@ async def test_command_pipe_write_propagates_non_epipe_errors() -> None:
         pytest.raises(OSError, match="bad file descriptor"),
     ):
         await writer.write(b"ACTION=STANDBY\n")
+
+
+@pytest.mark.asyncio
+async def test_cli_command_updates_timestamp_after_successful_delivery() -> None:
+    """A delivered command updates the player's last command timestamp."""
+    player = _make_player()
+    player.last_command_sent = 10.0
+    stream = AirPlayStream(player)
+    stream._cli_proc = MagicMock(closed=False)
+
+    with (
+        patch.object(stream.commands_pipe, "write", new=AsyncMock(return_value=True)),
+        patch("music_assistant.providers.airplay.stream.time.time", return_value=20.0),
+    ):
+        assert await stream.send_cli_command("ACTION=STANDBY") is True
+
+    assert player.last_command_sent == 20.0
+
+
+@pytest.mark.asyncio
+async def test_cli_command_preserves_timestamp_when_delivery_fails() -> None:
+    """A dropped command leaves the player's last command timestamp unchanged."""
+    player = _make_player()
+    player.last_command_sent = 10.0
+    stream = AirPlayStream(player)
+    stream._cli_proc = MagicMock(closed=False)
+
+    with patch.object(stream.commands_pipe, "write", new=AsyncMock(return_value=False)):
+        assert await stream.send_cli_command("ACTION=STANDBY") is False
+
+    assert player.last_command_sent == 10.0
+
+
+@pytest.mark.asyncio
+async def test_cli_command_preserves_timestamp_when_delivery_raises() -> None:
+    """A command write error leaves the player's last command timestamp unchanged."""
+    player = _make_player()
+    player.last_command_sent = 10.0
+    stream = AirPlayStream(player)
+    stream._cli_proc = MagicMock(closed=False)
+
+    with (
+        patch.object(
+            stream.commands_pipe,
+            "write",
+            new=AsyncMock(side_effect=OSError("command pipe failed")),
+        ),
+        pytest.raises(OSError, match="command pipe failed"),
+    ):
+        await stream.send_cli_command("ACTION=STANDBY")
+
+    assert player.last_command_sent == 10.0
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -1,8 +1,11 @@
 """Unit tests for the AirPlay stream CLI argument assembly."""
 
 import asyncio
+import errno
 import logging
+import os
 from collections.abc import AsyncGenerator
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
@@ -10,6 +13,7 @@ import pytest
 from music_assistant_models.enums import ContentType, PlaybackState
 from music_assistant_models.media_items import AudioFormat
 
+from music_assistant.helpers.named_pipe import AsyncNamedPipeWriter
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_ARTWORK_SIZE,
     CONF_ENCRYPTION,
@@ -328,6 +332,36 @@ def test_command_pipe_paths_are_unique_per_stream() -> None:
     first_stream = AirPlayStream(player)
     second_stream = AirPlayStream(player)
     assert first_stream.commands_pipe.path != second_stream.commands_pipe.path
+
+
+@pytest.mark.asyncio
+async def test_command_pipe_write_returns_false_without_reader(tmp_path: Path) -> None:
+    """A command pipe write reports when no reader can receive the command."""
+    pipe_path = tmp_path / "commands"
+    os.mkfifo(pipe_path)
+    writer = AsyncNamedPipeWriter(str(pipe_path))
+
+    with patch("music_assistant.helpers.named_pipe.time.sleep"):
+        assert await writer.write(b"ACTION=STANDBY\n") is False
+
+
+@pytest.mark.asyncio
+async def test_command_pipe_write_returns_false_and_resets_fd_on_epipe() -> None:
+    """A closed command pipe reader resets the writer for a later retry."""
+    writer = AsyncNamedPipeWriter("/tmp/commands")  # noqa: S108
+    writer._write_fd = 42
+
+    with (
+        patch(
+            "music_assistant.helpers.named_pipe.os.write",
+            side_effect=OSError(errno.EPIPE, "reader closed"),
+        ),
+        patch("music_assistant.helpers.named_pipe.os.close") as close_fd,
+    ):
+        assert await writer.write(b"ACTION=STANDBY\n") is False
+
+    close_fd.assert_called_once_with(42)
+    assert writer._write_fd is None
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -343,7 +343,7 @@ async def test_standby_supports_every_connected_streaming_protocol(
         player.player_id = f"player-{index}"
         player.protocol = protocol
         player.stream = MagicMock(running=True, connected=True)
-        player.stream.send_cli_command = AsyncMock()
+        player.stream.send_cli_command = AsyncMock(return_value=True)
         players.append(player)
     session.sync_clients = players
 
@@ -374,7 +374,7 @@ async def test_standby_resumes_next_generation_on_existing_streams(
         player.protocol = protocol
         player.config.get_value = MagicMock(return_value=0)
         player.stream = MagicMock(running=True, connected=True)
-        player.stream.send_cli_command = AsyncMock()
+        player.stream.send_cli_command = AsyncMock(return_value=True)
         player.stream.next_generation = MagicMock(return_value=1)
         player.stream.prepare_generation = AsyncMock()
         player.stream.wait_generation_primed = AsyncMock(return_value=True)
@@ -435,6 +435,42 @@ async def test_standby_requires_every_member_running_and_connected(stream_state:
     if unavailable_player.stream:
         unavailable_player.stream.send_cli_command.assert_not_awaited()
         unavailable_player.set_state_from_stream.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_standby_returns_false_when_command_is_not_delivered() -> None:
+    """Standby fails without changing state for a member that misses the command."""
+    session = _make_session(0, 0)
+    logger = MagicMock()
+    session.prov.logger = logger
+    delivered_player = MagicMock(player_id="delivered", protocol=StreamingProtocol.AIRPLAY2)
+    delivered_player.stream = MagicMock(running=True, connected=True)
+    delivered_player.stream.send_cli_command = AsyncMock(return_value=True)
+    dropped_player = MagicMock(player_id="dropped", protocol=StreamingProtocol.RAOP)
+    dropped_player.stream = MagicMock(running=True, connected=True)
+    dropped_player.stream.send_cli_command = AsyncMock(return_value=False)
+    session.sync_clients = [delivered_player, dropped_player]
+
+    assert await session.standby() is False
+    delivered_player.set_state_from_stream.assert_called_once()
+    dropped_player.set_state_from_stream.assert_not_called()
+    logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_standby_returns_false_when_command_raises() -> None:
+    """Standby fails without changing state when command delivery raises."""
+    session = _make_session(0, 0)
+    logger = MagicMock()
+    session.prov.logger = logger
+    player = MagicMock(player_id="failed", protocol=StreamingProtocol.AIRPLAY2)
+    player.stream = MagicMock(running=True, connected=True)
+    player.stream.send_cli_command = AsyncMock(side_effect=OSError("command pipe failed"))
+    session.sync_clients = [player]
+
+    assert await session.standby() is False
+    player.set_state_from_stream.assert_not_called()
+    logger.warning.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -449,11 +449,18 @@ async def test_standby_returns_false_when_command_is_not_delivered() -> None:
     dropped_player = MagicMock(player_id="dropped", protocol=StreamingProtocol.RAOP)
     dropped_player.stream = MagicMock(running=True, connected=True)
     dropped_player.stream.send_cli_command = AsyncMock(return_value=False)
-    session.sync_clients = [delivered_player, dropped_player]
+    pending_player = MagicMock(player_id="pending", protocol=StreamingProtocol.AIRPLAY2)
+    pending_player.stream = MagicMock(running=True, connected=True)
+    pending_player.stream.send_cli_command = AsyncMock(return_value=True)
+    session.sync_clients = [delivered_player, dropped_player, pending_player]
 
     assert await session.standby() is False
+    delivered_player.stream.send_cli_command.assert_awaited_once_with("ACTION=STANDBY")
     delivered_player.set_state_from_stream.assert_called_once()
+    dropped_player.stream.send_cli_command.assert_awaited_once_with("ACTION=STANDBY")
     dropped_player.set_state_from_stream.assert_not_called()
+    pending_player.stream.send_cli_command.assert_not_awaited()
+    pending_player.set_state_from_stream.assert_not_called()
     logger.warning.assert_called_once()
 
 


### PR DESCRIPTION
# What does this implement/fix?

Grouped AirPlay pause now safely disconnects the full group when standby cannot reach a member.

- Report dropped or failed AirPlay command-pipe writes.
- Only mark members paused after standby is delivered.

**Related issue (if applicable):**

- Follow-up to #4951

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.