### PR TITLE
Stop recurring Apple TV pairing prompts from control-channel flapping

### DIFF
--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -81,6 +81,14 @@ if TYPE_CHECKING:
 _CONTROL_RECONNECT_DELAY: Final[float] = 30.0
 _WAKE_TIMEOUT: Final[float] = 10.0
 
+# mDNS TXT keys whose values change with transient playback, session or group
+# state - most notably `flags`, which a receiver toggles while it is receiving a
+# stream. They never affect how the control connection is established, so a
+# change must not force a reconnect: doing so made Apple TVs tear down and
+# re-establish the control channel on every stream start and stop, each time
+# surfacing the on-screen pairing code. Compared case-insensitively (RFC 6763).
+_VOLATILE_DISCOVERY_KEYS: Final = frozenset({"flags", "gcgl", "gid", "igl", "gpn", "pgcgl"})
+
 _CONNECTION_ERRORS = (
     pyatv_exceptions.AuthenticationError,
     pyatv_exceptions.BackOffError,
@@ -1206,11 +1214,20 @@ class AirPlayControlPlayer(AirPlayPlayer):
         """Return fields that require a pyatv reconnection when changed."""
         if info is None:
             return None
+        # TXT keys are case-insensitive (RFC 6763); casefold them so a re-cased
+        # key is never mistaken for a connection-relevant change.
+        stable_properties = tuple(
+            sorted(
+                (key.casefold(), value)
+                for key, value in info.decoded_properties.items()
+                if key.casefold() not in _VOLATILE_DISCOVERY_KEYS
+            )
+        )
         return (
             info.name,
             info.port,
             tuple(info.addresses),
-            tuple(sorted(info.decoded_properties.items())),
+            stable_properties,
         )
 
 

--- a/tests/providers/airplay/test_control_player.py
+++ b/tests/providers/airplay/test_control_player.py
@@ -156,6 +156,40 @@ def test_companion_pairing_follows_advertised_flags(flags: str, supported: bool)
     assert PlayerFeature.NEXT_PREVIOUS not in player.supported_features
 
 
+def test_playback_state_churn_does_not_force_control_reconnect() -> None:
+    """A receiver toggling volatile TXT state must not change the reconnect signature."""
+    idle = _service_info(
+        AIRPLAY_DISCOVERY_TYPE,
+        properties={"deviceid": DEVICE_ID, "pk": "device-key", "flags": "0x4"},
+    )
+    # Same device while receiving a stream: only the session `flags` bit differs.
+    streaming = _service_info(
+        AIRPLAY_DISCOVERY_TYPE,
+        properties={"deviceid": DEVICE_ID, "pk": "device-key", "flags": "0x404"},
+    )
+    assert AirPlayControlPlayer._service_signature(idle) == AirPlayControlPlayer._service_signature(
+        streaming
+    )
+
+    # TXT keys are case-insensitive (RFC 6763): re-casing keys is not a change.
+    recased = _service_info(
+        AIRPLAY_DISCOVERY_TYPE,
+        properties={"DeviceID": DEVICE_ID, "PK": "device-key", "Flags": "0x4"},
+    )
+    assert AirPlayControlPlayer._service_signature(idle) == AirPlayControlPlayer._service_signature(
+        recased
+    )
+
+    # A change to a connection-relevant field still forces a reconnect.
+    rekeyed = _service_info(
+        AIRPLAY_DISCOVERY_TYPE,
+        properties={"deviceid": DEVICE_ID, "pk": "rotated-key", "flags": "0x4"},
+    )
+    assert AirPlayControlPlayer._service_signature(idle) != AirPlayControlPlayer._service_signature(
+        rekeyed
+    )
+
+
 def test_power_feature_requires_credentials_or_connection() -> None:
     """POWER is advertised for stored Companion credentials or a live channel."""
     paired = _make_control_player(config_values={CONF_COMPANION_CREDENTIALS: "companion-creds"})


### PR DESCRIPTION
Apple TVs toggle volatile `_airplay` TXT keys (notably `flags`) as their playback/session state changes, e.g. while receiving a stream. The control player's discovery signature compared the full TXT record, so this churn looked like a connection-relevant change and force-reconnected the Companion/MRP control channel on every stream start and stop — each reconnect making the device display the on-screen pairing code.

Follow-up to #4927 (which fixed the transient path but not this paired-channel flapping). Excludes volatile playback/session/group keys from the signature so only genuine connection changes (address, port, identity) trigger a reconnect.