### PR TITLE
Setup flow callback: keep params as plain strings

### DIFF
--- a/music_assistant/models/setup_flow.py
+++ b/music_assistant/models/setup_flow.py
@@ -347,7 +347,13 @@ class SetupSession:
         if request.method == "POST" and request.can_read_body:
             try:
                 if request.content_type == "application/json":
-                    params.update(json_loads(await request.read()))
+                    body = json_loads(await request.read())
+                    if isinstance(body, dict):
+                        # coerce to str so the declared params contract holds for
+                        # json bodies carrying numbers/bools
+                        params.update({str(key): str(val) for key, val in body.items()})
+                    else:
+                        LOGGER.error("Ignoring non-object JSON setup flow callback body")
                 else:
                     params.update({key: str(val) for key, val in (await request.post()).items()})
             except Exception as err:

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -302,6 +302,33 @@ async def test_external_step_callback_roundtrip(flow_mass: MusicAssistant) -> No
     await _wait_for(lambda: callback_path not in registered_routes)
 
 
+async def test_external_callback_json_body_coerced(flow_mass: MusicAssistant) -> None:
+    """A JSON callback body with non-string values is coerced to the str params contract."""
+    received: dict[str, str] = {}
+
+    async def run_setup(session: SetupSession) -> None:
+        received.update(await session.external("https://example.com/authorize"))
+        await session.finish({})
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        session = flow_mass.config._setup_flows[step.flow_id].session
+        request = SimpleNamespace(
+            query={"state": "xyz"},
+            method="POST",
+            can_read_body=True,
+            content_type="application/json",
+            read=AsyncMock(return_value=b'{"code": 123, "granted": true}'),
+        )
+        response = await session.handle_callback(cast("Any", request))
+        assert response.status == 200
+        await _wait_for(lambda: session.finished)
+    assert received == {"state": "xyz", "code": "123", "granted": "True"}
+
+
 async def test_form_expiry_aborts_flow(
     flow_mass: MusicAssistant, flow_events: list[MassEvent]
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up on #4952 (flagged in review): the setup-flow external-step callback declares its params as `dict[str, str]`, but a JSON POST body could inject numbers/bools into it.

- Coerce JSON body keys/values to strings before merging into the callback params
- Ignore non-object JSON bodies (logged) instead of merging garbage
- Test covering a JSON callback body with non-string values

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
