### PR TITLE
Drop the AirPlay --ptp-follow clock-follow path

### DIFF
--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -127,7 +127,6 @@ class AirPlayStream:
     async def start(
         self,
         use_shared_ptp: bool | None = None,
-        ptp_follow: bool = False,
     ) -> None:
         """
         Start cliairplay and connect to the receiver.
@@ -137,12 +136,8 @@ class AirPlayStream:
             passes the same value to every member so a group never mixes PTP and
             NTP timing. None (single-stream callers) falls back to the daemon's
             live state.
-        :param ptp_follow: Solo-session clock negotiation: the binary may yield
-            the timeline to a receiver that announces itself as a master
-            (Samsung renders only on its own clock). Never combined with the
-            shared daemon.
         """
-        args = await self._build_cli_args(use_shared_ptp, ptp_follow)
+        args = await self._build_cli_args(use_shared_ptp)
         self.player.logger.debug("Starting cliairplay for player %s", self.player.player_id)
         self._cli_proc = AsyncProcess(args, stdin=True, stdout=True, stderr=True, name="cliairplay")
         try:
@@ -418,7 +413,6 @@ class AirPlayStream:
     async def _build_cli_args(  # noqa: PLR0915
         self,
         use_shared_ptp: bool | None = None,
-        ptp_follow: bool = False,
     ) -> list[str]:
         """
         Assemble the cliairplay argument list for this stream.
@@ -427,11 +421,7 @@ class AirPlayStream:
             shared PTP clock daemon. The stream session passes an explicit
             group-wide decision so members never mix PTP and NTP timing; None
             (single-stream callers) falls back to the daemon's live state.
-        :param ptp_follow: Whether a solo native AirPlay 2 stream may follow
-            the receiver's PTP clock.
         """
-        if use_shared_ptp and ptp_follow:
-            raise ValueError("Shared PTP and receiver clock-follow are mutually exclusive")
         cli_binary = await get_cli_binary()
         prov = cast("AirPlayProvider", self.prov)
         airplay_info = self.player.airplay_discovery_info
@@ -531,12 +521,7 @@ class AirPlayStream:
         # daemon's live state.
         if target_protocol == StreamingProtocol.AIRPLAY2:
             shared_ptp = prov.ptp_daemon_running if use_shared_ptp is None else use_shared_ptp
-            if ptp_follow:
-                # Solo session: negotiate the clock honestly and yield to a
-                # master-or-mute receiver (Samsung); never via the shared
-                # daemon, which always holds grandmaster.
-                args += ["--ptp-follow"]
-            elif shared_ptp:
+            if shared_ptp:
                 args += ["--ptp-shared"]
 
         # Local interface binding

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -66,10 +66,6 @@ class AirPlayStreamSession:
         # sync group can never mix shared-PTP and NTP members.
         self.use_shared_ptp: bool = False
         self._shared_ptp_resolved = False
-        # A lone native AirPlay 2 player negotiates the clock honestly and may
-        # yield the timeline to a master-or-mute receiver (Samsung); groups
-        # keep the sender-owned shared timeline.
-        self._ptp_follow = False
         self._ptp_degraded_warning_logged = False
         # Raw PCM ring buffer for late joiners. When a late joiner arrives we
         # send this buffer to prime its pipeline so it starts playing quickly
@@ -83,8 +79,7 @@ class AirPlayStreamSession:
     async def start(self, audio_source: AsyncGenerator[bytes]) -> None:
         """Initialize stream session for all players."""
         ap2_members = sum(1 for p in self.sync_clients if p.protocol == StreamingProtocol.AIRPLAY2)
-        self._ptp_follow = ap2_members == 1 and len(self.sync_clients) == 1
-        if ap2_members and not self._ptp_follow:
+        if ap2_members:
             # Resolve the timing source before calculating the audible anchor so
             # a bounded daemon-readiness wait cannot consume the setup lead.
             self.use_shared_ptp = await self._resolve_shared_ptp(ap2_members)
@@ -312,11 +307,6 @@ class AirPlayStreamSession:
            the client so the live stream continues priming it.
         4. Start generation 0 only after the client reports primed.
         """
-        if self._ptp_follow:
-            # A group needs the sender-owned timeline; the solo session
-            # yielded its clock to the receiver, so restart as a group.
-            await self._regroup_from_follow()
-            return
         await self._resolve_late_joiner_ptp(airplay_player)
         async with self._lock:
             if not self.sync_clients:
@@ -527,20 +517,6 @@ class AirPlayStreamSession:
             ap2_members,
         )
 
-    async def _regroup_from_follow(self) -> None:
-        """
-        Restart a yielded (receiver-clocked) solo session as a proper group.
-
-        The late joiner is already in the leader's group_members, so the
-        queue's resume rebuilds playback as a sender-clocked group including
-        it. The resume runs as a task because the caller holds the leader's
-        lock (resume ends in play_media, which takes the same lock).
-        """
-        queue_id = self.media.source_id
-        await self.stop()
-        if queue_id:
-            self.mass.create_task(self.mass.player_queues.resume(queue_id, fade_in=False))
-
     async def _cleanup_after_removal(
         self, airplay_player: AirPlayPlayer, reason: str = "client removed"
     ) -> None:
@@ -690,7 +666,7 @@ class AirPlayStreamSession:
         stream_pcm_format = airplay_player.get_stream_pcm_format(self.pcm_format)
         airplay_player.stream = AirPlayStream(airplay_player, pcm_format=stream_pcm_format)
         airplay_player.stream.session = self
-        await airplay_player.stream.start(use_shared_ptp, ptp_follow=self._ptp_follow)
+        await airplay_player.stream.start(use_shared_ptp)
         # Start ffmpeg to feed audio to CLI stdin
         if ffmpeg := self._player_ffmpeg.pop(airplay_player.player_id, None):
             await ffmpeg.close()

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -162,15 +162,6 @@ async def test_cli_args_no_ptp_shared_without_daemon() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cli_args_reject_shared_ptp_with_clock_follow() -> None:
-    """Shared PTP and receiver clock-follow cannot be requested together."""
-    stream = AirPlayStream(_make_player())
-
-    with pytest.raises(ValueError, match="mutually exclusive"):
-        await stream._build_cli_args(use_shared_ptp=True, ptp_follow=True)
-
-
-@pytest.mark.asyncio
 async def test_cli_args_no_latency_override() -> None:
     """The playback lead/buffer is binary-managed; MA never passes --latency."""
     player = _make_player()

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -218,6 +218,7 @@ async def test_initial_single_player_uses_commanded_generation_zero(
 
     with (
         patch.object(session, "_start_client", side_effect=start_client),
+        patch.object(session, "_resolve_shared_ptp", new_callable=AsyncMock, return_value=False),
         patch.object(session, "_audio_streamer", new_callable=AsyncMock),
         patch("music_assistant.providers.airplay.stream_session.time.time", return_value=200.0),
     ):


### PR DESCRIPTION
The cliairplay binary now handles receiver-clock (Samsung) timing itself, so the server-side `--ptp-follow` solo-session mechanism is obsolete — and passing `--ptp-follow` to a binary that no longer accepts the flag aborts the stream immediately.

Removes the flag and its plumbing: solo native AirPlay 2 streams now take the same shared-PTP path as groups, and the receiver-follow regroup-on-late-join is gone. Verified against a locally built cliairplay `main` binary.