### PR TITLE
Keep AirPlay warm playback reliable

### DIFF
--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -149,6 +149,37 @@ class AsyncNamedPipeWriter:
         return False
 
 
+async def open_named_pipe_writer(pipe_path: str, timeout: float = 1.0) -> int:
+    """
+    Open a named pipe writer after its reader is expected to be ready.
+
+    :param pipe_path: Filesystem path of the named pipe.
+    :param timeout: Maximum time to wait for the reader in seconds.
+    :return: A blocking file descriptor suitable for subprocess inheritance.
+    :raises TimeoutError: If no reader becomes available before the timeout.
+    :raises OSError: If opening or configuring the pipe fails.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        try:
+            fd = os.open(pipe_path, os.O_WRONLY | os.O_NONBLOCK)
+        except OSError as err:
+            if err.errno not in (errno_module.ENXIO, errno_module.ENOENT):
+                raise
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise TimeoutError(f"Timed out opening named pipe writer: {pipe_path}") from err
+            await asyncio.sleep(min(0.05, remaining))
+            continue
+        try:
+            os.set_blocking(fd, True)
+        except BaseException:
+            os.close(fd)
+            raise
+        return fd
+
+
 async def read_named_pipe(
     pipe_path: str,
     chunk_size: int = 4096,

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -21,6 +21,7 @@ import asyncio
 import os
 import time
 from contextlib import suppress
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from aiosendspin.models.core import ClientHelloPayload
@@ -139,6 +140,18 @@ def device_buffer_ahead_seconds(
     """
     cursor_play_time_s = start_unix_ms / 1000 + bytes_written / bytes_per_second
     return cursor_play_time_s - unix_now
+
+
+def _close_fd(fd: int) -> None:
+    """Close a file descriptor if it is still open."""
+    with suppress(OSError):
+        os.close(fd)
+
+
+def _unlink_fifo(path: str) -> None:
+    """Remove a fifo path if it still exists."""
+    with suppress(OSError):
+        Path(path).unlink()
 
 
 class SendspinAirPlayBridge:
@@ -555,10 +568,9 @@ class SendspinAirPlayBridge:
 
         The new generation is staged on a fresh fifo while ``stream`` keeps playing
         its current one, then committed with a single START once primed. Returns
-        True once the switch is committed. Any failure (staging, a prime timeout,
-        or this task being superseded before commit) reverts the writer to the
-        stdin sink and returns False so the caller falls back to a cold restart of
-        the kept stream; the fifo node is never left behind.
+        True once the switch is committed. Any failure returns False so the caller
+        falls back to a cold restart of the kept stream; the fifo node is never
+        left behind.
 
         :param stream: The kept AirPlayStream to stage the new generation on.
         :param start_unix_ms: The audible-start instant to commit the generation at.
@@ -567,6 +579,7 @@ class SendspinAirPlayBridge:
         fifo = f"/tmp/ma-bridge-{self.airplay_player.player_id}-{gen}.pcm"  # noqa: S108
         started_at = time.monotonic()
         commit_attempted = False
+        fifo_fd: int | None = None
         try:
             with suppress(FileNotFoundError):
                 await asyncio.to_thread(os.unlink, fifo)
@@ -577,12 +590,11 @@ class SendspinAirPlayBridge:
                 raise RuntimeError(f"generation {gen} reader ready timed out")
             self._log_generation_phase(gen, "ready", started_at)
             fifo_fd = await open_named_pipe_writer(fifo)
-            self._log_generation_phase(gen, "writer-open", started_at)
             # Both ends now hold the fifo open; drop the directory entry right away
             # so no stale pipe nodes accumulate even if a later step fails.
-            with suppress(OSError):
-                await asyncio.to_thread(os.unlink, fifo)
-            await self._set_sink_fd(fifo_fd)
+            _unlink_fifo(fifo)
+            await self._publish_sink_fd(fifo_fd)
+            self._log_generation_phase(gen, "writer-open", started_at)
             # Unblocks the writer task, which was waiting on this event; it can
             # now prefill the pipe while the generation primes.
             self._airplay_stream_ready.set()
@@ -590,14 +602,9 @@ class SendspinAirPlayBridge:
                 raise RuntimeError(f"generation {gen} prime timed out")
             self._log_generation_phase(gen, "primed", started_at)
             if asyncio.current_task() is not self._airplay_stream_start_task:
-                # A newer stream start already owns the bridge; abandon this
-                # generation. Do NOT close fifo_fd here: it was published as
-                # self._sink_fd above, so it is either still the writer's active
-                # sink (closing it would break the writer with EBADF) or already
-                # closed/replaced by the newer task's _set_sink_fd. The sink fd's
-                # lifecycle is owned by _set_sink_fd / teardown, not this task.
-                # The binary safely collapses a superseded staged generation on
-                # its next PREPARE.
+                # A newer stream start owns the bridge. The published sink remains
+                # managed by _set_sink_fd or teardown so this stale task cannot
+                # close a sink the newer task may already be using.
                 await self._discard_generation(stream, gen, started_at)
                 return False
             commit_attempted = True
@@ -613,19 +620,16 @@ class SendspinAirPlayBridge:
         except asyncio.CancelledError:
             if not commit_attempted:
                 await self._discard_generation(stream, gen, started_at)
-            with suppress(Exception):
-                await self._set_sink_fd(None)
             raise
         except Exception as err:
-            self.logger.warning(
-                "Warm handover failed for %s (%r), falling back to a cold restart",
-                self.airplay_player.display_name,
+            await self._handle_warm_generation_failure(
+                stream,
+                gen,
+                started_at,
                 err,
+                fifo_fd,
+                discard=not commit_attempted,
             )
-            if not commit_attempted:
-                await self._discard_generation(stream, gen, started_at)
-            with suppress(Exception):
-                await self._set_sink_fd(None)
             return False
         finally:
             with suppress(OSError):
@@ -633,6 +637,28 @@ class SendspinAirPlayBridge:
             with suppress(OSError):
                 await asyncio.to_thread(os.unlink, fifo)
         return True
+
+    async def _handle_warm_generation_failure(
+        self,
+        stream: AirPlayStream,
+        generation: int,
+        started_at: float,
+        error: Exception,
+        fifo_fd: int | None,
+        *,
+        discard: bool,
+    ) -> None:
+        """Clean up a failed warm generation before its cold fallback."""
+        self.logger.warning(
+            "Warm handover failed for %s (%r), falling back to a cold restart",
+            self.airplay_player.display_name,
+            error,
+        )
+        if discard:
+            await self._discard_generation(stream, generation, started_at)
+        if fifo_fd is not None and self._sink_fd is fifo_fd:
+            with suppress(Exception):
+                await self._set_sink_fd(None)
 
     async def _discard_generation(
         self,
@@ -843,6 +869,15 @@ class SendspinAirPlayBridge:
             return False
         self._write_queue.put_nowait(chunk.data)
         return True
+
+    async def _publish_sink_fd(self, fd: int) -> None:
+        """Transfer a fifo descriptor to the bridge sink."""
+        try:
+            await self._set_sink_fd(fd)
+        except BaseException:
+            if self._sink_fd is not fd:
+                _close_fd(fd)
+            raise
 
     async def _set_sink_fd(self, fd: int | None) -> None:
         """

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -30,6 +30,7 @@ from aiosendspin.models.types import AudioCodec, PlayerCommand
 from music_assistant_models.enums import IdentifierType
 
 from music_assistant.constants import CONF_SYNC_ADJUST
+from music_assistant.helpers.named_pipe import open_named_pipe_writer
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.providers.sendspin.bridge_manager import SendspinBridgeManagerBase
 from music_assistant.providers.sendspin.bridge_role import (
@@ -498,6 +499,8 @@ class SendspinAirPlayBridge:
                 self._airplay_stream = new_stream
                 self.airplay_player.stream = new_stream
                 await new_stream.prepare_generation(0, "-", 0)
+                if not await new_stream.wait_generation_ready(0):
+                    raise RuntimeError("generation 0 reader ready timed out")
                 self._airplay_stream_ready.set()
                 if not await new_stream.wait_generation_primed(0):
                     raise RuntimeError("generation 0 prime timed out")
@@ -543,16 +546,18 @@ class SendspinAirPlayBridge:
         """
         gen = stream.next_generation()
         fifo = f"/tmp/ma-bridge-{self.airplay_player.player_id}-{gen}.pcm"  # noqa: S108
-        opened = False
+        started_at = time.monotonic()
         try:
             with suppress(FileNotFoundError):
                 await asyncio.to_thread(os.unlink, fifo)
             await asyncio.to_thread(os.mkfifo, fifo)
             await stream.prepare_generation(gen, fifo, 0)
-            fifo_fd = await asyncio.wait_for(
-                asyncio.to_thread(os.open, fifo, os.O_WRONLY), timeout=5
-            )
-            opened = True
+            self._log_generation_phase(gen, "prepare-delivered", started_at)
+            if not await stream.wait_generation_ready(gen):
+                raise RuntimeError(f"generation {gen} reader ready timed out")
+            self._log_generation_phase(gen, "ready", started_at)
+            fifo_fd = await open_named_pipe_writer(fifo)
+            self._log_generation_phase(gen, "writer-open", started_at)
             # Both ends now hold the fifo open; drop the directory entry right away
             # so no stale pipe nodes accumulate even if a later step fails.
             with suppress(OSError):
@@ -569,6 +574,7 @@ class SendspinAirPlayBridge:
                 with suppress(Exception):
                     await self._set_sink_fd(None)
                 return False
+            self._log_generation_phase(gen, "primed", started_at)
             if asyncio.current_task() is not self._airplay_stream_start_task:
                 # A newer stream start already owns the bridge; abandon this
                 # generation. Do NOT close fifo_fd here: it was published as
@@ -581,6 +587,7 @@ class SendspinAirPlayBridge:
                 return False
             await stream.start_generation(gen, 0, start_unix_ms)
             self._generation_started = True
+            self._log_generation_phase(gen, "commit", started_at)
             self.logger.info(
                 "Bridge warm handover for %s (generation=%d, start_unix_ms=%d)",
                 self.airplay_player.display_name,
@@ -597,14 +604,21 @@ class SendspinAirPlayBridge:
                 await self._set_sink_fd(None)
             return False
         finally:
-            if not opened:
-                # Unblock a writer-open still pending on a failed pipe by briefly
-                # opening the read side, then remove the pipe node either way.
-                with suppress(OSError):
-                    os.close(os.open(fifo, os.O_RDONLY | os.O_NONBLOCK))
-                with suppress(OSError):
-                    await asyncio.to_thread(os.unlink, fifo)
+            with suppress(OSError):
+                os.close(os.open(fifo, os.O_WRONLY | os.O_NONBLOCK))
+            with suppress(OSError):
+                await asyncio.to_thread(os.unlink, fifo)
         return True
+
+    def _log_generation_phase(self, generation: int, phase: str, started_at: float) -> None:
+        """Log a bridge generation phase with elapsed staging time."""
+        self.logger.debug(
+            "AirPlay bridge generation: player=%s generation=%d phase=%s elapsed=%.3fs",
+            self.airplay_player.player_id,
+            generation,
+            phase,
+            time.monotonic() - started_at,
+        )
 
     def _on_volume_change(self, volume: int) -> None:
         """Forward volume changes to the AirPlay player."""

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -547,6 +547,7 @@ class SendspinAirPlayBridge:
         gen = stream.next_generation()
         fifo = f"/tmp/ma-bridge-{self.airplay_player.player_id}-{gen}.pcm"  # noqa: S108
         started_at = time.monotonic()
+        commit_attempted = False
         try:
             with suppress(FileNotFoundError):
                 await asyncio.to_thread(os.unlink, fifo)
@@ -567,13 +568,7 @@ class SendspinAirPlayBridge:
             # now prefill the pipe while the generation primes.
             self._airplay_stream_ready.set()
             if not await stream.wait_generation_primed(gen):
-                self.logger.warning(
-                    "Generation prime timed out for %s, falling back to a cold restart",
-                    self.airplay_player.display_name,
-                )
-                with suppress(Exception):
-                    await self._set_sink_fd(None)
-                return False
+                raise RuntimeError(f"generation {gen} prime timed out")
             self._log_generation_phase(gen, "primed", started_at)
             if asyncio.current_task() is not self._airplay_stream_start_task:
                 # A newer stream start already owns the bridge; abandon this
@@ -584,7 +579,9 @@ class SendspinAirPlayBridge:
                 # lifecycle is owned by _set_sink_fd / teardown, not this task.
                 # The binary safely collapses a superseded staged generation on
                 # its next PREPARE.
+                await self._discard_warm_generation(stream, gen, started_at)
                 return False
+            commit_attempted = True
             await stream.start_generation(gen, 0, start_unix_ms)
             self._generation_started = True
             self._log_generation_phase(gen, "commit", started_at)
@@ -600,6 +597,8 @@ class SendspinAirPlayBridge:
                 self.airplay_player.display_name,
                 err,
             )
+            if not commit_attempted:
+                await self._discard_warm_generation(stream, gen, started_at)
             with suppress(Exception):
                 await self._set_sink_fd(None)
             return False
@@ -609,6 +608,22 @@ class SendspinAirPlayBridge:
             with suppress(OSError):
                 await asyncio.to_thread(os.unlink, fifo)
         return True
+
+    async def _discard_warm_generation(
+        self, stream: AirPlayStream, generation: int, started_at: float
+    ) -> None:
+        """Best-effort discard a bridge generation staged before START."""
+        try:
+            await stream.discard_generation(generation)
+        except Exception as err:
+            self.logger.warning(
+                "Could not discard staged AirPlay generation %d for %s: %s",
+                generation,
+                self.airplay_player.display_name,
+                err,
+            )
+            return
+        self._log_generation_phase(generation, "discard", started_at)
 
     def _log_generation_phase(self, generation: int, phase: str, started_at: float) -> None:
         """Log a bridge generation phase with elapsed staging time."""

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -895,7 +895,7 @@ class SendspinAirPlayBridge:
         try:
             await self._set_sink_fd(fd)
         except BaseException:
-            if self._sink_fd is fd:
+            if self._sink_fd == fd:
                 await self._release_sink_fd(fd)
             else:
                 _close_fd(fd)
@@ -903,7 +903,7 @@ class SendspinAirPlayBridge:
 
     async def _release_sink_fd(self, fd: int) -> None:
         """Release a fifo descriptor currently owned by the bridge sink."""
-        if self._sink_fd is not fd:
+        if self._sink_fd != fd:
             return
         try:
             await self._set_sink_fd(None)
@@ -913,7 +913,7 @@ class SendspinAirPlayBridge:
                 self.airplay_player.display_name,
                 err,
             )
-            if self._sink_fd is fd:
+            if self._sink_fd == fd:
                 self._sink_fd = None
                 _close_fd(fd)
 

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -490,29 +490,8 @@ class SendspinAirPlayBridge:
             # for cleanup. If we assigned it earlier, the new stream would be missed
             # and leaked. Only publish once start() succeeds and this task is current.
             new_stream = AirPlayStream(self.airplay_player)
-            try:
-                await new_stream.start()
-                await new_stream.wait_for_connection()
-                if asyncio.current_task() is not self._airplay_stream_start_task:
-                    await new_stream.stop(force=True)
-                    return
-                self._airplay_stream = new_stream
-                self.airplay_player.stream = new_stream
-                await new_stream.prepare_generation(0, "-", 0)
-                if not await new_stream.wait_generation_ready(0):
-                    raise RuntimeError("generation 0 reader ready timed out")
-                self._airplay_stream_ready.set()
-                if not await new_stream.wait_generation_primed(0):
-                    raise RuntimeError("generation 0 prime timed out")
-                if asyncio.current_task() is not self._airplay_stream_start_task:
-                    await new_stream.stop(force=True)
-                    return
-                await new_stream.start_generation(0, 0, start_unix_ms)
-                self._generation_started = True
-            except BaseException:
-                with suppress(Exception):
-                    await new_stream.stop(force=True)
-                raise
+            if not await self._start_cold_generation(new_stream, start_unix_ms):
+                return
             self.logger.info(
                 "Bridge protocol started for %s (start_unix_ms=%s, lookahead=%.0fms)",
                 self.airplay_player.display_name,
@@ -529,6 +508,46 @@ class SendspinAirPlayBridge:
             self._is_streaming = False
             self._airplay_stream_ready.set()
             self._schedule_cleanup()
+
+    async def _start_cold_generation(self, stream: AirPlayStream, start_unix_ms: int) -> bool:
+        """
+        Connect and commit generation 0 for a new bridge transport.
+
+        :param stream: New AirPlay stream to start.
+        :param start_unix_ms: Audible-start instant for generation 0.
+        :return: True when generation 0 commits, False when superseded.
+        """
+        generation_prepared = False
+        commit_attempted = False
+        try:
+            await stream.start()
+            await stream.wait_for_connection()
+            if asyncio.current_task() is not self._airplay_stream_start_task:
+                await stream.stop(force=True)
+                return False
+            self._airplay_stream = stream
+            self.airplay_player.stream = stream
+            generation_prepared = True
+            await stream.prepare_generation(0, "-", 0)
+            if not await stream.wait_generation_ready(0):
+                raise RuntimeError("generation 0 reader ready timed out")
+            self._airplay_stream_ready.set()
+            if not await stream.wait_generation_primed(0):
+                raise RuntimeError("generation 0 prime timed out")
+            if asyncio.current_task() is not self._airplay_stream_start_task:
+                await self._discard_generation(stream, 0)
+                await stream.stop(force=True)
+                return False
+            commit_attempted = True
+            await stream.start_generation(0, 0, start_unix_ms)
+            self._generation_started = True
+        except BaseException:
+            if generation_prepared and not commit_attempted:
+                await self._discard_generation(stream, 0)
+            with suppress(Exception):
+                await stream.stop(force=True)
+            raise
+        return True
 
     async def _start_warm_generation(self, stream: AirPlayStream, start_unix_ms: int) -> bool:
         """
@@ -579,7 +598,7 @@ class SendspinAirPlayBridge:
                 # lifecycle is owned by _set_sink_fd / teardown, not this task.
                 # The binary safely collapses a superseded staged generation on
                 # its next PREPARE.
-                await self._discard_warm_generation(stream, gen, started_at)
+                await self._discard_generation(stream, gen, started_at)
                 return False
             commit_attempted = True
             await stream.start_generation(gen, 0, start_unix_ms)
@@ -591,6 +610,12 @@ class SendspinAirPlayBridge:
                 gen,
                 start_unix_ms,
             )
+        except asyncio.CancelledError:
+            if not commit_attempted:
+                await self._discard_generation(stream, gen, started_at)
+            with suppress(Exception):
+                await self._set_sink_fd(None)
+            raise
         except Exception as err:
             self.logger.warning(
                 "Warm handover failed for %s (%r), falling back to a cold restart",
@@ -598,7 +623,7 @@ class SendspinAirPlayBridge:
                 err,
             )
             if not commit_attempted:
-                await self._discard_warm_generation(stream, gen, started_at)
+                await self._discard_generation(stream, gen, started_at)
             with suppress(Exception):
                 await self._set_sink_fd(None)
             return False
@@ -609,8 +634,11 @@ class SendspinAirPlayBridge:
                 await asyncio.to_thread(os.unlink, fifo)
         return True
 
-    async def _discard_warm_generation(
-        self, stream: AirPlayStream, generation: int, started_at: float
+    async def _discard_generation(
+        self,
+        stream: AirPlayStream,
+        generation: int,
+        started_at: float | None = None,
     ) -> None:
         """Best-effort discard a bridge generation staged before START."""
         try:
@@ -623,7 +651,8 @@ class SendspinAirPlayBridge:
                 err,
             )
             return
-        self._log_generation_phase(generation, "discard", started_at)
+        if started_at is not None:
+            self._log_generation_phase(generation, "discard", started_at)
 
     def _log_generation_phase(self, generation: int, phase: str, started_at: float) -> None:
         """Log a bridge generation phase with elapsed staging time."""

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -154,6 +154,21 @@ def _unlink_fifo(path: str) -> None:
         Path(path).unlink()
 
 
+async def _create_fifo(path: str) -> None:
+    """Create a fresh fifo path."""
+    with suppress(FileNotFoundError):
+        await asyncio.to_thread(os.unlink, path)
+    await asyncio.to_thread(os.mkfifo, path)
+
+
+async def _cleanup_fifo(path: str) -> None:
+    """Unblock any fifo reader and remove its path."""
+    with suppress(OSError):
+        _close_fd(os.open(path, os.O_WRONLY | os.O_NONBLOCK))
+    with suppress(OSError):
+        await asyncio.to_thread(os.unlink, path)
+
+
 class SendspinAirPlayBridge:
     """
     Manages the Sendspin to AirPlay bridge for a single player.
@@ -580,10 +595,9 @@ class SendspinAirPlayBridge:
         started_at = time.monotonic()
         commit_attempted = False
         fifo_fd: int | None = None
+        published_fd: int | None = None
         try:
-            with suppress(FileNotFoundError):
-                await asyncio.to_thread(os.unlink, fifo)
-            await asyncio.to_thread(os.mkfifo, fifo)
+            await _create_fifo(fifo)
             await stream.prepare_generation(gen, fifo, 0)
             self._log_generation_phase(gen, "prepare-delivered", started_at)
             if not await stream.wait_generation_ready(gen):
@@ -593,7 +607,13 @@ class SendspinAirPlayBridge:
             # Both ends now hold the fifo open; drop the directory entry right away
             # so no stale pipe nodes accumulate even if a later step fails.
             _unlink_fifo(fifo)
-            await self._publish_sink_fd(fifo_fd)
+            try:
+                await self._publish_sink_fd(fifo_fd)
+            except BaseException:
+                fifo_fd = None
+                raise
+            published_fd = fifo_fd
+            fifo_fd = None
             self._log_generation_phase(gen, "writer-open", started_at)
             # Unblocks the writer task, which was waiting on this event; it can
             # now prefill the pipe while the generation primes.
@@ -618,6 +638,8 @@ class SendspinAirPlayBridge:
                 start_unix_ms,
             )
         except asyncio.CancelledError:
+            if published_fd is not None:
+                await self._release_sink_fd(published_fd)
             if not commit_attempted:
                 await self._discard_generation(stream, gen, started_at)
             raise
@@ -627,15 +649,14 @@ class SendspinAirPlayBridge:
                 gen,
                 started_at,
                 err,
-                fifo_fd,
+                published_fd,
                 discard=not commit_attempted,
             )
             return False
         finally:
-            with suppress(OSError):
-                os.close(os.open(fifo, os.O_WRONLY | os.O_NONBLOCK))
-            with suppress(OSError):
-                await asyncio.to_thread(os.unlink, fifo)
+            if fifo_fd is not None:
+                _close_fd(fifo_fd)
+            await _cleanup_fifo(fifo)
         return True
 
     async def _handle_warm_generation_failure(
@@ -644,7 +665,7 @@ class SendspinAirPlayBridge:
         generation: int,
         started_at: float,
         error: Exception,
-        fifo_fd: int | None,
+        published_fd: int | None,
         *,
         discard: bool,
     ) -> None:
@@ -654,11 +675,10 @@ class SendspinAirPlayBridge:
             self.airplay_player.display_name,
             error,
         )
+        if published_fd is not None:
+            await self._release_sink_fd(published_fd)
         if discard:
             await self._discard_generation(stream, generation, started_at)
-        if fifo_fd is not None and self._sink_fd is fifo_fd:
-            with suppress(Exception):
-                await self._set_sink_fd(None)
 
     async def _discard_generation(
         self,
@@ -875,9 +895,27 @@ class SendspinAirPlayBridge:
         try:
             await self._set_sink_fd(fd)
         except BaseException:
-            if self._sink_fd is not fd:
+            if self._sink_fd is fd:
+                await self._release_sink_fd(fd)
+            else:
                 _close_fd(fd)
             raise
+
+    async def _release_sink_fd(self, fd: int) -> None:
+        """Release a fifo descriptor currently owned by the bridge sink."""
+        if self._sink_fd is not fd:
+            return
+        try:
+            await self._set_sink_fd(None)
+        except BaseException as err:
+            self.logger.warning(
+                "Could not release AirPlay bridge sink for %s: %s",
+                self.airplay_player.display_name,
+                err,
+            )
+            if self._sink_fd is fd:
+                self._sink_fd = None
+                _close_fd(fd)
 
     async def _set_sink_fd(self, fd: int | None) -> None:
         """
@@ -889,8 +927,7 @@ class SendspinAirPlayBridge:
         old_fd = self._sink_fd
         self._sink_fd = fd
         if old_fd is not None:
-            with suppress(OSError):
-                await asyncio.to_thread(os.close, old_fd)
+            _close_fd(old_fd)
 
     async def _write_to_sink(self, fd: int, data: bytes) -> None:
         """

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
 from music_assistant_models.enums import PlaybackState
+from music_assistant_models.errors import PlayerCommandFailed
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.images import get_image_thumb_path
@@ -268,10 +269,26 @@ class AirPlayStream:
             raise RuntimeError("Cannot prepare a generation without a connected cliairplay process")
         self._gen_ready.setdefault(generation, asyncio.Event())
         self._gen_primed.setdefault(generation, asyncio.Event())
-        await self._write_cli_command(
+        command_delivered = await self._write_cli_command(
             f"GENERATION={generation}\nAUDIO={audio_path}\n"
             f"POSITION_MS={position_ms}\nACTION=PREPARE"
         )
+        if not command_delivered:
+            raise PlayerCommandFailed(
+                f"Could not deliver PREPARE for generation {generation} "
+                f"to AirPlay player {self.player.player_id}"
+            )
+
+    async def wait_generation_ready(self, generation: int, timeout: float = 5.0) -> bool:
+        """Wait until the staged generation has opened its audio source."""
+        event = self._gen_ready.get(generation)
+        if event is None:
+            return False
+        try:
+            await asyncio.wait_for(event.wait(), timeout)
+        except TimeoutError:
+            return False
+        return True
 
     async def wait_generation_primed(self, generation: int, timeout: float = 8.0) -> bool:
         """Wait until the staged generation has buffered enough to start."""

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -274,6 +274,8 @@ class AirPlayStream:
             f"POSITION_MS={position_ms}\nACTION=PREPARE"
         )
         if not command_delivered:
+            self._gen_ready.pop(generation, None)
+            self._gen_primed.pop(generation, None)
             raise PlayerCommandFailed(
                 f"Could not deliver PREPARE for generation {generation} "
                 f"to AirPlay player {self.player.player_id}"

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -290,6 +290,24 @@ class AirPlayStream:
             return False
         return True
 
+    async def discard_generation(self, generation: int) -> None:
+        """
+        Retire a staged generation without disturbing active playback.
+
+        :param generation: Staged generation number to retire.
+        :raises PlayerCommandFailed: If the FLUSH command cannot be delivered.
+        """
+        if generation == self._active_generation:
+            raise RuntimeError(f"Cannot discard active generation {generation}")
+        command_delivered = await self._write_cli_command(f"GENERATION={generation}\nACTION=FLUSH")
+        if not command_delivered:
+            raise PlayerCommandFailed(
+                f"Could not deliver FLUSH for generation {generation} "
+                f"to AirPlay player {self.player.player_id}"
+            )
+        self._gen_ready.pop(generation, None)
+        self._gen_primed.pop(generation, None)
+
     async def wait_generation_primed(self, generation: int, timeout: float = 8.0) -> bool:
         """Wait until the staged generation has buffered enough to start."""
         event = self._gen_primed.get(generation)

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -97,7 +97,7 @@ class AirPlayStream:
         # actually playing (only advances at START). Elapsed/EOF handling keys
         # off the active id so a staged generation never skews them mid-handover.
         self._generation = 0
-        self._active_generation = 0
+        self._active_generation: int | None = None
         self._generation_position: float = 0.0
         self._gen_ready: dict[int, asyncio.Event] = {}
         self._gen_primed: dict[int, asyncio.Event] = {}
@@ -269,13 +269,16 @@ class AirPlayStream:
             raise RuntimeError("Cannot prepare a generation without a connected cliairplay process")
         self._gen_ready.setdefault(generation, asyncio.Event())
         self._gen_primed.setdefault(generation, asyncio.Event())
-        command_delivered = await self._write_cli_command(
-            f"GENERATION={generation}\nAUDIO={audio_path}\n"
-            f"POSITION_MS={position_ms}\nACTION=PREPARE"
-        )
+        try:
+            command_delivered = await self._write_cli_command(
+                f"GENERATION={generation}\nAUDIO={audio_path}\n"
+                f"POSITION_MS={position_ms}\nACTION=PREPARE"
+            )
+        except BaseException:
+            self._remove_generation_events(generation)
+            raise
         if not command_delivered:
-            self._gen_ready.pop(generation, None)
-            self._gen_primed.pop(generation, None)
+            self._remove_generation_events(generation)
             raise PlayerCommandFailed(
                 f"Could not deliver PREPARE for generation {generation} "
                 f"to AirPlay player {self.player.player_id}"
@@ -301,14 +304,17 @@ class AirPlayStream:
         """
         if generation == self._active_generation:
             raise RuntimeError(f"Cannot discard active generation {generation}")
-        command_delivered = await self._write_cli_command(f"GENERATION={generation}\nACTION=FLUSH")
-        if not command_delivered:
-            raise PlayerCommandFailed(
-                f"Could not deliver FLUSH for generation {generation} "
-                f"to AirPlay player {self.player.player_id}"
+        try:
+            command_delivered = await self._write_cli_command(
+                f"GENERATION={generation}\nACTION=FLUSH"
             )
-        self._gen_ready.pop(generation, None)
-        self._gen_primed.pop(generation, None)
+            if not command_delivered:
+                raise PlayerCommandFailed(
+                    f"Could not deliver FLUSH for generation {generation} "
+                    f"to AirPlay player {self.player.player_id}"
+                )
+        finally:
+            self._remove_generation_events(generation)
 
     async def wait_generation_primed(self, generation: int, timeout: float = 8.0) -> bool:
         """Wait until the staged generation has buffered enough to start."""
@@ -785,6 +791,11 @@ class AirPlayStream:
             return int(line.split("generation=")[1].split(maxsplit=1)[0])
         except ValueError, IndexError:
             return -1
+
+    def _remove_generation_events(self, generation: int) -> None:
+        """Remove readiness bookkeeping for a generation that cannot be used."""
+        self._gen_ready.pop(generation, None)
+        self._gen_primed.pop(generation, None)
 
     def _update_elapsed(self, elapsed_time: float) -> None:
         """Update elapsed time against the active generation's media position."""

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -87,7 +87,8 @@ class AirPlayStreamSession:
             self._shared_ptp_resolved = True
         self.wait_start = max(p.wait_start for p in self.sync_clients) / 1000
         position_ms = int((self.media.elapsed_time or 0) * 1000)
-        generations = {player.player_id: 0 for player in self.sync_clients}
+        generations: dict[str, int] = {}
+        commit_attempted = False
         try:
             async with asyncio.TaskGroup() as task_group:
                 for player in self.sync_clients:
@@ -95,11 +96,7 @@ class AirPlayStreamSession:
             await asyncio.gather(
                 *[p.stream.wait_for_connection() for p in self.sync_clients if p.stream]
             )
-            async with asyncio.TaskGroup() as task_group:
-                for player in self.sync_clients:
-                    stream = player.stream
-                    assert stream
-                    task_group.create_task(stream.prepare_generation(0, "-", position_ms))
+            await self._prepare_initial_generations(generations, position_ms)
             ready = await asyncio.gather(
                 *[p.stream.wait_generation_ready(0) for p in self.sync_clients if p.stream]
             )
@@ -111,12 +108,17 @@ class AirPlayStreamSession:
             )
             if not all(primed):
                 raise PlayerCommandFailed("generation prime timeout")
+            commit_attempted = True
             await self._commit_generations(generations, position_ms)
         except asyncio.CancelledError:
+            if not commit_attempted:
+                await self._discard_generations(generations)
             await self.stop()
             raise
         except Exception as err:
             # playback failed to start, cleanup
+            if not commit_attempted:
+                await self._discard_generations(generations)
             await self.stop()
             raise PlayerCommandFailed("Playback failed to start") from err
 
@@ -210,12 +212,16 @@ class AirPlayStreamSession:
             for player_id, generation in generations.items():
                 self._log_generation_phase(player_id, generation, "commit", started_at)
             committed = True
+        except asyncio.CancelledError:
+            if not commit_attempted:
+                await self._discard_generations(generations, started_at)
+            raise
         except Exception as err:
             self.prov.logger.warning(
                 "Warm replacement failed (%r); falling back to a cold restart", err
             )
             if not commit_attempted:
-                await self._discard_warm_generations(generations, started_at)
+                await self._discard_generations(generations, started_at)
             return False
         finally:
             for fifo_fd in writer_fds.values():
@@ -456,6 +462,7 @@ class AirPlayStreamSession:
                 if buffered_pcm:
                     await self._write_chunk_to_player(airplay_player, buffered_pcm)
             except asyncio.CancelledError:
+                await self._discard_generation(airplay_player, stream, 0)
                 await self.stop_client(airplay_player, reason="late joiner prepare cancelled")
                 raise
             except Exception as err:
@@ -464,6 +471,7 @@ class AirPlayStreamSession:
                     airplay_player.player_id,
                     err,
                 )
+                await self._discard_generation(airplay_player, stream, 0)
                 await self.stop_client(airplay_player, reason="late joiner start/prime failed")
                 return
 
@@ -477,9 +485,11 @@ class AirPlayStreamSession:
                 )
                 self._warn_degraded_shared_ptp(ap2_members)
 
+        commit_attempted = False
         try:
             if not await stream.wait_generation_primed(0):
                 raise PlayerCommandFailed("generation prime timeout")
+            commit_attempted = True
             await self._commit_generations(
                 {airplay_player.player_id: 0},
                 position_ms,
@@ -487,6 +497,8 @@ class AirPlayStreamSession:
                 reanchor_session=False,
             )
         except asyncio.CancelledError:
+            if not commit_attempted:
+                await self._discard_generation(airplay_player, stream, 0)
             await self.remove_client(airplay_player, reason="late joiner prime cancelled")
             raise
         except Exception as err:
@@ -495,6 +507,8 @@ class AirPlayStreamSession:
                 airplay_player.player_id,
                 err,
             )
+            if not commit_attempted:
+                await self._discard_generation(airplay_player, stream, 0)
             await self.remove_client(airplay_player, reason="late joiner prime failed")
             return
         self.prov.logger.debug(
@@ -836,6 +850,24 @@ class AirPlayStreamSession:
             generations[player.player_id] = generation
             fifos[player.player_id] = fifo
 
+    async def _prepare_initial_generations(
+        self, generations: dict[str, int], position_ms: int
+    ) -> None:
+        """Deliver every generation-0 PREPARE before surfacing a startup failure."""
+        streams: list[AirPlayStream] = []
+        for player in self.sync_clients:
+            stream = player.stream
+            assert stream
+            generations[player.player_id] = 0
+            streams.append(stream)
+        results = await asyncio.gather(
+            *[stream.prepare_generation(0, "-", position_ms) for stream in streams],
+            return_exceptions=True,
+        )
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
+
     async def _prepare_warm_generations(
         self,
         generations: dict[str, int],
@@ -899,31 +931,46 @@ class AirPlayStreamSession:
             )
         self._log_generation_phase(player.player_id, generation, "primed", started_at)
 
-    async def _discard_warm_generations(
-        self, generations: dict[str, int], started_at: float
+    async def _discard_generations(
+        self, generations: dict[str, int], started_at: float | None = None
     ) -> None:
         """Best-effort discard every generation staged before shared START."""
-        streams: dict[str, AirPlayStream] = {}
+        members: dict[str, tuple[AirPlayPlayer, AirPlayStream]] = {}
         for player in self.sync_clients:
             if player.stream is not None:
-                streams[player.player_id] = player.stream
-        player_ids = [player_id for player_id in generations if player_id in streams]
-        results = await asyncio.gather(
+                members[player.player_id] = (player, player.stream)
+        player_ids = [player_id for player_id in generations if player_id in members]
+        await asyncio.gather(
             *[
-                streams[player_id].discard_generation(generations[player_id])
-                for player_id in player_ids
-            ],
-            return_exceptions=True,
-        )
-        for player_id, result in zip(player_ids, results, strict=True):
-            if isinstance(result, BaseException):
-                self.prov.logger.warning(
-                    "Could not discard staged AirPlay generation for player %s: %s",
-                    player_id,
-                    result,
+                self._discard_generation(
+                    members[player_id][0],
+                    members[player_id][1],
+                    generations[player_id],
+                    started_at,
                 )
-                continue
-            self._log_generation_phase(player_id, generations[player_id], "discard", started_at)
+                for player_id in player_ids
+            ]
+        )
+
+    async def _discard_generation(
+        self,
+        player: AirPlayPlayer,
+        stream: AirPlayStream,
+        generation: int,
+        started_at: float | None = None,
+    ) -> None:
+        """Best-effort discard one generation staged before START."""
+        try:
+            await stream.discard_generation(generation)
+        except Exception as err:
+            self.prov.logger.warning(
+                "Could not discard staged AirPlay generation for player %s: %s",
+                player.player_id,
+                err,
+            )
+            return
+        if started_at is not None:
+            self._log_generation_phase(player.player_id, generation, "discard", started_at)
 
     def _log_generation_phase(
         self, player_id: str, generation: int, phase: str, started_at: float

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -15,6 +15,7 @@ from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant.constants import CONF_SYNC_ADJUST
 from music_assistant.controllers.streams.audio_processing import get_media_session_id
 from music_assistant.helpers.ffmpeg import FFMpeg
+from music_assistant.helpers.named_pipe import open_named_pipe_writer
 
 from .constants import AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS, StreamingProtocol
 from .helpers import get_final_output_format
@@ -99,6 +100,11 @@ class AirPlayStreamSession:
                     stream = player.stream
                     assert stream
                     task_group.create_task(stream.prepare_generation(0, "-", position_ms))
+            ready = await asyncio.gather(
+                *[p.stream.wait_generation_ready(0) for p in self.sync_clients if p.stream]
+            )
+            if not all(ready):
+                raise PlayerCommandFailed("generation reader ready timeout")
             self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
             primed = await asyncio.gather(
                 *[p.stream.wait_generation_primed(0) for p in self.sync_clients if p.stream]
@@ -147,8 +153,10 @@ class AirPlayStreamSession:
         position_ms = int((media.elapsed_time or 0) * 1000)
         generations: dict[str, int] = {}
         fifos: dict[str, str] = {}
+        writer_fds: dict[str, int] = {}
+        started_at = time.monotonic()
+        committed = False
         try:
-            # stage the new generation on every member (old audio unaffected)
             for player in self.sync_clients:
                 stream = player.stream
                 assert stream
@@ -159,16 +167,41 @@ class AirPlayStreamSession:
                 await asyncio.to_thread(os.mkfifo, fifo)
                 generations[player.player_id] = gen
                 fifos[player.player_id] = fifo
-                await stream.prepare_generation(gen, fifo, position_ms)
 
-            # swap the source: retire the old flow + per-player DSP ffmpegs,
-            # spawn fresh ones writing into the generation pipes
+            async with asyncio.TaskGroup() as task_group:
+                for player in self.sync_clients:
+                    task_group.create_task(
+                        self._prepare_warm_generation(
+                            player,
+                            generations[player.player_id],
+                            fifos[player.player_id],
+                            position_ms,
+                            started_at,
+                        )
+                    )
+            async with asyncio.TaskGroup() as task_group:
+                for player in self.sync_clients:
+                    task_group.create_task(
+                        self._wait_warm_generation_ready(
+                            player,
+                            generations[player.player_id],
+                            started_at,
+                        )
+                    )
+
+            for player in self.sync_clients:
+                player_id = player.player_id
+                writer_fds[player_id] = await open_named_pipe_writer(fifos[player_id])
+                self._log_generation_phase(
+                    player_id, generations[player_id], "writer-open", started_at
+                )
+
             if self._audio_source_task and not self._audio_source_task.done():
                 self._audio_source_task.cancel()
                 with suppress(asyncio.CancelledError):
                     await self._audio_source_task
             for player in self.sync_clients:
-                await self._start_generation_ffmpeg(player, fifos[player.player_id], media)
+                await self._start_generation_ffmpeg(player, writer_fds.pop(player.player_id), media)
             self.media = media
             # The stream position counter and the late-join prime buffer both
             # describe the OLD generation's timeline; restart them before the
@@ -177,27 +210,35 @@ class AirPlayStreamSession:
             self._pcm_buffer.clear()
             self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
 
-            primed = await asyncio.gather(
-                *[
-                    p.stream.wait_generation_primed(generations[p.player_id])
-                    for p in self.sync_clients
-                    if p.stream
-                ]
-            )
-            if not all(primed):
-                raise PlayerCommandFailed("generation prime timeout")
+            async with asyncio.TaskGroup() as task_group:
+                for player in self.sync_clients:
+                    task_group.create_task(
+                        self._wait_warm_generation_primed(
+                            player,
+                            generations[player.player_id],
+                            started_at,
+                        )
+                    )
             await self._commit_generations(generations, position_ms)
+            for player_id, generation in generations.items():
+                self._log_generation_phase(player_id, generation, "commit", started_at)
+            committed = True
         except Exception as err:
             self.prov.logger.warning(
                 "Warm replacement failed (%r); falling back to a cold restart", err
             )
             return False
         finally:
-            for fifo in fifos.values():
-                # Unblock any writer-open still pending on a failed pipe by
-                # briefly opening the read side, then remove the pipe node.
+            for fifo_fd in writer_fds.values():
                 with suppress(OSError):
-                    os.close(os.open(fifo, os.O_RDONLY | os.O_NONBLOCK))
+                    os.close(fifo_fd)
+            for fifo in fifos.values():
+                if not committed:
+                    # Give a staged reader EOF before removing its path. There is no
+                    # generation-cancel command; the caller tears down the persistent
+                    # stream immediately after this method returns False.
+                    with suppress(OSError):
+                        os.close(os.open(fifo, os.O_WRONLY | os.O_NONBLOCK))
                 with suppress(OSError):
                     await asyncio.to_thread(os.unlink, fifo)
         return True
@@ -422,6 +463,8 @@ class AirPlayStreamSession:
 
             try:
                 await stream.prepare_generation(0, "-", position_ms)
+                if not await stream.wait_generation_ready(0):
+                    raise PlayerCommandFailed("generation reader ready timeout")
                 if buffered_pcm:
                     await self._write_chunk_to_player(airplay_player, buffered_pcm)
             except asyncio.CancelledError:
@@ -746,36 +789,36 @@ class AirPlayStreamSession:
             self.start_time = start_unix_ms / 1000
 
     async def _start_generation_ffmpeg(
-        self, player: AirPlayPlayer, fifo: str, media: PlayerMedia
+        self, player: AirPlayPlayer, fifo_fd: int, media: PlayerMedia
     ) -> None:
         """
         Start the per-player DSP ffmpeg for a staged generation.
 
         Retires the player's previous ffmpeg and spawns a fresh one writing
-        into the generation's pipe. The pipe's write side is opened here and
-        handed to ffmpeg as an inherited descriptor (like the stdin case in
-        ``_start_client``) because ffmpeg refuses to open an existing path.
-        The open pairs with the read side the binary opened at PREPARE.
+        into the prepared generation pipe.
+
+        :param player: AirPlay player receiving the generation.
+        :param fifo_fd: Blocking write descriptor paired with the prepared reader.
+        :param media: Media that owns the new generation.
         """
-        if ffmpeg := self._player_ffmpeg.pop(player.player_id, None):
-            # Kill, not close: a graceful close waits for the old ffmpeg to
-            # drain its buffered audio into the binary at playback speed
-            # (seconds), and that audio is superseded anyway. The binary keeps
-            # playing the old generation from its own ring until START lands.
-            await ffmpeg.kill()
-        stream = player.stream
-        assert stream
-        handoff_format = stream.pcm_format
-        output_plan = self.mass.streams.audio.get_player_output_plan(
-            player.player_id,
-            input_format=self.pcm_format,
-            output_format=get_final_output_format(handoff_format, player),
-            handoff_format=handoff_format,
-            queue_id=media.source_id,
-            session_id=get_media_session_id(media),
-        )
-        fifo_fd = await asyncio.wait_for(asyncio.to_thread(os.open, fifo, os.O_WRONLY), timeout=5)
         try:
+            if ffmpeg := self._player_ffmpeg.pop(player.player_id, None):
+                # Kill, not close: a graceful close waits for the old ffmpeg to
+                # drain its buffered audio into the binary at playback speed
+                # (seconds), and that audio is superseded anyway. The binary keeps
+                # playing the old generation from its own ring until START lands.
+                await ffmpeg.kill()
+            stream = player.stream
+            assert stream
+            handoff_format = stream.pcm_format
+            output_plan = self.mass.streams.audio.get_player_output_plan(
+                player.player_id,
+                input_format=self.pcm_format,
+                output_format=get_final_output_format(handoff_format, player),
+                handoff_format=handoff_format,
+                queue_id=media.source_id,
+                session_id=get_media_session_id(media),
+            )
             ffmpeg = FFMpeg(
                 audio_input="-",
                 input_format=self.pcm_format,
@@ -784,8 +827,58 @@ class AirPlayStreamSession:
                 audio_output=fifo_fd,
             )
             await ffmpeg.start()
+            self._player_ffmpeg[player.player_id] = ffmpeg
         finally:
             # the ffmpeg child inherited the descriptor; drop our copy so the
             # pipe sees EOF when ffmpeg exits
             os.close(fifo_fd)
-        self._player_ffmpeg[player.player_id] = ffmpeg
+
+    async def _prepare_warm_generation(
+        self,
+        player: AirPlayPlayer,
+        generation: int,
+        fifo: str,
+        position_ms: int,
+        started_at: float,
+    ) -> None:
+        """Deliver PREPARE for one member without changing its active generation."""
+        stream = player.stream
+        assert stream
+        await stream.prepare_generation(generation, fifo, position_ms)
+        self._log_generation_phase(player.player_id, generation, "prepare-delivered", started_at)
+
+    async def _wait_warm_generation_ready(
+        self, player: AirPlayPlayer, generation: int, started_at: float
+    ) -> None:
+        """Wait for one member to open its staged generation reader."""
+        stream = player.stream
+        assert stream
+        if not await stream.wait_generation_ready(generation):
+            raise PlayerCommandFailed(
+                f"generation {generation} reader ready timeout for {player.player_id}"
+            )
+        self._log_generation_phase(player.player_id, generation, "ready", started_at)
+
+    async def _wait_warm_generation_primed(
+        self, player: AirPlayPlayer, generation: int, started_at: float
+    ) -> None:
+        """Wait for one member to buffer its staged generation."""
+        stream = player.stream
+        assert stream
+        if not await stream.wait_generation_primed(generation):
+            raise PlayerCommandFailed(
+                f"generation {generation} prime timeout for {player.player_id}"
+            )
+        self._log_generation_phase(player.player_id, generation, "primed", started_at)
+
+    def _log_generation_phase(
+        self, player_id: str, generation: int, phase: str, started_at: float
+    ) -> None:
+        """Log a warm generation phase with elapsed staging time."""
+        self.prov.logger.debug(
+            "AirPlay warm generation: player=%s generation=%d phase=%s elapsed=%.3fs",
+            player_id,
+            generation,
+            phase,
+            time.monotonic() - started_at,
+        )

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -156,29 +156,15 @@ class AirPlayStreamSession:
         writer_fds: dict[str, int] = {}
         started_at = time.monotonic()
         committed = False
+        commit_attempted = False
         try:
-            for player in self.sync_clients:
-                stream = player.stream
-                assert stream
-                gen = stream.next_generation()
-                fifo = f"/tmp/ma-gen-{player.player_id}-{gen}.pcm"  # noqa: S108
-                with suppress(FileNotFoundError):
-                    await asyncio.to_thread(os.unlink, fifo)
-                await asyncio.to_thread(os.mkfifo, fifo)
-                generations[player.player_id] = gen
-                fifos[player.player_id] = fifo
-
-            async with asyncio.TaskGroup() as task_group:
-                for player in self.sync_clients:
-                    task_group.create_task(
-                        self._prepare_warm_generation(
-                            player,
-                            generations[player.player_id],
-                            fifos[player.player_id],
-                            position_ms,
-                            started_at,
-                        )
-                    )
+            await self._allocate_warm_generation_fifos(generations, fifos)
+            await self._prepare_warm_generations(
+                generations,
+                fifos,
+                position_ms,
+                started_at,
+            )
             async with asyncio.TaskGroup() as task_group:
                 for player in self.sync_clients:
                     task_group.create_task(
@@ -219,6 +205,7 @@ class AirPlayStreamSession:
                             started_at,
                         )
                     )
+            commit_attempted = True
             await self._commit_generations(generations, position_ms)
             for player_id, generation in generations.items():
                 self._log_generation_phase(player_id, generation, "commit", started_at)
@@ -227,6 +214,8 @@ class AirPlayStreamSession:
             self.prov.logger.warning(
                 "Warm replacement failed (%r); falling back to a cold restart", err
             )
+            if not commit_attempted:
+                await self._discard_warm_generations(generations, started_at)
             return False
         finally:
             for fifo_fd in writer_fds.values():
@@ -234,9 +223,8 @@ class AirPlayStreamSession:
                     os.close(fifo_fd)
             for fifo in fifos.values():
                 if not committed:
-                    # Give a staged reader EOF before removing its path. There is no
-                    # generation-cancel command; the caller tears down the persistent
-                    # stream immediately after this method returns False.
+                    # Give any staged reader EOF before removing its path. FLUSH has
+                    # no positive acknowledgement, so pipe cleanup remains explicit.
                     with suppress(OSError):
                         os.close(os.open(fifo, os.O_WRONLY | os.O_NONBLOCK))
                 with suppress(OSError):
@@ -833,6 +821,46 @@ class AirPlayStreamSession:
             # pipe sees EOF when ffmpeg exits
             os.close(fifo_fd)
 
+    async def _allocate_warm_generation_fifos(
+        self, generations: dict[str, int], fifos: dict[str, str]
+    ) -> None:
+        """Allocate one staged generation FIFO for every session member."""
+        for player in self.sync_clients:
+            stream = player.stream
+            assert stream
+            generation = stream.next_generation()
+            fifo = f"/tmp/ma-gen-{player.player_id}-{generation}.pcm"  # noqa: S108
+            with suppress(FileNotFoundError):
+                await asyncio.to_thread(os.unlink, fifo)
+            await asyncio.to_thread(os.mkfifo, fifo)
+            generations[player.player_id] = generation
+            fifos[player.player_id] = fifo
+
+    async def _prepare_warm_generations(
+        self,
+        generations: dict[str, int],
+        fifos: dict[str, str],
+        position_ms: int,
+        started_at: float,
+    ) -> None:
+        """Deliver every queued PREPARE before surfacing a partial-group failure."""
+        results = await asyncio.gather(
+            *[
+                self._prepare_warm_generation(
+                    player,
+                    generations[player.player_id],
+                    fifos[player.player_id],
+                    position_ms,
+                    started_at,
+                )
+                for player in self.sync_clients
+            ],
+            return_exceptions=True,
+        )
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
+
     async def _prepare_warm_generation(
         self,
         player: AirPlayPlayer,
@@ -870,6 +898,32 @@ class AirPlayStreamSession:
                 f"generation {generation} prime timeout for {player.player_id}"
             )
         self._log_generation_phase(player.player_id, generation, "primed", started_at)
+
+    async def _discard_warm_generations(
+        self, generations: dict[str, int], started_at: float
+    ) -> None:
+        """Best-effort discard every generation staged before shared START."""
+        streams: dict[str, AirPlayStream] = {}
+        for player in self.sync_clients:
+            if player.stream is not None:
+                streams[player.player_id] = player.stream
+        player_ids = [player_id for player_id in generations if player_id in streams]
+        results = await asyncio.gather(
+            *[
+                streams[player_id].discard_generation(generations[player_id])
+                for player_id in player_ids
+            ],
+            return_exceptions=True,
+        )
+        for player_id, result in zip(player_ids, results, strict=True):
+            if isinstance(result, BaseException):
+                self.prov.logger.warning(
+                    "Could not discard staged AirPlay generation for player %s: %s",
+                    player_id,
+                    result,
+                )
+                continue
+            self._log_generation_phase(player_id, generations[player_id], "discard", started_at)
 
     def _log_generation_phase(
         self, player_id: str, generation: int, phase: str, started_at: float

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -804,12 +804,14 @@ class AirPlayStreamSession:
         :param media: Media that owns the new generation.
         """
         try:
-            if ffmpeg := self._player_ffmpeg.pop(player.player_id, None):
+            if ffmpeg := self._player_ffmpeg.get(player.player_id):
                 # Kill, not close: a graceful close waits for the old ffmpeg to
                 # drain its buffered audio into the binary at playback speed
                 # (seconds), and that audio is superseded anyway. The binary keeps
                 # playing the old generation from its own ring until START lands.
                 await ffmpeg.kill()
+                if self._player_ffmpeg.get(player.player_id) is ffmpeg:
+                    self._player_ffmpeg.pop(player.player_id)
             stream = player.stream
             assert stream
             handoff_format = stream.pcm_format

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -586,6 +586,7 @@ async def test_raop_session_resolves_ptp_for_first_ap2_late_joiner() -> None:
         player.stream = MagicMock(running=True)
         player.stream.wait_for_connection = AsyncMock()
         player.stream.prepare_generation = AsyncMock()
+        player.stream.wait_generation_ready = AsyncMock(return_value=True)
         player.stream.wait_generation_primed = AsyncMock(return_value=True)
         player.stream.start_generation = AsyncMock()
 
@@ -611,6 +612,7 @@ async def test_session_start_applies_uniform_ptp_decision_to_all_members() -> No
         player.stream = MagicMock()
         player.stream.wait_for_connection = AsyncMock()
         player.stream.prepare_generation = AsyncMock()
+        player.stream.wait_generation_ready = AsyncMock(return_value=True)
         player.stream.wait_generation_primed = AsyncMock(return_value=True)
         player.stream.start_generation = AsyncMock()
     session = _make_ptp_session(prov, players)
@@ -636,6 +638,7 @@ async def test_session_start_calculates_anchor_after_ptp_resolution() -> None:
         player.stream = MagicMock()
         player.stream.wait_for_connection = AsyncMock()
         player.stream.prepare_generation = AsyncMock()
+        player.stream.wait_generation_ready = AsyncMock(return_value=True)
         player.stream.wait_generation_primed = AsyncMock(return_value=True)
         player.stream.start_generation = AsyncMock()
     session = _make_ptp_session(prov, players)

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -17,6 +17,7 @@ tests are deterministic and independent of the host wall-clock:
 
 import asyncio
 import errno
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -647,13 +648,13 @@ async def test_warm_generation_cancellation_before_sink_publication_closes_fd() 
     ):
         await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
 
-    close_fd.assert_any_call(55)
+    assert sum(call.args == (55,) for call in close_fd.call_args_list) == 1
     kept_stream.discard_generation.assert_awaited_once_with(1)
     assert bridge._sink_fd is None
 
 
-async def test_warm_generation_cancellation_after_sink_publication_keeps_owner_fd() -> None:
-    """Cancellation after publication leaves the active sink under bridge ownership."""
+async def test_warm_generation_cancellation_after_sink_publication_releases_fd() -> None:
+    """Cancellation during sink publication releases the owner-managed fd."""
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     kept_stream = MagicMock()
     kept_stream.next_generation = MagicMock(return_value=1)
@@ -662,9 +663,13 @@ async def test_warm_generation_cancellation_after_sink_publication_keeps_owner_f
     kept_stream.discard_generation = AsyncMock()
     bridge._airplay_stream_start_task = asyncio.current_task()
 
-    async def publish_then_cancel(fd: int) -> None:
+    async def publish_then_cancel(fd: int | None) -> None:
+        old_fd = bridge._sink_fd
         bridge._sink_fd = fd
-        raise asyncio.CancelledError
+        if fd == 77:
+            raise asyncio.CancelledError
+        if old_fd is not None:
+            os.close(old_fd)
 
     with (
         patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
@@ -686,7 +691,82 @@ async def test_warm_generation_cancellation_after_sink_publication_keeps_owner_f
     ):
         await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
 
-    assert bridge._sink_fd == 77
-    assert all(call.args[0] != 77 for call in close_fd.call_args_list)
+    assert bridge._sink_fd is None
+    assert sum(call.args == (77,) for call in close_fd.call_args_list) == 1
     kept_stream.discard_generation.assert_awaited_once_with(1)
-    bridge._sink_fd = None
+
+
+async def test_warm_generation_exception_before_sink_publication_closes_fd() -> None:
+    """A failed sink publication closes its locally owned writer fd once."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    kept_stream = MagicMock()
+    kept_stream.next_generation = MagicMock(return_value=1)
+    kept_stream.prepare_generation = AsyncMock()
+    kept_stream.wait_generation_ready = AsyncMock(return_value=True)
+    kept_stream.discard_generation = AsyncMock()
+    bridge._airplay_stream_start_task = asyncio.current_task()
+
+    with (
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
+            new_callable=AsyncMock,
+            return_value=55,
+        ),
+        patch.object(
+            bridge,
+            "_set_sink_fd",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("swap failed"),
+        ),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=100),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as close_fd,
+    ):
+        assert await bridge._start_warm_generation(kept_stream, 1_784_000_000_000) is False
+
+    assert sum(call.args == (55,) for call in close_fd.call_args_list) == 1
+    kept_stream.discard_generation.assert_awaited_once_with(1)
+    assert bridge._sink_fd is None
+
+
+async def test_warm_generation_exception_after_sink_publication_releases_fd() -> None:
+    """A failed published sink swap releases its owner-managed writer fd once."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    kept_stream = MagicMock()
+    kept_stream.next_generation = MagicMock(return_value=1)
+    kept_stream.prepare_generation = AsyncMock()
+    kept_stream.wait_generation_ready = AsyncMock(return_value=True)
+    kept_stream.discard_generation = AsyncMock()
+    bridge._airplay_stream_start_task = asyncio.current_task()
+
+    async def publish_then_fail(fd: int | None) -> None:
+        old_fd = bridge._sink_fd
+        bridge._sink_fd = fd
+        if fd == 77:
+            raise RuntimeError("swap failed")
+        if old_fd is not None:
+            os.close(old_fd)
+
+    with (
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
+            new_callable=AsyncMock,
+            return_value=77,
+        ),
+        patch.object(
+            bridge,
+            "_set_sink_fd",
+            new_callable=AsyncMock,
+            side_effect=publish_then_fail,
+        ),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=100),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as close_fd,
+    ):
+        assert await bridge._start_warm_generation(kept_stream, 1_784_000_000_000) is False
+
+    assert bridge._sink_fd is None
+    assert sum(call.args == (77,) for call in close_fd.call_args_list) == 1
+    kept_stream.discard_generation.assert_awaited_once_with(1)

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -416,6 +416,7 @@ async def test_warm_generation_commits_on_kept_stream_instance() -> None:
     kept_stream.prepare_generation = AsyncMock()
     kept_stream.wait_generation_ready = AsyncMock(return_value=True)
     kept_stream.wait_generation_primed = AsyncMock(return_value=True)
+    kept_stream.discard_generation = AsyncMock()
     kept_stream.start_generation = AsyncMock()
     bridge._airplay_stream = kept_stream
     bridge._airplay_stream_start_task = asyncio.current_task()
@@ -438,6 +439,7 @@ async def test_warm_generation_commits_on_kept_stream_instance() -> None:
     kept_stream.prepare_generation.assert_awaited_once_with(3, expected_fifo, 0)
     kept_stream.wait_generation_ready.assert_awaited_once_with(3)
     kept_stream.wait_generation_primed.assert_awaited_once_with(3)
+    kept_stream.discard_generation.assert_not_awaited()
     kept_stream.start_generation.assert_awaited_once_with(3, 0, 1_784_000_000_000)
     assert bridge._sink_fd == 99
     assert bridge._airplay_stream_ready.is_set()
@@ -451,6 +453,7 @@ async def test_warm_generation_prime_timeout_falls_back_to_cold_restart() -> Non
     kept_stream.prepare_generation = AsyncMock()
     kept_stream.wait_generation_ready = AsyncMock(return_value=True)
     kept_stream.wait_generation_primed = AsyncMock(return_value=False)
+    kept_stream.discard_generation = AsyncMock()
     kept_stream.start_generation = AsyncMock()
     bridge._airplay_stream = kept_stream
     bridge._airplay_stream_start_task = asyncio.current_task()
@@ -469,6 +472,7 @@ async def test_warm_generation_prime_timeout_falls_back_to_cold_restart() -> Non
         committed = await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
 
     assert committed is False
+    kept_stream.discard_generation.assert_awaited_once_with(1)
     kept_stream.start_generation.assert_not_awaited()
     assert bridge._sink_fd is None  # reverted so the cold-path writer uses stdin again
     mock_close.assert_any_call(55)
@@ -482,6 +486,7 @@ async def test_warm_generation_superseded_before_commit_does_not_start() -> None
     kept_stream.prepare_generation = AsyncMock()
     kept_stream.wait_generation_ready = AsyncMock(return_value=True)
     kept_stream.wait_generation_primed = AsyncMock(return_value=True)
+    kept_stream.discard_generation = AsyncMock()
     kept_stream.start_generation = AsyncMock()
     bridge._airplay_stream = kept_stream
     # Simulate a newer stream start having already replaced the tracked task.
@@ -501,6 +506,7 @@ async def test_warm_generation_superseded_before_commit_does_not_start() -> None
         committed = await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
 
     assert committed is False
+    kept_stream.discard_generation.assert_awaited_once_with(2)
     kept_stream.start_generation.assert_not_awaited()
     # The stale attempt must NOT close the fd: it was published as self._sink_fd,
     # so closing it here would break the writer (EBADF) or double-close a fd a
@@ -516,6 +522,7 @@ async def test_warm_generation_ready_timeout_does_not_open_writer() -> None:
     kept_stream.next_generation = MagicMock(return_value=1)
     kept_stream.prepare_generation = AsyncMock()
     kept_stream.wait_generation_ready = AsyncMock(return_value=False)
+    kept_stream.discard_generation = AsyncMock()
     kept_stream.start_generation = AsyncMock()
     bridge._airplay_stream = kept_stream
     bridge._airplay_stream_start_task = asyncio.current_task()
@@ -535,5 +542,6 @@ async def test_warm_generation_ready_timeout_does_not_open_writer() -> None:
         assert await bridge._start_warm_generation(kept_stream, 1_784_000_000_000) is False
 
     open_writer.assert_not_awaited()
+    kept_stream.discard_generation.assert_awaited_once_with(1)
     kept_stream.start_generation.assert_not_awaited()
     assert bridge._sink_fd is None

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -16,6 +16,7 @@ tests are deterministic and independent of the host wall-clock:
 """
 
 import asyncio
+import errno
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiosendspin.clock import ManualClock
@@ -290,6 +291,7 @@ async def test_cold_start_connects_then_prepares_and_starts_generation_zero() ->
     stream.start = AsyncMock()
     stream.wait_for_connection = AsyncMock()
     stream.prepare_generation = AsyncMock()
+    stream.wait_generation_ready = AsyncMock(return_value=True)
     stream.wait_generation_primed = AsyncMock(return_value=True)
     stream.start_generation = AsyncMock()
 
@@ -308,6 +310,7 @@ async def test_cold_start_connects_then_prepares_and_starts_generation_zero() ->
     stream.start.assert_awaited_once_with()
     stream.wait_for_connection.assert_awaited_once_with()
     stream.prepare_generation.assert_awaited_once_with(0, "-", 0)
+    stream.wait_generation_ready.assert_awaited_once_with(0)
     stream.wait_generation_primed.assert_awaited_once_with(0)
     stream.start_generation.assert_awaited_once_with(0, 0, int(UNIX_NOW_S * 1000) + AP2_LEAD_MS)
     assert bridge._airplay_stream is stream
@@ -411,6 +414,7 @@ async def test_warm_generation_commits_on_kept_stream_instance() -> None:
     kept_stream = MagicMock()
     kept_stream.next_generation = MagicMock(return_value=3)
     kept_stream.prepare_generation = AsyncMock()
+    kept_stream.wait_generation_ready = AsyncMock(return_value=True)
     kept_stream.wait_generation_primed = AsyncMock(return_value=True)
     kept_stream.start_generation = AsyncMock()
     bridge._airplay_stream = kept_stream
@@ -420,13 +424,19 @@ async def test_warm_generation_commits_on_kept_stream_instance() -> None:
     with (
         patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
         patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=99),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
+            new_callable=AsyncMock,
+            return_value=99,
+        ),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=100),
     ):
         committed = await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
 
     assert committed is True
     assert bridge._airplay_stream is kept_stream  # no new instance was built
     kept_stream.prepare_generation.assert_awaited_once_with(3, expected_fifo, 0)
+    kept_stream.wait_generation_ready.assert_awaited_once_with(3)
     kept_stream.wait_generation_primed.assert_awaited_once_with(3)
     kept_stream.start_generation.assert_awaited_once_with(3, 0, 1_784_000_000_000)
     assert bridge._sink_fd == 99
@@ -439,6 +449,7 @@ async def test_warm_generation_prime_timeout_falls_back_to_cold_restart() -> Non
     kept_stream = MagicMock()
     kept_stream.next_generation = MagicMock(return_value=1)
     kept_stream.prepare_generation = AsyncMock()
+    kept_stream.wait_generation_ready = AsyncMock(return_value=True)
     kept_stream.wait_generation_primed = AsyncMock(return_value=False)
     kept_stream.start_generation = AsyncMock()
     bridge._airplay_stream = kept_stream
@@ -447,7 +458,12 @@ async def test_warm_generation_prime_timeout_falls_back_to_cold_restart() -> Non
     with (
         patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
         patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=55),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
+            new_callable=AsyncMock,
+            return_value=55,
+        ),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=100),
         patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as mock_close,
     ):
         committed = await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
@@ -464,6 +480,7 @@ async def test_warm_generation_superseded_before_commit_does_not_start() -> None
     kept_stream = MagicMock()
     kept_stream.next_generation = MagicMock(return_value=2)
     kept_stream.prepare_generation = AsyncMock()
+    kept_stream.wait_generation_ready = AsyncMock(return_value=True)
     kept_stream.wait_generation_primed = AsyncMock(return_value=True)
     kept_stream.start_generation = AsyncMock()
     bridge._airplay_stream = kept_stream
@@ -473,7 +490,12 @@ async def test_warm_generation_superseded_before_commit_does_not_start() -> None
     with (
         patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
         patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=77),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
+            new_callable=AsyncMock,
+            return_value=77,
+        ),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=100),
         patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as mock_close,
     ):
         committed = await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
@@ -485,3 +507,33 @@ async def test_warm_generation_superseded_before_commit_does_not_start() -> None
     # newer task already replaced. Its lifecycle is owned by _set_sink_fd/teardown.
     assert all(call.args[0] != 77 for call in mock_close.call_args_list)
     assert bridge._sink_fd == 77
+
+
+async def test_warm_generation_ready_timeout_does_not_open_writer() -> None:
+    """A missing ready status abandons the staged FIFO before publishing a sink."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    kept_stream = MagicMock()
+    kept_stream.next_generation = MagicMock(return_value=1)
+    kept_stream.prepare_generation = AsyncMock()
+    kept_stream.wait_generation_ready = AsyncMock(return_value=False)
+    kept_stream.start_generation = AsyncMock()
+    bridge._airplay_stream = kept_stream
+    bridge._airplay_stream_start_task = asyncio.current_task()
+
+    with (
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
+            new_callable=AsyncMock,
+        ) as open_writer,
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.os.open",
+            side_effect=OSError(errno.ENXIO, "no reader"),
+        ),
+    ):
+        assert await bridge._start_warm_generation(kept_stream, 1_784_000_000_000) is False
+
+    open_writer.assert_not_awaited()
+    kept_stream.start_generation.assert_not_awaited()
+    assert bridge._sink_fd is None

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -665,8 +665,9 @@ async def test_warm_generation_cancellation_after_sink_publication_releases_fd()
 
     async def publish_then_cancel(fd: int | None) -> None:
         old_fd = bridge._sink_fd
-        bridge._sink_fd = fd
-        if fd == 77:
+        bridge._sink_fd = int(str(fd)) if fd is not None else None
+        if fd == 1000:
+            assert bridge._sink_fd is not fd
             raise asyncio.CancelledError
         if old_fd is not None:
             os.close(old_fd)
@@ -677,7 +678,7 @@ async def test_warm_generation_cancellation_after_sink_publication_releases_fd()
         patch(
             "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
             new_callable=AsyncMock,
-            return_value=77,
+            return_value=1000,
         ),
         patch.object(
             bridge,
@@ -692,7 +693,7 @@ async def test_warm_generation_cancellation_after_sink_publication_releases_fd()
         await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
 
     assert bridge._sink_fd is None
-    assert sum(call.args == (77,) for call in close_fd.call_args_list) == 1
+    assert sum(call.args == (1000,) for call in close_fd.call_args_list) == 1
     kept_stream.discard_generation.assert_awaited_once_with(1)
 
 
@@ -742,8 +743,9 @@ async def test_warm_generation_exception_after_sink_publication_releases_fd() ->
 
     async def publish_then_fail(fd: int | None) -> None:
         old_fd = bridge._sink_fd
-        bridge._sink_fd = fd
-        if fd == 77:
+        bridge._sink_fd = int(str(fd)) if fd is not None else None
+        if fd == 1000:
+            assert bridge._sink_fd is not fd
             raise RuntimeError("swap failed")
         if old_fd is not None:
             os.close(old_fd)
@@ -754,7 +756,7 @@ async def test_warm_generation_exception_after_sink_publication_releases_fd() ->
         patch(
             "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
             new_callable=AsyncMock,
-            return_value=77,
+            return_value=1000,
         ),
         patch.object(
             bridge,
@@ -768,5 +770,5 @@ async def test_warm_generation_exception_after_sink_publication_releases_fd() ->
         assert await bridge._start_warm_generation(kept_stream, 1_784_000_000_000) is False
 
     assert bridge._sink_fd is None
-    assert sum(call.args == (77,) for call in close_fd.call_args_list) == 1
+    assert sum(call.args == (1000,) for call in close_fd.call_args_list) == 1
     kept_stream.discard_generation.assert_awaited_once_with(1)

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -615,3 +615,78 @@ async def test_warm_generation_cancellation_discards_staging() -> None:
 
     kept_stream.discard_generation.assert_awaited_once_with(1)
     assert bridge._sink_fd is None
+
+
+async def test_warm_generation_cancellation_before_sink_publication_closes_fd() -> None:
+    """Cancellation before sink publication closes the locally owned writer fd."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    kept_stream = MagicMock()
+    kept_stream.next_generation = MagicMock(return_value=1)
+    kept_stream.prepare_generation = AsyncMock()
+    kept_stream.wait_generation_ready = AsyncMock(return_value=True)
+    kept_stream.discard_generation = AsyncMock()
+    bridge._airplay_stream_start_task = asyncio.current_task()
+
+    with (
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
+            new_callable=AsyncMock,
+            return_value=55,
+        ),
+        patch.object(
+            bridge,
+            "_set_sink_fd",
+            new_callable=AsyncMock,
+            side_effect=asyncio.CancelledError,
+        ),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=100),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as close_fd,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
+
+    close_fd.assert_any_call(55)
+    kept_stream.discard_generation.assert_awaited_once_with(1)
+    assert bridge._sink_fd is None
+
+
+async def test_warm_generation_cancellation_after_sink_publication_keeps_owner_fd() -> None:
+    """Cancellation after publication leaves the active sink under bridge ownership."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    kept_stream = MagicMock()
+    kept_stream.next_generation = MagicMock(return_value=1)
+    kept_stream.prepare_generation = AsyncMock()
+    kept_stream.wait_generation_ready = AsyncMock(return_value=True)
+    kept_stream.discard_generation = AsyncMock()
+    bridge._airplay_stream_start_task = asyncio.current_task()
+
+    async def publish_then_cancel(fd: int) -> None:
+        bridge._sink_fd = fd
+        raise asyncio.CancelledError
+
+    with (
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
+            new_callable=AsyncMock,
+            return_value=77,
+        ),
+        patch.object(
+            bridge,
+            "_set_sink_fd",
+            new_callable=AsyncMock,
+            side_effect=publish_then_cancel,
+        ),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=100),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as close_fd,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
+
+    assert bridge._sink_fd == 77
+    assert all(call.args[0] != 77 for call in close_fd.call_args_list)
+    kept_stream.discard_generation.assert_awaited_once_with(1)
+    bridge._sink_fd = None

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -19,6 +19,7 @@ import asyncio
 import errno
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from aiosendspin.clock import ManualClock
 from aiosendspin.server.roles import AudioChunk
 
@@ -293,6 +294,7 @@ async def test_cold_start_connects_then_prepares_and_starts_generation_zero() ->
     stream.prepare_generation = AsyncMock()
     stream.wait_generation_ready = AsyncMock(return_value=True)
     stream.wait_generation_primed = AsyncMock(return_value=True)
+    stream.discard_generation = AsyncMock()
     stream.start_generation = AsyncMock()
 
     with (
@@ -316,6 +318,37 @@ async def test_cold_start_connects_then_prepares_and_starts_generation_zero() ->
     assert bridge._airplay_stream is stream
     assert bridge.airplay_player.stream is stream
     assert bridge._generation_started is True
+
+
+async def test_cold_start_ready_timeout_discards_generation_zero() -> None:
+    """A cold bridge start FLUSHes generation 0 before stopping its transport."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + AP2_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    stream = MagicMock()
+    stream.start = AsyncMock()
+    stream.stop = AsyncMock()
+    stream.wait_for_connection = AsyncMock()
+    stream.prepare_generation = AsyncMock()
+    stream.wait_generation_ready = AsyncMock(return_value=False)
+    stream.discard_generation = AsyncMock()
+    stream.start_generation = AsyncMock()
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=stream,
+        ),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.time",
+            return_value=UNIX_NOW_S,
+        ),
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    stream.discard_generation.assert_awaited_once_with(0)
+    stream.start_generation.assert_not_awaited()
+    stream.stop.assert_awaited_once_with(force=True)
 
 
 # --- Warm handover: a kept stream survives a new stream start and absorbs a generation ---
@@ -544,4 +577,41 @@ async def test_warm_generation_ready_timeout_does_not_open_writer() -> None:
     open_writer.assert_not_awaited()
     kept_stream.discard_generation.assert_awaited_once_with(1)
     kept_stream.start_generation.assert_not_awaited()
+    assert bridge._sink_fd is None
+
+
+async def test_warm_generation_cancellation_discards_staging() -> None:
+    """Cancellation while awaiting ready FLUSHes the bridge generation."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    kept_stream = MagicMock()
+    kept_stream.next_generation = MagicMock(return_value=1)
+    kept_stream.prepare_generation = AsyncMock()
+    ready_waiting = asyncio.Event()
+
+    async def wait_ready(_generation: int) -> bool:
+        ready_waiting.set()
+        await asyncio.Event().wait()
+        return True
+
+    kept_stream.wait_generation_ready = AsyncMock(side_effect=wait_ready)
+    kept_stream.discard_generation = AsyncMock()
+    bridge._airplay_stream = kept_stream
+
+    with (
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.os.open",
+            side_effect=OSError(errno.ENXIO, "no reader"),
+        ),
+    ):
+        warm_task = asyncio.create_task(
+            bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
+        )
+        await ready_waiting.wait()
+        warm_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await warm_task
+
+    kept_stream.discard_generation.assert_awaited_once_with(1)
     assert bridge._sink_fd is None

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -629,6 +629,9 @@ async def test_prepare_generation_raises_when_command_is_dropped() -> None:
     ):
         await stream.prepare_generation(1, "/tmp/generation.pcm", 0)  # noqa: S108
 
+    assert 1 not in stream._gen_ready
+    assert 1 not in stream._gen_primed
+
 
 @pytest.mark.asyncio
 async def test_wait_generation_ready_times_out() -> None:

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -12,9 +12,10 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from music_assistant_models.enums import ContentType, PlaybackState
+from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import AudioFormat
 
-from music_assistant.helpers.named_pipe import AsyncNamedPipeWriter
+from music_assistant.helpers.named_pipe import AsyncNamedPipeWriter, open_named_pipe_writer
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_ARTWORK_SIZE,
     CONF_ENCRYPTION,
@@ -598,6 +599,8 @@ async def test_generation_zero_uses_prepare_and_start_commands() -> None:
 
     with patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command:
         await stream.prepare_generation(0, "-", 12_000)
+        assert stream._handle_status_line("[STATUS] ready generation=0") is False
+        assert await stream.wait_generation_ready(0)
         assert stream._handle_status_line("[STATUS] primed generation=0") is False
         assert await stream.wait_generation_primed(0)
         await stream.start_generation(0, 12_000, START_UNIX_MS)
@@ -606,6 +609,87 @@ async def test_generation_zero_uses_prepare_and_start_commands() -> None:
         "GENERATION=0\nAUDIO=-\nPOSITION_MS=12000\nACTION=PREPARE",
         f"GENERATION=0\nSTART_UNIX_MS={START_UNIX_MS}\nACTION=START",
     ]
+
+
+@pytest.mark.asyncio
+async def test_prepare_generation_raises_when_command_is_dropped() -> None:
+    """A dropped PREPARE command is surfaced before its generation can be awaited."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+
+    with (
+        patch.object(
+            stream,
+            "_write_cli_command",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        pytest.raises(PlayerCommandFailed, match="Could not deliver PREPARE"),
+    ):
+        await stream.prepare_generation(1, "/tmp/generation.pcm", 0)  # noqa: S108
+
+
+@pytest.mark.asyncio
+async def test_wait_generation_ready_times_out() -> None:
+    """A generation without a ready status fails its bounded readiness wait."""
+    stream = AirPlayStream(_make_player())
+    stream.next_generation()
+
+    assert await stream.wait_generation_ready(1, timeout=0) is False
+
+
+@pytest.mark.asyncio
+async def test_named_pipe_writer_open_is_bounded_without_worker_thread() -> None:
+    """A missing FIFO reader times out without stranding a blocking worker thread."""
+    open_error = OSError(errno.ENXIO, "no reader")
+    with (
+        patch(
+            "music_assistant.helpers.named_pipe.os.open",
+            side_effect=open_error,
+        ),
+        patch(
+            "music_assistant.helpers.named_pipe.asyncio.to_thread",
+            new_callable=AsyncMock,
+        ) as to_thread,
+        pytest.raises(TimeoutError, match="Timed out opening named pipe writer"),
+    ):
+        await open_named_pipe_writer("/tmp/generation.pcm", timeout=0)  # noqa: S108
+
+    to_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_named_pipe_writer_open_cancellation_has_no_fd_to_leak() -> None:
+    """Cancellation while waiting for a reader leaves no worker or descriptor behind."""
+    with (
+        patch(
+            "music_assistant.helpers.named_pipe.os.open",
+            side_effect=OSError(errno.ENXIO, "no reader"),
+        ),
+        patch("music_assistant.helpers.named_pipe.os.close") as close_fd,
+    ):
+        open_task = asyncio.create_task(
+            open_named_pipe_writer("/tmp/generation.pcm", timeout=10)  # noqa: S108
+        )
+        await asyncio.sleep(0)
+        open_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await open_task
+
+    close_fd.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_named_pipe_writer_open_restores_blocking_mode() -> None:
+    """The descriptor inherited by ffmpeg is switched out of nonblocking mode."""
+    with (
+        patch("music_assistant.helpers.named_pipe.os.open", return_value=42),
+        patch("music_assistant.helpers.named_pipe.os.set_blocking") as set_blocking,
+    ):
+        assert await open_named_pipe_writer("/tmp/generation.pcm") == 42  # noqa: S108
+
+    set_blocking.assert_called_once_with(42, True)
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -612,25 +612,27 @@ async def test_generation_zero_uses_prepare_and_start_commands() -> None:
 
 
 @pytest.mark.asyncio
-async def test_prepare_generation_raises_when_command_is_dropped() -> None:
-    """A dropped PREPARE command is surfaced before its generation can be awaited."""
+async def test_repeated_prepare_failures_do_not_grow_generation_events() -> None:
+    """Dropped and failed PREPARE writes always remove their generation events."""
     stream = AirPlayStream(_make_player())
     stream._cli_proc = MagicMock(closed=False)
     stream._connected.set()
 
-    with (
-        patch.object(
-            stream,
-            "_write_cli_command",
-            new_callable=AsyncMock,
-            return_value=False,
-        ),
-        pytest.raises(PlayerCommandFailed, match="Could not deliver PREPARE"),
+    with patch.object(
+        stream,
+        "_write_cli_command",
+        new_callable=AsyncMock,
+        side_effect=[False, OSError("write failed"), False],
     ):
-        await stream.prepare_generation(1, "/tmp/generation.pcm", 0)  # noqa: S108
-
-    assert 1 not in stream._gen_ready
-    assert 1 not in stream._gen_primed
+        for generation in range(1, 4):
+            with pytest.raises((PlayerCommandFailed, OSError)):
+                await stream.prepare_generation(
+                    generation,
+                    "/tmp/generation.pcm",  # noqa: S108
+                    0,
+                )
+            assert stream._gen_ready == {}
+            assert stream._gen_primed == {}
 
 
 @pytest.mark.asyncio
@@ -652,19 +654,23 @@ async def test_discard_generation_propagates_flush_delivery() -> None:
         stream,
         "_write_cli_command",
         new_callable=AsyncMock,
-        side_effect=[True, False],
+        side_effect=[True, False, OSError("write failed")],
     ) as write_command:
         await stream.discard_generation(1)
         stream.next_generation()
         with pytest.raises(PlayerCommandFailed, match="Could not deliver FLUSH"):
             await stream.discard_generation(2)
+        stream.next_generation()
+        with pytest.raises(OSError, match="write failed"):
+            await stream.discard_generation(3)
 
     assert write_command.await_args_list == [
         call("GENERATION=1\nACTION=FLUSH"),
         call("GENERATION=2\nACTION=FLUSH"),
+        call("GENERATION=3\nACTION=FLUSH"),
     ]
-    assert 1 not in stream._gen_ready
-    assert 2 in stream._gen_ready
+    assert stream._gen_ready == {}
+    assert stream._gen_primed == {}
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -640,6 +640,31 @@ async def test_wait_generation_ready_times_out() -> None:
 
 
 @pytest.mark.asyncio
+async def test_discard_generation_propagates_flush_delivery() -> None:
+    """A staged discard sends targeted FLUSH and surfaces dropped delivery."""
+    stream = AirPlayStream(_make_player())
+    stream.next_generation()
+
+    with patch.object(
+        stream,
+        "_write_cli_command",
+        new_callable=AsyncMock,
+        side_effect=[True, False],
+    ) as write_command:
+        await stream.discard_generation(1)
+        stream.next_generation()
+        with pytest.raises(PlayerCommandFailed, match="Could not deliver FLUSH"):
+            await stream.discard_generation(2)
+
+    assert write_command.await_args_list == [
+        call("GENERATION=1\nACTION=FLUSH"),
+        call("GENERATION=2\nACTION=FLUSH"),
+    ]
+    assert 1 not in stream._gen_ready
+    assert 2 in stream._gen_ready
+
+
+@pytest.mark.asyncio
 async def test_named_pipe_writer_open_is_bounded_without_worker_thread() -> None:
     """A missing FIFO reader times out without stranding a blocking worker thread."""
     open_error = OSError(errno.ENXIO, "no reader")

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -758,11 +758,34 @@ async def test_generation_writer_fd_closes_when_old_ffmpeg_kill_fails() -> None:
 
     with (
         patch("music_assistant.providers.airplay.stream_session.os.close") as close_fd,
+        patch("music_assistant.providers.airplay.stream_session.FFMpeg") as ffmpeg_factory,
         pytest.raises(OSError, match="kill failed"),
     ):
         await session._start_generation_ffmpeg(player, 42, MagicMock())
 
     close_fd.assert_called_once_with(42)
+    ffmpeg_factory.assert_not_called()
+    assert session._player_ffmpeg[player.player_id] is old_ffmpeg
+
+
+@pytest.mark.asyncio
+async def test_generation_writer_kill_cancellation_keeps_old_ffmpeg_tracked() -> None:
+    """Cancellation during old ffmpeg kill retains it and closes the staged fd."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    old_ffmpeg = MagicMock()
+    old_ffmpeg.kill = AsyncMock(side_effect=asyncio.CancelledError)
+    session._player_ffmpeg[player.player_id] = old_ffmpeg
+
+    with (
+        patch("music_assistant.providers.airplay.stream_session.os.close") as close_fd,
+        patch("music_assistant.providers.airplay.stream_session.FFMpeg") as ffmpeg_factory,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await session._start_generation_ffmpeg(player, 42, MagicMock())
+
+    close_fd.assert_called_once_with(42)
+    ffmpeg_factory.assert_not_called()
     assert session._player_ffmpeg[player.player_id] is old_ffmpeg
 
 

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -763,6 +763,7 @@ async def test_generation_writer_fd_closes_when_old_ffmpeg_kill_fails() -> None:
         await session._start_generation_ffmpeg(player, 42, MagicMock())
 
     close_fd.assert_called_once_with(42)
+    assert session._player_ffmpeg[player.player_id] is old_ffmpeg
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -72,6 +72,7 @@ def _setup_stream(player: MagicMock) -> Any:
         player.stream.wait_for_connection = AsyncMock()
         player.stream.prepare_generation = AsyncMock()
         player.stream.wait_generation_ready = AsyncMock(return_value=True)
+        player.stream.discard_generation = AsyncMock()
         player.stream.wait_generation_primed = AsyncMock(return_value=True)
         player.stream.start_generation = AsyncMock()
 
@@ -256,6 +257,7 @@ async def test_initial_prime_timeout_never_starts_partial_group() -> None:
         stream.wait_for_connection = AsyncMock()
         stream.prepare_generation = AsyncMock()
         stream.wait_generation_ready = AsyncMock(return_value=True)
+        stream.discard_generation = AsyncMock()
         stream.wait_generation_primed = AsyncMock(return_value=player is not second_player)
         stream.start_generation = AsyncMock()
         player.stream = stream
@@ -270,6 +272,7 @@ async def test_initial_prime_timeout_never_starts_partial_group() -> None:
 
     for player in session.sync_clients:
         stream: Any = player.stream
+        stream.discard_generation.assert_awaited_once_with(0)
         stream.start_generation.assert_not_awaited()
     stop_session.assert_awaited_once()
 
@@ -500,6 +503,59 @@ async def test_warm_replace_waits_for_every_reader_before_old_teardown() -> None
     last_ready = max(i for i, operation in enumerate(operations) if operation.startswith("ready:"))
     assert last_ready < operations.index("old-audio-cancelled")
     assert last_ready < operations.index("ffmpeg-switched")
+
+
+@pytest.mark.asyncio
+async def test_warm_replace_cancellation_discards_before_old_teardown() -> None:
+    """Cancellation while awaiting ready FLUSHes staging without touching old audio."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    stream = player.stream
+    ready_waiting = asyncio.Event()
+    old_audio_cancelled = asyncio.Event()
+    stream.next_generation = MagicMock(return_value=1)
+    stream.prepare_generation = AsyncMock()
+
+    async def wait_ready(_generation: int) -> bool:
+        ready_waiting.set()
+        await asyncio.Event().wait()
+        return True
+
+    stream.wait_generation_ready = AsyncMock(side_effect=wait_ready)
+    stream.discard_generation = AsyncMock()
+
+    async def old_audio() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            old_audio_cancelled.set()
+            raise
+
+    session._audio_source_task = asyncio.create_task(old_audio())
+    with (
+        patch(
+            "music_assistant.providers.airplay.stream_session.open_named_pipe_writer",
+            new_callable=AsyncMock,
+        ) as open_writer,
+        patch("music_assistant.providers.airplay.stream_session.os.unlink"),
+        patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
+        patch(
+            "music_assistant.providers.airplay.stream_session.os.open",
+            side_effect=OSError(errno.ENXIO, "no reader"),
+        ),
+    ):
+        replace_task = asyncio.create_task(session.replace(MagicMock(), MagicMock(elapsed_time=0)))
+        await ready_waiting.wait()
+        replace_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await replace_task
+
+    stream.discard_generation.assert_awaited_once_with(1)
+    open_writer.assert_not_awaited()
+    assert not old_audio_cancelled.is_set()
+    session._audio_source_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await session._audio_source_task
 
 
 @pytest.mark.asyncio
@@ -839,6 +895,27 @@ async def test_late_join_adds_to_sync_clients() -> None:
         await session.add_client(player)
 
     assert player in session.sync_clients
+
+
+@pytest.mark.asyncio
+async def test_late_join_ready_timeout_discards_generation_zero() -> None:
+    """A late joiner FLUSHes its staged generation before transport teardown."""
+    session = _make_session(time.time() - 10, 12.5)
+    player = _make_late_joiner()
+
+    def setup_unready_stream(*_args: Any, **_kwargs: Any) -> None:
+        _setup_stream(player)()
+        player.stream.wait_generation_ready = AsyncMock(return_value=False)
+
+    with (
+        patch.object(session, "_start_client", side_effect=setup_unready_stream),
+        patch.object(session, "stop_client", new_callable=AsyncMock) as stop_client,
+    ):
+        await session.add_client(player)
+
+    player.stream.discard_generation.assert_awaited_once_with(0)
+    stop_client.assert_awaited_once_with(player, reason="late joiner start/prime failed")
+    assert player not in session.sync_clients
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -1,6 +1,7 @@
 """Unit tests for AirPlay stream session late-join logic."""
 
 import asyncio
+import errno
 import time
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -70,6 +71,7 @@ def _setup_stream(player: MagicMock) -> Any:
         player.stream.running = True
         player.stream.wait_for_connection = AsyncMock()
         player.stream.prepare_generation = AsyncMock()
+        player.stream.wait_generation_ready = AsyncMock(return_value=True)
         player.stream.wait_generation_primed = AsyncMock(return_value=True)
         player.stream.start_generation = AsyncMock()
 
@@ -161,6 +163,10 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
             assert (generation, audio_path, position_ms) == (0, "-", 12_000)
             operations.append(f"prepared:{player.player_id}")
 
+        async def wait_generation_ready(_generation: int) -> bool:
+            operations.append(f"ready:{player.player_id}")
+            return True
+
         async def wait_generation_primed(_generation: int) -> bool:
             operations.append(f"primed:{player.player_id}")
             return True
@@ -170,6 +176,7 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
 
         stream.wait_for_connection = AsyncMock(side_effect=wait_for_connection)
         stream.prepare_generation = AsyncMock(side_effect=prepare_generation)
+        stream.wait_generation_ready = AsyncMock(side_effect=wait_generation_ready)
         stream.wait_generation_primed = AsyncMock(side_effect=wait_generation_primed)
         stream.start_generation = AsyncMock(side_effect=start_generation)
         player.stream = stream
@@ -184,9 +191,12 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
 
     first_prepare = min(i for i, op in enumerate(operations) if op.startswith("prepared:"))
     last_connected = max(i for i, op in enumerate(operations) if op.startswith("connected:"))
+    first_primed = min(i for i, op in enumerate(operations) if op.startswith("primed:"))
+    last_ready = max(i for i, op in enumerate(operations) if op.startswith("ready:"))
     first_start = min(i for i, op in enumerate(operations) if op.startswith("started:"))
     last_primed = max(i for i, op in enumerate(operations) if op.startswith("primed:"))
     assert last_connected < first_prepare
+    assert last_ready < first_primed
     assert last_primed < first_start
     starts = {int(op.rsplit(":", 1)[1]) for op in operations if op.startswith("started:")}
     assert starts == {100_750}
@@ -210,6 +220,7 @@ async def test_initial_single_player_uses_commanded_generation_zero(
     stream = MagicMock(running=True)
     stream.wait_for_connection = AsyncMock()
     stream.prepare_generation = AsyncMock()
+    stream.wait_generation_ready = AsyncMock(return_value=True)
     stream.wait_generation_primed = AsyncMock(return_value=True)
     stream.start_generation = AsyncMock()
 
@@ -244,6 +255,7 @@ async def test_initial_prime_timeout_never_starts_partial_group() -> None:
         stream = MagicMock(running=True)
         stream.wait_for_connection = AsyncMock()
         stream.prepare_generation = AsyncMock()
+        stream.wait_generation_ready = AsyncMock(return_value=True)
         stream.wait_generation_primed = AsyncMock(return_value=player is not second_player)
         stream.start_generation = AsyncMock()
         player.stream = stream
@@ -356,16 +368,18 @@ async def test_standby_supports_every_connected_streaming_protocol(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "protocols",
+    ("protocols", "start_lead_ms"),
     [
-        (StreamingProtocol.RAOP, StreamingProtocol.RAOP),
-        (StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2),
+        ((StreamingProtocol.RAOP,), 400),
+        ((StreamingProtocol.AIRPLAY2,), 400),
+        ((StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2), 750),
     ],
 )
 async def test_standby_resumes_next_generation_on_existing_streams(
-    protocols: tuple[StreamingProtocol, StreamingProtocol],
+    protocols: tuple[StreamingProtocol, ...],
+    start_lead_ms: int,
 ) -> None:
-    """All-RAOP and mixed sessions resume warm on their parked streams."""
+    """RAOP, AirPlay 2 and mixed sessions resume warm on their parked streams."""
     session = _make_session(0, 0)
     players: Any = []
     original_streams: dict[str, MagicMock] = {}
@@ -378,6 +392,7 @@ async def test_standby_resumes_next_generation_on_existing_streams(
         player.stream.send_cli_command = AsyncMock(return_value=True)
         player.stream.next_generation = MagicMock(return_value=1)
         player.stream.prepare_generation = AsyncMock()
+        player.stream.wait_generation_ready = AsyncMock(return_value=True)
         player.stream.wait_generation_primed = AsyncMock(return_value=True)
         player.stream.start_generation = AsyncMock()
         players.append(player)
@@ -393,7 +408,12 @@ async def test_standby_resumes_next_generation_on_existing_streams(
         patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0),
         patch("music_assistant.providers.airplay.stream_session.os.unlink"),
         patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
-        patch("music_assistant.providers.airplay.stream_session.os.open", return_value=99),
+        patch(
+            "music_assistant.providers.airplay.stream_session.open_named_pipe_writer",
+            new_callable=AsyncMock,
+            return_value=99,
+        ),
+        patch("music_assistant.providers.airplay.stream_session.os.open", return_value=100),
         patch("music_assistant.providers.airplay.stream_session.os.close"),
     ):
         assert await session.replace(MagicMock(), media)
@@ -406,8 +426,164 @@ async def test_standby_resumes_next_generation_on_existing_streams(
             f"/tmp/ma-gen-{player.player_id}-1.pcm",  # noqa: S108
             10_000,
         )
+        stream.wait_generation_ready.assert_awaited_once_with(1)
         stream.wait_generation_primed.assert_awaited_once_with(1)
-        stream.start_generation.assert_awaited_once_with(1, 10_000, 100_750)
+        stream.start_generation.assert_awaited_once_with(1, 10_000, 100_000 + start_lead_ms)
+
+
+@pytest.mark.asyncio
+async def test_warm_replace_waits_for_every_reader_before_old_teardown() -> None:
+    """Old audio remains active until every staged member reports its reader ready."""
+    session = _make_session(0, 0)
+    operations: list[str] = []
+    players: list[Any] = []
+    release_delayed = asyncio.Event()
+    delayed_waiting = asyncio.Event()
+
+    for player_id in ("first", "delayed"):
+        player = MagicMock(player_id=player_id, protocol=StreamingProtocol.AIRPLAY2)
+        stream = MagicMock(running=True, connected=True)
+        stream.next_generation = MagicMock(return_value=1)
+        stream.prepare_generation = AsyncMock()
+
+        async def wait_ready(_generation: int, *, current_id: str = player_id) -> bool:
+            operations.append(f"ready-wait:{current_id}")
+            if current_id == "delayed":
+                delayed_waiting.set()
+                await release_delayed.wait()
+            operations.append(f"ready:{current_id}")
+            return True
+
+        stream.wait_generation_ready = AsyncMock(side_effect=wait_ready)
+        stream.wait_generation_primed = AsyncMock(return_value=True)
+        stream.start_generation = AsyncMock()
+        player.stream = stream
+        player.config.get_value = MagicMock(return_value=0)
+        players.append(player)
+    session.sync_clients = players
+
+    async def old_audio() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            operations.append("old-audio-cancelled")
+            raise
+
+    session._audio_source_task = asyncio.create_task(old_audio())
+
+    async def open_writer(_fifo: str) -> int:
+        operations.append("writer-open")
+        return 99
+
+    async def start_ffmpeg(_player: Any, _fifo_fd: int, _media: Any) -> None:
+        operations.append("ffmpeg-switched")
+
+    with (
+        patch.object(session, "_start_generation_ffmpeg", side_effect=start_ffmpeg),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch(
+            "music_assistant.providers.airplay.stream_session.open_named_pipe_writer",
+            side_effect=open_writer,
+        ),
+        patch("music_assistant.providers.airplay.stream_session.os.unlink"),
+        patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
+        patch("music_assistant.providers.airplay.stream_session.os.open", return_value=100),
+        patch("music_assistant.providers.airplay.stream_session.os.close"),
+    ):
+        replace_task = asyncio.create_task(session.replace(MagicMock(), MagicMock(elapsed_time=0)))
+        await delayed_waiting.wait()
+        assert "old-audio-cancelled" not in operations
+        assert "ffmpeg-switched" not in operations
+        release_delayed.set()
+        assert await replace_task
+
+    last_ready = max(i for i, operation in enumerate(operations) if operation.startswith("ready:"))
+    assert last_ready < operations.index("old-audio-cancelled")
+    assert last_ready < operations.index("ffmpeg-switched")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_phase", ["prepare", "ready"])
+async def test_warm_replace_pre_ready_failure_preserves_old_resources(
+    failure_phase: str,
+) -> None:
+    """Dropped PREPARE and reader timeout leave the active source and ffmpeg untouched."""
+    session = _make_session(0, 0)
+    players: list[Any] = []
+    old_ffmpegs: list[MagicMock] = []
+    old_audio_cancelled = asyncio.Event()
+
+    for player_id in ("working", "failed"):
+        player = MagicMock(player_id=player_id, protocol=StreamingProtocol.RAOP)
+        stream = MagicMock(running=True, connected=True)
+        stream.next_generation = MagicMock(return_value=1)
+        if failure_phase == "prepare" and player_id == "failed":
+            stream.prepare_generation = AsyncMock(
+                side_effect=PlayerCommandFailed("PREPARE was not delivered")
+            )
+        else:
+            stream.prepare_generation = AsyncMock()
+        stream.wait_generation_ready = AsyncMock(
+            return_value=not (failure_phase == "ready" and player_id == "failed")
+        )
+        stream.wait_generation_primed = AsyncMock(return_value=True)
+        stream.start_generation = AsyncMock()
+        player.stream = stream
+        players.append(player)
+        ffmpeg = MagicMock(closed=False)
+        ffmpeg.kill = AsyncMock()
+        session._player_ffmpeg[player_id] = ffmpeg
+        old_ffmpegs.append(ffmpeg)
+    session.sync_clients = players
+
+    async def old_audio() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            old_audio_cancelled.set()
+            raise
+
+    session._audio_source_task = asyncio.create_task(old_audio())
+    with (
+        patch(
+            "music_assistant.providers.airplay.stream_session.open_named_pipe_writer",
+            new_callable=AsyncMock,
+        ) as open_writer,
+        patch("music_assistant.providers.airplay.stream_session.os.unlink"),
+        patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
+        patch(
+            "music_assistant.providers.airplay.stream_session.os.open",
+            side_effect=OSError(errno.ENXIO, "no reader"),
+        ),
+    ):
+        assert await session.replace(MagicMock(), MagicMock(elapsed_time=0)) is False
+
+    assert not old_audio_cancelled.is_set()
+    assert not session._audio_source_task.done()
+    open_writer.assert_not_awaited()
+    for ffmpeg in old_ffmpegs:
+        ffmpeg.kill.assert_not_awaited()
+    session._audio_source_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await session._audio_source_task
+
+
+@pytest.mark.asyncio
+async def test_generation_writer_fd_closes_when_old_ffmpeg_kill_fails() -> None:
+    """The prepared writer fd closes if switching away from the old ffmpeg fails."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    old_ffmpeg = MagicMock()
+    old_ffmpeg.kill = AsyncMock(side_effect=OSError("kill failed"))
+    session._player_ffmpeg[player.player_id] = old_ffmpeg
+
+    with (
+        patch("music_assistant.providers.airplay.stream_session.os.close") as close_fd,
+        pytest.raises(OSError, match="kill failed"),
+    ):
+        await session._start_generation_ffmpeg(player, 42, MagicMock())
+
+    close_fd.assert_called_once_with(42)
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -526,6 +526,7 @@ async def test_warm_replace_pre_ready_failure_preserves_old_resources(
         stream.wait_generation_ready = AsyncMock(
             return_value=not (failure_phase == "ready" and player_id == "failed")
         )
+        stream.discard_generation = AsyncMock()
         stream.wait_generation_primed = AsyncMock(return_value=True)
         stream.start_generation = AsyncMock()
         player.stream = stream
@@ -561,11 +562,133 @@ async def test_warm_replace_pre_ready_failure_preserves_old_resources(
     assert not old_audio_cancelled.is_set()
     assert not session._audio_source_task.done()
     open_writer.assert_not_awaited()
-    for ffmpeg in old_ffmpegs:
+    for player, ffmpeg in zip(players, old_ffmpegs, strict=True):
         ffmpeg.kill.assert_not_awaited()
+        player.stream.discard_generation.assert_awaited_once_with(1)
     session._audio_source_task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await session._audio_source_task
+
+
+@pytest.mark.asyncio
+async def test_warm_replace_discard_failure_does_not_mask_original_failure() -> None:
+    """Failed staged cleanup still returns control to the caller's cold fallback."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    stream = player.stream
+    stream.next_generation = MagicMock(return_value=1)
+    stream.prepare_generation = AsyncMock()
+    stream.wait_generation_ready = AsyncMock(return_value=False)
+    stream.discard_generation = AsyncMock(side_effect=OSError("flush failed"))
+
+    with (
+        patch("music_assistant.providers.airplay.stream_session.os.unlink"),
+        patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
+        patch(
+            "music_assistant.providers.airplay.stream_session.os.open",
+            side_effect=OSError(errno.ENXIO, "no reader"),
+        ),
+        patch.object(session.prov.logger, "warning") as warning,
+    ):
+        assert await session.replace(MagicMock(), MagicMock(elapsed_time=0)) is False
+
+    stream.discard_generation.assert_awaited_once_with(1)
+    assert warning.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_partial_group_prepare_completes_before_discard() -> None:
+    """Every queued PREPARE completes before partial-group FLUSH cleanup starts."""
+    session = _make_session(0, 0)
+    operations: list[str] = []
+    delayed_started = asyncio.Event()
+    release_delayed = asyncio.Event()
+    players: list[Any] = []
+
+    for player_id in ("delayed", "failed"):
+        player = MagicMock(player_id=player_id, protocol=StreamingProtocol.AIRPLAY2)
+        stream = MagicMock(running=True, connected=True)
+        stream.next_generation = MagicMock(return_value=1)
+
+        async def prepare(
+            _generation: int,
+            _fifo: str,
+            _position_ms: int,
+            *,
+            current_id: str = player_id,
+        ) -> None:
+            if current_id == "delayed":
+                delayed_started.set()
+                await release_delayed.wait()
+                operations.append("prepare:delayed")
+                return
+            await delayed_started.wait()
+            operations.append("prepare:failed")
+            release_delayed.set()
+            raise PlayerCommandFailed("PREPARE was not delivered")
+
+        async def discard(_generation: int, *, current_id: str = player_id) -> None:
+            operations.append(f"discard:{current_id}")
+
+        stream.prepare_generation = AsyncMock(side_effect=prepare)
+        stream.discard_generation = AsyncMock(side_effect=discard)
+        player.stream = stream
+        players.append(player)
+    session.sync_clients = players
+
+    with (
+        patch("music_assistant.providers.airplay.stream_session.os.unlink"),
+        patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
+        patch(
+            "music_assistant.providers.airplay.stream_session.os.open",
+            side_effect=OSError(errno.ENXIO, "no reader"),
+        ),
+    ):
+        assert await session.replace(MagicMock(), MagicMock(elapsed_time=0)) is False
+
+    last_prepare = max(
+        index for index, operation in enumerate(operations) if operation.startswith("prepare:")
+    )
+    first_discard = min(
+        index for index, operation in enumerate(operations) if operation.startswith("discard:")
+    )
+    assert last_prepare < first_discard
+
+
+@pytest.mark.asyncio
+async def test_warm_replace_does_not_discard_after_start_is_attempted() -> None:
+    """A failed shared START cannot FLUSH a generation that may already be active."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    stream = player.stream
+    stream.next_generation = MagicMock(return_value=1)
+    stream.prepare_generation = AsyncMock()
+    stream.wait_generation_ready = AsyncMock(return_value=True)
+    stream.wait_generation_primed = AsyncMock(return_value=True)
+    stream.discard_generation = AsyncMock()
+
+    with (
+        patch.object(session, "_start_generation_ffmpeg", new_callable=AsyncMock),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch.object(
+            session,
+            "_commit_generations",
+            new_callable=AsyncMock,
+            side_effect=OSError("start failed"),
+        ),
+        patch(
+            "music_assistant.providers.airplay.stream_session.open_named_pipe_writer",
+            new_callable=AsyncMock,
+            return_value=42,
+        ),
+        patch("music_assistant.providers.airplay.stream_session.os.unlink"),
+        patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
+        patch("music_assistant.providers.airplay.stream_session.os.open", return_value=43),
+        patch("music_assistant.providers.airplay.stream_session.os.close"),
+    ):
+        assert await session.replace(MagicMock(), MagicMock(elapsed_time=0)) is False
+
+    stream.discard_generation.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

AirPlay seek and next could intermittently lose a warm handover when the CLI had not opened the staged audio input yet.

- Wait for every player to confirm its staged reader is ready before replacing active audio resources.
- Surface dropped prepare commands and clean up failed staged generations safely.
- Use bounded FIFO writer opens and add generation phase timing logs.
- Apply the same readiness handshake to initial and Sendspin generation starts.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.