### PR TITLE
AirPlay companion control follow-ups

### DIFF
--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from music_assistant_models.constants import PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_NONE
 from music_assistant_models.enums import CrossfadeMode
 
 from music_assistant.constants import (
@@ -160,6 +161,12 @@ async def migrate(data: dict[str, Any]) -> bool:  # noqa: PLR0915
     # (shairport-sync) advertisements before discovery learned to filter them out.
     # TODO: remove after 2.10 release
     if _migrate_airplay_receiver_ghost_players(data):
+        changed = True
+
+    # Give Apple TVs paired before native power control existed the current
+    # default ("native") instead of the stale "none" that hid their power button.
+    # TODO: remove after 2.11 release
+    if _migrate_airplay_apple_power_control(data):
         changed = True
 
     # Drop the stored value of the removed output limiter player setting; clipping protection
@@ -681,6 +688,37 @@ def _migrate_airplay_receiver_ghost_players(data: dict[str, Any]) -> bool:
         len(ghost_ids),
     )
     return True
+
+
+def _migrate_airplay_apple_power_control(data: dict[str, Any]) -> bool:
+    """
+    Enable native power control for Apple TVs paired before the feature existed.
+
+    Native on/off (Companion) power control was added to Apple TVs later, but
+    players configured earlier kept the power_control default from that time
+    ("none"), so the power button stayed hidden. Flip that stale default to
+    "native" for paired Apple devices (those with Companion credentials, i.e.
+    the ones that actually gained the feature); a device that turns out not to
+    support power degrades back to "none" at runtime.
+    """
+    all_player_configs = data.get(CONF_PLAYERS, {})
+    if not isinstance(all_player_configs, dict):
+        return False
+    changed = False
+    for player_id, player_cfg in all_player_configs.items():
+        if not isinstance(player_cfg, dict):
+            continue
+        if not str(player_cfg.get("provider", "")).startswith("airplay"):
+            continue
+        values = player_cfg.get("values")
+        if not isinstance(values, dict) or not values.get("companion_credentials"):
+            continue
+        if values.get("power_control") != PLAYER_CONTROL_NONE:
+            continue
+        values["power_control"] = PLAYER_CONTROL_NATIVE
+        LOGGER.info("Enabled native power control for paired Apple device %s", player_id)
+        changed = True
+    return changed
 
 
 def _migrate_output_limiter(data: dict[str, Any]) -> bool:

--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -277,9 +277,15 @@ class AirPlayControlPlayer(AirPlayPlayer):
         await self._run_control_command(device.remote_control.pause(), "pause")
 
     async def stop(self) -> None:
-        """Stop Music Assistant or external playback."""
+        """Stop Music Assistant playback, or return the device to its home screen."""
         if self._stream_active:
             await super().stop()
+            return
+        # For external playback there is no real "stop"; returning to the home
+        # screen backgrounds the current app, which is the closest equivalent.
+        device = self._device_for_feature(FeatureName.Home)
+        if device is not None:
+            await self._run_control_command(device.remote_control.home(), "stop")
             return
         device = self._device_for_feature(FeatureName.Stop)
         if device is not None:
@@ -305,7 +311,7 @@ class AirPlayControlPlayer(AirPlayPlayer):
         if device is None:
             await super().volume_set(volume_level)
             return
-        await self._run_control_command(device.audio.set_volume(volume_level), "set volume")
+        await self._run_volume_command(device.audio.set_volume(volume_level), "set volume")
         self._handle_volume_update("command", volume_level)
 
     async def volume_mute(self, muted: bool) -> None:
@@ -321,13 +327,13 @@ class AirPlayControlPlayer(AirPlayPlayer):
                 return
             if self.volume_level and self.volume_level > 0:
                 self._volume_before_mute = self.volume_level
-            await self._run_control_command(device.audio.set_volume(0), "mute")
+            await self._run_volume_command(device.audio.set_volume(0), "mute")
             self._handle_volume_update("command", 0)
             return
         if not self.volume_muted:
             return
         volume = self._volume_before_mute or self.volume_level or FALLBACK_VOLUME
-        await self._run_control_command(device.audio.set_volume(volume), "unmute")
+        await self._run_volume_command(device.audio.set_volume(volume), "unmute")
         self._handle_volume_update("command", volume)
 
     async def next_track(self) -> None:
@@ -684,6 +690,25 @@ class AirPlayControlPlayer(AirPlayPlayer):
         """Run a pyatv command and expose failures as player command errors."""
         try:
             await command
+        except _COMMAND_ERRORS as err:
+            raise PlayerCommandFailed(
+                f"Unable to {description} {self.display_name}: {err}"
+            ) from err
+
+    async def _run_volume_command(self, command: Awaitable[None], description: str) -> None:
+        """Run a native volume command, tolerating a missing confirmation event."""
+        # pyatv waits (up to 5s) for a pushed volume confirmation after a Companion
+        # volume command. Apple TVs that pass volume through to an HDMI-CEC amplifier
+        # apply the change but never emit that event, so the call times out even
+        # though it succeeded. Treat the timeout as success and let the caller apply
+        # the requested level; genuine command failures still surface.
+        try:
+            await command
+        except TimeoutError:
+            self.logger.debug(
+                "No volume confirmation from %s; assuming the change was applied",
+                self.display_name,
+            )
         except _COMMAND_ERRORS as err:
             raise PlayerCommandFailed(
                 f"Unable to {description} {self.display_name}: {err}"
@@ -1119,12 +1144,23 @@ class AirPlayControlPlayer(AirPlayPlayer):
         """Apply external playback state received over the MRP tunnel."""
         if self._stream_active:
             return
+        app = self._mrp_device.metadata.app if self._mrp_device else None
         playback_state = {
             DeviceState.Playing: PlaybackState.PLAYING,
             DeviceState.Loading: PlaybackState.PLAYING,
             DeviceState.Seeking: PlaybackState.PLAYING,
             DeviceState.Paused: PlaybackState.PAUSED,
         }.get(playing.device_state, PlaybackState.IDLE)
+        # Many tvOS apps (e.g. Netflix) report Idle rather than Paused when
+        # paused. While the same app stays the active source, keep it paused
+        # instead of going idle so transport controls resume the app itself
+        # rather than falling back to the Music Assistant queue.
+        if (
+            playback_state == PlaybackState.IDLE
+            and app is not None
+            and self._attr_active_source == app.identifier
+        ):
+            playback_state = PlaybackState.PAUSED
         self._attr_playback_state = playback_state
         if playback_state == PlaybackState.IDLE:
             self._attr_active_source = None
@@ -1132,7 +1168,6 @@ class AirPlayControlPlayer(AirPlayPlayer):
             self.update_state()
             return
 
-        app = self._mrp_device.metadata.app if self._mrp_device else None
         source_id = app.identifier if app else "airplay_control"
         source_name = (app.name or app.identifier) if app else "AirPlay device"
         self._attr_active_source = source_id

--- a/tests/controllers/config/test_migrations.py
+++ b/tests/controllers/config/test_migrations.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from music_assistant.controllers.config.migrations import (
+    _migrate_airplay_apple_power_control,
     _migrate_airplay_receiver_ghost_players,
     _migrate_output_limiter,
 )
@@ -211,3 +212,33 @@ def test_migrate_airplay_receiver_ghosts_noop_without_receivers() -> None:
 
     assert _migrate_airplay_receiver_ghost_players(data) is False
     assert "apdb1ff0aae80e" in data["players"]
+
+
+def test_migrate_airplay_apple_power_control_flips_stale_default() -> None:
+    """Paired Apple TVs stuck on the old 'none' default get native power control."""
+    data: dict[str, Any] = {
+        "players": {
+            "ap_paired_stale": {
+                "provider": "airplay--x",
+                "values": {"companion_credentials": "enc", "power_control": "none"},
+            },
+            "ap_unpaired": {"provider": "airplay--x", "values": {"power_control": "none"}},
+            "ap_already_native": {
+                "provider": "airplay--x",
+                "values": {"companion_credentials": "enc", "power_control": "native"},
+            },
+            "cast_x": {
+                "provider": "chromecast",
+                "values": {"companion_credentials": "enc", "power_control": "none"},
+            },
+        }
+    }
+    assert _migrate_airplay_apple_power_control(data) is True
+    values = data["players"]
+    # only the paired Apple device on the stale default is changed
+    assert values["ap_paired_stale"]["values"]["power_control"] == "native"
+    assert values["ap_unpaired"]["values"]["power_control"] == "none"
+    assert values["ap_already_native"]["values"]["power_control"] == "native"
+    assert values["cast_x"]["values"]["power_control"] == "none"
+    # idempotent: nothing left to migrate on a second pass
+    assert _migrate_airplay_apple_power_control(data) is False


### PR DESCRIPTION
Small fixes to the Apple TV control plane from #4882, found while testing on hardware:

- **Volume** — tolerate the missing volume-confirmation event so a Companion volume command no longer fails after it has already applied. Apple TVs passing volume through HDMI-CEC never send the pushed event pyatv waits for, so `set_volume` timed out (5 s) and surfaced as a failure even though the volume changed.
- **Resume / now-playing** — keep the external source active when the device reports `Idle` while its app stays in the foreground. Many tvOS apps (e.g. Netflix) report `Idle` instead of `Paused` when paused; MA was nulling the active source, so play fell back to the local queue instead of resuming the app.
- **Stop → home** — map stop to returning the device to its home screen, backgrounding the current app.
- **Power migration** — one-time `power_control` `none → native` for paired Apple TVs. Devices paired before native power control existed kept the old `none` default, hiding the power button; new ones already default to `native`. Degrades safely to `none` at runtime if a device does not support power.