### PR TITLE
Preserve AirPlay cleanup cancellation

### DIFF
--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -907,7 +907,12 @@ class SendspinAirPlayBridge:
             return
         try:
             await self._set_sink_fd(None)
-        except BaseException as err:
+        except asyncio.CancelledError:
+            if self._sink_fd == fd:
+                self._sink_fd = None
+            _close_fd(fd)
+            raise
+        except Exception as err:
             self.logger.warning(
                 "Could not release AirPlay bridge sink for %s: %s",
                 self.airplay_player.display_name,
@@ -915,7 +920,7 @@ class SendspinAirPlayBridge:
             )
             if self._sink_fd == fd:
                 self._sink_fd = None
-                _close_fd(fd)
+            _close_fd(fd)
 
     async def _set_sink_fd(self, fd: int | None) -> None:
         """

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -772,3 +772,28 @@ async def test_warm_generation_exception_after_sink_publication_releases_fd() ->
     assert bridge._sink_fd is None
     assert sum(call.args == (1000,) for call in close_fd.call_args_list) == 1
     kept_stream.discard_generation.assert_awaited_once_with(1)
+
+
+async def test_release_sink_fd_propagates_cancellation_after_clearing_owner() -> None:
+    """Sink cleanup closes its fd and propagates cancellation."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._sink_fd = 1000
+
+    async def clear_then_cancel(fd: int | None) -> None:
+        bridge._sink_fd = fd
+        raise asyncio.CancelledError
+
+    with (
+        patch.object(
+            bridge,
+            "_set_sink_fd",
+            new_callable=AsyncMock,
+            side_effect=clear_then_cancel,
+        ),
+        patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as close_fd,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await bridge._release_sink_fd(1000)
+
+    close_fd.assert_called_once_with(1000)
+    assert bridge._sink_fd is None


### PR DESCRIPTION
# What does this implement/fix?

Preserves task cancellation while safely releasing a staged Sendspin AirPlay sink.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
