### PR TITLE
Keep AirPlay bridge helpers ordered

### DIFF
--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -142,33 +142,6 @@ def device_buffer_ahead_seconds(
     return cursor_play_time_s - unix_now
 
 
-def _close_fd(fd: int) -> None:
-    """Close a file descriptor if it is still open."""
-    with suppress(OSError):
-        os.close(fd)
-
-
-def _unlink_fifo(path: str) -> None:
-    """Remove a fifo path if it still exists."""
-    with suppress(OSError):
-        Path(path).unlink()
-
-
-async def _create_fifo(path: str) -> None:
-    """Create a fresh fifo path."""
-    with suppress(FileNotFoundError):
-        await asyncio.to_thread(os.unlink, path)
-    await asyncio.to_thread(os.mkfifo, path)
-
-
-async def _cleanup_fifo(path: str) -> None:
-    """Unblock any fifo reader and remove its path."""
-    with suppress(OSError):
-        _close_fd(os.open(path, os.O_WRONLY | os.O_NONBLOCK))
-    with suppress(OSError):
-        await asyncio.to_thread(os.unlink, path)
-
-
 class SendspinAirPlayBridge:
     """
     Manages the Sendspin to AirPlay bridge for a single player.
@@ -1106,3 +1079,30 @@ class SendspinBridgeManager(SendspinBridgeManagerBase[SendspinAirPlayBridge]):
     def _should_have_bridge(self, player: Player) -> bool:
         """Return whether an AirPlay player should have a Sendspin bridge."""
         return get_bridge_client_id(cast("AirPlayPlayer", player)) is not None
+
+
+def _close_fd(fd: int) -> None:
+    """Close a file descriptor if it is still open."""
+    with suppress(OSError):
+        os.close(fd)
+
+
+def _unlink_fifo(path: str) -> None:
+    """Remove a fifo path if it still exists."""
+    with suppress(OSError):
+        Path(path).unlink()
+
+
+async def _create_fifo(path: str) -> None:
+    """Create a fresh fifo path."""
+    with suppress(FileNotFoundError):
+        await asyncio.to_thread(os.unlink, path)
+    await asyncio.to_thread(os.mkfifo, path)
+
+
+async def _cleanup_fifo(path: str) -> None:
+    """Unblock any fifo reader and remove its path."""
+    with suppress(OSError):
+        _close_fd(os.open(path, os.O_WRONLY | os.O_NONBLOCK))
+    with suppress(OSError):
+        await asyncio.to_thread(os.unlink, path)


### PR DESCRIPTION
# What does this implement/fix?

Moves private AirPlay bridge FIFO helpers below the module's public classes to follow the server file-order convention.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
