### PR TITLE
Install Git for temporary aiolibdatachannel source build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,11 +43,16 @@ COPY requirements_all.txt .
 
 # miniaudio has no Linux arm64 wheels, so pyatv requires a source build there.
 # The compiler stays in this disposable builder stage and is not copied to the final image.
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        apt-get update && \
-        apt-get install -y --no-install-recommends gcc g++ && \
-        rm -rf /var/lib/apt/lists/*; \
-    fi
+# RUN if [ "$TARGETARCH" = "arm64" ]; then \
+#         apt-get update && \
+#         apt-get install -y --no-install-recommends gcc g++ && \
+#         rm -rf /var/lib/apt/lists/*; \
+#     fi
+
+# TODO: Remove git after aiodatalibchannel is installed from pypi
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git gcc g++ && \
+    rm -rf /var/lib/apt/lists/*
 
 # ensure UV is installed
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/


### PR DESCRIPTION
## Summary

- install Git and native compiler tooling for all architectures in the disposable Docker builder stage
- preserve the previous ARM64-only installation block for restoration once aiolibdatachannel is available from PyPI

## Validation

- built the Docker image successfully for `linux/arm64`
- built the Docker image successfully for `linux/amd64`