### PR TITLE
Move provider credentials into guided setup flows

### DIFF
--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -74,6 +74,8 @@ class ProviderConfigMixin:
 
         def encrypt_string(self, str_value: str) -> str: ...  # noqa: D102
 
+        def decrypt_string(self, encrypted_str: str) -> str: ...  # noqa: D102
+
         async def set_onboard_complete(self) -> None: ...  # noqa: D102
 
     @api_command("config/providers", required_scope=Scope.CONFIG_PROVIDERS_READ)
@@ -389,6 +391,27 @@ class ProviderConfigMixin:
                 self.get(f"{CONF_PROVIDERS}/{provider_instance}/{key}", default),
             ),
         )
+
+    def get_provider_setup_value(
+        self, instance_id: str, key: str, default: ConfigValueType = None
+    ) -> ConfigValueType:
+        """
+        Return a single (decrypted) setup_data value for a provider from storage.
+
+        Falls back to the legacy raw config values for installs configured before
+        setup flows existed. Works without a loaded provider instance.
+
+        :param instance_id: The provider instance ID.
+        :param key: The setup data key to retrieve.
+        :param default: Value to return when the key is not present anywhere.
+        """
+        setup_data = self.get(f"{CONF_PROVIDERS}/{instance_id}/setup_data") or {}
+        value = setup_data.get(key)
+        if value is None:
+            value = self.get_raw_provider_config_value(instance_id, key, default)
+        if isinstance(value, str):
+            return self.decrypt_string(value)
+        return value
 
     def set_raw_provider_config_value(
         self,

--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -406,8 +406,11 @@ class ProviderConfigMixin:
         :param default: Value to return when the key is not present anywhere.
         """
         setup_data = self.get(f"{CONF_PROVIDERS}/{instance_id}/setup_data") or {}
-        value = setup_data.get(key)
-        if value is None:
+        # presence check (not None check): an explicitly cleared value must not
+        # fall back to (and resurrect) a stale legacy config value
+        if key in setup_data:
+            value = cast("ConfigValueType", setup_data[key])
+        else:
             value = self.get_raw_provider_config_value(instance_id, key, default)
         if isinstance(value, str):
             return self.decrypt_string(value)

--- a/music_assistant/providers/amplipi/__init__.py
+++ b/music_assistant/providers/amplipi/__init__.py
@@ -9,14 +9,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from music_assistant_models.config_entries import ConfigEntry
-from music_assistant_models.enums import ConfigEntryType, ProviderFeature
+from music_assistant_models.enums import ProviderFeature
 
-from .constants import CONF_HOST
 from .provider import AmpliPiPlayerProvider
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ConfigValueType, ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -47,10 +45,4 @@ async def get_config_entries(
     :param action: [optional] action key called from config entries UI.
     :param values: the (intermediate) raw values for config entries sent with the action.
     """
-    return (
-        ConfigEntry(
-            key=CONF_HOST,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-    )
+    return ()

--- a/music_assistant/providers/amplipi/provider.py
+++ b/music_assistant/providers/amplipi/provider.py
@@ -71,7 +71,7 @@ class AmpliPiPlayerProvider(PlayerProvider):
         self._ma_streams = {}
         self._streams = []
         self._stream_locks = {}
-        host = cast("str", self.config.get_value(CONF_HOST))
+        host = cast("str", self.get_setup_value(CONF_HOST))
         if host.startswith(("http://", "https://")):
             # a full URL is used as-is, but a schemed host with no path (e.g.
             # "https://amplipi.local") still needs the AmpliPi "/api" base appended

--- a/music_assistant/providers/amplipi/setup_flow.py
+++ b/music_assistant/providers/amplipi/setup_flow.py
@@ -37,4 +37,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/amplipi/setup_flow.py
+++ b/music_assistant/providers/amplipi/setup_flow.py
@@ -1,0 +1,40 @@
+"""Setup flow for the AmpliPi provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.amplipi.constants import CONF_HOST
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(
+        key=CONF_HOST,
+        type=ConfigEntryType.STRING,
+        required=True,
+    ),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the connection details and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/ard_audiothek/__init__.py
+++ b/music_assistant/providers/ard_audiothek/__init__.py
@@ -150,79 +150,31 @@ async def get_config_entries(
     values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
-    if values is None:
-        values = {}
-
-    authenticated = True
-    if values.get(CONF_TOKEN_BEARER) is None or values.get(CONF_USERID) is None:
-        authenticated = False
-
+    # credentials and the token/user-id/expiry stash are collected/persisted by the
+    # setup flow; the options surface only shows who is signed in plus the tunables
+    display_name = ""
+    email = ""
+    if instance_id and (prov := mass.get_provider(instance_id, return_unavailable=True)):
+        display_name = str(prov.get_setup_value(CONF_DISPLAY_NAME) or "")
+        email = str(prov.get_setup_value(CONF_EMAIL) or "")
     return (
         ConfigEntry(
             key="label_text",
             type=ConfigEntryType.LABEL,
-            translation_params=[
-                str(values.get(CONF_DISPLAY_NAME)),
-                str(values.get(CONF_EMAIL, "")).replace("@", "(at)"),
-            ],
-            hidden=not authenticated,
-        ),
-        ConfigEntry(
-            key=CONF_EMAIL,
-            type=ConfigEntryType.STRING,
-            required=False,
-            hidden=authenticated,
-            value=values.get(CONF_EMAIL),
-        ),
-        ConfigEntry(
-            key=CONF_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=False,
-            hidden=authenticated,
-            value=values.get(CONF_PASSWORD),
+            translation_params=[display_name, email.replace("@", "(at)")],
+            hidden=not display_name,
         ),
         ConfigEntry(
             key=CONF_MAX_BITRATE,
             type=ConfigEntryType.INTEGER,
             required=False,
             default_value=0,
-            value=values.get(CONF_MAX_BITRATE),
         ),
         ConfigEntry(
             key=CONF_PODCAST_FINISHED,
             type=ConfigEntryType.INTEGER,
             required=False,
             default_value=95,
-            value=values.get(CONF_PODCAST_FINISHED),
-        ),
-        ConfigEntry(
-            key=CONF_TOKEN_BEARER,
-            type=ConfigEntryType.SECURE_STRING,
-            hidden=True,
-            required=False,
-            value=values.get(CONF_TOKEN_BEARER),
-        ),
-        ConfigEntry(
-            key=CONF_USERID,
-            type=ConfigEntryType.SECURE_STRING,
-            hidden=True,
-            required=False,
-            value=values.get(CONF_USERID),
-        ),
-        ConfigEntry(
-            key=CONF_EXPIRY_TIME,
-            type=ConfigEntryType.SECURE_STRING,
-            hidden=True,
-            required=False,
-            default_value=0,
-            value=values.get(CONF_EXPIRY_TIME),
-        ),
-        ConfigEntry(
-            key=CONF_DISPLAY_NAME,
-            type=ConfigEntryType.STRING,
-            hidden=True,
-            required=False,
-            value=values.get(CONF_DISPLAY_NAME),
         ),
     )
 
@@ -236,11 +188,13 @@ class ARDAudiothek(MusicProvider):
 
         This happens when the token is expired or user credentials are updated.
         """
-        _email = self.config.get_value(CONF_EMAIL)
-        _password = self.config.get_value(CONF_PASSWORD)
-        self.token = self.config.get_value(CONF_TOKEN_BEARER)
-        self.user_id = self.config.get_value(CONF_USERID)
-        self.token_expire = from_utc_timestamp(float(str(self.config.get_value(CONF_EXPIRY_TIME))))
+        _email = self.get_setup_value(CONF_EMAIL)
+        _password = self.get_setup_value(CONF_PASSWORD)
+        self.token = self.get_setup_value(CONF_TOKEN_BEARER)
+        self.user_id = self.get_setup_value(CONF_USERID)
+        self.token_expire = from_utc_timestamp(
+            float(str(self.get_setup_value(CONF_EXPIRY_TIME, 0)))
+        )
 
         self.max_bitrate = int(float(str(self.config.get_value(CONF_MAX_BITRATE))))
 
@@ -252,10 +206,10 @@ class ARDAudiothek(MusicProvider):
             self.token, self.user_id, _display_name = await _login(
                 self.mass.http_session, str(_email), str(_password)
             )
-            self._update_config_value(CONF_TOKEN_BEARER, self.token, encrypted=True)
-            self._update_config_value(CONF_USERID, self.user_id, encrypted=True)
-            self._update_config_value(CONF_DISPLAY_NAME, _display_name)
-            self._update_config_value(CONF_EXPIRY_TIME, str(future_timestamp(hours=1)))
+            self._update_setup_data(CONF_TOKEN_BEARER, self.token)
+            self._update_setup_data(CONF_USERID, self.user_id)
+            self._update_setup_data(CONF_DISPLAY_NAME, _display_name)
+            self._update_setup_data(CONF_EXPIRY_TIME, str(future_timestamp(hours=1)))
             self._client_initialized = False
 
         if not self._client_initialized:

--- a/music_assistant/providers/ard_audiothek/setup_flow.py
+++ b/music_assistant/providers/ard_audiothek/setup_flow.py
@@ -35,4 +35,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/ard_audiothek/setup_flow.py
+++ b/music_assistant/providers/ard_audiothek/setup_flow.py
@@ -1,0 +1,38 @@
+"""Setup flow for the ARD Audiothek provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_PASSWORD
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.ard_audiothek import CONF_EMAIL
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(key=CONF_EMAIL, type=ConfigEntryType.STRING, required=False),
+    ConfigEntry(key=CONF_PASSWORD, type=ConfigEntryType.SECURE_STRING, required=False),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the (optional) account credentials and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -183,43 +183,6 @@ async def get_config_entries(
     # ruff: noqa: ARG001
     return (
         ConfigEntry(
-            key="label",
-            type=ConfigEntryType.LABEL,
-        ),
-        ConfigEntry(
-            key=CONF_URL,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=False,
-        ),
-        ConfigEntry(
-            key=CONF_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=False,
-        ),
-        ConfigEntry(
-            key=CONF_API_TOKEN,
-            type=ConfigEntryType.SECURE_STRING,
-            required=False,
-        ),
-        ConfigEntry(
-            key=CONF_OLD_TOKEN,
-            type=ConfigEntryType.SECURE_STRING,
-            required=False,
-            hidden=True,
-        ),
-        ConfigEntry(
-            key=CONF_VERIFY_SSL,
-            type=ConfigEntryType.BOOLEAN,
-            required=False,
-            advanced=True,
-            default_value=True,
-        ),
-        ConfigEntry(
             key=CONF_HIDE_EMPTY_PODCASTS,
             type=ConfigEntryType.BOOLEAN,
             required=False,
@@ -261,12 +224,12 @@ class Audiobookshelf(RecommendationPayloadMixin, MusicProvider):
         self._on_unload_callbacks: list[Callable[[], None]] = []
         self.sessions: dict[str, SessionHelper] = {}  # key is the mass_item_id
         self.create_session_lock = asyncio.Lock()
-        base_url = str(self.config.get_value(CONF_URL))
-        username = str(self.config.get_value(CONF_USERNAME))
-        password = str(self.config.get_value(CONF_PASSWORD))
-        token_old = self.config.get_value(CONF_OLD_TOKEN)
-        token_api = self.config.get_value(CONF_API_TOKEN)
-        verify_ssl = bool(self.config.get_value(CONF_VERIFY_SSL))
+        base_url = str(self.get_setup_value(CONF_URL))
+        username = str(self.get_setup_value(CONF_USERNAME))
+        password = str(self.get_setup_value(CONF_PASSWORD))
+        token_old = self.get_setup_value(CONF_OLD_TOKEN)
+        token_api = self.get_setup_value(CONF_API_TOKEN)
+        verify_ssl = bool(self.get_setup_value(CONF_VERIFY_SSL))
         session_config = AbsSessionConfiguration(
             session=self.mass.http_session,
             url=base_url,
@@ -480,7 +443,7 @@ for more details.
                     instance_id=self.instance_id,
                     domain=self.domain,
                     token=self._client.token,
-                    base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+                    base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
                 )
             for abs_narrator in await self._client.get_library_narrators(library_id=book_lib_id):
                 self.libraries.narrators[book_lib_id].add(abs_narrator.id_)
@@ -542,7 +505,7 @@ for more details.
             instance_id=self.instance_id,
             domain=self.domain,
             token=self._client.token,
-            base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+            base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
         )
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
@@ -566,7 +529,7 @@ for more details.
                             instance_id=self.instance_id,
                             domain=self.domain,
                             token=self._client.token,
-                            base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+                            base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
                             owner=self.abs_username,
                             media_type=media_type,
                         )
@@ -610,7 +573,7 @@ for more details.
                         domain=self.domain,
                         token=self._client.token,
                         media_progress=progress,
-                        base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+                        base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
                     )
                 )
             elif isinstance(item, AbsPlaylistItemExpandedPodcast):
@@ -626,7 +589,7 @@ for more details.
                         instance_id=self.instance_id,
                         domain=self.domain,
                         token=self._client.token,
-                        base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+                        base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
                         media_progress=progress,
                         cover_path=item.library_item.media.cover_path,
                         cover_version=item.library_item.updated_at,
@@ -666,7 +629,7 @@ for more details.
                 instance_id=self.instance_id,
                 domain=self.domain,
                 token=self._client.token,
-                base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+                base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
                 owner=self.abs_username,
                 media_type=media_type,
             )
@@ -760,7 +723,7 @@ for more details.
                         instance_id=self.instance_id,
                         domain=self.domain,
                         token=self._client.token,
-                        base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+                        base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
                     )
                     if (
                         bool(self.config.get_value(CONF_HIDE_EMPTY_PODCASTS))
@@ -810,7 +773,7 @@ for more details.
             instance_id=self.instance_id,
             domain=self.domain,
             token=self._client.token,
-            base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+            base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
         )
 
     async def get_podcast_episodes(self, prov_podcast_id: str) -> AsyncGenerator[PodcastEpisode]:
@@ -840,7 +803,7 @@ for more details.
                 instance_id=self.instance_id,
                 domain=self.domain,
                 token=self._client.token,
-                base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+                base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
                 media_progress=progress,
                 cover_path=abs_podcast.media.cover_path,
                 cover_version=abs_podcast.updated_at,
@@ -871,7 +834,7 @@ for more details.
                     instance_id=self.instance_id,
                     domain=self.domain,
                     token=self._client.token,
-                    base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+                    base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
                     media_progress=progress,
                     cover_path=abs_podcast.media.cover_path,
                     cover_version=abs_podcast.updated_at,
@@ -905,7 +868,7 @@ for more details.
                         instance_id=self.instance_id,
                         domain=self.domain,
                         token=self._client.token,
-                        base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+                        base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
                     )
                     yield mass_audiobook
 
@@ -935,7 +898,7 @@ for more details.
             instance_id=self.instance_id,
             domain=self.domain,
             token=self._client.token,
-            base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+            base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
             media_progress=progress,
         )
 
@@ -963,7 +926,7 @@ for more details.
         We always use a custom stream type, also for single file, such
         that we can handle an ffmpeg error and refresh our tokens.
         """
-        abs_base_url = str(self.config.get_value(CONF_URL))
+        abs_base_url = str(self.get_setup_value(CONF_URL))
         tracks = abs_session.audio_tracks
 
         if len(tracks) == 0:
@@ -1077,7 +1040,7 @@ for more details.
         except IndexError:
             return web.Response(status=404, text="Part not found")
 
-        base_url = str(self.config.get_value(CONF_URL))
+        base_url = str(self.get_setup_value(CONF_URL))
         stream_url = f"{base_url}{part_track.content_url}?token={self._client.token}"
         # redirect to the actual stream url
         raise web.HTTPFound(location=stream_url)
@@ -1174,7 +1137,7 @@ for more details.
                                 instance_id=self.instance_id,
                                 domain=self.domain,
                                 token=self._client.token,
-                                base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+                                base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
                                 cover_path=_cover_path,
                                 cover_version=_cover_version,
                             )
@@ -1753,7 +1716,7 @@ for more details.
                         instance_id=self.instance_id,
                         domain=self.domain,
                         token=self._client.token,
-                        base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+                        base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
                     ),
                     overwrite_existing=True,
                 )
@@ -1769,7 +1732,7 @@ for more details.
                     instance_id=self.instance_id,
                     domain=self.domain,
                     token=self._client.token,
-                    base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+                    base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
                 )
                 if not (
                     bool(self.config.get_value(CONF_HIDE_EMPTY_PODCASTS))
@@ -1854,7 +1817,7 @@ for more details.
                 instance_id=self.instance_id,
                 domain=self.domain,
                 token=self._client.token,
-                base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+                base_url=str(self.get_setup_value(CONF_URL)).rstrip("/"),
                 owner=self.abs_username,
                 media_type=media_type,
             )
@@ -1906,8 +1869,8 @@ for more details.
                 await asyncio.sleep(0.5)
         async with self.reauthenticate_lock:
             await self._client.session_config.authenticate(
-                username=str(self.config.get_value(CONF_USERNAME)),
-                password=str(self.config.get_value(CONF_PASSWORD)),
+                username=str(self.get_setup_value(CONF_USERNAME)),
+                password=str(self.get_setup_value(CONF_PASSWORD)),
             )
             self.reauthenticate_last = time.time()
 

--- a/music_assistant/providers/audiobookshelf/setup_flow.py
+++ b/music_assistant/providers/audiobookshelf/setup_flow.py
@@ -1,0 +1,79 @@
+"""Setup flow for the Audiobookshelf provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.audiobookshelf.constants import (
+    CONF_API_TOKEN,
+    CONF_OLD_TOKEN,
+    CONF_PASSWORD,
+    CONF_URL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(
+        key="label",
+        type=ConfigEntryType.LABEL,
+    ),
+    ConfigEntry(
+        key=CONF_URL,
+        type=ConfigEntryType.STRING,
+        required=True,
+    ),
+    ConfigEntry(
+        key=CONF_USERNAME,
+        type=ConfigEntryType.STRING,
+        required=False,
+    ),
+    ConfigEntry(
+        key=CONF_PASSWORD,
+        type=ConfigEntryType.SECURE_STRING,
+        required=False,
+    ),
+    ConfigEntry(
+        key=CONF_API_TOKEN,
+        type=ConfigEntryType.SECURE_STRING,
+        required=False,
+    ),
+    ConfigEntry(
+        key=CONF_OLD_TOKEN,
+        type=ConfigEntryType.SECURE_STRING,
+        required=False,
+        hidden=True,
+    ),
+    ConfigEntry(
+        key=CONF_VERIFY_SSL,
+        type=ConfigEntryType.BOOLEAN,
+        required=False,
+        advanced=True,
+        default_value=True,
+    ),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the connection details and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/audiobookshelf/setup_flow.py
+++ b/music_assistant/providers/audiobookshelf/setup_flow.py
@@ -76,4 +76,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/bandcamp/__init__.py
+++ b/music_assistant/providers/bandcamp/__init__.py
@@ -101,12 +101,6 @@ async def get_config_entries(
     return (
         CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
-            key=CONF_IDENTITY,
-            type=ConfigEntryType.SECURE_STRING,
-            required=False,
-            value=values.get(CONF_IDENTITY) if values else None,
-        ),
-        ConfigEntry(
             key=CONF_TOP_TRACKS_LIMIT,
             type=ConfigEntryType.INTEGER,
             required=False,
@@ -150,7 +144,7 @@ class BandcampProvider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async init of the Bandcamp provider."""
-        identity = self.config.get_value(CONF_IDENTITY)
+        identity = self.get_setup_value(CONF_IDENTITY)
         self.top_tracks_limit = cast(
             "int", self.config.get_value(CONF_TOP_TRACKS_LIMIT, DEFAULT_TOP_TRACKS_LIMIT)
         )

--- a/music_assistant/providers/bandcamp/setup_flow.py
+++ b/music_assistant/providers/bandcamp/setup_flow.py
@@ -1,0 +1,32 @@
+"""Setup flow for the Bandcamp provider."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.bandcamp.constants import CONF_IDENTITY
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (ConfigEntry(key=CONF_IDENTITY, type=ConfigEntryType.SECURE_STRING, required=False),)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the (optional) identity cookie and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        submitted = await session.form(
+            list(_ENTRIES), step_id="user", errors=errors, last_step=True
+        )
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/bandcamp/setup_flow.py
+++ b/music_assistant/providers/bandcamp/setup_flow.py
@@ -29,4 +29,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/bbc_sounds/__init__.py
+++ b/music_assistant/providers/bbc_sounds/__init__.py
@@ -103,16 +103,6 @@ async def get_config_entries(
             type=ConfigEntryType.LABEL,
         ),
         ConfigEntry(
-            key=CONF_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=False,
-        ),
-        ConfigEntry(
-            key=CONF_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=False,
-        ),
-        ConfigEntry(
             key=_Constants.CONF_SHOW_LOCAL,
             advanced=True,
             type=ConfigEntryType.BOOLEAN,
@@ -145,8 +135,8 @@ class BBCSoundsProvider(RecommendationPayloadMixin, MusicProvider):
         """Handle async initialization of the provider."""
         # If we have an account, authenticate. Testing shows all features work without auth
         # but BBC will be disabling BBC Sounds from outside the UK at some point
-        username = self.config.get_value(CONF_USERNAME)
-        password = self.config.get_value(CONF_PASSWORD)
+        username = self.get_setup_value(CONF_USERNAME)
+        password = self.get_setup_value(CONF_PASSWORD)
         if username and password:
             self.client = SoundsClient(
                 session=self.mass.http_session,

--- a/music_assistant/providers/bbc_sounds/setup_flow.py
+++ b/music_assistant/providers/bbc_sounds/setup_flow.py
@@ -1,0 +1,37 @@
+"""Setup flow for the BBC Sounds provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowError
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(key=CONF_USERNAME, type=ConfigEntryType.STRING, required=False),
+    ConfigEntry(key=CONF_PASSWORD, type=ConfigEntryType.SECURE_STRING, required=False),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the (optional) credentials and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/bbc_sounds/setup_flow.py
+++ b/music_assistant/providers/bbc_sounds/setup_flow.py
@@ -34,4 +34,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/bose_soundtouch/__init__.py
+++ b/music_assistant/providers/bose_soundtouch/__init__.py
@@ -12,16 +12,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from music_assistant_models.config_entries import ConfigEntry
-from music_assistant_models.enums import ConfigEntryType, ProviderFeature
+from music_assistant_models.enums import ProviderFeature
 
 from music_assistant.constants import CONF_ENTRY_MANUAL_DISCOVERY_IPS
 
-from .const import CONF_APP_KEY
 from .provider import BoseSoundTouchProvider
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ConfigValueType, ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -52,12 +50,4 @@ async def get_config_entries(
     action: [optional] action key called from config entries UI.
     values: the (intermediate) raw values for config entries sent with the action.
     """
-    return (
-        CONF_ENTRY_MANUAL_DISCOVERY_IPS,
-        ConfigEntry(
-            key=CONF_APP_KEY,
-            type=ConfigEntryType.SECURE_STRING,
-            translation_key="app_key",
-            required=False,
-        ),
-    )
+    return (CONF_ENTRY_MANUAL_DISCOVERY_IPS,)

--- a/music_assistant/providers/bose_soundtouch/player.py
+++ b/music_assistant/providers/bose_soundtouch/player.py
@@ -85,7 +85,7 @@ class BoseSoundTouchPlayer(Player):
         }
         # Native announcements require a Bose developer app key; when configured the
         # speaker plays them as an overlay (ducking and resuming the current playback).
-        app_key = provider.config.get_value(CONF_APP_KEY)
+        app_key = provider.get_setup_value(CONF_APP_KEY)
         self._app_key = str(app_key) if app_key else None
         if self._app_key:
             self._attr_supported_features.add(PlayerFeature.PLAY_ANNOUNCEMENT)

--- a/music_assistant/providers/bose_soundtouch/setup_flow.py
+++ b/music_assistant/providers/bose_soundtouch/setup_flow.py
@@ -36,4 +36,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/bose_soundtouch/setup_flow.py
+++ b/music_assistant/providers/bose_soundtouch/setup_flow.py
@@ -1,0 +1,39 @@
+"""Setup flow for the Bose SoundTouch provider."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.bose_soundtouch.const import CONF_APP_KEY
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(
+        key=CONF_APP_KEY,
+        type=ConfigEntryType.SECURE_STRING,
+        translation_key="app_key",
+        required=False,
+    ),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the (optional) developer app key and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        submitted = await session.form(
+            list(_ENTRIES), step_id="user", errors=errors, last_step=True
+        )
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -4,15 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
-from music_assistant_models.enums import ConfigEntryType
-
 from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
 
-from .provider import CONF_ARL_TOKEN, SUPPORTED_FEATURES, DeezerProvider
+from .provider import SUPPORTED_FEATURES, DeezerProvider
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant import MusicAssistant
@@ -32,15 +29,7 @@ async def get_config_entries(
     mass: MusicAssistant,  # noqa: ARG001
     instance_id: str | None = None,  # noqa: ARG001
     action: str | None = None,  # noqa: ARG001
-    values: dict[str, ConfigValueType] | None = None,
+    values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
 ) -> tuple[ConfigEntry, ...]:
     """Return Config entries to setup this provider."""
-    return (
-        CONF_ENTRY_UNOFFICIAL_PROVIDER,
-        ConfigEntry(
-            key=CONF_ARL_TOKEN,
-            type=ConfigEntryType.SECURE_STRING,
-            required=True,
-            value=values.get(CONF_ARL_TOKEN) if values else None,
-        ),
-    )
+    return (CONF_ENTRY_UNOFFICIAL_PROVIDER,)

--- a/music_assistant/providers/deezer/provider.py
+++ b/music_assistant/providers/deezer/provider.py
@@ -92,7 +92,7 @@ class DeezerProvider(RecommendationPayloadMixin, MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async init of the Deezer provider."""
-        arl_token = str(self.config.get_value(CONF_ARL_TOKEN))
+        arl_token = str(self.get_setup_value(CONF_ARL_TOKEN))
 
         try:
             self.gql_client = DeezerGQLClient(arl=arl_token, session=self.mass.http_session)

--- a/music_assistant/providers/deezer/setup_flow.py
+++ b/music_assistant/providers/deezer/setup_flow.py
@@ -1,0 +1,32 @@
+"""Setup flow for the Deezer provider."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.deezer.provider import CONF_ARL_TOKEN
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (ConfigEntry(key=CONF_ARL_TOKEN, type=ConfigEntryType.SECURE_STRING, required=True),)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the ARL token and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        submitted = await session.form(
+            list(_ENTRIES), step_id="user", errors=errors, last_step=True
+        )
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/deezer/setup_flow.py
+++ b/music_assistant/providers/deezer/setup_flow.py
@@ -29,4 +29,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/digitally_incorporated/__init__.py
+++ b/music_assistant/providers/digitally_incorporated/__init__.py
@@ -161,15 +161,6 @@ async def get_config_entries(
     """Return Config entries to setup this provider."""
     entries = []
 
-    # Listen key configuration
-    entries.append(
-        ConfigEntry(
-            key="listen_key",
-            type=ConfigEntryType.STRING,
-            required=True,
-        )
-    )
-
     # Network selection - multi-select instead of individual booleans
     network_options = [
         ConfigValueOption(network_key, title=network_info["display_name"])
@@ -214,7 +205,7 @@ class DigitallyIncorporatedProvider(MusicProvider):
             msg = f"{self.domain}: At least one network must be enabled"
             raise ProviderUnavailableError(msg)
 
-        listen_key = self.config.get_value("listen_key")
+        listen_key = self.get_setup_value("listen_key")
         if (
             not listen_key
             or not isinstance(listen_key, str)
@@ -534,7 +525,7 @@ class DigitallyIncorporatedProvider(MusicProvider):
     async def _fetch_favorites_pls(self, network_key: str) -> str:
         """Download favorites.pls from the listen.* host for this network."""
         domain = NETWORKS[network_key]["domain"]
-        listen_key = self.config.get_value("listen_key")
+        listen_key = self.get_setup_value("listen_key")
         timeout = aiohttp.ClientTimeout(total=API_TIMEOUT)
         params: dict[str, str] = {"listen_key": str(listen_key), **FAVORITES_PLS_EXTRA_PARAMS}
         try:
@@ -813,7 +804,7 @@ class DigitallyIncorporatedProvider(MusicProvider):
             "%s: Getting stream URLs for %s:%s", self.domain, network_key, channel_key
         )
 
-        listen_key = self.config.get_value("listen_key")
+        listen_key = self.get_setup_value("listen_key")
         if not listen_key:
             msg = f"{self.domain}: Listen key not configured"
             raise ProviderUnavailableError(msg)

--- a/music_assistant/providers/digitally_incorporated/setup_flow.py
+++ b/music_assistant/providers/digitally_incorporated/setup_flow.py
@@ -1,0 +1,33 @@
+"""Setup flow for the Digitally Incorporated provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (ConfigEntry(key="listen_key", type=ConfigEntryType.STRING, required=True),)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the listen key and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/digitally_incorporated/setup_flow.py
+++ b/music_assistant/providers/digitally_incorporated/setup_flow.py
@@ -30,4 +30,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/emby/__init__.py
+++ b/music_assistant/providers/emby/__init__.py
@@ -10,13 +10,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
 from aiohttp import ClientResponseError
-from music_assistant_models.config_entries import (
-    ConfigEntry,
-    ConfigValueType,
-    ProviderConfig,
-)
 from music_assistant_models.enums import (
-    ConfigEntryType,
     MediaType,
     ProviderFeature,
     StreamType,
@@ -62,6 +56,11 @@ from music_assistant.providers.emby.parsers import (
 )
 
 if TYPE_CHECKING:
+    from music_assistant_models.config_entries import (
+        ConfigEntry,
+        ConfigValueType,
+        ProviderConfig,
+    )
     from music_assistant_models.provider import ProviderManifest
 
 from music_assistant.constants import (
@@ -99,23 +98,7 @@ async def get_config_entries(
 ) -> tuple[ConfigEntry, ...]:
     """Get configuration entries for provider setup."""
     # ruff: noqa: ARG001
-    return (
-        ConfigEntry(
-            key=CONF_IP_ADDRESS,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=False,
-        ),
-    )
+    return ()
 
 
 class EmbyProvider(MusicProvider):
@@ -123,9 +106,9 @@ class EmbyProvider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Initialize provider(instance) with given configuration."""
-        username = str(self.config.get_value(CONF_USERNAME))
-        password = str(self.config.get_value(CONF_PASSWORD) or "")
-        self._base_url = str(self.config.get_value(CONF_IP_ADDRESS)).rstrip("/") + "/"
+        username = str(self.get_setup_value(CONF_USERNAME))
+        password = str(self.get_setup_value(CONF_PASSWORD) or "")
+        self._base_url = str(self.get_setup_value(CONF_IP_ADDRESS)).rstrip("/") + "/"
         self._session = self.mass.http_session
 
         # stable device id

--- a/music_assistant/providers/emby/setup_flow.py
+++ b/music_assistant/providers/emby/setup_flow.py
@@ -47,4 +47,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/emby/setup_flow.py
+++ b/music_assistant/providers/emby/setup_flow.py
@@ -1,0 +1,50 @@
+"""Setup flow for the Emby provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowError
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(
+        key=CONF_IP_ADDRESS,
+        type=ConfigEntryType.STRING,
+        required=True,
+    ),
+    ConfigEntry(
+        key=CONF_USERNAME,
+        type=ConfigEntryType.STRING,
+        required=True,
+    ),
+    ConfigEntry(
+        key=CONF_PASSWORD,
+        type=ConfigEntryType.SECURE_STRING,
+        required=False,
+    ),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the connection details and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -19,7 +19,9 @@ import aiofiles
 import shortuuid
 import xmltodict
 from aiofiles.os import wrap
+from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import (
+    ConfigEntryType,
     ContentType,
     EventType,
     ExternalID,
@@ -93,15 +95,13 @@ from .constants import (
     CACHE_CATEGORY_FOLDER_IMAGES,
     CACHE_CATEGORY_PODCAST_METADATA,
     CACHE_CATEGORY_SOUND_EFFECTS,
-    CONF_ENTRY_CONTENT_TYPE,
-    CONF_ENTRY_CONTENT_TYPE_READ_ONLY,
+    CONF_CONTENT_TYPE,
     CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
     CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS,
     CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS,
     CONF_ENTRY_LIBRARY_SYNC_PODCASTS,
     CONF_ENTRY_LIBRARY_SYNC_TRACKS,
     CONF_ENTRY_MISSING_ALBUM_ARTIST,
-    CONF_ENTRY_PATH,
     CONF_ENTRY_PROPAGATE_GENRES,
     CUE_EXTENSIONS,
     DEFAULT_AUDIOBOOK_PODCAST_GENRE,
@@ -131,7 +131,7 @@ from .helpers import (
 from .parsers import parse_album_nfo
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+    from music_assistant_models.config_entries import ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -156,15 +156,14 @@ async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
     """Initialize provider(instance) with given configuration."""
-    base_path = cast("str", config.get_value(CONF_PATH))
-    return LocalFileSystemProvider(mass, manifest, config, base_path)
+    return LocalFileSystemProvider(mass, manifest, config)
 
 
 async def get_config_entries(
     mass: MusicAssistant,
     instance_id: str | None = None,
-    action: str | None = None,
-    values: dict[str, ConfigValueType] | None = None,
+    action: str | None = None,  # noqa: ARG001
+    values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
 ) -> tuple[ConfigEntry, ...]:
     """
     Return Config entries to setup this provider.
@@ -173,9 +172,13 @@ async def get_config_entries(
     action: [optional] action key called from config entries UI.
     values: the (intermediate) raw values for config entries sent with the action.
     """
-    # ruff: noqa: ARG001
-    base_entries = [
-        CONF_ENTRY_PATH,
+    # content type and path are collected by the setup flow; surface the (immutable)
+    # content type read-only so the sync options' depends_on chains still resolve
+    content_type = "music"
+    if instance_id and (prov := mass.get_provider(instance_id, return_unavailable=True)):
+        content_type = getattr(prov, "media_content_type", content_type)
+    return (
+        ConfigEntry(key=CONF_CONTENT_TYPE, type=ConfigEntryType.LABEL, value=content_type),
         CONF_ENTRY_MISSING_ALBUM_ARTIST,
         CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
         CONF_ENTRY_LIBRARY_SYNC_TRACKS,
@@ -183,10 +186,7 @@ async def get_config_entries(
         CONF_ENTRY_LIBRARY_SYNC_PODCASTS,
         CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS,
         CONF_ENTRY_PROPAGATE_GENRES,
-    ]
-    if instance_id is None or values is None:
-        return (CONF_ENTRY_CONTENT_TYPE, *base_entries)
-    return (CONF_ENTRY_CONTENT_TYPE_READ_ONLY, *base_entries)
+    )
 
 
 class LocalFileSystemProvider(MusicProvider):
@@ -206,16 +206,20 @@ class LocalFileSystemProvider(MusicProvider):
         mass: MusicAssistant,
         manifest: ProviderManifest,
         config: ProviderConfig,
-        base_path: str,
+        base_path: str | None = None,
     ) -> None:
         """Initialize MusicProvider."""
         super().__init__(mass, manifest, config, SUPPORTED_FEATURES)
-        self.base_path: str = base_path
+        # subclasses (NFS/SMB/...) mount elsewhere and pass their own base_path;
+        # the plain local provider reads its scan directory from the setup data
+        self.base_path: str = (
+            base_path if base_path is not None else cast("str", self.get_setup_value(CONF_PATH))
+        )
         self.write_access: bool = False
         self.sync_running: bool = False
         self._sync_tracks: bool = True
         self._sync_playlists: bool = True
-        self.media_content_type = cast("str", config.get_value(CONF_ENTRY_CONTENT_TYPE.key))
+        self.media_content_type = cast("str", self.get_setup_value(CONF_CONTENT_TYPE))
         self._cue = CueSheetHandler(self)
 
     @property

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -175,8 +175,12 @@ async def get_config_entries(
     # content type and path are collected by the setup flow; surface the (immutable)
     # content type read-only so the sync options' depends_on chains still resolve
     content_type = "music"
-    if instance_id and (prov := mass.get_provider(instance_id, return_unavailable=True)):
-        content_type = getattr(prov, "media_content_type", content_type)
+    if instance_id:
+        # read the persisted value so the depends_on chains resolve correctly
+        # even when the provider (instance) is not currently loaded
+        content_type = str(
+            mass.config.get_provider_setup_value(instance_id, CONF_CONTENT_TYPE, "music")
+        )
     return (
         ConfigEntry(key=CONF_CONTENT_TYPE, type=ConfigEntryType.LABEL, value=content_type),
         CONF_ENTRY_MISSING_ALBUM_ARTIST,

--- a/music_assistant/providers/filesystem_local/setup_flow.py
+++ b/music_assistant/providers/filesystem_local/setup_flow.py
@@ -1,0 +1,34 @@
+"""Setup flow for the local filesystem provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.filesystem_local.constants import (
+    CONF_ENTRY_CONTENT_TYPE,
+    CONF_ENTRY_PATH,
+)
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (CONF_ENTRY_CONTENT_TYPE, CONF_ENTRY_PATH)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the content type and path, then create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/filesystem_local/setup_flow.py
+++ b/music_assistant/providers/filesystem_local/setup_flow.py
@@ -31,4 +31,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/filesystem_nfs/__init__.py
+++ b/music_assistant/providers/filesystem_nfs/__init__.py
@@ -54,8 +54,12 @@ async def get_config_entries(
     # connection details and content type are collected by the setup flow; surface the
     # (immutable) content type read-only so the sync options' depends_on chains resolve
     content_type = "music"
-    if instance_id and (prov := mass.get_provider(instance_id, return_unavailable=True)):
-        content_type = getattr(prov, "media_content_type", content_type)
+    if instance_id:
+        # read the persisted value so the depends_on chains resolve correctly
+        # even when the provider (instance) is not currently loaded
+        content_type = str(
+            mass.config.get_provider_setup_value(instance_id, CONF_CONTENT_TYPE, "music")
+        )
     return (
         ConfigEntry(key=CONF_CONTENT_TYPE, type=ConfigEntryType.LABEL, value=content_type),
         CONF_ENTRY_MISSING_ALBUM_ARTIST,

--- a/music_assistant/providers/filesystem_nfs/__init__.py
+++ b/music_assistant/providers/filesystem_nfs/__init__.py
@@ -4,19 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from music_assistant_models.config_entries import (
-    ConfigEntry,
-    ConfigValueOption,
-    ConfigValueType,
-)
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType
-from music_assistant_models.errors import SetupFailedError
 
-from music_assistant.helpers.security import is_safe_path
-from music_assistant.helpers.util import get_ip_from_host
 from music_assistant.providers.filesystem_local.constants import (
-    CONF_ENTRY_CONTENT_TYPE,
-    CONF_ENTRY_CONTENT_TYPE_READ_ONLY,
+    CONF_CONTENT_TYPE,
     CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
     CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS,
     CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS,
@@ -26,7 +18,6 @@ from music_assistant.providers.filesystem_local.constants import (
     CONF_ENTRY_PROPAGATE_GENRES,
 )
 
-from .constants import CONF_EXPORT_PATH, CONF_HOST, CONF_NFS_VERSION, CONF_SUBFOLDER
 from .provider import NFSFileSystemProvider
 
 if TYPE_CHECKING:
@@ -41,20 +32,6 @@ async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
     """Initialize provider(instance) with given configuration."""
-    # check if valid dns name is given for the host
-    server = str(config.get_value(CONF_HOST))
-    if not await get_ip_from_host(server):
-        msg = f"Unable to resolve {server}, make sure the address is resolvable."
-        raise SetupFailedError(
-            msg,
-            translation_key="host_unresolvable",
-            translation_args=[server],
-        )
-    # check if export path is valid
-    export_path = str(config.get_value(CONF_EXPORT_PATH))
-    if not export_path or not export_path.startswith("/") or not is_safe_path(export_path):
-        msg = "Invalid export path: must be an absolute path starting with /"
-        raise SetupFailedError(msg)
     # base_path will be the path where we're going to mount the NFS export
     base_path = f"/tmp/{config.instance_id}"  # noqa: S108
     return NFSFileSystemProvider(mass, manifest, config, base_path)
@@ -63,8 +40,8 @@ async def setup(
 async def get_config_entries(
     mass: MusicAssistant,
     instance_id: str | None = None,
-    action: str | None = None,
-    values: dict[str, ConfigValueType] | None = None,
+    action: str | None = None,  # noqa: ARG001
+    values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
 ) -> tuple[ConfigEntry, ...]:
     """
     Return Config entries to setup this provider.
@@ -74,38 +51,13 @@ async def get_config_entries(
     :param action: [optional] action key called from config entries UI.
     :param values: the (intermediate) raw values for config entries sent with the action.
     """
-    # ruff: noqa: ARG001
-    base_entries = (
-        ConfigEntry(
-            key=CONF_HOST,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_EXPORT_PATH,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_SUBFOLDER,
-            type=ConfigEntryType.STRING,
-            required=False,
-            default_value="",
-        ),
-        ConfigEntry(
-            key=CONF_NFS_VERSION,
-            type=ConfigEntryType.STRING,
-            required=False,
-            advanced=True,
-            default_value="",
-            options=[
-                ConfigValueOption(""),
-                ConfigValueOption("3"),
-                ConfigValueOption("4"),
-                ConfigValueOption("4.1"),
-                ConfigValueOption("4.2"),
-            ],
-        ),
+    # connection details and content type are collected by the setup flow; surface the
+    # (immutable) content type read-only so the sync options' depends_on chains resolve
+    content_type = "music"
+    if instance_id and (prov := mass.get_provider(instance_id, return_unavailable=True)):
+        content_type = getattr(prov, "media_content_type", content_type)
+    return (
+        ConfigEntry(key=CONF_CONTENT_TYPE, type=ConfigEntryType.LABEL, value=content_type),
         CONF_ENTRY_MISSING_ALBUM_ARTIST,
         CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
         CONF_ENTRY_LIBRARY_SYNC_TRACKS,
@@ -113,14 +65,4 @@ async def get_config_entries(
         CONF_ENTRY_LIBRARY_SYNC_PODCASTS,
         CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS,
         CONF_ENTRY_PROPAGATE_GENRES,
-    )
-
-    if instance_id is None or values is None:
-        return (
-            CONF_ENTRY_CONTENT_TYPE,
-            *base_entries,
-        )
-    return (
-        *base_entries,
-        CONF_ENTRY_CONTENT_TYPE_READ_ONLY,
     )

--- a/music_assistant/providers/filesystem_nfs/provider.py
+++ b/music_assistant/providers/filesystem_nfs/provider.py
@@ -10,6 +10,8 @@ from music_assistant_models.errors import SetupFailedError
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.process import check_output
+from music_assistant.helpers.security import is_safe_path
+from music_assistant.helpers.util import get_ip_from_host
 from music_assistant.providers.filesystem_local import (
     LocalFileSystemProvider,
     exists,
@@ -32,8 +34,8 @@ class NFSFileSystemProvider(LocalFileSystemProvider):
     @property
     def instance_name_postfix(self) -> str | None:
         """Return a (default) instance name postfix for this provider instance."""
-        export_path = str(self.config.get_value(CONF_EXPORT_PATH))
-        subfolder = str(self.config.get_value(CONF_SUBFOLDER) or "")
+        export_path = str(self.get_setup_value(CONF_EXPORT_PATH))
+        subfolder = str(self.get_setup_value(CONF_SUBFOLDER) or "")
         if subfolder:
             return subfolder
         if export_path:
@@ -42,6 +44,19 @@ class NFSFileSystemProvider(LocalFileSystemProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
+        # validate the connection details before attempting to mount
+        server = str(self.get_setup_value(CONF_HOST))
+        if not await get_ip_from_host(server):
+            msg = f"Unable to resolve {server}, make sure the address is resolvable."
+            raise SetupFailedError(
+                msg,
+                translation_key="host_unresolvable",
+                translation_args=[server],
+            )
+        export_path = str(self.get_setup_value(CONF_EXPORT_PATH))
+        if not export_path or not export_path.startswith("/") or not is_safe_path(export_path):
+            msg = "Invalid export path: must be an absolute path starting with /"
+            raise SetupFailedError(msg)
         if not await exists(self.base_path):
             await makedirs(self.base_path)
         try:
@@ -70,11 +85,11 @@ class NFSFileSystemProvider(LocalFileSystemProvider):
 
     async def mount(self) -> None:
         """Mount the NFS export to a temporary folder."""
-        server = str(self.config.get_value(CONF_HOST))
-        export_path = str(self.config.get_value(CONF_EXPORT_PATH))
+        server = str(self.get_setup_value(CONF_HOST))
+        export_path = str(self.get_setup_value(CONF_EXPORT_PATH))
 
         # build full export path including optional subfolder
-        subfolder = str(self.config.get_value(CONF_SUBFOLDER) or "").strip()
+        subfolder = str(self.get_setup_value(CONF_SUBFOLDER) or "").strip()
         full_export = (
             str(PurePosixPath(export_path) / subfolder.lstrip("/")) if subfolder else export_path
         )
@@ -110,7 +125,7 @@ class NFSFileSystemProvider(LocalFileSystemProvider):
         else:
             options = ["noatime", "nolock", "tcp", "soft", "timeo=30", "retrans=5"]
 
-        nfs_version = str(self.config.get_value(CONF_NFS_VERSION) or "")
+        nfs_version = str(self.get_setup_value(CONF_NFS_VERSION) or "")
         if nfs_version:
             options.append(f"vers={nfs_version}")
 

--- a/music_assistant/providers/filesystem_nfs/setup_flow.py
+++ b/music_assistant/providers/filesystem_nfs/setup_flow.py
@@ -52,4 +52,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/filesystem_nfs/setup_flow.py
+++ b/music_assistant/providers/filesystem_nfs/setup_flow.py
@@ -1,0 +1,55 @@
+"""Setup flow for the NFS filesystem provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.filesystem_local.constants import CONF_ENTRY_CONTENT_TYPE
+
+from .constants import CONF_EXPORT_PATH, CONF_HOST, CONF_NFS_VERSION, CONF_SUBFOLDER
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    CONF_ENTRY_CONTENT_TYPE,
+    ConfigEntry(key=CONF_HOST, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(key=CONF_EXPORT_PATH, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(key=CONF_SUBFOLDER, type=ConfigEntryType.STRING, required=False, default_value=""),
+    ConfigEntry(
+        key=CONF_NFS_VERSION,
+        type=ConfigEntryType.STRING,
+        required=False,
+        advanced=True,
+        default_value="",
+        options=[
+            ConfigValueOption(""),
+            ConfigValueOption("3"),
+            ConfigValueOption("4"),
+            ConfigValueOption("4.1"),
+            ConfigValueOption("4.2"),
+        ],
+    ),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the NFS connection details and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/filesystem_smb/__init__.py
+++ b/music_assistant/providers/filesystem_smb/__init__.py
@@ -71,8 +71,12 @@ async def get_config_entries(
     # connection details and content type are collected by the setup flow; surface the
     # (immutable) content type read-only so the sync options' depends_on chains resolve
     content_type = "music"
-    if instance_id and (prov := mass.get_provider(instance_id, return_unavailable=True)):
-        content_type = getattr(prov, "media_content_type", content_type)
+    if instance_id:
+        # read the persisted value so the depends_on chains resolve correctly
+        # even when the provider (instance) is not currently loaded
+        content_type = str(
+            mass.config.get_provider_setup_value(instance_id, CONF_CONTENT_TYPE, "music")
+        )
     return (
         ConfigEntry(key=CONF_CONTENT_TYPE, type=ConfigEntryType.LABEL, value=content_type),
         ConfigEntry(

--- a/music_assistant/providers/filesystem_smb/__init__.py
+++ b/music_assistant/providers/filesystem_smb/__init__.py
@@ -22,8 +22,7 @@ from music_assistant.providers.filesystem_local import (
     makedirs,
 )
 from music_assistant.providers.filesystem_local.constants import (
-    CONF_ENTRY_CONTENT_TYPE,
-    CONF_ENTRY_CONTENT_TYPE_READ_ONLY,
+    CONF_CONTENT_TYPE,
     CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
     CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS,
     CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS,
@@ -51,20 +50,6 @@ async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
     """Initialize provider(instance) with given configuration."""
-    # check if valid dns name is given for the host
-    server = str(config.get_value(CONF_HOST))
-    if not await get_ip_from_host(server):
-        msg = f"Unable to resolve {server}, make sure the address is resolvable."
-        raise LoginFailed(
-            msg,
-            translation_key="host_unresolvable",
-            translation_args=[server],
-        )
-    # check if share is valid
-    share = str(config.get_value(CONF_SHARE))
-    if not share or "/" in share or "\\" in share:
-        msg = "Invalid share name"
-        raise LoginFailed(msg)
     # base_path will be the path where we're going to mount the remote share
     base_path = f"/tmp/{config.instance_id}"  # noqa: S108
     return SMBFileSystemProvider(mass, manifest, config, base_path)
@@ -73,8 +58,8 @@ async def setup(
 async def get_config_entries(
     mass: MusicAssistant,
     instance_id: str | None = None,
-    action: str | None = None,
-    values: dict[str, ConfigValueType] | None = None,
+    action: str | None = None,  # noqa: ARG001
+    values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
 ) -> tuple[ConfigEntry, ...]:
     """
     Return Config entries to setup this provider.
@@ -83,51 +68,13 @@ async def get_config_entries(
     action: [optional] action key called from config entries UI.
     values: the (intermediate) raw values for config entries sent with the action.
     """
-    # ruff: noqa: ARG001
-    base_entries = (
-        ConfigEntry(
-            key=CONF_HOST,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_SHARE,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=False,
-            default_value="guest",
-        ),
-        ConfigEntry(
-            key=CONF_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=False,
-            default_value=None,
-        ),
-        ConfigEntry(
-            key=CONF_SUBFOLDER,
-            type=ConfigEntryType.STRING,
-            required=False,
-            default_value="",
-        ),
-        ConfigEntry(
-            key=CONF_SMB_VERSION,
-            type=ConfigEntryType.STRING,
-            required=False,
-            advanced=True,
-            default_value="3.0",
-            options=[
-                ConfigValueOption(""),
-                ConfigValueOption("1.0"),
-                ConfigValueOption("2.0"),
-                ConfigValueOption("2.1"),
-                ConfigValueOption("3.0"),
-                ConfigValueOption("3.1.1"),
-            ],
-        ),
+    # connection details and content type are collected by the setup flow; surface the
+    # (immutable) content type read-only so the sync options' depends_on chains resolve
+    content_type = "music"
+    if instance_id and (prov := mass.get_provider(instance_id, return_unavailable=True)):
+        content_type = getattr(prov, "media_content_type", content_type)
+    return (
+        ConfigEntry(key=CONF_CONTENT_TYPE, type=ConfigEntryType.LABEL, value=content_type),
         ConfigEntry(
             key=CONF_CACHE_MODE,
             type=ConfigEntryType.STRING,
@@ -149,16 +96,6 @@ async def get_config_entries(
         CONF_ENTRY_PROPAGATE_GENRES,
     )
 
-    if instance_id is None or values is None:
-        return (
-            CONF_ENTRY_CONTENT_TYPE,
-            *base_entries,
-        )
-    return (
-        *base_entries,
-        CONF_ENTRY_CONTENT_TYPE_READ_ONLY,
-    )
-
 
 class SMBFileSystemProvider(LocalFileSystemProvider):
     """
@@ -173,8 +110,8 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
     @property
     def instance_name_postfix(self) -> str | None:
         """Return a (default) instance name postfix for this provider instance."""
-        share = str(self.config.get_value(CONF_SHARE))
-        subfolder = str(self.config.get_value(CONF_SUBFOLDER))
+        share = str(self.get_setup_value(CONF_SHARE))
+        subfolder = str(self.get_setup_value(CONF_SUBFOLDER))
         if subfolder:
             return subfolder
         if share:
@@ -183,6 +120,19 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
+        # validate the connection details before attempting to mount
+        server = str(self.get_setup_value(CONF_HOST))
+        if not await get_ip_from_host(server):
+            msg = f"Unable to resolve {server}, make sure the address is resolvable."
+            raise LoginFailed(
+                msg,
+                translation_key="host_unresolvable",
+                translation_args=[server],
+            )
+        share = str(self.get_setup_value(CONF_SHARE))
+        if not share or "/" in share or "\\" in share:
+            msg = "Invalid share name"
+            raise LoginFailed(msg)
         if not await exists(self.base_path):
             await makedirs(self.base_path)
         try:
@@ -211,15 +161,15 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
 
     async def mount(self) -> None:
         """Mount the SMB location to a temporary folder."""
-        server = str(self.config.get_value(CONF_HOST))
-        username = str(self.config.get_value(CONF_USERNAME) or "guest")
-        password = self.config.get_value(CONF_PASSWORD)
+        server = str(self.get_setup_value(CONF_HOST))
+        username = str(self.get_setup_value(CONF_USERNAME) or "guest")
+        password = self.get_setup_value(CONF_PASSWORD)
         # Type narrowing: password can be str or None
         password_str: str | None = str(password) if password is not None else None
-        share = str(self.config.get_value(CONF_SHARE))
+        share = str(self.get_setup_value(CONF_SHARE))
 
         # handle optional subfolder
-        subfolder = str(self.config.get_value(CONF_SUBFOLDER) or "")
+        subfolder = str(self.get_setup_value(CONF_SUBFOLDER) or "")
         if subfolder:
             subfolder = subfolder.replace("\\", "/")
             if not subfolder.startswith("/"):
@@ -260,7 +210,7 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
         mount_options = []
 
         # Add SMB version if specified
-        smb_version = str(self.config.get_value(CONF_SMB_VERSION) or "")
+        smb_version = str(self.get_setup_value(CONF_SMB_VERSION) or "")
         if smb_version:
             # macOS uses different version format (e.g., smb2, smb3)
             if smb_version.startswith("3"):
@@ -317,7 +267,7 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
             options.append("guest")
 
         # SMB version for better compatibility and performance
-        smb_version = str(self.config.get_value(CONF_SMB_VERSION) or "")
+        smb_version = str(self.get_setup_value(CONF_SMB_VERSION) or "")
         if smb_version:
             options.append(f"vers={smb_version}")
 

--- a/music_assistant/providers/filesystem_smb/setup_flow.py
+++ b/music_assistant/providers/filesystem_smb/setup_flow.py
@@ -64,4 +64,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/filesystem_smb/setup_flow.py
+++ b/music_assistant/providers/filesystem_smb/setup_flow.py
@@ -1,0 +1,67 @@
+"""Setup flow for the SMB filesystem provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.filesystem_local.constants import CONF_ENTRY_CONTENT_TYPE
+from music_assistant.providers.filesystem_smb import (
+    CONF_HOST,
+    CONF_SHARE,
+    CONF_SMB_VERSION,
+    CONF_SUBFOLDER,
+)
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    CONF_ENTRY_CONTENT_TYPE,
+    ConfigEntry(key=CONF_HOST, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(key=CONF_SHARE, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(
+        key=CONF_USERNAME, type=ConfigEntryType.STRING, required=False, default_value="guest"
+    ),
+    ConfigEntry(
+        key=CONF_PASSWORD, type=ConfigEntryType.SECURE_STRING, required=False, default_value=None
+    ),
+    ConfigEntry(key=CONF_SUBFOLDER, type=ConfigEntryType.STRING, required=False, default_value=""),
+    ConfigEntry(
+        key=CONF_SMB_VERSION,
+        type=ConfigEntryType.STRING,
+        required=False,
+        advanced=True,
+        default_value="3.0",
+        options=[
+            ConfigValueOption(""),
+            ConfigValueOption("1.0"),
+            ConfigValueOption("2.0"),
+            ConfigValueOption("2.1"),
+            ConfigValueOption("3.0"),
+            ConfigValueOption("3.1.1"),
+        ],
+    ),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the SMB connection details and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/ibroadcast/__init__.py
+++ b/music_assistant/providers/ibroadcast/__init__.py
@@ -6,9 +6,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse, urlunparse
 
 from ibroadcastaio import IBroadcastClient
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import (
-    ConfigEntryType,
     ContentType,
     ImageType,
     MediaType,
@@ -53,7 +51,7 @@ SUPPORTED_FEATURES = {
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -64,9 +62,6 @@ async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
     """Initialize provider(instance) with given configuration."""
-    if not config.get_value(CONF_USERNAME) or not config.get_value(CONF_PASSWORD):
-        msg = "Invalid login credentials"
-        raise LoginFailed(msg)
     return IBroadcastProvider(mass, manifest, config, SUPPORTED_FEATURES)
 
 
@@ -84,18 +79,7 @@ async def get_config_entries(
     values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
-    return (
-        ConfigEntry(
-            key=CONF_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=True,
-        ),
-    )
+    return ()
 
 
 class IBroadcastProvider(MusicProvider):
@@ -106,11 +90,13 @@ class IBroadcastProvider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Set up the iBroadcast provider."""
+        username = self.get_setup_value(CONF_USERNAME)
+        password = self.get_setup_value(CONF_PASSWORD)
+        if not username or not password:
+            msg = "Invalid login credentials"
+            raise LoginFailed(msg)
         self._client = IBroadcastClient(self.mass.http_session)
-        status = await self._client.login(
-            self.config.get_value(CONF_USERNAME),
-            self.config.get_value(CONF_PASSWORD),
-        )
+        status = await self._client.login(username, password)
         self._user_id = status["user"]["id"]
 
         # temporary call to refresh library until ibroadcast provides a detailed api

--- a/music_assistant/providers/ibroadcast/setup_flow.py
+++ b/music_assistant/providers/ibroadcast/setup_flow.py
@@ -34,4 +34,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/ibroadcast/setup_flow.py
+++ b/music_assistant/providers/ibroadcast/setup_flow.py
@@ -1,0 +1,37 @@
+"""Setup flow for the iBroadcast provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowError
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(key=CONF_USERNAME, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(key=CONF_PASSWORD, type=ConfigEntryType.SECURE_STRING, required=True),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the credentials and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/jellyfin/__init__.py
+++ b/music_assistant/providers/jellyfin/__init__.py
@@ -11,8 +11,7 @@ from typing import TYPE_CHECKING
 from aiojellyfin import MediaLibrary as JellyMediaLibrary
 from aiojellyfin import NotFound, authenticate_by_name
 from aiojellyfin.session import SessionConfiguration
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
-from music_assistant_models.enums import ConfigEntryType, MediaType, ProviderFeature, StreamType
+from music_assistant_models.enums import MediaType, ProviderFeature, StreamType
 from music_assistant_models.errors import LoginFailed, MediaNotFoundError
 from music_assistant_models.media_items import (
     Album,
@@ -55,6 +54,7 @@ from .const import (
 )
 
 if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
 CONF_URL = "url"
@@ -93,32 +93,8 @@ async def get_config_entries(
     action: [optional] action key called from config entries UI.
     values: the (intermediate) raw values for config entries sent with the action.
     """
-    # config flow auth action/step (authenticate button clicked)
     # ruff: noqa: ARG001
-    return (
-        ConfigEntry(
-            key=CONF_URL,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=False,
-        ),
-        ConfigEntry(
-            key=CONF_VERIFY_SSL,
-            type=ConfigEntryType.BOOLEAN,
-            required=False,
-            advanced=True,
-            default_value=True,
-        ),
-    )
+    return ()
 
 
 class JellyfinProvider(MusicProvider):
@@ -126,7 +102,7 @@ class JellyfinProvider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Initialize provider(instance) with given configuration."""
-        username = str(self.config.get_value(CONF_USERNAME))
+        username = str(self.get_setup_value(CONF_USERNAME))
 
         # Device ID should be stable between reboots
         # Otherwise every time the provider starts we "leak" a new device
@@ -143,13 +119,13 @@ class JellyfinProvider(MusicProvider):
         # to be an opaque identifier
 
         device_id = hashlib.sha256(f"{self.mass.server_id}+{username}".encode()).hexdigest()
-        verify_ssl = bool(self.config.get_value(CONF_VERIFY_SSL))
+        verify_ssl = bool(self.get_setup_value(CONF_VERIFY_SSL))
         http_session = self.mass.http_session if verify_ssl else self.mass.http_session_no_ssl
 
         session_config = SessionConfiguration(
             session=http_session,
-            url=str(self.config.get_value(CONF_URL)),
-            verify_ssl=bool(self.config.get_value(CONF_VERIFY_SSL)),
+            url=str(self.get_setup_value(CONF_URL)),
+            verify_ssl=verify_ssl,
             app_name=USER_APP_NAME,
             app_version=self.mass.version,
             device_name=socket.gethostname(),
@@ -160,7 +136,7 @@ class JellyfinProvider(MusicProvider):
             self._client = await authenticate_by_name(
                 session_config,
                 username,
-                str(self.config.get_value(CONF_PASSWORD) or ""),
+                str(self.get_setup_value(CONF_PASSWORD) or ""),
             )
         except Exception as err:
             raise LoginFailed(f"Authentication failed: {err}") from err

--- a/music_assistant/providers/jellyfin/setup_flow.py
+++ b/music_assistant/providers/jellyfin/setup_flow.py
@@ -1,0 +1,50 @@
+"""Setup flow for the Jellyfin provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.jellyfin import (
+    CONF_PASSWORD,
+    CONF_URL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(key=CONF_URL, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(key=CONF_USERNAME, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(key=CONF_PASSWORD, type=ConfigEntryType.SECURE_STRING, required=False),
+    ConfigEntry(
+        key=CONF_VERIFY_SSL,
+        type=ConfigEntryType.BOOLEAN,
+        required=False,
+        advanced=True,
+        default_value=True,
+    ),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the connection details and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/jellyfin/setup_flow.py
+++ b/music_assistant/providers/jellyfin/setup_flow.py
@@ -47,4 +47,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -13,9 +13,8 @@ from typing import TYPE_CHECKING, ClassVar, Final
 import requests.exceptions
 from liblistenbrainz import Listen, ListenBrainz
 from liblistenbrainz.errors import ListenBrainzException
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
 from music_assistant_models.constants import SECURE_STRING_SUBSTITUTE
-from music_assistant_models.enums import ConfigEntryType, EventType, MediaType, ProviderFeature
+from music_assistant_models.enums import EventType, MediaType, ProviderFeature
 from music_assistant_models.errors import SetupFailedError
 
 from music_assistant.constants import UNKNOWN_ARTIST
@@ -25,6 +24,7 @@ from music_assistant.models import ProviderInstanceType
 from music_assistant.models.plugin import PluginProvider
 
 if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
     from music_assistant_models.provider import ProviderManifest
 
@@ -41,34 +41,35 @@ async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
     """Initialize provider(instance) with given configuration."""
-    token = config.get_value(CONF_USER_TOKEN)
-    api_base_url = config.get_value(CONF_API_BASE_URL) or LISTENBRAINZ_API_URL
-
-    if not token:
-        raise SetupFailedError("User token needs to be set")
-
-    assert token != SECURE_STRING_SUBSTITUTE
-
-    client = ListenBrainz(api_base_url=api_base_url)
-    client.set_auth_token(token)
-
-    return ListenBrainzScrobbleProvider(mass, manifest, config, client)
+    return ListenBrainzScrobbleProvider(mass, manifest, config, SUPPORTED_FEATURES)
 
 
 class ListenBrainzScrobbleProvider(PluginProvider):
     """Plugin provider to support scrobbling of tracks."""
+
+    _client: ListenBrainz
 
     def __init__(
         self,
         mass: MusicAssistant,
         manifest: ProviderManifest,
         config: ProviderConfig,
-        client: ListenBrainz,
+        supported_features: set[ProviderFeature],
     ) -> None:
         """Initialize MusicProvider."""
-        super().__init__(mass, manifest, config, SUPPORTED_FEATURES)
-        self._client = client
+        super().__init__(mass, manifest, config, supported_features)
         self._on_unload: list[Callable[[], None]] = []
+
+    async def handle_async_init(self) -> None:
+        """Create the ListenBrainz client from the configured user token."""
+        token = self.get_setup_value(CONF_USER_TOKEN)
+        api_base_url = self.get_setup_value(CONF_API_BASE_URL) or LISTENBRAINZ_API_URL
+        if not token:
+            raise SetupFailedError("User token needs to be set")
+        assert token != SECURE_STRING_SUBSTITUTE
+        client = ListenBrainz(api_base_url=str(api_base_url))
+        client.set_auth_token(str(token))
+        self._client = client
 
     async def loaded_in_mass(self) -> None:
         """Call after the provider has been loaded."""
@@ -169,19 +170,4 @@ async def get_config_entries(
     values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
     """Return Config entries to setup this provider."""
-    return (
-        *await ScrobblerConfig.get_shared_config_entries(mass, values),
-        ConfigEntry(
-            key=CONF_USER_TOKEN,
-            type=ConfigEntryType.SECURE_STRING,
-            required=True,
-            value=values.get(CONF_USER_TOKEN) if values else None,
-        ),
-        ConfigEntry(
-            key=CONF_API_BASE_URL,
-            type=ConfigEntryType.STRING,
-            required=False,
-            value=values.get(CONF_API_BASE_URL) if values else None,
-            advanced=True,
-        ),
-    )
+    return tuple(await ScrobblerConfig.get_shared_config_entries(mass, values))

--- a/music_assistant/providers/listenbrainz_scrobble/setup_flow.py
+++ b/music_assistant/providers/listenbrainz_scrobble/setup_flow.py
@@ -34,4 +34,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/listenbrainz_scrobble/setup_flow.py
+++ b/music_assistant/providers/listenbrainz_scrobble/setup_flow.py
@@ -1,0 +1,37 @@
+"""Setup flow for the ListenBrainz scrobble provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.listenbrainz_scrobble import CONF_API_BASE_URL, CONF_USER_TOKEN
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(key=CONF_USER_TOKEN, type=ConfigEntryType.SECURE_STRING, required=True),
+    ConfigEntry(key=CONF_API_BASE_URL, type=ConfigEntryType.STRING, required=False, advanced=True),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the user token and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/musicme/__init__.py
+++ b/music_assistant/providers/musicme/__init__.py
@@ -4,20 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
-from music_assistant_models.enums import ConfigEntryType
-
-from music_assistant.constants import (
-    CONF_ENTRY_UNOFFICIAL_PROVIDER,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-)
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
 
 from .constants import SUPPORTED_FEATURES
 from .provider import MusicMeProvider
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant import MusicAssistant
@@ -46,16 +39,4 @@ async def get_config_entries(
     :param values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
-    return (
-        CONF_ENTRY_UNOFFICIAL_PROVIDER,
-        ConfigEntry(
-            key=CONF_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=True,
-        ),
-    )
+    return (CONF_ENTRY_UNOFFICIAL_PROVIDER,)

--- a/music_assistant/providers/musicme/provider.py
+++ b/music_assistant/providers/musicme/provider.py
@@ -75,7 +75,7 @@ class MusicMeProvider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        if not self.config.get_value(CONF_USERNAME) or not self.config.get_value(CONF_PASSWORD):
+        if not self.get_setup_value(CONF_USERNAME) or not self.get_setup_value(CONF_PASSWORD):
             msg = "Missing MusicMe email or password"
             raise SetupFailedError(msg)
         # Dedicated session with its own cookie jar to support multi-instance
@@ -768,8 +768,8 @@ class MusicMeProvider(MusicProvider):
 
     async def _login(self) -> None:
         """Authenticate with MusicMe via web login and extract the userId."""
-        email = self.config.get_value(CONF_USERNAME)
-        password = self.config.get_value(CONF_PASSWORD)
+        email = self.get_setup_value(CONF_USERNAME)
+        password = self.get_setup_value(CONF_PASSWORD)
 
         try:
             async with self.http_session.post(

--- a/music_assistant/providers/musicme/setup_flow.py
+++ b/music_assistant/providers/musicme/setup_flow.py
@@ -1,0 +1,45 @@
+"""Setup flow for the MusicMe provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowError
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(
+        key=CONF_USERNAME,
+        type=ConfigEntryType.STRING,
+        required=True,
+    ),
+    ConfigEntry(
+        key=CONF_PASSWORD,
+        type=ConfigEntryType.SECURE_STRING,
+        required=True,
+    ),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the credentials and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/musicme/setup_flow.py
+++ b/music_assistant/providers/musicme/setup_flow.py
@@ -42,4 +42,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/nicovideo/config/categories/auth.py
+++ b/music_assistant/providers/nicovideo/config/categories/auth.py
@@ -41,19 +41,9 @@ class AuthConfigCategory(ConfigCategoryBase):
     )
 
     def save_user_session(self, value: str) -> None:
-        """Save user session to config."""
-        self.writer.set_raw_provider_config_value(
-            self.provider.instance_id,
-            "user_session",
-            value,
-            True,
-        )
+        """Save user session to the setup data."""
+        self.provider._update_setup_data("user_session", value)
 
     def clear_mfa_code(self) -> None:
         """Clear MFA code after successful use (one-time password should not be reused)."""
-        self.writer.set_raw_provider_config_value(
-            self.provider.instance_id,
-            "mfa",
-            None,
-            True,
-        )
+        self.provider._update_setup_data("mfa", None)

--- a/music_assistant/providers/nicovideo/config/categories/base.py
+++ b/music_assistant/providers/nicovideo/config/categories/base.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, override
 
-from music_assistant.controllers.config import ConfigController
 from music_assistant.providers.nicovideo.config.descriptor import ConfigReader
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ConfigValueType, ProviderConfig
+    from music_assistant_models.config_entries import ConfigValueType
 
     from music_assistant.models.provider import Provider
 
@@ -20,17 +19,7 @@ class ConfigCategoryBase(ConfigReader):
         """Initialize category with provider instance."""
         self.provider = provider
 
-    @property
-    def reader(self) -> ProviderConfig:
-        """Get the config reader interface."""
-        return self.provider.config
-
-    @property
-    def writer(self) -> ConfigController:
-        """Get the config writer interface."""
-        return self.provider.mass.config
-
     @override
     def get_value(self, key: str) -> ConfigValueType:
         """Get config value from provider."""
-        return self.reader.get_value(key)
+        return self.provider.get_setup_value(key)

--- a/music_assistant/providers/nicovideo/config/factory.py
+++ b/music_assistant/providers/nicovideo/config/factory.py
@@ -194,7 +194,11 @@ class ConfigFactory:
         return _cast
 
 
+def get_setup_config_entries() -> tuple[ConfigEntry, ...]:
+    """Return the (credential) config entries collected by the setup flow."""
+    return tuple(_registry)
+
+
 async def get_config_entries_impl() -> tuple[ConfigEntry, ...]:
     """Return Config entries to setup this provider."""
-    # Combine entries from logical categories
-    return (CONF_ENTRY_UNOFFICIAL_PROVIDER, *_registry)
+    return (CONF_ENTRY_UNOFFICIAL_PROVIDER,)

--- a/music_assistant/providers/nicovideo/setup_flow.py
+++ b/music_assistant/providers/nicovideo/setup_flow.py
@@ -27,4 +27,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/nicovideo/setup_flow.py
+++ b/music_assistant/providers/nicovideo/setup_flow.py
@@ -1,0 +1,30 @@
+"""Setup flow for the nicovideo provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.nicovideo.config.factory import get_setup_config_entries
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the account credentials and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    base_entries = get_setup_config_entries()
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in base_entries
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/nugs/__init__.py
+++ b/music_assistant/providers/nugs/__init__.py
@@ -8,9 +8,7 @@ from time import time
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import ClientTimeout
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import (
-    ConfigEntryType,
     ContentType,
     ImageType,
     MediaType,
@@ -51,7 +49,7 @@ from music_assistant.helpers.util import infer_album_type, parse_title_and_versi
 from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -88,19 +86,7 @@ async def get_config_entries(
     values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
-    return (
-        CONF_ENTRY_UNOFFICIAL_PROVIDER,
-        ConfigEntry(
-            key=CONF_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=True,
-        ),
-    )
+    return (CONF_ENTRY_UNOFFICIAL_PROVIDER,)
 
 
 class NugsProvider(MusicProvider):
@@ -496,12 +482,12 @@ class NugsProvider(MusicProvider):
         """Login to nugs.net and return the token."""
         if self._auth_token and (self._token_expiry > time()):
             return self._auth_token
-        if not self.config.get_value(CONF_USERNAME) or not self.config.get_value(CONF_PASSWORD):
+        if not self.get_setup_value(CONF_USERNAME) or not self.get_setup_value(CONF_PASSWORD):
             msg = "Invalid login credentials"
             raise LoginFailed(msg)
         login_data = {
-            "username": self.config.get_value(CONF_USERNAME),
-            "password": self.config.get_value(CONF_PASSWORD),
+            "username": self.get_setup_value(CONF_USERNAME),
+            "password": self.get_setup_value(CONF_PASSWORD),
             "scope": "offline_access nugsnet:api nugsnet:legacyapi openid profile email",
             "grant_type": "password",
             "client_id": "Eg7HuH873H65r5rt325UytR5429",

--- a/music_assistant/providers/nugs/setup_flow.py
+++ b/music_assistant/providers/nugs/setup_flow.py
@@ -1,0 +1,45 @@
+"""Setup flow for the Nugs.net provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowError
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(
+        key=CONF_USERNAME,
+        type=ConfigEntryType.STRING,
+        required=True,
+    ),
+    ConfigEntry(
+        key=CONF_PASSWORD,
+        type=ConfigEntryType.SECURE_STRING,
+        required=True,
+    ),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the credentials and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/nugs/setup_flow.py
+++ b/music_assistant/providers/nugs/setup_flow.py
@@ -42,4 +42,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/opensubsonic/__init__.py
+++ b/music_assistant/providers/opensubsonic/__init__.py
@@ -7,10 +7,7 @@ from typing import TYPE_CHECKING
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 
-from music_assistant.constants import CONF_PASSWORD, CONF_PATH, CONF_PORT, CONF_USERNAME
-
 from .sonic_provider import (
-    CONF_BASE_URL,
     CONF_ENABLE_LEGACY_AUTH,
     CONF_ENABLE_PODCASTS,
     CONF_NEW_ALBUMS,
@@ -66,31 +63,6 @@ async def get_config_entries(
 ) -> tuple[ConfigEntry, ...]:
     """Return Config entries to setup this provider."""
     return (
-        ConfigEntry(
-            key=CONF_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_BASE_URL,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_PORT,
-            type=ConfigEntryType.INTEGER,
-            required=False,
-        ),
-        ConfigEntry(
-            key=CONF_PATH,
-            type=ConfigEntryType.STRING,
-            required=False,
-        ),
         ConfigEntry(
             key=CONF_ENABLE_PODCASTS,
             type=ConfigEntryType.BOOLEAN,

--- a/music_assistant/providers/opensubsonic/setup_flow.py
+++ b/music_assistant/providers/opensubsonic/setup_flow.py
@@ -1,0 +1,41 @@
+"""Setup flow for the Open Subsonic provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_PASSWORD, CONF_PATH, CONF_PORT, CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.opensubsonic.sonic_provider import CONF_BASE_URL
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(key=CONF_USERNAME, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(key=CONF_PASSWORD, type=ConfigEntryType.SECURE_STRING, required=True),
+    ConfigEntry(key=CONF_BASE_URL, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(key=CONF_PORT, type=ConfigEntryType.INTEGER, required=False),
+    ConfigEntry(key=CONF_PATH, type=ConfigEntryType.STRING, required=False),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the connection details and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/opensubsonic/setup_flow.py
+++ b/music_assistant/providers/opensubsonic/setup_flow.py
@@ -38,4 +38,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -109,17 +109,17 @@ class OpenSonicProvider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Set up the music provider and test the connection."""
-        port = self.config.get_value(CONF_PORT)
+        port = self.get_setup_value(CONF_PORT)
         port = int(str(port)) if port is not None else 443
-        path = self.config.get_value(CONF_PATH)
+        path = self.get_setup_value(CONF_PATH)
 
         if path is None:
             path = ""
 
         self.conn = SonicConnection(
-            str(self.config.get_value(CONF_BASE_URL)),
-            username=str(self.config.get_value(CONF_USERNAME)),
-            password=str(self.config.get_value(CONF_PASSWORD)),
+            str(self.get_setup_value(CONF_BASE_URL)),
+            username=str(self.get_setup_value(CONF_USERNAME)),
+            password=str(self.get_setup_value(CONF_PASSWORD)),
             legacy_auth=bool(self.config.get_value(CONF_ENABLE_LEGACY_AUTH)),
             port=port,
             server_path=str(path),
@@ -132,13 +132,13 @@ class OpenSonicProvider(MusicProvider):
                 raise CredentialError
         except (AuthError, CredentialError) as e:
             msg = (
-                f"Failed to connect to {self.config.get_value(CONF_BASE_URL)}, check your settings."
+                f"Failed to connect to {self.get_setup_value(CONF_BASE_URL)}, check your settings."
             )
             raise LoginFailed(
                 msg,
                 translation_key="connect_failed",
                 translation_owner=self.translation_owner,
-                translation_args=[self.config.get_value(CONF_BASE_URL)],
+                translation_args=[self.get_setup_value(CONF_BASE_URL)],
             ) from e
 
         try:

--- a/music_assistant/providers/pocketcasts/__init__.py
+++ b/music_assistant/providers/pocketcasts/__init__.py
@@ -7,9 +7,7 @@ import logging
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import (
-    ConfigEntryType,
     ContentType,
     ImageType,
     MediaType,
@@ -48,7 +46,7 @@ from .api_client import PocketCastsClient
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.models import ProviderInstanceType
@@ -175,18 +173,7 @@ async def get_config_entries(
     values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
 ) -> tuple[ConfigEntry, ...]:
     """Return Config entries to setup this provider."""
-    return (
-        ConfigEntry(
-            key=CONF_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=True,
-        ),
-    )
+    return ()
 
 
 class PocketCastsProvider(MusicProvider):
@@ -199,8 +186,8 @@ class PocketCastsProvider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        email = self.config.get_value(CONF_USERNAME)
-        password = self.config.get_value(CONF_PASSWORD)
+        email = self.get_setup_value(CONF_USERNAME)
+        password = self.get_setup_value(CONF_PASSWORD)
         if not email or not password:
             raise LoginFailed("Email and password are required for Pocket Casts")
         self._announced_episodes = set()

--- a/music_assistant/providers/pocketcasts/setup_flow.py
+++ b/music_assistant/providers/pocketcasts/setup_flow.py
@@ -1,0 +1,45 @@
+"""Setup flow for the Pocket Casts provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowError
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(
+        key=CONF_USERNAME,
+        type=ConfigEntryType.STRING,
+        required=True,
+    ),
+    ConfigEntry(
+        key=CONF_PASSWORD,
+        type=ConfigEntryType.SECURE_STRING,
+        required=True,
+    ),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the credentials and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/pocketcasts/setup_flow.py
+++ b/music_assistant/providers/pocketcasts/setup_flow.py
@@ -42,4 +42,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/podcast_index/__init__.py
+++ b/music_assistant/providers/podcast_index/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 
-from .constants import CONF_API_KEY, CONF_API_SECRET, CONF_STORED_PODCASTS
+from .constants import CONF_STORED_PODCASTS
 from .provider import PodcastIndexProvider
 
 if TYPE_CHECKING:
@@ -45,16 +45,6 @@ async def get_config_entries(
     """
     # ruff: noqa: ARG001
     return (
-        ConfigEntry(
-            key=CONF_API_KEY,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_API_SECRET,
-            type=ConfigEntryType.SECURE_STRING,
-            required=True,
-        ),
         ConfigEntry(
             key=CONF_STORED_PODCASTS,
             type=ConfigEntryType.STRING,

--- a/music_assistant/providers/podcast_index/provider.py
+++ b/music_assistant/providers/podcast_index/provider.py
@@ -47,8 +47,8 @@ class PodcastIndexProvider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        self.api_key = str(self.config.get_value(CONF_API_KEY))
-        self.api_secret = str(self.config.get_value(CONF_API_SECRET))
+        self.api_key = str(self.get_setup_value(CONF_API_KEY))
+        self.api_secret = str(self.get_setup_value(CONF_API_SECRET))
 
         if not self.api_key or not self.api_secret:
             raise LoginFailed("API key and secret are required")

--- a/music_assistant/providers/podcast_index/setup_flow.py
+++ b/music_assistant/providers/podcast_index/setup_flow.py
@@ -42,4 +42,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/podcast_index/setup_flow.py
+++ b/music_assistant/providers/podcast_index/setup_flow.py
@@ -1,0 +1,45 @@
+"""Setup flow for the Podcast Index provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.podcast_index.constants import CONF_API_KEY, CONF_API_SECRET
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(
+        key=CONF_API_KEY,
+        type=ConfigEntryType.STRING,
+        required=True,
+    ),
+    ConfigEntry(
+        key=CONF_API_SECRET,
+        type=ConfigEntryType.SECURE_STRING,
+        required=True,
+    ),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the credentials and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/podcastfeed/__init__.py
+++ b/music_assistant/providers/podcastfeed/__init__.py
@@ -14,9 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 import podcastparser
 from aiohttp.client_exceptions import ClientError
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import (
-    ConfigEntryType,
     ContentType,
     MediaType,
     ProviderFeature,
@@ -43,7 +41,7 @@ from music_assistant.helpers.podcast_parsers import (
 from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -63,9 +61,6 @@ async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
     """Initialize provider(instance) with given configuration."""
-    if not config.get_value(CONF_FEED_URL):
-        msg = "No podcast feed set"
-        raise InvalidProviderURI(msg)
     return PodcastMusicprovider(mass, manifest, config, SUPPORTED_FEATURES)
 
 
@@ -83,13 +78,7 @@ async def get_config_entries(
     values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
-    return (
-        ConfigEntry(
-            key=CONF_FEED_URL,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-    )
+    return ()
 
 
 class PodcastMusicprovider(MusicProvider):
@@ -97,7 +86,11 @@ class PodcastMusicprovider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        self.feed_url = podcastparser.normalize_feed_url(str(self.config.get_value(CONF_FEED_URL)))
+        feed_url = self.get_setup_value(CONF_FEED_URL)
+        if not feed_url:
+            msg = "No podcast feed set"
+            raise InvalidProviderURI(msg)
+        self.feed_url = podcastparser.normalize_feed_url(str(feed_url))
         if self.feed_url is None:
             raise MediaNotFoundError("The specified feed url cannot be used.")
 

--- a/music_assistant/providers/podcastfeed/setup_flow.py
+++ b/music_assistant/providers/podcastfeed/setup_flow.py
@@ -1,0 +1,34 @@
+"""Setup flow for the Podcast RSS Feed provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.podcastfeed import CONF_FEED_URL
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (ConfigEntry(key=CONF_FEED_URL, type=ConfigEntryType.STRING, required=True),)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the podcast feed URL and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/podcastfeed/setup_flow.py
+++ b/music_assistant/providers/podcastfeed/setup_flow.py
@@ -31,4 +31,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/qobuz/__init__.py
+++ b/music_assistant/providers/qobuz/__init__.py
@@ -121,16 +121,6 @@ async def get_config_entries(
     return (
         CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
-            key=CONF_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=True,
-        ),
-        ConfigEntry(
             key=CONF_QUALITY,
             type=ConfigEntryType.STRING,
             default_value="27",
@@ -154,13 +144,13 @@ class QobuzProvider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        if not self.config.get_value(CONF_USERNAME) or not self.config.get_value(CONF_PASSWORD):
+        if not self.get_setup_value(CONF_USERNAME) or not self.get_setup_value(CONF_PASSWORD):
             msg = "Invalid login credentials"
             raise LoginFailed(msg)
         # try to get a token, raise if that fails
         token = await self._auth_token()
         if not token:
-            msg = f"Login failed for user {self.config.get_value(CONF_USERNAME)}"
+            msg = f"Login failed for user {self.get_setup_value(CONF_USERNAME)}"
             raise LoginFailed(msg)
 
     @use_cache(3600 * 24 * 14)  # Cache for 14 days
@@ -818,8 +808,8 @@ class QobuzProvider(MusicProvider):
         # TODO: move credentials from query string to POST body to remove the
         # residual exposure via HTTP session tracing / upstream proxy logs.
         params: dict[str, Any] = {
-            "username": self.config.get_value(CONF_USERNAME),
-            "password": self.config.get_value(CONF_PASSWORD),
+            "username": self.get_setup_value(CONF_USERNAME),
+            "password": self.get_setup_value(CONF_PASSWORD),
             "device_manufacturer_id": "music_assistant",
         }
         details = await self._get_data("user/login", **params)

--- a/music_assistant/providers/qobuz/setup_flow.py
+++ b/music_assistant/providers/qobuz/setup_flow.py
@@ -34,4 +34,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/qobuz/setup_flow.py
+++ b/music_assistant/providers/qobuz/setup_flow.py
@@ -1,0 +1,37 @@
+"""Setup flow for the Qobuz provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowError
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(key=CONF_USERNAME, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(key=CONF_PASSWORD, type=ConfigEntryType.SECURE_STRING, required=True),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the credentials and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/siriusxm/__init__.py
+++ b/music_assistant/providers/siriusxm/__init__.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator, Sequence
 from typing import TYPE_CHECKING, Any
 
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
 from music_assistant_models.enums import (
-    ConfigEntryType,
     ContentType,
     ImageType,
     LinkType,
@@ -38,7 +36,7 @@ from music_assistant.helpers.webserver import Webserver
 from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant import MusicAssistant
@@ -80,29 +78,7 @@ async def get_config_entries(
     values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
-    return (
-        CONF_ENTRY_UNOFFICIAL_PROVIDER,
-        ConfigEntry(
-            key=CONF_SXM_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_SXM_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_SXM_REGION,
-            type=ConfigEntryType.STRING,
-            default_value="US",
-            options=[
-                ConfigValueOption("US"),
-                ConfigValueOption("CA"),
-            ],
-            required=True,
-        ),
-    )
+    return (CONF_ENTRY_UNOFFICIAL_PROVIDER,)
 
 
 class SiriusXMProvider(MusicProvider):
@@ -122,13 +98,13 @@ class SiriusXMProvider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        username = self.config.get_value(CONF_SXM_USERNAME)
+        username = self.get_setup_value(CONF_SXM_USERNAME)
         assert isinstance(username, str)  # for type checker
-        password = self.config.get_value(CONF_SXM_PASSWORD)
+        password = self.get_setup_value(CONF_SXM_PASSWORD)
         assert isinstance(password, str)  # for type checker
 
         region: RegionChoice = (
-            RegionChoice.US if self.config.get_value(CONF_SXM_REGION) == "US" else RegionChoice.CA
+            RegionChoice.US if self.get_setup_value(CONF_SXM_REGION) == "US" else RegionChoice.CA
         )
 
         self._client = SXMClientAsync(

--- a/music_assistant/providers/siriusxm/setup_flow.py
+++ b/music_assistant/providers/siriusxm/setup_flow.py
@@ -48,4 +48,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/siriusxm/setup_flow.py
+++ b/music_assistant/providers/siriusxm/setup_flow.py
@@ -1,0 +1,51 @@
+"""Setup flow for the SiriusXM provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.siriusxm import (
+    CONF_SXM_PASSWORD,
+    CONF_SXM_REGION,
+    CONF_SXM_USERNAME,
+)
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(key=CONF_SXM_USERNAME, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(key=CONF_SXM_PASSWORD, type=ConfigEntryType.SECURE_STRING, required=True),
+    ConfigEntry(
+        key=CONF_SXM_REGION,
+        type=ConfigEntryType.STRING,
+        default_value="US",
+        options=[
+            ConfigValueOption("US"),
+            ConfigValueOption("CA"),
+        ],
+        required=True,
+    ),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the credentials and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/soundcloud/__init__.py
+++ b/music_assistant/providers/soundcloud/__init__.py
@@ -7,9 +7,7 @@ from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import parse_qs, quote, urlparse
 
 from aiohttp import ClientError
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import (
-    ConfigEntryType,
     ContentType,
     ImageType,
     MediaType,
@@ -60,7 +58,7 @@ SEARCH_DURATION_COMPARISON_TOLERANCE = 1000
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.media_items import BrowseFolder, ItemMapping, MediaItemType
     from music_assistant_models.provider import ProviderManifest
 
@@ -72,9 +70,6 @@ async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
     """Initialize provider(instance) with given configuration."""
-    if not config.get_value(CONF_CLIENT_ID) or not config.get_value(CONF_AUTHORIZATION):
-        msg = "Invalid login credentials"
-        raise LoginFailed(msg)
     return SoundcloudMusicProvider(mass, manifest, config, SUPPORTED_FEATURES)
 
 
@@ -92,19 +87,7 @@ async def get_config_entries(
     values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
-    return (
-        CONF_ENTRY_UNOFFICIAL_PROVIDER,
-        ConfigEntry(
-            key=CONF_CLIENT_ID,
-            type=ConfigEntryType.SECURE_STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_AUTHORIZATION,
-            type=ConfigEntryType.SECURE_STRING,
-            required=True,
-        ),
-    )
+    return (CONF_ENTRY_UNOFFICIAL_PROVIDER,)
 
 
 class SoundcloudMusicProvider(RecommendationPayloadMixin, MusicProvider):
@@ -119,8 +102,11 @@ class SoundcloudMusicProvider(RecommendationPayloadMixin, MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Set up the Soundcloud provider."""
-        client_id = self.config.get_value(CONF_CLIENT_ID)
-        auth_token = self.config.get_value(CONF_AUTHORIZATION)
+        client_id = self.get_setup_value(CONF_CLIENT_ID)
+        auth_token = self.get_setup_value(CONF_AUTHORIZATION)
+        if not client_id or not auth_token:
+            msg = "Invalid login credentials"
+            raise LoginFailed(msg)
         self._soundcloud = SoundcloudAsyncAPI(auth_token, client_id, self.mass.http_session)
         await self._soundcloud.login()
         self._me = await self._soundcloud.get_account_details()

--- a/music_assistant/providers/soundcloud/setup_flow.py
+++ b/music_assistant/providers/soundcloud/setup_flow.py
@@ -32,4 +32,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/soundcloud/setup_flow.py
+++ b/music_assistant/providers/soundcloud/setup_flow.py
@@ -1,0 +1,35 @@
+"""Setup flow for the SoundCloud provider."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.soundcloud import CONF_AUTHORIZATION, CONF_CLIENT_ID
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(key=CONF_CLIENT_ID, type=ConfigEntryType.SECURE_STRING, required=True),
+    ConfigEntry(key=CONF_AUTHORIZATION, type=ConfigEntryType.SECURE_STRING, required=True),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the credentials and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        submitted = await session.form(
+            list(_ENTRIES), step_id="user", errors=errors, last_step=True
+        )
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/teddycloud/__init__.py
+++ b/music_assistant/providers/teddycloud/__init__.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
-from music_assistant_models.enums import ConfigEntryType, ProviderFeature
+from music_assistant_models.enums import ProviderFeature
 
-from .constants import CONF_URL
 from .provider import TeddyCloudProvider
 
 if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -42,14 +41,4 @@ async def get_config_entries(
     action: [optional] action key called from config entries UI.
     values: the (intermediate) raw values for config entries sent with the action.
     """
-    return (
-        ConfigEntry(
-            key="label",
-            type=ConfigEntryType.LABEL,
-        ),
-        ConfigEntry(
-            key=CONF_URL,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-    )
+    return ()

--- a/music_assistant/providers/teddycloud/provider.py
+++ b/music_assistant/providers/teddycloud/provider.py
@@ -118,7 +118,7 @@ class TeddyCloudProvider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Read config, prepare the HTTP client and verify connectivity."""
-        base_url = str(self.config.get_value(CONF_URL)).rstrip("/")
+        base_url = str(self.get_setup_value(CONF_URL)).rstrip("/")
         # accept a bare host/IP and default to http:// (TeddyCloud is usually plain HTTP on
         # the local network); an explicit http(s):// scheme is always respected.
         if not base_url.startswith(("http://", "https://")):

--- a/music_assistant/providers/teddycloud/setup_flow.py
+++ b/music_assistant/providers/teddycloud/setup_flow.py
@@ -41,4 +41,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/teddycloud/setup_flow.py
+++ b/music_assistant/providers/teddycloud/setup_flow.py
@@ -1,0 +1,44 @@
+"""Setup flow for the TeddyCloud provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.teddycloud.constants import CONF_URL
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(
+        key="label",
+        type=ConfigEntryType.LABEL,
+    ),
+    ConfigEntry(
+        key=CONF_URL,
+        type=ConfigEntryType.STRING,
+        required=True,
+    ),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the connection details and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/tunein/__init__.py
+++ b/music_assistant/providers/tunein/__init__.py
@@ -6,9 +6,7 @@ import random
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote
 
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import (
-    ConfigEntryType,
     ContentType,
     ImageType,
     MediaType,
@@ -38,7 +36,7 @@ from music_assistant.models.music_provider import MusicProvider
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant import MusicAssistant
@@ -60,10 +58,6 @@ async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
     """Initialize provider(instance) with given configuration."""
-    if not config.get_value(CONF_USERNAME):
-        msg = "Username is invalid"
-        raise LoginFailed(msg)
-
     return TuneInProvider(mass, manifest, config, SUPPORTED_FEATURES)
 
 
@@ -81,13 +75,7 @@ async def get_config_entries(
     values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
-    return (
-        ConfigEntry(
-            key=CONF_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-    )
+    return ()
 
 
 class TuneInProvider(MusicProvider):
@@ -100,7 +88,10 @@ class TuneInProvider(MusicProvider):
         """Handle async initialization of the provider."""
         self._throttler = Throttler(rate_limit=1, period=2)
         self._browse_url_map = {}
-        username = self.config.get_value(CONF_USERNAME)
+        username = self.get_setup_value(CONF_USERNAME)
+        if not username:
+            msg = "Username is invalid"
+            raise LoginFailed(msg)
         if isinstance(username, str) and "@" in username:
             self.logger.warning(
                 "Email address detected instead of username, "
@@ -509,7 +500,7 @@ class TuneInProvider(MusicProvider):
         else:
             url = f"https://opml.radiotime.com/{endpoint}"
             kwargs["formats"] = "ogg,aac,wma,mp3,hls"
-            kwargs["username"] = self.config.get_value(CONF_USERNAME)
+            kwargs["username"] = self.get_setup_value(CONF_USERNAME)
             kwargs["partnerId"] = "1"
             kwargs["render"] = "json"
         locale = self.mass.metadata.locale.replace("_", "-")

--- a/music_assistant/providers/tunein/setup_flow.py
+++ b/music_assistant/providers/tunein/setup_flow.py
@@ -1,0 +1,34 @@
+"""Setup flow for the TuneIn provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowError
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (ConfigEntry(key=CONF_USERNAME, type=ConfigEntryType.STRING, required=True),)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the TuneIn username and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/tunein/setup_flow.py
+++ b/music_assistant/providers/tunein/setup_flow.py
@@ -31,4 +31,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/webdav/__init__.py
+++ b/music_assistant/providers/webdav/__init__.py
@@ -54,8 +54,12 @@ async def get_config_entries(
     # connection details and content type are collected by the setup flow; surface the
     # (immutable) content type read-only so the sync options' depends_on chains resolve
     content_type = "music"
-    if instance_id and (prov := mass.get_provider(instance_id, return_unavailable=True)):
-        content_type = getattr(prov, "media_content_type", content_type)
+    if instance_id:
+        # read the persisted value so the depends_on chains resolve correctly
+        # even when the provider (instance) is not currently loaded
+        content_type = str(
+            mass.config.get_provider_setup_value(instance_id, CONF_CONTENT_TYPE, "music")
+        )
     return (
         ConfigEntry(key=CONF_CONTENT_TYPE, type=ConfigEntryType.LABEL, value=content_type),
         CONF_ENTRY_MISSING_ALBUM_ARTIST,

--- a/music_assistant/providers/webdav/__init__.py
+++ b/music_assistant/providers/webdav/__init__.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
+from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 
-from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
 from music_assistant.providers.filesystem_local.constants import (
     CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
     CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS,
@@ -18,7 +17,7 @@ from music_assistant.providers.filesystem_local.constants import (
     CONF_ENTRY_PROPAGATE_GENRES,
 )
 
-from .constants import CONF_CONTENT_TYPE, CONF_URL, CONF_VERIFY_SSL
+from .constants import CONF_CONTENT_TYPE
 from .provider import WebDAVFileSystemProvider
 
 if TYPE_CHECKING:
@@ -48,43 +47,17 @@ async def setup(
 async def get_config_entries(
     mass: MusicAssistant,
     instance_id: str | None = None,
-    action: str | None = None,
-    values: dict[str, ConfigValueType] | None = None,
+    action: str | None = None,  # noqa: ARG001
+    values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
 ) -> tuple[ConfigEntry, ...]:
     """Return Config entries to setup this provider."""
-    # ruff: noqa: ARG001
+    # connection details and content type are collected by the setup flow; surface the
+    # (immutable) content type read-only so the sync options' depends_on chains resolve
+    content_type = "music"
+    if instance_id and (prov := mass.get_provider(instance_id, return_unavailable=True)):
+        content_type = getattr(prov, "media_content_type", content_type)
     return (
-        ConfigEntry(
-            key=CONF_CONTENT_TYPE,
-            type=ConfigEntryType.STRING,
-            options=[
-                ConfigValueOption("music"),
-                ConfigValueOption("audiobooks"),
-                ConfigValueOption("podcasts"),
-            ],
-            default_value="music",
-            hidden=instance_id is not None,
-        ),
-        ConfigEntry(
-            key=CONF_URL,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=False,
-        ),
-        ConfigEntry(
-            key=CONF_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=False,
-        ),
-        ConfigEntry(
-            key=CONF_VERIFY_SSL,
-            type=ConfigEntryType.BOOLEAN,
-            default_value=False,
-        ),
+        ConfigEntry(key=CONF_CONTENT_TYPE, type=ConfigEntryType.LABEL, value=content_type),
         CONF_ENTRY_MISSING_ALBUM_ARTIST,
         CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
         CONF_ENTRY_LIBRARY_SYNC_TRACKS,

--- a/music_assistant/providers/webdav/constants.py
+++ b/music_assistant/providers/webdav/constants.py
@@ -5,6 +5,6 @@ from typing import Final
 # Only WebDAV-specific constants
 CONF_URL: Final[str] = "url"
 CONF_VERIFY_SSL: Final[str] = "verify_ssl"
-CONF_CONTENT_TYPE: Final[str] = "content_type"  # This one stays - it's in config
+CONF_CONTENT_TYPE: Final[str] = "content_type"
 MAX_CONCURRENT_TASKS: Final[int] = 5
 WEBDAV_TIMEOUT: Final[int] = 30

--- a/music_assistant/providers/webdav/provider.py
+++ b/music_assistant/providers/webdav/provider.py
@@ -48,13 +48,15 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
         config: ProviderConfig,
     ) -> None:
         """Initialize WebDAV FileSystem Provider."""
-        base_url = cast("str", config.get_value(CONF_URL)).rstrip("/")
-        super().__init__(mass, manifest, config, base_url)
-        self.base_url = base_url
-        self.username = cast("str | None", config.get_value(CONF_USERNAME))
-        self.password = cast("str | None", config.get_value(CONF_PASSWORD))
-        self.verify_ssl = cast("bool", config.get_value(CONF_VERIFY_SSL))
-        self.media_content_type = cast("str", config.get_value(CONF_CONTENT_TYPE))
+        # the base path (WebDAV URL) is resolved from the setup data below, which needs
+        # the initialized instance, so hand the base class a placeholder and set it after
+        super().__init__(mass, manifest, config, base_path="")
+        self.base_url = cast("str", self.get_setup_value(CONF_URL)).rstrip("/")
+        self.base_path = self.base_url
+        self.username = cast("str | None", self.get_setup_value(CONF_USERNAME))
+        self.password = cast("str | None", self.get_setup_value(CONF_PASSWORD))
+        self.verify_ssl = cast("bool", self.get_setup_value(CONF_VERIFY_SSL))
+        self.media_content_type = cast("str", self.get_setup_value(CONF_CONTENT_TYPE))
 
     @property
     def instance_name_postfix(self) -> str | None:

--- a/music_assistant/providers/webdav/setup_flow.py
+++ b/music_assistant/providers/webdav/setup_flow.py
@@ -1,0 +1,51 @@
+"""Setup flow for the WebDAV filesystem provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowError
+
+from .constants import CONF_CONTENT_TYPE, CONF_URL, CONF_VERIFY_SSL
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(
+        key=CONF_CONTENT_TYPE,
+        type=ConfigEntryType.STRING,
+        options=[
+            ConfigValueOption("music"),
+            ConfigValueOption("audiobooks"),
+            ConfigValueOption("podcasts"),
+        ],
+        default_value="music",
+    ),
+    ConfigEntry(key=CONF_URL, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(key=CONF_USERNAME, type=ConfigEntryType.STRING, required=False),
+    ConfigEntry(key=CONF_PASSWORD, type=ConfigEntryType.SECURE_STRING, required=False),
+    ConfigEntry(key=CONF_VERIFY_SSL, type=ConfigEntryType.BOOLEAN, default_value=False),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the WebDAV connection details and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/webdav/setup_flow.py
+++ b/music_assistant/providers/webdav/setup_flow.py
@@ -48,4 +48,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/yousee/__init__.py
+++ b/music_assistant/providers/yousee/__init__.py
@@ -10,11 +10,7 @@ from music_assistant_models.enums import (
     ProviderFeature,
 )
 
-from music_assistant.constants import (
-    CONF_ENTRY_UNOFFICIAL_PROVIDER,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-)
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
 from music_assistant.providers.yousee.constants import CONF_QUALITY
 from music_assistant.providers.yousee.provider import YouSeeMusikProvider
 
@@ -73,16 +69,6 @@ async def get_config_entries(
     # ruff: noqa: ARG001
     return (
         CONF_ENTRY_UNOFFICIAL_PROVIDER,
-        ConfigEntry(
-            key=CONF_USERNAME,
-            type=ConfigEntryType.STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_PASSWORD,
-            type=ConfigEntryType.SECURE_STRING,
-            required=True,
-        ),
         ConfigEntry(
             key=CONF_QUALITY,
             type=ConfigEntryType.INTEGER,

--- a/music_assistant/providers/yousee/auth_manager.py
+++ b/music_assistant/providers/yousee/auth_manager.py
@@ -87,8 +87,8 @@ class YouSeeAuthManager:
             async with self.mass.http_session.post(
                 f"https://login.yousee.dk{post_action_re.group(1)}",
                 data={
-                    "pf.username": self.provider.config.get_value(CONF_USERNAME),
-                    "pf.pass": self.provider.config.get_value(CONF_PASSWORD),
+                    "pf.username": self.provider.get_setup_value(CONF_USERNAME),
+                    "pf.pass": self.provider.get_setup_value(CONF_PASSWORD),
                     "pf.ok": "clicked",
                     "pf.adapterId": "MusicUsernamePasswordAdapter",
                 },

--- a/music_assistant/providers/yousee/provider.py
+++ b/music_assistant/providers/yousee/provider.py
@@ -62,7 +62,7 @@ class YouSeeMusikProvider(RecommendationPayloadMixin, MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        if not self.config.get_value(CONF_USERNAME) or not self.config.get_value(CONF_PASSWORD):
+        if not self.get_setup_value(CONF_USERNAME) or not self.get_setup_value(CONF_PASSWORD):
             msg = "Invalid login credentials"
             raise LoginFailed(msg)
         # try to get a token, raise if that fails
@@ -76,7 +76,7 @@ class YouSeeMusikProvider(RecommendationPayloadMixin, MusicProvider):
 
         token = await self.auth.auth_token()
         if not token:
-            msg = f"Login failed for user {self.config.get_value(CONF_USERNAME)}"
+            msg = f"Login failed for user {self.get_setup_value(CONF_USERNAME)}"
             raise LoginFailed(msg)
 
     async def search(

--- a/music_assistant/providers/yousee/setup_flow.py
+++ b/music_assistant/providers/yousee/setup_flow.py
@@ -34,4 +34,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/yousee/setup_flow.py
+++ b/music_assistant/providers/yousee/setup_flow.py
@@ -1,0 +1,37 @@
+"""Setup flow for the YouSee Musik provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowError
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(key=CONF_USERNAME, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(key=CONF_PASSWORD, type=ConfigEntryType.SECURE_STRING, required=True),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the credentials and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -15,10 +15,8 @@ from urllib.parse import parse_qs, unquote, urlparse
 
 from aiohttp import ClientError
 from duration_parser import parse as parse_str_duration
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import (
     AlbumType,
-    ConfigEntryType,
     ContentType,
     ImageType,
     MediaType,
@@ -90,7 +88,7 @@ from .helpers import (
 )
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant import MusicAssistant
@@ -173,21 +171,7 @@ async def get_config_entries(
     action: [optional] action key called from config entries UI.
     values: the (intermediate) raw values for config entries sent with the action.
     """
-    return (
-        CONF_ENTRY_UNOFFICIAL_PROVIDER,
-        ConfigEntry(key=CONF_USERNAME, type=ConfigEntryType.STRING, required=True),
-        ConfigEntry(
-            key=CONF_COOKIE,
-            type=ConfigEntryType.SECURE_STRING,
-            required=True,
-        ),
-        ConfigEntry(
-            key=CONF_PO_TOKEN_SERVER_URL,
-            type=ConfigEntryType.STRING,
-            default_value=DEFAULT_PO_TOKEN_SERVER_URL,
-            required=True,
-        ),
-    )
+    return (CONF_ENTRY_UNOFFICIAL_PROVIDER,)
 
 
 class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
@@ -205,9 +189,9 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
         """Set up the YTMusic provider."""
         logging.getLogger("yt_dlp").setLevel(self.logger.level + 10)
         await self._install_packages()
-        self._cookie = str(self.config.get_value(CONF_COOKIE))
+        self._cookie = str(self.get_setup_value(CONF_COOKIE))
         self._po_token_server_url = (
-            self.config.get_value(CONF_PO_TOKEN_SERVER_URL) or DEFAULT_PO_TOKEN_SERVER_URL
+            self.get_setup_value(CONF_PO_TOKEN_SERVER_URL) or DEFAULT_PO_TOKEN_SERVER_URL
         )
         if not await self._verify_po_token_url():
             raise LoginFailed(
@@ -215,7 +199,7 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
                 "Make sure you have installed the YT Music PO Token Generator "
                 "and that it is running."
             )
-        yt_username = str(self.config.get_value(CONF_USERNAME))
+        yt_username = str(self.get_setup_value(CONF_USERNAME))
         self._yt_user = yt_username if is_brand_account(yt_username) else None
         # yt-dlp needs a netscape formatted cookie
         self._netscape_cookie = convert_to_netscape(self._cookie, YTM_COOKIE_DOMAIN)

--- a/music_assistant/providers/ytmusic/setup_flow.py
+++ b/music_assistant/providers/ytmusic/setup_flow.py
@@ -1,0 +1,52 @@
+"""Setup flow for the Youtube Music provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowError
+from music_assistant.providers.ytmusic import (
+    CONF_COOKIE,
+    CONF_PO_TOKEN_SERVER_URL,
+    DEFAULT_PO_TOKEN_SERVER_URL,
+)
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(key=CONF_USERNAME, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(
+        key=CONF_COOKIE,
+        type=ConfigEntryType.SECURE_STRING,
+        required=True,
+    ),
+    ConfigEntry(
+        key=CONF_PO_TOKEN_SERVER_URL,
+        type=ConfigEntryType.STRING,
+        default_value=DEFAULT_PO_TOKEN_SERVER_URL,
+        required=True,
+    ),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the credentials and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": str(err)}

--- a/music_assistant/providers/ytmusic/setup_flow.py
+++ b/music_assistant/providers/ytmusic/setup_flow.py
@@ -49,4 +49,4 @@ async def run_setup(session: SetupSession) -> None:
             await session.finish(setup_data)
             return
         except SetupFlowError as err:
-            errors = {"base": str(err)}
+            errors = {"base": err.translation_key or str(err)}

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -796,7 +796,9 @@ async def test_real_provider_flow_retry_on_error(flow_mass: MusicAssistant) -> N
             step.flow_id, {"username": "marcel", "password": "wrong"}
         )
         assert retry_step.type == FlowStepType.FORM
-        assert retry_step.errors == {"base": "bad creds"}
+        # the error slug (LoginFailed.translation_key) is used so it localizes
+        # at serialization; the raw message is the fallback for keyless errors
+        assert retry_step.errors == {"base": "login_failed"}
         finish_step = await flow_mass.config.submit_setup_flow(
             step.flow_id, {"username": "marcel", "password": "right"}
         )

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -20,6 +20,10 @@ from music_assistant.constants import CONF_PLAYERS, CONF_PROVIDERS, ENCRYPT_SUFF
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.player import Player
 from music_assistant.models.setup_flow import AbortFlow, SetupSession, StepExpiredError
+from music_assistant.providers.filesystem_local.setup_flow import (
+    run_setup as filesystem_local_run_setup,
+)
+from music_assistant.providers.qobuz.setup_flow import run_setup as qobuz_run_setup
 from tests.common import MockPlayer, MockProvider
 
 if TYPE_CHECKING:
@@ -736,3 +740,65 @@ async def test_secure_values_never_echoed_on_step(flow_mass: MusicAssistant) -> 
         )
         assert received["password"] == "sssh"
         await flow_mass.config.abort_setup_flow(step.flow_id)
+
+
+# --- real provider setup flows driven through the engine (migrated plain-cred providers) ---
+
+
+async def test_real_provider_flow_qobuz(flow_mass: MusicAssistant) -> None:
+    """Qobuz's run_setup collects credentials and persists them as (encrypted) setup_data."""
+    with (
+        _use_flow(flow_mass, qobuz_run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()) as mock_load,
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        assert step.type == FlowStepType.FORM
+        # only the setup credentials are on the form; the quality option stays behind
+        assert {entry.key for entry in step.entries} == {"username", "password"}
+        finish_step = await flow_mass.config.submit_setup_flow(
+            step.flow_id, {"username": "marcel", "password": "hunter2"}
+        )
+    assert finish_step.type == FlowStepType.FINISH
+    mock_load.assert_awaited_once()
+    raw_conf = flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}")
+    assert flow_mass.config.decrypt_string(raw_conf["setup_data"]["username"]) == "marcel"
+    assert flow_mass.config.decrypt_string(raw_conf["setup_data"]["password"]) == "hunter2"
+
+
+async def test_real_provider_flow_filesystem_local(flow_mass: MusicAssistant) -> None:
+    """filesystem_local's run_setup collects the content type and path as setup_data."""
+    with (
+        _use_flow(flow_mass, filesystem_local_run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()) as mock_load,
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        assert step.type == FlowStepType.FORM
+        assert {"content_type", "path"} <= {entry.key for entry in step.entries}
+        finish_step = await flow_mass.config.submit_setup_flow(
+            step.flow_id, {"content_type": "podcasts", "path": "/media/podcasts"}
+        )
+    assert finish_step.type == FlowStepType.FINISH
+    mock_load.assert_awaited_once()
+    raw_conf = flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}")
+    assert flow_mass.config.decrypt_string(raw_conf["setup_data"]["content_type"]) == "podcasts"
+    assert flow_mass.config.decrypt_string(raw_conf["setup_data"]["path"]) == "/media/podcasts"
+
+
+async def test_real_provider_flow_retry_on_error(flow_mass: MusicAssistant) -> None:
+    """A failing load makes the author's loop re-render the form with the error, then succeed."""
+    load_mock = AsyncMock(side_effect=[LoginFailed("bad creds"), None])
+    with (
+        _use_flow(flow_mass, qobuz_run_setup),
+        patch.object(flow_mass, "load_provider_config", load_mock),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        retry_step = await flow_mass.config.submit_setup_flow(
+            step.flow_id, {"username": "marcel", "password": "wrong"}
+        )
+        assert retry_step.type == FlowStepType.FORM
+        assert retry_step.errors == {"base": "bad creds"}
+        finish_step = await flow_mass.config.submit_setup_flow(
+            step.flow_id, {"username": "marcel", "password": "right"}
+        )
+    assert finish_step.type == FlowStepType.FINISH
+    assert flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}") is not None

--- a/tests/providers/amplipi/test_provider.py
+++ b/tests/providers/amplipi/test_provider.py
@@ -11,7 +11,7 @@ import pytest
 from music_assistant_models.errors import PlayerCommandFailed, SetupFailedError
 from pyamplipi.error import AmpliPiUnreachableError
 
-from music_assistant.providers.amplipi import get_config_entries, setup
+from music_assistant.providers.amplipi import get_config_entries, setup, setup_flow
 from music_assistant.providers.amplipi.constants import CONF_HOST, MA_STREAM_NAME, MA_STREAM_TYPE
 from music_assistant.providers.amplipi.provider import AmpliPiPlayerProvider
 
@@ -47,6 +47,10 @@ class TestHandleAsyncInit:
         prov.config = MagicMock()
         prov.config.get_value.return_value = "amplipi.local"
         prov.mass = MagicMock()
+        # setup_data is unset here, so get_setup_value falls through to config.get_value
+        prov.config.values = {}
+        prov.mass.config.get.return_value = None
+        prov.mass.config.get_raw_provider_config_value.return_value = None
         fake_api = MagicMock()
         fake_api.get_status = AsyncMock(return_value="STATUS")
         created: dict[str, object] = {}
@@ -69,6 +73,10 @@ class TestHandleAsyncInit:
         prov.config = MagicMock()
         prov.config.get_value.return_value = "http://1.2.3.4/api"
         prov.mass = MagicMock()
+        # setup_data is unset here, so get_setup_value falls through to config.get_value
+        prov.config.values = {}
+        prov.mass.config.get.return_value = None
+        prov.mass.config.get_raw_provider_config_value.return_value = None
         fake_api = MagicMock()
         fake_api.get_status = AsyncMock(return_value="STATUS")
         created: dict[str, object] = {}
@@ -87,6 +95,10 @@ class TestHandleAsyncInit:
         prov.config = MagicMock()
         prov.config.get_value.return_value = "https://amplipi.local/"
         prov.mass = MagicMock()
+        # setup_data is unset here, so get_setup_value falls through to config.get_value
+        prov.config.values = {}
+        prov.mass.config.get.return_value = None
+        prov.mass.config.get_raw_provider_config_value.return_value = None
         fake_api = MagicMock()
         fake_api.get_status = AsyncMock(return_value="STATUS")
         created: dict[str, object] = {}
@@ -105,6 +117,10 @@ class TestHandleAsyncInit:
         prov.config = MagicMock()
         prov.config.get_value.return_value = "http-livingroom.local"
         prov.mass = MagicMock()
+        # setup_data is unset here, so get_setup_value falls through to config.get_value
+        prov.config.values = {}
+        prov.mass.config.get.return_value = None
+        prov.mass.config.get_raw_provider_config_value.return_value = None
         fake_api = MagicMock()
         fake_api.get_status = AsyncMock(return_value="STATUS")
         created: dict[str, object] = {}
@@ -123,6 +139,10 @@ class TestHandleAsyncInit:
         prov.config = MagicMock()
         prov.config.get_value.return_value = "amplipi.local"
         prov.mass = MagicMock()
+        # setup_data is unset here, so get_setup_value falls through to config.get_value
+        prov.config.values = {}
+        prov.mass.config.get.return_value = None
+        prov.mass.config.get_raw_provider_config_value.return_value = None
         fake_api = MagicMock()
         fake_api.get_status = AsyncMock(side_effect=AmpliPiUnreachableError("no route"))
         monkeypatch.setattr(
@@ -397,8 +417,12 @@ class TestModuleEntryPoints:
         result = await setup(MagicMock(), MagicMock(), MagicMock())
         assert result == "PROVIDER"  # type: ignore[comparison-overlap]
 
-    async def test_get_config_entries_exposes_host(self) -> None:
-        """The provider must expose a required Host config entry."""
+    async def test_get_config_entries_has_no_setup_entries(self) -> None:
+        """The host moved to the setup flow, so the options entries no longer expose it."""
         entries = await get_config_entries(MagicMock())
-        host = next(e for e in entries if e.key == CONF_HOST)
+        assert all(e.key != CONF_HOST for e in entries)
+
+    async def test_setup_flow_exposes_host(self) -> None:
+        """The setup flow must collect a required Host entry."""
+        host = next(e for e in setup_flow._ENTRIES if e.key == CONF_HOST)
         assert host.required is True

--- a/tests/providers/bandcamp/test_provider.py
+++ b/tests/providers/bandcamp/test_provider.py
@@ -66,6 +66,10 @@ def mass_mock() -> Mock:
     mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
     mass.cache.set = AsyncMock()
     mass.cache.delete = AsyncMock()
+    # setup_data is unset in these unit tests, so get_setup_value falls through to
+    # the provider config's get_value (which the config mock stubs)
+    mass.config.get = Mock(return_value=None)
+    mass.config.get_raw_provider_config_value = Mock(return_value=None)
     return mass
 
 
@@ -84,6 +88,7 @@ def config_mock() -> Mock:
     config.name = "Bandcamp Test"
     config.instance_id = "bandcamp_test"
     config.enabled = True
+    config.values = {}
     config.get_value.side_effect = lambda key, default=None: {
         "identity": "mock_identity_token",
         "search_limit": 10,
@@ -151,6 +156,7 @@ async def test_handle_async_init_with_identity(provider: BandcampProvider) -> No
 async def test_handle_async_init_without_identity(mass_mock: Mock, manifest_mock: Mock) -> None:
     """Test async initialization without identity token."""
     config = Mock()
+    config.values = {}
     config.get_value.side_effect = lambda key, default=None: (
         default if default is not None else ("INFO" if key == "log_level" else None)
     )

--- a/tests/providers/bandcamp/test_recommendations.py
+++ b/tests/providers/bandcamp/test_recommendations.py
@@ -19,6 +19,10 @@ def mass_mock() -> Mock:
     mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
     mass.cache.set = AsyncMock()
     mass.cache.delete = AsyncMock()
+    # setup_data is unset in these unit tests, so get_setup_value falls through to
+    # the provider config's get_value (which the config mock stubs)
+    mass.config.get = Mock(return_value=None)
+    mass.config.get_raw_provider_config_value = Mock(return_value=None)
     return mass
 
 
@@ -37,6 +41,7 @@ def config_mock() -> Mock:
     config.name = "Bandcamp Test"
     config.instance_id = "bandcamp_test"
     config.enabled = True
+    config.values = {}
     config.get_value.side_effect = lambda key, default=None: {
         "identity": "mock_identity_token",
         "search_limit": 10,

--- a/tests/providers/teddycloud/test_provider.py
+++ b/tests/providers/teddycloud/test_provider.py
@@ -79,6 +79,10 @@ def mass_mock() -> Mock:
     mass.http_session = Mock()
     mass.cache.get = AsyncMock(return_value=None)
     mass.cache.set = AsyncMock()
+    # setup_data is unset in these unit tests, so get_setup_value falls through to
+    # the provider config's get_value (which the config mock below stubs)
+    mass.config.get = Mock(return_value=None)
+    mass.config.get_raw_provider_config_value = Mock(return_value=None)
     return mass
 
 
@@ -97,6 +101,8 @@ def config_mock() -> Mock:
     config.name = "TeddyCloud Test"
     config.instance_id = "teddycloud_test"
     config.enabled = True
+    # empty values dict so get_setup_value's read-through reaches config.get_value below
+    config.values = {}
     # the base provider reads the log level from config on init; return a valid level.
     config.get_value.side_effect = lambda key, default=None: (
         "INFO" if key == "log_level" else default
@@ -344,6 +350,7 @@ async def test_handle_async_init_prepends_scheme(
     """A server entered as a bare host/IP is normalized to an http:// base URL."""
     config = Mock()
     config.instance_id = "teddycloud_test"
+    config.values = {}
     values: dict[str, Any] = {"url": "192.168.3.225", "log_level": "INFO"}
     config.get_value.side_effect = lambda key, default=None: values.get(key, default)
     prov = TeddyCloudProvider(mass_mock, manifest_mock, config, SUPPORTED_FEATURES)


### PR DESCRIPTION
# What does this implement/fix?

Second part of the setup-flows series (after #4952): all credential-based music/metadata providers now use a real setup flow instead of mixing their credentials into the options form.

- 30 providers get a `setup_flow.py` (one-form flow with retry-on-error and reconfigure prefill): deezer, emby, jellyfin, qobuz, ytmusic, the filesystem/webdav family, opensubsonic, audiobookshelf, tunein and friends
- Credential/connection entries moved out of the options form; behavior options (quality, sync toggles, …) stay
- Collected values are stored as encrypted `setup_data`; providers read them via `get_setup_value` with fallback to legacy stored values, so existing installs keep working without migration
- Runtime token/session refreshes (nicovideo, ard_audiothek) now persist via `_update_setup_data` instead of hidden config entries
- The filesystem "read-only duplicate content-type entry" workaround is gone (options show a plain label)

⚠️ Part of the setup-flows train — merge together with the rest of the series (the old add-provider form loses its credential fields here).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
