### PR TITLE
Reduce AirPlay debug log noise

### DIFF
--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -317,7 +317,7 @@ class AirPlayProvider(PlayerProvider):
         return cast("AirPlayPlayer | None", self.mass.players.get_player(player_id))
 
     def _set_pyatv_log_level(self) -> None:
-        """Align pyatv's log level with the provider's log level."""
+        """Keep pyatv's (very chatty) logging quiet unless verbose logging is enabled."""
         # pyatv is extremely chatty at debug level (it logs every protocol
         # message and heartbeat of each control connection), so only pass
         # through its debug logging when verbose logging is enabled

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -5,17 +5,19 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import logging
 import socket
 import time
 from contextlib import suppress
 from ipaddress import IPv4Address, IPv6Address, ip_address
-from typing import Final, cast
+from typing import TYPE_CHECKING, Final, cast
 
 from music_assistant_models.enums import PlaybackState
 from zeroconf import ServiceStateChange
 from zeroconf.asyncio import AsyncServiceInfo
 
 from music_assistant.constants import (
+    CONF_LOG_LEVEL,
     CONF_PLAYERS,
     CONF_PROVIDERS,
     CONF_SYNC_ADJUST,
@@ -59,6 +61,9 @@ from .helpers import (
 )
 from .player import AirPlayPlayer, GenericAirPlayPlayer
 from .sendspin_bridge import SendspinBridgeManager
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ProviderConfig
 
 # Marker the `cliairplay --ptp-daemon` process prints once it has bound the
 # privileged PTP ports (UDP 319/320) and opened its control channel. Until this
@@ -171,6 +176,7 @@ class AirPlayProvider(PlayerProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
+        self._set_pyatv_log_level()
         self._companion_info_by_address: dict[str, AsyncServiceInfo] = {}
         self._mrp_info_by_address: dict[str, AsyncServiceInfo] = {}
 
@@ -208,6 +214,14 @@ class AirPlayProvider(PlayerProvider):
         # AirPlay 2 streams attach to it (--ptp-shared) so multi-room sync groups
         # lock to a single grandmaster while UDP 319/320 is bound only once.
         await self._start_ptp_daemon()
+
+    async def update_config(self, config: ProviderConfig, changed_keys: set[str]) -> None:
+        """Handle logic when the config is updated."""
+        await super().update_config(config, changed_keys)
+        # a log level(-only) change does not reload the provider,
+        # so realign pyatv's logger here
+        if f"values/{CONF_LOG_LEVEL}" in changed_keys:
+            self._set_pyatv_log_level()
 
     async def on_mdns_service_state_change(
         self, name: str, state_change: ServiceStateChange, info: AsyncServiceInfo | None
@@ -301,6 +315,16 @@ class AirPlayProvider(PlayerProvider):
     def get_player(self, player_id: str) -> AirPlayPlayer | None:
         """Return AirplayPlayer by id."""
         return cast("AirPlayPlayer | None", self.mass.players.get_player(player_id))
+
+    def _set_pyatv_log_level(self) -> None:
+        """Align pyatv's log level with the provider's log level."""
+        # pyatv is extremely chatty at debug level (it logs every protocol
+        # message and heartbeat of each control connection), so only pass
+        # through its debug logging when verbose logging is enabled
+        if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+            logging.getLogger("pyatv").setLevel(logging.DEBUG)
+        else:
+            logging.getLogger("pyatv").setLevel(self.logger.level + 10)
 
     async def _setup_player(
         self, player_id: str, display_name: str, discovery_info: AsyncServiceInfo

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -357,6 +357,27 @@ async def test_ptp_daemon_spawn_traces_at_verbose_level() -> None:
     assert process_cls.call_args.args[0][-2:] == ["--debug", "10"]
 
 
+def test_pyatv_logging_quiet_at_debug_level() -> None:
+    """A normal debug session keeps pyatv's own (very chatty) logging quiet."""
+    prov = _ptp_provider()
+    prov.logger.setLevel(logging.DEBUG)
+
+    prov._set_pyatv_log_level()
+
+    # pyatv debug output is dropped; only INFO and above pass through
+    assert logging.getLogger("pyatv").level == logging.INFO
+
+
+def test_pyatv_logging_traces_at_verbose_level() -> None:
+    """A verbose session passes pyatv's debug logging through."""
+    prov = _ptp_provider()
+    prov.logger.setLevel(VERBOSE_LOG_LEVEL)
+
+    prov._set_pyatv_log_level()
+
+    assert logging.getLogger("pyatv").level == logging.DEBUG
+
+
 def test_ptp_daemon_ready_event_set_on_daemon_up_line() -> None:
     """The readiness event is set when the daemon prints its 'daemon up' line."""
     prov = _ptp_provider()


### PR DESCRIPTION
# What does this implement/fix?

The AirPlay provider keeps live control connections to Apple devices open through the `pyatv` library, and `pyatv` logs at debug level very aggressively (every protocol message and a periodic heartbeat per connection). As a result, running the server with debug logging fills the log with pyatv noise (well over half of all log lines), making it hard to find anything useful.

This brings AirPlay in line with the Chromecast and Sonos providers, which already keep their underlying library quiet: pyatv's debug logging is now only passed through when the AirPlay provider is set to verbose logging, and stays quiet otherwise.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Clamp the `pyatv` logger to the AirPlay provider's log level: full debug only at verbose, quiet otherwise.
- Re-apply the clamp on a runtime log-level change (a log-level-only change does not reload the provider).

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
