### PR TITLE
Chromecast and Sonos: apply verbose logging changes without a restart

### DIFF
--- a/music_assistant/providers/chromecast/provider.py
+++ b/music_assistant/providers/chromecast/provider.py
@@ -17,6 +17,7 @@ from pychromecast.discovery import CastBrowser, SimpleCastListener
 from music_assistant.constants import (
     CONF_ENABLED,
     CONF_ENTRY_MANUAL_DISCOVERY_IPS,
+    CONF_LOG_LEVEL,
     VERBOSE_LOG_LEVEL,
 )
 from music_assistant.helpers.json import SerializableType
@@ -70,11 +71,7 @@ class ChromecastProvider(PlayerProvider):
         self._discovery_running = False
         self.bridge_manager = SendspinBridgeManager(self)
         self.dashboards = ChromecastDashboards(self)
-        # set-up pychromecast logging
-        if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
-            logging.getLogger("pychromecast").setLevel(logging.DEBUG)
-        else:
-            logging.getLogger("pychromecast").setLevel(self.logger.level + 10)
+        self._set_pychromecast_log_level()
 
     async def discover_players(self) -> None:
         """Discover Cast players on the network."""
@@ -112,6 +109,14 @@ class ChromecastProvider(PlayerProvider):
 
             await self.mass.loop.run_in_executor(None, stop_discovery)
 
+    async def update_config(self, config: ProviderConfig, changed_keys: set[str]) -> None:
+        """Handle logic when the config is updated."""
+        await super().update_config(config, changed_keys)
+        # a log level(-only) change does not reload the provider,
+        # so realign pychromecast's logger here
+        if f"values/{CONF_LOG_LEVEL}" in changed_keys:
+            self._set_pychromecast_log_level()
+
     async def get_diagnostics(self) -> dict[str, SerializableType]:
         """Return diagnostics info for this provider to include in diagnostics reports."""
         cast_players = [player for player in self.players if isinstance(player, ChromecastPlayer)]
@@ -130,6 +135,16 @@ class ChromecastProvider(PlayerProvider):
             ),
             "models": models,
         }
+
+    def _set_pychromecast_log_level(self) -> None:
+        """Align pychromecast's log level with the provider's log level."""
+        # pychromecast is very chatty at debug level (it logs every socket
+        # message of each cast connection), so only pass through its debug
+        # logging when verbose logging is enabled
+        if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+            logging.getLogger("pychromecast").setLevel(logging.DEBUG)
+        else:
+            logging.getLogger("pychromecast").setLevel(self.logger.level + 10)
 
     ### Discovery callbacks
 

--- a/music_assistant/providers/sonos/__init__.py
+++ b/music_assistant/providers/sonos/__init__.py
@@ -7,12 +7,11 @@ https://github.com/music-assistant/aiosonos
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import ProviderFeature
 
-from music_assistant.constants import CONF_ENTRY_MANUAL_DISCOVERY_IPS, VERBOSE_LOG_LEVEL
+from music_assistant.constants import CONF_ENTRY_MANUAL_DISCOVERY_IPS
 
 from .provider import SonosPlayerProvider
 
@@ -32,13 +31,7 @@ async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
     """Initialize provider(instance) with given configuration."""
-    prov = SonosPlayerProvider(mass, manifest, config, SUPPORTED_FEATURES)
-    # set-up aiosonos logging
-    if prov.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
-        logging.getLogger("aiosonos").setLevel(logging.DEBUG)
-    else:
-        logging.getLogger("aiosonos").setLevel(prov.logger.level + 10)
-    return prov
+    return SonosPlayerProvider(mass, manifest, config, SUPPORTED_FEATURES)
 
 
 async def get_config_entries(

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -7,6 +7,7 @@ https://github.com/music-assistant/aiosonos
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp import web
@@ -18,6 +19,7 @@ from zeroconf import ServiceStateChange
 
 from music_assistant.constants import (
     CONF_ENTRY_MANUAL_DISCOVERY_IPS,
+    CONF_LOG_LEVEL,
     MASS_LOGO_ONLINE,
     VERBOSE_LOG_LEVEL,
 )
@@ -29,6 +31,7 @@ from .helpers import get_primary_ip_address
 from .player import SonosPlayer
 
 if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ProviderConfig
     from music_assistant_models.player import PlayerMedia
     from zeroconf.asyncio import AsyncServiceInfo
 
@@ -38,6 +41,7 @@ class SonosPlayerProvider(PlayerProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
+        self._set_aiosonos_log_level()
         self.mass.streams.register_dynamic_route(
             "/sonos_queue/*", self._handle_sonos_cloud_queue_request
         )
@@ -66,6 +70,14 @@ class SonosPlayerProvider(PlayerProvider):
     async def unload(self, is_removed: bool = False) -> None:
         """Handle close/cleanup of the provider."""
         self.mass.streams.unregister_dynamic_route("/sonos_queue/*")
+
+    async def update_config(self, config: ProviderConfig, changed_keys: set[str]) -> None:
+        """Handle logic when the config is updated."""
+        await super().update_config(config, changed_keys)
+        # a log level(-only) change does not reload the provider,
+        # so realign aiosonos's logger here
+        if f"values/{CONF_LOG_LEVEL}" in changed_keys:
+            self._set_aiosonos_log_level()
 
     async def get_diagnostics(self) -> dict[str, SerializableType]:
         """Return diagnostics info for this provider to include in diagnostics reports."""
@@ -126,6 +138,15 @@ class SonosPlayerProvider(PlayerProvider):
         # can arrive in (duplicated) bursts
         task_id = f"setup_sonos_{player_id}"
         self.mass.call_later(5, self._setup_player, player_id, name, info, task_id=task_id)
+
+    def _set_aiosonos_log_level(self) -> None:
+        """Align aiosonos's log level with the provider's log level."""
+        # aiosonos is very chatty at debug level, so only pass through its
+        # debug logging when verbose logging is enabled
+        if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+            logging.getLogger("aiosonos").setLevel(logging.DEBUG)
+        else:
+            logging.getLogger("aiosonos").setLevel(self.logger.level + 10)
 
     async def _setup_player(self, player_id: str, name: str, info: AsyncServiceInfo) -> None:
         """Handle setup of a new player that is discovered using mdns."""


### PR DESCRIPTION
# What does this implement/fix?

Changing a Chromecast or Sonos provider's log level to Verbose at runtime did not actually enable the underlying library's debug logging (`pychromecast` / `aiosonos`) until the provider was fully reloaded. A log-level-only config change doesn't reload the provider, so the one-time clamp applied at setup was never refreshed. This brings both providers in line with the AirPlay provider.

- Moved each provider's library log-level clamp into a small private helper.
- Re-apply it from an `update_config` override when the log level changes, so verbose logging takes effect immediately.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
