### PR TITLE
Fix AirPlay provider sometimes failing to reload

### DIFF
--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -417,15 +417,30 @@ class AsyncProcess:
         self._stderr_reader_task = task
 
 
-async def check_output(*args: str, env: dict[str, str] | None = None) -> tuple[int, bytes]:
-    """Run subprocess and return returncode and output."""
+async def check_output(
+    *args: str, env: dict[str, str] | None = None, timeout: float | None = None
+) -> tuple[int, bytes]:
+    """
+    Run subprocess and return returncode and output.
+
+    :param env: Optional environment overrides for the subprocess.
+    :param timeout: Maximum seconds to wait for the process to exit. On expiry the
+        process is killed and TimeoutError is raised; None (default) waits forever.
+    """
     proc = await asyncio.create_subprocess_exec(
         *args,
         stderr=asyncio.subprocess.STDOUT,
         stdout=asyncio.subprocess.PIPE,
         env=get_subprocess_env(env),
     )
-    stdout, _ = await proc.communicate()
+    try:
+        async with asyncio.timeout(timeout):
+            stdout, _ = await proc.communicate()
+    except TimeoutError:
+        proc.kill()
+        with suppress(ProcessLookupError):
+            await proc.wait()
+        raise
     assert proc.returncode is not None  # for type checking
     return (proc.returncode, stdout)
 

--- a/music_assistant/providers/airplay/helpers.py
+++ b/music_assistant/providers/airplay/helpers.py
@@ -24,6 +24,11 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 _COMPANION_PAIRING_DISABLED = 0x04
 _COMPANION_PAIRING_WITH_PIN = 0x4000
+# Bound the binary's `--check` probe. It normally answers instantly, but the first
+# execution of a freshly-fetched binary can stall (e.g. macOS Gatekeeper verification
+# of an unsigned download), and a wedged binary would otherwise block provider load or
+# a stream start indefinitely.
+_CLI_BINARY_CHECK_TIMEOUT = 15.0
 
 
 async def resolve_if_ip(mass: MusicAssistant, target_ip: str) -> str:
@@ -252,10 +257,18 @@ async def get_cli_binary() -> str:
     binary_path = os.path.join(base_path, binary_name)
 
     try:
-        returncode, output = await check_output(binary_path, "--check")
+        returncode, output = await check_output(
+            binary_path, "--check", timeout=_CLI_BINARY_CHECK_TIMEOUT
+        )
         output_str = output.strip().decode()
         if returncode == 0 and "cliairplay" in output_str and "check" in output_str:
             return binary_path
+    except TimeoutError:
+        msg = (
+            f"{binary_name} did not respond to --check within "
+            f"{_CLI_BINARY_CHECK_TIMEOUT:.0f}s (first-run verification or a wedged binary)"
+        )
+        raise RuntimeError(msg) from None
     except OSError:
         pass
 

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -13,7 +13,7 @@ from ipaddress import IPv4Address, IPv6Address, ip_address
 from typing import TYPE_CHECKING, Final, cast
 
 from music_assistant_models.enums import PlaybackState
-from zeroconf import ServiceStateChange
+from zeroconf import NonUniqueNameException, ServiceStateChange
 from zeroconf.asyncio import AsyncServiceInfo
 
 from music_assistant.constants import (
@@ -75,6 +75,9 @@ PTP_DAEMON_READY_MARKER: Final[str] = "[PTP] daemon up"
 # session that starts while the daemon is still coming up (or never binds) pays
 # any of this, and only up to the moment readiness is signalled.
 PTP_DAEMON_READY_TIMEOUT: Final[float] = 3.0
+# Grace period after broadcasting a goodbye for a stale DACP registration before
+# re-registering the (name-stable) service, letting the cache flush the old record.
+DACP_RECLAIM_DELAY: Final[float] = 1.0
 
 
 class AirPlayProvider(PlayerProvider):
@@ -205,7 +208,7 @@ class AirPlayProvider(PlayerProvider):
             },
             server=f"{socket.gethostname()}.local",
         )
-        await self.mass.discovery.aiozc.async_register_service(self._dacp_info)
+        await self._register_dacp_service()
 
         self._migrate_protocol_preferences()
         self._migrate_sync_adjust()
@@ -719,6 +722,30 @@ class AirPlayProvider(PlayerProvider):
         self.mass.config.set_raw_provider_config_value(
             self.instance_id, CONF_PROTOCOL_MIGRATION_MARKER, True
         )
+
+    async def _register_dacp_service(self) -> None:
+        """
+        Register the DACP ActiveRemote mDNS service, reclaiming a stale name if needed.
+
+        The service name is derived from the (persistent) server id, so it is identical
+        across every reload and restart. A previous registration that was not cleanly
+        torn down - a reload racing a slow initial load, or a leftover from a prior crash -
+        keeps the same name in the zeroconf cache and makes a plain register raise
+        NonUniqueNameException. In that case we broadcast a goodbye for the name to flush
+        the stale record, then register again.
+        """
+        aiozc = self.mass.discovery.aiozc
+        try:
+            await aiozc.async_register_service(self._dacp_info)
+            return
+        except NonUniqueNameException:
+            self.logger.debug(
+                "DACP service %s already advertised - reclaiming stale registration",
+                self._dacp_info.name,
+            )
+        await aiozc.async_unregister_service(self._dacp_info)
+        await asyncio.sleep(DACP_RECLAIM_DELAY)
+        await aiozc.async_register_service(self._dacp_info)
 
     async def _start_ptp_daemon(self) -> None:
         """Spawn the shared PTP clock daemon (cliairplay --ptp-daemon)."""

--- a/tests/providers/airplay/test_helpers.py
+++ b/tests/providers/airplay/test_helpers.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from music_assistant.providers.airplay.helpers import (
+    _CLI_BINARY_CHECK_TIMEOUT,
     get_cli_binary,
     get_decoded_property,
     serialize_txt_records,
@@ -122,4 +123,19 @@ async def test_get_cli_binary_uses_release_asset_name(
     result = await get_cli_binary()
 
     assert result.endswith(f"/bin/{expected_name}")
-    check_output.assert_awaited_once_with(result, "--check")
+    check_output.assert_awaited_once_with(result, "--check", timeout=_CLI_BINARY_CHECK_TIMEOUT)
+
+
+async def test_get_cli_binary_raises_when_check_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A binary that never answers --check surfaces as RuntimeError, not a hang."""
+    check_output = AsyncMock(side_effect=TimeoutError)
+    monkeypatch.setattr(
+        "music_assistant.providers.airplay.helpers.platform.system", lambda: "Darwin"
+    )
+    monkeypatch.setattr(
+        "music_assistant.providers.airplay.helpers.platform.machine", lambda: "aarch64"
+    )
+    monkeypatch.setattr("music_assistant.providers.airplay.helpers.check_output", check_output)
+
+    with pytest.raises(RuntimeError, match="did not respond to --check"):
+        await get_cli_binary()


### PR DESCRIPTION
# What does this implement/fix?

Reloading the AirPlay provider (on a config change, or automatically during startup) could fail with an error and leave AirPlay unavailable until much later.

This happened when the check that verifies the AirPlay helper binary got stuck — for example when macOS verifies a freshly downloaded binary on first run. That stall blocked the provider from finishing its load, so a reload couldn't clean up the previous instance and then tried to claim a network service name that was still in use.

- Time-box the helper binary check so a slow or stuck check no longer blocks the provider from loading (it falls back gracefully).
- Re-register the AirPlay control (DACP) service defensively: if the name is still held by a leftover registration, clear it and register again.
- Add tests for the binary-check timeout.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
