### PR TITLE
Make Open Subsonic provider use GET methods

### DIFF
--- a/music_assistant/providers/opensubsonic/manifest.json
+++ b/music_assistant/providers/opensubsonic/manifest.json
@@ -6,7 +6,7 @@
   "description": "Stream music from your OpenSubsonic compatible server — your own cloud jukebox.",
   "codeowners": ["@khers"],
   "credits": ["[py-opensonic](https://github.com/khers/py-opensonic)"],
-  "requirements": ["py-opensonic==10.1.0"],
+  "requirements": ["py-opensonic==10.2.1"],
   "documentation": "https://music-assistant.io/music-providers/subsonic/",
   "multi_instance": true
 }

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
-from urllib.parse import urlencode
 
 from libopensonic import AsyncConnection as SonicConnection
 from libopensonic.errors import (
@@ -178,6 +177,7 @@ class OpenSonicProvider(MusicProvider):
             legacy_auth=bool(self.config.get_value(CONF_ENABLE_LEGACY_AUTH)),
             port=port,
             server_path=str(path),
+            use_get=True,
             app_name="Music Assistant",
         )
 
@@ -198,25 +198,11 @@ class OpenSonicProvider(MusicProvider):
 
         try:
             extensions: list[OpenSubsonicExtension] = await self.conn.get_open_subsonic_extensions()
-        except OSError as e:
-            msg = "Failed to query server for OpenSubsonic extensions"
-            raise LoginFailed(
-                msg, translation_key="extension_failure", translation_owner=self.translation_owner
-            ) from e
-
-        formpost_supported = False
-        for entry in extensions:
-            if entry.name == "formpost":
-                formpost_supported = True
-            if entry.name == "songLyrics":
-                self._id_lyrics = True
-        if not formpost_supported:
-            msg = (
-                "Server does not support the 'formpost' OpenSubsonic extension, which is required."
-            )
-            raise LoginFailed(
-                msg, translation_key="formpost_missing", translation_owner=self.translation_owner
-            )
+            for entry in extensions:
+                if entry.name == "songLyrics":
+                    self._id_lyrics = True
+        except OSError:
+            self.logger.info("Failed to query server for OpenSubsonic extensions")
 
         self._enable_podcasts = bool(self.config.get_value(CONF_ENABLE_PODCASTS))
         self._show_faves = bool(self.config.get_value(CONF_RECO_FAVES))
@@ -817,16 +803,8 @@ class OpenSonicProvider(MusicProvider):
             msg = f"Unsupported media type encountered '{media_type}'"
             raise UnsupportedFeaturedException(msg)
 
-        # The stream URL carries no query string; id/auth/format all travel in the POST body
-        # so they never end up in proxy logs, server logs, or a `ps aux` listing. ffmpeg is
-        # handed the URL as its input and re-sends this same body on every Range-based reconnect
-        # it issues while seeking, so seeking is handled entirely by ffmpeg's own demuxer rather
-        # than the transcodeOffset extension.
         fmat = "raw" if self._raw_file else None
-        url, params = self.conn.get_stream_url(item.id, tformat=fmat, estimate_length=True)
-        # ffmpeg's -post_data is a binary AVOption: it must be given as a hex string of the
-        # raw bytes, a plain string value is silently rejected ("Invalid argument").
-        post_data = urlencode(params).encode().hex()
+        url, _ = self.conn.get_stream_url(item.id, tformat=fmat, estimate_length=True)
 
         return StreamDetails(
             item_id=item.id,
@@ -842,14 +820,6 @@ class OpenSonicProvider(MusicProvider):
             ),
             stream_type=StreamType.HTTP,
             path=url,
-            extra_input_args=[
-                "-method",
-                "POST",
-                "-content_type",
-                "application/x-www-form-urlencoded",
-                "-post_data",
-                post_data,
-            ],
             duration=item.duration or 0,
         )
 

--- a/music_assistant/providers/opensubsonic/strings.json
+++ b/music_assistant/providers/opensubsonic/strings.json
@@ -65,8 +65,6 @@
   },
   "errors": {
     "connect_failed": "Failed to connect to {0}, check your settings.",
-    "create_playlist_failed": "Failed to create playlist with name '{0}'.",
-    "extension_failure": "Failed to query server for OpenSubsonic extensions",
-    "formpost_missing": "Server does not support the 'formpost' OpenSubsonic extension, which is required."
+    "create_playlist_failed": "Failed to create playlist with name '{0}'."
   }
 }

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1612,8 +1612,6 @@
   "provider.opensubsonic.config_entries.username.description": "Your username for this Open Subsonic server",
   "provider.opensubsonic.errors.connect_failed": "Failed to connect to {0}, check your settings.",
   "provider.opensubsonic.errors.create_playlist_failed": "Failed to create playlist with name '{0}'.",
-  "provider.opensubsonic.errors.extension_failure": "Failed to query server for OpenSubsonic extensions",
-  "provider.opensubsonic.errors.formpost_missing": "Server does not support the 'formpost' OpenSubsonic extension, which is required.",
   "provider.opensubsonic.manifest.description": "Stream music from your OpenSubsonic compatible server — your own cloud jukebox.",
   "provider.opensubsonic.media.recommendations.starred_items.name": "Starred Items",
   "provider.orf_radiothek.config_entries.catchup_proto.description": "Use 'progressive' (mp3) or 'hls' (m3u8) URLs from the broadcast detail.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -65,7 +65,7 @@ plexapi==4.18.2
 podcastparser==0.6.11
 propcache>=0.2.1
 psutil==7.2.2
-py-opensonic==10.1.0
+py-opensonic==10.2.1
 pyacoustid==1.3.1
 pyamplipi==0.4.12
 pyatv==0.18.0


### PR DESCRIPTION
Using form POST to submit requests will keep arguments in the request body but prevents ffmpeg from being able to make range requests when attempting to decode a stream. Make the connection object use GET requests instead and provide the appropriate URL with params to ffmpeg.

Apologies for the translation churn.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5210

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
