### PR TITLE
⬆️ Update music-assistant-frontend to 2.17.234

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "ifaddr==0.2.0",
   "getmac==0.9.5",
   "mashumaro==3.20",
-  "music-assistant-frontend==2.17.233",
+  "music-assistant-frontend==2.17.234",
   "music-assistant-models==1.1.169",
   "mutagen==1.48.1",
   "orjson==3.11.6",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -50,7 +50,7 @@ lyricsgenius==3.12.2
 markdownify==1.2.3
 mashumaro==3.20
 modern_colorthief==0.2.1
-music-assistant-frontend==2.17.233
+music-assistant-frontend==2.17.234
 music-assistant-models==1.1.169
 mutagen==1.48.1
 niconico.py-ma==2.1.0.post2


### PR DESCRIPTION
Update music-assistant-frontend to version [2.17.234](https://github.com/music-assistant/frontend/releases/tag/2.17.234)


## 🚀 Features and enhancements

- Register transport listeners before connecting (by @MarvinSchenkel in [#2187](https://github.com/music-assistant/frontend/pull/2187))

## 🧰 Maintenance and dependency bumps

- Support immutable GitHub releases (by @marcelveldt in [#2186](https://github.com/music-assistant/frontend/pull/2186))


## :bow: Contributors

@marcelveldt, @MarvinSchenkel and @Copilot