### PR TITLE
Add Stereo Width and Crossfeed DSP filters

### DIFF
--- a/music_assistant/helpers/dsp.py
+++ b/music_assistant/helpers/dsp.py
@@ -213,8 +213,10 @@ def filter_to_ffmpeg_params(dsp_filter: DSPFilter, input_format: AudioFormat) ->
         # crossfeed blends the left and right channels for headphone listening
         # and is only meaningful on stereo streams
         if input_format.channels == 2:
+            # crossfeed is turned off by disabling the filter, never by a zero strength
+            # level_in defaults to 0.9, which would attenuate every crossfed stream
             filter_params.append(
-                f"crossfeed=strength={dsp_filter.strength}:range={dsp_filter.soundstage}"
+                f"crossfeed=strength={dsp_filter.strength}:range={dsp_filter.soundstage}:level_in=1"
             )
 
     return filter_params

--- a/music_assistant/helpers/dsp.py
+++ b/music_assistant/helpers/dsp.py
@@ -204,7 +204,10 @@ def filter_to_ffmpeg_params(dsp_filter: DSPFilter, input_format: AudioFormat) ->
         # width scales the side (L-R) signal; a non-stereo source has no side
         # component, so only apply it to stereo streams
         if input_format.channels == 2:
-            filter_params.append(f"extrastereo=m={dsp_filter.width}")
+            # c=0 disables the internal hard clipping extrastereo applies by default,
+            # which would clamp a widened signal before any later filter or the output
+            # gain can bring it down. The float internal format exists for that headroom
+            filter_params.append(f"extrastereo=m={dsp_filter.width}:c=0")
 
     if isinstance(dsp_filter, CrossfeedFilter):
         # crossfeed blends the left and right channels for headphone listening

--- a/music_assistant/helpers/dsp.py
+++ b/music_assistant/helpers/dsp.py
@@ -7,12 +7,14 @@ from typing import TYPE_CHECKING
 from music_assistant_models.dsp import (
     AudioChannel,
     BalanceFilter,
+    CrossfeedFilter,
     DSPFilter,
     GainFilter,
     HighLowPassFilter,
     HighLowPassMode,
     ParametricEQBandType,
     ParametricEQFilter,
+    StereoWidthFilter,
     ToneControlFilter,
     TransposeFilter,
 )
@@ -197,6 +199,20 @@ def filter_to_ffmpeg_params(dsp_filter: DSPFilter, input_format: AudioFormat) ->
             q = 1 / (2 * math.cos(math.pi * (2 * section + 1) / (2 * order)))
             alpha = sin_w0 / (2 * q)
             filter_params.append(_pass_biquad_params(high_pass=high_pass, w_0=w_0, alpha=alpha))
+
+    if isinstance(dsp_filter, StereoWidthFilter) and dsp_filter.width != 1.0:
+        # width scales the side (L-R) signal; a non-stereo source has no side
+        # component, so only apply it to stereo streams
+        if input_format.channels == 2:
+            filter_params.append(f"extrastereo=m={dsp_filter.width}")
+
+    if isinstance(dsp_filter, CrossfeedFilter):
+        # crossfeed blends the left and right channels for headphone listening
+        # and is only meaningful on stereo streams
+        if input_format.channels == 2:
+            filter_params.append(
+                f"crossfeed=strength={dsp_filter.strength}:range={dsp_filter.soundstage}"
+            )
 
     return filter_params
 

--- a/tests/helpers/test_dsp.py
+++ b/tests/helpers/test_dsp.py
@@ -132,7 +132,7 @@ def test_crossfeed_filter() -> None:
     """Test that a crossfeed filter maps to an ffmpeg crossfeed filter."""
     dsp_filter = CrossfeedFilter(enabled=True, strength=0.35, soundstage=0.6)
     assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == [
-        "crossfeed=strength=0.35:range=0.6"
+        "crossfeed=strength=0.35:range=0.6:level_in=1"
     ]
 
 

--- a/tests/helpers/test_dsp.py
+++ b/tests/helpers/test_dsp.py
@@ -5,6 +5,7 @@ import math
 from music_assistant_models.dsp import (
     AudioChannel,
     BalanceFilter,
+    CrossfeedFilter,
     GainFilter,
     HighLowPassFilter,
     HighLowPassMode,
@@ -12,6 +13,7 @@ from music_assistant_models.dsp import (
     ParametricEQBand,
     ParametricEQBandType,
     ParametricEQFilter,
+    StereoWidthFilter,
     ToneControlFilter,
     TransposeFilter,
 )
@@ -91,6 +93,46 @@ def test_transpose_filter_zero_is_passthrough() -> None:
     """Test that a transpose filter of 0 semitones emits no ffmpeg filter."""
     dsp_filter = TransposeFilter(enabled=True, semitones=0.0)
     assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == []
+
+
+def test_stereo_width_filter_wide() -> None:
+    """Test that a widened stereo width maps to an extrastereo filter."""
+    dsp_filter = StereoWidthFilter(enabled=True, width=1.5)
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == ["extrastereo=m=1.5"]
+
+
+def test_stereo_width_filter_mono() -> None:
+    """Test that zero width collapses the side signal to mono."""
+    dsp_filter = StereoWidthFilter(enabled=True, width=0.0)
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == ["extrastereo=m=0.0"]
+
+
+def test_stereo_width_filter_neutral_is_passthrough() -> None:
+    """Test that a unity stereo width emits no ffmpeg filter."""
+    dsp_filter = StereoWidthFilter(enabled=True, width=1.0)
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == []
+
+
+def test_stereo_width_filter_mono_is_skipped() -> None:
+    """Test that stereo width is skipped on a mono source (stereo-only operation)."""
+    dsp_filter = StereoWidthFilter(enabled=True, width=1.5)
+    mono_format = AudioFormat(sample_rate=48000, channels=1)
+    assert filter_to_ffmpeg_params(dsp_filter, mono_format) == []
+
+
+def test_crossfeed_filter() -> None:
+    """Test that a crossfeed filter maps to an ffmpeg crossfeed filter."""
+    dsp_filter = CrossfeedFilter(enabled=True, strength=0.35, soundstage=0.6)
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == [
+        "crossfeed=strength=0.35:range=0.6"
+    ]
+
+
+def test_crossfeed_filter_mono_is_skipped() -> None:
+    """Test that crossfeed is skipped on a mono source (stereo-only operation)."""
+    dsp_filter = CrossfeedFilter(enabled=True, strength=0.2, soundstage=0.5)
+    mono_format = AudioFormat(sample_rate=48000, channels=1)
+    assert filter_to_ffmpeg_params(dsp_filter, mono_format) == []
 
 
 def test_tone_control_filter() -> None:

--- a/tests/helpers/test_dsp.py
+++ b/tests/helpers/test_dsp.py
@@ -98,13 +98,21 @@ def test_transpose_filter_zero_is_passthrough() -> None:
 def test_stereo_width_filter_wide() -> None:
     """Test that a widened stereo width maps to an extrastereo filter."""
     dsp_filter = StereoWidthFilter(enabled=True, width=1.5)
-    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == ["extrastereo=m=1.5"]
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == ["extrastereo=m=1.5:c=0"]
+
+
+def test_stereo_width_filter_does_not_clip_internally() -> None:
+    """Test that widening never uses the internal clipping extrastereo enables by default."""
+    for width in (0.0, 0.5, 1.5, 2.0):
+        dsp_filter = StereoWidthFilter(enabled=True, width=width)
+        params = filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT)
+        assert params == [f"extrastereo=m={width}:c=0"]
 
 
 def test_stereo_width_filter_mono() -> None:
     """Test that zero width collapses the side signal to mono."""
     dsp_filter = StereoWidthFilter(enabled=True, width=0.0)
-    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == ["extrastereo=m=0.0"]
+    assert filter_to_ffmpeg_params(dsp_filter, INPUT_FORMAT) == ["extrastereo=m=0.0:c=0"]
 
 
 def test_stereo_width_filter_neutral_is_passthrough() -> None:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Adds support for two DSP filters, Stereo Width and Crossfeed.

Frontend PR https://github.com/music-assistant/frontend/pull/2189

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [X] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
