### PR TITLE
Make CI tests faster and more reliable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,10 @@ permissions:
 env:
   URLLIB3_NO_OVERRIDE: "1"
 
+concurrency:
+  group: test-${{ github.event_name }}-${{ github.event.pull_request.number || inputs.ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ test = [
   "pytest-aiohttp==1.1.0",
   "pytest-codspeed==5.0.3",
   "pytest-cov==7.0.0",
+  "pytest-timeout==2.4.0",
   "syrupy==5.2.0",
   "tomli==2.4.1",
   "ruff==0.15.22",
@@ -183,6 +184,7 @@ line-ending = "lf"
 [tool.pytest.ini_options]
 addopts = "--cov music_assistant"
 asyncio_mode = "auto"
+timeout = 120
 filterwarnings = [
   # Suppress Python 3.14 AsyncMock internal warnings about unawaited coroutines
   "ignore:coroutine.*was never awaited:RuntimeWarning",

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import logging
 import pathlib
-from collections.abc import AsyncGenerator, Iterator
+from collections.abc import AsyncGenerator, Callable, Iterator
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -63,6 +63,23 @@ async def wait_for_sync_completion(mass: MusicAssistant) -> AsyncGenerator[None]
 SUPPRESSED_BUILTIN_PROVIDERS = {"local_audio"}
 
 _orig_create_builtin_provider_config = ProviderConfigMixin.create_builtin_provider_config
+
+
+@contextlib.contextmanager
+def use_ephemeral_server_ports(port_factory: Callable[[], int]) -> Iterator[None]:
+    """
+    Give a full-server test fixture unused web and stream server ports.
+
+    :param port_factory: Callable returning an unused TCP port.
+    """
+    with (
+        patch(
+            "music_assistant.controllers.webserver.controller.DEFAULT_SERVER_PORT",
+            port_factory(),
+        ),
+        patch("music_assistant.controllers.streams.controller.DEFAULT_PORT", port_factory()),
+    ):
+        yield
 
 
 @contextlib.contextmanager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,8 @@ import asyncio
 import logging
 import pathlib
 import threading
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Callable, Generator
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, NonCallableMagicMock, patch
 
 import pytest
@@ -14,8 +15,10 @@ from zeroconf.asyncio import AsyncZeroconf
 from music_assistant.controllers.cache import CacheController
 from music_assistant.controllers.config import ConfigController
 from music_assistant.controllers.discovery import DiscoveryController
+from music_assistant.controllers.music import MusicController
+from music_assistant.controllers.tasks import TasksController
 from music_assistant.mass import MusicAssistant
-from tests.common import suppress_auto_loaded_providers
+from tests.common import suppress_auto_loaded_providers, use_ephemeral_server_ports
 
 
 @pytest.fixture(autouse=True)
@@ -63,7 +66,10 @@ def _create_mock_zeroconf() -> MagicMock:
 
 
 @pytest.fixture
-async def mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
+async def mass(
+    tmp_path: pathlib.Path,
+    unused_tcp_port_factory: Callable[[], int],
+) -> AsyncGenerator[MusicAssistant]:
     """
     Start a Music Assistant in test mode.
 
@@ -78,16 +84,12 @@ async def mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
 
     mass_instance = MusicAssistant(str(storage_path), str(cache_path))
 
-    # TODO: Configure a random port to avoid conflicts when MA is already running
-    # The conftest was modified in PR #2738 to add port configuration but it doesn't
-    # work correctly - the settings.json file is created but the config isn't respected.
-    # For now, tests that use the `mass` fixture will fail if MA is running on port 8095.
-
     # Mock zeroconf to prevent real network I/O during tests
     mock_zc = _create_mock_zeroconf()
     mock_browser = NonCallableMagicMock()  # Use NonCallable to avoid api_cmd issues
 
     with (
+        use_ephemeral_server_ports(unused_tcp_port_factory),
         patch(
             "music_assistant.controllers.discovery.controller.AsyncZeroconf",
             return_value=mock_zc,
@@ -124,6 +126,33 @@ async def mass_minimal(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]
 
     :param tmp_path: Temporary directory for test data.
     """
+    async with _minimal_mass_context(tmp_path) as mass_instance:
+        yield mass_instance
+
+
+@pytest.fixture(scope="class")
+async def music_mass_class(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> AsyncGenerator[MusicAssistant]:
+    """Create a class-scoped Music Assistant instance with only library storage."""
+    async with _music_mass_context(tmp_path_factory.mktemp("music_class")) as mass_instance:
+        yield mass_instance
+
+
+@pytest.fixture(scope="module")
+async def music_mass_module(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> AsyncGenerator[MusicAssistant]:
+    """Create a module-scoped Music Assistant instance with only library storage."""
+    async with _music_mass_context(tmp_path_factory.mktemp("music_module")) as mass_instance:
+        yield mass_instance
+
+
+@asynccontextmanager
+async def _minimal_mass_context(
+    tmp_path: pathlib.Path,
+) -> AsyncGenerator[MusicAssistant]:
+    """Create a minimal Music Assistant instance for a fixture."""
     storage_path = tmp_path / "data"
     cache_path = tmp_path / "cache"
     storage_path.mkdir(parents=True)
@@ -132,20 +161,42 @@ async def mass_minimal(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]
     logging.getLogger("aiosqlite").level = logging.INFO
 
     mass_instance = MusicAssistant(str(storage_path), str(cache_path))
-
     mass_instance.loop = asyncio.get_running_loop()
-    # fixture runs on the event loop thread, like MusicAssistant.start()
     mass_instance.loop_thread_id = threading.get_ident()
-
     mass_instance.config = ConfigController(mass_instance)
     await mass_instance.config.setup()
     mass_instance.discovery = DiscoveryController(mass_instance)
-
     mass_instance.cache = CacheController(mass_instance)
 
     try:
         yield mass_instance
     finally:
-        if mass_instance.cache.database:
-            await mass_instance.cache.database.close()
+        await mass_instance.cache.close()
         await mass_instance.config.close()
+
+
+@asynccontextmanager
+async def _music_mass_context(
+    tmp_path: pathlib.Path,
+) -> AsyncGenerator[MusicAssistant]:
+    """Create a minimal Music Assistant instance with a real library database."""
+    async with _minimal_mass_context(tmp_path) as mass_instance:
+        mass_instance.tasks = TasksController(mass_instance)
+        tasks_config = await mass_instance.config.get_core_config(mass_instance.tasks.domain)
+        await mass_instance.tasks.setup(tasks_config)
+
+        mass_instance.metadata = MagicMock()
+        mass_instance.metadata.schedule_update_metadata = MagicMock()
+        mass_instance.metadata.invalidate_image_cache = AsyncMock()
+        mass_instance.webserver = MagicMock()
+        mass_instance.webserver.auth.list_users = AsyncMock(return_value=[])
+
+        mass_instance.music = MusicController(mass_instance)
+        music_config = await mass_instance.config.get_core_config(mass_instance.music.domain)
+        await mass_instance.music.setup(music_config)
+        await mass_instance.music.post_setup()
+        try:
+            yield mass_instance
+        finally:
+            await mass_instance.tasks.close()
+            await mass_instance.music.close()

--- a/tests/controllers/music/test_genres.py
+++ b/tests/controllers/music/test_genres.py
@@ -1,16 +1,14 @@
 """
 Integration tests for the GenreController (V3 schema).
 
-Uses the ``mass`` fixture from ``tests/conftest.py`` which creates a full
-MusicAssistant instance with a real SQLite database in a temporary directory.
+Uses a database-only MusicAssistant instance with a real SQLite database in a
+temporary directory.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
-import logging
-from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
@@ -52,21 +50,10 @@ from music_assistant.mass import MusicAssistant
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="class")
-async def mass(tmp_path_factory: pytest.TempPathFactory) -> AsyncGenerator[MusicAssistant]:
-    """Class-scoped MusicAssistant instance (one per test class)."""
-    tmp_path = tmp_path_factory.mktemp("genre_tests")
-    storage_path = tmp_path / "data"
-    cache_path = tmp_path / "cache"
-    storage_path.mkdir(parents=True)
-    cache_path.mkdir(parents=True)
-    logging.getLogger("aiosqlite").level = logging.INFO
-    mass_instance = MusicAssistant(str(storage_path), str(cache_path))
-    await mass_instance.start()
-    try:
-        yield mass_instance
-    finally:
-        await mass_instance.stop()
+@pytest.fixture(scope="class", name="mass")
+def mass_fixture(music_mass_class: MusicAssistant) -> MusicAssistant:
+    """Return the class-scoped database-only Music Assistant fixture."""
+    return music_mass_class
 
 
 @pytest.fixture(scope="class")

--- a/tests/controllers/music/test_library_listing_queries.py
+++ b/tests/controllers/music/test_library_listing_queries.py
@@ -14,10 +14,8 @@ results straight from the sort index. These tests verify that:
 from __future__ import annotations
 
 import json
-import logging
-from collections.abc import AsyncGenerator
 from typing import Any
-from unittest.mock import AsyncMock, NonCallableMagicMock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -40,54 +38,17 @@ from music_assistant.constants import (
 from music_assistant.controllers.music.media.base import MediaControllerBase
 from music_assistant.helpers.compare import create_safe_string
 from music_assistant.mass import MusicAssistant
-from tests.common import suppress_auto_loaded_providers
 
 pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture(scope="module")
 async def seeded_mass(
-    tmp_path_factory: pytest.TempPathFactory,
-) -> AsyncGenerator[MusicAssistant]:
-    """Module-scoped hermetic MusicAssistant instance with a seeded library."""
-    tmp_path = tmp_path_factory.mktemp("listing_query_tests")
-    storage_path = tmp_path / "data"
-    cache_path = tmp_path / "cache"
-    storage_path.mkdir(parents=True)
-    cache_path.mkdir(parents=True)
-    logging.getLogger("aiosqlite").level = logging.INFO
-    mass_instance = MusicAssistant(str(storage_path), str(cache_path))
-    with (
-        patch(
-            "music_assistant.controllers.discovery.controller.AsyncZeroconf",
-            return_value=NonCallableMagicMock(
-                async_register_service=AsyncMock(),
-                async_update_service=AsyncMock(),
-                async_unregister_service=AsyncMock(),
-                async_close=AsyncMock(),
-            ),
-        ),
-        patch(
-            "music_assistant.controllers.discovery.controller.AsyncServiceBrowser",
-            return_value=NonCallableMagicMock(),
-        ),
-        patch(
-            "music_assistant.controllers.streams.controller.check_ffmpeg_version",
-            new=AsyncMock(),
-        ),
-        # hermetic: no real SSDP search
-        patch(
-            "music_assistant.controllers.discovery.controller.async_upnp_search",
-            new=AsyncMock(),
-        ),
-        suppress_auto_loaded_providers(),
-    ):
-        await mass_instance.start()
-        try:
-            await _seed_library(mass_instance)
-            yield mass_instance
-        finally:
-            await mass_instance.stop()
+    music_mass_module: MusicAssistant,
+) -> MusicAssistant:
+    """Return a module-scoped database-only instance with a seeded library."""
+    await _seed_library(music_mass_module)
+    return music_mass_module
 
 
 def _mapping(provider_instance: str = "prov_a_inst") -> ProviderMapping:

--- a/tests/controllers/music/test_playlists.py
+++ b/tests/controllers/music/test_playlists.py
@@ -1,15 +1,12 @@
 """
 Integration tests for the PlaylistController.
 
-Uses a full MusicAssistant instance with a real SQLite database in a temporary
-directory (mirroring ``tests/controllers/music/test_genres.py``) to verify that a
+Uses a database-only MusicAssistant instance with a real SQLite database in a
+temporary directory to verify that a
 playlist's ``translation_key`` survives the library round-trip.
 """
 
 from __future__ import annotations
-
-import logging
-from collections.abc import AsyncGenerator
 
 import pytest
 from music_assistant_models.media_items import Playlist, ProviderMapping
@@ -18,21 +15,10 @@ from music_assistant.controllers.music.media.playlists import PlaylistController
 from music_assistant.mass import MusicAssistant
 
 
-@pytest.fixture(scope="class")
-async def mass(tmp_path_factory: pytest.TempPathFactory) -> AsyncGenerator[MusicAssistant]:
-    """Class-scoped MusicAssistant instance (one per test class)."""
-    tmp_path = tmp_path_factory.mktemp("playlist_tests")
-    storage_path = tmp_path / "data"
-    cache_path = tmp_path / "cache"
-    storage_path.mkdir(parents=True)
-    cache_path.mkdir(parents=True)
-    logging.getLogger("aiosqlite").level = logging.INFO
-    mass_instance = MusicAssistant(str(storage_path), str(cache_path))
-    await mass_instance.start()
-    try:
-        yield mass_instance
-    finally:
-        await mass_instance.stop()
+@pytest.fixture(scope="class", name="mass")
+def mass_fixture(music_mass_class: MusicAssistant) -> MusicAssistant:
+    """Return the class-scoped database-only Music Assistant fixture."""
+    return music_mass_class
 
 
 @pytest.fixture(scope="class")

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
+from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -804,7 +805,12 @@ class TestPlayMediaOverride:
         controller._player_command_locks = {}
 
         media = MagicMock(uri="x", source_id="src")
-        await controller.play_media("member", media)
+        with patch.object(
+            controller,
+            "wait_for_player_update",
+            _skip_player_update_wait,
+        ):
+            await controller.play_media("member", media)
 
         # the member was removed from the group ...
         assert set_members_calls == [{"player_id": "g1", "remove": ["member"]}]
@@ -868,7 +874,12 @@ class TestPlayMediaOverride:
         controller._player_command_locks = {}
 
         media = MagicMock(uri="x", source_id="src")
-        await controller.play_media("member", media)
+        with patch.object(
+            controller,
+            "wait_for_player_update",
+            _skip_player_update_wait,
+        ):
+            await controller.play_media("member", media)
 
         # powerless group + static member: we should have stopped the group ...
         assert stop_calls == ["g1"]
@@ -1378,6 +1389,15 @@ class TestScheduleActiveOutputProtocolClear:
 
         wait_mock.assert_awaited_once_with(player, PlaybackState.IDLE, timeout=10)
         player.set_active_output_protocol.assert_called_once_with(None)
+
+
+@contextlib.asynccontextmanager
+async def _skip_player_update_wait(
+    *_args: object,
+    **_kwargs: object,
+) -> AsyncIterator[None]:
+    """Skip provider-driven state propagation in command-routing tests."""
+    yield
 
 
 if __name__ == "__main__":

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,7 +22,7 @@ from zeroconf.asyncio import AsyncZeroconf
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.models.player import Player
-from tests.common import suppress_auto_loaded_providers
+from tests.common import suppress_auto_loaded_providers, use_ephemeral_server_ports
 
 NUM_DEMO_PLAYERS = 3
 
@@ -88,7 +88,10 @@ def _create_mock_zeroconf() -> MagicMock:
 
 
 @pytest.fixture
-async def e2e_mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
+async def e2e_mass(
+    tmp_path: pathlib.Path,
+    unused_tcp_port_factory: Callable[[], int],
+) -> AsyncGenerator[MusicAssistant]:
     """
     Boot a hermetic MusicAssistant with only the fake `test` + demo player providers.
 
@@ -108,6 +111,7 @@ async def e2e_mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
     mass_instance.dev_mode = True
 
     with (
+        use_ephemeral_server_ports(unused_tcp_port_factory),
         patch(
             "music_assistant.controllers.discovery.controller.AsyncZeroconf",
             return_value=_create_mock_zeroconf(),

--- a/tests/integration/test_background_scan_streaming.py
+++ b/tests/integration/test_background_scan_streaming.py
@@ -131,13 +131,14 @@ async def test_streaming_background_scan_loudness_end_to_end() -> None:
     # None is not VolumeNormalizationMode.DISABLED, so loudness analysis proceeds
     streamdetails.volume_normalization_mode = None
 
-    await controller._run_background_streaming_for_track(streamdetails, [provider])
-
-    # Drain any tasks spawned by _finalize_providers (finalize is dispatched via create_task)
-    for _ in range(5):
-        await asyncio.sleep(0.05)
-    if created_tasks:
-        await asyncio.gather(*created_tasks, return_exceptions=True)
+    try:
+        await controller._run_background_streaming_for_track(streamdetails, [provider])
+        finalize_tasks = [
+            task for task in created_tasks if task is not controller._idle_unload_task
+        ]
+        await asyncio.wait_for(asyncio.gather(*finalize_tasks), timeout=5)
+    finally:
+        await controller.close()
 
     # Assertions
     assert len(captured_rows) == 1, f"expected exactly one analysis row; got {len(captured_rows)}"

--- a/tests/providers/bandcamp/test_provider.py
+++ b/tests/providers/bandcamp/test_provider.py
@@ -32,6 +32,7 @@ from music_assistant_models.errors import (
 from music_assistant_models.media_items import Album, Artist, BrowseFolder, Track
 from music_assistant_models.streamdetails import StreamDetails
 
+from music_assistant.helpers.throttle_retry import ThrottlerManager
 from music_assistant.providers.bandcamp import BandcampProvider, split_id
 from music_assistant.providers.bandcamp.constants import (
     CACHE_EMPTY_RESULTS,
@@ -102,6 +103,12 @@ def config_mock() -> Mock:
 async def provider(mass_mock: Mock, manifest_mock: Mock, config_mock: Mock) -> BandcampProvider:
     """Return a BandcampProvider instance."""
     provider = BandcampProvider(mass_mock, manifest_mock, config_mock, SUPPORTED_FEATURES)
+    provider.throttler = ThrottlerManager(
+        rate_limit=provider.throttler.throttler.rate_limit,
+        period=provider.throttler.throttler.period,
+        retry_attempts=provider.throttler.retry_attempts,
+        initial_backoff=provider.throttler.initial_backoff,
+    )
 
     # Initialize the provider
     with patch("music_assistant.providers.bandcamp.BandcampAPIClient") as mock_client_class:
@@ -609,9 +616,7 @@ async def test_fetch_api_track_rate_limit_error(provider: BandcampProvider) -> N
         await provider._fetch_api_track("123-456-789")
 
     assert mock_get_album.call_count == provider.throttler.retry_attempts
-    # At least retry_attempts - 1 sleeps from backoff; may be higher if the
-    # class-level Throttler also called asyncio.sleep due to accumulated entries.
-    assert mock_sleep.call_count >= provider.throttler.retry_attempts - 1
+    assert mock_sleep.call_count == provider.throttler.retry_attempts - 1
 
 
 async def test_fetch_api_track_generic_api_error(provider: BandcampProvider) -> None:

--- a/tests/providers/smart_fades/test_provider.py
+++ b/tests/providers/smart_fades/test_provider.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import math
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
@@ -15,10 +15,14 @@ import torch
 from music_assistant_models.enums import ContentType, MediaType
 from music_assistant_models.errors import SetupFailedError
 from music_assistant_models.media_items import AudioFormat
+from torchaudio.transforms import SpectralCentroid
 
 from music_assistant.models.audio_analysis import AudioAnalysisData, AudioAnalysisError
-from music_assistant.providers.smart_fades.provider import SmartFadesProvider
-from music_assistant.providers.smart_fades.vocal_activity import infer_firered_chunk
+from music_assistant.providers.smart_fades.provider import ANALYSIS_SAMPLE_RATE, SmartFadesProvider
+from music_assistant.providers.smart_fades.vocal_activity import (
+    FIRERED_MEL_BINS,
+    infer_firered_chunk,
+)
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 # Synthetic 120 BPM drum pattern (kick-hat-snare-hat): 44100 Hz, stereo, float32, ~15.7s
@@ -26,10 +30,7 @@ FIXTURE_DIR = Path(__file__).parent / "fixtures"
 # Clip ends 0.2s after the last beat to avoid end-of-track hallucination.
 FIXTURE_PCM = FIXTURE_DIR / "test_120bpm_44100_2_32.pcm"
 
-# Expected values from both beat_this File2Beats(checkpoint_path="final0", dbn=False)
-# and the MA streaming pipeline (identical output, 0ms diff between the two).
-# All 32 beats match ground truth within 20ms; all 8 downbeats match within 20ms.
-# Zero false positives.
+# Expected beat grid for the deterministic 120 BPM fixture.
 EXPECTED_BEATS = [
     0.000,
     0.500,
@@ -117,14 +118,64 @@ def config_mock() -> Mock:
 
 @pytest.fixture
 async def provider(mass_mock: Mock, manifest_mock: Mock, config_mock: Mock) -> SmartFadesProvider:
-    """Return a SmartFadesProvider with mocked MA but real Beat This model."""
+    """Return a SmartFadesProvider without loading external model assets."""
     prov = SmartFadesProvider(mass_mock, manifest_mock, config_mock, set())
-    await prov.handle_async_init()
+    with patch.object(prov, "_load_models", new=AsyncMock()):
+        await prov.handle_async_init()
+    prov._spectral_centroid = SpectralCentroid(
+        sample_rate=ANALYSIS_SAMPLE_RATE,
+        hop_length=512,
+    )
+    prov._firered_model = Mock()
+    prov._firered_cmvn_means = np.zeros(FIRERED_MEL_BINS, dtype=np.float64)
+    prov._firered_cmvn_inverse_std = np.ones(FIRERED_MEL_BINS, dtype=np.float64)
     return prov
 
 
-async def test_beat_detection(provider: SmartFadesProvider, mass_mock: Mock) -> None:
-    """Test that the provider detects correct beats and downbeats from a PCM fixture."""
+@pytest.fixture
+def feature_provider(provider: SmartFadesProvider) -> Generator[SmartFadesProvider]:
+    """Return a provider with model-backed feature extraction disabled."""
+    with (
+        patch.object(provider, "_compute_musical_key_features"),
+        patch.object(provider, "_compute_vocal_features"),
+    ):
+        yield provider
+
+
+@pytest.fixture
+def deterministic_provider(
+    feature_provider: SmartFadesProvider,
+) -> Generator[SmartFadesProvider]:
+    """Return a provider with deterministic model inference."""
+    with (
+        patch.object(
+            feature_provider,
+            "_infer_beat_timings",
+            return_value=(
+                np.asarray(EXPECTED_BEATS, dtype=np.float32),
+                np.asarray(EXPECTED_DOWNBEATS, dtype=np.float32),
+                4,
+            ),
+        ),
+        patch.object(
+            feature_provider,
+            "_infer_musical_key",
+            return_value=("C", "major"),
+        ),
+        patch.object(
+            feature_provider,
+            "_infer_vocal_activity",
+            new=AsyncMock(return_value=np.zeros(2, dtype=np.float32)),
+        ),
+    ):
+        yield feature_provider
+
+
+async def test_beat_analysis_pipeline(
+    deterministic_provider: SmartFadesProvider,
+    mass_mock: Mock,
+) -> None:
+    """Test that the provider stores beats and downbeats from a PCM fixture."""
     audio_format = AudioFormat(
         content_type=ContentType.PCM_F32LE,
         bit_depth=32,
@@ -141,7 +192,7 @@ async def test_beat_detection(provider: SmartFadesProvider, mass_mock: Mock) -> 
     stream_details.duration = 120
 
     session_id = "test:test:test_120bpm"
-    await provider.start_analysis(session_id, stream_details, audio_format)
+    await deterministic_provider.start_analysis(session_id, stream_details, audio_format)
 
     # Feed PCM in 1-second chunks (matching the real streaming pipeline)
     pcm_data = FIXTURE_PCM.read_bytes()
@@ -149,10 +200,10 @@ async def test_beat_detection(provider: SmartFadesProvider, mass_mock: Mock) -> 
     offset = 0
     while offset < len(pcm_data):
         chunk = pcm_data[offset : offset + chunk_size]
-        await provider.process_pcm_chunk(session_id, chunk)
+        await deterministic_provider.process_pcm_chunk(session_id, chunk)
         offset += chunk_size
 
-    await provider.finalize(session_id)
+    await deterministic_provider.finalize(session_id)
 
     # Verify set_audio_analysis was called with correct data
     set_aa_mock = mass_mock.streams.audio_analysis.set_audio_analysis
@@ -188,7 +239,10 @@ async def test_beat_detection(provider: SmartFadesProvider, mass_mock: Mock) -> 
     assert analysis.beats_per_bar == 4
 
 
-async def test_extended_analysis_fields(provider: SmartFadesProvider, mass_mock: Mock) -> None:
+async def test_extended_analysis_fields(
+    deterministic_provider: SmartFadesProvider,
+    mass_mock: Mock,
+) -> None:
     """Test that extended analysis fields (energy, centroid, key) are populated."""
     audio_format = AudioFormat(
         content_type=ContentType.PCM_F32LE,
@@ -206,17 +260,17 @@ async def test_extended_analysis_fields(provider: SmartFadesProvider, mass_mock:
     stream_details.duration = 120
 
     session_id = "test:test:test_120bpm_extended"
-    await provider.start_analysis(session_id, stream_details, audio_format)
+    await deterministic_provider.start_analysis(session_id, stream_details, audio_format)
 
     pcm_data = FIXTURE_PCM.read_bytes()
     chunk_size = 44100 * 2 * 4  # 1 second at 44100 Hz, stereo, float32
     offset = 0
     while offset < len(pcm_data):
         chunk = pcm_data[offset : offset + chunk_size]
-        await provider.process_pcm_chunk(session_id, chunk)
+        await deterministic_provider.process_pcm_chunk(session_id, chunk)
         offset += chunk_size
 
-    await provider.finalize(session_id)
+    await deterministic_provider.finalize(session_id)
 
     set_aa_mock = mass_mock.streams.audio_analysis.set_audio_analysis
     analysis = set_aa_mock.call_args.kwargs["analysis"]
@@ -272,7 +326,9 @@ async def test_extended_analysis_fields(provider: SmartFadesProvider, mass_mock:
     assert all(math.isfinite(value) and 0.0 <= value <= 1.0 for value in vocal_probabilities)
 
 
-async def test_finalize_returns_audio_analysis_data(provider: SmartFadesProvider) -> None:
+async def test_finalize_returns_audio_analysis_data(
+    deterministic_provider: SmartFadesProvider,
+) -> None:
     """Test that _finalize returns an AudioAnalysisData on success."""
     audio_format = AudioFormat(
         content_type=ContentType.PCM_F32LE,
@@ -290,22 +346,24 @@ async def test_finalize_returns_audio_analysis_data(provider: SmartFadesProvider
     stream_details.duration = 120
 
     session_id = "test:test:test_finalize_return"
-    await provider.start_analysis(session_id, stream_details, audio_format)
+    await deterministic_provider.start_analysis(session_id, stream_details, audio_format)
 
     pcm_data = FIXTURE_PCM.read_bytes()
     chunk_size = 44100 * 2 * 4
     offset = 0
     while offset < len(pcm_data):
         chunk = pcm_data[offset : offset + chunk_size]
-        await provider.process_pcm_chunk(session_id, chunk)
+        await deterministic_provider.process_pcm_chunk(session_id, chunk)
         offset += chunk_size
 
-    result = await provider._finalize(session_id)
+    result = await deterministic_provider._finalize(session_id)
 
     assert isinstance(result, AudioAnalysisData)
 
 
-async def test_finalize_raises_when_not_enough_beats(provider: SmartFadesProvider) -> None:
+async def test_finalize_raises_when_not_enough_beats(
+    feature_provider: SmartFadesProvider,
+) -> None:
     """Test that _finalize raises AudioAnalysisError when not enough beats are detected."""
     audio_format = AudioFormat(
         content_type=ContentType.PCM_F32LE,
@@ -323,26 +381,26 @@ async def test_finalize_raises_when_not_enough_beats(provider: SmartFadesProvide
     stream_details.duration = 120
 
     session_id = "test:test:test_finalize_none"
-    await provider.start_analysis(session_id, stream_details, audio_format)
+    await feature_provider.start_analysis(session_id, stream_details, audio_format)
 
     pcm_data = FIXTURE_PCM.read_bytes()
     chunk_size = 44100 * 2 * 4
     offset = 0
     while offset < len(pcm_data):
         chunk = pcm_data[offset : offset + chunk_size]
-        await provider.process_pcm_chunk(session_id, chunk)
+        await feature_provider.process_pcm_chunk(session_id, chunk)
         offset += chunk_size
 
     # Patch _infer_beat_timings to return fewer than 2 beats → deterministic skip
     with (
         patch.object(
-            provider,
+            feature_provider,
             "_infer_beat_timings",
             return_value=(np.array([0.5]), np.array([]), 4),
         ),
         pytest.raises(AudioAnalysisError, match="beat"),
     ):
-        await provider._finalize(session_id)
+        await feature_provider._finalize(session_id)
 
 
 async def test_digital_silence_yields_finite_spectral_centroid(
@@ -377,6 +435,64 @@ async def test_setup_raises_when_requirements_not_met(
         pytest.raises(SetupFailedError),
     ):
         await smart_fades.setup(mass_mock, manifest_mock, config_mock)
+
+
+def test_initialize_models_uses_expected_components(provider: SmartFadesProvider) -> None:
+    """Model initialization wires the expected local and third-party components."""
+    beat_model = Mock()
+    original_beat_module = beat_model.model
+    quantized_beat_module = Mock()
+    beat_post_processor = Mock()
+    skey_components = (Mock(), Mock(), Mock())
+    spectral_centroid = Mock()
+    firered_components = (
+        Mock(),
+        np.zeros(FIRERED_MEL_BINS, dtype=np.float64),
+        np.ones(FIRERED_MEL_BINS, dtype=np.float64),
+    )
+
+    with (
+        patch(
+            "music_assistant.providers.smart_fades.provider.Spect2Frames",
+            return_value=beat_model,
+        ) as spect2frames,
+        patch(
+            "music_assistant.providers.smart_fades.provider.torch.ao.quantization.quantize_dynamic",
+            return_value=quantized_beat_module,
+        ) as quantize_dynamic,
+        patch(
+            "music_assistant.providers.smart_fades.provider.DBNDownBeatTracker",
+            return_value=beat_post_processor,
+        ),
+        patch(
+            "music_assistant.providers.smart_fades.provider.load_skey_components",
+            return_value=skey_components,
+        ),
+        patch(
+            "music_assistant.providers.smart_fades.provider.SpectralCentroid",
+            return_value=spectral_centroid,
+        ),
+        patch(
+            "music_assistant.providers.smart_fades.provider.load_firered_components",
+            return_value=firered_components,
+        ),
+    ):
+        components = provider._initialize_models()
+
+    spect2frames.assert_called_once_with(checkpoint_path="small0", device="cpu")
+    quantize_dynamic.assert_called_once_with(
+        original_beat_module,
+        {torch.nn.Linear},
+        dtype=torch.qint8,
+    )
+    assert beat_model.model is quantized_beat_module
+    assert components == (
+        beat_model,
+        beat_post_processor,
+        *skey_components,
+        spectral_centroid,
+        *firered_components,
+    )
 
 
 async def test_analysis_version_is_3(provider: SmartFadesProvider) -> None:

--- a/tests/providers/yandex_ynison/test_provider.py
+++ b/tests/providers/yandex_ynison/test_provider.py
@@ -25,7 +25,7 @@ from music_assistant_models.media_items import AudioFormat, AudioSource
 from ya_passport_auth import SecretStr
 from ya_passport_auth.ma import BorrowedCredentialSource, list_yandex_music_instances
 
-from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER
+from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER, ThrottlerManager
 from music_assistant.providers.yandex_ynison.constants import (
     CONF_ALLOW_PLAYER_SWITCH,
     CONF_DEVICE_ID,
@@ -152,7 +152,9 @@ def _make_provider(player_id: str = PLAYER_ID_AUTO) -> YandexYnisonProvider:
     mass = _make_mock_mass()
     config = _make_mock_config({CONF_MASS_PLAYER_ID: player_id})
     manifest = _make_mock_manifest()
-    return YandexYnisonProvider(mass, manifest, config, {ProviderFeature.AUDIO_SOURCE})
+    provider = YandexYnisonProvider(mass, manifest, config, {ProviderFeature.AUDIO_SOURCE})
+    provider._api_throttler = ThrottlerManager(rate_limit=1000)
+    return provider
 
 
 # ------------------------------------------------------------------
@@ -1281,12 +1283,16 @@ class TestPCMNormalization:
         """If get_stream_details fails, _stream_track yields nothing."""
         provider = _make_provider()
         mock_yandex = MagicMock()
-        mock_yandex.get_stream_details = AsyncMock(side_effect=Exception("API error"))
         provider._yandex_provider = mock_yandex
 
         collected: list[bytes] = []
-        async for chunk in provider._stream_track("track:bad"):
-            collected.append(chunk)
+        with patch.object(
+            provider,
+            "_get_stream_details_with_retry",
+            new=AsyncMock(side_effect=Exception("API error")),
+        ):
+            async for chunk in provider._stream_track("track:bad"):
+                collected.append(chunk)
 
         assert collected == []
 
@@ -2387,8 +2393,13 @@ class TestAdvanceQueueIndex:
 
         type(mock_yn).connected = property(_get_connected)
 
-        await provider._advance_queue_index(1)
+        with patch(
+            "music_assistant.providers.yandex_ynison.provider.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sleep:
+            await provider._advance_queue_index(1)
 
+        assert sleep.await_count == 2
         mock_yn.update_player_state.assert_awaited_once()
 
     async def test_timeout_no_send(self) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Recent test runs could take 11–30 minutes because several tests waited on production timers, retries, full server startup, or a remote model download.

- Keep tests isolated from external model services and fixed server ports.
- Use lightweight library fixtures where a full server is unnecessary.
- Cancel superseded runs and stop individual tests that exceed two minutes.
- Remove real retry and provider-state waits from unit tests.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.