### PR TITLE
Instant AirPlay seek and next-track via flush-and-refill

### DIFF
--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -225,17 +225,17 @@ Apple TV and Mac devices require pairing before they can be used for streaming.
 The `AirPlayStreamSession` class in [stream_session.py](stream_session.py) manages streaming to one or more synchronized players:
 
 1. **Initialization** (`start()` method)
-   - Connects every member before preparing playback
-   - Prepares generation 0 on every connected CLI and starts feeding audio
-   - Waits until every member reports the generation primed
-   - Sends one shared audible start instant to every member
+   - Connects every member before anchoring playback
+   - Wires each member's ffmpeg into its persistent CLI stdin and starts feeding audio
+   - Sends one shared audible start instant to every member; the setup lead plus
+     the binary's deadline pacing fill the receiver before that instant
 
 2. **Client Setup** (per player, `_start_client()` method)
    - Creates an `AirPlayStream` instance with the player's PCM format
      (16-bit default, 24-bit s32le when hi-res is enabled)
-   - Starts the CLI process and connects to the receiver without starting playback
-   - Configures FFmpeg for audio format conversion and optional DSP filters
-   - Keeps process stdin connected so generation 0 can select it with `AUDIO=-`
+   - Starts the CLI process and connects to the receiver without anchoring playback
+   - Configures FFmpeg for audio format conversion and optional DSP filters,
+     feeding its output into the CLI's persistent stdin
 
 3. **Audio Streaming** (`_audio_streamer()` method)
    - Receives PCM audio chunks from Music Assistant core
@@ -378,22 +378,25 @@ and verify it against that release's `SHA256SUMS`. For local source development,
 ### Binary Communication
 
 **Input** (stdin):
-- Generation 0 PCM selected by command-pipe `PREPARE` with `AUDIO=-`: s16le
-  for 16-bit, raw s32le for 24-bit
-  (the binary truncates 32→24 internally when `--bitdepth 24` is passed)
+- A single persistent PCM stream for the whole CLI lifetime: s16le for 16-bit,
+  raw s32le for 24-bit (the binary truncates 32→24 internally when
+  `--bitdepth 24` is passed). The binary reads stdin into one ring buffer.
 - May be written eagerly, ahead of the scheduled start; byte 0 maps to the
-  sample audible at the start instant
+  sample audible at the start instant. A seek/next flushes the ring in place and
+  refills it — the stdin connection is never closed between tracks (only the
+  per-seek ffmpeg feeding it is restarted).
 
 **Commands** (named pipe):
 - Interactive commands sent via `AsyncNamedPipeWriter`
-- Required for every streaming protocol; audio sources are supplied only by
-  generation `PREPARE` (`AUDIO=-` for stdin or `AUDIO=<fifo path>`)
+- `ACTION=START` + `START_UNIX_MS=<t>` anchors/re-anchors playback;
+  `ACTION=FLUSH` flushes the live stream in place (acknowledged by
+  `[STATUS] flushed`) so the same stdin can be refilled for a seek/next
 - Examples: `ACTION=PLAY`, `ACTION=PAUSE`, `VOLUME=50`, `TITLE=Song Name`
 - MA creates the pipe and sends text metadata immediately after process start;
   timeline-anchored metadata and artwork are refreshed once the receiver connects
 
 **Output** (stderr):
-- Normalized `[STATUS]` messages (connected/playing/paused/eof), logs and errors
+- Normalized `[STATUS]` messages (connected/playing/paused/flushed/eof), logs and errors
 
 **Output** (stdout):
 - `[STATUS] latency ...` line with the effective lead and the device's
@@ -407,24 +410,25 @@ The provider monitors stderr in a separate task (`_stderr_reader()` in [stream.p
 
 ## Start Timing and Synchronization
 
-The provider never handles NTP fixed-point formats: every media generation is
-prepared and started over the command pipe. `START_UNIX_MS` is a plain unix
-epoch millisecond meaning "**the first sample is audible exactly at this
-instant**" on every protocol path (RAOP, AirPlay 2 RAOP-compat and native).
+The provider never handles NTP fixed-point formats: playback is anchored over
+the command pipe. `START_UNIX_MS` is a plain unix epoch millisecond meaning
+"**the first pending stdin sample is audible exactly at this instant**" on every
+protocol path (RAOP, AirPlay 2 RAOP-compat and native).
 
 1. Start every CLI and wait until every group member reports connected
-2. Send `PREPARE` for generation 0 to every member, begin feeding PCM, and wait
-   until every member reports primed
-3. Calculate one explicit start instant with a short post-prime lead and send
-   the same value in `START` to every member
-4. The binary owns receiver-buffer handling from there, so the commanded start
-   cannot race connection or pre-fill
-5. Warm seek, next-track and grouped resume use the same PREPARE/prime/START
-   barrier for later generations on legacy RAOP, RAOP-compatible AirPlay 2 and
-   native AirPlay 2; standby keeps each protocol connection alive
-6. Sendspin starts preserve its externally supplied audible instant after the
-   same connection and prime gates
-7. Per-player `sync_adjust` config allows fine-tuning (+/- milliseconds)
+2. Wire each member's ffmpeg into its persistent stdin and begin feeding PCM
+3. Send one shared `START` (now + the per-protocol setup lead) to every member;
+   the lead plus the binary's deadline pacing fill the receiver before the
+   commanded instant, so the start cannot race connection or pre-fill
+4. **Warm seek / next-track / grouped resume** reuse the live connections: MA
+   stops feeding old audio, kills the per-seek ffmpeg (never the persistent
+   stdin), sends `ACTION=FLUSH` to every member and awaits `[STATUS] flushed`,
+   then feeds a fresh ffmpeg into the same stdin and sends one shared `START`.
+   Standby keeps each protocol connection alive for the same flush-refill resume
+5. Sendspin starts preserve its externally supplied audible instant, riding the
+   same persistent-stdin flush-refill (cold connect + `START`, warm `FLUSH` +
+   `START`) instead of a cold reconnect
+6. Per-player `sync_adjust` config allows fine-tuning (+/- milliseconds)
 
 ### Shared PTP Clock Daemon
 

--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -227,8 +227,10 @@ The `AirPlayStreamSession` class in [stream_session.py](stream_session.py) manag
 1. **Initialization** (`start()` method)
    - Connects every member before anchoring playback
    - Wires each member's ffmpeg into its persistent CLI stdin and starts feeding audio
-   - Sends one shared audible start instant to every member; the setup lead plus
-     the binary's deadline pacing fill the receiver before that instant
+   - Waits until every member's binary confirms the feed flowing (`[STATUS] audio`),
+     then sends one shared audible start instant with a short anchor lead
+     (250 ms solo / 500 ms group); readiness is fully event-driven, so no
+     setup time is guessed and the binary bursts the receiver pre-fill after START
 
 2. **Client Setup** (per player, `_start_client()` method)
    - Creates an `AirPlayStream` instance with the player's PCM format
@@ -244,7 +246,7 @@ The `AirPlayStreamSession` class in [stream_session.py](stream_session.py) manag
    - Handles silence padding if audio source is slow (watchdog mechanism)
 
 4. **Connection Monitoring**
-   - Waits for all devices to connect and prime before starting playback
+   - Waits for all devices to connect and confirm audio flowing before anchoring playback
    - Monitors CLI stderr for connection status and errors
    - Removes players that fail to keep up (write timeouts)
 
@@ -280,8 +282,8 @@ The provider supports synchronized multi-room audio by:
 When adding a player to an already-playing session (`add_client()` in [stream_session.py](stream_session.py)):
 
 1. **Ring buffer**: Session maintains a few seconds of recent audio chunks in memory
-2. **Immediate buffered feed**: Late joiner receives buffered chunks immediately to prime the ffmpeg/CLI pipeline
-3. **Compensated start time**: The joiner's start instant accounts for the buffer duration: `start_time + (seconds_streamed - buffer_duration)`, shifted forward (with the buffer head trimmed) when it would land in the past
+2. **Compensated start time**: The joiner's start instant accounts for the buffer duration: `start_time + (seconds_streamed - buffer_duration)`, shifted forward (with the buffer head trimmed) when it would land in the past
+3. **Anchor first, then prime**: The joiner's START is sent before the buffered chunks; pre-START the binary only buffers its bounded ring and sends nothing, so anchoring first lets it drain the prime as it streams in
 4. **Fast catch-up**: Device processes buffered audio and catches up to real-time position
 5. **Seamless sync**: Joins live stream perfectly synchronized with other players
 
@@ -396,7 +398,9 @@ and verify it against that release's `SHA256SUMS`. For local source development,
   timeline-anchored metadata and artwork are refreshed once the receiver connects
 
 **Output** (stderr):
-- Normalized `[STATUS]` messages (connected/playing/paused/flushed/eof), logs and errors
+- Normalized `[STATUS]` messages (connected/playing/paused/flushed/audio/eof), logs
+  and errors. `[STATUS] audio` is a one-shot per start cycle (re-armed by each
+  FLUSH) reporting the first stdin bytes arriving; MA anchors START only after it
 
 **Output** (stdout):
 - `[STATUS] latency ...` line with the effective lead and the device's
@@ -416,14 +420,16 @@ the command pipe. `START_UNIX_MS` is a plain unix epoch millisecond meaning
 protocol path (RAOP, AirPlay 2 RAOP-compat and native).
 
 1. Start every CLI and wait until every group member reports connected
-2. Wire each member's ffmpeg into its persistent stdin and begin feeding PCM
-3. Send one shared `START` (now + the per-protocol setup lead) to every member;
-   the lead plus the binary's deadline pacing fill the receiver before the
-   commanded instant, so the start cannot race connection or pre-fill
+2. Wire each member's ffmpeg into its persistent stdin, begin feeding PCM and
+   wait until every member confirms the feed flowing (`[STATUS] audio`)
+3. Send one shared `START` (now + 250 ms solo / 500 ms group) to every member;
+   readiness is event-confirmed so the anchor covers only the receiver re-anchor,
+   and the binary bursts the receiver pre-fill from START
 4. **Warm seek / next-track / grouped resume** reuse the live connections: MA
    stops feeding old audio, kills the per-seek ffmpeg (never the persistent
    stdin), sends `ACTION=FLUSH` to every member and awaits `[STATUS] flushed`,
-   then feeds a fresh ffmpeg into the same stdin and sends one shared `START`.
+   then feeds a fresh ffmpeg into the same stdin, awaits `[STATUS] audio` and
+   sends one shared `START`.
    Standby keeps each protocol connection alive for the same flush-refill resume
 5. Sendspin starts preserve its externally supplied audible instant, riding the
    same persistent-stdin flush-refill (cold connect + `START`, warm `FLUSH` +

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -60,6 +60,15 @@ AIRPLAY_AP2_SETUP_LEAD_MS: Final[int] = 2500
 # Late joiners keep a more conservative headroom: besides connecting, their
 # pipeline must also be primed from the session's history buffer.
 AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 2000
+# Anchor lead for a readiness-confirmed START (cold and warm alike): the
+# session only anchors after the binary confirmed the connection ([STATUS]
+# connected) and the new audio flowing ([STATUS] audio), so the lead no longer
+# guesses at setup or transcoder spin-up time. It covers just the receiver
+# re-anchor (accepted down to ~150 ms in the flush-ladder measurements; the
+# binary clamps below its own 350 ms floor) plus, for groups, fanning the
+# shared instant out to every member.
+AIRPLAY_START_LEAD_MS: Final[int] = 500
+AIRPLAY_GROUP_START_LEAD_MS: Final[int] = 750
 
 # Cover art is rendered to a local JPEG for the binary to embed (the binary
 # does not fetch URLs). 512px keeps the SET_PARAMETER payload small while still

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -65,10 +65,10 @@ AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 2000
 # connected) and the new audio flowing ([STATUS] audio), so the lead no longer
 # guesses at setup or transcoder spin-up time. It covers just the receiver
 # re-anchor (accepted down to ~150 ms in the flush-ladder measurements; the
-# binary clamps below its own 350 ms floor) plus, for groups, fanning the
+# binary clamps below its own 250 ms floor) plus, for groups, fanning the
 # shared instant out to every member.
-AIRPLAY_START_LEAD_MS: Final[int] = 500
-AIRPLAY_GROUP_START_LEAD_MS: Final[int] = 750
+AIRPLAY_START_LEAD_MS: Final[int] = 250
+AIRPLAY_GROUP_START_LEAD_MS: Final[int] = 500
 
 # Cover art is rendered to a local JPEG for the binary to embed (the binary
 # does not fetch URLs). 512px keeps the SET_PARAMETER payload small while still

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -315,8 +315,8 @@ class AirPlayPlayer(Player):
         if self.group_members or self.synced_to:
             # Grouped pause parks the whole session (standby); unpausing one
             # member cannot restart the group in sync. Resume via the queue
-            # instead: play_media commits a fresh generation to every parked
-            # member at one shared instant.
+            # instead: play_media flushes and re-anchors every parked member at
+            # one shared instant.
             queue_id = self.synced_to or self.player_id
             await self.mass.player_queues.resume(queue_id, fade_in=False)
             return
@@ -330,7 +330,7 @@ class AirPlayPlayer(Player):
             # A broadcast pause cannot keep independent member processes
             # sample-aligned on resume. Instead the session is parked: every
             # member stalls but keeps its connection (and remote control), and
-            # the queue's resume commits a new generation over the live
+            # the queue's resume flushes and re-anchors over the live
             # connections — the same coordinated warm restart as seek/next.
             if (
                 self.stream
@@ -361,8 +361,8 @@ class AirPlayPlayer(Player):
             sync_clients = self._get_sync_clients()
             session_pcm_format = self._get_session_pcm_format(sync_clients, media)
 
-            # Warm path: a live, compatible session absorbs the new media as
-            # its next generation (seek/next never pays the reconnect cost).
+            # Warm path: a live, compatible session absorbs the new media via a
+            # flush-refill in place (seek/next never pays the reconnect cost).
             if (
                 self.stream
                 and self.stream.running

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -18,10 +18,8 @@ Sendspin PushStream → BridgePlayerRole.on_audio_chunk → AirPlay CLI process
 from __future__ import annotations
 
 import asyncio
-import os
 import time
 from contextlib import suppress
-from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from aiosendspin.models.core import ClientHelloPayload
@@ -31,7 +29,6 @@ from aiosendspin.models.types import AudioCodec, PlayerCommand
 from music_assistant_models.enums import IdentifierType
 
 from music_assistant.constants import CONF_SYNC_ADJUST
-from music_assistant.helpers.named_pipe import open_named_pipe_writer
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.providers.sendspin.bridge_manager import SendspinBridgeManagerBase
 from music_assistant.providers.sendspin.bridge_role import (
@@ -98,7 +95,7 @@ def sendspin_audible_instant_to_unix_ms(
     Map an audible instant on the Sendspin clock to a unix epoch millisecond.
 
     Sendspin schedules playback on its own monotonic clock (``server.clock.now_us()``)
-    whereas the AirPlay generation START command uses unix wall-clock.
+    whereas the AirPlay START command uses unix wall-clock.
     The two clocks share no epoch, so only the *offset from now* transfers between
     them: this takes how far ``audible_instant_us`` sits in the future on the
     Sendspin clock and applies that same offset to a unix reading captured at the
@@ -183,18 +180,16 @@ class SendspinAirPlayBridge:
         # Used to pace writes so the device buffer stays bounded (see _cli_writer).
         self._start_unix_ms: int = 0
         self._write_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
-        # Raw-fd sink for a warm generation's fifo (None = write to the CLI's
-        # stdin via self._airplay_stream.write_audio, i.e. generation 0).
-        self._sink_fd: int | None = None
         self._writer_task: asyncio.Task[None] | None = None
         self._airplay_stream_start_task: asyncio.Task[None] | None = None
         self._airplay_stream_ready = asyncio.Event()
-        self._generation_started = False
+        # Whether the current stream has been anchored with its first START.
+        self._started = False
         self._cleanup_task: asyncio.Task[None] | None = None
         # Timer id for the deferred teardown on stream end. A seek/next ends the
         # sendspin stream and immediately starts a new one; deferring the CLI
         # teardown across that gap lets the next stream reuse the connected
-        # binary as a warm generation instead of a cold reconnect.
+        # binary via flush-refill instead of a cold reconnect.
         self._teardown_timer_id = f"bridge_teardown_{airplay_player.player_id}"
         self._lock = asyncio.Lock()
 
@@ -322,16 +317,14 @@ class SendspinAirPlayBridge:
 
     def _stream_is_warm_eligible(self) -> bool:
         """
-        Return whether the current AirPlayStream can absorb a new stream as a generation.
+        Return whether the current AirPlayStream can absorb a new stream via flush-refill.
 
-        A kept stream must still be running, already connected, and have a
-        committed generation. Every streaming route supports persistent
-        generations.
+        A kept stream must still be running, already connected, and already
+        anchored with its first START. Every streaming route rides the same
+        persistent stdin flush-refill.
         """
         stream = self._airplay_stream
-        return (
-            stream is not None and stream.running and stream.connected and self._generation_started
-        )
+        return stream is not None and stream.running and stream.connected and self._started
 
     def _on_stream_start(self, request: ExternalStreamStartRequest) -> None:
         """
@@ -354,7 +347,7 @@ class SendspinAirPlayBridge:
             return
         # A new stream arrived within the grace window: cancel the deferred
         # teardown so the previous stream's still-connected CLI survives to be
-        # reused as a warm generation instead of cold-restarting.
+        # reused via flush-refill instead of cold-restarting.
         self.mass.cancel_timer(self._teardown_timer_id)
         # Bridge outlives config changes, so re-read the current timing values.
         self._refresh_bridge_timing()
@@ -388,7 +381,7 @@ class SendspinAirPlayBridge:
         self._drop_until_us = 0
         self._start_aligned = False
         self._start_unix_ms = 0
-        self._generation_started = keep_stream
+        self._started = keep_stream
 
     def _on_bridge_stream_start(self) -> None:
         """
@@ -425,7 +418,7 @@ class SendspinAirPlayBridge:
         self._drop_until_us = 0
         self._start_aligned = False
         self._start_unix_ms = 0
-        self._generation_started = keep_stream
+        self._started = keep_stream
         # Drain stale audio data from the previous stream
         while not self._write_queue.empty():
             self._write_queue.get_nowait()
@@ -449,7 +442,7 @@ class SendspinAirPlayBridge:
             # Derive the audible start instant from _drop_until_us (set on first
             # chunk arrival) so the CLI has enough lead to connect and establish
             # the session. _drop_until_us is on the Sendspin (monotonic) clock;
-            # map it to the unix epoch ms used by the generation START command.
+            # map it to the unix epoch ms used by the START command.
             sendspin_clock_now_us = self.sendspin_server.clock.now_us()
             unix_clock_now = time.time()
             start_unix_ms = sendspin_audible_instant_to_unix_ms(
@@ -474,11 +467,11 @@ class SendspinAirPlayBridge:
             self._start_unix_ms = start_unix_ms
 
             # A kept, still-connected stream (see _stream_is_warm_eligible,
-            # checked by the stream-start callbacks) absorbs the new media as a
-            # warm generation instead of paying a cold reconnect.
+            # checked by the stream-start callbacks) absorbs the new media via a
+            # flush-refill on the SAME cli stdin instead of a cold reconnect.
             kept_stream = self._airplay_stream
             if kept_stream is not None:
-                if await self._start_warm_generation(kept_stream, start_unix_ms):
+                if await self._start_warm_stream(kept_stream, start_unix_ms):
                     return
                 # Warm handover failed - tear down the kept stream and fall through
                 # to the cold path below, which spawns a fresh process.
@@ -489,9 +482,9 @@ class SendspinAirPlayBridge:
 
             # On a rapid skip, _on_bridge_stream_start snapshots self._airplay_stream
             # for cleanup. If we assigned it earlier, the new stream would be missed
-            # and leaked. Only publish once start() succeeds and this task is current.
+            # and leaked. Only publish once connect() succeeds and this task is current.
             new_stream = AirPlayStream(self.airplay_player)
-            if not await self._start_cold_generation(new_stream, start_unix_ms):
+            if not await self._start_cold_stream(new_stream, start_unix_ms):
                 return
             self.logger.info(
                 "Bridge protocol started for %s (start_unix_ms=%s, lookahead=%.0fms)",
@@ -510,178 +503,72 @@ class SendspinAirPlayBridge:
             self._airplay_stream_ready.set()
             self._schedule_cleanup()
 
-    async def _start_cold_generation(self, stream: AirPlayStream, start_unix_ms: int) -> bool:
+    async def _start_cold_stream(self, stream: AirPlayStream, start_unix_ms: int) -> bool:
         """
-        Connect and commit generation 0 for a new bridge transport.
+        Connect a fresh bridge transport and anchor its first START.
 
         :param stream: New AirPlay stream to start.
-        :param start_unix_ms: Audible-start instant for generation 0.
-        :return: True when generation 0 commits, False when superseded.
+        :param start_unix_ms: Audible-start instant for the first sample.
+        :return: True when the stream is anchored, False when superseded.
         """
-        generation_prepared = False
-        commit_attempted = False
         try:
-            await stream.start()
+            await stream.connect()
             await stream.wait_for_connection()
             if asyncio.current_task() is not self._airplay_stream_start_task:
                 await stream.stop(force=True)
                 return False
             self._airplay_stream = stream
             self.airplay_player.stream = stream
-            generation_prepared = True
-            await stream.prepare_generation(0, "-", 0)
-            if not await stream.wait_generation_ready(0):
-                raise RuntimeError("generation 0 reader ready timed out")
+            # The binary buffers stdin into its ring from process start; unblock
+            # the writer so it feeds PCM, then anchor the start.
             self._airplay_stream_ready.set()
-            if not await stream.wait_generation_primed(0):
-                raise RuntimeError("generation 0 prime timed out")
-            if asyncio.current_task() is not self._airplay_stream_start_task:
-                await self._discard_generation(stream, 0)
-                await stream.stop(force=True)
-                return False
-            commit_attempted = True
-            await stream.start_generation(0, 0, start_unix_ms)
-            self._generation_started = True
+            await stream.start(start_unix_ms)
+            self._started = True
         except BaseException:
-            if generation_prepared and not commit_attempted:
-                await self._discard_generation(stream, 0)
             with suppress(Exception):
                 await stream.stop(force=True)
             raise
         return True
 
-    async def _start_warm_generation(self, stream: AirPlayStream, start_unix_ms: int) -> bool:
+    async def _start_warm_stream(self, stream: AirPlayStream, start_unix_ms: int) -> bool:
         """
-        Stage and commit a new media generation on a kept, still-connected stream.
+        Flush a kept, still-connected stream and resume it on the new track.
 
-        The new generation is staged on a fresh fifo while ``stream`` keeps playing
-        its current one, then committed with a single START once primed. Returns
-        True once the switch is committed. Any failure returns False so the caller
-        falls back to a cold restart of the kept stream; the fifo node is never
-        left behind.
+        The stream is flushed in place (receiver + ring + stdin drained) while
+        its connection stays alive, then the new PCM is fed into the SAME cli
+        stdin and re-anchored with a single START. Returns True once resumed; any
+        failure returns False so the caller falls back to a cold restart.
 
-        :param stream: The kept AirPlayStream to stage the new generation on.
-        :param start_unix_ms: The audible-start instant to commit the generation at.
+        :param stream: The kept AirPlayStream to flush and resume.
+        :param start_unix_ms: The audible-start instant to re-anchor at.
         """
-        gen = stream.next_generation()
-        fifo = f"/tmp/ma-bridge-{self.airplay_player.player_id}-{gen}.pcm"  # noqa: S108
-        started_at = time.monotonic()
-        commit_attempted = False
-        fifo_fd: int | None = None
-        published_fd: int | None = None
         try:
-            await _create_fifo(fifo)
-            await stream.prepare_generation(gen, fifo, 0)
-            self._log_generation_phase(gen, "prepare-delivered", started_at)
-            if not await stream.wait_generation_ready(gen):
-                raise RuntimeError(f"generation {gen} reader ready timed out")
-            self._log_generation_phase(gen, "ready", started_at)
-            fifo_fd = await open_named_pipe_writer(fifo)
-            # Both ends now hold the fifo open; drop the directory entry right away
-            # so no stale pipe nodes accumulate even if a later step fails.
-            _unlink_fifo(fifo)
-            try:
-                await self._publish_sink_fd(fifo_fd)
-            except BaseException:
-                fifo_fd = None
-                raise
-            published_fd = fifo_fd
-            fifo_fd = None
-            self._log_generation_phase(gen, "writer-open", started_at)
-            # Unblocks the writer task, which was waiting on this event; it can
-            # now prefill the pipe while the generation primes.
-            self._airplay_stream_ready.set()
-            if not await stream.wait_generation_primed(gen):
-                raise RuntimeError(f"generation {gen} prime timed out")
-            self._log_generation_phase(gen, "primed", started_at)
-            if asyncio.current_task() is not self._airplay_stream_start_task:
-                # A newer stream start owns the bridge. The published sink remains
-                # managed by _set_sink_fd or teardown so this stale task cannot
-                # close a sink the newer task may already be using.
-                await self._discard_generation(stream, gen, started_at)
+            if not await stream.flush():
                 return False
-            commit_attempted = True
-            await stream.start_generation(gen, 0, start_unix_ms)
-            self._generation_started = True
-            self._log_generation_phase(gen, "commit", started_at)
+            if asyncio.current_task() is not self._airplay_stream_start_task:
+                # A newer stream start owns the bridge; leave the stream to it.
+                return False
+            # The binary drained its ring + stdin on flush and keeps reading
+            # stdin; unblock the writer to feed the new track into the SAME cli
+            # stdin, then re-anchor the resumed start.
+            self._airplay_stream_ready.set()
+            await stream.start(start_unix_ms)
+            self._started = True
             self.logger.info(
-                "Bridge warm handover for %s (generation=%d, start_unix_ms=%d)",
+                "Bridge warm handover for %s (start_unix_ms=%d)",
                 self.airplay_player.display_name,
-                gen,
                 start_unix_ms,
             )
         except asyncio.CancelledError:
-            if published_fd is not None:
-                await self._release_sink_fd(published_fd)
-            if not commit_attempted:
-                await self._discard_generation(stream, gen, started_at)
             raise
         except Exception as err:
-            await self._handle_warm_generation_failure(
-                stream,
-                gen,
-                started_at,
-                err,
-                published_fd,
-                discard=not commit_attempted,
-            )
-            return False
-        finally:
-            if fifo_fd is not None:
-                _close_fd(fifo_fd)
-            await _cleanup_fifo(fifo)
-        return True
-
-    async def _handle_warm_generation_failure(
-        self,
-        stream: AirPlayStream,
-        generation: int,
-        started_at: float,
-        error: Exception,
-        published_fd: int | None,
-        *,
-        discard: bool,
-    ) -> None:
-        """Clean up a failed warm generation before its cold fallback."""
-        self.logger.warning(
-            "Warm handover failed for %s (%r), falling back to a cold restart",
-            self.airplay_player.display_name,
-            error,
-        )
-        if published_fd is not None:
-            await self._release_sink_fd(published_fd)
-        if discard:
-            await self._discard_generation(stream, generation, started_at)
-
-    async def _discard_generation(
-        self,
-        stream: AirPlayStream,
-        generation: int,
-        started_at: float | None = None,
-    ) -> None:
-        """Best-effort discard a bridge generation staged before START."""
-        try:
-            await stream.discard_generation(generation)
-        except Exception as err:
             self.logger.warning(
-                "Could not discard staged AirPlay generation %d for %s: %s",
-                generation,
+                "Warm handover failed for %s (%r), falling back to a cold restart",
                 self.airplay_player.display_name,
                 err,
             )
-            return
-        if started_at is not None:
-            self._log_generation_phase(generation, "discard", started_at)
-
-    def _log_generation_phase(self, generation: int, phase: str, started_at: float) -> None:
-        """Log a bridge generation phase with elapsed staging time."""
-        self.logger.debug(
-            "AirPlay bridge generation: player=%s generation=%d phase=%s elapsed=%.3fs",
-            self.airplay_player.player_id,
-            generation,
-            phase,
-            time.monotonic() - started_at,
-        )
+            return False
+        return True
 
     def _on_volume_change(self, volume: int) -> None:
         """Forward volume changes to the AirPlay player."""
@@ -698,7 +585,7 @@ class SendspinAirPlayBridge:
         A seek or next-track ends the stream and immediately starts a new one.
         Tearing the CLI down here would force every such switch through a cold
         reconnect; instead we keep the connected binary alive for a short grace
-        window so the next stream can reuse it as a warm generation. If no new
+        window so the next stream can reuse it via flush-refill. If no new
         stream arrives within the window (a real stop), the deferred cleanup
         kills the CLI so AirPlay stops instead of draining its buffer.
         """
@@ -863,77 +750,14 @@ class SendspinAirPlayBridge:
         self._write_queue.put_nowait(chunk.data)
         return True
 
-    async def _publish_sink_fd(self, fd: int) -> None:
-        """Transfer a fifo descriptor to the bridge sink."""
-        try:
-            await self._set_sink_fd(fd)
-        except BaseException:
-            if self._sink_fd == fd:
-                await self._release_sink_fd(fd)
-            else:
-                _close_fd(fd)
-            raise
-
-    async def _release_sink_fd(self, fd: int) -> None:
-        """Release a fifo descriptor currently owned by the bridge sink."""
-        if self._sink_fd != fd:
-            return
-        try:
-            await self._set_sink_fd(None)
-        except asyncio.CancelledError:
-            if self._sink_fd == fd:
-                self._sink_fd = None
-            _close_fd(fd)
-            raise
-        except Exception as err:
-            self.logger.warning(
-                "Could not release AirPlay bridge sink for %s: %s",
-                self.airplay_player.display_name,
-                err,
-            )
-            if self._sink_fd == fd:
-                self._sink_fd = None
-            _close_fd(fd)
-
-    async def _set_sink_fd(self, fd: int | None) -> None:
-        """
-        Swap the writer's raw-fd sink, closing whatever fd it replaces.
-
-        :param fd: The new warm-generation fifo fd to write to, or None to
-            switch the writer back to the CLI's stdin (cold/generation 0).
-        """
-        old_fd = self._sink_fd
-        self._sink_fd = fd
-        if old_fd is not None:
-            _close_fd(old_fd)
-
-    async def _write_to_sink(self, fd: int, data: bytes) -> None:
-        """
-        Write raw audio bytes to a warm-generation fifo fd, off the event loop.
-
-        :param fd: The fifo fd to write to (a snapshot of self._sink_fd).
-        :param data: Raw audio bytes to write.
-        """
-
-        def _write() -> None:
-            view = memoryview(data)
-            while view:
-                view = view[os.write(fd, view) :]
-
-        await asyncio.to_thread(_write)
-
     async def _cli_writer(self) -> None:
         """
-        Write queued audio data to the CLI's stdin, or a warm generation's fifo.
+        Write queued audio data to the CLI's persistent stdin.
 
-        Waits for any pending cleanup and then for the new protocol to be
-        ready before writing. Runs as a single task so writes are serialised
-        and ordered. A None sentinel signals end-of-stream: write EOF to
-        stdin and exit.
-
-        Writes go to self._sink_fd (a warm generation's fifo) when set, else
-        to the CLI's stdin via self._airplay_stream.write_audio -- see
-        _start_warm_generation, which is the only place that sets the sink.
+        Waits for any pending cleanup and then for the new stream to be ready
+        before writing. Runs as a single task so writes are serialised and
+        ordered. A None sentinel signals end-of-stream: write EOF to stdin and
+        exit.
 
         Writes are paced against the audible anchor so the device is never
         buffered more than ``MAX_DEVICE_BUFFER_SECONDS`` ahead of real time.
@@ -982,25 +806,19 @@ class SendspinAirPlayBridge:
                     if ahead > MAX_DEVICE_BUFFER_SECONDS:
                         await asyncio.sleep(ahead - MAX_DEVICE_BUFFER_SECONDS)
                 with suppress(Exception):
-                    if (sink_fd := self._sink_fd) is not None:
-                        await self._write_to_sink(sink_fd, data)
-                    else:
-                        await self._airplay_stream.write_audio(data)
+                    await self._airplay_stream.write_audio(data)
                     bytes_written += len(data)
         finally:
             # Only clear if this writer is still the active one.
             if self._writer_task is asyncio.current_task():
                 self._writer_task = None
-            # Release whatever fifo fd this writer was using, if any.
-            with suppress(Exception):
-                await self._set_sink_fd(None)
 
     async def _stop_streaming(self) -> None:
         """Stop streaming (internal, called with lock held)."""
         self._is_streaming = False
         self._next_expected_timestamp_us = None
         self._airplay_stream_ready.clear()
-        self._generation_started = False
+        self._started = False
         if self._airplay_stream_start_task:
             self._airplay_stream_start_task.cancel()
             with suppress(asyncio.CancelledError, Exception):
@@ -1017,10 +835,6 @@ class SendspinAirPlayBridge:
             await self._airplay_stream.stop(force=True)
             self._airplay_stream = None
             self.airplay_player.stream = None
-        # Belt-and-suspenders: the writer task closes its own sink fd on exit,
-        # but guard against a leak if it never ran.
-        with suppress(Exception):
-            await self._set_sink_fd(None)
 
 
 class SendspinBridgeManager(SendspinBridgeManagerBase[SendspinAirPlayBridge]):
@@ -1079,30 +893,3 @@ class SendspinBridgeManager(SendspinBridgeManagerBase[SendspinAirPlayBridge]):
     def _should_have_bridge(self, player: Player) -> bool:
         """Return whether an AirPlay player should have a Sendspin bridge."""
         return get_bridge_client_id(cast("AirPlayPlayer", player)) is not None
-
-
-def _close_fd(fd: int) -> None:
-    """Close a file descriptor if it is still open."""
-    with suppress(OSError):
-        os.close(fd)
-
-
-def _unlink_fifo(path: str) -> None:
-    """Remove a fifo path if it still exists."""
-    with suppress(OSError):
-        Path(path).unlink()
-
-
-async def _create_fifo(path: str) -> None:
-    """Create a fresh fifo path."""
-    with suppress(FileNotFoundError):
-        await asyncio.to_thread(os.unlink, path)
-    await asyncio.to_thread(os.mkfifo, path)
-
-
-async def _cleanup_fifo(path: str) -> None:
-    """Unblock any fifo reader and remove its path."""
-    with suppress(OSError):
-        _close_fd(os.open(path, os.O_WRONLY | os.O_NONBLOCK))
-    with suppress(OSError):
-        await asyncio.to_thread(os.unlink, path)

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -83,6 +83,11 @@ class AirPlayStream:
         self._connected = asyncio.Event()
         # Set when the binary acknowledges an in-place FLUSH ([STATUS] flushed).
         self._flushed = asyncio.Event()
+        # Set when the binary reports the first audio bytes of the current
+        # start cycle arriving on its stdin ([STATUS] audio). Together with
+        # `connected` this makes readiness fully event-driven, so START can
+        # use a short re-anchor lead instead of a guessed setup time.
+        self._audio_present = asyncio.Event()
         self._metadata_checksum = ""
         self._metadata_text_checksum = ""
         self._pending_metadata_checksum = ""
@@ -265,10 +270,31 @@ class AirPlayStream:
         if not self.running or not self.connected:
             return False
         self._flushed.clear()
+        # The flush drain re-arms the binary's one-shot audio signal; the next
+        # [STATUS] audio belongs to the new track.
+        self._audio_present.clear()
         if not await self._write_cli_command("ACTION=FLUSH"):
             return False
         try:
             await asyncio.wait_for(self._flushed.wait(), timeout)
+        except TimeoutError:
+            return False
+        return True
+
+    async def wait_audio_present(self, timeout: float = 5.0) -> bool:
+        """
+        Wait until the binary reports the current start cycle's audio arriving.
+
+        The binary emits a one-shot ``[STATUS] audio`` when the first bytes of
+        a start cycle land on its stdin (re-armed by each flush). Waiting for
+        it before commanding START removes source/transcoder spin-up from the
+        start lead.
+
+        :param timeout: Seconds to wait for the signal.
+        :return: True once audio is flowing; False on timeout.
+        """
+        try:
+            await asyncio.wait_for(self._audio_present.wait(), timeout)
         except TimeoutError:
             return False
         return True
@@ -697,6 +723,8 @@ class AirPlayStream:
             player.set_state_from_stream(state=PlaybackState.PAUSED, stream=self)
         elif "[STATUS] flushed" in line:
             self._flushed.set()
+        elif "[STATUS] audio " in line:
+            self._audio_present.set()
         elif "[STATUS] idle_timeout" in line:
             # a parked (paused) session outlived the binary's idle cap;
             # treat it as a normal end of stream

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
 from music_assistant_models.enums import PlaybackState
+from music_assistant_models.errors import PlayerCommandFailed
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.images import get_image_thumb_path
@@ -311,6 +312,7 @@ class AirPlayStream:
             clamps to its minimum lead).
         :param position_ms: Media position mapped to that first sample, used as
             the base for elapsed reporting.
+        :raises PlayerCommandFailed: If the START command cannot be delivered.
         """
         if not self.running or not self.connected:
             raise RuntimeError("Cannot start playback without a connected cliairplay process")
@@ -319,7 +321,12 @@ class AirPlayStream:
         # the binary's first status arrives, interpolation would otherwise keep
         # extending the previous anchor's clock, briefly mapping a bogus position.
         self.player.set_state_from_stream(elapsed_time=self._start_position, stream=self)
-        await self._write_cli_command(f"START_UNIX_MS={start_unix_ms}\nACTION=START")
+        if not await self._write_cli_command(f"START_UNIX_MS={start_unix_ms}\nACTION=START"):
+            # Surfacing the dropped delivery lets the session fall back to a
+            # cold restart instead of waiting on an anchor that never happens.
+            raise PlayerCommandFailed(
+                f"Could not deliver START to AirPlay player {self.player.player_id}"
+            )
 
     async def send_metadata(
         self,

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
 from music_assistant_models.enums import PlaybackState
-from music_assistant_models.errors import PlayerCommandFailed
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.images import get_image_thumb_path
@@ -82,6 +81,8 @@ class AirPlayStream:
         self._cleanup_complete = False
         self._stop_lock = asyncio.Lock()
         self._connected = asyncio.Event()
+        # Set when the binary acknowledges an in-place FLUSH ([STATUS] flushed).
+        self._flushed = asyncio.Event()
         self._metadata_checksum = ""
         self._metadata_text_checksum = ""
         self._pending_metadata_checksum = ""
@@ -89,18 +90,11 @@ class AirPlayStream:
         self._metadata_lock = asyncio.Lock()
         self._artwork_render_generations: set[int] = set()
         self._last_progress_sent: int = -1
-        # Persistent generations: the binary keeps one connection alive and
-        # plays numbered media generations over it (seek/next = new generation
-        # on a fresh pipe instead of a reconnect).
-        # _generation is the latest ALLOCATED id (bumped at PREPARE, while the
-        # previous generation is still playing); _active_generation is the one
-        # actually playing (only advances at START). Elapsed/EOF handling keys
-        # off the active id so a staged generation never skews them mid-handover.
-        self._generation = 0
-        self._active_generation: int | None = None
-        self._generation_position: float = 0.0
-        self._gen_ready: dict[int, asyncio.Event] = {}
-        self._gen_primed: dict[int, asyncio.Event] = {}
+        # Media position (seconds) mapped to the first sample of the current
+        # START anchor. The binary reports "playing elapsed_ms" relative to that
+        # anchor (resetting to ~0 at each START), so elapsed is this base plus
+        # the reported delta.
+        self._start_position: float = 0.0
         self._stdout_reader_task: asyncio.Task[None] | None = None
         # Device latency info reported by the binary after connect (0 = unreported)
         self.latency_lead_ms: int = 0
@@ -125,12 +119,16 @@ class AirPlayStream:
         """Return boolean if the device connection has been established."""
         return self._connected.is_set()
 
-    async def start(
+    async def connect(
         self,
         use_shared_ptp: bool | None = None,
     ) -> None:
         """
-        Start cliairplay and connect to the receiver.
+        Spawn cliairplay and connect to the receiver.
+
+        Establishes the process, command pipe and device connection that persist
+        for the whole stream lifetime. Playback itself is anchored separately with
+        :meth:`start` once audio is being fed on the persistent stdin.
 
         :param use_shared_ptp: Session-wide decision on whether native AirPlay 2
             members attach to the shared PTP clock daemon. The stream session
@@ -175,9 +173,9 @@ class AirPlayStream:
         self._metadata_text_checksum = ""
         self._pending_metadata_checksum = ""
         self._metadata_generation += 1
-        # Push track metadata before PREPARE/START. Some receivers (notably
-        # Sonos) hold back audio rendering until they receive track metadata;
-        # deferring it can keep them silent past the commanded start.
+        # Push track metadata before START. Some receivers (notably Sonos) hold
+        # back audio rendering until they receive track metadata; deferring it
+        # can keep them silent past the commanded start.
         self.player._on_player_media_updated()
 
     async def stop(self, force: bool = False) -> None:
@@ -250,113 +248,52 @@ class AirPlayStream:
             return False
         return await self._write_cli_command(command)
 
-    def next_generation(self) -> int:
-        """Allocate the next media generation number and its status events."""
-        self._generation += 1
-        self._gen_ready[self._generation] = asyncio.Event()
-        self._gen_primed[self._generation] = asyncio.Event()
-        return self._generation
-
-    async def prepare_generation(self, generation: int, audio_path: str, position_ms: int) -> None:
+    async def flush(self, timeout: float = 2.0) -> bool:
         """
-        Stage a media generation on the connected binary.
+        Flush the live stream in place and wait for the binary's acknowledgement.
 
-        The binary opens the given audio source and prefills from it while the
-        current generation keeps playing; `primed` is reported once enough
-        audio is buffered for an underrun-free start.
+        Sends ``ACTION=FLUSH`` — the binary stops sending audio, flushes the
+        receiver, discards its input ring and drains stdin, then reports
+        ``[STATUS] flushed`` while keeping the connection and stdin reader alive.
+        The caller must have stopped feeding old audio before calling this so the
+        drain removes exactly the pre-flush bytes.
+
+        :param timeout: Seconds to wait for the flushed acknowledgement.
+        :return: True once the flush is acknowledged; False on a delivery failure
+            or timeout so the caller can fall back to a cold restart.
         """
         if not self.running or not self.connected:
-            raise RuntimeError("Cannot prepare a generation without a connected cliairplay process")
-        self._gen_ready.setdefault(generation, asyncio.Event())
-        self._gen_primed.setdefault(generation, asyncio.Event())
-        try:
-            command_delivered = await self._write_cli_command(
-                f"GENERATION={generation}\nAUDIO={audio_path}\n"
-                f"POSITION_MS={position_ms}\nACTION=PREPARE"
-            )
-        except BaseException:
-            self._remove_generation_events(generation)
-            raise
-        if not command_delivered:
-            self._remove_generation_events(generation)
-            raise PlayerCommandFailed(
-                f"Could not deliver PREPARE for generation {generation} "
-                f"to AirPlay player {self.player.player_id}"
-            )
-
-    async def wait_generation_ready(self, generation: int, timeout: float = 5.0) -> bool:
-        """Wait until the staged generation has opened its audio source."""
-        event = self._gen_ready.get(generation)
-        if event is None:
+            return False
+        self._flushed.clear()
+        if not await self._write_cli_command("ACTION=FLUSH"):
             return False
         try:
-            await asyncio.wait_for(event.wait(), timeout)
+            await asyncio.wait_for(self._flushed.wait(), timeout)
         except TimeoutError:
             return False
         return True
 
-    async def discard_generation(self, generation: int) -> None:
+    async def start(self, start_unix_ms: int = 0, position_ms: int = 0) -> None:
         """
-        Retire a staged generation without disturbing active playback.
+        Anchor playback so the first pending stdin sample is audible at an instant.
 
-        :param generation: Staged generation number to retire.
-        :raises PlayerCommandFailed: If the FLUSH command cannot be delivered.
-        """
-        if generation == self._active_generation:
-            raise RuntimeError(f"Cannot discard active generation {generation}")
-        try:
-            command_delivered = await self._write_cli_command(
-                f"GENERATION={generation}\nACTION=FLUSH"
-            )
-            if not command_delivered:
-                raise PlayerCommandFailed(
-                    f"Could not deliver FLUSH for generation {generation} "
-                    f"to AirPlay player {self.player.player_id}"
-                )
-        finally:
-            self._remove_generation_events(generation)
+        The first call begins playback (connection already established); a call
+        after :meth:`flush` re-bases the frozen anchor and resumes from the ring.
 
-    async def wait_generation_primed(self, generation: int, timeout: float = 8.0) -> bool:
-        """Wait until the staged generation has buffered enough to start."""
-        event = self._gen_primed.get(generation)
-        if event is None:
-            return False
-        try:
-            await asyncio.wait_for(event.wait(), timeout)
-        except TimeoutError:
-            return False
-        return True
-
-    async def start_generation(
-        self, generation: int, position_ms: int, start_unix_ms: int = 0
-    ) -> None:
-        """
-        Commit the staged generation: warm-flush and start it.
-
-        start_unix_ms 0 means as soon as possible (the binary clamps to its
-        minimum warm lead); a group start passes the same instant to every
-        primed member.
+        :param start_unix_ms: Unix-epoch milliseconds at which the first pending
+            stdin sample must be audible. 0 means as soon as possible (the binary
+            clamps to its minimum lead).
+        :param position_ms: Media position mapped to that first sample, used as
+            the base for elapsed reporting.
         """
         if not self.running or not self.connected:
-            raise RuntimeError("Cannot start a generation without a connected cliairplay process")
-        primed = self._gen_primed.get(generation)
-        if primed is None or not primed.is_set():
-            raise RuntimeError(f"Cannot start generation {generation} before it is primed")
-        self._generation_position = position_ms / 1000
-        self._active_generation = generation
-        # Stamp the player's elapsed onto the new generation's base right away:
-        # until the binary's first status arrives, interpolation would otherwise
-        # keep extending the SUPERSEDED generation's clock, which briefly maps
-        # onto the new stream log as a bogus position.
-        self.player.set_state_from_stream(elapsed_time=self._generation_position, stream=self)
-        await self._write_cli_command(
-            f"GENERATION={generation}\nSTART_UNIX_MS={start_unix_ms}\nACTION=START"
-        )
-        # drop event bookkeeping for superseded generations
-        for gen in list(self._gen_ready):
-            if gen < generation:
-                self._gen_ready.pop(gen, None)
-                self._gen_primed.pop(gen, None)
+            raise RuntimeError("Cannot start playback without a connected cliairplay process")
+        self._start_position = position_ms / 1000
+        # Stamp the player's elapsed onto the new anchor's base right away: until
+        # the binary's first status arrives, interpolation would otherwise keep
+        # extending the previous anchor's clock, briefly mapping a bogus position.
+        self.player.set_state_from_stream(elapsed_time=self._start_position, stream=self)
+        await self._write_cli_command(f"START_UNIX_MS={start_unix_ms}\nACTION=START")
 
     async def send_metadata(
         self,
@@ -605,8 +542,9 @@ class AirPlayStream:
         elif self.prov.logger.isEnabledFor(logging.DEBUG):
             args += ["--debug", "5"]
 
-        # Audio is supplied only by command-pipe PREPARE. Keep process stdin
-        # connected because AUDIO=- selects it for generation 0.
+        # Audio is fed continuously on the process stdin; the binary reads it into
+        # a single ring buffer for the whole session lifetime (flushed and
+        # refilled in place on a seek, never reconnected).
         args.append(self.player.address)
         return args
 
@@ -757,21 +695,8 @@ class AirPlayStream:
                 self._update_elapsed(millis / 1000)
         elif "[STATUS] paused" in line:
             player.set_state_from_stream(state=PlaybackState.PAUSED, stream=self)
-        elif "[STATUS] ready generation=" in line:
-            if (event := self._gen_ready.get(self._parse_generation(line))) is not None:
-                event.set()
-        elif "[STATUS] primed generation=" in line:
-            if (event := self._gen_primed.get(self._parse_generation(line))) is not None:
-                event.set()
-        elif "[STATUS] input_eof generation=" in line:
-            player.logger.debug("cliairplay: %s", line.strip())
-        elif "[STATUS] eof generation=" in line:
-            # A generation's input finished. Only the ACTIVE generation
-            # ending matters; a retired generation's eof is just noise.
-            # The plain "[STATUS] eof" line that follows drives the
-            # end-of-stream path for the final generation.
-            if self._parse_generation(line) != self._active_generation:
-                player.logger.debug("stale generation eof ignored: %s", line.strip())
+        elif "[STATUS] flushed" in line:
+            self._flushed.set()
         elif "[STATUS] idle_timeout" in line:
             # a parked (paused) session outlived the binary's idle cap;
             # treat it as a normal end of stream
@@ -784,23 +709,10 @@ class AirPlayStream:
             player.logger.error("cliairplay: %s", line.strip())
         return False
 
-    @staticmethod
-    def _parse_generation(line: str) -> int:
-        """Extract the generation number from a generation-tagged status line."""
-        try:
-            return int(line.split("generation=")[1].split(maxsplit=1)[0])
-        except ValueError, IndexError:
-            return -1
-
-    def _remove_generation_events(self, generation: int) -> None:
-        """Remove readiness bookkeeping for a generation that cannot be used."""
-        self._gen_ready.pop(generation, None)
-        self._gen_primed.pop(generation, None)
-
     def _update_elapsed(self, elapsed_time: float) -> None:
-        """Update elapsed time against the active generation's media position."""
-        # elapsed restarts per generation; report against its media base
-        elapsed_time += self._generation_position
+        """Update elapsed time against the current start anchor's media position."""
+        # the binary's elapsed restarts at each START; report against its base
+        elapsed_time += self._start_position
         # The binary only emits this status while actually playing, so it is
         # also the signal that drives the player into the PLAYING state.
         self.player.set_state_from_stream(

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -306,9 +306,9 @@ class AirPlayStreamSession:
            resulting start anchor is in the past, shift it forward to
            ``now + min_headroom`` and trim that many seconds from the buffer
            head so timing stays aligned with the rest of the group.
-        3. Feed the (possibly trimmed) buffer into the joiner's stdin and add
+        3. Anchor the joiner with a single START at the computed group-aligned
+           time, then feed the (possibly trimmed) buffer into its stdin and add
            the client so the live stream continues priming it.
-        4. Anchor the joiner with a single START at the computed group-aligned time.
         """
         await self._resolve_late_joiner_ptp(airplay_player)
         async with self._lock:
@@ -414,20 +414,26 @@ class AirPlayStreamSession:
             )
 
             try:
-                # The binary buffers stdin into its ring from process start, so
-                # the prime buffer is fed straight in; START anchors it later.
+                # Anchor the joiner BEFORE feeding the prime: pre-START the
+                # binary only buffers stdin into its bounded ring and sends
+                # nothing, so a prime longer than that ring would wedge the
+                # write here — and, through the session lock, stall the whole
+                # group's feed. Anchored, the binary drains the prime as it
+                # streams in. The START does not re-anchor the session
+                # timeline (the group keeps playing).
+                await stream.start(start_unix_ms, position_ms)
                 if buffered_pcm:
                     await self._write_chunk_to_player(airplay_player, buffered_pcm)
             except asyncio.CancelledError:
-                await self.stop_client(airplay_player, reason="late joiner prime cancelled")
+                await self.stop_client(airplay_player, reason="late joiner start cancelled")
                 raise
             except Exception as err:
                 self.prov.logger.warning(
-                    "Late joiner %s: failed to prime pipeline: %s",
+                    "Late joiner %s: failed to start/prime pipeline: %r",
                     airplay_player.player_id,
                     err,
                 )
-                await self.stop_client(airplay_player, reason="late joiner prime failed")
+                await self.stop_client(airplay_player, reason="late joiner start/prime failed")
                 return
 
             if airplay_player not in self.sync_clients:
@@ -440,21 +446,6 @@ class AirPlayStreamSession:
                 )
                 self._warn_degraded_shared_ptp(ap2_members)
 
-        try:
-            # A single START anchors the joiner at the group-aligned instant;
-            # it does not re-anchor the session timeline (the group keeps playing).
-            await stream.start(start_unix_ms, position_ms)
-        except asyncio.CancelledError:
-            await self.remove_client(airplay_player, reason="late joiner start cancelled")
-            raise
-        except Exception as err:
-            self.prov.logger.warning(
-                "Late joiner %s: failed to start: %s",
-                airplay_player.player_id,
-                err,
-            )
-            await self.remove_client(airplay_player, reason="late joiner start failed")
-            return
         self.prov.logger.debug(
             "Late joiner %s: started after %.2fs",
             airplay_player.player_id,

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import time
 from collections.abc import AsyncGenerator
 from contextlib import suppress
@@ -15,7 +14,6 @@ from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant.constants import CONF_SYNC_ADJUST
 from music_assistant.controllers.streams.audio_processing import get_media_session_id
 from music_assistant.helpers.ffmpeg import FFMpeg
-from music_assistant.helpers.named_pipe import open_named_pipe_writer
 
 from .constants import AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS, StreamingProtocol
 from .helpers import get_final_output_format
@@ -78,7 +76,14 @@ class AirPlayStreamSession:
         self._pcm_buffer_max = pcm_format.pcm_sample_size * 10  # 10 seconds
 
     async def start(self, audio_source: AsyncGenerator[bytes]) -> None:
-        """Initialize stream session for all players."""
+        """
+        Connect every member and anchor synchronized playback.
+
+        Spawns and connects each member's CLI, wires the per-seek ffmpeg into its
+        persistent stdin and starts feeding audio, then commands one shared
+        audible start instant. On any failure the whole session is stopped so the
+        caller can fall back to a cold restart.
+        """
         ap2_members = sum(1 for p in self.sync_clients if p.protocol == StreamingProtocol.AIRPLAY2)
         if ap2_members:
             # Resolve the timing source before calculating the audible anchor so
@@ -87,8 +92,6 @@ class AirPlayStreamSession:
             self._shared_ptp_resolved = True
         self.wait_start = max(p.wait_start for p in self.sync_clients) / 1000
         position_ms = int((self.media.elapsed_time or 0) * 1000)
-        generations: dict[str, int] = {}
-        commit_attempted = False
         try:
             async with asyncio.TaskGroup() as task_group:
                 for player in self.sync_clients:
@@ -96,29 +99,16 @@ class AirPlayStreamSession:
             await asyncio.gather(
                 *[p.stream.wait_for_connection() for p in self.sync_clients if p.stream]
             )
-            await self._prepare_initial_generations(generations, position_ms)
-            ready = await asyncio.gather(
-                *[p.stream.wait_generation_ready(0) for p in self.sync_clients if p.stream]
-            )
-            if not all(ready):
-                raise PlayerCommandFailed("generation reader ready timeout")
+            # The binary buffers stdin into its ring from process start; feed audio
+            # first, then anchor. The setup lead plus deadline pacing fill the
+            # receiver before the commanded start (no PREPARE / prime barrier).
             self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
-            primed = await asyncio.gather(
-                *[p.stream.wait_generation_primed(0) for p in self.sync_clients if p.stream]
-            )
-            if not all(primed):
-                raise PlayerCommandFailed("generation prime timeout")
-            commit_attempted = True
-            await self._commit_generations(generations, position_ms)
+            await self._start_members(position_ms)
         except asyncio.CancelledError:
-            if not commit_attempted:
-                await self._discard_generations(generations)
             await self.stop()
             raise
         except Exception as err:
             # playback failed to start, cleanup
-            if not commit_attempted:
-                await self._discard_generations(generations)
             await self.stop()
             raise PlayerCommandFailed("Playback failed to start") from err
 
@@ -146,103 +136,56 @@ class AirPlayStreamSession:
         """
         Warm-replace the playing media with a new source (seek/next-track).
 
-        Each member stages the new source as its next generation on a fresh
-        pipe while the old audio keeps playing; once every member reports
-        primed, one shared START commits the switch (warm flush + re-anchor)
-        a few hundred milliseconds later. Returns False when anything fails,
-        so the caller can fall back to the cold path.
+        Stops feeding old audio and kills each member's ffmpeg (never the
+        persistent cli stdin), flushes every member's live stream in place, then
+        feeds a fresh ffmpeg into the same stdin and anchors all members at one
+        shared instant. A group flushes every member and awaits all acks before
+        the shared start. Returns False when anything fails so the caller can
+        fall back to the cold path.
         """
         position_ms = int((media.elapsed_time or 0) * 1000)
-        generations: dict[str, int] = {}
-        fifos: dict[str, str] = {}
-        writer_fds: dict[str, int] = {}
-        started_at = time.monotonic()
-        committed = False
-        commit_attempted = False
         try:
-            await self._allocate_warm_generation_fifos(generations, fifos)
-            await self._prepare_warm_generations(
-                generations,
-                fifos,
-                position_ms,
-                started_at,
-            )
-            async with asyncio.TaskGroup() as task_group:
-                for player in self.sync_clients:
-                    task_group.create_task(
-                        self._wait_warm_generation_ready(
-                            player,
-                            generations[player.player_id],
-                            started_at,
-                        )
-                    )
-
-            for player in self.sync_clients:
-                player_id = player.player_id
-                writer_fds[player_id] = await open_named_pipe_writer(fifos[player_id])
-                self._log_generation_phase(
-                    player_id, generations[player_id], "writer-open", started_at
-                )
-
+            # Stop feeding old audio and drop each member's buffered ffmpeg output
+            # before flushing: the binary drains stdin to EAGAIN on FLUSH, so no
+            # bytes may be written between the old ffmpeg dying and the flush ack.
+            # Killing ffmpeg never closes the cli stdin (MA holds the write end),
+            # so the binary keeps its stdin reader alive across the seek.
             if self._audio_source_task and not self._audio_source_task.done():
                 self._audio_source_task.cancel()
                 with suppress(asyncio.CancelledError):
                     await self._audio_source_task
             for player in self.sync_clients:
-                await self._start_generation_ffmpeg(player, writer_fds.pop(player.player_id), media)
+                if ffmpeg := self._player_ffmpeg.pop(player.player_id, None):
+                    await ffmpeg.kill()
+            flushed = await asyncio.gather(
+                *[self._flush_member(player) for player in self.sync_clients]
+            )
+            if not all(flushed):
+                raise PlayerCommandFailed("warm flush was not acknowledged")
+            for player in self.sync_clients:
+                await self._start_player_ffmpeg(player, media)
             self.media = media
             # The stream position counter and the late-join prime buffer both
-            # describe the OLD generation's timeline; restart them before the
-            # new source starts pumping.
+            # describe the OLD timeline; restart them before the new source pumps.
             self.seconds_streamed = 0
             self._pcm_buffer.clear()
             self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
-
-            async with asyncio.TaskGroup() as task_group:
-                for player in self.sync_clients:
-                    task_group.create_task(
-                        self._wait_warm_generation_primed(
-                            player,
-                            generations[player.player_id],
-                            started_at,
-                        )
-                    )
-            commit_attempted = True
-            await self._commit_generations(generations, position_ms)
-            for player_id, generation in generations.items():
-                self._log_generation_phase(player_id, generation, "commit", started_at)
-            committed = True
+            await self._start_members(position_ms)
         except asyncio.CancelledError:
-            if not commit_attempted:
-                await self._discard_generations(generations, started_at)
             raise
         except Exception as err:
             self.prov.logger.warning(
                 "Warm replacement failed (%r); falling back to a cold restart", err
             )
-            if not commit_attempted:
-                await self._discard_generations(generations, started_at)
             return False
-        finally:
-            for fifo_fd in writer_fds.values():
-                with suppress(OSError):
-                    os.close(fifo_fd)
-            for fifo in fifos.values():
-                if not committed:
-                    # Give any staged reader EOF before removing its path. FLUSH has
-                    # no positive acknowledgement, so pipe cleanup remains explicit.
-                    with suppress(OSError):
-                        os.close(os.open(fifo, os.O_WRONLY | os.O_NONBLOCK))
-                with suppress(OSError):
-                    await asyncio.to_thread(os.unlink, fifo)
         return True
 
     async def standby(self) -> bool:
         """
         Park the session: stall every member but keep the connections alive.
 
-        The next play_media (resume or seek) commits a new generation over the
-        live connections — the same coordinated warm restart as seek/next.
+        The next play_media (resume or seek) replaces the media warm over the
+        live connections — the same coordinated flush-refill as seek/next.
         Returns False when any member lacks a running, connected stream or its
         standby command cannot be delivered so the caller can fall back to a
         full stop.
@@ -345,15 +288,15 @@ class AirPlayStreamSession:
         buffered PCM, so the first sample we send maps to the correct future
         stream position.
 
-        1. Connect the new client without starting playback.
+        1. Connect the new client without anchoring playback.
         2. Snapshot the ring buffer and map its first byte to its stream
            position; if the
            resulting start anchor is in the past, shift it forward to
            ``now + min_headroom`` and trim that many seconds from the buffer
            head so timing stays aligned with the rest of the group.
-        3. Prepare generation 0, write the (possibly trimmed) buffer, and add
+        3. Feed the (possibly trimmed) buffer into the joiner's stdin and add
            the client so the live stream continues priming it.
-        4. Start generation 0 only after the client reports primed.
+        4. Anchor the joiner with a single START at the computed group-aligned time.
         """
         await self._resolve_late_joiner_ptp(airplay_player)
         async with self._lock:
@@ -440,6 +383,9 @@ class AirPlayStreamSession:
                 start_at = max(start_at, target_start_at)
 
             start_unix_ms = int(start_at * 1000)
+            sync_adjust = airplay_player.config.get_value(CONF_SYNC_ADJUST, 0)
+            if isinstance(sync_adjust, int):
+                start_unix_ms += sync_adjust
             position_ms = int(((self.media.elapsed_time or 0) + first_sample_pos) * 1000)
 
             self.prov.logger.debug(
@@ -456,23 +402,20 @@ class AirPlayStreamSession:
             )
 
             try:
-                await stream.prepare_generation(0, "-", position_ms)
-                if not await stream.wait_generation_ready(0):
-                    raise PlayerCommandFailed("generation reader ready timeout")
+                # The binary buffers stdin into its ring from process start, so
+                # the prime buffer is fed straight in; START anchors it later.
                 if buffered_pcm:
                     await self._write_chunk_to_player(airplay_player, buffered_pcm)
             except asyncio.CancelledError:
-                await self._discard_generation(airplay_player, stream, 0)
-                await self.stop_client(airplay_player, reason="late joiner prepare cancelled")
+                await self.stop_client(airplay_player, reason="late joiner prime cancelled")
                 raise
             except Exception as err:
                 self.prov.logger.warning(
-                    "Late joiner %s: failed to start/prime pipeline: %s",
+                    "Late joiner %s: failed to prime pipeline: %s",
                     airplay_player.player_id,
                     err,
                 )
-                await self._discard_generation(airplay_player, stream, 0)
-                await self.stop_client(airplay_player, reason="late joiner start/prime failed")
+                await self.stop_client(airplay_player, reason="late joiner prime failed")
                 return
 
             if airplay_player not in self.sync_clients:
@@ -485,34 +428,23 @@ class AirPlayStreamSession:
                 )
                 self._warn_degraded_shared_ptp(ap2_members)
 
-        commit_attempted = False
         try:
-            if not await stream.wait_generation_primed(0):
-                raise PlayerCommandFailed("generation prime timeout")
-            commit_attempted = True
-            await self._commit_generations(
-                {airplay_player.player_id: 0},
-                position_ms,
-                start_unix_ms,
-                reanchor_session=False,
-            )
+            # A single START anchors the joiner at the group-aligned instant;
+            # it does not re-anchor the session timeline (the group keeps playing).
+            await stream.start(start_unix_ms, position_ms)
         except asyncio.CancelledError:
-            if not commit_attempted:
-                await self._discard_generation(airplay_player, stream, 0)
-            await self.remove_client(airplay_player, reason="late joiner prime cancelled")
+            await self.remove_client(airplay_player, reason="late joiner start cancelled")
             raise
         except Exception as err:
             self.prov.logger.warning(
-                "Late joiner %s: failed to prime generation: %s",
+                "Late joiner %s: failed to start: %s",
                 airplay_player.player_id,
                 err,
             )
-            if not commit_attempted:
-                await self._discard_generation(airplay_player, stream, 0)
-            await self.remove_client(airplay_player, reason="late joiner prime failed")
+            await self.remove_client(airplay_player, reason="late joiner start failed")
             return
         self.prov.logger.debug(
-            "Late joiner %s: device primed after %.2fs",
+            "Late joiner %s: started after %.2fs",
             airplay_player.player_id,
             time.time() - now,
         )
@@ -711,7 +643,7 @@ class AirPlayStreamSession:
 
     async def _start_client(self, airplay_player: AirPlayPlayer, use_shared_ptp: bool) -> None:
         """
-        Connect a CLI process and start ffmpeg for a single client.
+        Connect a CLI process and start its ffmpeg for a single client.
 
         :param airplay_player: The player to start streaming to.
         :param use_shared_ptp: The session-wide shared-PTP decision applied to
@@ -724,20 +656,73 @@ class AirPlayStreamSession:
         stream_pcm_format = airplay_player.get_stream_pcm_format(self.pcm_format)
         airplay_player.stream = AirPlayStream(airplay_player, pcm_format=stream_pcm_format)
         airplay_player.stream.session = self
-        await airplay_player.stream.start(use_shared_ptp)
-        # Start ffmpeg to feed audio to CLI stdin
-        if ffmpeg := self._player_ffmpeg.pop(airplay_player.player_id, None):
+        await airplay_player.stream.connect(use_shared_ptp)
+        await self._start_player_ffmpeg(airplay_player, self.media)
+
+    async def _start_members(
+        self,
+        position_ms: int,
+        start_unix_ms: int | None = None,
+        *,
+        reanchor_session: bool = True,
+    ) -> None:
+        """
+        Anchor every member's playback at one shared audible instant.
+
+        :param position_ms: Media position mapped to the first sample of the anchor.
+        :param start_unix_ms: Shared audible-start instant in unix epoch ms; when
+            None it is derived from now plus the session setup lead.
+        :param reanchor_session: Whether this start becomes the session timeline anchor.
+        """
+        if start_unix_ms is None:
+            start_unix_ms = int(time.time() * 1000) + int(self.wait_start * 1000)
+        async with asyncio.TaskGroup() as task_group:
+            for player in self.sync_clients:
+                stream = player.stream
+                if stream is None:
+                    continue
+                member_start = start_unix_ms
+                sync_adjust = player.config.get_value(CONF_SYNC_ADJUST, 0)
+                if isinstance(sync_adjust, int):
+                    member_start += sync_adjust
+                task_group.create_task(stream.start(member_start, position_ms))
+        if reanchor_session:
+            self.start_unix_ms = start_unix_ms
+            self.start_time = start_unix_ms / 1000
+
+    async def _flush_member(self, player: AirPlayPlayer) -> bool:
+        """Flush one member's live stream in place and report the binary's ack."""
+        stream = player.stream
+        if stream is None:
+            return False
+        return await stream.flush()
+
+    async def _start_player_ffmpeg(self, player: AirPlayPlayer, media: PlayerMedia) -> None:
+        """
+        Start the per-seek ffmpeg feeding a member's persistent cli stdin.
+
+        Retires any ffmpeg still tracked for the player and wires a fresh one to
+        the same cli stdin fd. Killing ffmpeg never closes cli stdin (MA holds
+        the write end via its process transport), so the binary's stdin reader
+        survives a warm seek.
+
+        :param player: The member whose ffmpeg is (re)started.
+        :param media: Media whose queue/session identify the output plan.
+        """
+        if ffmpeg := self._player_ffmpeg.pop(player.player_id, None):
             await ffmpeg.close()
-        handoff_format = airplay_player.stream.pcm_format
+        stream = player.stream
+        assert stream
+        handoff_format = stream.pcm_format
         output_plan = self.mass.streams.audio.get_player_output_plan(
-            airplay_player.player_id,
+            player.player_id,
             input_format=self.pcm_format,
-            output_format=get_final_output_format(handoff_format, airplay_player),
+            output_format=get_final_output_format(handoff_format, player),
             handoff_format=handoff_format,
-            queue_id=self.media.source_id,
-            session_id=get_media_session_id(self.media),
+            queue_id=media.source_id,
+            session_id=get_media_session_id(media),
         )
-        cli_proc = airplay_player.stream._cli_proc
+        cli_proc = stream._cli_proc
         assert cli_proc
         assert cli_proc.proc
         assert cli_proc.proc.stdin
@@ -751,237 +736,4 @@ class AirPlayStreamSession:
             audio_output=audio_output,
         )
         await ffmpeg.start()
-        self._player_ffmpeg[airplay_player.player_id] = ffmpeg
-
-    async def _commit_generations(
-        self,
-        generations: dict[str, int],
-        position_ms: int,
-        start_unix_ms: int | None = None,
-        *,
-        reanchor_session: bool = True,
-    ) -> None:
-        """
-        Start prepared member generations at one audible instant.
-
-        :param generations: Generation number keyed by player ID.
-        :param position_ms: Media position represented by each generation's first sample.
-        :param start_unix_ms: Optional audible-start instant in unix epoch milliseconds.
-        :param reanchor_session: Whether this generation becomes the session timeline anchor.
-        """
-        if start_unix_ms is None:
-            start_lead_ms = 400 if len(generations) == 1 else 750
-            start_unix_ms = int(time.time() * 1000) + start_lead_ms
-        async with asyncio.TaskGroup() as task_group:
-            for player in self.sync_clients:
-                generation = generations.get(player.player_id)
-                if generation is None:
-                    continue
-                member_start = start_unix_ms
-                sync_adjust = player.config.get_value(CONF_SYNC_ADJUST, 0)
-                if isinstance(sync_adjust, int):
-                    member_start += sync_adjust
-                stream = player.stream
-                assert stream
-                task_group.create_task(
-                    stream.start_generation(generation, position_ms, member_start)
-                )
-        if reanchor_session:
-            self.start_unix_ms = start_unix_ms
-            self.start_time = start_unix_ms / 1000
-
-    async def _start_generation_ffmpeg(
-        self, player: AirPlayPlayer, fifo_fd: int, media: PlayerMedia
-    ) -> None:
-        """
-        Start the per-player DSP ffmpeg for a staged generation.
-
-        Retires the player's previous ffmpeg and spawns a fresh one writing
-        into the prepared generation pipe.
-
-        :param player: AirPlay player receiving the generation.
-        :param fifo_fd: Blocking write descriptor paired with the prepared reader.
-        :param media: Media that owns the new generation.
-        """
-        try:
-            if ffmpeg := self._player_ffmpeg.get(player.player_id):
-                # Kill, not close: a graceful close waits for the old ffmpeg to
-                # drain its buffered audio into the binary at playback speed
-                # (seconds), and that audio is superseded anyway. The binary keeps
-                # playing the old generation from its own ring until START lands.
-                await ffmpeg.kill()
-                if self._player_ffmpeg.get(player.player_id) is ffmpeg:
-                    self._player_ffmpeg.pop(player.player_id)
-            stream = player.stream
-            assert stream
-            handoff_format = stream.pcm_format
-            output_plan = self.mass.streams.audio.get_player_output_plan(
-                player.player_id,
-                input_format=self.pcm_format,
-                output_format=get_final_output_format(handoff_format, player),
-                handoff_format=handoff_format,
-                queue_id=media.source_id,
-                session_id=get_media_session_id(media),
-            )
-            ffmpeg = FFMpeg(
-                audio_input="-",
-                input_format=self.pcm_format,
-                output_format=handoff_format,
-                filter_params=output_plan.filter_params,
-                audio_output=fifo_fd,
-            )
-            await ffmpeg.start()
-            self._player_ffmpeg[player.player_id] = ffmpeg
-        finally:
-            # the ffmpeg child inherited the descriptor; drop our copy so the
-            # pipe sees EOF when ffmpeg exits
-            os.close(fifo_fd)
-
-    async def _allocate_warm_generation_fifos(
-        self, generations: dict[str, int], fifos: dict[str, str]
-    ) -> None:
-        """Allocate one staged generation FIFO for every session member."""
-        for player in self.sync_clients:
-            stream = player.stream
-            assert stream
-            generation = stream.next_generation()
-            fifo = f"/tmp/ma-gen-{player.player_id}-{generation}.pcm"  # noqa: S108
-            with suppress(FileNotFoundError):
-                await asyncio.to_thread(os.unlink, fifo)
-            await asyncio.to_thread(os.mkfifo, fifo)
-            generations[player.player_id] = generation
-            fifos[player.player_id] = fifo
-
-    async def _prepare_initial_generations(
-        self, generations: dict[str, int], position_ms: int
-    ) -> None:
-        """Deliver every generation-0 PREPARE before surfacing a startup failure."""
-        streams: list[AirPlayStream] = []
-        for player in self.sync_clients:
-            stream = player.stream
-            assert stream
-            generations[player.player_id] = 0
-            streams.append(stream)
-        results = await asyncio.gather(
-            *[stream.prepare_generation(0, "-", position_ms) for stream in streams],
-            return_exceptions=True,
-        )
-        for result in results:
-            if isinstance(result, BaseException):
-                raise result
-
-    async def _prepare_warm_generations(
-        self,
-        generations: dict[str, int],
-        fifos: dict[str, str],
-        position_ms: int,
-        started_at: float,
-    ) -> None:
-        """Deliver every queued PREPARE before surfacing a partial-group failure."""
-        results = await asyncio.gather(
-            *[
-                self._prepare_warm_generation(
-                    player,
-                    generations[player.player_id],
-                    fifos[player.player_id],
-                    position_ms,
-                    started_at,
-                )
-                for player in self.sync_clients
-            ],
-            return_exceptions=True,
-        )
-        for result in results:
-            if isinstance(result, BaseException):
-                raise result
-
-    async def _prepare_warm_generation(
-        self,
-        player: AirPlayPlayer,
-        generation: int,
-        fifo: str,
-        position_ms: int,
-        started_at: float,
-    ) -> None:
-        """Deliver PREPARE for one member without changing its active generation."""
-        stream = player.stream
-        assert stream
-        await stream.prepare_generation(generation, fifo, position_ms)
-        self._log_generation_phase(player.player_id, generation, "prepare-delivered", started_at)
-
-    async def _wait_warm_generation_ready(
-        self, player: AirPlayPlayer, generation: int, started_at: float
-    ) -> None:
-        """Wait for one member to open its staged generation reader."""
-        stream = player.stream
-        assert stream
-        if not await stream.wait_generation_ready(generation):
-            raise PlayerCommandFailed(
-                f"generation {generation} reader ready timeout for {player.player_id}"
-            )
-        self._log_generation_phase(player.player_id, generation, "ready", started_at)
-
-    async def _wait_warm_generation_primed(
-        self, player: AirPlayPlayer, generation: int, started_at: float
-    ) -> None:
-        """Wait for one member to buffer its staged generation."""
-        stream = player.stream
-        assert stream
-        if not await stream.wait_generation_primed(generation):
-            raise PlayerCommandFailed(
-                f"generation {generation} prime timeout for {player.player_id}"
-            )
-        self._log_generation_phase(player.player_id, generation, "primed", started_at)
-
-    async def _discard_generations(
-        self, generations: dict[str, int], started_at: float | None = None
-    ) -> None:
-        """Best-effort discard every generation staged before shared START."""
-        members: dict[str, tuple[AirPlayPlayer, AirPlayStream]] = {}
-        for player in self.sync_clients:
-            if player.stream is not None:
-                members[player.player_id] = (player, player.stream)
-        player_ids = [player_id for player_id in generations if player_id in members]
-        await asyncio.gather(
-            *[
-                self._discard_generation(
-                    members[player_id][0],
-                    members[player_id][1],
-                    generations[player_id],
-                    started_at,
-                )
-                for player_id in player_ids
-            ]
-        )
-
-    async def _discard_generation(
-        self,
-        player: AirPlayPlayer,
-        stream: AirPlayStream,
-        generation: int,
-        started_at: float | None = None,
-    ) -> None:
-        """Best-effort discard one generation staged before START."""
-        try:
-            await stream.discard_generation(generation)
-        except Exception as err:
-            self.prov.logger.warning(
-                "Could not discard staged AirPlay generation for player %s: %s",
-                player.player_id,
-                err,
-            )
-            return
-        if started_at is not None:
-            self._log_generation_phase(player.player_id, generation, "discard", started_at)
-
-    def _log_generation_phase(
-        self, player_id: str, generation: int, phase: str, started_at: float
-    ) -> None:
-        """Log a warm generation phase with elapsed staging time."""
-        self.prov.logger.debug(
-            "AirPlay warm generation: player=%s generation=%d phase=%s elapsed=%.3fs",
-            player_id,
-            generation,
-            phase,
-            time.monotonic() - started_at,
-        )
+        self._player_ffmpeg[player.player_id] = ffmpeg

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -15,7 +15,12 @@ from music_assistant.constants import CONF_SYNC_ADJUST
 from music_assistant.controllers.streams.audio_processing import get_media_session_id
 from music_assistant.helpers.ffmpeg import FFMpeg
 
-from .constants import AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS, StreamingProtocol
+from .constants import (
+    AIRPLAY_GROUP_START_LEAD_MS,
+    AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
+    AIRPLAY_START_LEAD_MS,
+    StreamingProtocol,
+)
 from .helpers import get_final_output_format
 from .stream import AirPlayStream
 
@@ -99,11 +104,14 @@ class AirPlayStreamSession:
             await asyncio.gather(
                 *[p.stream.wait_for_connection() for p in self.sync_clients if p.stream]
             )
-            # The binary buffers stdin into its ring from process start; feed audio
-            # first, then anchor. The setup lead plus deadline pacing fill the
-            # receiver before the commanded start (no PREPARE / prime barrier).
+            # The binary buffers stdin into its ring from process start; feed
+            # audio first and wait for every member to confirm it flowing, then
+            # anchor with a short lead. Readiness is fully event-driven
+            # (connected + audio), so no guessed setup time is needed; the
+            # binary bursts the receiver pre-fill after START.
             self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
-            await self._start_members(position_ms)
+            await self._wait_members_audio_present()
+            await self._start_members(position_ms, self._anchor_start_unix_ms())
         except asyncio.CancelledError:
             await self.stop()
             raise
@@ -170,7 +178,11 @@ class AirPlayStreamSession:
             self.seconds_streamed = 0
             self._pcm_buffer.clear()
             self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
-            await self._start_members(position_ms)
+            # Anchor only after every member confirms the new audio flowing;
+            # the live connection and clock survive the flush, so a short
+            # re-anchor lead replaces the full setup lead.
+            await self._wait_members_audio_present()
+            await self._start_members(position_ms, self._anchor_start_unix_ms())
         except asyncio.CancelledError:
             raise
         except Exception as err:
@@ -658,6 +670,21 @@ class AirPlayStreamSession:
         airplay_player.stream.session = self
         await airplay_player.stream.connect(use_shared_ptp)
         await self._start_player_ffmpeg(airplay_player, self.media)
+
+    def _anchor_start_unix_ms(self) -> int:
+        """Return the shared audible-start instant for a readiness-confirmed start."""
+        lead_ms = (
+            AIRPLAY_START_LEAD_MS if len(self.sync_clients) == 1 else AIRPLAY_GROUP_START_LEAD_MS
+        )
+        return int(time.time() * 1000) + lead_ms
+
+    async def _wait_members_audio_present(self) -> None:
+        """Wait until every member's binary reports the new audio flowing."""
+        results = await asyncio.gather(
+            *[p.stream.wait_audio_present() for p in self.sync_clients if p.stream]
+        )
+        if not all(results):
+            raise PlayerCommandFailed("audio feed was not confirmed")
 
     async def _start_members(
         self,

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -680,7 +680,7 @@ class AirPlayStreamSession:
     async def _start_members(
         self,
         position_ms: int,
-        start_unix_ms: int | None = None,
+        start_unix_ms: int,
         *,
         reanchor_session: bool = True,
     ) -> None:
@@ -688,12 +688,9 @@ class AirPlayStreamSession:
         Anchor every member's playback at one shared audible instant.
 
         :param position_ms: Media position mapped to the first sample of the anchor.
-        :param start_unix_ms: Shared audible-start instant in unix epoch ms; when
-            None it is derived from now plus the session setup lead.
+        :param start_unix_ms: Shared audible-start instant in unix epoch ms.
         :param reanchor_session: Whether this start becomes the session timeline anchor.
         """
-        if start_unix_ms is None:
-            start_unix_ms = int(time.time() * 1000) + int(self.wait_start * 1000)
         async with asyncio.TaskGroup() as task_group:
             for player in self.sync_clients:
                 stream = player.stream

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -604,12 +604,10 @@ async def test_raop_session_resolves_ptp_for_first_ap2_late_joiner() -> None:
     prov.wait_ptp_daemon_ready = AsyncMock(side_effect=_wait_ptp_daemon_ready)
 
     async def _start_client(player: MagicMock, _use_shared_ptp: bool) -> None:
-        player.stream = MagicMock(running=True)
+        player.stream = MagicMock(running=True, connected=True)
         player.stream.wait_for_connection = AsyncMock()
-        player.stream.prepare_generation = AsyncMock()
-        player.stream.wait_generation_ready = AsyncMock(return_value=True)
-        player.stream.wait_generation_primed = AsyncMock(return_value=True)
-        player.stream.start_generation = AsyncMock()
+        player.stream.flush = AsyncMock(return_value=True)
+        player.stream.start = AsyncMock()
 
     with patch.object(
         session, "_start_client", new_callable=AsyncMock, side_effect=_start_client
@@ -632,10 +630,7 @@ async def test_session_start_applies_uniform_ptp_decision_to_all_members() -> No
     for player in players:
         player.stream = MagicMock()
         player.stream.wait_for_connection = AsyncMock()
-        player.stream.prepare_generation = AsyncMock()
-        player.stream.wait_generation_ready = AsyncMock(return_value=True)
-        player.stream.wait_generation_primed = AsyncMock(return_value=True)
-        player.stream.start_generation = AsyncMock()
+        player.stream.start = AsyncMock()
     session = _make_ptp_session(prov, players)
 
     with (
@@ -658,10 +653,8 @@ async def test_session_start_calculates_anchor_after_ptp_resolution() -> None:
     for player in players:
         player.stream = MagicMock()
         player.stream.wait_for_connection = AsyncMock()
-        player.stream.prepare_generation = AsyncMock()
-        player.stream.wait_generation_ready = AsyncMock(return_value=True)
-        player.stream.wait_generation_primed = AsyncMock(return_value=True)
-        player.stream.start_generation = AsyncMock()
+        player.stream.start = AsyncMock()
+        player.config.get_value = MagicMock(return_value=0)
     session = _make_ptp_session(prov, players)
     now = 100.0
 
@@ -681,10 +674,11 @@ async def test_session_start_calculates_anchor_after_ptp_resolution() -> None:
     ):
         await session.start(MagicMock())
 
-    assert session.start_unix_ms == 103_750
+    # anchor = now (103_000 ms) + max member setup lead (AP2 = 2500 ms)
+    assert session.start_unix_ms == 105_500
     for player in players:
-        player.stream.start_generation.assert_awaited_once()
-        assert player.stream.start_generation.await_args.args[2] == 103_750
+        player.stream.start.assert_awaited_once()
+        assert player.stream.start.await_args.args[0] == 105_500
 
 
 # --- Session decision reaches the CLI args (overrides bare liveness) ------------

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -676,12 +676,12 @@ async def test_session_start_calculates_anchor_after_ptp_resolution() -> None:
     ):
         await session.start(MagicMock())
 
-    # anchor = now (103_000 ms) + the group start lead (750 ms); readiness is
+    # anchor = now (103_000 ms) + the group start lead (500 ms); readiness is
     # event-confirmed, so no setup-time guess is added on top.
-    assert session.start_unix_ms == 103_750
+    assert session.start_unix_ms == 103_500
     for player in players:
         player.stream.start.assert_awaited_once()
-        assert player.stream.start.await_args.args[0] == 103_750
+        assert player.stream.start.await_args.args[0] == 103_500
 
 
 # --- Session decision reaches the CLI args (overrides bare liveness) ------------

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -630,6 +630,7 @@ async def test_session_start_applies_uniform_ptp_decision_to_all_members() -> No
     for player in players:
         player.stream = MagicMock()
         player.stream.wait_for_connection = AsyncMock()
+        player.stream.wait_audio_present = AsyncMock(return_value=True)
         player.stream.start = AsyncMock()
     session = _make_ptp_session(prov, players)
 
@@ -653,6 +654,7 @@ async def test_session_start_calculates_anchor_after_ptp_resolution() -> None:
     for player in players:
         player.stream = MagicMock()
         player.stream.wait_for_connection = AsyncMock()
+        player.stream.wait_audio_present = AsyncMock(return_value=True)
         player.stream.start = AsyncMock()
         player.config.get_value = MagicMock(return_value=0)
     session = _make_ptp_session(prov, players)
@@ -674,11 +676,12 @@ async def test_session_start_calculates_anchor_after_ptp_resolution() -> None:
     ):
         await session.start(MagicMock())
 
-    # anchor = now (103_000 ms) + max member setup lead (AP2 = 2500 ms)
-    assert session.start_unix_ms == 105_500
+    # anchor = now (103_000 ms) + the group start lead (750 ms); readiness is
+    # event-confirmed, so no setup-time guess is added on top.
+    assert session.start_unix_ms == 103_750
     for player in players:
         player.stream.start.assert_awaited_once()
-        assert player.stream.start.await_args.args[0] == 105_500
+        assert player.stream.start.await_args.args[0] == 103_750
 
 
 # --- Session decision reaches the CLI args (overrides bare liveness) ------------

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -5,19 +5,18 @@ Cover four things, with the Sendspin clock mocked via ``ManualClock`` so the
 tests are deterministic and independent of the host wall-clock:
 
 * the clock-domain conversion turning a Sendspin audible instant (Sendspin's own
-  monotonic clock) into the unix epoch ms used by the generation START command;
+  monotonic clock) into the unix epoch ms used by the START command;
 * the start anchor: byte 0 is anchored to the first chunk Sendspin delivers, so a
   fresh track keeps position 0 and a late joiner lands at the group's live position;
 * the write pacing that keeps the device buffered a bounded amount ahead of real
   time so a late-join catch-up backlog is not dumped into the CLI;
 * the warm handover: a running, connected stream is kept (not torn down) across
-  a new Sendspin stream, and stages/commits a new generation on itself
-  instead of a cold reconnect -- with prime-timeout and superseded-task fallback.
+  a new Sendspin stream and rides the persistent-stdin flush-refill (FLUSH +
+  re-anchoring START) instead of a cold reconnect -- with flush-timeout and
+  superseded-task fallback.
 """
 
 import asyncio
-import errno
-import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -284,19 +283,15 @@ async def test_failed_cli_write_does_not_advance_pacing_cursor() -> None:
 # --- Commanded cold start and warm handover ------------------------------------
 
 
-async def test_cold_start_connects_then_prepares_and_starts_generation_zero() -> None:
-    """A fresh bridge stream commands generation 0 only after the CLI connects."""
+async def test_cold_start_connects_then_anchors_first_start() -> None:
+    """A fresh bridge stream anchors its first START only after the CLI connects."""
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     bridge._drop_until_us = SENDSPIN_EPOCH_US + AP2_LEAD_MS * 1_000
     bridge._airplay_stream_start_task = asyncio.current_task()
     stream = MagicMock()
-    stream.start = AsyncMock()
+    stream.connect = AsyncMock()
     stream.wait_for_connection = AsyncMock()
-    stream.prepare_generation = AsyncMock()
-    stream.wait_generation_ready = AsyncMock(return_value=True)
-    stream.wait_generation_primed = AsyncMock(return_value=True)
-    stream.discard_generation = AsyncMock()
-    stream.start_generation = AsyncMock()
+    stream.start = AsyncMock()
 
     with (
         patch(
@@ -310,30 +305,26 @@ async def test_cold_start_connects_then_prepares_and_starts_generation_zero() ->
     ):
         await bridge._start_protocol_from_chunk()
 
-    stream.start.assert_awaited_once_with()
+    stream.connect.assert_awaited_once_with()
     stream.wait_for_connection.assert_awaited_once_with()
-    stream.prepare_generation.assert_awaited_once_with(0, "-", 0)
-    stream.wait_generation_ready.assert_awaited_once_with(0)
-    stream.wait_generation_primed.assert_awaited_once_with(0)
-    stream.start_generation.assert_awaited_once_with(0, 0, int(UNIX_NOW_S * 1000) + AP2_LEAD_MS)
+    stream.start.assert_awaited_once_with(int(UNIX_NOW_S * 1000) + AP2_LEAD_MS)
     assert bridge._airplay_stream is stream
     assert bridge.airplay_player.stream is stream
-    assert bridge._generation_started is True
+    assert bridge._started is True
+    assert bridge._airplay_stream_ready.is_set()
 
 
-async def test_cold_start_ready_timeout_discards_generation_zero() -> None:
-    """A cold bridge start FLUSHes generation 0 before stopping its transport."""
+async def test_cold_start_superseded_before_start_stops_transport() -> None:
+    """A cold bridge start that is superseded after connect stops its transport."""
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     bridge._drop_until_us = SENDSPIN_EPOCH_US + AP2_LEAD_MS * 1_000
-    bridge._airplay_stream_start_task = asyncio.current_task()
+    # a different task owns the bridge: this cold start is stale
+    bridge._airplay_stream_start_task = MagicMock()
     stream = MagicMock()
-    stream.start = AsyncMock()
+    stream.connect = AsyncMock()
     stream.stop = AsyncMock()
     stream.wait_for_connection = AsyncMock()
-    stream.prepare_generation = AsyncMock()
-    stream.wait_generation_ready = AsyncMock(return_value=False)
-    stream.discard_generation = AsyncMock()
-    stream.start_generation = AsyncMock()
+    stream.start = AsyncMock()
 
     with (
         patch(
@@ -347,12 +338,11 @@ async def test_cold_start_ready_timeout_discards_generation_zero() -> None:
     ):
         await bridge._start_protocol_from_chunk()
 
-    stream.discard_generation.assert_awaited_once_with(0)
-    stream.start_generation.assert_not_awaited()
+    stream.start.assert_not_awaited()
     stream.stop.assert_awaited_once_with(force=True)
 
 
-# --- Warm handover: a kept stream survives a new stream start and absorbs a generation ---
+# --- Warm handover: a kept stream survives a new stream start and rides flush-refill ---
 
 
 def _make_kept_stream(*, running: bool = True, connected: bool = True) -> MagicMock:
@@ -369,7 +359,7 @@ def test_on_bridge_stream_start_keeps_warm_eligible_stream() -> None:
     kept_stream = _make_kept_stream()
     bridge._airplay_stream = kept_stream
     bridge.airplay_player.stream = kept_stream
-    bridge._generation_started = True
+    bridge._started = True
 
     bridge._on_bridge_stream_start()
 
@@ -379,7 +369,7 @@ def test_on_bridge_stream_start_keeps_warm_eligible_stream() -> None:
 
 
 def test_on_bridge_stream_start_keeps_raop_stream() -> None:
-    """A committed legacy RAOP stream is eligible for warm Sendspin generations."""
+    """A started legacy RAOP stream is eligible for warm Sendspin flush-refill."""
     bridge = _make_bridge(
         clock_now_us=SENDSPIN_EPOCH_US,
         wait_start_ms=RAOP_LEAD_MS,
@@ -388,7 +378,7 @@ def test_on_bridge_stream_start_keeps_raop_stream() -> None:
     old_stream = _make_kept_stream()
     bridge._airplay_stream = old_stream
     bridge.airplay_player.stream = old_stream
-    bridge._generation_started = True
+    bridge._started = True
 
     bridge._on_bridge_stream_start()
 
@@ -406,7 +396,7 @@ def test_sendspin_callbacks_keep_raop_stream_until_warm_handover() -> None:
     kept_stream = _make_kept_stream()
     bridge._airplay_stream = kept_stream
     bridge.airplay_player.stream = kept_stream
-    bridge._generation_started = True
+    bridge._started = True
 
     bridge._on_stream_start(MagicMock())
     bridge._on_bridge_stream_start()
@@ -416,7 +406,7 @@ def test_sendspin_callbacks_keep_raop_stream_until_warm_handover() -> None:
 
 
 def test_on_bridge_stream_start_replaces_uncommitted_stream() -> None:
-    """A connected stream cannot be retained before generation 0 has started."""
+    """A connected stream cannot be retained before its first START."""
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     old_stream = _make_kept_stream()
     bridge._airplay_stream = old_stream
@@ -434,7 +424,7 @@ def test_on_stream_start_keeps_warm_eligible_stream() -> None:
     kept_stream = _make_kept_stream()
     bridge._airplay_stream = kept_stream
     bridge.airplay_player.stream = kept_stream
-    bridge._generation_started = True
+    bridge._started = True
 
     bridge._on_stream_start(MagicMock())
 
@@ -442,358 +432,77 @@ def test_on_stream_start_keeps_warm_eligible_stream() -> None:
     assert bridge.airplay_player.stream is kept_stream
 
 
-async def test_warm_generation_commits_on_kept_stream_instance() -> None:
-    """A warm handover stages and commits a new generation on the same stream instance."""
+async def test_warm_stream_flushes_and_reanchors_on_kept_instance() -> None:
+    """A warm handover flushes and re-anchors START on the same stream instance."""
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     kept_stream = MagicMock()
-    kept_stream.next_generation = MagicMock(return_value=3)
-    kept_stream.prepare_generation = AsyncMock()
-    kept_stream.wait_generation_ready = AsyncMock(return_value=True)
-    kept_stream.wait_generation_primed = AsyncMock(return_value=True)
-    kept_stream.discard_generation = AsyncMock()
-    kept_stream.start_generation = AsyncMock()
+    kept_stream.flush = AsyncMock(return_value=True)
+    kept_stream.start = AsyncMock()
     bridge._airplay_stream = kept_stream
     bridge._airplay_stream_start_task = asyncio.current_task()
-    expected_fifo = f"/tmp/ma-bridge-{bridge.airplay_player.player_id}-3.pcm"  # noqa: S108
 
-    with (
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
-        patch(
-            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
-            new_callable=AsyncMock,
-            return_value=99,
-        ),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=100),
-    ):
-        committed = await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
+    committed = await bridge._start_warm_stream(kept_stream, 1_784_000_000_000)
 
     assert committed is True
     assert bridge._airplay_stream is kept_stream  # no new instance was built
-    kept_stream.prepare_generation.assert_awaited_once_with(3, expected_fifo, 0)
-    kept_stream.wait_generation_ready.assert_awaited_once_with(3)
-    kept_stream.wait_generation_primed.assert_awaited_once_with(3)
-    kept_stream.discard_generation.assert_not_awaited()
-    kept_stream.start_generation.assert_awaited_once_with(3, 0, 1_784_000_000_000)
-    assert bridge._sink_fd == 99
+    kept_stream.flush.assert_awaited_once_with()
+    kept_stream.start.assert_awaited_once_with(1_784_000_000_000)
+    assert bridge._started is True
     assert bridge._airplay_stream_ready.is_set()
 
 
-async def test_warm_generation_prime_timeout_falls_back_to_cold_restart() -> None:
-    """A prime timeout never commits and reverts the writer to the stdin sink."""
+async def test_warm_stream_flush_timeout_falls_back_to_cold() -> None:
+    """A flush that is never acknowledged never re-anchors and falls back to cold."""
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     kept_stream = MagicMock()
-    kept_stream.next_generation = MagicMock(return_value=1)
-    kept_stream.prepare_generation = AsyncMock()
-    kept_stream.wait_generation_ready = AsyncMock(return_value=True)
-    kept_stream.wait_generation_primed = AsyncMock(return_value=False)
-    kept_stream.discard_generation = AsyncMock()
-    kept_stream.start_generation = AsyncMock()
+    kept_stream.flush = AsyncMock(return_value=False)
+    kept_stream.start = AsyncMock()
     bridge._airplay_stream = kept_stream
     bridge._airplay_stream_start_task = asyncio.current_task()
 
-    with (
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
-        patch(
-            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
-            new_callable=AsyncMock,
-            return_value=55,
-        ),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=100),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as mock_close,
-    ):
-        committed = await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
+    committed = await bridge._start_warm_stream(kept_stream, 1_784_000_000_000)
 
     assert committed is False
-    kept_stream.discard_generation.assert_awaited_once_with(1)
-    kept_stream.start_generation.assert_not_awaited()
-    assert bridge._sink_fd is None  # reverted so the cold-path writer uses stdin again
-    mock_close.assert_any_call(55)
+    kept_stream.start.assert_not_awaited()
+    assert bridge._started is False
 
 
-async def test_warm_generation_superseded_before_commit_does_not_start() -> None:
-    """If a newer stream start already owns the bridge, the stale attempt never commits."""
+async def test_warm_stream_superseded_before_start_does_not_anchor() -> None:
+    """If a newer stream start already owns the bridge, the stale flush never re-anchors."""
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     kept_stream = MagicMock()
-    kept_stream.next_generation = MagicMock(return_value=2)
-    kept_stream.prepare_generation = AsyncMock()
-    kept_stream.wait_generation_ready = AsyncMock(return_value=True)
-    kept_stream.wait_generation_primed = AsyncMock(return_value=True)
-    kept_stream.discard_generation = AsyncMock()
-    kept_stream.start_generation = AsyncMock()
+    kept_stream.flush = AsyncMock(return_value=True)
+    kept_stream.start = AsyncMock()
     bridge._airplay_stream = kept_stream
     # Simulate a newer stream start having already replaced the tracked task.
     bridge._airplay_stream_start_task = MagicMock()
 
-    with (
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
-        patch(
-            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
-            new_callable=AsyncMock,
-            return_value=77,
-        ),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=100),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as mock_close,
-    ):
-        committed = await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
+    committed = await bridge._start_warm_stream(kept_stream, 1_784_000_000_000)
 
     assert committed is False
-    kept_stream.discard_generation.assert_awaited_once_with(2)
-    kept_stream.start_generation.assert_not_awaited()
-    # The stale attempt must NOT close the fd: it was published as self._sink_fd,
-    # so closing it here would break the writer (EBADF) or double-close a fd a
-    # newer task already replaced. Its lifecycle is owned by _set_sink_fd/teardown.
-    assert all(call.args[0] != 77 for call in mock_close.call_args_list)
-    assert bridge._sink_fd == 77
+    kept_stream.start.assert_not_awaited()
 
 
-async def test_warm_generation_ready_timeout_does_not_open_writer() -> None:
-    """A missing ready status abandons the staged FIFO before publishing a sink."""
+async def test_warm_stream_cancellation_propagates() -> None:
+    """Cancellation while flushing propagates without re-anchoring."""
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     kept_stream = MagicMock()
-    kept_stream.next_generation = MagicMock(return_value=1)
-    kept_stream.prepare_generation = AsyncMock()
-    kept_stream.wait_generation_ready = AsyncMock(return_value=False)
-    kept_stream.discard_generation = AsyncMock()
-    kept_stream.start_generation = AsyncMock()
-    bridge._airplay_stream = kept_stream
-    bridge._airplay_stream_start_task = asyncio.current_task()
+    flush_waiting = asyncio.Event()
 
-    with (
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
-        patch(
-            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
-            new_callable=AsyncMock,
-        ) as open_writer,
-        patch(
-            "music_assistant.providers.airplay.sendspin_bridge.os.open",
-            side_effect=OSError(errno.ENXIO, "no reader"),
-        ),
-    ):
-        assert await bridge._start_warm_generation(kept_stream, 1_784_000_000_000) is False
-
-    open_writer.assert_not_awaited()
-    kept_stream.discard_generation.assert_awaited_once_with(1)
-    kept_stream.start_generation.assert_not_awaited()
-    assert bridge._sink_fd is None
-
-
-async def test_warm_generation_cancellation_discards_staging() -> None:
-    """Cancellation while awaiting ready FLUSHes the bridge generation."""
-    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    kept_stream = MagicMock()
-    kept_stream.next_generation = MagicMock(return_value=1)
-    kept_stream.prepare_generation = AsyncMock()
-    ready_waiting = asyncio.Event()
-
-    async def wait_ready(_generation: int) -> bool:
-        ready_waiting.set()
+    async def flush(*_args: object, **_kwargs: object) -> bool:
+        bridge._airplay_stream_start_task = asyncio.current_task()
+        flush_waiting.set()
         await asyncio.Event().wait()
         return True
 
-    kept_stream.wait_generation_ready = AsyncMock(side_effect=wait_ready)
-    kept_stream.discard_generation = AsyncMock()
+    kept_stream.flush = AsyncMock(side_effect=flush)
+    kept_stream.start = AsyncMock()
     bridge._airplay_stream = kept_stream
 
-    with (
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
-        patch(
-            "music_assistant.providers.airplay.sendspin_bridge.os.open",
-            side_effect=OSError(errno.ENXIO, "no reader"),
-        ),
-    ):
-        warm_task = asyncio.create_task(
-            bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
-        )
-        await ready_waiting.wait()
-        warm_task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await warm_task
+    warm_task = asyncio.create_task(bridge._start_warm_stream(kept_stream, 1_784_000_000_000))
+    await flush_waiting.wait()
+    warm_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await warm_task
 
-    kept_stream.discard_generation.assert_awaited_once_with(1)
-    assert bridge._sink_fd is None
-
-
-async def test_warm_generation_cancellation_before_sink_publication_closes_fd() -> None:
-    """Cancellation before sink publication closes the locally owned writer fd."""
-    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    kept_stream = MagicMock()
-    kept_stream.next_generation = MagicMock(return_value=1)
-    kept_stream.prepare_generation = AsyncMock()
-    kept_stream.wait_generation_ready = AsyncMock(return_value=True)
-    kept_stream.discard_generation = AsyncMock()
-    bridge._airplay_stream_start_task = asyncio.current_task()
-
-    with (
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
-        patch(
-            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
-            new_callable=AsyncMock,
-            return_value=55,
-        ),
-        patch.object(
-            bridge,
-            "_set_sink_fd",
-            new_callable=AsyncMock,
-            side_effect=asyncio.CancelledError,
-        ),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=100),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as close_fd,
-        pytest.raises(asyncio.CancelledError),
-    ):
-        await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
-
-    assert sum(call.args == (55,) for call in close_fd.call_args_list) == 1
-    kept_stream.discard_generation.assert_awaited_once_with(1)
-    assert bridge._sink_fd is None
-
-
-async def test_warm_generation_cancellation_after_sink_publication_releases_fd() -> None:
-    """Cancellation during sink publication releases the owner-managed fd."""
-    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    kept_stream = MagicMock()
-    kept_stream.next_generation = MagicMock(return_value=1)
-    kept_stream.prepare_generation = AsyncMock()
-    kept_stream.wait_generation_ready = AsyncMock(return_value=True)
-    kept_stream.discard_generation = AsyncMock()
-    bridge._airplay_stream_start_task = asyncio.current_task()
-
-    async def publish_then_cancel(fd: int | None) -> None:
-        old_fd = bridge._sink_fd
-        bridge._sink_fd = int(str(fd)) if fd is not None else None
-        if fd == 1000:
-            assert bridge._sink_fd is not fd
-            raise asyncio.CancelledError
-        if old_fd is not None:
-            os.close(old_fd)
-
-    with (
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
-        patch(
-            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
-            new_callable=AsyncMock,
-            return_value=1000,
-        ),
-        patch.object(
-            bridge,
-            "_set_sink_fd",
-            new_callable=AsyncMock,
-            side_effect=publish_then_cancel,
-        ),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=100),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as close_fd,
-        pytest.raises(asyncio.CancelledError),
-    ):
-        await bridge._start_warm_generation(kept_stream, 1_784_000_000_000)
-
-    assert bridge._sink_fd is None
-    assert sum(call.args == (1000,) for call in close_fd.call_args_list) == 1
-    kept_stream.discard_generation.assert_awaited_once_with(1)
-
-
-async def test_warm_generation_exception_before_sink_publication_closes_fd() -> None:
-    """A failed sink publication closes its locally owned writer fd once."""
-    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    kept_stream = MagicMock()
-    kept_stream.next_generation = MagicMock(return_value=1)
-    kept_stream.prepare_generation = AsyncMock()
-    kept_stream.wait_generation_ready = AsyncMock(return_value=True)
-    kept_stream.discard_generation = AsyncMock()
-    bridge._airplay_stream_start_task = asyncio.current_task()
-
-    with (
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
-        patch(
-            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
-            new_callable=AsyncMock,
-            return_value=55,
-        ),
-        patch.object(
-            bridge,
-            "_set_sink_fd",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("swap failed"),
-        ),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=100),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as close_fd,
-    ):
-        assert await bridge._start_warm_generation(kept_stream, 1_784_000_000_000) is False
-
-    assert sum(call.args == (55,) for call in close_fd.call_args_list) == 1
-    kept_stream.discard_generation.assert_awaited_once_with(1)
-    assert bridge._sink_fd is None
-
-
-async def test_warm_generation_exception_after_sink_publication_releases_fd() -> None:
-    """A failed published sink swap releases its owner-managed writer fd once."""
-    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    kept_stream = MagicMock()
-    kept_stream.next_generation = MagicMock(return_value=1)
-    kept_stream.prepare_generation = AsyncMock()
-    kept_stream.wait_generation_ready = AsyncMock(return_value=True)
-    kept_stream.discard_generation = AsyncMock()
-    bridge._airplay_stream_start_task = asyncio.current_task()
-
-    async def publish_then_fail(fd: int | None) -> None:
-        old_fd = bridge._sink_fd
-        bridge._sink_fd = int(str(fd)) if fd is not None else None
-        if fd == 1000:
-            assert bridge._sink_fd is not fd
-            raise RuntimeError("swap failed")
-        if old_fd is not None:
-            os.close(old_fd)
-
-    with (
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.unlink"),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.mkfifo"),
-        patch(
-            "music_assistant.providers.airplay.sendspin_bridge.open_named_pipe_writer",
-            new_callable=AsyncMock,
-            return_value=1000,
-        ),
-        patch.object(
-            bridge,
-            "_set_sink_fd",
-            new_callable=AsyncMock,
-            side_effect=publish_then_fail,
-        ),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.open", return_value=100),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as close_fd,
-    ):
-        assert await bridge._start_warm_generation(kept_stream, 1_784_000_000_000) is False
-
-    assert bridge._sink_fd is None
-    assert sum(call.args == (1000,) for call in close_fd.call_args_list) == 1
-    kept_stream.discard_generation.assert_awaited_once_with(1)
-
-
-async def test_release_sink_fd_propagates_cancellation_after_clearing_owner() -> None:
-    """Sink cleanup closes its fd and propagates cancellation."""
-    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    bridge._sink_fd = 1000
-
-    async def clear_then_cancel(fd: int | None) -> None:
-        bridge._sink_fd = fd
-        raise asyncio.CancelledError
-
-    with (
-        patch.object(
-            bridge,
-            "_set_sink_fd",
-            new_callable=AsyncMock,
-            side_effect=clear_then_cancel,
-        ),
-        patch("music_assistant.providers.airplay.sendspin_bridge.os.close") as close_fd,
-        pytest.raises(asyncio.CancelledError),
-    ):
-        await bridge._release_sink_fd(1000)
-
-    close_fd.assert_called_once_with(1000)
-    assert bridge._sink_fd is None
+    kept_stream.start.assert_not_awaited()

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from music_assistant_models.enums import ContentType, PlaybackState
+from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.helpers.named_pipe import AsyncNamedPipeWriter, open_named_pipe_writer
@@ -659,6 +660,20 @@ async def test_flush_returns_false_when_command_not_delivered() -> None:
 
     with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=False):
         assert await stream.flush() is False
+
+
+@pytest.mark.asyncio
+async def test_start_raises_when_command_not_delivered() -> None:
+    """A dropped START surfaces as an error so the caller can fall back cold."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+
+    with (
+        patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=False),
+        pytest.raises(PlayerCommandFailed, match="Could not deliver START"),
+    ):
+        await stream.start(1_750_000_000_000, 0)
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -12,7 +12,6 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from music_assistant_models.enums import ContentType, PlaybackState
-from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.helpers.named_pipe import AsyncNamedPipeWriter, open_named_pipe_writer
@@ -506,7 +505,7 @@ async def test_cli_command_preserves_timestamp_when_delivery_raises() -> None:
 
 
 @pytest.mark.asyncio
-async def test_start_queues_text_metadata_before_connection() -> None:
+async def test_connect_queues_text_metadata_before_connection() -> None:
     """Text metadata is queued as soon as cliairplay starts."""
     player = _make_player()
     stream = AirPlayStream(player)
@@ -542,14 +541,14 @@ async def test_start_queues_text_metadata_before_connection() -> None:
         patch.object(stream.commands_pipe, "create", side_effect=create_pipe),
         patch.object(stream, "send_metadata", side_effect=send_metadata) as send_metadata_mock,
     ):
-        await stream.start()
+        await stream.connect()
 
     assert operation_order == ["pipe", "process", "metadata"]
     send_metadata_mock.assert_awaited_once_with(12, metadata, send_artwork=False)
 
 
 @pytest.mark.asyncio
-async def test_start_failure_cleans_up_process_and_pipe() -> None:
+async def test_connect_failure_cleans_up_process_and_pipe() -> None:
     """A metadata write failure cannot leave a live cliairplay process or FIFO."""
     player = _make_player()
     stream = AirPlayStream(player)
@@ -582,7 +581,7 @@ async def test_start_failure_cleans_up_process_and_pipe() -> None:
         ),
         pytest.raises(OSError, match="metadata write failed"),
     ):
-        await stream.start()
+        await stream.connect()
 
     process.kill.assert_awaited_once()
     remove_pipe.assert_awaited_once()
@@ -591,86 +590,88 @@ async def test_start_failure_cleans_up_process_and_pipe() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generation_zero_uses_prepare_and_start_commands() -> None:
-    """The first generation is prepared, primed, and started over the command pipe."""
-    stream = AirPlayStream(_make_player())
+async def test_start_sends_command_and_stamps_position() -> None:
+    """START is delivered over the command pipe and stamps the media position."""
+    player = _make_player()
+    stream = AirPlayStream(player)
     stream._cli_proc = MagicMock(closed=False)
     stream._connected.set()
 
     with patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command:
-        await stream.prepare_generation(0, "-", 12_000)
-        assert stream._handle_status_line("[STATUS] ready generation=0") is False
-        assert await stream.wait_generation_ready(0)
-        assert stream._handle_status_line("[STATUS] primed generation=0") is False
-        assert await stream.wait_generation_primed(0)
-        await stream.start_generation(0, 12_000, START_UNIX_MS)
+        await stream.start(START_UNIX_MS, 12_000)
 
-    assert [call.args[0] for call in write_command.await_args_list] == [
-        "GENERATION=0\nAUDIO=-\nPOSITION_MS=12000\nACTION=PREPARE",
-        f"GENERATION=0\nSTART_UNIX_MS={START_UNIX_MS}\nACTION=START",
-    ]
+    write_command.assert_awaited_once_with(f"START_UNIX_MS={START_UNIX_MS}\nACTION=START")
+    assert stream._start_position == 12.0
+    player.set_state_from_stream.assert_called_once_with(elapsed_time=12.0, stream=stream)
 
 
 @pytest.mark.asyncio
-async def test_repeated_prepare_failures_do_not_grow_generation_events() -> None:
-    """Dropped and failed PREPARE writes always remove their generation events."""
+async def test_start_requires_connected_process() -> None:
+    """START is rejected without a connected cliairplay process."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    # not connected: _connected event never set
+
+    with (
+        patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command,
+        pytest.raises(RuntimeError, match="without a connected cliairplay process"),
+    ):
+        await stream.start(START_UNIX_MS, 0)
+
+    write_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_flush_sends_command_and_awaits_ack() -> None:
+    """FLUSH is delivered and resolves once the binary reports it flushed."""
     stream = AirPlayStream(_make_player())
     stream._cli_proc = MagicMock(closed=False)
     stream._connected.set()
 
     with patch.object(
-        stream,
-        "_write_cli_command",
-        new_callable=AsyncMock,
-        side_effect=[False, OSError("write failed"), False],
-    ):
-        for generation in range(1, 4):
-            with pytest.raises((PlayerCommandFailed, OSError)):
-                await stream.prepare_generation(
-                    generation,
-                    "/tmp/generation.pcm",  # noqa: S108
-                    0,
-                )
-            assert stream._gen_ready == {}
-            assert stream._gen_primed == {}
-
-
-@pytest.mark.asyncio
-async def test_wait_generation_ready_times_out() -> None:
-    """A generation without a ready status fails its bounded readiness wait."""
-    stream = AirPlayStream(_make_player())
-    stream.next_generation()
-
-    assert await stream.wait_generation_ready(1, timeout=0) is False
-
-
-@pytest.mark.asyncio
-async def test_discard_generation_propagates_flush_delivery() -> None:
-    """A staged discard sends targeted FLUSH and surfaces dropped delivery."""
-    stream = AirPlayStream(_make_player())
-    stream.next_generation()
-
-    with patch.object(
-        stream,
-        "_write_cli_command",
-        new_callable=AsyncMock,
-        side_effect=[True, False, OSError("write failed")],
+        stream, "_write_cli_command", new_callable=AsyncMock, return_value=True
     ) as write_command:
-        await stream.discard_generation(1)
-        stream.next_generation()
-        with pytest.raises(PlayerCommandFailed, match="Could not deliver FLUSH"):
-            await stream.discard_generation(2)
-        stream.next_generation()
-        with pytest.raises(OSError, match="write failed"):
-            await stream.discard_generation(3)
+        flush_task = asyncio.create_task(stream.flush())
+        await asyncio.sleep(0)
+        assert stream._handle_status_line("[STATUS] flushed") is False
+        assert await flush_task is True
 
-    assert write_command.await_args_list == [
-        call("GENERATION=1\nACTION=FLUSH"),
-        call("GENERATION=2\nACTION=FLUSH"),
-        call("GENERATION=3\nACTION=FLUSH"),
-    ]
-    assert stream._gen_ready == {}
-    assert stream._gen_primed == {}
+    write_command.assert_awaited_once_with("ACTION=FLUSH")
+
+
+@pytest.mark.asyncio
+async def test_flush_times_out_without_ack() -> None:
+    """FLUSH returns False when the binary never acknowledges it."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+
+    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True):
+        assert await stream.flush(timeout=0) is False
+
+
+@pytest.mark.asyncio
+async def test_flush_returns_false_when_command_not_delivered() -> None:
+    """FLUSH reports failure when the command cannot be delivered."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+
+    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=False):
+        assert await stream.flush() is False
+
+
+@pytest.mark.asyncio
+async def test_flush_returns_false_when_not_connected() -> None:
+    """FLUSH is a no-op returning False before the device connects."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    # not connected
+
+    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command:
+        assert await stream.flush() is False
+
+    write_command.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -726,45 +727,21 @@ async def test_named_pipe_writer_open_restores_blocking_mode() -> None:
     set_blocking.assert_called_once_with(42, True)
 
 
-@pytest.mark.asyncio
-async def test_generation_cannot_start_before_primed() -> None:
-    """A START command is rejected until that generation has reported primed."""
+def test_flushed_status_sets_flush_event() -> None:
+    """The [STATUS] flushed line releases the flush acknowledgement event."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
-    stream._connected.set()
+    assert not stream._flushed.is_set()
 
-    with (
-        patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command,
-        pytest.raises(RuntimeError, match="before it is primed"),
-    ):
-        await stream.start_generation(0, 0, START_UNIX_MS)
+    assert stream._handle_status_line("[STATUS] flushed") is False
 
-    write_command.assert_not_awaited()
+    assert stream._flushed.is_set()
 
 
-@pytest.mark.asyncio
-async def test_generation_cannot_start_after_process_exit() -> None:
-    """A primed generation is not started after its CLI process exits."""
-    stream = AirPlayStream(_make_player())
-    process = MagicMock(closed=False)
-    stream._cli_proc = process
-    stream._connected.set()
-
-    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command:
-        await stream.prepare_generation(0, "-", 0)
-        stream._handle_status_line("[STATUS] primed generation=0")
-        process.closed = True
-        with pytest.raises(RuntimeError, match="without a connected cliairplay process"):
-            await stream.start_generation(0, 0, START_UNIX_MS)
-
-    write_command.assert_awaited_once_with("GENERATION=0\nAUDIO=-\nPOSITION_MS=0\nACTION=PREPARE")
-
-
-def test_generation_zero_elapsed_includes_position_once() -> None:
-    """Generation-0 progress is based on its media position without session offset."""
+def test_elapsed_includes_start_position() -> None:
+    """Reported progress is the current anchor's media base plus the binary delta."""
     player = _make_player()
     stream = AirPlayStream(player)
-    stream._generation_position = 12.0
+    stream._start_position = 12.0
 
     stream._update_elapsed(1.5)
 

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -39,6 +39,7 @@ def _make_session(
     leader.stream = MagicMock()
     leader.stream.running = True
     leader.stream.connected = True
+    leader.stream.wait_audio_present = AsyncMock(return_value=True)
     leader.config.get_value = MagicMock(return_value=0)
 
     session = AirPlayStreamSession(prov, [leader], pcm_format, MagicMock(elapsed_time=0))
@@ -70,6 +71,7 @@ def _setup_stream(player: MagicMock) -> Any:
         player.stream.running = True
         player.stream.connected = True
         player.stream.wait_for_connection = AsyncMock()
+        player.stream.wait_audio_present = AsyncMock(return_value=True)
         player.stream.flush = AsyncMock(return_value=True)
         player.stream.start = AsyncMock()
 
@@ -162,6 +164,7 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
             operations.append(f"started:{player.player_id}:{start_unix_ms}")
 
         stream.wait_for_connection = AsyncMock(side_effect=wait_for_connection)
+        stream.wait_audio_present = AsyncMock(return_value=True)
         stream.start = AsyncMock(side_effect=start)
         player.stream = stream
 
@@ -176,9 +179,9 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
     last_connected = max(i for i, op in enumerate(operations) if op.startswith("connected:"))
     first_start = min(i for i, op in enumerate(operations) if op.startswith("started:"))
     assert last_connected < first_start
-    # start = now (100_000 ms) + max member setup lead (2500 ms), one shared instant
+    # start = now (100_000 ms) + the group start lead (750 ms), one shared instant
     starts = {int(op.rsplit(":", 1)[1]) for op in operations if op.startswith("started:")}
-    assert starts == {102_500}
+    assert starts == {100_750}
 
 
 @pytest.mark.asyncio
@@ -198,6 +201,7 @@ async def test_initial_single_player_starts_after_connect(
     player.config.get_value = MagicMock(return_value=0)
     stream = MagicMock(running=True)
     stream.wait_for_connection = AsyncMock()
+    stream.wait_audio_present = AsyncMock(return_value=True)
     stream.flush = AsyncMock(return_value=True)
     stream.start = AsyncMock()
 
@@ -212,8 +216,8 @@ async def test_initial_single_player_starts_after_connect(
     ):
         await session.start(MagicMock())
 
-    # start = now (200_000 ms) + the player's setup lead (2500 ms), position 0
-    stream.start.assert_awaited_once_with(202_500, 0)
+    # start = now (200_000 ms) + the solo start lead (500 ms), position 0
+    stream.start.assert_awaited_once_with(200_500, 0)
 
 
 @pytest.mark.asyncio
@@ -363,6 +367,7 @@ async def test_standby_resumes_warm_on_existing_streams(
         player.config.get_value = MagicMock(return_value=0)
         player.stream = MagicMock(running=True, connected=True)
         player.stream.send_cli_command = AsyncMock(return_value=True)
+        player.stream.wait_audio_present = AsyncMock(return_value=True)
         player.stream.flush = AsyncMock(return_value=True)
         player.stream.start = AsyncMock()
         players.append(player)
@@ -379,12 +384,13 @@ async def test_standby_resumes_warm_on_existing_streams(
     ):
         assert await session.replace(MagicMock(), media)
 
+    # start = now (100_000 ms) + solo/group start lead, position 10s
+    expected_start = 100_000 + (500 if len(protocols) == 1 else 750)
     for player in players:
         stream = original_streams[player.player_id]
         assert player.stream is stream
         stream.flush.assert_awaited_once_with()
-        # start = now (100_000 ms) + session lead (wait_start 2.0s), position 10s
-        stream.start.assert_awaited_once_with(102_000, 10_000)
+        stream.start.assert_awaited_once_with(expected_start, 10_000)
 
 
 @pytest.mark.asyncio
@@ -407,6 +413,7 @@ async def test_warm_replace_flushes_all_before_starting_any() -> None:
             return True
 
         stream.flush = AsyncMock(side_effect=flush)
+        stream.wait_audio_present = AsyncMock(return_value=True)
         stream.start = AsyncMock()
         player.stream = stream
         players.append(player)
@@ -427,8 +434,8 @@ async def test_warm_replace_flushes_all_before_starting_any() -> None:
 
     for player in players:
         player.stream.flush.assert_awaited_once_with()
-        # start = now (100_000 ms) + session lead (wait_start 2.0s), position 0
-        player.stream.start.assert_awaited_once_with(102_000, 0)
+        # start = now (100_000 ms) + the group start lead (750 ms), position 0
+        player.stream.start.assert_awaited_once_with(100_750, 0)
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -1,7 +1,6 @@
 """Unit tests for AirPlay stream session late-join logic."""
 
 import asyncio
-import errno
 import time
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -69,19 +68,17 @@ def _setup_stream(player: MagicMock) -> Any:
     def _side_effect(*_args: Any, **_kwargs: Any) -> None:
         player.stream = MagicMock()
         player.stream.running = True
+        player.stream.connected = True
         player.stream.wait_for_connection = AsyncMock()
-        player.stream.prepare_generation = AsyncMock()
-        player.stream.wait_generation_ready = AsyncMock(return_value=True)
-        player.stream.discard_generation = AsyncMock()
-        player.stream.wait_generation_primed = AsyncMock(return_value=True)
-        player.stream.start_generation = AsyncMock()
+        player.stream.flush = AsyncMock(return_value=True)
+        player.stream.start = AsyncMock()
 
     return _side_effect
 
 
 def _captured_start_at(player: MagicMock) -> float:
-    """Return the start time passed to the player's generation-0 START."""
-    start_unix_ms = player.stream.start_generation.call_args[0][2]
+    """Return the start time passed to the player's START command."""
+    start_unix_ms = player.stream.start.call_args[0][0]
     assert isinstance(start_unix_ms, int)
     return start_unix_ms / 1000
 
@@ -140,7 +137,7 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
     first_protocol: StreamingProtocol,
     second_protocol: StreamingProtocol,
 ) -> None:
-    """Generation 0 starts at one instant only after every member connects and primes."""
+    """Every member connects before one shared START anchors the group."""
     session = _make_session(0, 0)
     first_player: Any = session.sync_clients[0]
     first_player.player_id = "first"
@@ -160,26 +157,12 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
         async def wait_for_connection() -> None:
             operations.append(f"connected:{player.player_id}")
 
-        async def prepare_generation(generation: int, audio_path: str, position_ms: int) -> None:
-            assert (generation, audio_path, position_ms) == (0, "-", 12_000)
-            operations.append(f"prepared:{player.player_id}")
-
-        async def wait_generation_ready(_generation: int) -> bool:
-            operations.append(f"ready:{player.player_id}")
-            return True
-
-        async def wait_generation_primed(_generation: int) -> bool:
-            operations.append(f"primed:{player.player_id}")
-            return True
-
-        async def start_generation(_generation: int, _position_ms: int, start_unix_ms: int) -> None:
+        async def start(start_unix_ms: int, position_ms: int) -> None:
+            assert position_ms == 12_000
             operations.append(f"started:{player.player_id}:{start_unix_ms}")
 
         stream.wait_for_connection = AsyncMock(side_effect=wait_for_connection)
-        stream.prepare_generation = AsyncMock(side_effect=prepare_generation)
-        stream.wait_generation_ready = AsyncMock(side_effect=wait_generation_ready)
-        stream.wait_generation_primed = AsyncMock(side_effect=wait_generation_primed)
-        stream.start_generation = AsyncMock(side_effect=start_generation)
+        stream.start = AsyncMock(side_effect=start)
         player.stream = stream
 
     with (
@@ -190,17 +173,12 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
     ):
         await session.start(MagicMock())
 
-    first_prepare = min(i for i, op in enumerate(operations) if op.startswith("prepared:"))
     last_connected = max(i for i, op in enumerate(operations) if op.startswith("connected:"))
-    first_primed = min(i for i, op in enumerate(operations) if op.startswith("primed:"))
-    last_ready = max(i for i, op in enumerate(operations) if op.startswith("ready:"))
     first_start = min(i for i, op in enumerate(operations) if op.startswith("started:"))
-    last_primed = max(i for i, op in enumerate(operations) if op.startswith("primed:"))
-    assert last_connected < first_prepare
-    assert last_ready < first_primed
-    assert last_primed < first_start
+    assert last_connected < first_start
+    # start = now (100_000 ms) + max member setup lead (2500 ms), one shared instant
     starts = {int(op.rsplit(":", 1)[1]) for op in operations if op.startswith("started:")}
-    assert starts == {100_750}
+    assert starts == {102_500}
 
 
 @pytest.mark.asyncio
@@ -208,10 +186,10 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
     "protocol",
     [StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2],
 )
-async def test_initial_single_player_uses_commanded_generation_zero(
+async def test_initial_single_player_starts_after_connect(
     protocol: StreamingProtocol,
 ) -> None:
-    """A standalone player follows the same generation-0 flow with the solo lead."""
+    """A standalone player is anchored with a single START once connected."""
     session = _make_session(0, 0)
     player: Any = session.sync_clients[0]
     player.player_id = "solo"
@@ -220,10 +198,8 @@ async def test_initial_single_player_uses_commanded_generation_zero(
     player.config.get_value = MagicMock(return_value=0)
     stream = MagicMock(running=True)
     stream.wait_for_connection = AsyncMock()
-    stream.prepare_generation = AsyncMock()
-    stream.wait_generation_ready = AsyncMock(return_value=True)
-    stream.wait_generation_primed = AsyncMock(return_value=True)
-    stream.start_generation = AsyncMock()
+    stream.flush = AsyncMock(return_value=True)
+    stream.start = AsyncMock()
 
     async def start_client(_player: MagicMock, _use_shared_ptp: bool) -> None:
         player.stream = stream
@@ -236,14 +212,13 @@ async def test_initial_single_player_uses_commanded_generation_zero(
     ):
         await session.start(MagicMock())
 
-    stream.prepare_generation.assert_awaited_once_with(0, "-", 0)
-    stream.wait_generation_primed.assert_awaited_once_with(0)
-    stream.start_generation.assert_awaited_once_with(0, 0, 200_400)
+    # start = now (200_000 ms) + the player's setup lead (2500 ms), position 0
+    stream.start.assert_awaited_once_with(202_500, 0)
 
 
 @pytest.mark.asyncio
-async def test_initial_prime_timeout_never_starts_partial_group() -> None:
-    """If any member fails to prime, no member receives START and the group is stopped."""
+async def test_initial_connection_failure_never_starts_partial_group() -> None:
+    """If any member fails to connect, no member receives START and the group is stopped."""
     session = _make_session(0, 0)
     first_player: Any = session.sync_clients[0]
     first_player.protocol = StreamingProtocol.RAOP
@@ -254,12 +229,11 @@ async def test_initial_prime_timeout_never_starts_partial_group() -> None:
 
     async def start_client(player: MagicMock, _use_shared_ptp: bool) -> None:
         stream = MagicMock(running=True)
-        stream.wait_for_connection = AsyncMock()
-        stream.prepare_generation = AsyncMock()
-        stream.wait_generation_ready = AsyncMock(return_value=True)
-        stream.discard_generation = AsyncMock()
-        stream.wait_generation_primed = AsyncMock(return_value=player is not second_player)
-        stream.start_generation = AsyncMock()
+        if player is second_player:
+            stream.wait_for_connection = AsyncMock(side_effect=TimeoutError("connect timeout"))
+        else:
+            stream.wait_for_connection = AsyncMock()
+        stream.start = AsyncMock()
         player.stream = stream
 
     with (
@@ -272,14 +246,13 @@ async def test_initial_prime_timeout_never_starts_partial_group() -> None:
 
     for player in session.sync_clients:
         stream: Any = player.stream
-        stream.discard_generation.assert_awaited_once_with(0)
-        stream.start_generation.assert_not_awaited()
+        stream.start.assert_not_awaited()
     stop_session.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_initial_connection_cancellation_never_prepares_group() -> None:
-    """Cancellation while connecting cleans up without preparing or starting."""
+async def test_initial_connection_cancellation_never_starts_group() -> None:
+    """Cancellation while connecting cleans up without anchoring playback."""
     session = _make_session(0, 0)
     player: Any = session.sync_clients[0]
     player.player_id = "solo"
@@ -293,8 +266,7 @@ async def test_initial_connection_cancellation_never_prepares_group() -> None:
         await asyncio.Event().wait()
 
     stream.wait_for_connection = AsyncMock(side_effect=wait_for_connection)
-    stream.prepare_generation = AsyncMock()
-    stream.start_generation = AsyncMock()
+    stream.start = AsyncMock()
 
     async def start_client(_player: MagicMock, _use_shared_ptp: bool) -> None:
         player.stream = stream
@@ -309,8 +281,7 @@ async def test_initial_connection_cancellation_never_prepares_group() -> None:
         with pytest.raises(asyncio.CancelledError):
             await start_task
 
-    stream.prepare_generation.assert_not_awaited()
-    stream.start_generation.assert_not_awaited()
+    stream.start.assert_not_awaited()
     stop_session.assert_awaited_once()
 
 
@@ -371,18 +342,17 @@ async def test_standby_supports_every_connected_streaming_protocol(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("protocols", "start_lead_ms"),
+    "protocols",
     [
-        ((StreamingProtocol.RAOP,), 400),
-        ((StreamingProtocol.AIRPLAY2,), 400),
-        ((StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2), 750),
+        (StreamingProtocol.RAOP,),
+        (StreamingProtocol.AIRPLAY2,),
+        (StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2),
     ],
 )
-async def test_standby_resumes_next_generation_on_existing_streams(
+async def test_standby_resumes_warm_on_existing_streams(
     protocols: tuple[StreamingProtocol, ...],
-    start_lead_ms: int,
 ) -> None:
-    """RAOP, AirPlay 2 and mixed sessions resume warm on their parked streams."""
+    """RAOP, AirPlay 2 and mixed sessions resume warm via flush-refill on parked streams."""
     session = _make_session(0, 0)
     players: Any = []
     original_streams: dict[str, MagicMock] = {}
@@ -393,11 +363,8 @@ async def test_standby_resumes_next_generation_on_existing_streams(
         player.config.get_value = MagicMock(return_value=0)
         player.stream = MagicMock(running=True, connected=True)
         player.stream.send_cli_command = AsyncMock(return_value=True)
-        player.stream.next_generation = MagicMock(return_value=1)
-        player.stream.prepare_generation = AsyncMock()
-        player.stream.wait_generation_ready = AsyncMock(return_value=True)
-        player.stream.wait_generation_primed = AsyncMock(return_value=True)
-        player.stream.start_generation = AsyncMock()
+        player.stream.flush = AsyncMock(return_value=True)
+        player.stream.start = AsyncMock()
         players.append(player)
         original_streams[player.player_id] = player.stream
     session.sync_clients = players
@@ -406,393 +373,204 @@ async def test_standby_resumes_next_generation_on_existing_streams(
     assert session.can_replace(players, session.pcm_format)
     media = MagicMock(elapsed_time=10)
     with (
-        patch.object(session, "_start_generation_ffmpeg", new_callable=AsyncMock),
+        patch.object(session, "_start_player_ffmpeg", new_callable=AsyncMock),
         patch.object(session, "_audio_streamer", new_callable=AsyncMock),
         patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0),
-        patch("music_assistant.providers.airplay.stream_session.os.unlink"),
-        patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
-        patch(
-            "music_assistant.providers.airplay.stream_session.open_named_pipe_writer",
-            new_callable=AsyncMock,
-            return_value=99,
-        ),
-        patch("music_assistant.providers.airplay.stream_session.os.open", return_value=100),
-        patch("music_assistant.providers.airplay.stream_session.os.close"),
     ):
         assert await session.replace(MagicMock(), media)
 
     for player in players:
         stream = original_streams[player.player_id]
         assert player.stream is stream
-        stream.prepare_generation.assert_awaited_once_with(
-            1,
-            f"/tmp/ma-gen-{player.player_id}-1.pcm",  # noqa: S108
-            10_000,
-        )
-        stream.wait_generation_ready.assert_awaited_once_with(1)
-        stream.wait_generation_primed.assert_awaited_once_with(1)
-        stream.start_generation.assert_awaited_once_with(1, 10_000, 100_000 + start_lead_ms)
+        stream.flush.assert_awaited_once_with()
+        # start = now (100_000 ms) + session lead (wait_start 2.0s), position 10s
+        stream.start.assert_awaited_once_with(102_000, 10_000)
 
 
 @pytest.mark.asyncio
-async def test_warm_replace_waits_for_every_reader_before_old_teardown() -> None:
-    """Old audio remains active until every staged member reports its reader ready."""
+async def test_warm_replace_flushes_all_before_starting_any() -> None:
+    """A group flushes every member and awaits all acks before any shared START."""
     session = _make_session(0, 0)
-    operations: list[str] = []
     players: list[Any] = []
     release_delayed = asyncio.Event()
     delayed_waiting = asyncio.Event()
 
     for player_id in ("first", "delayed"):
         player = MagicMock(player_id=player_id, protocol=StreamingProtocol.AIRPLAY2)
+        player.config.get_value = MagicMock(return_value=0)
         stream = MagicMock(running=True, connected=True)
-        stream.next_generation = MagicMock(return_value=1)
-        stream.prepare_generation = AsyncMock()
 
-        async def wait_ready(_generation: int, *, current_id: str = player_id) -> bool:
-            operations.append(f"ready-wait:{current_id}")
+        async def flush(*, current_id: str = player_id) -> bool:
             if current_id == "delayed":
                 delayed_waiting.set()
                 await release_delayed.wait()
-            operations.append(f"ready:{current_id}")
             return True
 
-        stream.wait_generation_ready = AsyncMock(side_effect=wait_ready)
-        stream.wait_generation_primed = AsyncMock(return_value=True)
-        stream.start_generation = AsyncMock()
+        stream.flush = AsyncMock(side_effect=flush)
+        stream.start = AsyncMock()
         player.stream = stream
-        player.config.get_value = MagicMock(return_value=0)
         players.append(player)
     session.sync_clients = players
 
-    async def old_audio() -> None:
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            operations.append("old-audio-cancelled")
-            raise
-
-    session._audio_source_task = asyncio.create_task(old_audio())
-
-    async def open_writer(_fifo: str) -> int:
-        operations.append("writer-open")
-        return 99
-
-    async def start_ffmpeg(_player: Any, _fifo_fd: int, _media: Any) -> None:
-        operations.append("ffmpeg-switched")
-
     with (
-        patch.object(session, "_start_generation_ffmpeg", side_effect=start_ffmpeg),
+        patch.object(session, "_start_player_ffmpeg", new_callable=AsyncMock),
         patch.object(session, "_audio_streamer", new_callable=AsyncMock),
-        patch(
-            "music_assistant.providers.airplay.stream_session.open_named_pipe_writer",
-            side_effect=open_writer,
-        ),
-        patch("music_assistant.providers.airplay.stream_session.os.unlink"),
-        patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
-        patch("music_assistant.providers.airplay.stream_session.os.open", return_value=100),
-        patch("music_assistant.providers.airplay.stream_session.os.close"),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0),
     ):
         replace_task = asyncio.create_task(session.replace(MagicMock(), MagicMock(elapsed_time=0)))
         await delayed_waiting.wait()
-        assert "old-audio-cancelled" not in operations
-        assert "ffmpeg-switched" not in operations
+        # one member's flush is still pending: no member may have been started yet
+        for player in players:
+            player.stream.start.assert_not_awaited()
         release_delayed.set()
         assert await replace_task
 
-    last_ready = max(i for i, operation in enumerate(operations) if operation.startswith("ready:"))
-    assert last_ready < operations.index("old-audio-cancelled")
-    assert last_ready < operations.index("ffmpeg-switched")
+    for player in players:
+        player.stream.flush.assert_awaited_once_with()
+        # start = now (100_000 ms) + session lead (wait_start 2.0s), position 0
+        player.stream.start.assert_awaited_once_with(102_000, 0)
 
 
 @pytest.mark.asyncio
-async def test_warm_replace_cancellation_discards_before_old_teardown() -> None:
-    """Cancellation while awaiting ready FLUSHes staging without touching old audio."""
-    session = _make_session(0, 0)
-    player: Any = session.sync_clients[0]
-    stream = player.stream
-    ready_waiting = asyncio.Event()
-    old_audio_cancelled = asyncio.Event()
-    stream.next_generation = MagicMock(return_value=1)
-    stream.prepare_generation = AsyncMock()
-
-    async def wait_ready(_generation: int) -> bool:
-        ready_waiting.set()
-        await asyncio.Event().wait()
-        return True
-
-    stream.wait_generation_ready = AsyncMock(side_effect=wait_ready)
-    stream.discard_generation = AsyncMock()
-
-    async def old_audio() -> None:
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            old_audio_cancelled.set()
-            raise
-
-    session._audio_source_task = asyncio.create_task(old_audio())
-    with (
-        patch(
-            "music_assistant.providers.airplay.stream_session.open_named_pipe_writer",
-            new_callable=AsyncMock,
-        ) as open_writer,
-        patch("music_assistant.providers.airplay.stream_session.os.unlink"),
-        patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
-        patch(
-            "music_assistant.providers.airplay.stream_session.os.open",
-            side_effect=OSError(errno.ENXIO, "no reader"),
-        ),
-    ):
-        replace_task = asyncio.create_task(session.replace(MagicMock(), MagicMock(elapsed_time=0)))
-        await ready_waiting.wait()
-        replace_task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await replace_task
-
-    stream.discard_generation.assert_awaited_once_with(1)
-    open_writer.assert_not_awaited()
-    assert not old_audio_cancelled.is_set()
-    session._audio_source_task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await session._audio_source_task
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("failure_phase", ["prepare", "ready"])
-async def test_warm_replace_pre_ready_failure_preserves_old_resources(
-    failure_phase: str,
-) -> None:
-    """Dropped PREPARE and reader timeout leave the active source and ffmpeg untouched."""
-    session = _make_session(0, 0)
-    players: list[Any] = []
-    old_ffmpegs: list[MagicMock] = []
-    old_audio_cancelled = asyncio.Event()
-
-    for player_id in ("working", "failed"):
-        player = MagicMock(player_id=player_id, protocol=StreamingProtocol.RAOP)
-        stream = MagicMock(running=True, connected=True)
-        stream.next_generation = MagicMock(return_value=1)
-        if failure_phase == "prepare" and player_id == "failed":
-            stream.prepare_generation = AsyncMock(
-                side_effect=PlayerCommandFailed("PREPARE was not delivered")
-            )
-        else:
-            stream.prepare_generation = AsyncMock()
-        stream.wait_generation_ready = AsyncMock(
-            return_value=not (failure_phase == "ready" and player_id == "failed")
-        )
-        stream.discard_generation = AsyncMock()
-        stream.wait_generation_primed = AsyncMock(return_value=True)
-        stream.start_generation = AsyncMock()
-        player.stream = stream
-        players.append(player)
-        ffmpeg = MagicMock(closed=False)
-        ffmpeg.kill = AsyncMock()
-        session._player_ffmpeg[player_id] = ffmpeg
-        old_ffmpegs.append(ffmpeg)
-    session.sync_clients = players
-
-    async def old_audio() -> None:
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            old_audio_cancelled.set()
-            raise
-
-    session._audio_source_task = asyncio.create_task(old_audio())
-    with (
-        patch(
-            "music_assistant.providers.airplay.stream_session.open_named_pipe_writer",
-            new_callable=AsyncMock,
-        ) as open_writer,
-        patch("music_assistant.providers.airplay.stream_session.os.unlink"),
-        patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
-        patch(
-            "music_assistant.providers.airplay.stream_session.os.open",
-            side_effect=OSError(errno.ENXIO, "no reader"),
-        ),
-    ):
-        assert await session.replace(MagicMock(), MagicMock(elapsed_time=0)) is False
-
-    assert not old_audio_cancelled.is_set()
-    assert not session._audio_source_task.done()
-    open_writer.assert_not_awaited()
-    for player, ffmpeg in zip(players, old_ffmpegs, strict=True):
-        ffmpeg.kill.assert_not_awaited()
-        player.stream.discard_generation.assert_awaited_once_with(1)
-    session._audio_source_task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await session._audio_source_task
-
-
-@pytest.mark.asyncio
-async def test_warm_replace_discard_failure_does_not_mask_original_failure() -> None:
-    """Failed staged cleanup still returns control to the caller's cold fallback."""
-    session = _make_session(0, 0)
-    player: Any = session.sync_clients[0]
-    stream = player.stream
-    stream.next_generation = MagicMock(return_value=1)
-    stream.prepare_generation = AsyncMock()
-    stream.wait_generation_ready = AsyncMock(return_value=False)
-    stream.discard_generation = AsyncMock(side_effect=OSError("flush failed"))
-
-    with (
-        patch("music_assistant.providers.airplay.stream_session.os.unlink"),
-        patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
-        patch(
-            "music_assistant.providers.airplay.stream_session.os.open",
-            side_effect=OSError(errno.ENXIO, "no reader"),
-        ),
-        patch.object(session.prov.logger, "warning") as warning,
-    ):
-        assert await session.replace(MagicMock(), MagicMock(elapsed_time=0)) is False
-
-    stream.discard_generation.assert_awaited_once_with(1)
-    assert warning.call_count == 2
-
-
-@pytest.mark.asyncio
-async def test_partial_group_prepare_completes_before_discard() -> None:
-    """Every queued PREPARE completes before partial-group FLUSH cleanup starts."""
+async def test_warm_replace_stops_old_audio_and_ffmpeg_before_flush() -> None:
+    """The old audio feed and ffmpeg are torn down before any FLUSH is sent."""
     session = _make_session(0, 0)
     operations: list[str] = []
-    delayed_started = asyncio.Event()
-    release_delayed = asyncio.Event()
+    player: Any = session.sync_clients[0]
+    player.config.get_value = MagicMock(return_value=0)
+    stream = player.stream
+    stream.running = True
+    stream.connected = True
+
+    async def flush() -> bool:
+        operations.append("flush")
+        return True
+
+    stream.flush = AsyncMock(side_effect=flush)
+    stream.start = AsyncMock()
+    old_ffmpeg = MagicMock(closed=False)
+
+    async def kill_ffmpeg() -> None:
+        operations.append("ffmpeg-killed")
+
+    old_ffmpeg.kill = AsyncMock(side_effect=kill_ffmpeg)
+    session._player_ffmpeg[player.player_id] = old_ffmpeg
+
+    async def old_audio() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            operations.append("audio-cancelled")
+            raise
+
+    session._audio_source_task = asyncio.create_task(old_audio())
+    # let old_audio reach its await so the cancellation lands inside its try/except
+    await asyncio.sleep(0)
+
+    with (
+        patch.object(session, "_start_player_ffmpeg", new_callable=AsyncMock),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0),
+    ):
+        assert await session.replace(MagicMock(), MagicMock(elapsed_time=0))
+
+    assert operations.index("audio-cancelled") < operations.index("flush")
+    assert operations.index("ffmpeg-killed") < operations.index("flush")
+    old_ffmpeg.kill.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_warm_replace_flush_failure_falls_back_to_cold() -> None:
+    """A member that never acknowledges its flush makes the whole replace fall back."""
+    session = _make_session(0, 0)
     players: list[Any] = []
-
-    for player_id in ("delayed", "failed"):
-        player = MagicMock(player_id=player_id, protocol=StreamingProtocol.AIRPLAY2)
+    for player_id, acked in (("ok", True), ("failed", False)):
+        player = MagicMock(player_id=player_id, protocol=StreamingProtocol.RAOP)
+        player.config.get_value = MagicMock(return_value=0)
         stream = MagicMock(running=True, connected=True)
-        stream.next_generation = MagicMock(return_value=1)
-
-        async def prepare(
-            _generation: int,
-            _fifo: str,
-            _position_ms: int,
-            *,
-            current_id: str = player_id,
-        ) -> None:
-            if current_id == "delayed":
-                delayed_started.set()
-                await release_delayed.wait()
-                operations.append("prepare:delayed")
-                return
-            await delayed_started.wait()
-            operations.append("prepare:failed")
-            release_delayed.set()
-            raise PlayerCommandFailed("PREPARE was not delivered")
-
-        async def discard(_generation: int, *, current_id: str = player_id) -> None:
-            operations.append(f"discard:{current_id}")
-
-        stream.prepare_generation = AsyncMock(side_effect=prepare)
-        stream.discard_generation = AsyncMock(side_effect=discard)
+        stream.flush = AsyncMock(return_value=acked)
+        stream.start = AsyncMock()
         player.stream = stream
         players.append(player)
     session.sync_clients = players
 
     with (
-        patch("music_assistant.providers.airplay.stream_session.os.unlink"),
-        patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
-        patch(
-            "music_assistant.providers.airplay.stream_session.os.open",
-            side_effect=OSError(errno.ENXIO, "no reader"),
-        ),
-    ):
-        assert await session.replace(MagicMock(), MagicMock(elapsed_time=0)) is False
-
-    last_prepare = max(
-        index for index, operation in enumerate(operations) if operation.startswith("prepare:")
-    )
-    first_discard = min(
-        index for index, operation in enumerate(operations) if operation.startswith("discard:")
-    )
-    assert last_prepare < first_discard
-
-
-@pytest.mark.asyncio
-async def test_warm_replace_does_not_discard_after_start_is_attempted() -> None:
-    """A failed shared START cannot FLUSH a generation that may already be active."""
-    session = _make_session(0, 0)
-    player: Any = session.sync_clients[0]
-    stream = player.stream
-    stream.next_generation = MagicMock(return_value=1)
-    stream.prepare_generation = AsyncMock()
-    stream.wait_generation_ready = AsyncMock(return_value=True)
-    stream.wait_generation_primed = AsyncMock(return_value=True)
-    stream.discard_generation = AsyncMock()
-
-    with (
-        patch.object(session, "_start_generation_ffmpeg", new_callable=AsyncMock),
+        patch.object(session, "_start_player_ffmpeg", new_callable=AsyncMock) as start_ffmpeg,
         patch.object(session, "_audio_streamer", new_callable=AsyncMock),
-        patch.object(
-            session,
-            "_commit_generations",
-            new_callable=AsyncMock,
-            side_effect=OSError("start failed"),
-        ),
-        patch(
-            "music_assistant.providers.airplay.stream_session.open_named_pipe_writer",
-            new_callable=AsyncMock,
-            return_value=42,
-        ),
-        patch("music_assistant.providers.airplay.stream_session.os.unlink"),
-        patch("music_assistant.providers.airplay.stream_session.os.mkfifo"),
-        patch("music_assistant.providers.airplay.stream_session.os.open", return_value=43),
-        patch("music_assistant.providers.airplay.stream_session.os.close"),
     ):
         assert await session.replace(MagicMock(), MagicMock(elapsed_time=0)) is False
 
-    stream.discard_generation.assert_not_awaited()
+    # no member is started and no fresh ffmpeg is wired once a flush is unacknowledged
+    for player in players:
+        player.stream.start.assert_not_awaited()
+    start_ffmpeg.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_generation_writer_fd_closes_when_old_ffmpeg_kill_fails() -> None:
-    """The prepared writer fd closes if switching away from the old ffmpeg fails."""
+async def test_warm_replace_start_failure_falls_back_to_cold() -> None:
+    """A failed shared START after flush returns False so the caller restarts cold."""
     session = _make_session(0, 0)
     player: Any = session.sync_clients[0]
-    old_ffmpeg = MagicMock()
-    old_ffmpeg.kill = AsyncMock(side_effect=OSError("kill failed"))
-    session._player_ffmpeg[player.player_id] = old_ffmpeg
+    player.config.get_value = MagicMock(return_value=0)
+    stream = player.stream
+    stream.running = True
+    stream.connected = True
+    stream.flush = AsyncMock(return_value=True)
+    stream.start = AsyncMock(side_effect=OSError("start failed"))
 
     with (
-        patch("music_assistant.providers.airplay.stream_session.os.close") as close_fd,
-        patch("music_assistant.providers.airplay.stream_session.FFMpeg") as ffmpeg_factory,
-        pytest.raises(OSError, match="kill failed"),
+        patch.object(session, "_start_player_ffmpeg", new_callable=AsyncMock),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0),
     ):
-        await session._start_generation_ffmpeg(player, 42, MagicMock())
-
-    close_fd.assert_called_once_with(42)
-    ffmpeg_factory.assert_not_called()
-    assert session._player_ffmpeg[player.player_id] is old_ffmpeg
+        assert await session.replace(MagicMock(), MagicMock(elapsed_time=0)) is False
 
 
 @pytest.mark.asyncio
-async def test_generation_writer_kill_cancellation_keeps_old_ffmpeg_tracked() -> None:
-    """Cancellation during old ffmpeg kill retains it and closes the staged fd."""
+async def test_start_player_ffmpeg_wires_persistent_cli_stdin() -> None:
+    """The per-seek ffmpeg is wired to the member's persistent cli stdin fd and tracked."""
     session = _make_session(0, 0)
     player: Any = session.sync_clients[0]
     old_ffmpeg = MagicMock()
-    old_ffmpeg.kill = AsyncMock(side_effect=asyncio.CancelledError)
+    old_ffmpeg.close = AsyncMock()
     session._player_ffmpeg[player.player_id] = old_ffmpeg
 
-    with (
-        patch("music_assistant.providers.airplay.stream_session.os.close") as close_fd,
-        patch("music_assistant.providers.airplay.stream_session.FFMpeg") as ffmpeg_factory,
-        pytest.raises(asyncio.CancelledError),
-    ):
-        await session._start_generation_ffmpeg(player, 42, MagicMock())
+    stream = MagicMock()
+    stream.pcm_format = session.pcm_format
+    cli_proc = MagicMock()
+    cli_proc.proc.stdin.transport.get_extra_info.return_value.fileno.return_value = 77
+    stream._cli_proc = cli_proc
+    player.stream = stream
+    new_ffmpeg = MagicMock()
+    new_ffmpeg.start = AsyncMock()
 
-    close_fd.assert_called_once_with(42)
-    ffmpeg_factory.assert_not_called()
-    assert session._player_ffmpeg[player.player_id] is old_ffmpeg
+    with (
+        patch(
+            "music_assistant.providers.airplay.stream_session.get_final_output_format",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "music_assistant.providers.airplay.stream_session.get_media_session_id",
+            return_value="session-id",
+        ),
+        patch(
+            "music_assistant.providers.airplay.stream_session.FFMpeg", return_value=new_ffmpeg
+        ) as ffmpeg_factory,
+    ):
+        await session._start_player_ffmpeg(player, MagicMock())
+
+    # the old ffmpeg is closed, never killing the shared cli stdin
+    old_ffmpeg.close.assert_awaited_once()
+    # the fresh ffmpeg writes into the cli process stdin fd (77)
+    assert ffmpeg_factory.call_args.kwargs["audio_output"] == 77
+    new_ffmpeg.start.assert_awaited_once()
+    assert session._player_ffmpeg[player.player_id] is new_ffmpeg
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("stream_state", ["missing", "stopped", "disconnected"])
 async def test_standby_requires_every_member_running_and_connected(stream_state: str) -> None:
-    """Standby is unavailable when any member lacks a reusable generation session."""
+    """Standby is unavailable when any member lacks a reusable connected session."""
     session = _make_session(0, 0)
     ready_player = MagicMock(player_id="ready", protocol=StreamingProtocol.AIRPLAY2)
     ready_player.stream = MagicMock(running=True, connected=True)
@@ -922,24 +700,23 @@ async def test_late_join_adds_to_sync_clients() -> None:
 
 
 @pytest.mark.asyncio
-async def test_late_join_ready_timeout_discards_generation_zero() -> None:
-    """A late joiner FLUSHes its staged generation before transport teardown."""
+async def test_late_join_start_failure_removes_client() -> None:
+    """A late joiner whose START fails is removed from the session."""
     session = _make_session(time.time() - 10, 12.5)
     player = _make_late_joiner()
 
-    def setup_unready_stream(*_args: Any, **_kwargs: Any) -> None:
+    def setup_failing_start(*_args: Any, **_kwargs: Any) -> None:
         _setup_stream(player)()
-        player.stream.wait_generation_ready = AsyncMock(return_value=False)
+        player.stream.start = AsyncMock(side_effect=OSError("start failed"))
 
     with (
-        patch.object(session, "_start_client", side_effect=setup_unready_stream),
-        patch.object(session, "stop_client", new_callable=AsyncMock) as stop_client,
+        patch.object(session, "_start_client", side_effect=setup_failing_start),
+        patch.object(session, "remove_client", new_callable=AsyncMock) as remove_client,
     ):
         await session.add_client(player)
 
-    player.stream.discard_generation.assert_awaited_once_with(0)
-    stop_client.assert_awaited_once_with(player, reason="late joiner start/prime failed")
-    assert player not in session.sync_clients
+    player.stream.start.assert_awaited_once()
+    remove_client.assert_awaited_once_with(player, reason="late joiner start failed")
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -179,9 +179,9 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
     last_connected = max(i for i, op in enumerate(operations) if op.startswith("connected:"))
     first_start = min(i for i, op in enumerate(operations) if op.startswith("started:"))
     assert last_connected < first_start
-    # start = now (100_000 ms) + the group start lead (750 ms), one shared instant
+    # start = now (100_000 ms) + the group start lead (500 ms), one shared instant
     starts = {int(op.rsplit(":", 1)[1]) for op in operations if op.startswith("started:")}
-    assert starts == {100_750}
+    assert starts == {100_500}
 
 
 @pytest.mark.asyncio
@@ -216,8 +216,8 @@ async def test_initial_single_player_starts_after_connect(
     ):
         await session.start(MagicMock())
 
-    # start = now (200_000 ms) + the solo start lead (500 ms), position 0
-    stream.start.assert_awaited_once_with(200_500, 0)
+    # start = now (200_000 ms) + the solo start lead (250 ms), position 0
+    stream.start.assert_awaited_once_with(200_250, 0)
 
 
 @pytest.mark.asyncio
@@ -385,7 +385,7 @@ async def test_standby_resumes_warm_on_existing_streams(
         assert await session.replace(MagicMock(), media)
 
     # start = now (100_000 ms) + solo/group start lead, position 10s
-    expected_start = 100_000 + (500 if len(protocols) == 1 else 750)
+    expected_start = 100_000 + (250 if len(protocols) == 1 else 500)
     for player in players:
         stream = original_streams[player.player_id]
         assert player.stream is stream
@@ -434,8 +434,8 @@ async def test_warm_replace_flushes_all_before_starting_any() -> None:
 
     for player in players:
         player.stream.flush.assert_awaited_once_with()
-        # start = now (100_000 ms) + the group start lead (750 ms), position 0
-        player.stream.start.assert_awaited_once_with(100_750, 0)
+        # start = now (100_000 ms) + the group start lead (500 ms), position 0
+        player.stream.start.assert_awaited_once_with(100_500, 0)
 
 
 @pytest.mark.asyncio
@@ -707,8 +707,8 @@ async def test_late_join_adds_to_sync_clients() -> None:
 
 
 @pytest.mark.asyncio
-async def test_late_join_start_failure_removes_client() -> None:
-    """A late joiner whose START fails is removed from the session."""
+async def test_late_join_start_failure_stops_client() -> None:
+    """A late joiner whose START fails is torn down before joining the session."""
     session = _make_session(time.time() - 10, 12.5)
     player = _make_late_joiner()
 
@@ -718,12 +718,15 @@ async def test_late_join_start_failure_removes_client() -> None:
 
     with (
         patch.object(session, "_start_client", side_effect=setup_failing_start),
-        patch.object(session, "remove_client", new_callable=AsyncMock) as remove_client,
+        patch.object(session, "stop_client", new_callable=AsyncMock) as stop_client,
     ):
         await session.add_client(player)
 
     player.stream.start.assert_awaited_once()
-    remove_client.assert_awaited_once_with(player, reason="late joiner start failed")
+    # START precedes the prime feed and the sync_clients append, so a failed
+    # joiner is stopped without ever having joined the session.
+    assert player not in session.sync_clients
+    stop_client.assert_awaited_once_with(player, reason="late joiner start/prime failed")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Replaces the per-generation FIFO staging for AirPlay warm seek/next-track with a single persistent stdin stream that is flushed and refilled in place, and anchors all starts on confirmed readiness instead of a guessed setup lead.

## Why

The generation model had two defects on the second warm seek: the binary's command thread wedged on a blocking stdin reader, and the per-seek pipe hand-off dropped the audio feed — playback went silent or stalled and fell back to a cold restart. It also required a hard 1.5-2.5s setup-lead guess for every start.

## How

- Warm seek/next = `ACTION=FLUSH` (binary flushes the receiver, drains its ring + stdin, acks with `[STATUS] flushed`) → fresh ffmpeg into the same persistent stdin → `ACTION=START`.
- The binary reports the first audio of each start cycle (`[STATUS] audio`); combined with `[STATUS] connected`, start readiness is fully event-driven, so cold and warm starts anchor with just 250 ms (solo) / 500 ms (group) leads.
- Late joiners are anchored before their prime buffer is fed, so an oversized prime can no longer wedge the session feed.
- Net −1100 lines in the provider.

Live-verified: solo and grouped playback, late join, sub-second seeks, fast cold starts.

## Dependency

Requires the matching cliairplay rework (music-assistant/airplay-cli flush-and-refill PR); the `CLIAIRPLAY_VERSION` pin must be bumped to its release tag before this merges.