### PR TITLE
Show clearer errors for invalid media files

### DIFF
--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -665,7 +665,7 @@ def parse_tags(
         "ffprobe",
         "-hide_banner",
         "-loglevel",
-        "fatal",
+        "error",
         "-threads",
         "0",
         "-show_error",
@@ -678,7 +678,7 @@ def parse_tags(
         input_file,
     )
     try:
-        res = subprocess.check_output(args)  # noqa: S603
+        res = subprocess.check_output(args, stderr=subprocess.PIPE)  # noqa: S603
         data = json.loads(res)
         if error := data.get("error"):
             raise InvalidDataError(error["string"])
@@ -711,11 +711,7 @@ def parse_tags(
                 tags.has_cover_image = True
         return tags
     except subprocess.CalledProcessError as err:
-        error_msg = f"Unable to retrieve info for {input_file}"
-        if output := getattr(err, "stdout", None):
-            err_details = json_loads(output)
-            with suppress(KeyError):
-                error_msg = f"{error_msg} ({err_details['error']['string']})"
+        error_msg = f"Unable to retrieve info for {input_file} ({_get_ffprobe_error(err)})"
         raise InvalidDataError(error_msg) from err
     except (KeyError, ValueError, JSONDecodeError, InvalidDataError) as err:
         try:
@@ -755,6 +751,40 @@ def get_file_duration(input_file: str) -> float:
     except Exception as err:
         error_msg = f"Unable to retrieve duration for {input_file}"
         raise InvalidDataError(error_msg) from err
+
+
+def _get_ffprobe_error(err: subprocess.CalledProcessError) -> str:
+    """
+    Return an actionable message for a failed FFprobe command.
+
+    :param err: The FFprobe process error.
+    """
+    unknown_error = "Unknown error occurred"
+    error_detail = "Invalid or unsupported media file"
+    if err.stdout:
+        with suppress(JSONDecodeError):
+            result = json_loads(err.stdout)
+            if (
+                isinstance(result, dict)
+                and isinstance(ffprobe_error := result.get("error"), dict)
+                and isinstance(message := ffprobe_error.get("string"), str)
+                and message != unknown_error
+            ):
+                error_detail = message
+
+    stderr = (
+        err.stderr.decode("utf-8", errors="replace")
+        if isinstance(err.stderr, bytes)
+        else err.stderr or ""
+    )
+    for line in stderr.splitlines():
+        stripped_line = line.strip()
+        if not stripped_line.startswith("["):
+            continue
+        _, separator, message = stripped_line.partition("] ")
+        if separator and message and unknown_error not in message:
+            return message
+    return error_detail
 
 
 def _decode_mp4_freeform_single(values: list[Any]) -> str:

--- a/tests/helpers/test_tags.py
+++ b/tests/helpers/test_tags.py
@@ -2,10 +2,12 @@
 
 import pathlib
 import shutil
+import subprocess
 from unittest.mock import MagicMock
 
 import mutagen
 import pytest
+from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.constants import UNKNOWN_ARTIST
 from music_assistant.helpers import tags
@@ -27,6 +29,39 @@ FILE_M4A = str(RESOURCES_DIR.joinpath("MyArtist - MyTitle.m4a"))
 FILE_FLAC = str(RESOURCES_DIR.joinpath("MultipleArtists.flac"))
 FILE_FLAC_SEMICOLON = str(RESOURCES_DIR.joinpath("ArtistWithSemicolon.flac"))
 FILE_WV = str(RESOURCES_DIR.joinpath("MyArtist - MyTitle.wv"))
+
+
+@pytest.mark.parametrize(
+    ("stderr", "expected_detail"),
+    [
+        (
+            b"[Vorbis parser @ 0x123] Invalid Setup header\n"
+            b"[ogg @ 0x456] Header processing failed: Unknown error occurred\n",
+            "Invalid Setup header",
+        ),
+        (b"broken.ogg: Unknown error occurred\n", "Invalid or unsupported media file"),
+    ],
+)
+def test_parse_tags_reports_actionable_ffprobe_error(
+    monkeypatch: pytest.MonkeyPatch, stderr: bytes, expected_detail: str
+) -> None:
+    """Test that tag parsing reports a useful FFprobe failure."""
+    process_error = subprocess.CalledProcessError(
+        returncode=1,
+        cmd=("ffprobe",),
+        output=b'{"error":{"code":-1,"string":"Unknown error occurred"}}',
+        stderr=stderr,
+    )
+    check_output = MagicMock(side_effect=process_error)
+    monkeypatch.setattr(subprocess, "check_output", check_output)
+
+    with pytest.raises(InvalidDataError) as err:
+        tags.parse_tags("broken.ogg")
+
+    assert str(err.value) == f"Unable to retrieve info for broken.ogg ({expected_detail})"
+    assert check_output.call_args.kwargs == {"stderr": subprocess.PIPE}
+    args = check_output.call_args.args[0]
+    assert args[args.index("-loglevel") + 1] == "error"
 
 
 async def test_parse_metadata_from_id3tags() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Improves the error shown when a media file cannot be inspected.

- Shows the specific decoder error when available.
- Replaces unknown failures with "Invalid or unsupported media file".
- Adds coverage for both error paths.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] No shared model changes require a companion PR.
- [x] No UI changes require a companion PR.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] No documentation change is required.