### PR TITLE
Update airplay-cli to v0.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ ARG BASE_IMAGE_VERSION=latest
 FROM --platform=$BUILDPLATFORM ghcr.io/music-assistant/base:$BASE_IMAGE_VERSION AS cliairplay-download
 
 # Bump the version and checksum-manifest hash together.
-ARG CLIAIRPLAY_VERSION=v0.3.3
-ARG CLIAIRPLAY_CHECKSUMS_SHA256=062b277d97215a813734ab487651a5b462216ce6250b9c05e9eb677dc34ce1f4
+ARG CLIAIRPLAY_VERSION=v0.3.4
+ARG CLIAIRPLAY_CHECKSUMS_SHA256=1d35e41a1b96a84e80088a5db702170181b292c11f6e7ae2b634e50914daf1cc
 ARG TARGETARCH
 
 # Download the cliairplay release asset for this image architecture.


### PR DESCRIPTION
# What does this implement/fix?

Updates the server Dockerfile to use the verified
[airplay-cli v0.3.4 release](https://github.com/music-assistant/airplay-cli/releases/tag/v0.3.4).

- Pins `CLIAIRPLAY_VERSION` to `v0.3.4`.
- Pins `CLIAIRPLAY_CHECKSUMS_SHA256` to `1d35e41a1b96a84e80088a5db702170181b292c11f6e7ae2b634e50914daf1cc`.
- The release workflow verified the four published binaries and `SHA256SUMS` before opening this PR.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [x] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally. (Release assets and pin updates were verified in CI; no local server build is run.)
- [ ] `pre-commit run --all-files` passes. (Not run by this pin-only automation.)
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable. (Not applicable to a Dockerfile pin-only change.)
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (Not applicable.)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (Not applicable.)
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions. (Not applicable to this automated pin-only PR.)
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (Not applicable.)