### PR TITLE
Migrate provider setup values into setup_data (one-off)

### DIFF
--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -27,7 +27,7 @@ from music_assistant.controllers.config.constants import DEFAULT_SAVE_DELAY
 from music_assistant.controllers.config.core import CoreConfigMixin
 from music_assistant.controllers.config.dsp import DSPConfigMixin
 from music_assistant.controllers.config.flows import SetupFlowMixin
-from music_assistant.controllers.config.migrations import migrate
+from music_assistant.controllers.config.migrations import migrate, migrate_provider_setup_data
 from music_assistant.controllers.config.players import PlayerConfigMixin
 from music_assistant.controllers.config.providers import ProviderConfigMixin
 from music_assistant.controllers.config.queues import PlayerQueueConfigMixin
@@ -74,6 +74,11 @@ class ConfigController(
         self._init_encryption()
         config_entries.ENCRYPT_CALLBACK = self.encrypt_string
         config_entries.DECRYPT_CALLBACK = self.decrypt_string
+        # one-off: move pre-setup-flow provider values into (encrypted) setup_data.
+        # runs here, after encryption is initialized, so string values are encrypted
+        # at rest (the migrate() pass in _load() runs before encryption is available).
+        if migrate_provider_setup_data(self._data, self.encrypt_string):
+            self.save(immediate=True)
         if not self.onboard_done:
             self.mass.register_api_command(
                 "config/onboard_complete",

--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.constants import PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_NONE
 from music_assistant_models.enums import CrossfadeMode
@@ -31,10 +31,126 @@ from music_assistant.controllers.player_queues.constants import (
     CONF_SMART_SHUFFLE_SONG_RECENCY,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 LOGGER = logging.getLogger(__name__)
 
 # removed player config key, only referenced by its migration
 LEGACY_CONF_OUTPUT_LIMITER = "output_limiter"
+
+# Config keys each provider's setup flow owns: the keys it reads back with
+# get_setup_value / get_provider_setup_value (and rotates via _update_setup_data) from
+# `setup_data` rather than `values`. The one-off migrate_provider_setup_data step below
+# moves these keys from the raw `values` dict into `setup_data` (encrypting string values
+# at rest) for installs that were configured before setup flows existed. Keys that stayed
+# regular options (quality, sync toggles, output settings, ...) are intentionally absent:
+# they keep being read via get_config_value from `values`.
+# The literal strings are the persisted config keys, not the CONF_* symbol names; some
+# providers redefine common names (e.g. the Hue bridge stores its user under
+# "hue_username", the scrobblers under "_username", Open Subsonic its url under "baseURL").
+# Notes on the non-obvious entries:
+# - the filesystem providers' "content_type" is also surfaced by get_config_entries, but
+#   only as a read-only LABEL mirror (UI_ONLY, never persisted back to values), so moving
+#   it to setup_data is safe and required (it is read via get_provider_setup_value).
+# - hass "url"/"token"/"verify_ssl": on a Home Assistant add-on these come from fixed
+#   (hidden) config entries whose values equal what a stored copy would hold, so moving a
+#   stored copy is a harmless no-op there while restoring normal installs.
+# - spotify is deliberately absent: its own _migrate_legacy_token still reads the legacy
+#   "refresh_token" and "client_id" from `values`, so this migration must not move them.
+# TODO: remove after 2.13 release
+PROVIDER_SETUP_FLOW_KEYS: dict[str, tuple[str, ...]] = {
+    "alexa": ("url", "username", "password", "api_url", "api_username", "api_password"),
+    "amplipi": ("host",),
+    "apple_music": ("music_app_token", "music_user_token", "music_user_manual_token"),
+    "ard_audiothek": ("email", "password", "token", "user_id", "token_expiry", "display_name"),
+    "audible": ("auth_file", "locale"),
+    "audiobookshelf": ("url", "username", "password", "token", "api_token", "verify_ssl"),
+    "bandcamp": ("identity",),
+    "bbc_sounds": ("username", "password"),
+    "bose_soundtouch": ("app_key",),
+    "deezer": ("arl_token",),
+    "digitally_incorporated": ("listen_key",),
+    "emby": ("ip_address", "username", "password"),
+    "filesystem_google_drive": (
+        "content_type",
+        "client_id",
+        "client_secret",
+        "folder_id",
+        "refresh_token",
+    ),
+    "filesystem_local": ("content_type", "path"),
+    "filesystem_nfs": ("content_type", "host", "export_path", "subfolder", "nfs_version"),
+    "filesystem_onedrive": (
+        "content_type",
+        "client_id",
+        "client_secret",
+        "folder_id",
+        "refresh_token",
+    ),
+    "filesystem_smb": (
+        "content_type",
+        "host",
+        "share",
+        "username",
+        "password",
+        "subfolder",
+        "smb_version",
+    ),
+    "gpodder": ("url", "username", "password", "device_id", "token", "url_nc", "verify_ssl"),
+    "hass": ("url", "token", "verify_ssl"),
+    "hue_entertainment": ("bridge_host", "hue_username", "hue_clientkey", "bridge_id"),
+    "ibroadcast": ("username", "password"),
+    "jellyfin": ("url", "username", "password", "verify_ssl"),
+    "lastfm_scrobble": ("_provider", "_api_session_key", "_username", "_api_key", "_api_secret"),
+    "listenbrainz_scrobble": ("_user_token", "api_base_url"),
+    "musicme": ("username", "password"),
+    "neteasecloudmusic": ("api_base_url", "cookie", "uid"),
+    "nicovideo": ("mail", "password", "user_session"),
+    "nugs": ("username", "password"),
+    "opensubsonic": ("username", "password", "baseURL", "port", "path"),
+    "plex": (
+        "token",
+        "local_server_ip",
+        "local_server_port",
+        "local_server_ssl",
+        "local_server_verify_cert",
+        "library_id",
+        "library_type",
+    ),
+    "pocketcasts": ("username", "password"),
+    "podcast_index": ("api_key", "api_secret"),
+    "podcastfeed": ("feed_url",),
+    "qobuz": ("username", "password"),
+    "qqmusic": ("uin", "musicid", "musickey", "login_type", "credential_json"),
+    "siriusxm": ("sxm_email_address", "sxm_password", "sxm_region"),
+    "soundcloud": ("client_id", "authorization"),
+    "teddycloud": ("url",),
+    "tidal": ("auth_token", "refresh_token", "expiry_time", "user_id"),
+    "tunein": ("username",),
+    "webdav": ("content_type", "url", "username", "password", "verify_ssl"),
+    "yandex_music": ("token", "x_token", "refresh_token"),
+    "yandex_smarthome": (
+        "connection_type",
+        "cloud_instance_id",
+        "cloud_instance_password",
+        "cloud_connection_token",
+        "skill_id",
+        "skill_token",
+        "direct_access_token",
+        "direct_client_secret",
+    ),
+    "yandex_station": (
+        "ym_instance",
+        "music_token",
+        "x_token",
+        "refresh_token",
+        "remember_session",
+    ),
+    "yandex_ynison": ("ym_instance", "token", "x_token"),
+    "yousee": ("username", "password"),
+    "ytmusic": ("username", "cookie", "po_token_server_url"),
+}
 
 
 async def migrate(data: dict[str, Any]) -> bool:  # noqa: PLR0915
@@ -175,6 +291,47 @@ async def migrate(data: dict[str, Any]) -> bool:  # noqa: PLR0915
     if _migrate_output_limiter(data):
         changed = True
 
+    return changed
+
+
+def migrate_provider_setup_data(data: dict[str, Any], encrypt: Callable[[str], str]) -> bool:
+    """
+    Move each provider's setup-flow-owned keys from `values` to `setup_data` in-place.
+
+    Runs after encryption is initialized (unlike migrate()), so string values are
+    encrypted at rest with the given callback - matching how the setup flows persist
+    collected values. Returns True if anything changed.
+
+    :param data: The persistent settings data to migrate in-place.
+    :param encrypt: Callback that encrypts a string value (idempotent for already
+        encrypted values), used to encrypt migrated string values at rest.
+    """
+    all_provider_configs = data.get(CONF_PROVIDERS, {})
+    if not isinstance(all_provider_configs, dict):
+        return False
+    changed = False
+    for provider_cfg in all_provider_configs.values():
+        if not isinstance(provider_cfg, dict):
+            continue
+        owned_keys = PROVIDER_SETUP_FLOW_KEYS.get(provider_cfg.get("domain", ""))
+        if not owned_keys:
+            continue
+        values = provider_cfg.get("values")
+        if not isinstance(values, dict):
+            continue
+        movable_keys = [key for key in owned_keys if key in values]
+        if not movable_keys:
+            continue
+        setup_data = provider_cfg.setdefault("setup_data", {})
+        for key in movable_keys:
+            # a value already collected into setup_data wins; only drop the stale copy
+            if key not in setup_data:
+                value = values[key]
+                setup_data[key] = encrypt(value) if isinstance(value, str) else value
+            del values[key]
+        changed = True
+    if changed:
+        LOGGER.info("Migrated provider setup values into setup_data")
     return changed
 
 

--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -398,20 +398,17 @@ class ProviderConfigMixin:
         """
         Return a single (decrypted) setup_data value for a provider from storage.
 
-        Falls back to the legacy raw config values for installs configured before
-        setup flows existed. Works without a loaded provider instance.
+        Returns the given default when the key is not present in setup_data.
+        Works without a loaded provider instance.
 
         :param instance_id: The provider instance ID.
         :param key: The setup data key to retrieve.
-        :param default: Value to return when the key is not present anywhere.
+        :param default: Value to return when the key is not present in setup_data.
         """
         setup_data = self.get(f"{CONF_PROVIDERS}/{instance_id}/setup_data") or {}
-        # presence check (not None check): an explicitly cleared value must not
-        # fall back to (and resurrect) a stale legacy config value
-        if key in setup_data:
-            value = cast("ConfigValueType", setup_data[key])
-        else:
-            value = self.get_raw_provider_config_value(instance_id, key, default)
+        if key not in setup_data:
+            return default
+        value = cast("ConfigValueType", setup_data[key])
         if isinstance(value, str):
             return self.decrypt_string(value)
         return value

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -280,9 +280,9 @@ class Provider:
         """
         Return a value collected by this provider's setup flow (from setup_data).
 
-        Encrypted (string) values are decrypted transparently. Falls back to the
-        legacy config values for installs that were configured before setup flows
-        existed, so no data migration is needed.
+        Encrypted (string) values are decrypted transparently. When the key is not
+        present in setup_data, the active config entry value or the given default is
+        returned.
 
         :param key: The setup data key to retrieve.
         :param default: Value to return when the key is not present anywhere.
@@ -291,11 +291,7 @@ class Provider:
         if key in setup_data:
             value = setup_data[key]
             return self.mass.config.decrypt_string(value) if isinstance(value, str) else value
-        # read-through to the legacy (pre-setup-flow) config values, no migration
-        value = self.mass.config.get_raw_provider_config_value(self.instance_id, key)
-        if value is None:
-            return self.get_config_value(key, default)
-        return self.mass.config.decrypt_string(value) if isinstance(value, str) else value
+        return self.get_config_value(key, default)
 
     def _update_setup_data(self, key: str, value: ConfigValueType, immediate: bool = True) -> None:
         """

--- a/tests/controllers/config/test_migrations.py
+++ b/tests/controllers/config/test_migrations.py
@@ -1,12 +1,25 @@
 """Tests for (settings.json) config migrations."""
 
-from typing import Any
+from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
+from music_assistant.constants import ENCRYPT_SUFFIX
 from music_assistant.controllers.config.migrations import (
+    PROVIDER_SETUP_FLOW_KEYS,
     _migrate_airplay_apple_power_control,
     _migrate_airplay_receiver_ghost_players,
     _migrate_output_limiter,
+    migrate_provider_setup_data,
 )
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _fake_encrypt(value: str) -> str:
+    """Mirror ConfigController.encrypt_string: prefix once, idempotent for encrypted values."""
+    return value if value.startswith(ENCRYPT_SUFFIX) else ENCRYPT_SUFFIX + value
 
 
 def test_migrate_output_limiter_drops_stored_values() -> None:
@@ -242,3 +255,109 @@ def test_migrate_airplay_apple_power_control_flips_stale_default() -> None:
     assert values["cast_x"]["values"]["power_control"] == "none"
     # idempotent: nothing left to migrate on a second pass
     assert _migrate_airplay_apple_power_control(data) is False
+
+
+def test_migrate_provider_setup_data_moves_and_encrypts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Owned string keys move to setup_data encrypted; non-strings move raw; options stay."""
+    monkeypatch.setitem(PROVIDER_SETUP_FLOW_KEYS, "demo", ("username", "password", "port"))
+    data: dict[str, Any] = {
+        "providers": {
+            "demo": {
+                "domain": "demo",
+                "values": {
+                    "username": "bob",
+                    "password": "sekret",
+                    "port": 8096,
+                    "quality": "high",
+                },
+            }
+        }
+    }
+    assert migrate_provider_setup_data(data, _fake_encrypt) is True
+    cfg = data["providers"]["demo"]
+    # the (non-owned) option key stays untouched in values
+    assert cfg["values"] == {"quality": "high"}
+    # owned string values are encrypted at rest, non-string values move as-is
+    assert cfg["setup_data"]["username"] == ENCRYPT_SUFFIX + "bob"
+    assert cfg["setup_data"]["password"] == ENCRYPT_SUFFIX + "sekret"
+    assert cfg["setup_data"]["port"] == 8096
+
+
+def test_migrate_provider_setup_data_idempotent_and_preserves_existing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Already-encrypted values move unchanged, existing setup_data wins, second run is a no-op."""
+    monkeypatch.setitem(PROVIDER_SETUP_FLOW_KEYS, "demo", ("token", "secret"))
+    data: dict[str, Any] = {
+        "providers": {
+            "demo": {
+                "domain": "demo",
+                "values": {"token": ENCRYPT_SUFFIX + "abc", "secret": "raw"},
+                # a value already collected into setup_data must not be clobbered
+                "setup_data": {"secret": ENCRYPT_SUFFIX + "kept"},
+            }
+        }
+    }
+    assert migrate_provider_setup_data(data, _fake_encrypt) is True
+    cfg = data["providers"]["demo"]
+    # an already-encrypted value is moved without re-encrypting (no double prefix)
+    assert cfg["setup_data"]["token"] == ENCRYPT_SUFFIX + "abc"
+    # the pre-existing setup_data value survives; the stale values copy is dropped
+    assert cfg["setup_data"]["secret"] == ENCRYPT_SUFFIX + "kept"
+    assert cfg["values"] == {}
+    # a second pass finds nothing left to move
+    assert migrate_provider_setup_data(data, _fake_encrypt) is False
+
+
+def test_migrate_provider_setup_data_multi_instance_and_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All instances of a mapped domain migrate; unmapped domains are left untouched."""
+    monkeypatch.setitem(PROVIDER_SETUP_FLOW_KEYS, "demo", ("host",))
+    data: dict[str, Any] = {
+        "providers": {
+            "demo--a": {"domain": "demo", "values": {"host": "h1"}},
+            "demo--b": {"domain": "demo", "values": {"host": "h2", "quality": "x"}},
+            "other": {"domain": "other", "values": {"host": "keep"}},
+        }
+    }
+    assert migrate_provider_setup_data(data, _fake_encrypt) is True
+    prov = data["providers"]
+    assert prov["demo--a"]["setup_data"]["host"] == ENCRYPT_SUFFIX + "h1"
+    assert prov["demo--a"]["values"] == {}
+    assert prov["demo--b"]["setup_data"]["host"] == ENCRYPT_SUFFIX + "h2"
+    assert prov["demo--b"]["values"] == {"quality": "x"}
+    # a provider whose domain is not in the map is never touched
+    assert prov["other"]["values"] == {"host": "keep"}
+    assert "setup_data" not in prov["other"]
+
+
+def test_migrate_provider_setup_data_noop() -> None:
+    """Missing or empty provider config store reports no change."""
+    assert migrate_provider_setup_data({}, _fake_encrypt) is False
+    assert migrate_provider_setup_data({"providers": {}}, _fake_encrypt) is False
+
+
+def test_migrate_provider_setup_data_real_domain_opensubsonic() -> None:
+    """A real mapped domain moves its setup keys (incl. the redefined baseURL literal)."""
+    data: dict[str, Any] = {
+        "providers": {
+            "opensubsonic--x": {
+                "domain": "opensubsonic",
+                "values": {
+                    "username": "alice",
+                    "password": "pw",
+                    "baseURL": "https://music.example",
+                    "port": 4533,
+                    "enable_podcasts": True,
+                },
+            }
+        }
+    }
+    assert migrate_provider_setup_data(data, _fake_encrypt) is True
+    cfg = data["providers"]["opensubsonic--x"]
+    assert cfg["setup_data"]["username"] == ENCRYPT_SUFFIX + "alice"
+    assert cfg["setup_data"]["baseURL"] == ENCRYPT_SUFFIX + "https://music.example"
+    assert cfg["setup_data"]["port"] == 4533
+    # a genuine provider option is not part of the setup-flow key set and stays put
+    assert cfg["values"] == {"enable_podcasts": True}

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -855,6 +855,8 @@ async def test_real_provider_flow_retry_on_error(flow_mass: MusicAssistant) -> N
         )
     assert finish_step.type == FlowStepType.FINISH
     assert flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}") is not None
+
+
 async def test_spotify_flow_hosted_bounce_roundtrip(
     flow_mass: MusicAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -35,7 +35,7 @@ def _state(entity_id: str, friendly_name: str) -> dict[str, Any]:
 
 
 def _config(**values: str) -> MagicMock:
-    """Return a provider config with the given persisted (legacy) values."""
+    """Return a provider config exposing the given values via get_value (entry defaults)."""
     persisted_values = {
         CONF_URL: "http://homeassistant.local:8123",
         CONF_AUTH_TOKEN: "token",

--- a/tests/providers/teddycloud/test_provider.py
+++ b/tests/providers/teddycloud/test_provider.py
@@ -101,7 +101,7 @@ def config_mock() -> Mock:
     config.name = "TeddyCloud Test"
     config.instance_id = "teddycloud_test"
     config.enabled = True
-    # empty values dict so get_setup_value's read-through reaches config.get_value below
+    # empty values dict so get_setup_value falls through to config.get_value below
     config.values = {}
     # the base provider reads the log level from config on init; return a valid level.
     config.get_value.side_effect = lambda key, default=None: (

--- a/tests/providers/yandex_smarthome/test_direct.py
+++ b/tests/providers/yandex_smarthome/test_direct.py
@@ -51,9 +51,8 @@ def mock_mass() -> MagicMock:
     mass.webserver.register_dynamic_route = MagicMock(return_value=MagicMock())
     mass.players = []
     mass.http_session = MagicMock()
-    # No setup_data / raw values persisted on the mock config store, so get_setup_value
-    # exercises its legacy fallback and reads straight from the provided ProviderConfig
-    # (the "install configured before setup flows existed" path).
+    # No setup_data persisted on the mock config store, so get_setup_value falls through
+    # to the config entry value/default via get_config_value (the provided ProviderConfig).
     mass.config.get = MagicMock(return_value=None)
     mass.config.get_raw_provider_config_value = MagicMock(return_value=None)
     return mass
@@ -783,7 +782,7 @@ def _make_direct_config(**overrides: Any) -> MagicMock:
     }
     defaults.update(overrides)
     config = MagicMock()
-    # accept the optional default arg too: get_setup_value's fallback reads via
+    # accept the optional default arg too: get_setup_value falls through via
     # get_config_value(key, default), a two-argument call
     config.get_value = MagicMock(side_effect=lambda key, *_: defaults.get(key, ""))
     return config

--- a/tests/providers/yandex_station/test_provider_cascade.py
+++ b/tests/providers/yandex_station/test_provider_cascade.py
@@ -86,8 +86,8 @@ class _StubCoreConfig:
         Serve config paths used by Provider.get_setup_value / _update_setup_data.
 
         Returns an empty setup_data dict so setup-data reads fall through to the
-        legacy config value (config.get_value), and a truthy marker for the
-        provider-exists precondition in _update_setup_data.
+        config entry value (config.get_value, via get_config_value), and a truthy
+        marker for the provider-exists precondition in _update_setup_data.
         """
         if path.endswith("/setup_data"):
             return {}

--- a/tests/providers/yandex_ynison/test_provider.py
+++ b/tests/providers/yandex_ynison/test_provider.py
@@ -115,8 +115,8 @@ def _make_mock_mass() -> MagicMock:
     mass.get_providers = MagicMock(return_value=[])
     mass.config.set_raw_provider_config_value = MagicMock()
     # Auth values now live in setup_data; the provider reads them via
-    # get_setup_value. Empty setup_data + no raw value routes those reads
-    # through the legacy fallback to config.get_value (the seeded stub above).
+    # get_setup_value. Empty setup_data routes those reads through to
+    # config.get_value (via get_config_value; the seeded stub above).
     mass.config.get = MagicMock(return_value={})
     mass.config.get_raw_provider_config_value = MagicMock(return_value=None)
 


### PR DESCRIPTION
Part of the setup-flows train (stacked on the integration branch). Moves provider credential/setup values out of the legacy `values` dict into the flow-owned `setup_data` (encrypted at rest) via a one-off boot migration, then removes the temporary read-through fallback so setup values have a single source of truth.

- One-off migration (runs after encryption init): moves each setup-flow provider's owned keys `values` → `setup_data`, encrypting plaintext strings; idempotent, multi-instance safe
- Removes the legacy-`values` fallback from `get_setup_value` / `get_provider_setup_value`
- spotify keeps its own token migration (excluded); players deferred to the player-flow PR

⚠️ Stacked on setup-flows-integration — merges with the train.