### PR TITLE
Expose current Music Quiz state to dashboard displays

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -286,6 +286,7 @@ class MusicQuizPlugin(PluginProvider):
             ("music_quiz/info", self.get_game_info),
             ("music_quiz/join", self.join_game),
             ("music_quiz/state", self.get_player_state),
+            ("music_quiz/public_state", self.get_public_state),
             ("music_quiz/heartbeat", self.heartbeat),
             ("music_quiz/submit_answer", self.submit_answer),
             ("music_quiz/answer", self.answer),
@@ -616,6 +617,22 @@ class MusicQuizPlugin(PluginProvider):
             player = _get_player(game, player_id)
             self._refresh_player_presence(player)
             return _player_state(game, player, answer_type)
+
+    async def get_public_state(self) -> dict[str, Any] | None:
+        """
+        Return the guest-safe public game state for a non-participant display.
+
+        Mirrors the ``game_updated`` broadcast payload so a display client (e.g. a
+        lobby dashboard) can render the full current state on cold launch without
+        joining as a player.
+
+        :return: The full public game state, or None when no game is active.
+        """
+        async with self._game_lock:
+            if self._game is None:
+                return None
+            game, _, answer_type = self._require_game_strategies()
+            return _public_state(game, answer_type)
 
     async def heartbeat(self, player_id: str) -> bool:
         """

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -90,6 +90,7 @@ GUEST_COMMANDS = (
     "music_quiz/info",
     "music_quiz/join",
     "music_quiz/state",
+    "music_quiz/public_state",
     "music_quiz/heartbeat",
     "music_quiz/submit_answer",
     "music_quiz/answer",
@@ -3721,6 +3722,65 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
     alice = next(player for player in state["players"] if player["name"] == "Alice")
     assert set(alice) == {*public_player_keys, "last_answer"}
     assert set(alice["last_answer"]) == {"suggestion_id", "correct", "points"}
+
+
+@pytest.mark.asyncio
+async def test_public_state_returns_none_without_active_game() -> None:
+    """The non-participant public state getter is empty (not an error) without a game."""
+    plugin = _create_plugin()
+
+    assert await plugin.get_public_state() is None
+
+
+@pytest.mark.asyncio
+async def test_public_state_exposes_full_state_for_non_participant() -> None:
+    """A display client fetches the full broadcast state without joining as a player."""
+    plugin = _create_plugin()
+    player_ids = await _create_started_game(plugin)
+    broadcast_state = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]["state"]
+
+    state = await plugin.get_public_state()
+
+    # identical to the game_updated broadcast payload, with no personal "you" section
+    assert state == broadcast_state
+    assert state is not None
+    assert "you" not in state
+    assert state["phase"] == "answering"
+    assert {player["name"] for player in state["players"]} == set(player_ids)
+    current_round = state["current_round"]
+    assert current_round is not None
+    assert "question" in current_round
+    assert current_round["suggestions"]
+    # the getter takes no player_id and never leaks the private player credentials
+    serialized = str(state)
+    for player_id in player_ids.values():
+        assert player_id not in serialized
+    # a participant's personal state is this same public state plus their own "you" view
+    personal_state = await plugin.get_player_state(player_ids["Alice"])
+    assert set(personal_state) == {*state, "you"}
+
+
+@pytest.mark.asyncio
+async def test_public_state_command_is_guest_tier_and_needs_no_player_id() -> None:
+    """music_quiz/public_state is registered guest-safe and requires no player credential."""
+    plugin = _create_plugin()
+    registered: dict[str, APICommandHandler] = {}
+
+    def _register(command: str, handler: Any, **kwargs: Any) -> Any:
+        registered[command] = APICommandHandler.parse(command, handler, **kwargs)
+        return MagicMock()
+
+    cast("MagicMock", plugin.mass.register_api_command).side_effect = _register
+    await plugin.loaded_in_mass()
+
+    handler = registered["music_quiz/public_state"]
+    assert handler.target == plugin.get_public_state
+    # None scope == any authenticated user (the guest-safe tier), unlike host commands
+    assert handler.required_scope is None
+    assert registered["music_quiz/create"].required_scope == Scope.USERS_INVITE
+    # resolves with no arguments, unlike the participant-scoped music_quiz/state
+    assert "player_id" not in handler.signature.parameters
+    assert parse_arguments(handler.signature, handler.type_hints, {}) == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Adds a guest-safe `music_quiz/public_state` command that returns the current public quiz state without needing a participant `player_id`. A dashboard display (such as the Apple TV app) is not a participant, so on connect it could previously only read quiz metadata and had to wait for the next live event before it could render the full game. This lets a display render the complete current state immediately on cold launch or reconnect.

- New guest-safe `music_quiz/public_state` → the full public state (players + current round), or nothing when no game is running.
- Returns the same public payload already broadcast by the `game_updated` event, so no new models.
- Read-only: no game mutation and no participant-presence side effects.

**Related issue (if applicable):**

- Supports the Apple TV dashboard app (#4979)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
