### PR TITLE
Fix missing AirPlay cover art

### DIFF
--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -150,12 +150,7 @@ class AirPlayStream:
             await self._cli_proc.start()
             self._cli_proc.attach_stderr_reader(self.mass.create_task(self._stderr_reader()))
             self._stdout_reader_task = self.mass.create_task(self._stdout_reader())
-            metadata = self.player.current_media
-            if metadata is None and self.session:
-                metadata = self.session.media
-            if metadata:
-                progress = int(metadata.corrected_elapsed_time or 0)
-                await self.send_metadata(progress, metadata, send_artwork=False)
+            await self._send_current_metadata(send_artwork=False)
         except BaseException:
             try:
                 await self._cleanup_failed_start()
@@ -175,10 +170,11 @@ class AirPlayStream:
         volume = 0 if self.player.volume_muted else self.player.volume_level
         await self.send_cli_command(f"VOLUME={volume}")
         self.mass.call_later(2, self.send_cli_command(f"VOLUME={volume}"))
-        self._metadata_checksum = ""
-        self._metadata_text_checksum = ""
-        self._pending_metadata_checksum = ""
-        self._metadata_generation += 1
+        async with self._metadata_lock:
+            self._metadata_checksum = ""
+            self._metadata_text_checksum = ""
+            self._pending_metadata_checksum = ""
+            self._metadata_generation += 1
         # Push track metadata before START. Some receivers (notably Sonos) hold
         # back audio rendering until they receive track metadata; deferring it
         # can keep them silent past the commanded start.
@@ -321,12 +317,23 @@ class AirPlayStream:
         # the binary's first status arrives, interpolation would otherwise keep
         # extending the previous anchor's clock, briefly mapping a bogus position.
         self.player.set_state_from_stream(elapsed_time=self._start_position, stream=self)
-        if not await self._write_cli_command(f"START_UNIX_MS={start_unix_ms}\nACTION=START"):
-            # Surfacing the dropped delivery lets the session fall back to a
-            # cold restart instead of waiting on an anchor that never happens.
-            raise PlayerCommandFailed(
-                f"Could not deliver START to AirPlay player {self.player.player_id}"
-            )
+        async with self._metadata_lock:
+            if not await self._write_cli_command(f"START_UNIX_MS={start_unix_ms}\nACTION=START"):
+                # Surfacing the dropped delivery lets the session fall back to a
+                # cold restart instead of waiting on an anchor that never happens.
+                raise PlayerCommandFailed(
+                    f"Could not deliver START to AirPlay player {self.player.player_id}"
+                )
+            # A receiver may discard artwork sent before a new playback anchor.
+            # Start a fresh generation so an in-flight pre-transition render is
+            # superseded and the artwork is pushed again after START.
+            self._metadata_checksum = ""
+            self._metadata_generation += 1
+        self.mass.create_task(
+            self._send_current_metadata,
+            task_id=f"airplay_metadata_after_start_{self._stream_id}",
+            abort_existing=True,
+        )
 
     async def send_metadata(
         self,
@@ -375,7 +382,8 @@ class AirPlayStream:
                 if metadata_checksum != self._metadata_text_checksum:
                     cmd = f"TITLE={title}\nARTIST={artist}\nALBUM={album}\n"
                     cmd += f"DURATION={duration}\nPROGRESS=0\nACTION=SENDMETA\n"
-                    await self.send_cli_command(cmd)
+                    if not await self.send_cli_command(cmd):
+                        return
                     self._metadata_text_checksum = metadata_checksum
                     self._last_progress_sent = 0
                 if metadata_generation != self._metadata_generation:
@@ -388,11 +396,11 @@ class AirPlayStream:
                 ):
                     self._artwork_render_generations.add(metadata_generation)
                     artwork_url = metadata.image_url
-                elif not send_artwork or not metadata.image_url or not needs_artwork:
+                elif not metadata.image_url or not needs_artwork:
                     self._metadata_checksum = metadata_checksum
             if progress is not None and abs(progress - self._last_progress_sent) >= 2:
-                self._last_progress_sent = progress
-                await self.send_cli_command(f"PROGRESS={progress}")
+                if await self.send_cli_command(f"PROGRESS={progress}"):
+                    self._last_progress_sent = progress
 
         if artwork_url is not None and metadata_checksum is not None:
             await self._render_and_send_artwork(artwork_url, metadata_checksum, metadata_generation)
@@ -421,9 +429,10 @@ class AirPlayStream:
                 and not self._stopping
                 and metadata_generation == self._metadata_generation
             ):
-                await self.send_cli_command(f"ARTWORK={artwork}")
+                artwork_delivered = await self.send_cli_command(f"ARTWORK={artwork}")
                 if (
-                    not self._stopped
+                    artwork_delivered
+                    and not self._stopped
                     and not self._stopping
                     and metadata_generation == self._metadata_generation
                 ):
@@ -777,6 +786,18 @@ class AirPlayStream:
         except Exception as err:
             self.player.logger.debug("Could not prepare artwork: %s", err)
             return None
+
+    async def _send_current_metadata(self, send_artwork: bool = True) -> None:
+        """
+        Send metadata for the media owned by the active stream.
+
+        :param send_artwork: Whether artwork should be rendered and sent.
+        """
+        metadata = self.session.media if self.session else self.player.current_media
+        if not metadata:
+            return
+        progress = int(metadata.corrected_elapsed_time or 0)
+        await self.send_metadata(progress, metadata, send_artwork=send_artwork)
 
     async def _cleanup_failed_start(self) -> None:
         """Release all resources owned by a cliairplay process that failed to start."""

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -607,6 +607,81 @@ async def test_start_sends_command_and_stamps_position() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "complete_before_start",
+    [True, False],
+    ids=["delivered", "rendering"],
+)
+async def test_start_repushes_transition_artwork(complete_before_start: bool) -> None:
+    """START re-sends artwork prepared before or during a track transition."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+    metadata = MagicMock(
+        corrected_elapsed_time=0,
+        title="New track",
+        artist="Artist",
+        album="Album",
+        duration=180,
+        image_url="new-image",
+    )
+    stream.session = MagicMock(media=metadata)
+    render_started = asyncio.Event()
+    release_render = asyncio.Event()
+    metadata_tasks: list[asyncio.Task[Any]] = []
+    render_count = 0
+
+    def create_task(target: Any, **_kwargs: Any) -> asyncio.Task[Any]:
+        task = asyncio.create_task(target())
+        metadata_tasks.append(task)
+        return task
+
+    async def prepare_artwork(_image_url: str, _generation: int) -> str:
+        nonlocal render_count
+        render_count += 1
+        if render_count == 1:
+            render_started.set()
+            if not complete_before_start:
+                await release_render.wait()
+            return "/cache/pretransition.jpg"
+        return "/cache/posttransition.jpg"
+
+    player.provider.mass.create_task.side_effect = create_task
+    with (
+        patch.object(
+            stream,
+            "_write_cli_command",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as write_command,
+        patch.object(
+            stream,
+            "_prepare_artwork",
+            new_callable=AsyncMock,
+            side_effect=prepare_artwork,
+        ),
+    ):
+        pretransition_task = asyncio.create_task(stream.send_metadata(None, metadata))
+        await render_started.wait()
+        if complete_before_start:
+            await pretransition_task
+        await stream.start(START_UNIX_MS, 0)
+        await asyncio.gather(*metadata_tasks)
+        release_render.set()
+        await pretransition_task
+
+    commands = [args.args[0] for args in write_command.await_args_list]
+    assert commands[-2:] == [
+        f"START_UNIX_MS={START_UNIX_MS}\nACTION=START",
+        "ARTWORK=/cache/posttransition.jpg",
+    ]
+    assert ("ARTWORK=/cache/pretransition.jpg" in commands) is complete_before_start
+    assert stream._metadata_generation == 2
+    assert stream._metadata_checksum == "New track|Artist|Album|180|new-image"
+
+
+@pytest.mark.asyncio
 async def test_start_requires_connected_process() -> None:
     """START is rejected without a connected cliairplay process."""
     stream = AirPlayStream(_make_player())
@@ -1224,3 +1299,42 @@ async def test_send_metadata_passes_cached_artwork_path_to_binary() -> None:
         await stream.send_metadata(None, metadata)
 
     assert send_command.await_args_list[-1] == call(f"ARTWORK={cached_path}")
+
+
+@pytest.mark.asyncio
+async def test_failed_artwork_delivery_is_retried() -> None:
+    """A dropped ARTWORK command remains pending for the next metadata update."""
+    stream = AirPlayStream(_make_player())
+    metadata = MagicMock(
+        duration=180,
+        title="Track",
+        artist="Artist",
+        album="Album",
+        image_url="image",
+    )
+    metadata_checksum = "Track|Artist|Album|180|image"
+    artwork_path = "/cache/thumbnails/artwork.jpg"
+
+    with (
+        patch.object(
+            stream,
+            "_prepare_artwork",
+            new_callable=AsyncMock,
+            return_value=artwork_path,
+        ) as prepare_artwork,
+        patch.object(
+            stream,
+            "send_cli_command",
+            new_callable=AsyncMock,
+            side_effect=[True, False, True],
+        ) as send_command,
+    ):
+        await stream.send_metadata(None, metadata)
+        assert stream._metadata_checksum == ""
+        await stream.send_metadata(None, metadata)
+
+    assert prepare_artwork.await_count == 2
+    assert [args.args[0] for args in send_command.await_args_list].count(
+        f"ARTWORK={artwork_path}"
+    ) == 2
+    assert stream._metadata_checksum == metadata_checksum


### PR DESCRIPTION
# What does this implement/fix?

Fixes cover art sometimes disappearing on AirPlay players after track changes.

- Re-send the current cover after playback starts.
- Retry artwork when a track change interrupts delivery.
- Add regression tests for track changes and delivery retries.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.