### PR TITLE
Resume synced AirPlay groups after pausing

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -316,9 +316,14 @@ class AirPlayPlayer(Player):
             # Grouped pause parks the whole session (standby); unpausing one
             # member cannot restart the group in sync. Resume via the queue
             # instead: play_media flushes and re-anchors every parked member at
-            # one shared instant.
-            queue_id = self.synced_to or self.player_id
-            await self.mass.player_queues.resume(queue_id, fade_in=False)
+            # one shared instant. The queue can belong to a linked native parent
+            # (for example Sonos), so resolve it instead of using the AirPlay ID.
+            active_queue = self.mass.players.get_active_queue(self)
+            if active_queue is None:
+                raise PlayerCommandFailed(
+                    f"Cannot resume grouped AirPlay player {self.display_name} without an active queue"
+                )
+            await self.mass.player_queues.resume(active_queue.queue_id, fade_in=False)
             return
         async with self._lock:
             if self.stream and self.stream.running:

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -786,8 +786,8 @@ def test_supported_features_always_includes_pause(airplay_player: AirPlayPlayer)
     PAUSE stays advertised whether or not the player is grouped.
 
     Keeping PAUSE keeps the AirPlay player itself as the pause control target, so a
-    grouped pause maps to a full session stop (see pause()) instead of the players
-    controller falling through to a linked native player's pause - which would only
+    grouped pause parks the complete session (see pause()) instead of the players
+    controller falling through to a linked native player's pause, which would only
     pause the sync leader while the other members keep playing.
     """
     airplay_player._attr_group_members = []
@@ -795,6 +795,39 @@ def test_supported_features_always_includes_pause(airplay_player: AirPlayPlayer)
     # sync leader: still advertises PAUSE
     airplay_player._attr_group_members = ["test_player", "child"]
     assert PlayerFeature.PAUSE in airplay_player.supported_features
+
+
+@pytest.mark.asyncio
+async def test_single_player_play_sends_action_play(airplay_player: AirPlayPlayer) -> None:
+    """An unsynced player resumes its paused stream in place with ACTION=PLAY."""
+    airplay_player._attr_group_members = []
+    send_cmd = _setup_running_stream(airplay_player)
+
+    await airplay_player.play()
+
+    send_cmd.assert_awaited_once_with("ACTION=PLAY")
+
+
+@pytest.mark.asyncio
+async def test_grouped_play_resumes_active_native_queue(airplay_player: AirPlayPlayer) -> None:
+    """A linked AirPlay group resumes the queue owned by its native parent."""
+    airplay_player._attr_group_members = ["test_player", "child"]
+    send_cmd = _setup_running_stream(airplay_player)
+    active_queue = MagicMock(queue_id="native_parent")
+
+    with (
+        patch.object(
+            airplay_player.mass.players, "get_active_queue", return_value=active_queue
+        ) as get_active_queue,
+        patch.object(
+            airplay_player.mass.player_queues, "resume", new_callable=AsyncMock
+        ) as resume_queue,
+    ):
+        await airplay_player.play()
+
+    get_active_queue.assert_called_once_with(airplay_player)
+    resume_queue.assert_awaited_once_with("native_parent", fade_in=False)
+    send_cmd.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -320,6 +320,8 @@ def test_warm_replace_supports_every_streaming_protocol(
     [
         (StreamingProtocol.AIRPLAY2,),
         (StreamingProtocol.RAOP,),
+        (StreamingProtocol.AIRPLAY2, StreamingProtocol.AIRPLAY2),
+        (StreamingProtocol.RAOP, StreamingProtocol.RAOP),
         (StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2),
     ],
 )
@@ -389,6 +391,7 @@ async def test_standby_resumes_warm_on_existing_streams(
     for player in players:
         stream = original_streams[player.player_id]
         assert player.stream is stream
+        stream.send_cli_command.assert_awaited_once_with("ACTION=STANDBY")
         stream.flush.assert_awaited_once_with()
         stream.start.assert_awaited_once_with(expected_start, 10_000)
 


### PR DESCRIPTION
# What does this implement/fix?

Synced AirPlay groups using a linked player could pause but failed to resume because playback targeted the AirPlay endpoint instead of its active queue.

- Resumes the active player queue for linked and direct AirPlay groups
- Keeps the existing synchronized restart path for all group members
- Covers solo, AirPlay 2, RAOP, and mixed-group pause/resume behavior

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.