### PR TITLE
Make server releases immutable-safe

### DIFF
--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -8,9 +8,13 @@ inputs:
     description: 'The previous release tag to compare against'
     required: false
     default: ''
-  branch:
-    description: 'The branch being released from'
+  head-sha:
+    description: 'The exact source commit used as the comparison head'
     required: true
+  repository-path:
+    description: 'Path to the checked-out release source'
+    required: false
+    default: '.'
   channel:
     description: 'The release channel (stable, rc, beta, nightly)'
     required: true
@@ -29,9 +33,9 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v6.2.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version-file: '.python-version'
+        python-version-file: '${{ inputs.repository-path }}/.python-version'
         check-latest: true
 
     - name: Install dependencies
@@ -46,11 +50,12 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         VERSION: ${{ inputs.version }}
         PREVIOUS_TAG: ${{ inputs.previous-tag }}
-        BRANCH: ${{ inputs.branch }}
+        HEAD_SHA: ${{ inputs.head-sha }}
         CHANNEL: ${{ inputs.channel }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_SERVER_URL: ${{ github.server_url }}
         IMPORTANT_NOTES: ${{ inputs.important-notes }}
       run: |
+        cd "${{ inputs.repository-path }}"
         chmod +x ${{ github.action_path }}/generate_notes.py
         python3 ${{ github.action_path }}/generate_notes.py

--- a/.github/actions/generate-release-notes/generate_notes.py
+++ b/.github/actions/generate-release-notes/generate_notes.py
@@ -56,8 +56,8 @@ def get_released_pr_numbers(repo, merge_base_sha, previous_tag):
     return released
 
 
-def get_prs_between_tags(repo, previous_tag, current_branch):
-    """Get all merged PRs between the previous tag and current HEAD."""
+def get_prs_between_tags(repo, previous_tag, head_sha):
+    """Get all merged PRs between the previous tag and exact source commit."""
     pr_pattern = re.compile(r"#(\d+)")
     merge_pattern = re.compile(r"Merge pull request #(\d+)")
 
@@ -66,12 +66,12 @@ def get_prs_between_tags(repo, previous_tag, current_branch):
     if not previous_tag:
         print("No previous tag specified, will include all PRs from branch history")  # noqa: T201
         # Get the first commit on the branch
-        commits = list(repo.get_commits(sha=current_branch))
+        commits = list(repo.get_commits(sha=head_sha))
         # Limit to last 100 commits to avoid going too far back
         commits = commits[:100]
     else:
-        print(f"Finding PRs between {previous_tag} and {current_branch}")  # noqa: T201
-        comparison = repo.compare(previous_tag, current_branch)
+        print(f"Finding PRs between {previous_tag} and {head_sha}")  # noqa: T201
+        comparison = repo.compare(previous_tag, head_sha)
         commits = comparison.commits
         print(f"Found {comparison.total_commits} commits")  # noqa: T201
         if comparison.behind_by:
@@ -83,7 +83,7 @@ def get_prs_between_tags(repo, previous_tag, current_branch):
             merge_base = comparison.merge_base_commit
             cutoff_date = merge_base.commit.committer.date
             print(  # noqa: T201
-                f"Previous tag {previous_tag} has diverged from {current_branch}, "
+                f"Previous tag {previous_tag} has diverged from {head_sha}, "
                 f"using merge base date {cutoff_date} as cutoff"
             )
             released_pr_numbers = get_released_pr_numbers(repo, merge_base.sha, previous_tag)
@@ -402,18 +402,18 @@ def main():
     github_token = os.environ.get("GITHUB_TOKEN")
     version = os.environ.get("VERSION")
     previous_tag = os.environ.get("PREVIOUS_TAG", "")
-    branch = os.environ.get("BRANCH")
+    head_sha = os.environ.get("HEAD_SHA")
     channel = os.environ.get("CHANNEL")
     repo_name = os.environ.get("GITHUB_REPOSITORY")
     important_notes = os.environ.get("IMPORTANT_NOTES", "")
 
-    if not all([github_token, version, branch, channel, repo_name]):
+    if not all([github_token, version, head_sha, channel, repo_name]):
         print("Error: Missing required environment variables")  # noqa: T201
         sys.exit(1)
 
     print(f"Generating release notes for {version} ({channel} channel)")  # noqa: T201
     print(f"Repository: {repo_name}")  # noqa: T201
-    print(f"Branch: {branch}")  # noqa: T201
+    print(f"Source SHA: {head_sha}")  # noqa: T201
     print(f"Previous tag: {previous_tag or 'None (first release)'}")  # noqa: T201
 
     # Initialize GitHub API
@@ -425,7 +425,7 @@ def main():
     print(f"Loaded config with {len(config.get('categories', []))} categories")  # noqa: T201
 
     # Get PRs between tags
-    prs = get_prs_between_tags(repo, previous_tag, branch)
+    prs = get_prs_between_tags(repo, previous_tag, head_sha)
     print(f"Processing {len(prs)} merged PRs")  # noqa: T201
 
     if not prs:

--- a/.github/workflows/RELEASE_NOTES_GENERATION.md
+++ b/.github/workflows/RELEASE_NOTES_GENERATION.md
@@ -1,212 +1,65 @@
-# Release Notes Generation - Channel-Specific Behavior
+# Release Notes Generation
 
-## Overview
+Release notes are generated from the exact `source_sha` selected at the start of a
+release. Branch names determine the channel source, but they are never used as the notes
+comparison head after the SHA is captured.
 
-The release workflow generates release notes **specific to each channel** by leveraging Release Drafter's `filter-by-commitish` feature. This ensures that:
+## Previous-tag selection
 
-- **Stable** releases only show commits from the `stable` branch
-- **Beta** releases only show commits from the `dev` branch since the last beta
-- **Nightly** releases only show commits from the `dev` branch since the last nightly
+The workflow discovers prior releases from Git tags:
 
-The workflow uses the **release notes configuration** (`.github/release-notes-config.yml`) for label-based categorization and formatting.
+| Channel | Previous tag |
+|---|---|
+| Stable | Latest `X.Y.Z` tag |
+| Beta | Latest `X.Y.ZbN` or `X.Y.ZrcN` tag |
+| RC1 | Latest `X.Y.ZbN` tag |
+| RC2+ | Previous RC for the same base version, falling back to the latest beta |
+| Nightly | Latest `X.Y.Z.devN` tag |
 
-## How It Works
+The version currently being prepared is always excluded. This matters for retries and
+for deleted release records whose Git tag still exists.
 
-### 1. Filter by Branch (commitish)
+For linear histories, pull requests come from the commits between the previous tag and
+`source_sha`. A stable minor branch can diverge from the previous stable patch branch.
+In that case, the generator uses the merge base as its cutoff and excludes pull requests
+that already shipped on the old patch branch.
 
-The `.github/release-notes-config.yml` file includes:
+## Note contents
 
-```yaml
-filter-by-commitish: true
-```
+`.github/release-notes-config.yml` defines label categories, exclusions, formatting, and
+contributors. The generator:
 
-This tells Release Drafter to only consider releases that have the same `target_commitish` (branch) when calculating the commit range. Combined with setting the `commitish` parameter to the appropriate branch:
+1. Finds merged pull requests represented in the exact Git comparison.
+2. Excludes pull requests merged before the comparison cutoff or already released on a
+   diverged stable patch branch.
+3. Categorizes changes using the release-notes configuration.
+4. Extracts notes from frontend dependency-update pull requests in the same comparison.
+5. Merges and deduplicates server and frontend contributors.
+6. Places manually supplied important notes first.
 
-- **Stable releases**: Use `commitish: stable` → Only sees releases created from `stable` branch
-- **Beta releases**: Use `commitish: dev` → Only sees releases created from `dev` branch
-- **Nightly releases**: Use `commitish: dev` → Only sees releases created from `dev` branch
+The resulting body is finalized on the matching draft before publication. Reruns may
+refresh draft notes, but release assets and the source SHA must remain exact. After
+publication, the release is verified as immutable and release/asset attestations are
+checked before downstream promotion.
 
-### 2. Previous Release Detection
+## Verification
 
-The workflow also manually identifies the previous release for context headers using tag patterns:
-
-#### Stable Channel
-- **Pattern**: `^[0-9]+\.[0-9]+\.[0-9]+$` (e.g., `2.1.0`, `2.0.5`)
-- **Branch**: `stable`
-- **Finds**: Latest stable release (no suffix)
-
-#### Beta Channel
-- **Pattern**: `^[0-9]+\.[0-9]+\.[0-9]+b[0-9]+$` (e.g., `2.1.0b1`, `2.1.0b2`)
-- **Branch**: `dev`
-- **Finds**: Latest beta release (`bN` suffix)
-
-#### Nightly Channel
-- **Pattern**: `^[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+$` (e.g., `2.1.0.dev20251023`)
-- **Branch**: `dev`
-- **Finds**: Latest nightly release (`.devYYYYMMDD` suffix)
-
-### 3. Release Notes Generation
-
-Release Drafter automatically:
-
-1. **Finds commit range**: Determines commits between the previous release (same branch) and HEAD
-2. **Extracts PRs**: Identifies all merged pull requests in that range
-3. **Categorizes by labels**: Applies the category rules from `.github/release-notes-config.yml`:
-   - ⚠ Breaking Changes (`breaking-change` label)
-   - 🚀 New Providers (`new-provider` label)
-   - 🚀 Features and enhancements (`feature`, `enhancement`, `new-feature` labels)
-   - 🐛 Bugfixes (`bugfix` label)
-   - 🧰 Maintenance (`ci`, `documentation`, `maintenance`, `dependencies` labels)
-4. **Lists contributors**: Adds all unique contributors from the PRs
-
-The workflow then enhances these notes by:
-- Adding a context header showing the previous release
-- Extracting and appending frontend changes from frontend update PRs
-- Merging and deduplicating contributors from both server and frontend
-
-### 4. What This Means
-
-#### ✅ Stable Release Notes
-- Include **only commits since the last stable release**
-- **Do NOT include** beta or nightly commits that happened in between
-- Example: `2.0.5` → `2.1.0` only shows stable branch commits
-
-#### ✅ Beta Release Notes
-- Include **only commits since the last beta release**
-- **Do NOT include** nightly commits
-- **Do NOT include** stable commits from stable branch
-- Example: `2.1.0b2` → `2.1.0b3` only shows dev branch commits since b2
-
-#### ✅ Nightly Release Notes
-- Include **only commits since the last nightly release**
-- **Do NOT include** beta or stable releases in between
-- Example: `2.1.0.dev20251022` → `2.1.0.dev20251023` only shows dev branch commits since yesterday
-
-## Release Notes Configuration
-
-✅ The workflow uses a **custom release notes generator** that reads `.github/release-notes-config.yml`:
-
-```yaml
-# .github/release-notes-config.yml
-change-template: '- $TITLE (by @$AUTHOR in #$NUMBER)'
-
-categories:
-  - title: "⚠ Breaking Changes"
-    labels: ['breaking-change']
-  # ... more categories
-```
-
-This approach ensures:
-- **Full control over commit range** (explicit previous tag parameter)
-- **No mysterious failures** (clear Python code you can debug)
-- **Consistent formatting** (same config format as Release Drafter used)
-- **Branch-based separation** (stable vs dev commits via explicit tag comparison)
-
-The configuration includes:
-- Category definitions (labels → section headers)
-- Category titles and emoji
-- Excluded contributors (bots)
-- PR title format
-- Collapse settings for long categories
-
-## Example Release Notes Format
-
-```markdown
-## 📦 Beta Release
-
-_Changes since [2.1.0b1](https://github.com/music-assistant/server/releases/tag/2.1.0b1)_
-
-### ⚠ Breaking Changes
-
-- Major API refactoring (by @contributor1 in #123)
-
-### 🚀 Features and enhancements
-
-- Add new audio processor (by @contributor2 in #124)
-- Improve queue management (by @contributor3 in #125)
-
-### 🐛 Bugfixes
-
-- Fix playback issue (by @contributor1 in #126)
-
-### 🧰 Maintenance and dependency bumps
-
-- Update dependencies (by @dependabot in #127)
-- Improve CI pipeline (by @contributor2 in #128)
-
-## :bow: Thanks to our contributors
-
-Special thanks to the following contributors who helped with this release:
-
-@contributor1, @contributor2, @contributor3
-```
-
-## Testing
-
-To verify channel-specific release notes:
-
-1. **Create a beta release** after a stable release:
-   ```bash
-   # Should only show commits on dev branch since last beta
-   # Should NOT include stable branch commits
-   ```
-
-2. **Create a nightly release** after a beta release:
-   ```bash
-   # Should only show commits since yesterday's nightly
-   # Should NOT include beta release notes
-   ```
-
-3. **Create a stable release** after multiple betas:
-   ```bash
-   # Should only show commits on stable branch since last stable
-   # Should NOT include any beta or nightly commits
-   ```
-
-## Verification Commands
+The focused tests cover linear and diverged comparisons:
 
 ```bash
-# Check what will be in next stable release
-git log $(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)..stable --oneline
-
-# Check what will be in next beta release
-git log $(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.b[0-9]+$' | sort -V | tail -1)..dev --oneline
-
-# Check what will be in next nightly release
-git log $(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+$' | sort -V | tail -1)..dev --oneline
+pytest tests/test_generate_release_notes.py tests/scripts/test_release_workflow.py
 ```
 
-## Testing
-
-To verify channel-specific release notes:
-
-1. **Create a beta release** after a stable release:
-   ```bash
-   # Should only show commits on dev branch since last beta
-   # Should NOT include stable branch commits
-   ```
-
-2. **Create a nightly release** after a beta release:
-   ```bash
-   # Should only show commits since yesterday's nightly
-   # Should NOT include beta release notes
-   ```
-
-3. **Create a stable release** after multiple betas:
-   ```bash
-   # Should only show commits on stable branch since last stable
-   # Should NOT include any beta or nightly commits
-   ```
-
-## Verification Commands
+To inspect a pending comparison manually, use the source SHA reported by auto-release:
 
 ```bash
-# Check what will be in next stable release
-git log $(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)..stable --oneline
+git log PREVIOUS_TAG..SOURCE_SHA --oneline
+```
 
-# Check what will be in next beta release
-git log $(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.b[0-9]+$' | sort -V | tail -1)..dev --oneline
+For a diverged stable tag, inspect both sides from their merge base:
 
-# Check what will be in next nightly release
-git log $(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+$' | sort -V | tail -1)..dev --oneline
+```bash
+base=$(git merge-base PREVIOUS_TAG SOURCE_SHA)
+git log "$base..SOURCE_SHA" --oneline
+git log "$base..PREVIOUS_TAG" --oneline
 ```

--- a/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
+++ b/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
@@ -1,199 +1,139 @@
 # Release Workflow Guide
 
-This document explains how to use the new release workflow for Music Assistant.
+The server release workflows publish one verified source commit as an immutable GitHub
+release and an exact multi-architecture GHCR image before changing any rolling channel.
+The server package is attached to GitHub releases only; it is not published to PyPI.
 
-## Overview
+## Release channels
 
-The release workflow has been completely reworked to **create releases** rather than being triggered by them. This gives you more control over the release process and ensures consistency across different release channels.
+| Channel | Source branch | Version format | GitHub release |
+|---|---|---|---|
+| Stable | `stable` | `X.Y.Z` | Release |
+| RC | `stable` | `X.Y.ZrcN` | Prerelease |
+| Beta | `dev` | `X.Y.ZbN` | Prerelease |
+| Nightly | `dev` | `X.Y.Z.devN` | Prerelease |
 
-## How to Create a Release
+Auto-release checks out the channel branch explicitly and captures its full commit SHA.
+That `source_sha` is passed to the reusable release workflow and remains the source for
+tests, release notes, package contents, the Git tag, the exact container image, and
+frontend-version extraction even if the branch advances during the run.
 
-1. Go to the **Actions** tab in GitHub
-2. Select the **"Create Release"** workflow
-3. Click **"Run workflow"**
-4. Fill in the required inputs:
-   - **Version number**: Enter the version in the appropriate format (see below)
-   - **Release channel**: Select from `stable`, `beta`, or `nightly`
-5. Click **"Run workflow"** to start the release process
+Automatic versions come from Git tags, not release records. The workflow validates the
+previous channel tag's relationship to `source_sha` and counts its Git commit range.
+Deleted release records therefore cannot make a tag/version reusable. Stable automatic
+releases continue to increment the patch component only. Nightlies require at least two
+commits after the previous nightly tag.
 
-## Version Format Requirements
+## Publishing sequence
 
-The workflow validates version numbers based on the selected channel:
+Only one release workflow runs at a time, and queued runs are never cancelled.
 
-### Stable Channel
-- **Format**: `X.Y.Z` (e.g., `2.1.0`, `2.1.1`)
-- **Examples**:
-  - ✅ `2.1.0`
-  - ✅ `1.5.3`
-  - ❌ `2.1.0.b1` (beta suffix not allowed for stable)
+1. Resolve the channel branch and exact `source_sha`.
+2. Require the repository's immutable-release setting using a short-lived GitHub App
+   token with Administration read access.
+3. If the version is not already published, run the full test workflow against
+   `source_sha`.
+4. Build the wheel and source distribution, or recover the exact two verified assets
+   from a matching draft.
+5. Create an annotated exact tag with `github-actions[bot]`, then create or update only a
+   draft whose version, tag, and target SHA match. Replace incomplete draft assets, then
+   verify both asset names, sizes, upload state, and SHA-256 digests.
+6. Build and push only `ghcr.io/music-assistant/server:$VERSION`. The image index must
+   contain `linux/amd64` and `linux/arm64`, identify `source_sha` and the wheel digest,
+   and produce one captured OCI digest. An existing exact tag is verified and never
+   overwritten.
+7. Revalidate the draft, recheck the immutable-release setting, and publish once.
+8. Require an immutable release, the tag at `source_sha`, matching release assets,
+   successful release and asset attestations, and the same exact OCI digest.
+9. Promote that digest without rebuilding to the channel aliases:
+   - Stable: `X.Y`, `X`, `stable`, `latest`
+   - RC and beta: `beta`
+   - Nightly: `nightly`
+10. Deterministically update the matching Home Assistant add-on and dispatch the
+    frontend version from `source_sha` to `app.music-assistant.io`.
 
-### Beta Channel
-- **Format**: `X.Y.Z.bN` (e.g., `2.1.0.b1`, `2.1.0.b2`)
-- **Examples**:
-  - ✅ `2.1.0.b1`
-  - ✅ `2.2.0.b3`
-  - ❌ `2.1.0` (must have beta suffix)
+The exact image tag is already the full version (`X.Y.Z`, `X.Y.ZbN`, `X.Y.ZrcN`, or
+`X.Y.Z.devN`). Rolling aliases are never pushed before the immutable release verifies.
 
-### Nightly Channel
-- **Format**: `X.Y.Z.devN` (e.g., `2.1.0.dev1`, `2.1.0.dev20251023`)
-- **Examples**:
-  - ✅ `2.1.0.dev1`
-  - ✅ `2.1.0.dev20251023`
-  - ❌ `2.1.0` (must have dev suffix)
+## Starting a release
 
-## What the Workflow Does
+The scheduled workflow checks nightly releases automatically. For a manual version:
 
-### 1. Validation & Build (`validate-and-build` job)
-- ✅ Validates the version number format matches the selected channel
-- ✅ Updates the version in `pyproject.toml`
-- ✅ Builds the Python package (wheel and source distribution)
-- ✅ Uploads artifacts for use in subsequent jobs
+1. Run **Auto Release** from the `dev` branch.
+2. Select `stable`, `rc`, `beta`, or `nightly`.
+3. Add important notes when needed.
 
-### 2. Create Release (`create-release` job)
-- ✅ Checks out the correct branch (stable for stable releases, dev for beta/nightly)
-- ✅ Determines the previous release tag for the same channel
-- ✅ Uses Release Drafter to generate release notes from PRs/commits on that branch
-- ✅ **Extracts and appends frontend changes** from music-assistant-frontend update PRs
-- ✅ **Merges and deduplicates contributors** from both server and frontend PRs
-- ✅ Creates a GitHub release (marked as prerelease for beta/nightly)
-- ✅ Attaches the built Python packages to the release
+Auto-release calculates the next version and invokes **Create Release** with its captured
+source SHA. **Create Release** can also be dispatched directly with an explicit version;
+for direct runs it resolves and freezes the current channel branch head itself.
 
-#### Branch Strategy
-- **Stable releases** (`X.Y.Z`): Built from the `stable` branch
-- **Beta releases** (`X.Y.Z.bN`): Built from the `dev` branch
-- **Nightly releases** (`X.Y.Z.devN`): Built from the `dev` branch
+Do not create or publish a GitHub release manually. A draft created outside the workflow
+is accepted only when its exact tag name and target SHA match; conflicting tags,
+published mutable releases, and mismatched drafts fail closed.
 
-This ensures stable releases only include changes that have been merged to stable, while beta and nightly releases include the latest development changes.
+## Authentication
 
-#### Frontend Changes Integration
-The workflow automatically finds all "⬆️ Update music-assistant-frontend to X.X.X" PRs that were merged since the last release and extracts their release notes. These are appended to the server release notes under a "🎨 Frontend Changes" section as a unified list of all frontend changes across all versions. This ensures users can see both server and frontend changes in one place.
+Same-repository tags, releases, assets, attestations, and GHCR writes use the job's
+built-in `GITHUB_TOKEN` and `github-actions[bot]`.
 
-#### Contributor Merging
-The workflow also extracts all `@username` mentions from both the server release notes (generated by Release Drafter) and the frontend PR descriptions, then merges and deduplicates them. The final "Thanks to our contributors" section includes everyone who contributed to both the server and frontend in this release cycle.
+Administrative and cross-repository work uses a fresh installation token in each job
+from the private `music-assistant-bot` GitHub App. Tokens are never passed between jobs
+and are restricted to one repository and the permission needed by that job.
 
-**Example of final release notes structure:**
-```markdown
-## ⚠ Breaking Changes
-- Server breaking change (by @serverdev in #123)
+The server repository must define:
 
-## 🚀 Features and enhancements
-- Server feature 1 (by @contributor1 in #124)
-- Server feature 2 (by @contributor2 in #125)
+- Repository variable `MUSIC_ASSISTANT_BOT_CLIENT_ID`
+- Repository secret `MUSIC_ASSISTANT_BOT_PRIVATE_KEY`
 
-## 🐛 Bugfixes
-- Server bugfix (by @contributor1 in #126)
+The App installation must include these selected repositories:
 
-## 🎨 Frontend Changes
-• Add the provider type on items on search (by @frontenddev in #1174)
-• Fix player menu position (by @contributor3 in #1175)
-• Update translations (by @translator in #1170)
-• Fix dark mode styling issue (by @frontenddev in #1171)
+| Repository | Token permission used by this workflow |
+|---|---|
+| `music-assistant/server` | Administration: read |
+| `music-assistant/appvars` | Contents: read |
+| `music-assistant/home-assistant-addon` | Contents: write |
+| `music-assistant/app.music-assistant.io` | Contents: write |
 
-## :bow: Thanks to our contributors
+The App itself must be approved for Administration read and Contents write. Each minted
+token is downscoped from those installation permissions. The workflow verifies that the
+token's App slug is `musicassistant-bot`.
 
-Special thanks to the following contributors who helped with this release:
+## Recovery
 
-@contributor1, @contributor2, @contributor3, @frontenddev, @serverdev, @translator
-```
+Rerun the failed workflow with the same version and `source_sha`.
 
-### 3. Docker Image Build (`build-and-push-container-image` job)
-- ✅ Builds multi-platform Docker images (amd64 + arm64)
-- ✅ Uses the correct base image version for the channel
-- ✅ Tags images appropriately based on the channel:
+- **Before publication:** The matching draft remains mutable. Complete assets are
+  downloaded and reused byte-for-byte; incomplete assets are replaced. If the exact
+  image already exists, its source, wheel digest, platforms, and OCI digest must match,
+  otherwise the rerun stops without overwriting it. Run-scoped build artifacts remain
+  available to GitHub's **Re-run failed jobs** path. A crash after exact tag creation but
+  before draft creation can resume only when the annotated tag has the workflow's exact
+  source marker and `github-actions[bot]` identity.
+- **After publication:** Tests, package builds, draft mutation, and publication are
+  skipped. The immutable release, assets, attestations, tag, and exact image are verified
+  again, then rolling aliases and downstream updates resume. If a newer release already
+  superseded this version, verification still runs but older downstream state is not
+  restored.
 
-#### Stable Release Tags
-- `ghcr.io/music-assistant/server:X.Y.Z`
-- `ghcr.io/music-assistant/server:X.Y`
-- `ghcr.io/music-assistant/server:X`
-- `ghcr.io/music-assistant/server:stable`
-- `ghcr.io/music-assistant/server:latest`
+An immutable release with incorrect contents cannot be repaired. Publish a new version
+that supersedes it. A published mutable release is also never adopted by this workflow.
 
-#### Beta Release Tags
-- `ghcr.io/music-assistant/server:X.Y.Z.bN`
-- `ghcr.io/music-assistant/server:beta`
+The add-on changelog update removes duplicate entries for the same version, prepends one
+canonical entry using the GitHub publication date, and retains three distinct releases.
+Repeated frontend dispatches carry the same channel, frontend version, server version,
+source SHA, and image digest; the receiver converges on the same channel state.
 
-#### Nightly Release Tags
-- `ghcr.io/music-assistant/server:X.Y.Z.devN`
-- `ghcr.io/music-assistant/server:nightly`
+## Rollout
 
-### 4. Update Add-on Repository (`update-addon-repository` job)
-- ✅ Determines the correct add-on folder based on channel:
-  - **Stable**: `music_assistant`
-  - **Beta**: `music_assistant_beta`
-  - **Nightly**: `music_assistant_nightly`
-- ✅ Updates `config.yaml` with the new version number
-- ✅ Updates `CHANGELOG.md` with the full release notes
-- ✅ Keeps only the last 2 versions in the changelog (removes older entries)
-- ✅ Commits and pushes changes directly to the `music-assistant/home-assistant-addon` repository
+Perform rollout in this order:
 
-This ensures the Home Assistant add-on is automatically updated with each release, making it immediately available to users!
+1. Merge the support hardening PR for existing `music-assistant-bot` token usage.
+2. Add/approve the App's Administration read and Contents write permissions and the four
+   selected repositories above.
+3. Merge the server release-workflow PR.
+4. Enable immutable releases for `music-assistant/server`.
+5. Run a unique nightly canary and verify its release, two assets, exact multi-arch image,
+   rolling `nightly` alias, add-on update, and frontend dispatch.
 
-## Base Image Versions
-
-The workflow uses different base image versions per channel (configured in workflow env vars):
-
-- **Stable**: `1.3.1`
-- **Beta**: `1.3.2`
-- **Nightly**: `1.3.2`
-
-These can be updated in the workflow file's `env` section.
-
-## Release Notes
-
-Release notes are automatically generated by our custom release notes generator based on:
-- Merged pull requests since the last release of the same channel
-- PR labels (breaking-change, feature, bugfix, etc.)
-- Contributors list (merged from server and frontend PRs)
-- Frontend changes extracted from frontend update PRs
-
-The configuration is in `.github/release-notes-config.yml`.
-
-See `.github/actions/generate-release-notes/README.md` for more details on how the generator works.
-
-## Examples
-
-### Creating a Stable Release
-```
-Version: 2.1.0
-Channel: stable
-```
-This will:
-- Create release `2.1.0` (not a prerelease)
-- Tag Docker images with `2.1.0`, `2.1`, `2`, `stable`, and `latest`
-
-### Creating a Beta Release
-```
-Version: 2.2.0.b1
-Channel: beta
-```
-This will:
-- Create release `2.2.0.b1` (marked as prerelease)
-- Tag Docker images with `2.2.0.b1` and `beta`
-
-### Creating a Nightly Release
-```
-Version: 2.2.0.dev20251023
-Channel: nightly
-```
-This will:
-- Create release `2.2.0.dev20251023` (marked as prerelease)
-- Tag Docker images with `2.2.0.dev20251023` and `nightly`
-
-## Troubleshooting
-
-### Workflow Fails During Validation
-- Check that your version number matches the format for the selected channel
-- Ensure the version doesn't already exist as a tag
-
-### Docker Build Fails
-- Check that the base image version exists
-- Verify the Dockerfile is compatible with the version being built
-
-## Migration Notes
-
-This workflow replaces the previous `release.yml` which was triggered by creating a release in GitHub. Key differences:
-
-- **Before**: Create a release manually → workflow publishes it
-- **Now**: Trigger workflow → it creates and publishes the release
-
-The new approach provides better automation, validation, and consistency across channels.
+Keep the immutable-release setting disabled until the server PR has merged. Enabling it
+against the previous publish-first workflow can strand incomplete public releases.

--- a/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
+++ b/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
@@ -49,11 +49,15 @@ Only one release workflow runs at a time, and queued runs are never cancelled.
    - Stable: `X.Y`, `X`, `stable`, `latest`
    - RC and beta: `beta`
    - Nightly: `nightly`
+   Each alias's current amd64 and arm64 image labels are checked independently. An alias
+   that already points to a newer release is never moved backward.
 10. Deterministically update the matching Home Assistant add-on and dispatch the
     frontend version from `source_sha` to `app.music-assistant.io`.
 
 The exact image tag is already the full version (`X.Y.Z`, `X.Y.ZbN`, `X.Y.ZrcN`, or
 `X.Y.Z.devN`). Rolling aliases are never pushed before the immutable release verifies.
+Normal channel releases are forward-only. This workflow does not define a legacy-branch
+backport process for publishing an older version after a newer channel release.
 
 ## Starting a release
 
@@ -96,7 +100,7 @@ The App installation must include these selected repositories:
 
 The App itself must be approved for Administration read and Contents write. Each minted
 token is downscoped from those installation permissions. The workflow verifies that the
-token's App slug is `musicassistant-bot`.
+token's App slug is `musicassistant-bot` and its installation ID is `146062122`.
 
 ## Recovery
 
@@ -120,8 +124,15 @@ that supersedes it. A published mutable release is also never adopted by this wo
 
 The add-on changelog update removes duplicate entries for the same version, prepends one
 canonical entry using the GitHub publication date, and retains three distinct releases.
-Repeated frontend dispatches carry the same channel, frontend version, server version,
-source SHA, and image digest; the receiver converges on the same channel state.
+The add-on repository's default branch is resolved through GitHub, and non-fast-forward
+updates retry a bounded pull/rebase/push sequence.
+
+Frontend recovery reads the target repository's `channels.json` first. Equal or newer
+frontend state suppresses the dispatch; an older state receives a payload containing a
+stable `server@$VERSION` idempotency key, channel, frontend and server versions, source
+SHA, and image digest. The receiver does not yet persist the idempotency key itself, so
+an immediate rerun while the first dispatch is still in flight can enqueue a replacement;
+the receiver's per-channel concurrency cancels the older in-flight run.
 
 ## Rollout
 

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,9 +1,8 @@
 name: Auto Release
 
-# Automatically creates releases with proper version increments
-# - Nightly: runs at 02:00 UTC daily if there are 2+ commits (format: 1.2.3.dev20251025HH)
-# - Beta: manual trigger (format: 1.2.0b1, 1.2.0b2, etc.)
-# - Stable: manual trigger (format: 1.2.3, 1.2.4, etc.)
+# Automatically creates releases with proper version increments.
+# - Nightly: runs at 05:00 Europe/Amsterdam with 2+ commits
+# - Beta, RC, stable: manually triggered
 
 on:
   schedule:
@@ -26,334 +25,101 @@ on:
         required: false
 
 permissions:
-  actions: write
-  contents: write
+  contents: read
+
+concurrency:
+  group: auto-release-${{ inputs.channel || 'nightly' }}
+  cancel-in-progress: false
 
 jobs:
-  check-and-release:
+  resolve-release:
+    name: Resolve release source and version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.next_version.outputs.version }}
-      should_release: ${{ steps.check_commits.outputs.has_commits }}
-      channel: ${{ steps.set_channel.outputs.channel }}
+      version: ${{ steps.version.outputs.version }}
+      should_release: ${{ steps.version.outputs.should_release }}
+      channel: ${{ steps.channel.outputs.channel }}
+      branch: ${{ steps.branch.outputs.branch }}
+      source_sha: ${{ steps.source.outputs.sha }}
     steps:
-      - name: Set release channel
-        id: set_channel
-        run: |
-          # Use input channel for manual runs, default to nightly for scheduled runs
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            CHANNEL="${{ inputs.channel }}"
-          else
-            CHANNEL="nightly"
-          fi
-          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
-          echo "Release channel: $CHANNEL"
-
-      - name: Checkout repository
-        uses: actions/checkout@v7
+      - name: Check out release workflow
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0 # Fetch all history for proper comparison
+          ref: ${{ github.workflow_sha }}
+          path: .release-workflow
+          persist-credentials: false
 
-      - name: Check for new commits
-        id: check_commits
-        run: |
-          CHANNEL="${{ steps.set_channel.outputs.channel }}"
-
-          # Define search patterns for each channel
-          case "$CHANNEL" in
-            nightly)
-              SEARCH_PATTERN="dev"
-              ;;
-            beta)
-              SEARCH_PATTERN="b"
-              ;;
-            rc)
-              SEARCH_PATTERN="rc"
-              ;;
-            stable)
-              # For stable, we want versions that don't contain dev or beta suffixes
-              SEARCH_PATTERN="stable"
-              ;;
-          esac
-
-          # Get the latest release for the channel
-          if [ "$CHANNEL" = "stable" ]; then
-            # For stable, get releases that don't contain dev, beta, or rc suffixes
-            LATEST_RELEASE=$(gh release list --exclude-drafts --limit 100 --json createdAt,tagName,isPrerelease --jq '.[] | select(.tagName | contains("dev") | not) | select(.tagName | test("b[0-9]") | not) | select(.tagName | contains("rc") | not)' 2>/dev/null | jq -s '.[0]' || echo "")
-          else
-            # For nightly and beta, filter by pattern
-            LATEST_RELEASE=$(gh release list --exclude-drafts --limit 100 --json createdAt,tagName,isPrerelease --jq ".[] | select(.tagName | contains(\"$SEARCH_PATTERN\"))" 2>/dev/null | jq -s '.[0]' || echo "")
-          fi
-
-          if [ -z "$LATEST_RELEASE" ] || [ "$LATEST_RELEASE" == "null" ]; then
-            echo "No previous $CHANNEL releases found"
-            echo "has_commits=true" >> $GITHUB_OUTPUT
-            echo "last_tag=" >> $GITHUB_OUTPUT
-          else
-            RELEASE_DATE=$(echo "$LATEST_RELEASE" | jq -r '.createdAt')
-            LAST_TAG=$(echo "$LATEST_RELEASE" | jq -r '.tagName')
-            echo "Latest $CHANNEL release: $LAST_TAG at $RELEASE_DATE"
-            echo "last_tag=$LAST_TAG" >> $GITHUB_OUTPUT
-
-            # Check if there are commits since the latest release
-            COMMITS_SINCE=$(git log --since="$RELEASE_DATE" --oneline | wc -l)
-            echo "Commits since last $CHANNEL release: $COMMITS_SINCE"
-
-            # Require at least 2 commits for auto-release (nightly only)
-            # For manual beta/stable releases, always proceed
-            if [ "$CHANNEL" = "nightly" ]; then
-              if [ "$COMMITS_SINCE" -ge 2 ]; then
-                echo "has_commits=true" >> $GITHUB_OUTPUT
-              else
-                echo "has_commits=false" >> $GITHUB_OUTPUT
-                echo "Only $COMMITS_SINCE commit(s) found. Need at least 2 commits for auto-release."
-              fi
-            else
-              # Manual releases (beta/stable) always proceed
-              echo "has_commits=true" >> $GITHUB_OUTPUT
-            fi
-          fi
+      - name: Set release channel
+        id: channel
         env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Get last stable release (for beta and nightly versioning)
-        id: last_stable
-        if: ${{ steps.set_channel.outputs.channel == 'beta' || steps.set_channel.outputs.channel == 'nightly' }}
+          DISPATCH_CHANNEL: ${{ inputs.channel }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          # Get the latest stable release (no dev, beta, or rc suffixes)
-          LATEST_STABLE=$(gh release list --exclude-drafts --limit 100 --json createdAt,tagName,isPrerelease --jq '.[] | select(.tagName | contains("dev") | not) | select(.tagName | test("b[0-9]") | not) | select(.tagName | contains("rc") | not)' 2>/dev/null | jq -s '.[0]' || echo "")
-
-          if [ -z "$LATEST_STABLE" ] || [ "$LATEST_STABLE" == "null" ]; then
-            echo "No previous stable releases found"
-            echo "stable_tag=" >> $GITHUB_OUTPUT
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            channel="$DISPATCH_CHANNEL"
           else
-            STABLE_TAG=$(echo "$LATEST_STABLE" | jq -r '.tagName')
-            echo "Latest stable release: $STABLE_TAG"
-            echo "stable_tag=$STABLE_TAG" >> $GITHUB_OUTPUT
+            channel="nightly"
           fi
-        env:
-          GH_TOKEN: ${{ github.token }}
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "Release channel: $channel"
 
-      - name: Get last beta release (for RC versioning)
-        id: last_beta
-        if: ${{ steps.set_channel.outputs.channel == 'rc' }}
+      - name: Resolve source branch
+        id: branch
+        run: >-
+          python3 .release-workflow/scripts/release_workflow.py branch
+          --channel "${{ steps.channel.outputs.channel }}"
+          --github-output "$GITHUB_OUTPUT"
+
+      - name: Check out release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.branch.outputs.branch }}
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+
+      - name: Capture source commit
+        id: source
         run: |
-          # Get the latest beta release
-          LATEST_BETA=$(gh release list --exclude-drafts --limit 100 --json createdAt,tagName,isPrerelease --jq '.[] | select(.tagName | test("b[0-9]"))' 2>/dev/null | jq -s '.[0]' || echo "")
-
-          if [ -z "$LATEST_BETA" ] || [ "$LATEST_BETA" == "null" ]; then
-            echo "No previous beta releases found"
-            echo "beta_tag=" >> $GITHUB_OUTPUT
-          else
-            BETA_TAG=$(echo "$LATEST_BETA" | jq -r '.tagName')
-            echo "Latest beta release: $BETA_TAG"
-            echo "beta_tag=$BETA_TAG" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
+          source_sha=$(git -C source rev-parse HEAD)
+          echo "sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "Release source: ${{ steps.branch.outputs.branch }}@$source_sha"
 
       - name: Calculate next version
-        id: next_version
-        if: steps.check_commits.outputs.has_commits == 'true'
-        run: |
-          LAST_TAG="${{ steps.check_commits.outputs.last_tag }}"
-          CHANNEL="${{ steps.set_channel.outputs.channel }}"
-
-          case "$CHANNEL" in
-            nightly)
-              # Nightly: format 1.2.3.devYYYYMMDDHH
-              # Always one minor version ahead of the last stable release
-              TODAY=$(date -u +%Y%m%d)
-              HOUR=$(date -u +%H)
-              LAST_STABLE_TAG="${{ steps.last_stable.outputs.stable_tag }}"
-
-              # Determine the base version (should be one minor version ahead of stable)
-              if [ -n "$LAST_STABLE_TAG" ]; then
-                STABLE_VERSION=$(echo "$LAST_STABLE_TAG" | sed 's/^v//')
-
-                if [[ "$STABLE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-                  MAJOR="${BASH_REMATCH[1]}"
-                  MINOR="${BASH_REMATCH[2]}"
-                  NEXT_MINOR=$((MINOR + 1))
-                  BASE_VERSION="${MAJOR}.${NEXT_MINOR}.0"
-                else
-                  BASE_VERSION="0.1.0"
-                fi
-              else
-                # No stable release found, start with default
-                BASE_VERSION="0.1.0"
-              fi
-
-              NEW_VERSION="${BASE_VERSION}.dev${TODAY}${HOUR}"
-              echo "Nightly version based on stable ${LAST_STABLE_TAG}: ${NEW_VERSION}"
-              ;;
-
-            beta)
-              # Beta: format 1.2.0b1, 1.2.0b2, etc.
-              # Always base the version on the last STABLE release, not dev versions
-              LAST_BETA_TAG="${{ steps.check_commits.outputs.last_tag }}"
-              LAST_STABLE_TAG="${{ steps.last_stable.outputs.stable_tag }}"
-
-              # Check if there's an existing beta version
-              if [ -n "$LAST_BETA_TAG" ]; then
-                BETA_VERSION=$(echo "$LAST_BETA_TAG" | sed 's/^v//')
-
-                # Check if it's already a beta version (e.g., 2.7.0b1)
-                if [[ "$BETA_VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)b([0-9]+)$ ]]; then
-                  BETA_BASE="${BASH_REMATCH[1]}"
-                  BETA_NUM="${BASH_REMATCH[2]}"
-
-                  # Extract major.minor from beta base
-                  if [[ "$BETA_BASE" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
-                    BETA_MAJOR="${BASH_REMATCH[1]}"
-                    BETA_MINOR="${BASH_REMATCH[2]}"
-                  fi
-
-                  # Check if stable has caught up to or surpassed the beta base version
-                  NEED_NEW_CYCLE=false
-                  if [ -n "$LAST_STABLE_TAG" ]; then
-                    STABLE_VERSION=$(echo "$LAST_STABLE_TAG" | sed 's/^v//')
-                    if [[ "$STABLE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-                      STABLE_MAJOR="${BASH_REMATCH[1]}"
-                      STABLE_MINOR="${BASH_REMATCH[2]}"
-
-                      if [ "$STABLE_MAJOR" -gt "$BETA_MAJOR" ] || \
-                         ([ "$STABLE_MAJOR" -eq "$BETA_MAJOR" ] && [ "$STABLE_MINOR" -ge "$BETA_MINOR" ]); then
-                        NEED_NEW_CYCLE=true
-                      fi
-                    fi
-                  fi
-
-                  if [ "$NEED_NEW_CYCLE" = true ]; then
-                    # Stable has caught up or surpassed beta — start new beta cycle
-                    NEXT_MINOR=$((STABLE_MINOR + 1))
-                    NEW_VERSION="${STABLE_MAJOR}.${NEXT_MINOR}.0b1"
-                    echo "Starting new beta cycle: stable ${LAST_STABLE_TAG} >= beta base ${BETA_BASE} -> ${NEW_VERSION}"
-                  else
-                    # Beta is still ahead of stable, increment beta number
-                    NEXT_BETA=$((BETA_NUM + 1))
-                    NEW_VERSION="${BETA_BASE}b${NEXT_BETA}"
-                    echo "Incrementing existing beta: ${LAST_BETA_TAG} -> ${NEW_VERSION}"
-                  fi
-                else
-                  # Should not happen, but fallback
-                  NEW_VERSION="0.1.0b1"
-                fi
-              elif [ -n "$LAST_STABLE_TAG" ]; then
-                # No beta exists, increment minor from last stable and start at b1
-                STABLE_VERSION=$(echo "$LAST_STABLE_TAG" | sed 's/^v//')
-
-                if [[ "$STABLE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-                  MAJOR="${BASH_REMATCH[1]}"
-                  MINOR="${BASH_REMATCH[2]}"
-                  NEXT_MINOR=$((MINOR + 1))
-                  NEW_VERSION="${MAJOR}.${NEXT_MINOR}.0b1"
-                  echo "Creating first beta based on stable ${LAST_STABLE_TAG}: ${NEW_VERSION}"
-                else
-                  NEW_VERSION="0.1.0b1"
-                fi
-              else
-                # No stable or beta found, start fresh
-                NEW_VERSION="0.1.0b1"
-              fi
-              ;;
-
-            rc)
-              # RC: format X.Y.ZrcN
-              # Base version comes from the latest beta tag
-              LAST_BETA_TAG="${{ steps.last_beta.outputs.beta_tag }}"
-              LAST_RC_TAG="${{ steps.check_commits.outputs.last_tag }}"
-
-              if [ -n "$LAST_BETA_TAG" ]; then
-                BETA_VERSION=$(echo "$LAST_BETA_TAG" | sed 's/^v//')
-
-                # Extract base version from beta tag (e.g., 2.8.0b22 -> 2.8.0)
-                if [[ "$BETA_VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)b[0-9]+$ ]]; then
-                  BETA_BASE="${BASH_REMATCH[1]}"
-                else
-                  echo "Error: Cannot parse beta version: $BETA_VERSION"
-                  exit 1
-                fi
-
-                # Check if there's an existing RC tag for this base version
-                if [ -n "$LAST_RC_TAG" ]; then
-                  RC_VERSION=$(echo "$LAST_RC_TAG" | sed 's/^v//')
-
-                  if [[ "$RC_VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)rc([0-9]+)$ ]]; then
-                    RC_BASE="${BASH_REMATCH[1]}"
-                    RC_NUM="${BASH_REMATCH[2]}"
-
-                    if [ "$RC_BASE" = "$BETA_BASE" ]; then
-                      # Same base version, increment RC number
-                      NEXT_RC=$((RC_NUM + 1))
-                      NEW_VERSION="${BETA_BASE}rc${NEXT_RC}"
-                      echo "Incrementing existing RC: ${LAST_RC_TAG} -> ${NEW_VERSION}"
-                    else
-                      # Different base version (new beta cycle), start at rc1
-                      NEW_VERSION="${BETA_BASE}rc1"
-                      echo "New RC cycle based on beta ${LAST_BETA_TAG}: ${NEW_VERSION}"
-                    fi
-                  else
-                    # Last RC tag doesn't parse, start fresh
-                    NEW_VERSION="${BETA_BASE}rc1"
-                  fi
-                else
-                  # No RC exists, start at rc1
-                  NEW_VERSION="${BETA_BASE}rc1"
-                  echo "Creating first RC based on beta ${LAST_BETA_TAG}: ${NEW_VERSION}"
-                fi
-              else
-                # No beta found, fallback
-                NEW_VERSION="0.1.0rc1"
-              fi
-              ;;
-
-            stable)
-              # Stable: format 1.2.3, increment patch version
-              if [ -z "$LAST_TAG" ]; then
-                NEW_VERSION="0.1.0"
-              else
-                VERSION=$(echo "$LAST_TAG" | sed 's/^v//')
-
-                # Extract major.minor.patch and increment patch
-                if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-                  MAJOR="${BASH_REMATCH[1]}"
-                  MINOR="${BASH_REMATCH[2]}"
-                  PATCH="${BASH_REMATCH[3]}"
-                  NEXT_PATCH=$((PATCH + 1))
-                  NEW_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
-                else
-                  NEW_VERSION="0.1.0"
-                fi
-              fi
-              ;;
-          esac
-
-          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "New $CHANNEL version: $NEW_VERSION"
+        id: version
+        working-directory: source
+        run: >-
+          python3 ../.release-workflow/scripts/release_workflow.py auto-version
+          --channel "${{ steps.channel.outputs.channel }}"
+          --source-sha "${{ steps.source.outputs.sha }}"
+          --github-output "$GITHUB_OUTPUT"
 
       - name: Log release decision
+        env:
+          CHANNEL: ${{ steps.channel.outputs.channel }}
+          COMMITS_SINCE: ${{ steps.version.outputs.commits_since }}
+          SHOULD_RELEASE: ${{ steps.version.outputs.should_release }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          CHANNEL="${{ steps.set_channel.outputs.channel }}"
-          if [ "${{ steps.check_commits.outputs.has_commits }}" == "true" ]; then
-            echo "✅ Will create $CHANNEL release ${{ steps.next_version.outputs.version }}"
+          if [ "$SHOULD_RELEASE" = "true" ]; then
+            echo "Will create $CHANNEL release $VERSION from $COMMITS_SINCE new commit(s)"
           else
-            echo "⏭️ Skipping release - not enough commits"
+            echo "Skipping $CHANNEL release with only $COMMITS_SINCE new commit(s)"
           fi
 
   trigger-release:
-    name: Trigger Release Workflow
-    needs: check-and-release
-    if: needs.check-and-release.outputs.should_release == 'true'
+    name: Create release
+    needs: resolve-release
+    if: needs.resolve-release.outputs.should_release == 'true'
     permissions:
-      actions: write
       contents: write
-      pull-requests: read
       packages: write
+      pull-requests: read
     uses: ./.github/workflows/release.yml
     with:
-      version: ${{ needs.check-and-release.outputs.version }}
-      channel: ${{ needs.check-and-release.outputs.channel }}
+      version: ${{ needs.resolve-release.outputs.version }}
+      channel: ${{ needs.resolve-release.outputs.channel }}
+      source_sha: ${{ needs.resolve-release.outputs.source_sha }}
       important_notes: ${{ inputs.important_notes }}
     secrets:
-      PRIVILEGED_GITHUB_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+      MUSIC_ASSISTANT_BOT_PRIVATE_KEY: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ env:
   BASE_IMAGE_VERSION_BETA: "1.6.0"
   BASE_IMAGE_VERSION_NIGHTLY: "1.6.0"
   EXPECTED_APP_SLUG: musicassistant-bot
+  EXPECTED_APP_INSTALLATION_ID: "146062122"
 
 permissions:
   contents: read
@@ -161,9 +162,11 @@ jobs:
       - name: Verify GitHub App identity
         env:
           APP_SLUG: ${{ steps.immutable_token.outputs.app-slug }}
+          INSTALLATION_ID: ${{ steps.immutable_token.outputs.installation-id }}
         run: |
-          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ]; then
-            echo "Unexpected GitHub App: $APP_SLUG" >&2
+          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ] || \
+             [ "$INSTALLATION_ID" != "$EXPECTED_APP_INSTALLATION_ID" ]; then
+            echo "Unexpected GitHub App installation: $APP_SLUG/$INSTALLATION_ID" >&2
             exit 1
           fi
 
@@ -321,7 +324,6 @@ jobs:
     if: needs.resolve.outputs.release_state != 'published'
     permissions:
       contents: read
-      pull-requests: read
     uses: ./.github/workflows/test.yml
     with:
       ref: ${{ needs.resolve.outputs.source_sha }}
@@ -393,9 +395,11 @@ jobs:
         if: needs.resolve.outputs.assets_ready != 'true'
         env:
           APP_SLUG: ${{ steps.appvars_token.outputs.app-slug }}
+          INSTALLATION_ID: ${{ steps.appvars_token.outputs.installation-id }}
         run: |
-          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ]; then
-            echo "Unexpected GitHub App: $APP_SLUG" >&2
+          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ] || \
+             [ "$INSTALLATION_ID" != "$EXPECTED_APP_INSTALLATION_ID" ]; then
+            echo "Unexpected GitHub App installation: $APP_SLUG/$INSTALLATION_ID" >&2
             exit 1
           fi
 
@@ -842,9 +846,11 @@ jobs:
             MASS_VERSION=${{ inputs.version }}
             BASE_IMAGE_VERSION=${{ needs.resolve.outputs.base_image_version }}
           labels: |
+            org.opencontainers.image.version=${{ inputs.version }}
             org.opencontainers.image.revision=${{ needs.resolve.outputs.source_sha }}
             io.music-assistant.wheel.sha256=${{ needs.prepare_draft.outputs.wheel_sha256 }}
           annotations: |
+            index:org.opencontainers.image.version=${{ inputs.version }}
             index:org.opencontainers.image.revision=${{ needs.resolve.outputs.source_sha }}
             index:io.music-assistant.wheel.sha256=${{ needs.prepare_draft.outputs.wheel_sha256 }}
 
@@ -1000,9 +1006,11 @@ jobs:
         if: steps.publication_state.outputs.already_published != 'true'
         env:
           APP_SLUG: ${{ steps.immutable_token.outputs.app-slug }}
+          INSTALLATION_ID: ${{ steps.immutable_token.outputs.installation-id }}
         run: |
-          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ]; then
-            echo "Unexpected GitHub App: $APP_SLUG" >&2
+          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ] || \
+             [ "$INSTALLATION_ID" != "$EXPECTED_APP_INSTALLATION_ID" ]; then
+            echo "Unexpected GitHub App installation: $APP_SLUG/$INSTALLATION_ID" >&2
             exit 1
           fi
 
@@ -1143,8 +1151,16 @@ jobs:
     needs: [resolve, exact_image, publish_release]
     if: needs.resolve.outputs.is_current == 'true'
     permissions:
+      contents: read
       packages: write
     steps:
+      - name: Check out release workflow
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-workflow
+          persist-credentials: false
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
@@ -1184,7 +1200,75 @@ jobs:
               ;;
           esac
 
+          promotion_aliases=()
           for alias in "${aliases[@]}"; do
+            target="$IMAGE_REPOSITORY:$alias"
+            error_file="$RUNNER_TEMP/alias-$alias-error.txt"
+            manifest_file="$RUNNER_TEMP/alias-$alias-manifest.json"
+            if docker buildx imagetools inspect "$target" \
+              --format '{{json .Manifest}}' \
+              > "$manifest_file" 2> "$error_file"; then
+              platforms=$(jq -r \
+                '.manifests[]
+                 | select(.platform.os != "unknown")
+                 | "\(.platform.os)/\(.platform.architecture)"' \
+                "$manifest_file" | sort)
+              if [ "$platforms" != $'linux/amd64\nlinux/arm64' ]; then
+                echo "$target has an unexpected platform set: $platforms" >&2
+                exit 1
+              fi
+
+              versions_file="$RUNNER_TEMP/alias-$alias-versions.txt"
+              : > "$versions_file"
+              while read -r runtime_digest; do
+                docker buildx imagetools inspect \
+                  "$IMAGE_REPOSITORY@$runtime_digest" \
+                  --format '{{json .Image}}' > "$RUNNER_TEMP/alias-image.json"
+                current_version=$(jq -r \
+                  '.config.Labels["org.opencontainers.image.version"]
+                   // .config.Labels["io.hass.version"]
+                   // empty' \
+                  "$RUNNER_TEMP/alias-image.json")
+                if [ -z "$current_version" ]; then
+                  echo "$target has no release version label" >&2
+                  exit 1
+                fi
+                echo "$current_version" >> "$versions_file"
+              done < <(jq -r \
+                '.manifests[]
+                 | select(.platform.os == "linux")
+                 | .digest' \
+                "$manifest_file")
+
+              mapfile -t current_versions < <(sort -u "$versions_file")
+              if [ "${#current_versions[@]}" -ne 1 ]; then
+                echo "$target has inconsistent release version labels" >&2
+                exit 1
+              fi
+              relation=$(python3 \
+                .release-workflow/scripts/release_workflow.py \
+                compare-release-versions \
+                --current "${current_versions[0]}" \
+                --requested "$VERSION" |
+                sed -n 's/^current_relation=//p')
+              if [ "$relation" = "newer" ]; then
+                echo "$target already points to newer version ${current_versions[0]}" >&2
+                exit 1
+              fi
+              current_digest=$(jq -r '.digest' "$manifest_file")
+              if [ "$relation" = "equal" ] && [ "$current_digest" = "$DIGEST" ]; then
+                echo "$target already points to $VERSION@$DIGEST"
+                continue
+              fi
+            elif ! grep -Eqi 'not found|manifest unknown|status.*404' "$error_file"; then
+              cat "$error_file" >&2
+              echo "Unable to inspect $target" >&2
+              exit 1
+            fi
+            promotion_aliases+=("$alias")
+          done
+
+          for alias in "${promotion_aliases[@]}"; do
             target="$IMAGE_REPOSITORY:$alias"
             docker buildx imagetools create \
               --tag "$target" \
@@ -1232,22 +1316,39 @@ jobs:
         env:
           APP_SLUG: ${{ steps.addon_token.outputs.app-slug }}
           GH_TOKEN: ${{ steps.addon_token.outputs.token }}
+          INSTALLATION_ID: ${{ steps.addon_token.outputs.installation-id }}
         run: |
-          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ]; then
-            echo "Unexpected GitHub App: $APP_SLUG" >&2
+          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ] || \
+             [ "$INSTALLATION_ID" != "$EXPECTED_APP_INSTALLATION_ID" ]; then
+            echo "Unexpected GitHub App installation: $APP_SLUG/$INSTALLATION_ID" >&2
             exit 1
           fi
           user_id=$(gh api "/users/$APP_SLUG%5Bbot%5D" --jq '.id')
           echo "slug=$APP_SLUG" >> "$GITHUB_OUTPUT"
           echo "user_id=$user_id" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve add-on default branch
+        id: addon_repository
+        env:
+          GH_TOKEN: ${{ steps.addon_token.outputs.token }}
+        run: |
+          default_branch=$(gh api \
+            repos/music-assistant/home-assistant-addon \
+            --jq '.default_branch')
+          if [ -z "$default_branch" ]; then
+            echo "Unable to resolve the add-on default branch" >&2
+            exit 1
+          fi
+          echo "default_branch=$default_branch" >> "$GITHUB_OUTPUT"
+
       - name: Check out add-on repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: music-assistant/home-assistant-addon
-          ref: main
+          ref: ${{ steps.addon_repository.outputs.default_branch }}
           token: ${{ steps.addon_token.outputs.token }}
           path: addon-repo
+          fetch-depth: 0
 
       - name: Resolve add-on channel
         id: channel
@@ -1292,6 +1393,7 @@ jobs:
           ADDON_FOLDER: ${{ steps.channel.outputs.folder }}
           APP_SLUG: ${{ steps.app.outputs.slug }}
           APP_USER_ID: ${{ steps.app.outputs.user_id }}
+          ADDON_BRANCH: ${{ steps.addon_repository.outputs.default_branch }}
           CHANNEL: ${{ inputs.channel }}
           VERSION: ${{ inputs.version }}
         run: |
@@ -1305,7 +1407,18 @@ jobs:
           git config user.email \
             "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
           git commit -m "🤖 Bump $CHANNEL add-on to version $VERSION"
-          git push origin HEAD:main
+          for attempt in {1..3}; do
+            if git pull --rebase origin "$ADDON_BRANCH" &&
+               git push origin "HEAD:$ADDON_BRANCH"; then
+              exit 0
+            fi
+            git rebase --abort 2>/dev/null || true
+            if [ "$attempt" -eq 3 ]; then
+              echo "Unable to push the add-on update after three attempts" >&2
+              exit 1
+            fi
+            sleep 5
+          done
 
   update_remote_app:
     name: Update app.music-assistant.io
@@ -1314,6 +1427,13 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Check out release workflow
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-workflow
+          persist-credentials: false
+
       - name: Check out exact release source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -1354,9 +1474,11 @@ jobs:
       - name: Verify GitHub App identity
         env:
           APP_SLUG: ${{ steps.app_token.outputs.app-slug }}
+          INSTALLATION_ID: ${{ steps.app_token.outputs.installation-id }}
         run: |
-          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ]; then
-            echo "Unexpected GitHub App: $APP_SLUG" >&2
+          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ] || \
+             [ "$INSTALLATION_ID" != "$EXPECTED_APP_INSTALLATION_ID" ]; then
+            echo "Unexpected GitHub App installation: $APP_SLUG/$INSTALLATION_ID" >&2
             exit 1
           fi
 
@@ -1369,12 +1491,34 @@ jobs:
           SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
           VERSION: ${{ inputs.version }}
         run: |
+          gh api \
+            -H "Accept: application/vnd.github.raw+json" \
+            repos/music-assistant/app.music-assistant.io/contents/channels.json \
+            > "$RUNNER_TEMP/channels.json"
+          current_version=$(jq -r \
+            --arg channel "$CHANNEL" \
+            '.[$channel] // empty' \
+            "$RUNNER_TEMP/channels.json")
+          if [ -n "$current_version" ]; then
+            relation=$(python3 \
+              .release-workflow/scripts/release_workflow.py \
+              compare-frontend-versions \
+              --current "$current_version" \
+              --requested "$FRONTEND_VERSION" |
+              sed -n 's/^current_relation=//p')
+            if [ "$relation" != "older" ]; then
+              echo "Skipping frontend dispatch: $CHANNEL already uses $current_version"
+              exit 0
+            fi
+          fi
+
           jq -n \
             --arg channel "$CHANNEL" \
             --arg frontend_version "$FRONTEND_VERSION" \
             --arg server_version "$VERSION" \
             --arg source_sha "$SOURCE_SHA" \
             --arg image_digest "$IMAGE_DIGEST" \
+            --arg idempotency_key "$GITHUB_REPOSITORY@$VERSION" \
             '{
               event_type: "frontend-update",
               client_payload: {
@@ -1382,7 +1526,8 @@ jobs:
                 frontend_version: $frontend_version,
                 server_version: $server_version,
                 source_sha: $source_sha,
-                image_digest: $image_digest
+                image_digest: $image_digest,
+                idempotency_key: $idempotency_key
               }
             }' > "$RUNNER_TEMP/dispatch.json"
           gh api --method POST \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,552 +29,1362 @@ on:
         description: "Release channel"
         required: true
         type: string
+      source_sha:
+        description: "Exact source commit to release"
+        required: true
+        type: string
       important_notes:
         description: "Important notes (breaking changes, critical info, etc.)"
         required: false
         type: string
     secrets:
-      PRIVILEGED_GITHUB_TOKEN:
+      MUSIC_ASSISTANT_BOT_PRIVATE_KEY:
         required: true
 
 env:
   BASE_IMAGE_VERSION_STABLE: "1.5.4"
   BASE_IMAGE_VERSION_BETA: "1.6.0"
   BASE_IMAGE_VERSION_NIGHTLY: "1.6.0"
+  EXPECTED_APP_SLUG: musicassistant-bot
 
 permissions:
   contents: read
 
+concurrency:
+  group: immutable-release
+  cancel-in-progress: false
+
 jobs:
-  determine-branch:
-    name: Determine release branch
+  resolve:
+    name: Resolve and validate release state
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
+      source_sha: ${{ steps.source.outputs.sha }}
+      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
+      base_image_version: ${{ steps.version.outputs.base_image_version }}
+      release_state: ${{ steps.state.outputs.release_state }}
+      is_current: ${{ steps.state.outputs.is_current }}
+      release_id: ${{ steps.state.outputs.release_id }}
+      assets_ready: ${{ steps.state.outputs.assets_ready }}
+      wheel_name: ${{ steps.state.outputs.wheel_name }}
+      wheel_size: ${{ steps.state.outputs.wheel_size }}
+      wheel_sha256: ${{ steps.state.outputs.wheel_sha256 }}
+      sdist_name: ${{ steps.state.outputs.sdist_name }}
+      sdist_size: ${{ steps.state.outputs.sdist_size }}
+      sdist_sha256: ${{ steps.state.outputs.sdist_sha256 }}
     steps:
-      - name: Determine branch to use
-        id: branch
-        run: |
-          CHANNEL="${{ inputs.channel }}"
+      - name: Check out release workflow
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-workflow
+          persist-credentials: false
 
-          if [ "$CHANNEL" = "stable" ] || [ "$CHANNEL" = "rc" ]; then
-            echo "branch=stable" >> $GITHUB_OUTPUT
-            echo "Using stable branch for $CHANNEL release"
+      - name: Resolve source branch
+        id: branch
+        run: >-
+          python3 .release-workflow/scripts/release_workflow.py branch
+          --channel "${{ inputs.channel }}"
+          --github-output "$GITHUB_OUTPUT"
+
+      - name: Check out source branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.branch.outputs.branch }}
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+
+      - name: Resolve exact source commit
+        id: source
+        env:
+          REQUESTED_SHA: ${{ inputs.source_sha }}
+        run: |
+          branch_sha=$(git -C source rev-parse HEAD)
+          if [ -n "$REQUESTED_SHA" ]; then
+            if ! [[ "$REQUESTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "source_sha must be a full lowercase commit SHA" >&2
+              exit 1
+            fi
+            source_sha=$(git -C source rev-parse "$REQUESTED_SHA^{commit}")
+            if ! git -C source merge-base --is-ancestor "$source_sha" "$branch_sha"; then
+              echo "$source_sha is not part of ${{ steps.branch.outputs.branch }}" >&2
+              exit 1
+            fi
           else
-            echo "branch=dev" >> $GITHUB_OUTPUT
-            echo "Using dev branch for $CHANNEL release"
+            source_sha="$branch_sha"
+          fi
+          echo "sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "Release source: ${{ steps.branch.outputs.branch }}@$source_sha"
+
+      - name: Validate version
+        id: version
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          python3 .release-workflow/scripts/release_workflow.py validate-version \
+            --channel "$CHANNEL" \
+            --version "$VERSION"
+          case "$CHANNEL" in
+            stable)
+              echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+              echo "base_image_version=${{ env.BASE_IMAGE_VERSION_STABLE }}" >> "$GITHUB_OUTPUT"
+              ;;
+            beta)
+              echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+              echo "base_image_version=${{ env.BASE_IMAGE_VERSION_BETA }}" >> "$GITHUB_OUTPUT"
+              ;;
+            rc)
+              echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+              echo "base_image_version=${{ env.BASE_IMAGE_VERSION_STABLE }}" >> "$GITHUB_OUTPUT"
+              ;;
+            nightly)
+              echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+              echo "base_image_version=${{ env.BASE_IMAGE_VERSION_NIGHTLY }}" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Create immutable-settings token
+        id: immutable_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.repository }}
+          permission-administration: read
+
+      - name: Verify GitHub App identity
+        env:
+          APP_SLUG: ${{ steps.immutable_token.outputs.app-slug }}
+        run: |
+          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ]; then
+            echo "Unexpected GitHub App: $APP_SLUG" >&2
+            exit 1
           fi
 
-  preflight-checks:
-    name: Run tests and linting before release
-    needs: determine-branch
+      - name: Require immutable releases
+        env:
+          GH_TOKEN: ${{ steps.immutable_token.outputs.token }}
+        run: |
+          enabled=$(gh api \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/$GITHUB_REPOSITORY/immutable-releases" \
+            --jq '.enabled')
+          if [ "$enabled" != "true" ]; then
+            echo "Immutable releases must be enabled before a release can run" >&2
+            exit 1
+          fi
+
+      - name: Inspect existing tag and release
+        id: state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IS_PRERELEASE: ${{ steps.version.outputs.is_prerelease }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          release_json="$RUNNER_TEMP/release.json"
+          release_error="$RUNNER_TEMP/release-error.txt"
+          if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" \
+            > "$release_json" 2> "$release_error"; then
+            release_exists=true
+          elif grep -q "HTTP 404" "$release_error"; then
+            release_exists=false
+          else
+            cat "$release_error" >&2
+            exit 1
+          fi
+
+          tag_sha=""
+          tag_is_resumable=false
+          if git -C source show-ref --verify --quiet "refs/tags/$VERSION"; then
+            tag_sha=$(git -C source rev-parse "refs/tags/$VERSION^{commit}")
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION" \
+              > "$RUNNER_TEMP/tag-ref.json"
+            if [ "$(jq -r '.object.type' "$RUNNER_TEMP/tag-ref.json")" = "tag" ]; then
+              tag_object_sha=$(jq -r '.object.sha' "$RUNNER_TEMP/tag-ref.json")
+              gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_object_sha" \
+                > "$RUNNER_TEMP/tag-object.json"
+              tag_message="Music Assistant release $VERSION from $SOURCE_SHA"
+              if jq -e \
+                --arg version "$VERSION" \
+                --arg source "$SOURCE_SHA" \
+                --arg message "$tag_message" \
+                '.tag == $version and
+                 .message == $message and
+                 .object.type == "commit" and
+                 .object.sha == $source and
+                 .tagger.name == "github-actions[bot]"' \
+                "$RUNNER_TEMP/tag-object.json" > /dev/null; then
+                tag_is_resumable=true
+              fi
+            fi
+          fi
+          current_outputs="$RUNNER_TEMP/current-version.txt"
+          python3 .release-workflow/scripts/release_workflow.py current-version \
+            --channel "${{ inputs.channel }}" \
+            --version "$VERSION" \
+            --repository source \
+            --github-output "$current_outputs"
+          cat "$current_outputs" >> "$GITHUB_OUTPUT"
+          is_current=$(sed -n 's/^is_current=//p' "$current_outputs")
+
+          if [ "$release_exists" = "false" ]; then
+            if [ -n "$tag_sha" ] && [ "$tag_is_resumable" != "true" ]; then
+              echo "Tag $VERSION already exists without a resumable workflow marker" >&2
+              exit 1
+            fi
+            if [ "$is_current" != "true" ]; then
+              echo "Version $VERSION is older than an existing channel tag" >&2
+              exit 1
+            fi
+            {
+              echo "release_state=new"
+              echo "release_id="
+              echo "assets_ready=false"
+            } >> "$GITHUB_OUTPUT"
+            if [ "$tag_is_resumable" = "true" ]; then
+              echo "Resuming the matching release tag $VERSION"
+            fi
+            exit 0
+          fi
+
+          release_id=$(jq -r '.id' "$release_json")
+          draft=$(jq -r '.draft' "$release_json")
+          immutable=$(jq -r '.immutable' "$release_json")
+          target=$(jq -r '.target_commitish' "$release_json")
+          prerelease=$(jq -r '.prerelease' "$release_json")
+          echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
+
+          if [ "$draft" = "true" ]; then
+            if [ "$immutable" != "false" ] || [ "$target" != "$SOURCE_SHA" ]; then
+              echo "Existing draft does not match source commit $SOURCE_SHA" >&2
+              exit 1
+            fi
+            if [ "$tag_is_resumable" != "true" ] || [ "$tag_sha" != "$SOURCE_SHA" ]; then
+              echo "Existing draft does not have its matching workflow-created tag" >&2
+              exit 1
+            fi
+            if [ "$is_current" != "true" ]; then
+              echo "Draft $VERSION was superseded by a newer channel tag" >&2
+              exit 1
+            fi
+            echo "release_state=draft" >> "$GITHUB_OUTPUT"
+            asset_outputs="$RUNNER_TEMP/draft-assets.txt"
+            if python3 .release-workflow/scripts/release_workflow.py assets \
+              --version "$VERSION" \
+              --release-json "$release_json" \
+              --github-output "$asset_outputs"; then
+              cat "$asset_outputs" >> "$GITHUB_OUTPUT"
+              echo "assets_ready=true" >> "$GITHUB_OUTPUT"
+              echo "Reusing the verified assets from draft $VERSION"
+            else
+              echo "assets_ready=false" >> "$GITHUB_OUTPUT"
+              echo "Draft assets are incomplete or inconsistent and will be replaced"
+            fi
+            exit 0
+          fi
+
+          if [ "$immutable" != "true" ]; then
+            echo "Published release $VERSION is mutable and cannot be resumed" >&2
+            exit 1
+          fi
+          if [ -z "$tag_sha" ] || [ "$tag_sha" != "$SOURCE_SHA" ]; then
+            echo "Immutable release tag $VERSION does not match $SOURCE_SHA" >&2
+            exit 1
+          fi
+          if [ "$prerelease" != "$IS_PRERELEASE" ]; then
+            echo "Immutable release $VERSION has the wrong prerelease state" >&2
+            exit 1
+          fi
+          python3 .release-workflow/scripts/release_workflow.py assets \
+            --version "$VERSION" \
+            --release-json "$release_json" \
+            --github-output "$GITHUB_OUTPUT"
+          {
+            echo "release_state=published"
+            echo "assets_ready=true"
+          } >> "$GITHUB_OUTPUT"
+          echo "Immutable release $VERSION is already published; resuming downstream work"
+          if [ "$is_current" != "true" ]; then
+            echo "A newer channel release exists; rolling downstream state will not be changed"
+          fi
+
+  preflight:
+    name: Test exact release source
+    needs: resolve
+    if: needs.resolve.outputs.release_state != 'published'
     permissions:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/test.yml
     with:
-      ref: ${{ needs.determine-branch.outputs.branch }}
+      ref: ${{ needs.resolve.outputs.source_sha }}
 
-  validate-and-build:
-    name: Validate version and build Python artifact
+  build_artifacts:
+    name: Build or recover release assets
     runs-on: ubuntu-latest
-    needs: [determine-branch, preflight-checks]
+    needs: [resolve, preflight]
+    if: needs.resolve.outputs.release_state != 'published'
+    permissions:
+      contents: read
     outputs:
-      version: ${{ inputs.version }}
-      is_prerelease: ${{ steps.validate.outputs.is_prerelease }}
-      base_image_version: ${{ steps.validate.outputs.base_image_version }}
-      branch: ${{ needs.determine-branch.outputs.branch }}
+      reused_assets: ${{ steps.mode.outputs.reused_assets }}
+      wheel_name: ${{ steps.assets.outputs.wheel_name }}
+      wheel_size: ${{ steps.assets.outputs.wheel_size }}
+      wheel_sha256: ${{ steps.assets.outputs.wheel_sha256 }}
+      sdist_name: ${{ steps.assets.outputs.sdist_name }}
+      sdist_size: ${{ steps.assets.outputs.sdist_size }}
+      sdist_sha256: ${{ steps.assets.outputs.sdist_sha256 }}
     steps:
-      - uses: actions/checkout@v7
+      - name: Check out release workflow
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ needs.determine-branch.outputs.branch }}
-          fetch-depth: 0
+          ref: ${{ github.workflow_sha }}
+          path: .release-workflow
+          persist-credentials: false
 
-      - name: Validate version number format
-        id: validate
+      - name: Check out release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          path: source
+          persist-credentials: false
+
+      - name: Select asset source
+        id: mode
+        env:
+          ASSETS_READY: ${{ needs.resolve.outputs.assets_ready }}
         run: |
-          VERSION="${{ inputs.version }}"
-          CHANNEL="${{ inputs.channel }}"
+          echo "reused_assets=$ASSETS_READY" >> "$GITHUB_OUTPUT"
+          mkdir -p source/dist
 
-          # Regex patterns for each channel
-          STABLE_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+$'
-          BETA_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+b[0-9]+$'
-          RC_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+rc[0-9]+$'
-          NIGHTLY_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+$'
+      - name: Recover matching draft assets
+        if: needs.resolve.outputs.assets_ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SDIST_NAME: ${{ needs.resolve.outputs.sdist_name }}
+          VERSION: ${{ inputs.version }}
+          WHEEL_NAME: ${{ needs.resolve.outputs.wheel_name }}
+        run: |
+          gh release download "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir source/dist \
+            --pattern "$WHEEL_NAME" \
+            --pattern "$SDIST_NAME"
 
-          # Validate version format matches channel
-          case "$CHANNEL" in
-            stable)
-              if ! [[ "$VERSION" =~ $STABLE_PATTERN ]]; then
-                echo "Error: Stable channel requires version format: X.Y.Z (e.g., 1.2.3)"
-                exit 1
-              fi
-              echo "is_prerelease=false" >> $GITHUB_OUTPUT
-              echo "base_image_version=${{ env.BASE_IMAGE_VERSION_STABLE }}" >> $GITHUB_OUTPUT
-              ;;
-            beta)
-              if ! [[ "$VERSION" =~ $BETA_PATTERN ]]; then
-                echo "Error: Beta channel requires version format: X.Y.ZbN (e.g., 1.2.3b1)"
-                exit 1
-              fi
-              echo "is_prerelease=true" >> $GITHUB_OUTPUT
-              echo "base_image_version=${{ env.BASE_IMAGE_VERSION_BETA }}" >> $GITHUB_OUTPUT
-              ;;
-            rc)
-              if ! [[ "$VERSION" =~ $RC_PATTERN ]]; then
-                echo "Error: RC channel requires version format: X.Y.ZrcN (e.g., 1.2.3rc1)"
-                exit 1
-              fi
-              echo "is_prerelease=true" >> $GITHUB_OUTPUT
-              echo "base_image_version=${{ env.BASE_IMAGE_VERSION_STABLE }}" >> $GITHUB_OUTPUT
-              ;;
-            nightly)
-              if ! [[ "$VERSION" =~ $NIGHTLY_PATTERN ]]; then
-                echo "Error: Nightly channel requires version format: X.Y.Z.devN (e.g., 1.2.3.dev1)"
-                exit 1
-              fi
-              echo "is_prerelease=true" >> $GITHUB_OUTPUT
-              echo "base_image_version=${{ env.BASE_IMAGE_VERSION_NIGHTLY }}" >> $GITHUB_OUTPUT
-              ;;
-            *)
-              echo "Error: Invalid channel: $CHANNEL"
-              exit 1
-              ;;
-          esac
+      - name: Create appvars token
+        if: needs.resolve.outputs.assets_ready != 'true'
+        id: appvars_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: appvars
+          permission-contents: read
 
-          echo "✅ Version $VERSION is valid for $CHANNEL channel"
+      - name: Verify GitHub App identity
+        if: needs.resolve.outputs.assets_ready != 'true'
+        env:
+          APP_SLUG: ${{ steps.appvars_token.outputs.app-slug }}
+        run: |
+          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ]; then
+            echo "Unexpected GitHub App: $APP_SLUG" >&2
+            exit 1
+          fi
 
       - name: Set up Python
-        uses: actions/setup-python@v7.0.0
+        if: needs.resolve.outputs.assets_ready != 'true'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version-file: ".python-version"
+          python-version-file: "source/.python-version"
           check-latest: true
 
       - name: Install build dependencies
-        run: >-
-          pip install build tomli tomli-w
+        if: needs.resolve.outputs.assets_ready != 'true'
+        run: python3 -m pip install build tomli tomli-w
 
-      - name: Update version in pyproject.toml
+      - name: Provision app secrets
+        if: needs.resolve.outputs.assets_ready != 'true'
+        env:
+          GH_TOKEN: ${{ steps.appvars_token.outputs.token }}
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github.raw+json" \
+            "repos/music-assistant/appvars/contents/app_secrets.json" \
+            > source/music_assistant/helpers/app_secrets.json
+
+      - name: Set package version
+        if: needs.resolve.outputs.assets_ready != 'true'
+        working-directory: source
         shell: python
-        run: |-
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          import os
           import tomli
           import tomli_w
 
-          with open("pyproject.toml", "rb") as f:
-            pyproject = tomli.load(f)
+          with open("pyproject.toml", "rb") as file_handle:
+              pyproject = tomli.load(file_handle)
+          pyproject["project"]["version"] = os.environ["VERSION"]
+          with open("pyproject.toml", "wb") as file_handle:
+              tomli_w.dump(pyproject, file_handle)
 
-          pyproject["project"]["version"] = "${{ inputs.version }}"
+      - name: Build wheel and source distribution
+        if: needs.resolve.outputs.assets_ready != 'true'
+        working-directory: source
+        run: python3 -m build
 
-          with open("pyproject.toml", "wb") as f:
-            tomli_w.dump(pyproject, f)
-
-          print(f"✅ Updated pyproject.toml version to ${{ inputs.version }}")
-
-      - name: Provision app secrets
+      - name: Verify exact assets
+        id: assets
         env:
-          TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          REUSED_ASSETS: ${{ steps.mode.outputs.reused_assets }}
+          VERSION: ${{ inputs.version }}
         run: |
-          curl -fsSL -H "Authorization: token ${TOKEN}" \
-            https://raw.githubusercontent.com/music-assistant/appvars/main/app_secrets.json \
-            -o music_assistant/helpers/app_secrets.json
+          extra_args=()
+          if [ "$REUSED_ASSETS" = "true" ]; then
+            gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" \
+              > "$RUNNER_TEMP/release.json"
+            extra_args=(--release-json "$RUNNER_TEMP/release.json")
+          fi
+          python3 .release-workflow/scripts/release_workflow.py assets \
+            --version "$VERSION" \
+            --directory source/dist \
+            "${extra_args[@]}" \
+            --github-output "$GITHUB_OUTPUT"
 
-      - name: Build python package
-        run: >-
-          python3 -m build
-
-      - name: Upload distributions
-        uses: actions/upload-artifact@v7
+      - name: Preserve release assets
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: release-dists
-          path: dist/
+          name: release-dists-${{ github.run_id }}
+          path: source/dist/
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+          overwrite: true
 
-  create-release:
-    name: Create GitHub Release with Release Drafter
+  prepare_draft:
+    name: Prepare and verify draft release
     runs-on: ubuntu-latest
-    needs: validate-and-build
+    needs: [resolve, build_artifacts]
+    if: needs.resolve.outputs.release_state != 'published'
     permissions:
       contents: write
       pull-requests: read
     outputs:
-      release_id: ${{ steps.create_release.outputs.id }}
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      release_id: ${{ steps.draft.outputs.release_id }}
+      wheel_name: ${{ steps.assets.outputs.wheel_name }}
+      wheel_size: ${{ steps.assets.outputs.wheel_size }}
+      wheel_sha256: ${{ steps.assets.outputs.wheel_sha256 }}
+      sdist_name: ${{ steps.assets.outputs.sdist_name }}
+      sdist_size: ${{ steps.assets.outputs.sdist_size }}
+      sdist_sha256: ${{ steps.assets.outputs.sdist_sha256 }}
     steps:
-      - uses: actions/checkout@v7
+      - name: Check out release workflow
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ needs.validate-and-build.outputs.branch }}
+          ref: ${{ github.workflow_sha }}
+          path: .release-workflow
+          persist-credentials: false
+
+      - name: Check out release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.resolve.outputs.source_sha }}
           fetch-depth: 0
+          path: source
+          persist-credentials: false
 
-      - name: Download distributions
-        uses: actions/download-artifact@v8
+      - name: Restore release assets
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
-          name: release-dists
-          path: dist/
+          name: release-dists-${{ github.run_id }}
+          path: source/dist/
 
-      - name: Determine previous version tag
-        id: prev_version
-        run: |
-          CHANNEL="${{ inputs.channel }}"
+      - name: Determine previous release tag
+        id: previous
+        working-directory: source
+        run: >-
+          python3 ../.release-workflow/scripts/release_workflow.py previous-tag
+          --channel "${{ inputs.channel }}"
+          --version "${{ inputs.version }}"
+          --github-output "$GITHUB_OUTPUT"
 
-          # Find the previous tag of this channel
-          case "$CHANNEL" in
-            stable)
-              PREV_TAG=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
-              ;;
-            beta)
-              # Include both beta (bN) and RC (rcN) tags since both go to the beta channel
-              PREV_TAG=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(b|rc)[0-9]+$' | head -n 1)
-              ;;
-            rc)
-              # RC1 diffs against latest beta, RC2+ diffs against previous RC
-              VERSION="${{ inputs.version }}"
-              if [[ "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)rc([0-9]+)$ ]]; then
-                BASE_VER="${BASH_REMATCH[1]}"
-                RC_NUM="${BASH_REMATCH[2]}"
-                if [ "$RC_NUM" -gt 1 ]; then
-                  # RC2+: diff against previous RC
-                  PREV_RC_NUM=$((RC_NUM - 1))
-                  PREV_TAG="${BASE_VER}rc${PREV_RC_NUM}"
-                  # Verify tag exists, fall back to latest beta if not
-                  if ! git tag -l "$PREV_TAG" | grep -q .; then
-                    PREV_TAG=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+b[0-9]+$' | head -n 1)
-                  fi
-                else
-                  # RC1: diff against latest beta
-                  PREV_TAG=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+b[0-9]+$' | head -n 1)
-                fi
-              fi
-              ;;
-            nightly)
-              PREV_TAG=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+$' | head -n 1)
-              ;;
-          esac
-
-          if [ -z "$PREV_TAG" ]; then
-            echo "⚠️  No previous $CHANNEL release found"
-            echo "prev_tag=" >> $GITHUB_OUTPUT
-            echo "has_prev_tag=false" >> $GITHUB_OUTPUT
-          else
-            echo "✅ Previous $CHANNEL release: $PREV_TAG"
-            echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
-            echo "has_prev_tag=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Generate complete release notes
-        id: generate_notes
-        uses: ./.github/actions/generate-release-notes
+      - name: Generate release notes
+        id: notes
+        uses: ./.release-workflow/.github/actions/generate-release-notes
         with:
           version: ${{ inputs.version }}
-          previous-tag: ${{ steps.prev_version.outputs.prev_tag }}
-          branch: ${{ needs.validate-and-build.outputs.branch }}
+          previous-tag: ${{ steps.previous.outputs.previous_tag }}
+          head-sha: ${{ needs.resolve.outputs.source_sha }}
+          repository-path: source
           channel: ${{ inputs.channel }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           important-notes: ${{ inputs.important_notes }}
 
       - name: Format release title
-        id: format_title
+        id: title
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${{ inputs.version }}"
-          CHANNEL="${{ inputs.channel }}"
+          case "$CHANNEL" in
+            nightly)
+              if [[ "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)\.dev([0-9]+)$ ]]; then
+                title="${BASH_REMATCH[1]} NIGHTLY ${BASH_REMATCH[2]}"
+              else
+                title="$VERSION NIGHTLY"
+              fi
+              ;;
+            beta)
+              if [[ "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)b([0-9]+)$ ]]; then
+                title="${BASH_REMATCH[1]} BETA ${BASH_REMATCH[2]}"
+              else
+                title="$VERSION BETA"
+              fi
+              ;;
+            rc)
+              if [[ "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)rc([0-9]+)$ ]]; then
+                title="${BASH_REMATCH[1]} RC ${BASH_REMATCH[2]}"
+              else
+                title="$VERSION RC"
+              fi
+              ;;
+            stable)
+              title="$VERSION"
+              ;;
+          esac
+          echo "title=$title" >> "$GITHUB_OUTPUT"
 
-          if [[ "$CHANNEL" == "nightly" ]]; then
-            # Extract base version and date from X.Y.Z.devYYYYMMDD
-            if [[ "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)\.dev([0-9]+)$ ]]; then
-              BASE="${BASH_REMATCH[1]}"
-              DATE="${BASH_REMATCH[2]}"
-              TITLE="$BASE NIGHTLY $DATE"
-            else
-              TITLE="$VERSION NIGHTLY"
-            fi
-          elif [[ "$CHANNEL" == "beta" ]]; then
-            # Extract base version and beta number from X.Y.ZbN
-            if [[ "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)b([0-9]+)$ ]]; then
-              BASE="${BASH_REMATCH[1]}"
-              BETA_NUM="${BASH_REMATCH[2]}"
-              TITLE="$BASE BETA $BETA_NUM"
-            else
-              TITLE="$VERSION BETA"
-            fi
-          elif [[ "$CHANNEL" == "rc" ]]; then
-            # Extract base version and RC number from X.Y.ZrcN
-            if [[ "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)rc([0-9]+)$ ]]; then
-              BASE="${BASH_REMATCH[1]}"
-              RC_NUM="${BASH_REMATCH[2]}"
-              TITLE="$BASE RC $RC_NUM"
-            else
-              TITLE="$VERSION RC"
-            fi
+      - name: Create or update matching draft
+        id: draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IS_PRERELEASE: ${{ needs.resolve.outputs.is_prerelease }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.release-notes }}
+          RELEASE_TITLE: ${{ steps.title.outputs.title }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          release_json="$RUNNER_TEMP/release.json"
+          release_error="$RUNNER_TEMP/release-error.txt"
+          if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" \
+            > "$release_json" 2> "$release_error"; then
+            release_exists=true
+          elif grep -q "HTTP 404" "$release_error"; then
+            release_exists=false
           else
-            # Stable release - just use the version
-            TITLE="$VERSION"
+            cat "$release_error" >&2
+            exit 1
           fi
 
-          echo "title=$TITLE" >> $GITHUB_OUTPUT
-          echo "Release title: $TITLE"
+          jq -n \
+            --arg tag "$VERSION" \
+            --arg target "$SOURCE_SHA" \
+            --arg name "$RELEASE_TITLE" \
+            --arg body "$RELEASE_NOTES" \
+            --argjson prerelease "$IS_PRERELEASE" \
+            '{
+              tag_name: $tag,
+              target_commitish: $target,
+              name: $name,
+              body: $body,
+              draft: true,
+              prerelease: $prerelease
+            }' > "$RUNNER_TEMP/release-payload.json"
 
-      - name: Create GitHub Release
-        id: create_release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ inputs.version }}
-          name: ${{ steps.format_title.outputs.title }}
-          body: ${{ steps.generate_notes.outputs.release-notes }}
-          prerelease: ${{ needs.validate-and-build.outputs.is_prerelease }}
-          target_commitish: ${{ needs.validate-and-build.outputs.branch }}
-          files: dist/*
+          tag_ref="$RUNNER_TEMP/tag-ref.json"
+          tag_error="$RUNNER_TEMP/tag-error.txt"
+          if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION" \
+            > "$tag_ref" 2> "$tag_error"; then
+            tag_exists=true
+          elif grep -q "HTTP 404" "$tag_error"; then
+            tag_exists=false
+          else
+            cat "$tag_error" >&2
+            exit 1
+          fi
+
+          tag_message="Music Assistant release $VERSION from $SOURCE_SHA"
+          if [ "$tag_exists" = "true" ]; then
+            if [ "$(jq -r '.object.type' "$tag_ref")" != "tag" ]; then
+              echo "Existing tag $VERSION was not created by this workflow" >&2
+              exit 1
+            fi
+            tag_object_sha=$(jq -r '.object.sha' "$tag_ref")
+            gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_object_sha" \
+              > "$RUNNER_TEMP/tag-object.json"
+            jq -e \
+              --arg version "$VERSION" \
+              --arg source "$SOURCE_SHA" \
+              --arg message "$tag_message" \
+              '.tag == $version and
+               .message == $message and
+               .object.type == "commit" and
+               .object.sha == $source and
+               .tagger.name == "github-actions[bot]"' \
+              "$RUNNER_TEMP/tag-object.json" > /dev/null
+          elif [ "$release_exists" = "true" ]; then
+            echo "Existing draft $VERSION has no matching release tag" >&2
+            exit 1
+          else
+            tag_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            jq -n \
+              --arg tag "$VERSION" \
+              --arg message "$tag_message" \
+              --arg object "$SOURCE_SHA" \
+              --arg date "$tag_date" \
+              '{
+                tag: $tag,
+                message: $message,
+                object: $object,
+                type: "commit",
+                tagger: {
+                  name: "github-actions[bot]",
+                  email: "41898282+github-actions[bot]@users.noreply.github.com",
+                  date: $date
+                }
+              }' > "$RUNNER_TEMP/tag-payload.json"
+            gh api --method POST \
+              "repos/$GITHUB_REPOSITORY/git/tags" \
+              --input "$RUNNER_TEMP/tag-payload.json" \
+              > "$RUNNER_TEMP/tag-object.json"
+            tag_object_sha=$(jq -r '.sha' "$RUNNER_TEMP/tag-object.json")
+            jq -n \
+              --arg ref "refs/tags/$VERSION" \
+              --arg sha "$tag_object_sha" \
+              '{ref: $ref, sha: $sha}' > "$RUNNER_TEMP/tag-ref-payload.json"
+            gh api --method POST \
+              "repos/$GITHUB_REPOSITORY/git/refs" \
+              --input "$RUNNER_TEMP/tag-ref-payload.json" \
+              > "$tag_ref"
+          fi
+
+          git -C source fetch origin \
+            "refs/tags/$VERSION:refs/tags/$VERSION" \
+            --quiet
+          tag_sha=$(git -C source rev-parse "refs/tags/$VERSION^{commit}")
+          if [ "$tag_sha" != "$SOURCE_SHA" ]; then
+            echo "Release tag $VERSION does not point to $SOURCE_SHA" >&2
+            exit 1
+          fi
+
+          if [ "$release_exists" = "true" ]; then
+            if [ "$(jq -r '.draft' "$release_json")" != "true" ] || \
+               [ "$(jq -r '.immutable' "$release_json")" != "false" ] || \
+               [ "$(jq -r '.target_commitish' "$release_json")" != "$SOURCE_SHA" ]; then
+              echo "Release $VERSION is no longer a matching mutable draft" >&2
+              exit 1
+            fi
+            release_id=$(jq -r '.id' "$release_json")
+            gh api --method PATCH \
+              "repos/$GITHUB_REPOSITORY/releases/$release_id" \
+              --input "$RUNNER_TEMP/release-payload.json" \
+              > "$release_json"
+          else
+            gh api --method POST \
+              "repos/$GITHUB_REPOSITORY/releases" \
+              --input "$RUNNER_TEMP/release-payload.json" \
+              > "$release_json"
+            release_id=$(jq -r '.id' "$release_json")
+          fi
+          echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
+
+      - name: Replace draft assets
+        if: needs.build_artifacts.outputs.reused_assets != 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Output release info
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ steps.draft.outputs.release_id }}
+          SDIST_NAME: ${{ needs.build_artifacts.outputs.sdist_name }}
+          VERSION: ${{ inputs.version }}
+          WHEEL_NAME: ${{ needs.build_artifacts.outputs.wheel_name }}
         run: |
-          echo "✅ Created release ${{ inputs.version }}"
-          echo "Release URL: ${{ steps.create_release.outputs.url }}"
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            --jq '.assets[].id' |
+            while read -r asset_id; do
+              gh api --method DELETE \
+                "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id"
+            done
+          gh release upload "$VERSION" \
+            "source/dist/$WHEEL_NAME" \
+            "source/dist/$SDIST_NAME" \
+            --repo "$GITHUB_REPOSITORY"
 
-  build-and-push-container-image:
-    name: Build and push Music Assistant Server container to ghcr.io
+      - name: Verify draft assets
+        id: assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ steps.draft.outputs.release_id }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            > "$RUNNER_TEMP/release.json"
+          if [ "$(jq -r '.draft' "$RUNNER_TEMP/release.json")" != "true" ] || \
+             [ "$(jq -r '.target_commitish' "$RUNNER_TEMP/release.json")" != "$SOURCE_SHA" ]; then
+            echo "Draft release changed while its assets were prepared" >&2
+            exit 1
+          fi
+          python3 .release-workflow/scripts/release_workflow.py assets \
+            --version "$VERSION" \
+            --directory source/dist \
+            --release-json "$RUNNER_TEMP/release.json" \
+            --github-output "$GITHUB_OUTPUT"
+
+  exact_image:
+    name: Build or verify exact container image
     runs-on: ubuntu-latest
+    needs: [resolve, prepare_draft]
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        needs.resolve.result == 'success' &&
+        (
+          needs.prepare_draft.result == 'success' ||
+          (
+            needs.resolve.outputs.release_state == 'published' &&
+            needs.prepare_draft.result == 'skipped'
+          )
+        )
+      }}
     permissions:
+      contents: read
       packages: write
-    needs:
-      - validate-and-build
-      - create-release
+    outputs:
+      digest: ${{ steps.verify.outputs.digest }}
     steps:
-      - uses: actions/checkout@v7
+      - name: Check out release workflow
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ needs.validate-and-build.outputs.branch }}
+          ref: ${{ github.workflow_sha }}
+          path: .release-workflow
+          persist-credentials: false
 
-      - name: Download distributions
-        uses: actions/download-artifact@v8
+      - name: Check out release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          name: release-dists
-          path: dist/
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          path: source
+          persist-credentials: false
 
-      - name: Log in to the GitHub container registry
-        uses: docker/login-action@v4.5.1
+      - name: Restore release assets
+        if: needs.resolve.outputs.release_state != 'published'
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: release-dists-${{ github.run_id }}
+          path: source/dist/
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ github.token }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.2.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Generate Docker tags
-        id: tags
+      - name: Inspect exact image
+        id: existing
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/server:${{ inputs.version }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          WHEEL_SHA256: ${{ needs.resolve.outputs.release_state == 'published' && needs.resolve.outputs.wheel_sha256 || needs.prepare_draft.outputs.wheel_sha256 }}
         run: |
-          VERSION="${{ inputs.version }}"
-          CHANNEL="${{ inputs.channel }}"
+          error_file="$RUNNER_TEMP/image-inspect-error.txt"
+          for attempt in 1 2 3; do
+            if docker buildx imagetools inspect "$IMAGE" \
+              --format '{{json .Manifest}}' \
+              > "$RUNNER_TEMP/exact-manifest.json" 2> "$error_file"; then
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              python3 .release-workflow/scripts/release_workflow.py verify-manifest \
+                --manifest-json "$RUNNER_TEMP/exact-manifest.json" \
+                --source-sha "$SOURCE_SHA" \
+                --wheel-sha256 "$WHEEL_SHA256"
+              exit 0
+            fi
+            if grep -Eqi 'not found|manifest unknown|status.*404' "$error_file"; then
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+              if [ "${{ needs.resolve.outputs.release_state }}" = "published" ]; then
+                echo "Immutable release ${{ inputs.version }} has no exact image" >&2
+                exit 1
+              fi
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              sleep 5
+            fi
+          done
+          cat "$error_file" >&2
+          exit 1
 
-          # Extract version components
-          if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            MAJOR="${BASH_REMATCH[1]}"
-            MINOR="${BASH_REMATCH[2]}"
-            PATCH="${BASH_REMATCH[3]}"
-          fi
-
-          TAGS="ghcr.io/${{ github.repository_owner }}/server:$VERSION"
-
-          case "$CHANNEL" in
-            stable)
-              # For stable: add major, minor, major.minor, stable, and latest tags
-              TAGS="$TAGS,ghcr.io/${{ github.repository_owner }}/server:$MAJOR.$MINOR.$PATCH"
-              TAGS="$TAGS,ghcr.io/${{ github.repository_owner }}/server:$MAJOR.$MINOR"
-              TAGS="$TAGS,ghcr.io/${{ github.repository_owner }}/server:$MAJOR"
-              TAGS="$TAGS,ghcr.io/${{ github.repository_owner }}/server:stable"
-              TAGS="$TAGS,ghcr.io/${{ github.repository_owner }}/server:latest"
-              ;;
-            beta)
-              # For beta: add beta tag
-              TAGS="$TAGS,ghcr.io/${{ github.repository_owner }}/server:beta"
-              ;;
-            rc)
-              # For RC: add beta rolling tag (RC updates the beta addon)
-              TAGS="$TAGS,ghcr.io/${{ github.repository_owner }}/server:beta"
-              ;;
-            nightly)
-              # For nightly: add nightly tag
-              TAGS="$TAGS,ghcr.io/${{ github.repository_owner }}/server:nightly"
-              ;;
-          esac
-
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
-          echo "Docker tags: $TAGS"
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7.3.0
+      - name: Build and push exact image
+        if: steps.existing.outputs.exists != 'true'
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: source
           platforms: linux/amd64,linux/arm64
-          file: Dockerfile
-          tags: ${{ steps.tags.outputs.tags }}
+          file: source/Dockerfile
+          tags: ghcr.io/${{ github.repository_owner }}/server:${{ inputs.version }}
           push: true
+          provenance: true
           build-args: |
             MASS_VERSION=${{ inputs.version }}
-            BASE_IMAGE_VERSION=${{ needs.validate-and-build.outputs.base_image_version }}
+            BASE_IMAGE_VERSION=${{ needs.resolve.outputs.base_image_version }}
+          labels: |
+            org.opencontainers.image.revision=${{ needs.resolve.outputs.source_sha }}
+            io.music-assistant.wheel.sha256=${{ needs.prepare_draft.outputs.wheel_sha256 }}
+          annotations: |
+            index:org.opencontainers.image.revision=${{ needs.resolve.outputs.source_sha }}
+            index:io.music-assistant.wheel.sha256=${{ needs.prepare_draft.outputs.wheel_sha256 }}
 
-  update-addon-repository:
-    name: Update Home Assistant Add-on Repository
-    runs-on: ubuntu-latest
-    needs:
-      - validate-and-build
-      - create-release
-      - build-and-push-container-image
-    steps:
-      - name: Determine addon folder
-        id: addon_folder
+      - name: Verify exact image
+        id: verify
+        env:
+          BUILT_DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/server:${{ inputs.version }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          WHEEL_SHA256: ${{ needs.resolve.outputs.release_state == 'published' && needs.resolve.outputs.wheel_sha256 || needs.prepare_draft.outputs.wheel_sha256 }}
         run: |
-          CHANNEL="${{ inputs.channel }}"
+          manifest_outputs=""
+          runtime_digests=""
+          for attempt in {1..12}; do
+            if docker buildx imagetools inspect "$IMAGE" \
+              --format '{{json .Manifest}}' \
+              > "$RUNNER_TEMP/exact-manifest.json"; then
+              if manifest_outputs=$(python3 \
+                .release-workflow/scripts/release_workflow.py verify-manifest \
+                --manifest-json "$RUNNER_TEMP/exact-manifest.json" \
+                --source-sha "$SOURCE_SHA" \
+                --wheel-sha256 "$WHEEL_SHA256"); then
+                printf '%s\n' "$manifest_outputs" >> "$GITHUB_OUTPUT"
+                runtime_digests=$(printf '%s\n' "$manifest_outputs" |
+                  sed -n 's/^runtime_digests=//p')
+                break
+              fi
+            fi
+            if [ "$attempt" -eq 12 ]; then
+              echo "Exact image did not become verifiable" >&2
+              exit 1
+            fi
+            sleep 5
+          done
 
+          digest=$(jq -r '.digest' "$RUNNER_TEMP/exact-manifest.json")
+          if [ -n "$BUILT_DIGEST" ] && [ "$BUILT_DIGEST" != "$digest" ]; then
+            echo "Build output digest $BUILT_DIGEST does not match registry digest $digest" >&2
+            exit 1
+          fi
+
+          for runtime_digest in $runtime_digests; do
+            docker buildx imagetools inspect \
+              "ghcr.io/${{ github.repository_owner }}/server@$runtime_digest" \
+              --format '{{json .Image}}' > "$RUNNER_TEMP/image-config.json"
+            jq -e \
+              --arg source "$SOURCE_SHA" \
+              --arg wheel "$WHEEL_SHA256" \
+              '.config.Labels["org.opencontainers.image.revision"] == $source and
+               .config.Labels["io.music-assistant.wheel.sha256"] == $wheel' \
+              "$RUNNER_TEMP/image-config.json" > /dev/null
+          done
+
+  publish_release:
+    name: Publish and verify immutable release
+    runs-on: ubuntu-latest
+    needs: [resolve, prepare_draft, exact_image]
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        needs.resolve.result == 'success' &&
+        needs.exact_image.result == 'success' &&
+        (
+          needs.prepare_draft.result == 'success' ||
+          (
+            needs.resolve.outputs.release_state == 'published' &&
+            needs.prepare_draft.result == 'skipped'
+          )
+        )
+      }}
+    permissions:
+      contents: write
+      packages: read
+    outputs:
+      wheel_sha256: ${{ steps.verify_assets.outputs.wheel_sha256 }}
+    steps:
+      - name: Check out release workflow
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-workflow
+          persist-credentials: false
+
+      - name: Check out release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+
+      - name: Detect live publication state
+        id: publication_state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" \
+            > "$RUNNER_TEMP/live-release.json"
+          draft=$(jq -r '.draft' "$RUNNER_TEMP/live-release.json")
+          immutable=$(jq -r '.immutable' "$RUNNER_TEMP/live-release.json")
+          if [ "$draft" = "true" ] && [ "$immutable" = "false" ]; then
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          elif [ "$draft" = "false" ] && [ "$immutable" = "true" ]; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "Release $VERSION is already immutable; skipping publication"
+          else
+            echo "Release $VERSION is neither a mutable draft nor immutable" >&2
+            exit 1
+          fi
+
+      - name: Restore draft assets
+        if: steps.publication_state.outputs.already_published != 'true'
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: release-dists-${{ github.run_id }}
+          path: source/dist/
+
+      - name: Revalidate draft
+        if: steps.publication_state.outputs.already_published != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.prepare_draft.outputs.release_id }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            > "$RUNNER_TEMP/release.json"
+          if [ "$(jq -r '.draft' "$RUNNER_TEMP/release.json")" != "true" ] || \
+             [ "$(jq -r '.immutable' "$RUNNER_TEMP/release.json")" != "false" ] || \
+             [ "$(jq -r '.target_commitish' "$RUNNER_TEMP/release.json")" != "$SOURCE_SHA" ]; then
+            echo "Release $VERSION is no longer the prepared draft" >&2
+            exit 1
+          fi
+          python3 .release-workflow/scripts/release_workflow.py assets \
+            --version "$VERSION" \
+            --directory source/dist \
+            --release-json "$RUNNER_TEMP/release.json"
+
+      - name: Create publication settings token
+        if: steps.publication_state.outputs.already_published != 'true'
+        id: immutable_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.repository }}
+          permission-administration: read
+
+      - name: Verify GitHub App identity
+        if: steps.publication_state.outputs.already_published != 'true'
+        env:
+          APP_SLUG: ${{ steps.immutable_token.outputs.app-slug }}
+        run: |
+          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ]; then
+            echo "Unexpected GitHub App: $APP_SLUG" >&2
+            exit 1
+          fi
+
+      - name: Recheck immutable releases
+        if: steps.publication_state.outputs.already_published != 'true'
+        env:
+          GH_TOKEN: ${{ steps.immutable_token.outputs.token }}
+        run: |
+          enabled=$(gh api \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/$GITHUB_REPOSITORY/immutable-releases" \
+            --jq '.enabled')
+          if [ "$enabled" != "true" ]; then
+            echo "Immutable releases were disabled before publication" >&2
+            exit 1
+          fi
+
+      - name: Publish release once
+        if: steps.publication_state.outputs.already_published != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.prepare_draft.outputs.release_id }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh api --method PATCH \
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            -F draft=false > "$RUNNER_TEMP/published-release.json"
+          if [ "$(jq -r '.immutable' "$RUNNER_TEMP/published-release.json")" != "true" ]; then
+            echo "GitHub published $VERSION without making it immutable" >&2
+            exit 1
+          fi
+
+      - name: Verify immutable release and assets
+        id: verify_assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IS_PRERELEASE: ${{ needs.resolve.outputs.is_prerelease }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          for attempt in {1..12}; do
+            if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" \
+              > "$RUNNER_TEMP/release.json" &&
+              [ "$(jq -r '.immutable' "$RUNNER_TEMP/release.json")" = "true" ]; then
+              break
+            fi
+            if [ "$attempt" -eq 12 ]; then
+              echo "Release $VERSION did not become immutable" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+
+          if [ "$(jq -r '.draft' "$RUNNER_TEMP/release.json")" != "false" ] || \
+             [ "$(jq -r '.prerelease' "$RUNNER_TEMP/release.json")" != "$IS_PRERELEASE" ]; then
+            echo "Published release metadata does not match the requested channel" >&2
+            exit 1
+          fi
+          if [ "$(gh release view "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json isImmutable \
+            --jq '.isImmutable')" != "true" ]; then
+            echo "GitHub CLI does not report $VERSION as immutable" >&2
+            exit 1
+          fi
+
+          git -C source fetch origin \
+            "refs/tags/$VERSION:refs/tags/$VERSION" \
+            --quiet
+          tag_sha=$(git -C source rev-parse "refs/tags/$VERSION^{commit}")
+          if [ "$tag_sha" != "$SOURCE_SHA" ]; then
+            echo "Published tag $VERSION points to $tag_sha, not $SOURCE_SHA" >&2
+            exit 1
+          fi
+
+          rm -rf "$RUNNER_TEMP/verified-assets"
+          mkdir -p "$RUNNER_TEMP/verified-assets"
+          python3 .release-workflow/scripts/release_workflow.py assets \
+            --version "$VERSION" \
+            --release-json "$RUNNER_TEMP/release.json"
+          gh release download "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir "$RUNNER_TEMP/verified-assets" \
+            --pattern "music_assistant-$VERSION*"
+          python3 .release-workflow/scripts/release_workflow.py assets \
+            --version "$VERSION" \
+            --directory "$RUNNER_TEMP/verified-assets" \
+            --release-json "$RUNNER_TEMP/release.json" \
+            --github-output "$GITHUB_OUTPUT"
+
+          for attempt in {1..12}; do
+            if gh release verify "$VERSION" --repo "$GITHUB_REPOSITORY"; then
+              break
+            fi
+            if [ "$attempt" -eq 12 ]; then
+              echo "Release attestation verification failed" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          for asset in "$RUNNER_TEMP/verified-assets"/*; do
+            gh release verify-asset "$VERSION" "$asset" --repo "$GITHUB_REPOSITORY"
+          done
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Verify published exact image
+        env:
+          EXPECTED_DIGEST: ${{ needs.exact_image.outputs.digest }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/server:${{ inputs.version }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          WHEEL_SHA256: ${{ steps.verify_assets.outputs.wheel_sha256 }}
+        run: |
+          docker buildx imagetools inspect "$IMAGE" \
+            --format '{{json .Manifest}}' \
+            > "$RUNNER_TEMP/exact-manifest.json"
+          python3 .release-workflow/scripts/release_workflow.py verify-manifest \
+            --manifest-json "$RUNNER_TEMP/exact-manifest.json" \
+            --source-sha "$SOURCE_SHA" \
+            --wheel-sha256 "$WHEEL_SHA256"
+          digest=$(jq -r '.digest' "$RUNNER_TEMP/exact-manifest.json")
+          if [ "$digest" != "$EXPECTED_DIGEST" ]; then
+            echo "Exact image digest changed before release verification" >&2
+            exit 1
+          fi
+
+  promote_image:
+    name: Promote verified image digest
+    runs-on: ubuntu-latest
+    needs: [resolve, exact_image, publish_release]
+    if: needs.resolve.outputs.is_current == 'true'
+    permissions:
+      packages: write
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Promote exact digest to rolling aliases
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          DIGEST: ${{ needs.exact_image.outputs.digest }}
+          IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/server
+          VERSION: ${{ inputs.version }}
+        run: |
+          aliases=()
           case "$CHANNEL" in
             stable)
-              echo "folder=music_assistant" >> $GITHUB_OUTPUT
-              echo "Updating stable add-on"
+              if ! [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+                echo "Unable to parse stable version $VERSION" >&2
+                exit 1
+              fi
+              aliases=(
+                "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+                "${BASH_REMATCH[1]}"
+                "stable"
+                "latest"
+              )
               ;;
-            beta)
-              echo "folder=music_assistant_beta" >> $GITHUB_OUTPUT
-              echo "Updating beta add-on"
-              ;;
-            rc)
-              echo "folder=music_assistant_beta" >> $GITHUB_OUTPUT
-              echo "Updating beta add-on (RC release)"
+            beta|rc)
+              aliases=("beta")
               ;;
             nightly)
-              echo "folder=music_assistant_nightly" >> $GITHUB_OUTPUT
-              echo "Updating nightly add-on"
+              aliases=("nightly")
               ;;
           esac
 
-      - name: Checkout add-on repository
-        uses: actions/checkout@v7
+          for alias in "${aliases[@]}"; do
+            target="$IMAGE_REPOSITORY:$alias"
+            docker buildx imagetools create \
+              --tag "$target" \
+              "$IMAGE_REPOSITORY@$DIGEST"
+            for attempt in {1..6}; do
+              alias_digest=$(docker buildx imagetools inspect "$target" \
+                --format '{{json .Manifest}}' | jq -r '.digest')
+              if [ "$alias_digest" = "$DIGEST" ]; then
+                break
+              fi
+              if [ "$attempt" -eq 6 ]; then
+                echo "$target does not point to $DIGEST" >&2
+                exit 1
+              fi
+              sleep 5
+            done
+          done
+
+  update_addon:
+    name: Update Home Assistant add-on
+    runs-on: ubuntu-latest
+    needs: [resolve, publish_release, promote_image]
+    permissions:
+      contents: read
+    steps:
+      - name: Check out release workflow
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-workflow
+          persist-credentials: false
+
+      - name: Create add-on repository token
+        id: addon_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: home-assistant-addon
+          permission-contents: write
+
+      - name: Verify GitHub App identity
+        id: app
+        env:
+          APP_SLUG: ${{ steps.addon_token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.addon_token.outputs.token }}
+        run: |
+          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ]; then
+            echo "Unexpected GitHub App: $APP_SLUG" >&2
+            exit 1
+          fi
+          user_id=$(gh api "/users/$APP_SLUG%5Bbot%5D" --jq '.id')
+          echo "slug=$APP_SLUG" >> "$GITHUB_OUTPUT"
+          echo "user_id=$user_id" >> "$GITHUB_OUTPUT"
+
+      - name: Check out add-on repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: music-assistant/home-assistant-addon
-          token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          ref: main
+          token: ${{ steps.addon_token.outputs.token }}
           path: addon-repo
 
-      - name: Get release notes
-        id: get_notes
+      - name: Resolve add-on channel
+        id: channel
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          case "$CHANNEL" in
+            stable)
+              folder="music_assistant"
+              ;;
+            beta|rc)
+              folder="music_assistant_beta"
+              ;;
+            nightly)
+              folder="music_assistant_nightly"
+              ;;
+          esac
+          echo "folder=$folder" >> "$GITHUB_OUTPUT"
+
+      - name: Update add-on release
+        env:
+          ADDON_FOLDER: ${{ steps.channel.outputs.folder }}
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" \
+            > "$RUNNER_TEMP/release.json"
+          jq -r '.body' "$RUNNER_TEMP/release.json" > "$RUNNER_TEMP/release-notes.md"
+          release_date=$(jq -r \
+            '.published_at | fromdateiso8601 | strftime("%d.%m.%Y")' \
+            "$RUNNER_TEMP/release.json")
+          python3 .release-workflow/scripts/release_workflow.py update-addon \
+            --config "addon-repo/$ADDON_FOLDER/config.yaml" \
+            --changelog "addon-repo/$ADDON_FOLDER/CHANGELOG.md" \
+            --version "$VERSION" \
+            --release-date "$release_date" \
+            --notes "$RUNNER_TEMP/release-notes.md" \
+            --retain 3
+
+      - name: Commit add-on update
+        env:
+          ADDON_FOLDER: ${{ steps.channel.outputs.folder }}
+          APP_SLUG: ${{ steps.app.outputs.slug }}
+          APP_USER_ID: ${{ steps.app.outputs.user_id }}
+          CHANNEL: ${{ inputs.channel }}
+          VERSION: ${{ inputs.version }}
         run: |
           cd addon-repo
+          git add "$ADDON_FOLDER/config.yaml" "$ADDON_FOLDER/CHANGELOG.md"
+          if git diff --cached --quiet; then
+            echo "Add-on $ADDON_FOLDER already references $VERSION"
+            exit 0
+          fi
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email \
+            "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git commit -m "🤖 Bump $CHANNEL add-on to version $VERSION"
+          git push origin HEAD:main
 
-          # Get the release body from the server repository
-          RELEASE_NOTES=$(gh release view "${{ inputs.version }}" --repo music-assistant/server --json body --jq .body)
+  update_remote_app:
+    name: Update app.music-assistant.io
+    runs-on: ubuntu-latest
+    needs: [resolve, exact_image, publish_release, promote_image]
+    permissions:
+      contents: read
+    steps:
+      - name: Check out exact release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          path: source
+          persist-credentials: false
 
-          # Save to file for processing
-          echo "$RELEASE_NOTES" > /tmp/release_notes.md
-
-      - name: Update config.yaml version
+      - name: Extract frontend version
+        id: frontend
+        working-directory: source
+        shell: python
         run: |
-          ADDON_FOLDER="${{ steps.addon_folder.outputs.folder }}"
-          VERSION="${{ inputs.version }}"
+          import os
+          import tomllib
 
-          cd addon-repo/$ADDON_FOLDER
+          with open("pyproject.toml", "rb") as file_handle:
+              dependencies = tomllib.load(file_handle)["project"]["dependencies"]
+          matches = [
+              dependency.removeprefix("music-assistant-frontend==")
+              for dependency in dependencies
+              if dependency.startswith("music-assistant-frontend==")
+          ]
+          if len(matches) != 1:
+              raise RuntimeError("Expected one pinned music-assistant-frontend dependency")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"version={matches[0]}\n")
 
-          # Update version in config.yaml using sed
-          sed -i "s/^version: .*/version: $VERSION/" config.yaml
+      - name: Create app repository token
+        id: app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: app.music-assistant.io
+          permission-contents: write
 
-          echo "✅ Updated config.yaml to version $VERSION"
-
-      - name: Update CHANGELOG.md
+      - name: Verify GitHub App identity
+        env:
+          APP_SLUG: ${{ steps.app_token.outputs.app-slug }}
         run: |
-          ADDON_FOLDER="${{ steps.addon_folder.outputs.folder }}"
-          VERSION="${{ inputs.version }}"
-
-          cd addon-repo/$ADDON_FOLDER
-
-          # Get current date
-          RELEASE_DATE=$(date +"%d.%m.%Y")
-
-          # Read the new release notes
-          NEW_NOTES=$(cat /tmp/release_notes.md)
-
-          # Create new changelog entry
-          {
-            echo "# [$VERSION] - $RELEASE_DATE"
-            echo ""
-            echo "$NEW_NOTES"
-            echo ""
-            echo ""
-          } > /tmp/new_changelog.md
-
-          # If CHANGELOG.md exists, keep only the last 2 versions
-          if [ -f CHANGELOG.md ]; then
-            # Extract headers to count versions
-            VERSION_COUNT=$(grep -c "^# \[" CHANGELOG.md || echo "0")
-
-            if [ "$VERSION_COUNT" -ge 2 ]; then
-              # Keep only first 2 versions (extract everything before the 3rd version header)
-              awk '/^# \[/{i++}i==3{exit}1' CHANGELOG.md > /tmp/old_changelog.md
-
-              # Combine new entry with trimmed old changelog
-              cat /tmp/new_changelog.md /tmp/old_changelog.md > CHANGELOG.md
-            else
-              # Less than 2 versions, just prepend
-              cat /tmp/new_changelog.md CHANGELOG.md > /tmp/combined_changelog.md
-              mv /tmp/combined_changelog.md CHANGELOG.md
-            fi
-          else
-            # No existing changelog, create new
-            mv /tmp/new_changelog.md CHANGELOG.md
+          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ]; then
+            echo "Unexpected GitHub App: $APP_SLUG" >&2
+            exit 1
           fi
 
-          echo "✅ Updated CHANGELOG.md with new release"
-
-      - name: Commit and push changes
+      - name: Dispatch frontend update
+        env:
+          CHANNEL: ${{ inputs.channel == 'rc' && 'beta' || inputs.channel }}
+          FRONTEND_VERSION: ${{ steps.frontend.outputs.version }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          IMAGE_DIGEST: ${{ needs.exact_image.outputs.digest }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          VERSION: ${{ inputs.version }}
         run: |
-          ADDON_FOLDER="${{ steps.addon_folder.outputs.folder }}"
-          VERSION="${{ inputs.version }}"
-          CHANNEL="${{ inputs.channel }}"
-
-          cd addon-repo
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git add "$ADDON_FOLDER/config.yaml" "$ADDON_FOLDER/CHANGELOG.md"
-
-          git commit -m "🤖 Bump $CHANNEL add-on to version $VERSION" || {
-            echo "No changes to commit"
-            exit 0
-          }
-
-          git push
-
-          echo "✅ Successfully updated add-on repository"
-
-  update-remote-app:
-    name: Update app.music-assistant.io frontend
-    runs-on: ubuntu-latest
-    needs:
-      - validate-and-build
-      - create-release
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.validate-and-build.outputs.branch }}
-
-      - name: Extract frontend version from pyproject.toml
-        id: frontend
-        run: |
-          # Extract frontend version from pyproject.toml
-          FRONTEND_VERSION=$(grep 'music-assistant-frontend==' pyproject.toml | sed 's/.*==\([^"]*\).*/\1/')
-          echo "version=${FRONTEND_VERSION}" >> $GITHUB_OUTPUT
-          echo "Frontend version: ${FRONTEND_VERSION}"
-
-      - name: Trigger app.music-assistant.io update
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
-          repository: music-assistant/app.music-assistant.io
-          event-type: frontend-update
-          client-payload: |
-            {
-              "channel": "${{ inputs.channel == 'rc' && 'beta' || inputs.channel }}",
-              "frontend_version": "${{ steps.frontend.outputs.version }}"
-            }
-
-      - name: Output update info
-        run: |
-          echo "✅ Triggered app.music-assistant.io update"
-          echo "Channel: ${{ inputs.channel }}"
-          echo "Frontend version: ${{ steps.frontend.outputs.version }}"
+          jq -n \
+            --arg channel "$CHANNEL" \
+            --arg frontend_version "$FRONTEND_VERSION" \
+            --arg server_version "$VERSION" \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg image_digest "$IMAGE_DIGEST" \
+            '{
+              event_type: "frontend-update",
+              client_payload: {
+                channel: $channel,
+                frontend_version: $frontend_version,
+                server_version: $server_version,
+                source_sha: $source_sha,
+                image_digest: $image_digest
+              }
+            }' > "$RUNNER_TEMP/dispatch.json"
+          gh api --method POST \
+            "repos/music-assistant/app.music-assistant.io/dispatches" \
+            --input "$RUNNER_TEMP/dispatch.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,11 +106,13 @@ jobs:
         run: |
           branch_sha=$(git -C source rev-parse HEAD)
           if [ -n "$REQUESTED_SHA" ]; then
-            if ! [[ "$REQUESTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-              echo "source_sha must be a full lowercase commit SHA" >&2
+            requested_sha=$(printf '%s' "$REQUESTED_SHA" |
+              tr '[:upper:]' '[:lower:]')
+            if ! [[ "$requested_sha" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "source_sha must be a full commit SHA" >&2
               exit 1
             fi
-            source_sha=$(git -C source rev-parse "$REQUESTED_SHA^{commit}")
+            source_sha=$(git -C source rev-parse "$requested_sha^{commit}")
             if ! git -C source merge-base --is-ancestor "$source_sha" "$branch_sha"; then
               echo "$source_sha is not part of ${{ steps.branch.outputs.branch }}" >&2
               exit 1

--- a/scripts/release_workflow.py
+++ b/scripts/release_workflow.py
@@ -15,6 +15,7 @@ import json
 import re
 import subprocess
 import sys
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -35,6 +36,7 @@ CHANNEL_BRANCHES = {
 SHA256_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 OCI_REVISION_ANNOTATION = "org.opencontainers.image.revision"
 OCI_WHEEL_ANNOTATION = "io.music-assistant.wheel.sha256"
+FRONTEND_VERSION_PATTERN = re.compile(r"^(?P<base>\d+(?:\.\d+)+)(?:\.post(?P<post>\d+))?$")
 
 
 class ReleaseWorkflowError(RuntimeError):
@@ -279,6 +281,34 @@ def is_current_release(
     return latest_tag is None or _release_version_key(version) >= _release_version_key(
         latest_tag
     ), latest_tag
+
+
+def compare_release_versions(current: str, requested: str) -> str:
+    """
+    Compare a deployed release version with a requested release version.
+
+    :param current: Version currently deployed to an alias.
+    :param requested: Version requested for promotion.
+    """
+    return _version_relation(
+        _release_version_key(current),
+        _release_version_key(requested),
+    )
+
+
+def compare_frontend_versions(current: str, requested: str) -> str:
+    """
+    Compare a deployed frontend version with a requested frontend version.
+
+    :param current: Frontend version currently configured for the channel.
+    :param requested: Frontend version requested for deployment.
+    """
+    current_base, current_post = _frontend_version_parts(current)
+    requested_base, requested_post = _frontend_version_parts(requested)
+    width = max(len(current_base), len(requested_base))
+    current_key = (*current_base, *((0,) * (width - len(current_base))), current_post)
+    requested_key = (*requested_base, *((0,) * (width - len(requested_base))), requested_post)
+    return _version_relation(current_key, requested_key)
 
 
 def inspect_assets(
@@ -540,6 +570,23 @@ def _release_version_key(version: str) -> tuple[int, int, int, int, int]:
     raise ReleaseWorkflowError(f"Unsupported release version: {version}")
 
 
+def _frontend_version_parts(version: str) -> tuple[tuple[int, ...], int]:
+    match = FRONTEND_VERSION_PATTERN.fullmatch(version)
+    if match is None:
+        raise ReleaseWorkflowError(f"Unsupported frontend version: {version}")
+    base = tuple(int(part) for part in match.group("base").split("."))
+    post = int(match.group("post")) if match.group("post") is not None else -1
+    return base, post
+
+
+def _version_relation(current: tuple[int, ...], requested: tuple[int, ...]) -> str:
+    if current > requested:
+        return "newer"
+    if current < requested:
+        return "older"
+    return "equal"
+
+
 def _first(values: list[str]) -> str | None:
     return values[0] if values else None
 
@@ -575,7 +622,10 @@ def _changelog_blocks(content: str) -> list[tuple[str, str]]:
     return blocks
 
 
-def _write_outputs(values: dict[str, str | int | bool | None], output_path: Path | None) -> None:
+def _write_outputs(
+    values: Mapping[str, str | int | bool | None],
+    output_path: Path | None,
+) -> None:
     lines = [
         f"{key}={str(value).lower() if isinstance(value, bool) else '' if value is None else value}"
         for key, value in values.items()
@@ -628,6 +678,16 @@ def _build_parser() -> argparse.ArgumentParser:
     current_parser.add_argument("--version", required=True)
     current_parser.add_argument("--repository", type=Path, default=Path.cwd())
     current_parser.add_argument("--github-output", type=Path)
+
+    release_order_parser = subparsers.add_parser("compare-release-versions")
+    release_order_parser.add_argument("--current", required=True)
+    release_order_parser.add_argument("--requested", required=True)
+    release_order_parser.add_argument("--github-output", type=Path)
+
+    frontend_order_parser = subparsers.add_parser("compare-frontend-versions")
+    frontend_order_parser.add_argument("--current", required=True)
+    frontend_order_parser.add_argument("--requested", required=True)
+    frontend_order_parser.add_argument("--github-output", type=Path)
 
     assets_parser = subparsers.add_parser("assets")
     assets_parser.add_argument("--version", required=True)
@@ -693,6 +753,26 @@ def main() -> int:
                 {
                     "is_current": is_current,
                     "latest_channel_tag": latest_tag,
+                },
+                args.github_output,
+            )
+        elif args.command == "compare-release-versions":
+            _write_outputs(
+                {
+                    "current_relation": compare_release_versions(
+                        args.current,
+                        args.requested,
+                    )
+                },
+                args.github_output,
+            )
+        elif args.command == "compare-frontend-versions":
+            _write_outputs(
+                {
+                    "current_relation": compare_frontend_versions(
+                        args.current,
+                        args.requested,
+                    )
                 },
                 args.github_output,
             )

--- a/scripts/release_workflow.py
+++ b/scripts/release_workflow.py
@@ -1,0 +1,736 @@
+"""
+Support immutable-safe GitHub release workflows.
+
+The command-line interface emits values to ``$GITHUB_OUTPUT`` when requested so
+the release workflows can keep version and artifact validation in tested Python.
+"""
+
+# ruff: noqa: T201
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+CHANNEL_PATTERNS = {
+    "stable": re.compile(r"^(?P<base>\d+\.\d+\.\d+)$"),
+    "beta": re.compile(r"^(?P<base>\d+\.\d+\.\d+)b(?P<number>\d+)$"),
+    "rc": re.compile(r"^(?P<base>\d+\.\d+\.\d+)rc(?P<number>\d+)$"),
+    "nightly": re.compile(r"^(?P<base>\d+\.\d+\.\d+)\.dev(?P<number>\d+)$"),
+}
+CHANNEL_BRANCHES = {
+    "stable": "stable",
+    "rc": "stable",
+    "beta": "dev",
+    "nightly": "dev",
+}
+SHA256_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+OCI_REVISION_ANNOTATION = "org.opencontainers.image.revision"
+OCI_WHEEL_ANNOTATION = "io.music-assistant.wheel.sha256"
+
+
+class ReleaseWorkflowError(RuntimeError):
+    """Report an unsafe or inconsistent release state."""
+
+
+@dataclass(frozen=True)
+class AutoRelease:
+    """Describe the next automatic release decision."""
+
+    version: str
+    should_release: bool
+    previous_tag: str | None
+    commits_since: int
+
+
+@dataclass(frozen=True)
+class Asset:
+    """Describe one exact release asset."""
+
+    name: str
+    size: int
+    sha256: str
+
+
+class GitRepository:
+    """Read release tags and commit relationships from a Git repository."""
+
+    def __init__(self, path: Path) -> None:
+        """
+        Initialize a repository reader.
+
+        :param path: Path to the Git worktree.
+        """
+        self.path = path
+
+    def resolve_commit(self, ref: str) -> str:
+        """
+        Resolve a Git ref to its commit SHA.
+
+        :param ref: Commit, branch, or tag to resolve.
+        """
+        return self._run("rev-parse", f"{ref}^{{commit}}")
+
+    def tags(self, pattern: re.Pattern[str]) -> list[str]:
+        """
+        Return version-sorted tags matching a release pattern.
+
+        :param pattern: Full tag-name pattern to match.
+        """
+        output = self._run("tag", "--sort=-version:refname")
+        return [tag for tag in output.splitlines() if pattern.fullmatch(tag)]
+
+    def all_tags(self) -> set[str]:
+        """Return all tag names."""
+        return set(self._run("tag").splitlines())
+
+    def commits_since(self, tag: str | None, source_sha: str, *, allow_diverged: bool) -> int:
+        """
+        Count source commits after a previous release tag.
+
+        :param tag: Previous release tag, or ``None`` for the full source history.
+        :param source_sha: Exact release source commit.
+        :param allow_diverged: Use the merge base when the tag is on a diverged branch.
+        """
+        if tag is None:
+            return int(self._run("rev-list", "--count", source_sha))
+
+        result = self._run_result("merge-base", "--is-ancestor", tag, source_sha)
+        if result.returncode == 0:
+            base = tag
+        elif result.returncode == 1 and allow_diverged:
+            base = self._run("merge-base", tag, source_sha)
+        elif result.returncode == 1:
+            msg = f"Previous {tag} is not an ancestor of source commit {source_sha}"
+            raise ReleaseWorkflowError(msg)
+        else:
+            raise ReleaseWorkflowError(result.stderr.strip() or f"Unable to compare {tag}")
+        return int(self._run("rev-list", "--count", f"{base}..{source_sha}"))
+
+    def _run(self, *args: str) -> str:
+        result = self._run_result(*args)
+        if result.returncode:
+            raise ReleaseWorkflowError(result.stderr.strip() or f"git {' '.join(args)} failed")
+        return result.stdout.strip()
+
+    def _run_result(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S603
+            ["git", "-C", str(self.path), *args],  # noqa: S607
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+
+def channel_branch(channel: str) -> str:
+    """
+    Return the source branch for a release channel.
+
+    :param channel: Release channel name.
+    """
+    try:
+        return CHANNEL_BRANCHES[channel]
+    except KeyError as err:
+        raise ReleaseWorkflowError(f"Unsupported release channel: {channel}") from err
+
+
+def validate_version(channel: str, version: str) -> None:
+    """
+    Validate a version against its release channel.
+
+    :param channel: Release channel name.
+    :param version: Version to validate.
+    """
+    try:
+        pattern = CHANNEL_PATTERNS[channel]
+    except KeyError as err:
+        raise ReleaseWorkflowError(f"Unsupported release channel: {channel}") from err
+    if not pattern.fullmatch(version):
+        raise ReleaseWorkflowError(f"Version {version} is invalid for the {channel} channel")
+
+
+def determine_auto_release(
+    repository: GitRepository,
+    channel: str,
+    source_sha: str,
+    *,
+    now: datetime | None = None,
+) -> AutoRelease:
+    """
+    Calculate the next channel version from Git tags and commit ancestry.
+
+    :param repository: Source Git repository.
+    :param channel: Release channel name.
+    :param source_sha: Exact release source commit.
+    :param now: Timestamp used for nightly versions.
+    """
+    source_sha = repository.resolve_commit(source_sha)
+    stable_tags = repository.tags(CHANNEL_PATTERNS["stable"])
+    beta_tags = repository.tags(CHANNEL_PATTERNS["beta"])
+    rc_tags = repository.tags(CHANNEL_PATTERNS["rc"])
+    nightly_tags = repository.tags(CHANNEL_PATTERNS["nightly"])
+    all_tags = repository.all_tags()
+
+    latest_stable = _first(stable_tags)
+    latest_beta = _first(beta_tags)
+    latest_rc = _first(rc_tags)
+    latest_nightly = _first(nightly_tags)
+
+    if channel == "stable":
+        previous_tag = latest_stable
+        commits_since = repository.commits_since(previous_tag, source_sha, allow_diverged=True)
+        version = _next_stable(latest_stable)
+    elif channel == "beta":
+        previous_tag = latest_beta
+        commits_since = repository.commits_since(previous_tag, source_sha, allow_diverged=False)
+        version = _next_beta(latest_beta, latest_stable)
+    elif channel == "rc":
+        version = _next_rc(latest_rc, latest_beta)
+        version_match = CHANNEL_PATTERNS["rc"].fullmatch(version)
+        assert version_match is not None
+        rc_base = version_match.group("base")
+        latest_rc_match = CHANNEL_PATTERNS["rc"].fullmatch(latest_rc or "")
+        if latest_rc_match and latest_rc_match.group("base") == rc_base:
+            previous_tag = latest_rc
+        else:
+            previous_tag = latest_beta
+        commits_since = repository.commits_since(previous_tag, source_sha, allow_diverged=False)
+    elif channel == "nightly":
+        previous_tag = latest_nightly
+        commits_since = repository.commits_since(previous_tag, source_sha, allow_diverged=False)
+        version = _next_nightly(
+            latest_nightly,
+            latest_stable,
+            now or datetime.now(UTC),
+        )
+    else:
+        raise ReleaseWorkflowError(f"Unsupported release channel: {channel}")
+
+    version = _ensure_unique(version, channel, all_tags)
+    return AutoRelease(
+        version=version,
+        should_release=channel != "nightly" or commits_since >= 2,
+        previous_tag=previous_tag,
+        commits_since=commits_since,
+    )
+
+
+def previous_release_tag(
+    repository: GitRepository,
+    channel: str,
+    version: str,
+) -> str | None:
+    """
+    Return the previous tag used as the release-notes base.
+
+    :param repository: Source Git repository.
+    :param channel: Release channel name.
+    :param version: Version currently being prepared.
+    """
+    validate_version(channel, version)
+    if channel == "stable":
+        tags = repository.tags(CHANNEL_PATTERNS["stable"])
+    elif channel == "beta":
+        combined_pattern = re.compile(r"^\d+\.\d+\.\d+(?:b|rc)\d+$")
+        tags = repository.tags(combined_pattern)
+    elif channel == "nightly":
+        tags = repository.tags(CHANNEL_PATTERNS["nightly"])
+    else:
+        match = CHANNEL_PATTERNS["rc"].fullmatch(version)
+        assert match is not None
+        rc_number = int(match.group("number"))
+        if rc_number > 1:
+            previous_rc = f"{match.group('base')}rc{rc_number - 1}"
+            if previous_rc in repository.all_tags():
+                return previous_rc
+        tags = repository.tags(CHANNEL_PATTERNS["beta"])
+    return next((tag for tag in tags if tag != version), None)
+
+
+def is_current_release(
+    repository: GitRepository,
+    channel: str,
+    version: str,
+) -> tuple[bool, str | None]:
+    """
+    Check whether a release is the newest version for its rolling channel.
+
+    :param repository: Source Git repository.
+    :param channel: Release channel name.
+    :param version: Release version to compare.
+    """
+    validate_version(channel, version)
+    if channel == "stable":
+        pattern = CHANNEL_PATTERNS["stable"]
+    elif channel == "nightly":
+        pattern = CHANNEL_PATTERNS["nightly"]
+    else:
+        pattern = re.compile(r"^\d+\.\d+\.\d+(?:b|rc)\d+$")
+    tags = repository.tags(pattern)
+    latest_tag = max(tags, key=_release_version_key, default=None)
+    return latest_tag is None or _release_version_key(version) >= _release_version_key(
+        latest_tag
+    ), latest_tag
+
+
+def inspect_assets(
+    version: str,
+    *,
+    directory: Path | None = None,
+    release_json: Path | None = None,
+) -> tuple[Asset, Asset]:
+    """
+    Validate and describe the exact wheel and source distribution.
+
+    :param version: Release version.
+    :param directory: Optional directory containing downloaded assets.
+    :param release_json: Optional GitHub release API response.
+    """
+    expected_names = _expected_asset_names(version)
+    api_assets: dict[str, Asset] | None = None
+    local_assets: dict[str, Asset] | None = None
+
+    if release_json is not None:
+        release = json.loads(release_json.read_text(encoding="utf-8"))
+        raw_assets = release.get("assets")
+        if not isinstance(raw_assets, list):
+            raise ReleaseWorkflowError("Release response does not contain an asset list")
+        if len(raw_assets) != len(expected_names):
+            raise ReleaseWorkflowError(
+                f"Release must contain exactly these assets: {', '.join(expected_names)}"
+            )
+        api_assets = {}
+        for raw_asset in raw_assets:
+            if not isinstance(raw_asset, dict):
+                raise ReleaseWorkflowError("Release response contains invalid asset metadata")
+            name = raw_asset.get("name")
+            size = raw_asset.get("size")
+            state = raw_asset.get("state")
+            digest = raw_asset.get("digest")
+            if (
+                not isinstance(name, str)
+                or not isinstance(size, int)
+                or state != "uploaded"
+                or not isinstance(digest, str)
+                or not SHA256_PATTERN.fullmatch(digest)
+                or size <= 0
+            ):
+                raise ReleaseWorkflowError(f"Release asset metadata is invalid: {name!r}")
+            if name in api_assets:
+                raise ReleaseWorkflowError(f"Release contains duplicate asset {name}")
+            api_assets[name] = Asset(name, size, digest.removeprefix("sha256:"))
+        if set(api_assets) != set(expected_names):
+            raise ReleaseWorkflowError(
+                f"Release must contain exactly these assets: {', '.join(expected_names)}"
+            )
+
+    if directory is not None:
+        files = sorted(path for path in directory.iterdir() if path.is_file())
+        if {path.name for path in files} != set(expected_names):
+            raise ReleaseWorkflowError(
+                f"Asset directory must contain exactly: {', '.join(expected_names)}"
+            )
+        local_assets = {
+            path.name: Asset(path.name, path.stat().st_size, _sha256(path)) for path in files
+        }
+        if any(asset.size <= 0 for asset in local_assets.values()):
+            raise ReleaseWorkflowError("Release assets must not be empty")
+
+    assets = local_assets or api_assets
+    if assets is None:
+        raise ReleaseWorkflowError("An asset directory or release response is required")
+    if local_assets is not None and api_assets is not None and local_assets != api_assets:
+        raise ReleaseWorkflowError("Downloaded assets do not match GitHub release metadata")
+    return assets[expected_names[0]], assets[expected_names[1]]
+
+
+def verify_oci_manifest(
+    manifest: dict[str, Any],
+    source_sha: str,
+    wheel_sha256: str,
+) -> tuple[str, list[str]]:
+    """
+    Validate the exact multi-platform image manifest and provenance annotations.
+
+    :param manifest: Formatted Buildx manifest JSON.
+    :param source_sha: Exact source commit expected in the image annotations.
+    :param wheel_sha256: Wheel digest expected in the image annotations.
+    """
+    digest = manifest.get("digest")
+    if not isinstance(digest, str) or not SHA256_PATTERN.fullmatch(digest):
+        raise ReleaseWorkflowError("OCI manifest does not contain a valid digest")
+    annotations = manifest.get("annotations")
+    if not isinstance(annotations, dict):
+        raise ReleaseWorkflowError("OCI manifest does not contain provenance annotations")
+    if annotations.get(OCI_REVISION_ANNOTATION) != source_sha:
+        raise ReleaseWorkflowError("OCI manifest source SHA does not match the release")
+    if annotations.get(OCI_WHEEL_ANNOTATION) != wheel_sha256:
+        raise ReleaseWorkflowError("OCI manifest wheel digest does not match the release")
+
+    raw_manifests = manifest.get("manifests")
+    if not isinstance(raw_manifests, list):
+        raise ReleaseWorkflowError("OCI image is not a multi-platform manifest")
+    runtime_manifests: dict[str, str] = {}
+    for item in raw_manifests:
+        if not isinstance(item, dict):
+            raise ReleaseWorkflowError("OCI manifest contains an invalid descriptor")
+        platform = item.get("platform")
+        child_digest = item.get("digest")
+        if not isinstance(platform, dict) or not isinstance(child_digest, str):
+            raise ReleaseWorkflowError("OCI manifest descriptor is incomplete")
+        operating_system = platform.get("os")
+        architecture = platform.get("architecture")
+        if operating_system == "unknown" and architecture == "unknown":
+            continue
+        if not SHA256_PATTERN.fullmatch(child_digest):
+            raise ReleaseWorkflowError("OCI child manifest digest is invalid")
+        platform_name = f"{operating_system}/{architecture}"
+        if platform_name in runtime_manifests:
+            raise ReleaseWorkflowError(f"OCI image contains duplicate platform {platform_name}")
+        runtime_manifests[platform_name] = child_digest
+    expected_platforms = {"linux/amd64", "linux/arm64"}
+    if set(runtime_manifests) != expected_platforms:
+        raise ReleaseWorkflowError("OCI image must contain linux/amd64 and linux/arm64")
+    return digest, [runtime_manifests[platform] for platform in sorted(expected_platforms)]
+
+
+def update_addon_release(
+    config_path: Path,
+    changelog_path: Path,
+    *,
+    version: str,
+    release_date: str,
+    notes: str,
+    retain: int = 3,
+) -> None:
+    """
+    Update an add-on channel to one canonical release entry.
+
+    :param config_path: Add-on ``config.yaml`` path.
+    :param changelog_path: Add-on ``CHANGELOG.md`` path.
+    :param version: Server version and image tag.
+    :param release_date: Canonical release date in ``DD.MM.YYYY`` format.
+    :param notes: Published server release notes.
+    :param retain: Total number of distinct changelog releases to retain.
+    """
+    if retain < 1:
+        raise ReleaseWorkflowError("At least one changelog release must be retained")
+    config = config_path.read_text(encoding="utf-8")
+    config, replacements = re.subn(
+        r"^version: .+$",
+        f"version: {version}",
+        config,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if replacements != 1:
+        raise ReleaseWorkflowError(f"Expected one version field in {config_path}")
+    config_path.write_text(config, encoding="utf-8")
+
+    existing = changelog_path.read_text(encoding="utf-8") if changelog_path.exists() else ""
+    blocks = _changelog_blocks(existing)
+    previous_blocks: list[str] = []
+    seen_versions = {version}
+    for block_version, block in blocks:
+        if block_version in seen_versions:
+            continue
+        seen_versions.add(block_version)
+        previous_blocks.append(block)
+    new_block = f"# [{version}] - {release_date}\n\n{notes.strip()}"
+    content = "\n\n\n".join([new_block, *previous_blocks[: retain - 1]]) + "\n"
+    changelog_path.write_text(content, encoding="utf-8")
+
+
+def _next_stable(latest_stable: str | None) -> str:
+    if latest_stable is None:
+        return "0.1.0"
+    major, minor, patch = _version_tuple(latest_stable)
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def _next_beta(latest_beta: str | None, latest_stable: str | None) -> str:
+    if latest_beta is not None:
+        match = CHANNEL_PATTERNS["beta"].fullmatch(latest_beta)
+        assert match is not None
+        beta_base = _version_tuple(match.group("base"))
+        if latest_stable is not None:
+            stable = _version_tuple(latest_stable)
+            if stable[:2] >= beta_base[:2]:
+                return f"{stable[0]}.{stable[1] + 1}.0b1"
+        return f"{match.group('base')}b{int(match.group('number')) + 1}"
+    if latest_stable is not None:
+        major, minor, _patch = _version_tuple(latest_stable)
+        return f"{major}.{minor + 1}.0b1"
+    return "0.1.0b1"
+
+
+def _next_rc(latest_rc: str | None, latest_beta: str | None) -> str:
+    if latest_beta is None:
+        return "0.1.0rc1"
+    beta_match = CHANNEL_PATTERNS["beta"].fullmatch(latest_beta)
+    assert beta_match is not None
+    beta_base = beta_match.group("base")
+    if latest_rc is not None:
+        rc_match = CHANNEL_PATTERNS["rc"].fullmatch(latest_rc)
+        assert rc_match is not None
+        if rc_match.group("base") == beta_base:
+            return f"{beta_base}rc{int(rc_match.group('number')) + 1}"
+    return f"{beta_base}rc1"
+
+
+def _next_nightly(
+    latest_nightly: str | None,
+    latest_stable: str | None,
+    now: datetime,
+) -> str:
+    if latest_stable is None:
+        base = "0.1.0"
+    else:
+        major, minor, _patch = _version_tuple(latest_stable)
+        base = f"{major}.{minor + 1}.0"
+    serial = int(now.astimezone(UTC).strftime("%Y%m%d%H"))
+    if latest_nightly is not None:
+        match = CHANNEL_PATTERNS["nightly"].fullmatch(latest_nightly)
+        assert match is not None
+        if match.group("base") == base:
+            serial = max(serial, int(match.group("number")) + 1)
+    return f"{base}.dev{serial}"
+
+
+def _ensure_unique(version: str, channel: str, tags: set[str]) -> str:
+    while version in tags:
+        match = CHANNEL_PATTERNS[channel].fullmatch(version)
+        assert match is not None
+        base = match.group("base")
+        if channel == "stable":
+            major, minor, patch = _version_tuple(base)
+            version = f"{major}.{minor}.{patch + 1}"
+        elif channel == "beta":
+            version = f"{base}b{int(match.group('number')) + 1}"
+        elif channel == "rc":
+            version = f"{base}rc{int(match.group('number')) + 1}"
+        else:
+            version = f"{base}.dev{int(match.group('number')) + 1}"
+    return version
+
+
+def _version_tuple(version: str) -> tuple[int, int, int]:
+    match = CHANNEL_PATTERNS["stable"].fullmatch(version)
+    if match is None:
+        raise ReleaseWorkflowError(f"Invalid base version: {version}")
+    return tuple(int(part) for part in version.split("."))  # type: ignore[return-value]
+
+
+def _release_version_key(version: str) -> tuple[int, int, int, int, int]:
+    for stage, channel in enumerate(("nightly", "beta", "rc", "stable")):
+        match = CHANNEL_PATTERNS[channel].fullmatch(version)
+        if match is None:
+            continue
+        major, minor, patch = _version_tuple(match.group("base"))
+        number = int(match.groupdict().get("number") or 0)
+        return major, minor, patch, stage, number
+    raise ReleaseWorkflowError(f"Unsupported release version: {version}")
+
+
+def _first(values: list[str]) -> str | None:
+    return values[0] if values else None
+
+
+def _expected_asset_names(version: str) -> tuple[str, str]:
+    return (
+        f"music_assistant-{version}-py3-none-any.whl",
+        f"music_assistant-{version}.tar.gz",
+    )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file_handle:
+        for chunk in iter(lambda: file_handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _changelog_blocks(content: str) -> list[tuple[str, str]]:
+    header_pattern = re.compile(r"(?m)^# \[([^\]]+)\] - .+$")
+    matches = list(header_pattern.finditer(content))
+    if not matches:
+        if content.strip():
+            raise ReleaseWorkflowError("Existing changelog has no release headings")
+        return []
+    if content[: matches[0].start()].strip():
+        raise ReleaseWorkflowError("Existing changelog has content before its first release")
+    blocks: list[tuple[str, str]] = []
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(content)
+        blocks.append((match.group(1), content[match.start() : end].strip()))
+    return blocks
+
+
+def _write_outputs(values: dict[str, str | int | bool | None], output_path: Path | None) -> None:
+    lines = [
+        f"{key}={str(value).lower() if isinstance(value, bool) else '' if value is None else value}"
+        for key, value in values.items()
+    ]
+    if output_path is not None:
+        with output_path.open("a", encoding="utf-8") as file_handle:
+            file_handle.write("\n".join(lines) + "\n")
+    print("\n".join(lines))
+
+
+def _asset_outputs(assets: tuple[Asset, Asset]) -> dict[str, str | int]:
+    wheel, source = assets
+    return {
+        "wheel_name": wheel.name,
+        "wheel_size": wheel.size,
+        "wheel_sha256": wheel.sha256,
+        "sdist_name": source.name,
+        "sdist_size": source.size,
+        "sdist_sha256": source.sha256,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    branch_parser = subparsers.add_parser("branch")
+    branch_parser.add_argument("--channel", required=True)
+    branch_parser.add_argument("--github-output", type=Path)
+
+    validate_parser = subparsers.add_parser("validate-version")
+    validate_parser.add_argument("--channel", required=True)
+    validate_parser.add_argument("--version", required=True)
+
+    auto_parser = subparsers.add_parser("auto-version")
+    auto_parser.add_argument("--channel", required=True)
+    auto_parser.add_argument("--source-sha", required=True)
+    auto_parser.add_argument("--repository", type=Path, default=Path.cwd())
+    auto_parser.add_argument("--timestamp")
+    auto_parser.add_argument("--github-output", type=Path)
+
+    previous_parser = subparsers.add_parser("previous-tag")
+    previous_parser.add_argument("--channel", required=True)
+    previous_parser.add_argument("--version", required=True)
+    previous_parser.add_argument("--repository", type=Path, default=Path.cwd())
+    previous_parser.add_argument("--github-output", type=Path)
+
+    current_parser = subparsers.add_parser("current-version")
+    current_parser.add_argument("--channel", required=True)
+    current_parser.add_argument("--version", required=True)
+    current_parser.add_argument("--repository", type=Path, default=Path.cwd())
+    current_parser.add_argument("--github-output", type=Path)
+
+    assets_parser = subparsers.add_parser("assets")
+    assets_parser.add_argument("--version", required=True)
+    assets_parser.add_argument("--directory", type=Path)
+    assets_parser.add_argument("--release-json", type=Path)
+    assets_parser.add_argument("--github-output", type=Path)
+
+    manifest_parser = subparsers.add_parser("verify-manifest")
+    manifest_parser.add_argument("--manifest-json", type=Path, required=True)
+    manifest_parser.add_argument("--source-sha", required=True)
+    manifest_parser.add_argument("--wheel-sha256", required=True)
+    manifest_parser.add_argument("--github-output", type=Path)
+
+    addon_parser = subparsers.add_parser("update-addon")
+    addon_parser.add_argument("--config", type=Path, required=True)
+    addon_parser.add_argument("--changelog", type=Path, required=True)
+    addon_parser.add_argument("--version", required=True)
+    addon_parser.add_argument("--release-date", required=True)
+    addon_parser.add_argument("--notes", type=Path, required=True)
+    addon_parser.add_argument("--retain", type=int, default=3)
+    return parser
+
+
+def main() -> int:
+    """Run a release workflow helper command."""
+    args = _build_parser().parse_args()
+    try:
+        if args.command == "branch":
+            _write_outputs({"branch": channel_branch(args.channel)}, args.github_output)
+        elif args.command == "validate-version":
+            validate_version(args.channel, args.version)
+        elif args.command == "auto-version":
+            timestamp = datetime.fromisoformat(args.timestamp) if args.timestamp else None
+            decision = determine_auto_release(
+                GitRepository(args.repository),
+                args.channel,
+                args.source_sha,
+                now=timestamp,
+            )
+            _write_outputs(
+                {
+                    "version": decision.version,
+                    "should_release": decision.should_release,
+                    "previous_tag": decision.previous_tag,
+                    "commits_since": decision.commits_since,
+                },
+                args.github_output,
+            )
+        elif args.command == "previous-tag":
+            tag = previous_release_tag(
+                GitRepository(args.repository),
+                args.channel,
+                args.version,
+            )
+            _write_outputs({"previous_tag": tag}, args.github_output)
+        elif args.command == "current-version":
+            is_current, latest_tag = is_current_release(
+                GitRepository(args.repository),
+                args.channel,
+                args.version,
+            )
+            _write_outputs(
+                {
+                    "is_current": is_current,
+                    "latest_channel_tag": latest_tag,
+                },
+                args.github_output,
+            )
+        elif args.command == "assets":
+            assets = inspect_assets(
+                args.version,
+                directory=args.directory,
+                release_json=args.release_json,
+            )
+            _write_outputs(_asset_outputs(assets), args.github_output)
+        elif args.command == "verify-manifest":
+            manifest = json.loads(args.manifest_json.read_text(encoding="utf-8"))
+            digest, runtime_digests = verify_oci_manifest(
+                manifest,
+                args.source_sha,
+                args.wheel_sha256,
+            )
+            _write_outputs(
+                {
+                    "digest": digest,
+                    "runtime_digests": " ".join(runtime_digests),
+                },
+                args.github_output,
+            )
+        elif args.command == "update-addon":
+            update_addon_release(
+                args.config,
+                args.changelog,
+                version=args.version,
+                release_date=args.release_date,
+                notes=args.notes.read_text(encoding="utf-8"),
+                retain=args.retain,
+            )
+        return 0
+    except (OSError, ReleaseWorkflowError, ValueError, json.JSONDecodeError) as err:
+        print(f"ERROR: {err}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
+import yaml
 
 from scripts.release_workflow import (
     OCI_REVISION_ANNOTATION,
@@ -17,6 +18,8 @@ from scripts.release_workflow import (
     GitRepository,
     ReleaseWorkflowError,
     channel_branch,
+    compare_frontend_versions,
+    compare_release_versions,
     determine_auto_release,
     inspect_assets,
     is_current_release,
@@ -142,6 +145,44 @@ def test_current_release_combines_beta_and_rc_channels(
         False,
         "2.10.0rc1",
     )
+
+
+@pytest.mark.parametrize(
+    ("current", "requested", "relation"),
+    [
+        ("2.10.0.dev2026072502", "2.10.0.dev2026072501", "newer"),
+        ("2.10.0b1", "2.10.0.dev2026072502", "newer"),
+        ("2.10.0rc1", "2.10.0b20", "newer"),
+        ("2.10.0", "2.10.0rc4", "newer"),
+        ("2.9.10", "2.10.0", "older"),
+        ("2.10.0b8", "2.10.0b8", "equal"),
+    ],
+)
+def test_release_version_order(
+    current: str,
+    requested: str,
+    relation: str,
+) -> None:
+    """Rolling aliases use release ordering across all supported stages."""
+    assert compare_release_versions(current, requested) == relation
+
+
+@pytest.mark.parametrize(
+    ("current", "requested", "relation"),
+    [
+        ("2.17.235", "2.17.234", "newer"),
+        ("2.17.186.post3", "2.17.186", "newer"),
+        ("2.17.186", "2.17.186.post1", "older"),
+        ("2.17.228", "2.17.228.0", "equal"),
+    ],
+)
+def test_frontend_version_order(
+    current: str,
+    requested: str,
+    relation: str,
+) -> None:
+    """Frontend dispatches compare numeric and post-release versions."""
+    assert compare_frontend_versions(current, requested) == relation
 
 
 def test_release_assets_match_names_sizes_and_digests(tmp_path: Path) -> None:
@@ -279,12 +320,41 @@ def test_release_workflows_pin_external_actions_and_drop_legacy_token() -> None:
     action_pattern = re.compile(r"^\s*uses:\s+([^./][^@]+)@(\S+)(?:\s+#\s+(.+))?$", re.MULTILINE)
     for workflow_path in PINNED_WORKFLOW_FILES:
         workflow = workflow_path.read_text(encoding="utf-8")
-        assert "PRIVILEGED_GITHUB_TOKEN" not in workflow
+        for forbidden in (
+            "PRIVILEGED_GITHUB_TOKEN",
+            "TRIAGE_GITHUB_TOKEN",
+            "music-assistant-machine",
+        ):
+            assert forbidden not in workflow
         matches = action_pattern.findall(workflow)
         assert matches
         for _action, ref, comment in matches:
             assert re.fullmatch(r"[0-9a-f]{40}", ref)
             assert re.fullmatch(r"v\d+(?:\.\d+){0,2}", comment)
+
+
+def test_release_workflow_uses_minimum_preflight_permissions_and_expected_app() -> None:
+    """Resolve and preflight stay read-only and every App token checks its installation."""
+    workflow_path = ROOT / ".github" / "workflows" / "release.yml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+    jobs = yaml.safe_load(workflow)["jobs"]
+
+    assert jobs["resolve"]["permissions"] == {"contents": "read"}
+    assert jobs["preflight"]["permissions"] == {"contents": "read"}
+    assert workflow.count("actions/create-github-app-token@") == 5
+    assert workflow.count("outputs.installation-id") == 5
+    assert 'EXPECTED_APP_INSTALLATION_ID: "146062122"' in workflow
+    assert set(re.findall(r"secrets\.([A-Z0-9_]+)", workflow)) == {
+        "MUSIC_ASSISTANT_BOT_PRIVATE_KEY"
+    }
+    assert set(re.findall(r"vars\.([A-Z0-9_]+)", workflow)) == {"MUSIC_ASSISTANT_BOT_CLIENT_ID"}
+    assert "ref: main" not in workflow
+    assert "HEAD:main" not in workflow
+    assert "compare-release-versions" in workflow
+    assert "compare-frontend-versions" in workflow
+    assert "idempotency_key" in workflow
+    assert "repos/music-assistant/home-assistant-addon" in workflow
+    assert "'.default_branch'" in workflow
 
 
 def _api_asset(path: Path) -> dict[str, str | int]:

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -1,0 +1,315 @@
+"""Tests for immutable-safe release workflow helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from scripts.release_workflow import (
+    OCI_REVISION_ANNOTATION,
+    OCI_WHEEL_ANNOTATION,
+    GitRepository,
+    ReleaseWorkflowError,
+    channel_branch,
+    determine_auto_release,
+    inspect_assets,
+    is_current_release,
+    update_addon_release,
+    verify_oci_manifest,
+)
+
+ROOT = Path(__file__).parents[2]
+PINNED_WORKFLOW_FILES = (
+    ROOT / ".github" / "workflows" / "release.yml",
+    ROOT / ".github" / "workflows" / "auto-release.yml",
+    ROOT / ".github" / "actions" / "generate-release-notes" / "action.yml",
+)
+
+
+@pytest.fixture(name="repository")
+def repository_fixture(tmp_path: Path) -> tuple[Path, GitRepository]:
+    """Create a Git repository with one initial commit."""
+    _git(tmp_path, "init", "-b", "dev")
+    _git(tmp_path, "config", "user.name", "Release Test")
+    _git(tmp_path, "config", "user.email", "release@example.com")
+    _commit(tmp_path, "initial")
+    return tmp_path, GitRepository(tmp_path)
+
+
+def test_channel_branch_is_explicit() -> None:
+    """Release channels map to their intended source branches."""
+    assert channel_branch("stable") == "stable"
+    assert channel_branch("rc") == "stable"
+    assert channel_branch("beta") == "dev"
+    assert channel_branch("nightly") == "dev"
+
+
+def test_nightly_uses_tag_commit_range_and_avoids_tag_collision(
+    repository: tuple[Path, GitRepository],
+) -> None:
+    """Nightly discovery counts commits from tags and never reuses a failed tag."""
+    path, git_repository = repository
+    _git(path, "tag", "2.9.9")
+    _git(path, "tag", "2.10.0.dev2026072501")
+    _commit(path, "change one")
+    _commit(path, "change two")
+
+    decision = determine_auto_release(
+        git_repository,
+        "nightly",
+        "HEAD",
+        now=datetime(2026, 7, 25, 1, tzinfo=UTC),
+    )
+
+    assert decision.version == "2.10.0.dev2026072502"
+    assert decision.previous_tag == "2.10.0.dev2026072501"
+    assert decision.commits_since == 2
+    assert decision.should_release is True
+
+
+def test_nightly_requires_two_commits(repository: tuple[Path, GitRepository]) -> None:
+    """A nightly is skipped when fewer than two commits follow its latest tag."""
+    path, git_repository = repository
+    _git(path, "tag", "2.9.9")
+    _git(path, "tag", "2.10.0.dev2026072405")
+    _commit(path, "only change")
+
+    decision = determine_auto_release(
+        git_repository,
+        "nightly",
+        "HEAD",
+        now=datetime(2026, 7, 25, 5, tzinfo=UTC),
+    )
+
+    assert decision.commits_since == 1
+    assert decision.should_release is False
+
+
+def test_beta_rejects_latest_tag_outside_source_history(
+    repository: tuple[Path, GitRepository],
+) -> None:
+    """A latest beta tag on another history cannot define a release range."""
+    path, git_repository = repository
+    source_sha = _git(path, "rev-parse", "HEAD")
+    _git(path, "checkout", "--orphan", "unrelated")
+    (path / "state").unlink()
+    _commit(path, "unrelated")
+    _git(path, "tag", "2.10.0b1")
+
+    with pytest.raises(ReleaseWorkflowError, match="not an ancestor"):
+        determine_auto_release(git_repository, "beta", source_sha)
+
+
+def test_stable_preserves_patch_versioning_across_diverged_branches(
+    repository: tuple[Path, GitRepository],
+) -> None:
+    """Stable release discovery allows a branch cut but still increments patch."""
+    path, git_repository = repository
+    _git(path, "branch", "stable")
+    _git(path, "checkout", "stable")
+    _commit(path, "stable patch")
+    _git(path, "tag", "2.9.9")
+    _git(path, "checkout", "dev")
+    _commit(path, "development")
+
+    decision = determine_auto_release(git_repository, "stable", "HEAD")
+
+    assert decision.version == "2.9.10"
+    assert decision.previous_tag == "2.9.9"
+    assert decision.commits_since == 1
+    assert decision.should_release is True
+
+
+def test_current_release_combines_beta_and_rc_channels(
+    repository: tuple[Path, GitRepository],
+) -> None:
+    """An older beta retry cannot move the shared beta channel behind an RC."""
+    path, git_repository = repository
+    _git(path, "tag", "2.10.0b8")
+    _git(path, "tag", "2.10.0rc1")
+
+    assert is_current_release(git_repository, "rc", "2.10.0rc1") == (
+        True,
+        "2.10.0rc1",
+    )
+    assert is_current_release(git_repository, "beta", "2.10.0b8") == (
+        False,
+        "2.10.0rc1",
+    )
+
+
+def test_release_assets_match_names_sizes_and_digests(tmp_path: Path) -> None:
+    """Local distributions must exactly match GitHub's two release assets."""
+    version = "2.10.0b8"
+    assets_directory = tmp_path / "assets"
+    assets_directory.mkdir()
+    wheel = assets_directory / f"music_assistant-{version}-py3-none-any.whl"
+    source = assets_directory / f"music_assistant-{version}.tar.gz"
+    wheel.write_bytes(b"wheel")
+    source.write_bytes(b"source")
+    release_json = tmp_path / "release.json"
+    release_json.write_text(
+        json.dumps(
+            {
+                "assets": [
+                    _api_asset(wheel),
+                    _api_asset(source),
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assets = inspect_assets(
+        version,
+        directory=assets_directory,
+        release_json=release_json,
+    )
+
+    assert assets[0].sha256 == hashlib.sha256(b"wheel").hexdigest()
+    assert assets[1].sha256 == hashlib.sha256(b"source").hexdigest()
+
+
+def test_release_assets_reject_extras(tmp_path: Path) -> None:
+    """A draft with any extra asset is not safe to publish."""
+    version = "2.10.0b8"
+    wheel = tmp_path / f"music_assistant-{version}-py3-none-any.whl"
+    source = tmp_path / f"music_assistant-{version}.tar.gz"
+    wheel.write_bytes(b"wheel")
+    source.write_bytes(b"source")
+    (tmp_path / "unexpected.txt").write_text("unexpected", encoding="utf-8")
+
+    with pytest.raises(ReleaseWorkflowError, match="exactly"):
+        inspect_assets(version, directory=tmp_path)
+
+
+def test_release_assets_reject_duplicate_api_entries(tmp_path: Path) -> None:
+    """Two API entries with the same expected name are not two exact assets."""
+    version = "2.10.0b8"
+    wheel = tmp_path / f"music_assistant-{version}-py3-none-any.whl"
+    wheel.write_bytes(b"wheel")
+    release_json = tmp_path / "release.json"
+    release_json.write_text(
+        json.dumps({"assets": [_api_asset(wheel), _api_asset(wheel)]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ReleaseWorkflowError, match="duplicate"):
+        inspect_assets(version, release_json=release_json)
+
+
+def test_oci_manifest_requires_exact_platforms_and_provenance() -> None:
+    """The exact image identifies its source and wheel on both target platforms."""
+    source_sha = "a" * 40
+    wheel_sha = "b" * 64
+    manifest = {
+        "digest": f"sha256:{'c' * 64}",
+        "annotations": {
+            OCI_REVISION_ANNOTATION: source_sha,
+            OCI_WHEEL_ANNOTATION: wheel_sha,
+        },
+        "manifests": [
+            {
+                "digest": f"sha256:{'d' * 64}",
+                "platform": {"os": "linux", "architecture": "amd64"},
+            },
+            {
+                "digest": f"sha256:{'e' * 64}",
+                "platform": {"os": "linux", "architecture": "arm64"},
+            },
+            {
+                "digest": f"sha256:{'f' * 64}",
+                "platform": {"os": "unknown", "architecture": "unknown"},
+            },
+        ],
+    }
+
+    digest, runtime_digests = verify_oci_manifest(manifest, source_sha, wheel_sha)
+
+    assert digest == f"sha256:{'c' * 64}"
+    assert runtime_digests == [f"sha256:{'d' * 64}", f"sha256:{'e' * 64}"]
+
+
+def test_addon_update_replaces_duplicate_version_and_retains_three(tmp_path: Path) -> None:
+    """Repeated downstream runs converge on one canonical three-release changelog."""
+    config = tmp_path / "config.yaml"
+    changelog = tmp_path / "CHANGELOG.md"
+    config.write_text("name: Test\nversion: old\nstage: stable\n", encoding="utf-8")
+    changelog.write_text(
+        "# [new] - 01.01.2026\n\nold duplicate\n\n\n"
+        "# [older] - 31.12.2025\n\nolder notes\n\n\n"
+        "# [new] - 30.12.2025\n\nsecond duplicate\n\n\n"
+        "# [older] - 30.12.2025\n\nolder duplicate\n\n\n"
+        "# [oldest] - 29.12.2025\n\noldest notes\n",
+        encoding="utf-8",
+    )
+
+    update_addon_release(
+        config,
+        changelog,
+        version="new",
+        release_date="02.01.2026",
+        notes="canonical notes",
+    )
+    first_result = changelog.read_text(encoding="utf-8")
+    update_addon_release(
+        config,
+        changelog,
+        version="new",
+        release_date="02.01.2026",
+        notes="canonical notes",
+    )
+
+    assert config.read_text(encoding="utf-8").splitlines()[1] == "version: new"
+    assert changelog.read_text(encoding="utf-8") == first_result
+    assert first_result.count("# [new]") == 1
+    assert first_result.count("# [older]") == 1
+    assert "# [older]" in first_result
+    assert "# [oldest]" in first_result
+
+
+def test_release_workflows_pin_external_actions_and_drop_legacy_token() -> None:
+    """Touched release flows use commit-pinned actions and no privileged PAT."""
+    action_pattern = re.compile(r"^\s*uses:\s+([^./][^@]+)@(\S+)(?:\s+#\s+(.+))?$", re.MULTILINE)
+    for workflow_path in PINNED_WORKFLOW_FILES:
+        workflow = workflow_path.read_text(encoding="utf-8")
+        assert "PRIVILEGED_GITHUB_TOKEN" not in workflow
+        matches = action_pattern.findall(workflow)
+        assert matches
+        for _action, ref, comment in matches:
+            assert re.fullmatch(r"[0-9a-f]{40}", ref)
+            assert re.fullmatch(r"v\d+(?:\.\d+){0,2}", comment)
+
+
+def _api_asset(path: Path) -> dict[str, str | int]:
+    return {
+        "name": path.name,
+        "size": path.stat().st_size,
+        "state": "uploaded",
+        "digest": f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}",
+    }
+
+
+def _commit(path: Path, message: str) -> str:
+    state = path / "state"
+    previous = state.read_text(encoding="utf-8") if state.exists() else ""
+    state.write_text(f"{previous}{message}\n", encoding="utf-8")
+    _git(path, "add", "state")
+    _git(path, "commit", "-m", message)
+    return _git(path, "rev-parse", "HEAD")
+
+
+def _git(path: Path, *args: str) -> str:
+    result = subprocess.run(  # noqa: S603
+        ["git", "-C", str(path), *args],  # noqa: S607
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()

--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -126,7 +126,7 @@ def test_linear_release_filters_prs_merged_before_previous_tag(
         ],
     )
     repo = FakeRepo(
-        comparisons={("2.9.0b1", "dev"): comparison},
+        comparisons={("2.9.0b1", "headsha"): comparison},
         pulls={
             200: FakePR(200, datetime(2026, 6, 5, tzinfo=UTC)),
             150: FakePR(150, datetime(2026, 1, 10, tzinfo=UTC)),
@@ -134,7 +134,7 @@ def test_linear_release_filters_prs_merged_before_previous_tag(
         tag_commits={"2.9.0b1": tag_commit},
     )
 
-    prs = generate_notes.get_prs_between_tags(repo, "2.9.0b1", "dev")
+    prs = generate_notes.get_prs_between_tags(repo, "2.9.0b1", "headsha")
 
     assert [pr.number for pr in prs] == [200]
 
@@ -173,7 +173,7 @@ def test_minor_release_with_diverged_previous_tag(
     tag_commit = FakeCommit("tagsha", "2.8.9 release", datetime(2026, 6, 3, tzinfo=UTC))
     repo = FakeRepo(
         comparisons={
-            ("2.8.9", "stable"): head_comparison,
+            ("2.8.9", "headsha"): head_comparison,
             ("mbsha", "2.8.9"): base_comparison,
         },
         pulls={
@@ -185,6 +185,6 @@ def test_minor_release_with_diverged_previous_tag(
         tag_commits={"2.8.9": tag_commit},
     )
 
-    prs = generate_notes.get_prs_between_tags(repo, "2.8.9", "stable")
+    prs = generate_notes.get_prs_between_tags(repo, "2.8.9", "headsha")
 
     assert [pr.number for pr in prs] == [100, 120]


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

GitHub releases currently become public before their exact assets, multi-architecture image, and downstream updates are verified.

- Freeze one source commit and prepare exact draft assets and image before publication.
- Verify release immutability, attestations, tag, assets, and OCI digest before promoting aliases.
- Replace the legacy privileged token with narrowly scoped GitHub App tokens and document recovery and rollout.

**Related issue (if applicable):**

- Depends on https://github.com/music-assistant/models/pull/326

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.