### PR TITLE
⬆️ Update music-assistant-frontend to 2.17.236

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "ifaddr==0.2.0",
   "getmac==0.9.5",
   "mashumaro==3.20",
-  "music-assistant-frontend==2.17.235",
+  "music-assistant-frontend==2.17.236",
   "music-assistant-models==1.1.169",
   "mutagen==1.48.1",
   "orjson==3.11.6",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -50,7 +50,7 @@ lyricsgenius==3.12.2
 markdownify==1.2.3
 mashumaro==3.20
 modern_colorthief==0.2.1
-music-assistant-frontend==2.17.235
+music-assistant-frontend==2.17.236
 music-assistant-models==1.1.169
 mutagen==1.48.1
 niconico.py-ma==2.1.0.post2


### PR DESCRIPTION
Update music-assistant-frontend to version [2.17.236](https://github.com/music-assistant/frontend/releases/tag/2.17.236)


## 🧰 Maintenance and dependency bumps

- Chore(deps): Bump tailwindcss from 4.3.2 to 4.3.3 (by @[dependabot[bot]](https://github.com/apps/dependabot) in [#2170](https://github.com/music-assistant/frontend/pull/2170))
- Chore(deps): Bump @tabler/icons-vue from 3.44.0 to 3.45.0 (by @[dependabot[bot]](https://github.com/apps/dependabot) in [#2171](https://github.com/music-assistant/frontend/pull/2171))


## :bow: Contributors

No contributors