### PR TITLE
Replace legacy GitHub credentials

### DIFF
--- a/.github/release-notes-config.yml
+++ b/.github/release-notes-config.yml
@@ -15,7 +15,7 @@ exclude-contributors:
   - dependabot[bot]
   - github-actions
   - github-actions[bot]
-  - music-assistant-machine
+  - musicassistant-bot[bot]
 
 categories:
 

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -8,36 +8,68 @@ on:
         required: true
         type: string
 
+env:
+  EXPECTED_APP_SLUG: musicassistant-bot
+  EXPECTED_APP_INSTALLATION_ID: "146062122"
+
 jobs:
   build-base-image:
     name: Builds and pushes the Music Assistant base container to ghcr.io
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Read Python version
         id: python
-        run: echo "version=$(cat .python-version)" >> $GITHUB_OUTPUT
-      - name: Download Widevine CDM client files from private repository
-        shell: bash
+        run: echo "version=$(cat .python-version)" >> "$GITHUB_OUTPUT"
+
+      - name: Create appvars token
+        id: appvars_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: appvars
+          permission-contents: read
+
+      - name: Verify GitHub App identity
         env:
-          TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          APP_SLUG: ${{ steps.appvars_token.outputs.app-slug }}
+          INSTALLATION_ID: ${{ steps.appvars_token.outputs.installation-id }}
         run: |
-          mkdir -p widevine_cdm && cd widevine_cdm
-          curl -OJ -H "Authorization: token ${TOKEN}" https://raw.githubusercontent.com/music-assistant/appvars/main/widevine_cdm_client/private_key.pem
-          curl -OJ -H "Authorization: token ${TOKEN}" https://raw.githubusercontent.com/music-assistant/appvars/main/widevine_cdm_client/client_id.bin
+          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ] || \
+             [ "$INSTALLATION_ID" != "$EXPECTED_APP_INSTALLATION_ID" ]; then
+            echo "Unexpected GitHub App installation: $APP_SLUG/$INSTALLATION_ID" >&2
+            exit 1
+          fi
+
+      - name: Download Widevine CDM client files from private repository
+        env:
+          GH_TOKEN: ${{ steps.appvars_token.outputs.token }}
+        run: |
+          mkdir -p widevine_cdm
+          gh api \
+            -H "Accept: application/vnd.github.raw+json" \
+            "repos/music-assistant/appvars/contents/widevine_cdm_client/private_key.pem" \
+            > widevine_cdm/private_key.pem
+          gh api \
+            -H "Accept: application/vnd.github.raw+json" \
+            "repos/music-assistant/appvars/contents/widevine_cdm_client/client_id.bin" \
+            > widevine_cdm/client_id.bin
       - name: Log in to the GitHub container registry
-        uses: docker/login-action@v4.5.1
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.2.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build and Push image
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/dependabot-sync-manifests.yml
+++ b/.github/workflows/dependabot-sync-manifests.yml
@@ -16,20 +16,23 @@ on:
 permissions:
   contents: read
 
+env:
+  EXPECTED_APP_SLUG: musicassistant-bot
+  EXPECTED_APP_INSTALLATION_ID: "146062122"
+
 jobs:
   sync-manifests:
     name: Back-sync provider manifests
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     permissions:
-      contents: write
+      contents: read
     steps:
-      # persist-credentials: false keeps the (privileged) push token out of the git config while
-      # the checked-out Dependabot branch contents are processed below. The push step re-attaches
-      # the music-assistant-machine credential (PRIVILEGED_GITHUB_TOKEN) only for the push itself,
-      # so the pushed commit re-triggers the required checks (the default GITHUB_TOKEN would not).
+      # Keep the checkout token out of git config while processing the Dependabot branch.
+      # A repository-scoped musicassistant-bot[bot] token is minted only for the push so the
+      # resulting commit re-triggers the required checks.
       - name: Check out the Dependabot branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           persist-credentials: false
@@ -61,7 +64,7 @@ jobs:
 
       - name: Set up Python
         if: steps.bumped.outputs.packages != ''
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version-file: ".python-version"
           check-latest: true
@@ -79,13 +82,37 @@ jobs:
           # Unstage the overlay so it is never part of the commit pushed back to the branch.
           git checkout "origin/$BASE_REF" -- scripts/
           git reset -q -- scripts/
-          python -m scripts.sync_manifest_from_requirements $PACKAGES
+          read -ra packages <<< "$PACKAGES"
+          python -m scripts.sync_manifest_from_requirements "${packages[@]}"
           python -m scripts.gen_requirements_all
+
+      - name: Create Dependabot branch token
+        if: steps.bumped.outputs.packages != ''
+        id: push_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
+      - name: Verify GitHub App identity
+        if: steps.bumped.outputs.packages != ''
+        env:
+          APP_SLUG: ${{ steps.push_token.outputs.app-slug }}
+          INSTALLATION_ID: ${{ steps.push_token.outputs.installation-id }}
+        run: |
+          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ] || \
+             [ "$INSTALLATION_ID" != "$EXPECTED_APP_INSTALLATION_ID" ]; then
+            echo "Unexpected GitHub App installation: $APP_SLUG/$INSTALLATION_ID" >&2
+            exit 1
+          fi
 
       - name: Commit and push the manifest sync
         if: steps.bumped.outputs.packages != ''
         env:
-          PUSH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          PUSH_TOKEN: ${{ steps.push_token.outputs.token }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           REPO: ${{ github.repository }}
         run: |

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -29,11 +29,10 @@ jobs:
   apply_label:
     name: Apply
     runs-on: ubuntu-latest
-    # GitHub-typed bots (Dependabot, etc.) don't follow the PR
-    # template and apply their own labels — skip them outright.
-    # PAT-driven service accounts (e.g. music-assistant-machine)
-    # report user.type == 'User', so we additionally skip below
-    # whenever the PR already carries a known-set label.
+    # GitHub-typed bots (Dependabot, musicassistant-bot[bot], etc.)
+    # don't follow the PR template and apply their own labels, so
+    # skip them outright. Trusted automation can also pre-apply a
+    # known-set label; those PRs are handled below.
     if: github.event.pull_request.user.type != 'Bot'
     steps:
       - name: 🏷 Apply label from PR description checkbox

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -342,7 +342,10 @@ def test_automation_drops_legacy_credentials() -> None:
 
 def test_automation_pins_external_actions() -> None:
     """Ensure migrated automation pins external actions to immutable commits."""
-    action_pattern = re.compile(r"^\s*uses:\s+([^./][^@]+)@(\S+)(?:\s+#\s+(.+))?$", re.MULTILINE)
+    action_pattern = re.compile(
+        r"^\s*(?:-\s+)?uses:\s+([^./][^@]+)@(\S+)(?:\s+#\s+(.+))?$",
+        re.MULTILINE,
+    )
     for workflow_path in PINNED_ACTION_FILES:
         workflow = workflow_path.read_text(encoding="utf-8")
         matches = action_pattern.findall(workflow)

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -28,10 +28,27 @@ from scripts.release_workflow import (
 )
 
 ROOT = Path(__file__).parents[2]
-PINNED_WORKFLOW_FILES = (
+PINNED_ACTION_FILES = (
     ROOT / ".github" / "workflows" / "release.yml",
     ROOT / ".github" / "workflows" / "auto-release.yml",
+    ROOT / ".github" / "workflows" / "build-base-image.yml",
+    ROOT / ".github" / "workflows" / "dependabot-sync-manifests.yml",
+    ROOT / ".github" / "workflows" / "pr-labels.yaml",
     ROOT / ".github" / "actions" / "generate-release-notes" / "action.yml",
+)
+LEGACY_AUTH_FILES = (
+    *PINNED_ACTION_FILES,
+    ROOT / ".github" / "release-notes-config.yml",
+)
+FORBIDDEN_LEGACY_IDENTIFIERS = tuple(
+    separator.join(parts)
+    for separator, parts in (
+        ("_", ("PRIVILEGED", "GITHUB", "TOKEN")),
+        ("_", ("TRIAGE", "GITHUB", "TOKEN")),
+        ("_", ("TRIAGE", "APP", "ID")),
+        ("_", ("TRIAGE", "APP", "PRIVATE", "KEY")),
+        ("-", ("music", "assistant", "machine")),
+    )
 )
 
 
@@ -315,17 +332,19 @@ def test_addon_update_replaces_duplicate_version_and_retains_three(tmp_path: Pat
     assert "# [oldest]" in first_result
 
 
-def test_release_workflows_pin_external_actions_and_drop_legacy_token() -> None:
-    """Touched release flows use commit-pinned actions and no privileged PAT."""
+def test_automation_drops_legacy_credentials() -> None:
+    """Ensure migrated automation does not reference retired bot credentials."""
+    for automation_path in LEGACY_AUTH_FILES:
+        automation = automation_path.read_text(encoding="utf-8")
+        for forbidden in FORBIDDEN_LEGACY_IDENTIFIERS:
+            assert forbidden not in automation
+
+
+def test_automation_pins_external_actions() -> None:
+    """Ensure migrated automation pins external actions to immutable commits."""
     action_pattern = re.compile(r"^\s*uses:\s+([^./][^@]+)@(\S+)(?:\s+#\s+(.+))?$", re.MULTILINE)
-    for workflow_path in PINNED_WORKFLOW_FILES:
+    for workflow_path in PINNED_ACTION_FILES:
         workflow = workflow_path.read_text(encoding="utf-8")
-        for forbidden in (
-            "PRIVILEGED_GITHUB_TOKEN",
-            "TRIAGE_GITHUB_TOKEN",
-            "music-assistant-machine",
-        ):
-            assert forbidden not in workflow
         matches = action_pattern.findall(workflow)
         assert matches
         for _action, ref, comment in matches:


### PR DESCRIPTION
# What does this implement/fix?

Replaces the remaining long-lived GitHub automation credentials with short-lived, repository-scoped tokens from the Music Assistant GitHub App.

- Uses read-only access for private build inputs and contents write only for Dependabot branch updates.
- Removes the retired machine-account identity and pins touched Actions to immutable commits.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.