### PR TITLE
Fix release workflow test permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,6 +326,7 @@ jobs:
     if: needs.resolve.outputs.release_state != 'published'
     permissions:
       contents: read
+      pull-requests: read
     uses: ./.github/workflows/test.yml
     with:
       ref: ${{ needs.resolve.outputs.source_sha }}

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -334,13 +334,16 @@ def test_release_workflows_pin_external_actions_and_drop_legacy_token() -> None:
 
 
 def test_release_workflow_uses_minimum_preflight_permissions_and_expected_app() -> None:
-    """Resolve and preflight stay read-only and every App token checks its installation."""
+    """Resolve stays read-only, preflight covers pull requests, and every App token checks its installation."""
     workflow_path = ROOT / ".github" / "workflows" / "release.yml"
     workflow = workflow_path.read_text(encoding="utf-8")
     jobs = yaml.safe_load(workflow)["jobs"]
 
     assert jobs["resolve"]["permissions"] == {"contents": "read"}
-    assert jobs["preflight"]["permissions"] == {"contents": "read"}
+    assert jobs["preflight"]["permissions"] == {
+        "contents": "read",
+        "pull-requests": "read",
+    }
     assert workflow.count("actions/create-github-app-token@") == 5
     assert workflow.count("outputs.installation-id") == 5
     assert 'EXPECTED_APP_INSTALLATION_ID: "146062122"' in workflow


### PR DESCRIPTION
# What does this implement/fix?

Update the release workflow test to expect the required `pull-requests: read` permission on `preflight`, matching the reusable test workflow.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
