### PR TITLE
Trust dependency auto-merge to the bot

### DIFF
--- a/.github/workflows/auto-merge-dependency-updates.yml
+++ b/.github/workflows/auto-merge-dependency-updates.yml
@@ -22,32 +22,39 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'auto-update-frontend-') ||
       startsWith(github.event.pull_request.head.ref, 'auto-update-models-')
 
+    env:
+      EXPECTED_BOT_LOGIN: musicassistant-bot[bot]
+
     permissions:
       contents: write
       pull-requests: write
 
     steps:
-      # Security check 1: Verify PR is from user with write access
+      # Security check 1: Verify PR is from the trusted bot and same repository
       - name: Verify PR is from trusted source
         id: verify_pr_author
+        env:
+          BASE_REPO: ${{ github.repository }}
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
-          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
-
-          # Check if PR author has write access to the repository (includes org members and bots)
-          if gh api "/repos/${{ github.repository }}/collaborators/$PR_AUTHOR/permission" --jq '.permission' 2>/dev/null | grep -qE "^(admin|write|maintain)$"; then
-            echo "✅ PR is from user with write access: $PR_AUTHOR"
-          else
-            echo "❌ PR author does not have write access: $PR_AUTHOR"
+          if [ "$PR_AUTHOR_LOGIN" != "$EXPECTED_BOT_LOGIN" ] || [ "$PR_AUTHOR_TYPE" != "Bot" ]; then
+            echo "❌ PR author is not the trusted GitHub App bot: $PR_AUTHOR_LOGIN ($PR_AUTHOR_TYPE)"
             exit 1
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          if [ "$PR_HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "❌ PR head repository is not trusted: $PR_HEAD_REPO"
+            exit 1
+          fi
+
+          echo "✅ PR is from the trusted bot and same repository"
 
       # Security check 2: Verify PR labels and source branch
       - name: Verify PR labels and source
         run: |
           LABELS="${{ join(github.event.pull_request.labels.*.name, ',') }}"
-          BRANCH="$BRANCH"
 
           if [[ "$LABELS" != *"dependencies"* ]]; then
             echo "❌ PR does not have 'dependencies' label"
@@ -71,9 +78,9 @@ jobs:
       - name: Get PR details
         id: pr
         run: |
-          echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
 
-      # Security check 4: Verify all commit authors have write access
+      # Security check 4: Verify all commit authors are the trusted bot
       - name: Verify commit authors
         run: |
           # A dependency bump PR only ever needs a handful of commits
@@ -93,26 +100,19 @@ jobs:
           fi
 
           # Commits whose author email is not linked to a GitHub account have
-          # no login to verify, so they must be rejected
-          UNATTRIBUTED=$(echo "$COMMITS" | jq '[.[] | select(.author.login == null)] | length')
+          # no login to verify, so they must be rejected. Every commit must
+          # also be attributed to the trusted GitHub App bot.
+          UNATTRIBUTED=$(echo "$COMMITS" | jq '[.[] | select(.author == null)] | length')
           if [ "$UNATTRIBUTED" -gt 0 ]; then
             echo "❌ $UNATTRIBUTED commit(s) have no linked GitHub author"
             exit 1
           fi
 
-          COMMIT_AUTHORS=$(echo "$COMMITS" | jq -r '[.[].author.login] | unique | .[]')
-
-          for AUTHOR in $COMMIT_AUTHORS; do
-            if gh api "/repos/${{ github.repository }}/collaborators/$AUTHOR/permission" --jq '.permission' 2>/dev/null | grep -qE "^(admin|write|maintain)$"; then
-              echo "✅ Commit author has write access: $AUTHOR"
-            else
-              echo "❌ Commit author does not have write access: $AUTHOR"
-              exit 1
-            fi
-          done
-
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NON_BOT=$(echo "$COMMITS" | jq '[.[] | select(.author.login != env.EXPECTED_BOT_LOGIN)] | length')
+          if [ "$NON_BOT" -gt 0 ]; then
+            echo "❌ $NON_BOT commit(s) are not authored by the trusted GitHub App bot"
+            exit 1
+          fi
 
       # Security check 5: Verify only dependency files were changed
       - name: Verify only dependency files were changed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,6 +326,7 @@ jobs:
     if: needs.resolve.outputs.release_state != 'published'
     permissions:
       contents: read
+      pull-requests: read
     uses: ./.github/workflows/test.yml
     with:
       ref: ${{ needs.resolve.outputs.source_sha }}

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -334,13 +334,16 @@ def test_release_workflows_pin_external_actions_and_drop_legacy_token() -> None:
 
 
 def test_release_workflow_uses_minimum_preflight_permissions_and_expected_app() -> None:
-    """Resolve and preflight stay read-only and every App token checks its installation."""
+    """Resolve stays read-only, preflight covers pull requests, and every App token checks its installation."""
     workflow_path = ROOT / ".github" / "workflows" / "release.yml"
     workflow = workflow_path.read_text(encoding="utf-8")
     jobs = yaml.safe_load(workflow)["jobs"]
 
     assert jobs["resolve"]["permissions"] == {"contents": "read"}
-    assert jobs["preflight"]["permissions"] == {"contents": "read"}
+    assert jobs["preflight"]["permissions"] == {
+        "contents": "read",
+        "pull-requests": "read",
+    }
     assert workflow.count("actions/create-github-app-token@") == 5
     assert workflow.count("outputs.installation-id") == 5
     assert 'EXPECTED_APP_INSTALLATION_ID: "146062122"' in workflow

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -8,6 +8,7 @@ import re
 import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TypedDict
 
 import pytest
 import yaml
@@ -28,6 +29,7 @@ from scripts.release_workflow import (
 )
 
 ROOT = Path(__file__).parents[2]
+AUTO_MERGE_WORKFLOW = ROOT / ".github" / "workflows" / "auto-merge-dependency-updates.yml"
 PINNED_WORKFLOW_FILES = (
     ROOT / ".github" / "workflows" / "release.yml",
     ROOT / ".github" / "workflows" / "auto-release.yml",
@@ -333,6 +335,130 @@ def test_release_workflows_pin_external_actions_and_drop_legacy_token() -> None:
             assert re.fullmatch(r"v\d+(?:\.\d+){0,2}", comment)
 
 
+def test_auto_merge_dependency_workflow_trust_checks_are_exact() -> None:
+    """The dependency auto-merge workflow only trusts the App bot and same-repo PRs."""
+    workflow = AUTO_MERGE_WORKFLOW.read_text(encoding="utf-8")
+    data = yaml.safe_load(workflow)
+
+    assert data["jobs"]["auto-merge"]["env"] == {"EXPECTED_BOT_LOGIN": "musicassistant-bot[bot]"}
+    assert "github.event.pull_request.user.login" in workflow
+    assert "github.event.pull_request.user.type" in workflow
+    assert "github.event.pull_request.head.repo.full_name" in workflow
+    assert "github.repository" in workflow
+    assert "collaborators/" not in workflow
+    assert "collaborators/$PR_AUTHOR/permission" not in workflow
+    assert "collaborators/$AUTHOR/permission" not in workflow
+    assert "author.login != env.EXPECTED_BOT_LOGIN" in workflow
+
+
+@pytest.mark.parametrize(
+    ("name", "event", "expected", "reason"),
+    [
+        (
+            "exact bot in repo",
+            {
+                "pr_author_login": "musicassistant-bot[bot]",
+                "pr_author_type": "Bot",
+                "head_repo": "music-assistant/server",
+                "declared_commit_count": 2,
+                "commits": [
+                    {"author": {"login": "musicassistant-bot[bot]", "type": "Bot"}},
+                    {"author": {"login": "musicassistant-bot[bot]", "type": "Bot"}},
+                ],
+            },
+            True,
+            "",
+        ),
+        (
+            "human collaborator",
+            {
+                "pr_author_login": "alice",
+                "pr_author_type": "User",
+                "head_repo": "music-assistant/server",
+                "declared_commit_count": 1,
+                "commits": [
+                    {"author": {"login": "alice", "type": "User"}},
+                ],
+            },
+            False,
+            "trusted GitHub App bot",
+        ),
+        (
+            "lookalike bot",
+            {
+                "pr_author_login": "musicassistant-bot-ops[bot]",
+                "pr_author_type": "Bot",
+                "head_repo": "music-assistant/server",
+                "declared_commit_count": 1,
+                "commits": [
+                    {"author": {"login": "musicassistant-bot-ops[bot]", "type": "Bot"}},
+                ],
+            },
+            False,
+            "trusted GitHub App bot",
+        ),
+        (
+            "fork",
+            {
+                "pr_author_login": "musicassistant-bot[bot]",
+                "pr_author_type": "Bot",
+                "head_repo": "someone/server",
+                "declared_commit_count": 1,
+                "commits": [
+                    {"author": {"login": "musicassistant-bot[bot]", "type": "Bot"}},
+                ],
+            },
+            False,
+            "trusted repository",
+        ),
+        (
+            "mixed commit authors",
+            {
+                "pr_author_login": "musicassistant-bot[bot]",
+                "pr_author_type": "Bot",
+                "head_repo": "music-assistant/server",
+                "declared_commit_count": 2,
+                "commits": [
+                    {"author": {"login": "musicassistant-bot[bot]", "type": "Bot"}},
+                    {"author": {"login": "alice", "type": "User"}},
+                ],
+            },
+            False,
+            "trusted GitHub App bot",
+        ),
+        (
+            "unattributed commit",
+            {
+                "pr_author_login": "musicassistant-bot[bot]",
+                "pr_author_type": "Bot",
+                "head_repo": "music-assistant/server",
+                "declared_commit_count": 2,
+                "commits": [
+                    {"author": {"login": "musicassistant-bot[bot]", "type": "Bot"}},
+                    {"author": None},
+                ],
+            },
+            False,
+            "linked GitHub author",
+        ),
+    ],
+)
+def test_auto_merge_dependency_trust_gate(
+    name: str,
+    event: _AutoMergeEvent,
+    expected: bool,
+    reason: str,
+) -> None:
+    """The trust gate accepts only the exact bot and rejects every other source."""
+    allowed, actual_reason = _auto_merge_dependency_trust_check(event)
+
+    assert allowed is expected, name
+    if expected:
+        assert actual_reason == "accepted"
+    else:
+        assert reason in actual_reason
+
+
 def test_release_workflow_uses_minimum_preflight_permissions_and_expected_app() -> None:
     """Resolve stays read-only, preflight covers pull requests, and every App token checks its installation."""
     workflow_path = ROOT / ".github" / "workflows" / "release.yml"
@@ -386,3 +512,50 @@ def _git(path: Path, *args: str) -> str:
         text=True,
     )
     return result.stdout.strip()
+
+
+class _AutoMergeCommit(TypedDict):
+    author: dict[str, str] | None
+
+
+class _AutoMergeEvent(TypedDict):
+    pr_author_login: str
+    pr_author_type: str
+    head_repo: str
+    declared_commit_count: int
+    commits: list[_AutoMergeCommit]
+
+
+def _auto_merge_dependency_trust_check(
+    event: _AutoMergeEvent,
+) -> tuple[bool, str]:
+    """
+    Evaluate the workflow trust gate against a minimal PR payload.
+
+    :param event: Minimal PR metadata and commit payload to validate.
+    """
+    expected_bot_login = "musicassistant-bot[bot]"
+    base_repo = "music-assistant/server"
+
+    if event["pr_author_login"] != expected_bot_login or event["pr_author_type"] != "Bot":
+        return False, "PR author is not the trusted GitHub App bot"
+
+    if event["head_repo"] != base_repo:
+        return False, "PR head repository is not the trusted repository"
+
+    declared_commit_count = event["declared_commit_count"]
+    commits = event["commits"]
+
+    if declared_commit_count > 20:
+        return False, "PR has too many commits"
+    if len(commits) != declared_commit_count:
+        return False, "Fetched commit count does not match the PR"
+
+    for commit in commits:
+        author = commit["author"]
+        if author is None:
+            return False, "One or more commits have no linked GitHub author"
+        if author["login"] != expected_bot_login:
+            return False, "One or more commits are not authored by the trusted GitHub App bot"
+
+    return True, "accepted"


### PR DESCRIPTION
## What does this implement/fix?

Lock the dependency auto-merge workflow to the exact `musicassistant-bot[bot]` GitHub App and the same repository, so human authors, lookalike bots, forks, and mixed/unattributed commit histories are rejected.

**Changes**

- Require the exact bot login/type and same-repo head before any merge checks run.
- Require every fetched commit to be attributed to the same exact bot login.
- Add focused tests for the accepted path and the rejection cases.

**Related issue (if applicable):**

N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
