### PR TITLE
Fix draft release lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -950,10 +950,34 @@ jobs:
         id: publication_state
         env:
           GH_TOKEN: ${{ github.token }}
+          DRAFT_RELEASE_ID: ${{ needs.prepare_draft.outputs.release_id }}
+          PUBLISHED_RELEASE_ID: ${{ needs.resolve.outputs.release_id }}
+          RELEASE_STATE: ${{ needs.resolve.outputs.release_state }}
           VERSION: ${{ inputs.version }}
         run: |
-          gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" \
+          case "$RELEASE_STATE" in
+            draft)
+              RELEASE_ID="$DRAFT_RELEASE_ID"
+              ;;
+            published)
+              RELEASE_ID="$PUBLISHED_RELEASE_ID"
+              ;;
+            *)
+              echo "Unsupported release state: $RELEASE_STATE" >&2
+              exit 1
+              ;;
+          esac
+          if [ -z "$RELEASE_ID" ]; then
+            echo "Missing release id for $RELEASE_STATE release $VERSION" >&2
+            exit 1
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
             > "$RUNNER_TEMP/live-release.json"
+          live_tag_name=$(jq -r '.tag_name' "$RUNNER_TEMP/live-release.json")
+          if [ "$live_tag_name" != "$VERSION" ]; then
+            echo "Release $VERSION resolves to tag $live_tag_name" >&2
+            exit 1
+          fi
           draft=$(jq -r '.draft' "$RUNNER_TEMP/live-release.json")
           immutable=$(jq -r '.immutable' "$RUNNER_TEMP/live-release.json")
           if [ "$draft" = "true" ] && [ "$immutable" = "false" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -956,7 +956,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           case "$RELEASE_STATE" in
-            draft)
+            new|draft)
               RELEASE_ID="$DRAFT_RELEASE_ID"
               ;;
             published)

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -382,6 +382,28 @@ def test_release_workflow_uses_minimum_preflight_permissions_and_expected_app() 
     assert "'.default_branch'" in workflow
 
 
+def test_release_workflow_publication_state_uses_release_ids() -> None:
+    """Publication lookup must use release IDs and fail closed on mismatches."""
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    assert "DRAFT_RELEASE_ID: ${{ needs.prepare_draft.outputs.release_id }}" in workflow
+    assert "PUBLISHED_RELEASE_ID: ${{ needs.resolve.outputs.release_id }}" in workflow
+    assert "RELEASE_STATE: ${{ needs.resolve.outputs.release_state }}" in workflow
+
+    publication_step = _workflow_step_run(
+        workflow,
+        job_name="publish_release",
+        step_name="Detect live publication state",
+    )
+
+    assert 'gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION"' not in publication_step
+    assert 'gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID"' in publication_step
+    assert 'case "$RELEASE_STATE" in' in publication_step
+    assert "Missing release id for $RELEASE_STATE release $VERSION" in publication_step
+    assert "tag_name" in publication_step
+    assert "Release $VERSION resolves to tag $live_tag_name" in publication_step
+    assert "Release $VERSION is neither a mutable draft nor immutable" in publication_step
+
+
 def _api_asset(path: Path) -> dict[str, str | int]:
     return {
         "name": path.name,
@@ -408,3 +430,12 @@ def _git(path: Path, *args: str) -> str:
         text=True,
     )
     return result.stdout.strip()
+
+
+def _workflow_step_run(workflow: str, job_name: str, step_name: str) -> str:
+    jobs = yaml.safe_load(workflow)["jobs"]
+    for step in jobs[job_name]["steps"]:
+        if step.get("name") == step_name:
+            return str(step["run"])
+    msg = f"Step {step_name!r} not found in job {job_name!r}"
+    raise AssertionError(msg)

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -398,6 +398,7 @@ def test_release_workflow_publication_state_uses_release_ids() -> None:
     assert 'gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION"' not in publication_step
     assert 'gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID"' in publication_step
     assert 'case "$RELEASE_STATE" in' in publication_step
+    assert "new|draft)" in publication_step
     assert "Missing release id for $RELEASE_STATE release $VERSION" in publication_step
     assert "tag_name" in publication_step
     assert "Release $VERSION resolves to tag $live_tag_name" in publication_step


### PR DESCRIPTION
# What does this implement/fix?

Use release IDs for live publication detection so draft releases do not hit the tag endpoint.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.