### PR TITLE
Add release recovery source SHA

### DIFF
--- a/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
+++ b/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
@@ -69,7 +69,8 @@ The scheduled workflow checks nightly releases automatically. For a manual versi
 
 Auto-release calculates the next version and invokes **Create Release** with its captured
 source SHA. **Create Release** can also be dispatched directly with an explicit version;
-for direct runs it resolves and freezes the current channel branch head itself.
+for direct runs it resolves and freezes the current channel branch head itself unless you
+pass `source_sha` to recover an exact draft or published release source.
 
 Do not create or publish a GitHub release manually. A draft created outside the workflow
 is accepted only when its exact tag name and target SHA match; conflicting tags,
@@ -105,6 +106,16 @@ token's App slug is `musicassistant-bot` and its installation ID is `146062122`.
 ## Recovery
 
 Rerun the failed workflow with the same version and `source_sha`.
+
+If you need to resume an exact draft or published release after the branch has advanced,
+reuse the workflow-created source SHA from the matching tag or draft target commit:
+
+```bash
+gh workflow run release.yml --ref dev -f version=2.10.0.dev2026072510 -f channel=nightly -f source_sha=a087405a28d2c0991803dbd9c037dc76fd05a631
+```
+
+Use the exact commit recorded by the workflow-created tag or draft. There is no moving
+branch recovery path.
 
 - **Before publication:** The matching draft remains mutable. Complete assets are
   downloaded and reused byte-for-byte; incomplete assets are replaced. If the exact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
           - beta
           - rc
           - nightly
+      source_sha:
+        description: "Exact full commit SHA for draft/published recovery; leave empty to resolve the current channel branch head"
+        required: false
+        type: string
       important_notes:
         description: "Important notes (breaking changes, critical info, etc.)"
         required: false

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -6,8 +6,10 @@ import hashlib
 import json
 import re
 import subprocess
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 import yaml
@@ -533,6 +535,56 @@ def test_release_workflow_uses_minimum_preflight_permissions_and_expected_app() 
     assert "'.default_branch'" in workflow
 
 
+def test_release_workflow_dispatch_source_sha_is_optional_for_recovery() -> None:
+    """Direct recovery keeps source_sha optional while workflow_call stays required."""
+    workflow = cast(
+        "Mapping[object, Any]",
+        yaml.safe_load(
+            (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+        ),
+    )
+    triggers = _workflow_triggers(workflow)
+
+    assert triggers["workflow_dispatch"]["inputs"]["source_sha"] == {
+        "description": (
+            "Exact full commit SHA for draft/published recovery; leave empty to "
+            "resolve the current channel branch head"
+        ),
+        "required": False,
+        "type": "string",
+    }
+    assert triggers["workflow_call"]["inputs"]["source_sha"] == {
+        "description": "Exact source commit to release",
+        "required": True,
+        "type": "string",
+    }
+
+
+def test_release_workflow_exact_source_resolution_uses_requested_sha() -> None:
+    """Resolve exact source commit honors recovery SHAs and rejects bad ones."""
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    resolve_step = _workflow_step(
+        cast("dict[str, Any]", yaml.safe_load(workflow)),
+        "resolve",
+        "Resolve exact source commit",
+    )
+
+    assert resolve_step["env"] == {"REQUESTED_SHA": "${{ inputs.source_sha }}"}
+    resolve_run = str(resolve_step["run"])
+
+    for required_snippet in (
+        'if [ -n "$REQUESTED_SHA" ]; then',
+        "requested_sha=$(printf '%s' \"$REQUESTED_SHA\" |",
+        "tr '[:upper:]' '[:lower:]')",
+        "source_sha must be a full commit SHA",
+        'source_sha=$(git -C source rev-parse "$requested_sha^{commit}")',
+        'if ! git -C source merge-base --is-ancestor "$source_sha" "$branch_sha"; then',
+        'source_sha="$branch_sha"',
+        'echo "sha=$source_sha" >> "$GITHUB_OUTPUT"',
+    ):
+        assert required_snippet in resolve_run
+
+
 def test_release_workflow_publication_state_uses_release_ids() -> None:
     """Publication lookup must use release IDs and fail closed on mismatches."""
     workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
@@ -584,10 +636,23 @@ def _git(path: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
-def _workflow_step_run(workflow: str, job_name: str, step_name: str) -> str:
-    jobs = yaml.safe_load(workflow)["jobs"]
+def _workflow_triggers(workflow: Mapping[object, Any]) -> dict[str, Any]:
+    trigger = workflow.get("on")
+    if trigger is None:
+        trigger = workflow[True]
+    assert isinstance(trigger, dict)
+    return cast("dict[str, Any]", trigger)
+
+
+def _workflow_step(workflow: Mapping[str, Any], job_name: str, step_name: str) -> dict[str, Any]:
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
     for step in jobs[job_name]["steps"]:
         if step.get("name") == step_name:
-            return str(step["run"])
+            return cast("dict[str, Any]", step)
     msg = f"Step {step_name!r} not found in job {job_name!r}"
     raise AssertionError(msg)
+
+
+def _workflow_step_run(workflow: str, job_name: str, step_name: str) -> str:
+    return str(_workflow_step(yaml.safe_load(workflow), job_name, step_name)["run"])

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -572,17 +572,25 @@ def test_release_workflow_exact_source_resolution_uses_requested_sha() -> None:
     assert resolve_step["env"] == {"REQUESTED_SHA": "${{ inputs.source_sha }}"}
     resolve_run = str(resolve_step["run"])
 
-    for required_snippet in (
-        'if [ -n "$REQUESTED_SHA" ]; then',
-        "requested_sha=$(printf '%s' \"$REQUESTED_SHA\" |",
-        "tr '[:upper:]' '[:lower:]')",
-        "source_sha must be a full commit SHA",
-        'source_sha=$(git -C source rev-parse "$requested_sha^{commit}")',
-        'if ! git -C source merge-base --is-ancestor "$source_sha" "$branch_sha"; then',
-        'source_sha="$branch_sha"',
-        'echo "sha=$source_sha" >> "$GITHUB_OUTPUT"',
-    ):
-        assert required_snippet in resolve_run
+    expected_resolution = """\
+if [ -n "$REQUESTED_SHA" ]; then
+  requested_sha=$(printf '%s' "$REQUESTED_SHA" |
+    tr '[:upper:]' '[:lower:]')
+  if ! [[ "$requested_sha" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "source_sha must be a full commit SHA" >&2
+    exit 1
+  fi
+  source_sha=$(git -C source rev-parse "$requested_sha^{commit}")
+  if ! git -C source merge-base --is-ancestor "$source_sha" "$branch_sha"; then
+    echo "$source_sha is not part of ${{ steps.branch.outputs.branch }}" >&2
+    exit 1
+  fi
+else
+  source_sha="$branch_sha"
+fi
+echo "sha=$source_sha" >> "$GITHUB_OUTPUT"
+"""
+    assert expected_resolution in resolve_run
 
 
 def test_release_workflow_publication_state_uses_release_ids() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Allow manual release retries to supply the exact source SHA of an existing draft after the channel branch advances.

- Add an optional `source_sha` dispatch input.
- Keep normal releases pinned to the current channel head when it is omitted.
- Document exact-SHA draft recovery.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.