### PR TITLE
Cast Party and Music Quiz to Apple TV

### DIFF
--- a/music_assistant/providers/airplay/dashboard.py
+++ b/music_assistant/providers/airplay/dashboard.py
@@ -21,8 +21,12 @@ if TYPE_CHECKING:
 
 # Version of the launch contract this adapter emits (see tvos/docs/launch-contract.md).
 LAUNCH_CONTRACT_VERSION = "1"
-# Dashboard types the tvOS app can render in this release.
-SUPPORTED_DASHBOARD_TYPES = {DashboardType.NOW_PLAYING}
+# Dashboard types the tvOS app has native views for.
+SUPPORTED_DASHBOARD_TYPES = {
+    DashboardType.NOW_PLAYING,
+    DashboardType.PARTY,
+    DashboardType.MUSIC_QUIZ,
+}
 
 
 class AirPlayDashboards:

--- a/tests/providers/airplay/test_dashboard.py
+++ b/tests/providers/airplay/test_dashboard.py
@@ -125,7 +125,11 @@ async def test_eligible_player_registers_once() -> None:
     device = handler.call_args[0][0]  # type: ignore[attr-defined]
     assert device.dashboard_id == f"airplay_{PLAYER_ID}"
     assert device.name == "Living Room"
-    assert device.supported_types == {DashboardType.NOW_PLAYING}
+    assert device.supported_types == {
+        DashboardType.NOW_PLAYING,
+        DashboardType.PARTY,
+        DashboardType.MUSIC_QUIZ,
+    }
     assert device.provider_domain_hint == "airplay"
 
 
@@ -263,6 +267,34 @@ async def test_on_show_builds_contract_launch_uri() -> None:
         "&dashboard_id=airplay_ap1234567890ab"
     )
     player.async_launch_app.assert_awaited_once_with(expected)
+
+
+async def test_on_show_party_launch_uri_needs_no_player() -> None:
+    """A dashboard that is not player-scoped launches through the real controller route."""
+    controller = DashboardController.__new__(DashboardController)
+    controller.mass = MagicMock()
+    controller.mass.webserver.base_url = "http://192.168.1.10:8095"
+    controller.logger = MagicMock()
+    controller._dashboards = {}
+    controller._sessions = {}
+
+    dashboards = _make_dashboards()
+    dashboards.mass.dashboard = controller
+    player = _make_player()
+    dashboards.mass.players.get_player.return_value = player  # type: ignore[attr-defined]
+    dashboards._register(player)
+    dashboard_id = f"airplay_{PLAYER_ID}"
+
+    with patch.object(DashboardController, "_get_dashboard_code", AsyncMock(return_value="ABC123")):
+        await controller.show_dashboard(dashboard_id, DashboardType.PARTY)
+
+    expected = (
+        "musicassistant://dashboard/show?v=1&type=party"
+        "&target=http%3A%2F%2F192.168.1.10%3A8095%3Fdashboard%3DABC123%26path%3D%252Fparty"
+        f"&dashboard_id={dashboard_id}"
+    )
+    player.async_launch_app.assert_awaited_once_with(expected)
+    assert controller._sessions[dashboard_id].player_id is None
 
 
 async def test_on_show_wakes_before_launching() -> None:


### PR DESCRIPTION
# What does this implement/fix?

The Apple TV app now has native Party and Music Quiz screens, but the AirPlay dashboard endpoint still only advertised Now Playing — so those screens could not be cast to an Apple TV. This advertises all three.

- Apple TV dashboard endpoints now support Party and Music Quiz alongside Now Playing.
- Party and Music Quiz are not tied to a player, and cast correctly without one.

**Related issue (if applicable):**

- Follow-up to #4979

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
