### PR TITLE
Fix draft release recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,16 +198,17 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           release_json="$RUNNER_TEMP/release.json"
-          release_error="$RUNNER_TEMP/release-error.txt"
-          if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" \
-            > "$release_json" 2> "$release_error"; then
-            release_exists=true
-          elif grep -q "HTTP 404" "$release_error"; then
-            release_exists=false
-          else
-            cat "$release_error" >&2
-            exit 1
-          fi
+          release_lookup="$RUNNER_TEMP/release-lookup.txt"
+          gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+            > "$RUNNER_TEMP/releases.json"
+          python3 .release-workflow/scripts/release_workflow.py select-release \
+            --version "$VERSION" \
+            --releases-json "$RUNNER_TEMP/releases.json" \
+            --release-json "$release_json" \
+            --github-output "$release_lookup"
+          release_exists=$(sed -n 's/^release_exists=//p' "$release_lookup")
+          release_id=$(sed -n 's/^release_id=//p' "$release_lookup")
 
           tag_sha=""
           tag_is_resumable=false
@@ -263,7 +264,6 @@ jobs:
             exit 0
           fi
 
-          release_id=$(jq -r '.id' "$release_json")
           draft=$(jq -r '.draft' "$release_json")
           immutable=$(jq -r '.immutable' "$release_json")
           target=$(jq -r '.target_commitish' "$release_json")
@@ -377,15 +377,44 @@ jobs:
         if: needs.resolve.outputs.assets_ready == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.resolve.outputs.release_id }}
           SDIST_NAME: ${{ needs.resolve.outputs.sdist_name }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
           VERSION: ${{ inputs.version }}
           WHEEL_NAME: ${{ needs.resolve.outputs.wheel_name }}
         run: |
-          gh release download "$VERSION" \
-            --repo "$GITHUB_REPOSITORY" \
-            --dir source/dist \
-            --pattern "$WHEEL_NAME" \
-            --pattern "$SDIST_NAME"
+          if [ -z "$RELEASE_ID" ]; then
+            echo "Missing release id for reusable draft assets" >&2
+            exit 1
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            > "$RUNNER_TEMP/release.json"
+          if [ "$(jq -r '.id // empty' "$RUNNER_TEMP/release.json")" != "$RELEASE_ID" ] || \
+             [ "$(jq -r '.tag_name // empty' "$RUNNER_TEMP/release.json")" != "$VERSION" ] || \
+             [ "$(jq -r '.draft' "$RUNNER_TEMP/release.json")" != "true" ] || \
+             [ "$(jq -r '.immutable' "$RUNNER_TEMP/release.json")" != "false" ] || \
+             [ "$(jq -r '.target_commitish' "$RUNNER_TEMP/release.json")" != "$SOURCE_SHA" ]; then
+            echo "Resolved release $RELEASE_ID is no longer the matching mutable draft" >&2
+            exit 1
+          fi
+          for asset_name in "$WHEEL_NAME" "$SDIST_NAME"; do
+            asset_count=$(jq \
+              --arg name "$asset_name" \
+              '[.assets[] | select(.name == $name)] | length' \
+              "$RUNNER_TEMP/release.json")
+            if [ "$asset_count" -ne 1 ]; then
+              echo "Draft must contain exactly one $asset_name asset" >&2
+              exit 1
+            fi
+            asset_id=$(jq -r \
+              --arg name "$asset_name" \
+              '.assets[] | select(.name == $name) | .id' \
+              "$RUNNER_TEMP/release.json")
+            gh api \
+              -H "Accept: application/octet-stream" \
+              "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" \
+              > "source/dist/$asset_name"
+          done
 
       - name: Create appvars token
         if: needs.resolve.outputs.assets_ready != 'true'
@@ -456,14 +485,11 @@ jobs:
       - name: Verify exact assets
         id: assets
         env:
-          GH_TOKEN: ${{ github.token }}
           REUSED_ASSETS: ${{ steps.mode.outputs.reused_assets }}
           VERSION: ${{ inputs.version }}
         run: |
           extra_args=()
           if [ "$REUSED_ASSETS" = "true" ]; then
-            gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" \
-              > "$RUNNER_TEMP/release.json"
             extra_args=(--release-json "$RUNNER_TEMP/release.json")
           fi
           python3 .release-workflow/scripts/release_workflow.py assets \
@@ -580,21 +606,27 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           IS_PRERELEASE: ${{ needs.resolve.outputs.is_prerelease }}
+          RELEASE_ID: ${{ needs.resolve.outputs.release_id }}
           RELEASE_NOTES: ${{ steps.notes.outputs.release-notes }}
           RELEASE_TITLE: ${{ steps.title.outputs.title }}
           SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
           VERSION: ${{ inputs.version }}
         run: |
           release_json="$RUNNER_TEMP/release.json"
-          release_error="$RUNNER_TEMP/release-error.txt"
-          if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" \
-            > "$release_json" 2> "$release_error"; then
+          if [ -n "$RELEASE_ID" ]; then
+            gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+              > "$release_json"
+            if [ "$(jq -r '.id // empty' "$release_json")" != "$RELEASE_ID" ] || \
+               [ "$(jq -r '.tag_name // empty' "$release_json")" != "$VERSION" ] || \
+               [ "$(jq -r '.draft' "$release_json")" != "true" ] || \
+               [ "$(jq -r '.immutable' "$release_json")" != "false" ] || \
+               [ "$(jq -r '.target_commitish' "$release_json")" != "$SOURCE_SHA" ]; then
+              echo "Resolved release $RELEASE_ID is no longer the matching mutable draft" >&2
+              exit 1
+            fi
             release_exists=true
-          elif grep -q "HTTP 404" "$release_error"; then
-            release_exists=false
           else
-            cat "$release_error" >&2
-            exit 1
+            release_exists=false
           fi
 
           jq -n \
@@ -689,15 +721,8 @@ jobs:
           fi
 
           if [ "$release_exists" = "true" ]; then
-            if [ "$(jq -r '.draft' "$release_json")" != "true" ] || \
-               [ "$(jq -r '.immutable' "$release_json")" != "false" ] || \
-               [ "$(jq -r '.target_commitish' "$release_json")" != "$SOURCE_SHA" ]; then
-              echo "Release $VERSION is no longer a matching mutable draft" >&2
-              exit 1
-            fi
-            release_id=$(jq -r '.id' "$release_json")
             gh api --method PATCH \
-              "repos/$GITHUB_REPOSITORY/releases/$release_id" \
+              "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
               --input "$RUNNER_TEMP/release-payload.json" \
               > "$release_json"
           else
@@ -705,7 +730,16 @@ jobs:
               "repos/$GITHUB_REPOSITORY/releases" \
               --input "$RUNNER_TEMP/release-payload.json" \
               > "$release_json"
-            release_id=$(jq -r '.id' "$release_json")
+          fi
+          release_id=$(jq -r '.id // empty' "$release_json")
+          if [ -z "$release_id" ] || \
+             { [ -n "$RELEASE_ID" ] && [ "$release_id" != "$RELEASE_ID" ]; } || \
+             [ "$(jq -r '.tag_name // empty' "$release_json")" != "$VERSION" ] || \
+             [ "$(jq -r '.draft' "$release_json")" != "true" ] || \
+             [ "$(jq -r '.immutable' "$release_json")" != "false" ] || \
+             [ "$(jq -r '.target_commitish' "$release_json")" != "$SOURCE_SHA" ]; then
+            echo "GitHub did not return the matching mutable draft for $VERSION" >&2
+            exit 1
           fi
           echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
 
@@ -724,10 +758,20 @@ jobs:
               gh api --method DELETE \
                 "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id"
             done
-          gh release upload "$VERSION" \
+          for asset_path in \
             "source/dist/$WHEEL_NAME" \
-            "source/dist/$SDIST_NAME" \
-            --repo "$GITHUB_REPOSITORY"
+            "source/dist/$SDIST_NAME"; do
+            asset_name=$(basename "$asset_path")
+            curl --fail-with-body --silent --show-error \
+              --request POST \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Content-Type: application/octet-stream" \
+              --header "X-GitHub-Api-Version: 2026-03-10" \
+              --data-binary "@$asset_path" \
+              "https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?name=$asset_name" \
+              > "$RUNNER_TEMP/upload-$asset_name.json"
+          done
 
       - name: Verify draft assets
         id: assets

--- a/scripts/release_workflow.py
+++ b/scripts/release_workflow.py
@@ -681,10 +681,6 @@ def _asset_outputs(assets: tuple[Asset, Asset]) -> dict[str, str | int]:
     }
 
 
-def _add_select_release_parser(subparsers: Any) -> None:
-    _configure_release_parser(subparsers.add_parser("select-release"))
-
-
 def _configure_release_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--version", required=True)
     parser.add_argument("--releases-json", type=Path, required=True)
@@ -733,7 +729,7 @@ def _build_parser() -> argparse.ArgumentParser:
     frontend_order_parser.add_argument("--requested", required=True)
     frontend_order_parser.add_argument("--github-output", type=Path)
 
-    _add_select_release_parser(subparsers)
+    _configure_release_parser(subparsers.add_parser("select-release"))
 
     assets_parser = subparsers.add_parser("assets")
     assets_parser.add_argument("--version", required=True)

--- a/scripts/release_workflow.py
+++ b/scripts/release_workflow.py
@@ -311,6 +311,39 @@ def compare_frontend_versions(current: str, requested: str) -> str:
     return _version_relation(current_key, requested_key)
 
 
+def select_release(release_pages: object, version: str) -> dict[str, Any] | None:
+    """
+    Return the only release whose tag exactly matches a version.
+
+    :param release_pages: Paginated responses from the GitHub releases API.
+    :param version: Exact release tag to select.
+    """
+    if not isinstance(release_pages, list):
+        raise ReleaseWorkflowError("GitHub releases response does not contain pages")
+
+    matches: list[dict[str, Any]] = []
+    for page in release_pages:
+        if not isinstance(page, list):
+            raise ReleaseWorkflowError("GitHub releases response contains an invalid page")
+        for release in page:
+            if not isinstance(release, dict):
+                raise ReleaseWorkflowError("GitHub releases response contains invalid metadata")
+            if release.get("tag_name") == version:
+                matches.append(release)
+
+    if len(matches) > 1:
+        release_ids = ", ".join(str(release.get("id", "unknown")) for release in matches)
+        raise ReleaseWorkflowError(f"Multiple releases match exact tag {version}: {release_ids}")
+    if not matches:
+        return None
+
+    release = matches[0]
+    release_id = release.get("id")
+    if not isinstance(release_id, int) or isinstance(release_id, bool) or release_id <= 0:
+        raise ReleaseWorkflowError(f"Release {version} does not contain a valid id")
+    return release
+
+
 def inspect_assets(
     version: str,
     *,
@@ -648,6 +681,17 @@ def _asset_outputs(assets: tuple[Asset, Asset]) -> dict[str, str | int]:
     }
 
 
+def _add_select_release_parser(subparsers: Any) -> None:
+    _configure_release_parser(subparsers.add_parser("select-release"))
+
+
+def _configure_release_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--releases-json", type=Path, required=True)
+    parser.add_argument("--release-json", type=Path, required=True)
+    parser.add_argument("--github-output", type=Path)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -688,6 +732,8 @@ def _build_parser() -> argparse.ArgumentParser:
     frontend_order_parser.add_argument("--current", required=True)
     frontend_order_parser.add_argument("--requested", required=True)
     frontend_order_parser.add_argument("--github-output", type=Path)
+
+    _add_select_release_parser(subparsers)
 
     assets_parser = subparsers.add_parser("assets")
     assets_parser.add_argument("--version", required=True)
@@ -776,6 +822,24 @@ def main() -> int:
                 },
                 args.github_output,
             )
+        elif args.command == "select-release":
+            release_pages = json.loads(args.releases_json.read_text(encoding="utf-8"))
+            release = select_release(release_pages, args.version)
+            if release is None:
+                args.release_json.unlink(missing_ok=True)
+                _write_outputs(
+                    {"release_exists": False, "release_id": None},
+                    args.github_output,
+                )
+            else:
+                args.release_json.write_text(
+                    json.dumps(release, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+                _write_outputs(
+                    {"release_exists": True, "release_id": release["id"]},
+                    args.github_output,
+                )
         elif args.command == "assets":
             assets = inspect_assets(
                 args.version,

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -25,6 +25,7 @@ from scripts.release_workflow import (
     determine_auto_release,
     inspect_assets,
     is_current_release,
+    select_release,
     update_addon_release,
     verify_oci_manifest,
 )
@@ -206,6 +207,48 @@ def test_frontend_version_order(
 ) -> None:
     """Frontend dispatches compare numeric and post-release versions."""
     assert compare_frontend_versions(current, requested) == relation
+
+
+def test_select_release_returns_none_without_an_exact_tag() -> None:
+    """Release selection ignores nonmatching tags across every API page."""
+    release_pages = [
+        [{"id": 10, "tag_name": "2.10.0b7"}],
+        [],
+        [{"id": 11, "tag_name": "2.10.0B8"}],
+    ]
+
+    assert select_release(release_pages, "2.10.0b8") is None
+
+
+def test_select_release_finds_one_exact_draft_across_pages() -> None:
+    """Release selection returns the exact draft and its existing id."""
+    expected = {
+        "id": 359740600,
+        "tag_name": "2.10.0b8",
+        "draft": True,
+        "immutable": False,
+    }
+    release_pages = [
+        [{"id": 10, "tag_name": "2.10.0b7"}],
+        [expected],
+        [{"id": 12, "tag_name": "2.10.0b80"}],
+    ]
+
+    assert select_release(release_pages, "2.10.0b8") is expected
+
+
+def test_select_release_rejects_duplicate_exact_tags() -> None:
+    """Release selection fails closed when multiple releases use the exact tag."""
+    release_pages = [
+        [{"id": 359740600, "tag_name": "2.10.0b8"}],
+        [{"id": 359752771, "tag_name": "2.10.0b8"}],
+    ]
+
+    with pytest.raises(
+        ReleaseWorkflowError,
+        match=re.escape("Multiple releases match exact tag 2.10.0b8: 359740600, 359752771"),
+    ):
+        select_release(release_pages, "2.10.0b8")
 
 
 def test_release_assets_match_names_sizes_and_digests(tmp_path: Path) -> None:
@@ -591,6 +634,90 @@ fi
 echo "sha=$source_sha" >> "$GITHUB_OUTPUT"
 """
     assert expected_resolution in resolve_run
+
+
+def test_release_workflow_discovers_exact_drafts_from_paginated_releases() -> None:
+    """Resolve discovers draft releases through the paginated releases endpoint."""
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    resolve_run = _workflow_step_run(
+        workflow,
+        job_name="resolve",
+        step_name="Inspect existing tag and release",
+    )
+
+    assert "gh api --paginate --slurp" in resolve_run
+    assert '"repos/$GITHUB_REPOSITORY/releases?per_page=100"' in resolve_run
+    assert "release_workflow.py select-release" in resolve_run
+    assert '--release-json "$release_json"' in resolve_run
+    assert "release_id=$(sed -n 's/^release_id=//p' \"$release_lookup\")" in resolve_run
+
+
+def test_release_workflow_reuses_resolved_draft_id() -> None:
+    """Draft recovery and updates revalidate and reuse the resolved release id."""
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    parsed_workflow = cast("dict[str, Any]", yaml.safe_load(workflow))
+    recover_step = _workflow_step(
+        parsed_workflow,
+        "build_artifacts",
+        "Recover matching draft assets",
+    )
+    assert recover_step["env"]["RELEASE_ID"] == "${{ needs.resolve.outputs.release_id }}"
+    recover_run = str(recover_step["run"])
+    assert 'if [ -z "$RELEASE_ID" ]; then' in recover_run
+    assert 'gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID"' in recover_run
+    assert "'.tag_name // empty'" in recover_run
+    assert "'.draft'" in recover_run
+    assert "'.immutable'" in recover_run
+    assert "'.target_commitish'" in recover_run
+    assert "gh release download" not in recover_run
+    assert "Draft must contain exactly one $asset_name asset" in recover_run
+    assert '"repos/$GITHUB_REPOSITORY/releases/assets/$asset_id"' in recover_run
+
+    draft_step = _workflow_step(
+        parsed_workflow,
+        "prepare_draft",
+        "Create or update matching draft",
+    )
+    assert draft_step["env"]["RELEASE_ID"] == "${{ needs.resolve.outputs.release_id }}"
+    draft_run = str(draft_step["run"])
+    assert 'if [ -n "$RELEASE_ID" ]; then' in draft_run
+    assert 'gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID"' in draft_run
+    assert '"repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \\\n' in draft_run
+    assert '"repos/$GITHUB_REPOSITORY/releases" \\\n' in draft_run
+    assert "release_exists=true" in draft_run
+    assert "release_exists=false" in draft_run
+
+    replace_run = str(
+        _workflow_step(
+            parsed_workflow,
+            "prepare_draft",
+            "Replace draft assets",
+        )["run"]
+    )
+    assert "gh release upload" not in replace_run
+    assert (
+        "https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/"
+        "$RELEASE_ID/assets?name=$asset_name"
+    ) in replace_run
+
+
+def test_release_workflow_avoids_prepublication_tag_release_lookups() -> None:
+    """Only post-publication work may use GitHub's published tag endpoint."""
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    parsed_workflow = cast("dict[str, Any]", yaml.safe_load(workflow))
+    tag_endpoint = "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION"
+
+    for job_name in ("resolve", "build_artifacts", "prepare_draft"):
+        for step in parsed_workflow["jobs"][job_name]["steps"]:
+            assert tag_endpoint not in str(step.get("run", ""))
+
+    publication_run = _workflow_step_run(
+        workflow,
+        job_name="publish_release",
+        step_name="Verify immutable release and assets",
+    )
+    assert tag_endpoint in publication_run
+    assert workflow.count(tag_endpoint) == 2
 
 
 def test_release_workflow_publication_state_uses_release_ids() -> None:


### PR DESCRIPTION
# What does this implement/fix?

GitHub's tag-specific release API does not return draft releases, so release retries could create a duplicate draft instead of resuming the existing one.

- Discover exact draft tags through the paginated releases API and reject duplicates.
- Reuse and revalidate the resolved release ID for draft assets and updates.
- Add focused contracts for exact matching and ID-based recovery.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.