### PR TITLE
Fix draft release discovery

### DIFF
--- a/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
+++ b/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
@@ -69,7 +69,8 @@ The scheduled workflow checks nightly releases automatically. For a manual versi
 
 Auto-release calculates the next version and invokes **Create Release** with its captured
 source SHA. **Create Release** can also be dispatched directly with an explicit version;
-for direct runs it resolves and freezes the current channel branch head itself.
+for direct runs it resolves and freezes the current channel branch head itself unless you
+pass `source_sha` to recover an exact draft or published release source.
 
 Do not create or publish a GitHub release manually. A draft created outside the workflow
 is accepted only when its exact tag name and target SHA match; conflicting tags,
@@ -105,6 +106,16 @@ token's App slug is `musicassistant-bot` and its installation ID is `146062122`.
 ## Recovery
 
 Rerun the failed workflow with the same version and `source_sha`.
+
+If you need to resume an exact draft or published release after the branch has advanced,
+reuse the workflow-created source SHA from the matching tag or draft target commit:
+
+```bash
+gh workflow run release.yml --ref dev -f version=2.10.0.dev2026072510 -f channel=nightly -f source_sha=a087405a28d2c0991803dbd9c037dc76fd05a631
+```
+
+Use the exact commit recorded by the workflow-created tag or draft. There is no moving
+branch recovery path.
 
 - **Before publication:** The matching draft remains mutable. Complete assets are
   downloaded and reused byte-for-byte; incomplete assets are replaced. If the exact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,16 +198,17 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           release_json="$RUNNER_TEMP/release.json"
-          release_error="$RUNNER_TEMP/release-error.txt"
-          if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" \
-            > "$release_json" 2> "$release_error"; then
-            release_exists=true
-          elif grep -q "HTTP 404" "$release_error"; then
-            release_exists=false
-          else
-            cat "$release_error" >&2
-            exit 1
-          fi
+          release_pages="$RUNNER_TEMP/releases.json"
+          release_outputs="$RUNNER_TEMP/release-outputs.txt"
+          gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+            > "$release_pages"
+          python3 .release-workflow/scripts/release_workflow.py select-release \
+            --tag "$VERSION" \
+            --releases-json "$release_pages" \
+            --release-json "$release_json" \
+            --github-output "$release_outputs"
+          cat "$release_outputs" >> "$GITHUB_OUTPUT"
+          release_id=$(sed -n 's/^release_id=//p' "$release_outputs")
 
           tag_sha=""
           tag_is_resumable=false
@@ -242,6 +243,10 @@ jobs:
             --github-output "$current_outputs"
           cat "$current_outputs" >> "$GITHUB_OUTPUT"
           is_current=$(sed -n 's/^is_current=//p' "$current_outputs")
+          release_exists=false
+          if [ -n "$release_id" ]; then
+            release_exists=true
+          fi
 
           if [ "$release_exists" = "false" ]; then
             if [ -n "$tag_sha" ] && [ "$tag_is_resumable" != "true" ]; then
@@ -377,15 +382,39 @@ jobs:
         if: needs.resolve.outputs.assets_ready == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.resolve.outputs.release_id }}
           SDIST_NAME: ${{ needs.resolve.outputs.sdist_name }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
           VERSION: ${{ inputs.version }}
           WHEEL_NAME: ${{ needs.resolve.outputs.wheel_name }}
         run: |
-          gh release download "$VERSION" \
-            --repo "$GITHUB_REPOSITORY" \
-            --dir source/dist \
-            --pattern "$WHEEL_NAME" \
-            --pattern "$SDIST_NAME"
+          if [ -z "$RELEASE_ID" ]; then
+            echo "Missing release id for reusable draft assets" >&2
+            exit 1
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            > "$RUNNER_TEMP/release.json"
+          if [ "$(jq -r '.tag_name' "$RUNNER_TEMP/release.json")" != "$VERSION" ] || \
+             [ "$(jq -r '.draft' "$RUNNER_TEMP/release.json")" != "true" ] || \
+             [ "$(jq -r '.immutable' "$RUNNER_TEMP/release.json")" != "false" ] || \
+             [ "$(jq -r '.target_commitish' "$RUNNER_TEMP/release.json")" != "$SOURCE_SHA" ]; then
+            echo "Release $VERSION is no longer a reusable mutable draft" >&2
+            exit 1
+          fi
+          for asset_name in "$WHEEL_NAME" "$SDIST_NAME"; do
+            asset_url=$(jq -r --arg name "$asset_name" \
+              '.assets[] | select(.name == $name) | .url' \
+              "$RUNNER_TEMP/release.json")
+            if [ -z "$asset_url" ] || [ "$asset_url" = "null" ]; then
+              echo "Missing release asset $asset_name" >&2
+              exit 1
+            fi
+            curl --fail --location --silent --show-error \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/octet-stream" \
+              "$asset_url" \
+              -o "source/dist/$asset_name"
+          done
 
       - name: Create appvars token
         if: needs.resolve.outputs.assets_ready != 'true'
@@ -462,8 +491,6 @@ jobs:
         run: |
           extra_args=()
           if [ "$REUSED_ASSETS" = "true" ]; then
-            gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" \
-              > "$RUNNER_TEMP/release.json"
             extra_args=(--release-json "$RUNNER_TEMP/release.json")
           fi
           python3 .release-workflow/scripts/release_workflow.py assets \
@@ -582,19 +609,23 @@ jobs:
           IS_PRERELEASE: ${{ needs.resolve.outputs.is_prerelease }}
           RELEASE_NOTES: ${{ steps.notes.outputs.release-notes }}
           RELEASE_TITLE: ${{ steps.title.outputs.title }}
+          RELEASE_ID: ${{ needs.resolve.outputs.release_id }}
           SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
           VERSION: ${{ inputs.version }}
         run: |
           release_json="$RUNNER_TEMP/release.json"
-          release_error="$RUNNER_TEMP/release-error.txt"
-          if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" \
-            > "$release_json" 2> "$release_error"; then
+          release_exists=false
+          if [ -n "$RELEASE_ID" ]; then
+            gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+              > "$release_json"
+            if [ "$(jq -r '.tag_name' "$release_json")" != "$VERSION" ] || \
+               [ "$(jq -r '.draft' "$release_json")" != "true" ] || \
+               [ "$(jq -r '.immutable' "$release_json")" != "false" ] || \
+               [ "$(jq -r '.target_commitish' "$release_json")" != "$SOURCE_SHA" ]; then
+              echo "Release $VERSION is no longer a matching mutable draft" >&2
+              exit 1
+            fi
             release_exists=true
-          elif grep -q "HTTP 404" "$release_error"; then
-            release_exists=false
-          else
-            cat "$release_error" >&2
-            exit 1
           fi
 
           jq -n \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
           - beta
           - rc
           - nightly
+      source_sha:
+        description: "Exact full commit SHA for draft/published recovery; leave empty to resolve the current channel branch head"
+        required: false
+        type: string
       important_notes:
         description: "Important notes (breaking changes, critical info, etc.)"
         required: false

--- a/scripts/release_workflow.py
+++ b/scripts/release_workflow.py
@@ -15,7 +15,7 @@ import json
 import re
 import subprocess
 import sys
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -382,6 +382,41 @@ def inspect_assets(
     return assets[expected_names[0]], assets[expected_names[1]]
 
 
+def load_paginated_releases(path: Path) -> list[dict[str, Any]]:
+    """
+    Load a paginated GitHub release listing.
+
+    :param path: Path to the raw ``gh api --paginate`` response body.
+    """
+    releases: list[dict[str, Any]] = []
+    for document in _load_json_documents(path):
+        if not isinstance(document, list):
+            raise ReleaseWorkflowError("Paginated release response must contain release lists")
+        for raw_release in document:
+            if not isinstance(raw_release, dict):
+                raise ReleaseWorkflowError(
+                    "Paginated release response contains invalid release data"
+                )
+            releases.append(raw_release)
+    return releases
+
+
+def select_exact_release(
+    releases: Sequence[Mapping[str, Any]],
+    tag: str,
+) -> Mapping[str, Any] | None:
+    """
+    Select the one release that matches a tag exactly.
+
+    :param releases: Release records returned by GitHub.
+    :param tag: Exact release tag to match.
+    """
+    matches = [release for release in releases if release.get("tag_name") == tag]
+    if len(matches) > 1:
+        raise ReleaseWorkflowError(f"More than one release matches tag {tag}")
+    return matches[0] if matches else None
+
+
 def verify_oci_manifest(
     manifest: dict[str, Any],
     source_sha: str,
@@ -598,6 +633,21 @@ def _expected_asset_names(version: str) -> tuple[str, str]:
     )
 
 
+def _load_json_documents(path: Path) -> list[Any]:
+    text = path.read_text(encoding="utf-8")
+    decoder = json.JSONDecoder()
+    documents: list[Any] = []
+    index = 0
+    while True:
+        while index < len(text) and text[index].isspace():
+            index += 1
+        if index >= len(text):
+            break
+        document, index = decoder.raw_decode(text, index)
+        documents.append(document)
+    return documents
+
+
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as file_handle:
@@ -648,7 +698,7 @@ def _asset_outputs(assets: tuple[Asset, Asset]) -> dict[str, str | int]:
     }
 
 
-def _build_parser() -> argparse.ArgumentParser:
+def _build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -694,6 +744,12 @@ def _build_parser() -> argparse.ArgumentParser:
     assets_parser.add_argument("--directory", type=Path)
     assets_parser.add_argument("--release-json", type=Path)
     assets_parser.add_argument("--github-output", type=Path)
+
+    select_parser = subparsers.add_parser("select-release")
+    select_parser.add_argument("--tag", required=True)
+    select_parser.add_argument("--releases-json", type=Path, required=True)
+    select_parser.add_argument("--release-json", type=Path)
+    select_parser.add_argument("--github-output", type=Path)
 
     manifest_parser = subparsers.add_parser("verify-manifest")
     manifest_parser.add_argument("--manifest-json", type=Path, required=True)
@@ -783,6 +839,20 @@ def main() -> int:
                 release_json=args.release_json,
             )
             _write_outputs(_asset_outputs(assets), args.github_output)
+        elif args.command == "select-release":
+            release = select_exact_release(
+                load_paginated_releases(args.releases_json),
+                args.tag,
+            )
+            if release is not None and args.release_json is not None:
+                args.release_json.write_text(
+                    json.dumps(release, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+            _write_outputs(
+                {"release_id": release.get("id") if release is not None else None},
+                args.github_output,
+            )
         elif args.command == "verify-manifest":
             manifest = json.loads(args.manifest_json.read_text(encoding="utf-8"))
             digest, runtime_digests = verify_oci_manifest(

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -6,8 +6,10 @@ import hashlib
 import json
 import re
 import subprocess
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 import yaml
@@ -533,6 +535,56 @@ def test_release_workflow_uses_minimum_preflight_permissions_and_expected_app() 
     assert "'.default_branch'" in workflow
 
 
+def test_release_workflow_dispatch_source_sha_is_optional_for_recovery() -> None:
+    """Direct recovery keeps source_sha optional while workflow_call stays required."""
+    workflow = cast(
+        "Mapping[object, Any]",
+        yaml.safe_load(
+            (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+        ),
+    )
+    triggers = _workflow_triggers(workflow)
+
+    assert triggers["workflow_dispatch"]["inputs"]["source_sha"] == {
+        "description": (
+            "Exact full commit SHA for draft/published recovery; leave empty to "
+            "resolve the current channel branch head"
+        ),
+        "required": False,
+        "type": "string",
+    }
+    assert triggers["workflow_call"]["inputs"]["source_sha"] == {
+        "description": "Exact source commit to release",
+        "required": True,
+        "type": "string",
+    }
+
+
+def test_release_workflow_exact_source_resolution_uses_requested_sha() -> None:
+    """Resolve exact source commit honors recovery SHAs and rejects bad ones."""
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    resolve_step = _workflow_step(
+        cast("dict[str, Any]", yaml.safe_load(workflow)),
+        "resolve",
+        "Resolve exact source commit",
+    )
+
+    assert resolve_step["env"] == {"REQUESTED_SHA": "${{ inputs.source_sha }}"}
+    resolve_run = str(resolve_step["run"])
+
+    for required_snippet in (
+        'if [ -n "$REQUESTED_SHA" ]; then',
+        "requested_sha=$(printf '%s' \"$REQUESTED_SHA\" |",
+        "tr '[:upper:]' '[:lower:]')",
+        "source_sha must be a full commit SHA",
+        'source_sha=$(git -C source rev-parse "$requested_sha^{commit}")',
+        'if ! git -C source merge-base --is-ancestor "$source_sha" "$branch_sha"; then',
+        'source_sha="$branch_sha"',
+        'echo "sha=$source_sha" >> "$GITHUB_OUTPUT"',
+    ):
+        assert required_snippet in resolve_run
+
+
 def test_release_workflow_publication_state_uses_release_ids() -> None:
     """Publication lookup must use release IDs and fail closed on mismatches."""
     workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
@@ -584,10 +636,23 @@ def _git(path: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
-def _workflow_step_run(workflow: str, job_name: str, step_name: str) -> str:
-    jobs = yaml.safe_load(workflow)["jobs"]
+def _workflow_triggers(workflow: Mapping[object, Any]) -> dict[str, Any]:
+    trigger = workflow.get("on")
+    if trigger is None:
+        trigger = workflow[True]
+    assert isinstance(trigger, dict)
+    return cast("dict[str, Any]", trigger)
+
+
+def _workflow_step(workflow: Mapping[str, Any], job_name: str, step_name: str) -> dict[str, Any]:
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
     for step in jobs[job_name]["steps"]:
         if step.get("name") == step_name:
-            return str(step["run"])
+            return cast("dict[str, Any]", step)
     msg = f"Step {step_name!r} not found in job {job_name!r}"
     raise AssertionError(msg)
+
+
+def _workflow_step_run(workflow: str, job_name: str, step_name: str) -> str:
+    return str(_workflow_step(yaml.safe_load(workflow), job_name, step_name)["run"])

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import subprocess
 from collections.abc import Mapping
@@ -25,6 +26,8 @@ from scripts.release_workflow import (
     determine_auto_release,
     inspect_assets,
     is_current_release,
+    load_paginated_releases,
+    select_exact_release,
     update_addon_release,
     verify_oci_manifest,
 )
@@ -579,10 +582,146 @@ def test_release_workflow_exact_source_resolution_uses_requested_sha() -> None:
         "source_sha must be a full commit SHA",
         'source_sha=$(git -C source rev-parse "$requested_sha^{commit}")',
         'if ! git -C source merge-base --is-ancestor "$source_sha" "$branch_sha"; then',
-        'source_sha="$branch_sha"',
         'echo "sha=$source_sha" >> "$GITHUB_OUTPUT"',
     ):
         assert required_snippet in resolve_run
+
+
+def test_release_workflow_exact_source_resolution_rejects_non_ancestor_sha(
+    tmp_path: Path,
+) -> None:
+    """Resolve exact source commit fails closed for SHAs outside the branch history."""
+    source = tmp_path / "source"
+    source.mkdir()
+    _git(source, "init", "-b", "dev")
+    _git(source, "config", "user.name", "Release Test")
+    _git(source, "config", "user.email", "release@example.com")
+    _commit(source, "initial")
+    requested_sha = _git(source, "rev-parse", "HEAD")
+
+    _git(source, "checkout", "--orphan", "unrelated")
+    (source / "state").unlink()
+    _commit(source, "unrelated")
+
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    resolve_step = _workflow_step(
+        cast("dict[str, Any]", yaml.safe_load(workflow)),
+        "resolve",
+        "Resolve exact source commit",
+    )
+    resolve_run = (
+        str(resolve_step["run"])
+        .replace("${{ steps.branch.outputs.branch }}", "dev")
+        .replace("git -C source", 'git -C "$SOURCE_DIR"')
+    )
+    output = tmp_path / "github-output.txt"
+    result = subprocess.run(  # noqa: S603
+        ["/bin/bash", "-lc", resolve_run],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "GITHUB_OUTPUT": str(output),
+            "REQUESTED_SHA": requested_sha,
+            "SOURCE_DIR": str(source),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "is not part of dev" in result.stderr
+
+
+def test_release_selection_returns_none_for_absent_tag(tmp_path: Path) -> None:
+    """A missing release tag is treated as absent."""
+    releases_json = tmp_path / "releases.json"
+    releases_json.write_text(
+        json.dumps(
+            [
+                {"id": 1, "tag_name": "2.10.0b8"},
+                {"id": 2, "tag_name": "2.10.0b9"},
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    releases = load_paginated_releases(releases_json)
+
+    assert select_exact_release(releases, "2.10.0b10") is None
+
+
+def test_release_selection_returns_exact_match_from_paginated_pages(
+    tmp_path: Path,
+) -> None:
+    """Paginated release lists can resolve one exact matching draft."""
+    releases_json = tmp_path / "releases.json"
+    releases_json.write_text(
+        json.dumps([{"id": 1, "tag_name": "2.10.0b8"}])
+        + "\n"
+        + json.dumps([{"id": 2, "tag_name": "2.10.0b9"}])
+        + "\n",
+        encoding="utf-8",
+    )
+
+    release = select_exact_release(load_paginated_releases(releases_json), "2.10.0b9")
+
+    assert release == {"id": 2, "tag_name": "2.10.0b9"}
+
+
+def test_release_selection_rejects_duplicate_tags(tmp_path: Path) -> None:
+    """Duplicate exact-tag releases are rejected instead of guessed."""
+    releases_json = tmp_path / "releases.json"
+    releases_json.write_text(
+        json.dumps([{"id": 1, "tag_name": "2.10.0b8"}])
+        + "\n"
+        + json.dumps([{"id": 2, "tag_name": "2.10.0b8"}])
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ReleaseWorkflowError, match="More than one release matches tag"):
+        select_exact_release(load_paginated_releases(releases_json), "2.10.0b8")
+
+
+def test_release_workflow_prepublication_steps_use_release_ids_only() -> None:
+    """Resolve, reuse, and draft prep all avoid tag lookups before publication."""
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    workflow_data = cast("dict[str, Any]", yaml.safe_load(workflow))
+
+    resolve_step = _workflow_step(workflow_data, "resolve", "Inspect existing tag and release")
+    resolve_run = str(resolve_step["run"])
+    assert 'gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100"' in resolve_run
+    assert "select-release" in resolve_run
+    assert 'gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION"' not in resolve_run
+
+    recovery_step = _workflow_step(
+        workflow_data, "build_artifacts", "Recover matching draft assets"
+    )
+    assert recovery_step["env"] == {
+        "GH_TOKEN": "${{ github.token }}",
+        "RELEASE_ID": "${{ needs.resolve.outputs.release_id }}",
+        "SDIST_NAME": "${{ needs.resolve.outputs.sdist_name }}",
+        "SOURCE_SHA": "${{ needs.resolve.outputs.source_sha }}",
+        "VERSION": "${{ inputs.version }}",
+        "WHEEL_NAME": "${{ needs.resolve.outputs.wheel_name }}",
+    }
+    recovery_run = str(recovery_step["run"])
+    assert 'if [ -z "$RELEASE_ID" ]; then' in recovery_run
+    assert 'gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID"' in recovery_run
+    assert 'gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION"' not in recovery_run
+    assert "Release $VERSION is no longer a reusable mutable draft" in recovery_run
+
+    draft_step = _workflow_step(workflow_data, "prepare_draft", "Create or update matching draft")
+    assert draft_step["env"]["RELEASE_ID"] == "${{ needs.resolve.outputs.release_id }}"
+    draft_run = str(draft_step["run"])
+    assert 'gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID"' in draft_run
+    assert 'gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION"' not in draft_run
+    assert "gh api --method POST" in draft_run
+    assert 'repos/$GITHUB_REPOSITORY/releases"' in draft_run
+    assert "gh api --method PATCH" in draft_run
+    assert 'repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID"' in draft_run
 
 
 def test_release_workflow_publication_state_uses_release_ids() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Fix draft release discovery for immutable releases. Pre-publication steps now resolve exact releases by paginating the release list and reusing draft release IDs instead of the draft-404 tag endpoint.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
