### PR TITLE
Fix smart playlist documentation URL

### DIFF
--- a/music_assistant/providers/smart_playlist/manifest.json
+++ b/music_assistant/providers/smart_playlist/manifest.json
@@ -6,7 +6,7 @@
   "description": "Create dynamic or fixed playlists based on rules: genres, artists, albums, favorites, similar tracks, release year, album type, explicit content, track duration, and rediscover forgotten tracks by filtering out recently played music.",
   "codeowners": ["@dmoo500"],
   "requirements": [],
-  "documentation": "https://music-assistant.io/features/smart-playlists/",
+  "documentation": "https://music-assistant.io/plugins/smart_playlist/",
   "multi_instance": false,
   "builtin": false,
   "icon": "playlist-star"


### PR DESCRIPTION
# What does this implement/fix?

Update the smart playlist documentation URL in the provider's manifest file to point to the correct page (the previous value 404'd).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
