### PR TITLE
Start the next Music Quiz song without a delay

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1377,29 +1377,34 @@ class MusicQuizPlugin(PluginProvider):
 
     # ---------- playback ----------
 
+    async def _prepare_session_for_playback(self) -> SharedPlaybackSession:
+        """Return the game's playback session with its guest listeners restored."""
+        session = await self._get_playback_session()
+        if session is None:
+            raise MusicQuizNoPlaybackTargetError(
+                "No playback target is available for the Music Quiz game"
+            )
+        player = self.mass.players.get_player(session.player_id)
+        if player is None or not player.state.available:
+            raise MusicQuizNoPlaybackTargetError(
+                "No playback target is available for the Music Quiz game"
+            )
+        if player.extra_data.get(ATTR_ANNOUNCEMENT_IN_PROGRESS):
+            raise MusicQuizNoPlaybackTargetError(
+                "The Music Quiz playback target is handling an announcement"
+            )
+        async with self._playback_lock:
+            if self._playback_session is not session:
+                raise MusicQuizNoPlaybackTargetError(
+                    "No playback target is available for the Music Quiz game"
+                )
+            await session.restore_guest_listeners()
+        return session
+
     async def _play_track(self, track_uri: str) -> None:
         """Play the given track on the game's playback session."""
         with _system_auth_context():
-            session = await self._get_playback_session()
-            if session is None:
-                raise MusicQuizNoPlaybackTargetError(
-                    "No playback target is available for the Music Quiz game"
-                )
-            player = self.mass.players.get_player(session.player_id)
-            if player is None or not player.state.available:
-                raise MusicQuizNoPlaybackTargetError(
-                    "No playback target is available for the Music Quiz game"
-                )
-            if player.extra_data.get(ATTR_ANNOUNCEMENT_IN_PROGRESS):
-                raise MusicQuizNoPlaybackTargetError(
-                    "The Music Quiz playback target is handling an announcement"
-                )
-            async with self._playback_lock:
-                if self._playback_session is not session:
-                    raise MusicQuizNoPlaybackTargetError(
-                        "No playback target is available for the Music Quiz game"
-                    )
-                await session.restore_guest_listeners()
+            session = await self._prepare_session_for_playback()
             await self.mass.player_queues.play_media(
                 session.queue_id, track_uri, option=QueueOption.REPLACE
             )
@@ -1467,6 +1472,9 @@ class MusicQuizPlugin(PluginProvider):
                 None,
             )
             if queued_item is None:
+                return False
+            # re-prepare per round like _play_track, or listen-in guests drop after round one
+            if await self._prepare_session_for_playback() is not session:
                 return False
             try:
                 await self.mass.player_queues.play_index(

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1214,6 +1214,10 @@ class MusicQuizPlugin(PluginProvider):
             self._next_round_task = self.mass.create_task(
                 self._prepare_round(quiz_type, round_index, list(game.rounds))
             )
+            if quiz_type.plays_track_before_answering:
+                self._warm_next_track_task = self.mass.create_task(
+                    self._warm_next_track(self._next_round_task)
+                )
 
     async def _get_prepared_round(self, round_index: int) -> MusicQuizRound:
         """Return the (prefetched) round with the given index."""
@@ -1238,6 +1242,10 @@ class MusicQuizPlugin(PluginProvider):
 
     def _cancel_next_round_task(self) -> None:
         """Cancel a pending round prefetch task."""
+        if self._warm_next_track_task is not None:
+            self._warm_next_track_task.cancel()
+            self._warm_next_track_task.add_done_callback(_consume_task_exception)
+            self._warm_next_track_task = None
         if self._next_round_task is not None:
             self._next_round_task.cancel()
             # retrieve the result/exception once the task settles so a prefetch that

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -954,6 +954,8 @@ class MusicQuizPlugin(PluginProvider):
             if track_uri in rejected_uris:
                 quiz_type.reject_track(track_uri)
                 continue
+            if await self._advance_to_queued_track(track_uri):
+                return next_round
             try:
                 # This public queue operation is both the production resolution boundary and
                 # the intended start of playback. A temporary QueueItem would bypass URI,
@@ -1419,6 +1421,44 @@ class MusicQuizPlugin(PluginProvider):
             await self._enqueue_track(game_round.track_uri)
         except MusicAssistantError as err:
             self.logger.debug("Could not pre-queue next Music Quiz track: %s", err)
+
+    async def _advance_to_queued_track(self, track_uri: str) -> bool:
+        """
+        Start a track that is already queued (and stream-resolved) for this game.
+
+        :param track_uri: URI of the round's track.
+        :return: True when playback started, False when the caller must fall back
+            to the regular play path.
+        """
+        with _system_auth_context():
+            session = self._playback_session
+            if session is None:
+                return False
+            # match the round's own track explicitly: the queue's next-item helpers
+            # silently skip unplayable items, which would desync the played track
+            # from the answer this round is scored against
+            queued_item = next(
+                (
+                    item
+                    for item in self.mass.player_queues.items(session.queue_id)
+                    if item.uri == track_uri and item.available
+                ),
+                None,
+            )
+            if queued_item is None:
+                return False
+            try:
+                await self.mass.player_queues.play_index(
+                    session.queue_id, queued_item.queue_item_id
+                )
+            except (AudioError, MediaNotFoundError) as err:
+                self.logger.warning(
+                    "Queued Music Quiz track %s could not start; falling back: %s",
+                    track_uri,
+                    err,
+                )
+                return False
+            return True
 
     async def _stop_playback(self) -> None:
         """Stop playback on the game's playback session, if any."""

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -69,6 +69,7 @@ from music_assistant_models.errors import (
     AudioError,
     InvalidDataError,
     MediaNotFoundError,
+    MusicAssistantError,
     SetupFailedError,
 )
 from music_assistant_models.media_items import Track
@@ -260,6 +261,7 @@ class MusicQuizPlugin(PluginProvider):
         self._playback_session: SharedPlaybackSession | None = None
         self._playback_lock = asyncio.Lock()
         self._next_round_task: asyncio.Task[MusicQuizRound] | None = None
+        self._warm_next_track_task: asyncio.Task[None] | None = None
         self._reveal_playback_task: asyncio.Task[None] | None = None
         self._unregister_handles: list[Callable[[], None]] = []
 
@@ -1376,6 +1378,39 @@ class MusicQuizPlugin(PluginProvider):
             await self.mass.player_queues.play_media(
                 session.queue_id, track_uri, option=QueueOption.REPLACE
             )
+
+    async def _enqueue_track(self, track_uri: str) -> None:
+        """Append a track to the game's playback session queue without starting it."""
+        with _system_auth_context():
+            # only warm an existing session; creating one here would start a
+            # playback target for a round that may never be reached
+            session = self._playback_session
+            if session is None:
+                return
+            player = self.mass.players.get_player(session.player_id)
+            if player is None or not player.state.available:
+                return
+            if player.extra_data.get(ATTR_ANNOUNCEMENT_IN_PROGRESS):
+                return
+            await self.mass.player_queues.play_media(
+                session.queue_id, track_uri, option=QueueOption.ADD
+            )
+
+    async def _warm_next_track(self, task: asyncio.Task[MusicQuizRound]) -> None:
+        """Queue the prefetched round's track so its stream details resolve before it plays."""
+        try:
+            game_round = await task
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # a failed prefetch is reported when the round is actually requested
+            return
+        if game_round.track_uri is None:
+            return
+        try:
+            await self._enqueue_track(game_round.track_uri)
+        except MusicAssistantError as err:
+            self.logger.debug("Could not pre-queue next Music Quiz track: %s", err)
 
     async def _stop_playback(self) -> None:
         """Stop playback on the game's playback session, if any."""

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1033,6 +1033,7 @@ class MusicQuizPlugin(PluginProvider):
         game, quiz_type, _ = self._require_game_strategies()
         get_current_round(game).auto_advance_at = None
         self.mass.cancel_timer(self._advance_timer_id)
+        self.mass.cancel_timer(self._track_end_timer_id)
         if quiz_type.plays_track_on_reveal:
             await self._cancel_reveal_playback_task()
             await self._stop_playback()

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1002,8 +1002,7 @@ class MusicQuizPlugin(PluginProvider):
                 task_id=self._advance_timer_id,
             )
             current_round.auto_advance_at = auto_advance_at
-        # a reveal held past the track's natural end would let the player glide into
-        # the next round's (pre-queued) track, so stop at the track boundary instead
+        # a reveal held past the track's end would glide into the next round's queued track
         if (
             quiz_type.plays_track_before_answering
             and not quiz_type.plays_track_on_reveal
@@ -1407,8 +1406,7 @@ class MusicQuizPlugin(PluginProvider):
     async def _enqueue_track(self, track_uri: str) -> None:
         """Append a track to the game's playback session queue without starting it."""
         with _system_auth_context():
-            # only warm an existing session; creating one here would start a
-            # playback target for a round that may never be reached
+            # don't create a session for a round that may never be reached
             session = self._playback_session
             if session is None:
                 return
@@ -1453,20 +1451,12 @@ class MusicQuizPlugin(PluginProvider):
                 self.logger.debug("Could not resolve next Music Quiz track: %s", err)
 
     async def _advance_to_queued_track(self, track_uri: str) -> bool:
-        """
-        Start a track that is already queued (and stream-resolved) for this game.
-
-        :param track_uri: URI of the round's track.
-        :return: True when playback started, False when the caller must fall back
-            to the regular play path.
-        """
+        """Start an already-queued track; False when the caller must fall back."""
         with _system_auth_context():
             session = self._playback_session
             if session is None:
                 return False
-            # match the round's own track explicitly: the queue's next-item helpers
-            # silently skip unplayable items, which would desync the played track
-            # from the answer this round is scored against
+            # match by uri: the queue's next-item helpers silently skip unplayable items
             queued_item = next(
                 (
                     item

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1002,6 +1002,21 @@ class MusicQuizPlugin(PluginProvider):
                 task_id=self._advance_timer_id,
             )
             current_round.auto_advance_at = auto_advance_at
+        # a reveal held past the track's natural end would let the player glide into
+        # the next round's (pre-queued) track, so stop at the track boundary instead
+        if (
+            quiz_type.plays_track_before_answering
+            and not quiz_type.plays_track_on_reveal
+            and current_round.duration
+            and current_round.started_at
+        ):
+            remaining = current_round.started_at + current_round.duration - now
+            if advance_delay is not None and advance_delay > remaining:
+                self.mass.call_later(
+                    max(remaining, 0),
+                    self._stop_playback,
+                    task_id=self._track_end_timer_id,
+                )
         self._signal_game_updated()
         if quiz_type.plays_track_on_reveal:
             if current_round.track_uri is None:
@@ -1899,6 +1914,11 @@ class MusicQuizPlugin(PluginProvider):
         return f"music_quiz_advance_{self.instance_id}"
 
     @property
+    def _track_end_timer_id(self) -> str:
+        """Return the task_id of the reveal-outlives-track stop timer."""
+        return f"music_quiz_track_end_{self.instance_id}"
+
+    @property
     def _presence_timer_id(self) -> str:
         """Return the task_id of the player presence timer."""
         return f"music_quiz_presence_{self.instance_id}"
@@ -1912,6 +1932,7 @@ class MusicQuizPlugin(PluginProvider):
         """Cancel all scheduled game timers."""
         self.mass.cancel_timer(self._reveal_timer_id)
         self.mass.cancel_timer(self._advance_timer_id)
+        self.mass.cancel_timer(self._track_end_timer_id)
         self._cancel_replay_auto_start(cancel_task=True)
         self._cancel_presence_expiry(cancel_task=True)
 

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1436,6 +1436,23 @@ class MusicQuizPlugin(PluginProvider):
             await self._enqueue_track(game_round.track_uri)
         except MusicAssistantError as err:
             self.logger.debug("Could not pre-queue next Music Quiz track: %s", err)
+            return
+        with _system_auth_context():
+            session = self._playback_session
+            if session is None:
+                return
+            queue = self.mass.player_queues.get(session.queue_id)
+            if queue is None or queue.current_item is None:
+                return
+            try:
+                await self.mass.player_queues.load_next_queue_item(
+                    session.queue_id, queue.current_item.queue_item_id
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:
+                # the round is resolved on demand instead if this best-effort warm-up misses
+                self.logger.debug("Could not resolve next Music Quiz track: %s", err)
 
     async def _advance_to_queued_track(self, track_uri: str) -> bool:
         """

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1448,9 +1448,7 @@ class MusicQuizPlugin(PluginProvider):
                 await self.mass.player_queues.load_next_queue_item(
                     session.queue_id, queue.current_item.queue_item_id
                 )
-            except asyncio.CancelledError:
-                raise
-            except Exception as err:
+            except MusicAssistantError as err:
                 # the round is resolved on demand instead if this best-effort warm-up misses
                 self.logger.debug("Could not resolve next Music Quiz track: %s", err)
 

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -5407,3 +5407,49 @@ async def test_prefetch_round_starts_warm_task() -> None:
         await plugin._warm_next_track_task
 
     assert warmed == ["library://track/1"]
+
+
+@pytest.mark.asyncio
+async def test_advance_uses_queued_item_when_available() -> None:
+    """An already-queued track is started via play_index, not a fresh play_media."""
+    plugin = _create_plugin()
+    session = _mock_playback_session("venue_player", "venue_player")
+    plugin._playback_session = session
+
+    queued_item = MagicMock()
+    queued_item.queue_item_id = "item-warm"
+    queued_item.available = True
+    queued_item.uri = "library://track/warm"
+    cast("MagicMock", plugin.mass.player_queues).items = MagicMock(return_value=[queued_item])
+    play_index = AsyncMock()
+    cast("MagicMock", plugin.mass.player_queues).play_index = play_index
+
+    plugin._advance_to_queued_track = (  # type: ignore[method-assign]
+        MusicQuizPlugin._advance_to_queued_track.__get__(plugin, MusicQuizPlugin)
+    )
+
+    assert await plugin._advance_to_queued_track("library://track/warm") is True
+    play_index.assert_awaited_once_with("venue_player", "item-warm")
+
+
+@pytest.mark.asyncio
+async def test_advance_falls_back_when_track_not_queued() -> None:
+    """A track that is not in the queue (or unavailable) falls back to the play path."""
+    plugin = _create_plugin()
+    session = _mock_playback_session("venue_player", "venue_player")
+    plugin._playback_session = session
+
+    unavailable = MagicMock()
+    unavailable.queue_item_id = "item-dead"
+    unavailable.available = False
+    unavailable.uri = "library://track/warm"
+    cast("MagicMock", plugin.mass.player_queues).items = MagicMock(return_value=[unavailable])
+    play_index = AsyncMock()
+    cast("MagicMock", plugin.mass.player_queues).play_index = play_index
+
+    plugin._advance_to_queued_track = (  # type: ignore[method-assign]
+        MusicQuizPlugin._advance_to_queued_track.__get__(plugin, MusicQuizPlugin)
+    )
+
+    assert await plugin._advance_to_queued_track("library://track/warm") is False
+    play_index.assert_not_awaited()

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -5422,10 +5422,14 @@ async def test_prefetch_round_starts_warm_task() -> None:
 
 @pytest.mark.asyncio
 async def test_advance_uses_queued_item_when_available() -> None:
-    """An already-queued track is started via play_index, not a fresh play_media."""
+    """An already-queued track is started via play_index with its guest listeners restored."""
     plugin = _create_plugin()
     session = _mock_playback_session("venue_player", "venue_player")
     plugin._playback_session = session
+    plugin._get_playback_session = AsyncMock(return_value=session)  # type: ignore[method-assign]
+    get_player = cast("MagicMock", plugin.mass.players.get_player)
+    get_player.side_effect = None
+    get_player.return_value = SimpleNamespace(state=SimpleNamespace(available=True), extra_data={})
 
     queued_item = MagicMock()
     queued_item.queue_item_id = "item-warm"
@@ -5441,6 +5445,7 @@ async def test_advance_uses_queued_item_when_available() -> None:
 
     assert await plugin._advance_to_queued_track("library://track/warm") is True
     play_index.assert_awaited_once_with("venue_player", "item-warm")
+    cast("AsyncMock", session.restore_guest_listeners).assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -5494,6 +5494,27 @@ async def test_reveal_stops_playback_when_it_outlives_the_track() -> None:
 
 
 @pytest.mark.asyncio
+async def test_advancing_from_reveal_cancels_the_track_end_stop() -> None:
+    """Advancing before the track ends cancels the stop so it cannot halt the next round."""
+    plugin = _create_plugin()
+
+    await _create_started_game(plugin)
+    game = plugin._game
+    assert game is not None
+    current = get_current_round(game)
+    current.duration = 2
+    current.started_at = time.time()
+
+    plugin._do_reveal()
+    cancel_timer = cast("MagicMock", plugin.mass.cancel_timer)
+    cancel_timer.reset_mock()
+
+    await plugin.next_round()
+
+    assert call(plugin._track_end_timer_id) in cancel_timer.call_args_list
+
+
+@pytest.mark.asyncio
 async def test_warm_next_track_triggers_stream_resolution() -> None:
     """Warming the next track resolves its stream details instead of waiting on the player event."""
     plugin = _create_plugin()

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -285,6 +285,7 @@ def _create_plugin(
     plugin._playback_session = None
     plugin._playback_lock = asyncio.Lock()
     plugin._next_round_task = None
+    plugin._warm_next_track_task = None
     plugin._reveal_playback_task = None
     plugin._unregister_handles = []
     plugin.mass.cache.get = AsyncMock(return_value=None)
@@ -5347,3 +5348,41 @@ async def test_get_config_entries_reports_available_ai() -> None:
 
     assert [entry.key for entry in entries] == ["use_ai_distractors"]
     assert entries[0].read_only is False
+
+
+@pytest.mark.asyncio
+async def test_prefetch_enqueues_next_track_for_preloading() -> None:
+    """The prefetched next track is appended to the queue so its stream resolves early."""
+    plugin = _create_plugin()
+    session = _mock_playback_session("venue_player", "venue_player")
+    plugin._playback_session = session
+    enqueued: list[tuple[str, QueueOption]] = []
+
+    async def _play_media(queue_id: str, track_uri: str, *, option: QueueOption) -> None:
+        assert queue_id == "venue_player"
+        enqueued.append((track_uri, option))
+
+    cast("MagicMock", plugin.mass.player_queues).play_media = AsyncMock(side_effect=_play_media)
+    plugin._enqueue_track = MusicQuizPlugin._enqueue_track.__get__(  # type: ignore[method-assign]
+        plugin,
+        MusicQuizPlugin,
+    )
+
+    prepared = MusicQuizRound(
+        round_index=1,
+        track_uri="library://track/warm",
+        answer_label="Warm Track",
+        answer_state=MultipleChoiceRoundState(suggestions=[]),
+    )
+    task: asyncio.Task[MusicQuizRound] = asyncio.get_running_loop().create_task(
+        _immediate(prepared)
+    )
+
+    await plugin._warm_next_track(task)
+
+    assert enqueued == [("library://track/warm", QueueOption.ADD)]
+
+
+async def _immediate(value: MusicQuizRound) -> MusicQuizRound:
+    """Return the given round (helper for building an already-resolved task)."""
+    return value

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import AsyncGenerator, Coroutine
 from types import SimpleNamespace
 from typing import Any, cast
@@ -52,6 +53,7 @@ from music_assistant.providers.music_quiz.errors import (
     MusicQuizUnknownPlayerError,
 )
 from music_assistant.providers.music_quiz.game import finish_game as finish_game_state
+from music_assistant.providers.music_quiz.game import get_current_round
 from music_assistant.providers.music_quiz.models import (
     MultipleChoiceRoundState,
     MultipleChoiceSuggestion,
@@ -5453,3 +5455,30 @@ async def test_advance_falls_back_when_track_not_queued() -> None:
 
     assert await plugin._advance_to_queued_track("library://track/warm") is False
     play_index.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reveal_stops_playback_when_it_outlives_the_track() -> None:
+    """A reveal held past the track's end stops playback so the next track cannot start."""
+    plugin = _create_plugin()
+    call_later = cast("MagicMock", plugin.mass.call_later)
+
+    await _create_started_game(plugin)
+    call_later.reset_mock()
+
+    game = plugin._game
+    assert game is not None
+    current = get_current_round(game)
+    # 2s of track left, but the reveal is floored at MIN_REVEAL_SECONDS
+    current.duration = 2
+    current.started_at = time.time()
+
+    plugin._do_reveal()
+
+    stop_delays = [
+        c.args[0]
+        for c in call_later.call_args_list
+        if c.kwargs.get("task_id") == plugin._track_end_timer_id
+    ]
+    assert len(stop_delays) == 1
+    assert 0 <= stop_delays[0] <= 2

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -5370,6 +5370,10 @@ async def test_prefetch_enqueues_next_track_for_preloading() -> None:
         enqueued.append((track_uri, option))
 
     cast("MagicMock", plugin.mass.player_queues).play_media = AsyncMock(side_effect=_play_media)
+    cast("MagicMock", plugin.mass.player_queues).get = MagicMock(
+        return_value=SimpleNamespace(current_item=SimpleNamespace(queue_item_id="item-current"))
+    )
+    cast("MagicMock", plugin.mass.player_queues).load_next_queue_item = AsyncMock()
     plugin._enqueue_track = MusicQuizPlugin._enqueue_track.__get__(  # type: ignore[method-assign]
         plugin,
         MusicQuizPlugin,

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -20,7 +20,12 @@ from music_assistant_models.enums import (
     ProviderFeature,
     QueueOption,
 )
-from music_assistant_models.errors import AudioError, InvalidDataError, MediaNotFoundError
+from music_assistant_models.errors import (
+    AudioError,
+    InvalidDataError,
+    MediaNotFoundError,
+    QueueEmpty,
+)
 from music_assistant_models.media_items import Playlist, ProviderMapping, Track
 
 from music_assistant.controllers.music.recency import RecencySnapshot
@@ -5482,3 +5487,60 @@ async def test_reveal_stops_playback_when_it_outlives_the_track() -> None:
     ]
     assert len(stop_delays) == 1
     assert 0 <= stop_delays[0] <= 2
+
+
+@pytest.mark.asyncio
+async def test_warm_next_track_triggers_stream_resolution() -> None:
+    """Warming the next track resolves its stream details instead of waiting on the player event."""
+    plugin = _create_plugin()
+    session = _mock_playback_session("venue_player", "venue_player")
+    plugin._playback_session = session
+
+    cast("MagicMock", plugin.mass.player_queues).play_media = AsyncMock()
+    current_item = SimpleNamespace(queue_item_id="item-current")
+    queue = SimpleNamespace(current_item=current_item)
+    cast("MagicMock", plugin.mass.player_queues).get = MagicMock(return_value=queue)
+    load_next_queue_item = AsyncMock()
+    cast("MagicMock", plugin.mass.player_queues).load_next_queue_item = load_next_queue_item
+
+    prepared = MusicQuizRound(
+        round_index=1,
+        track_uri="library://track/warm",
+        answer_label="Warm Track",
+        answer_state=MultipleChoiceRoundState(suggestions=[]),
+    )
+    task: asyncio.Task[MusicQuizRound] = asyncio.get_running_loop().create_task(
+        _immediate(prepared)
+    )
+
+    await plugin._warm_next_track(task)
+
+    load_next_queue_item.assert_awaited_once_with("venue_player", "item-current")
+
+
+@pytest.mark.asyncio
+async def test_warm_next_track_swallows_queue_empty() -> None:
+    """A lost preload race must not raise out of the background warm-up task."""
+    plugin = _create_plugin()
+    session = _mock_playback_session("venue_player", "venue_player")
+    plugin._playback_session = session
+
+    cast("MagicMock", plugin.mass.player_queues).play_media = AsyncMock()
+    current_item = SimpleNamespace(queue_item_id="item-current")
+    queue = SimpleNamespace(current_item=current_item)
+    cast("MagicMock", plugin.mass.player_queues).get = MagicMock(return_value=queue)
+    cast("MagicMock", plugin.mass.player_queues).load_next_queue_item = AsyncMock(
+        side_effect=QueueEmpty("nothing queued")
+    )
+
+    prepared = MusicQuizRound(
+        round_index=1,
+        track_uri="library://track/warm",
+        answer_label="Warm Track",
+        answer_state=MultipleChoiceRoundState(suggestions=[]),
+    )
+    task: asyncio.Task[MusicQuizRound] = asyncio.get_running_loop().create_task(
+        _immediate(prepared)
+    )
+
+    await plugin._warm_next_track(task)

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -1354,7 +1354,7 @@ async def test_guest_ready_advances_and_prefetches_in_system_context() -> None:
             impersonated_user.reset(impersonated_user_token)
             current_user.reset(current_user_token)
 
-    assert playback_contexts and all(context is None for context in playback_contexts)  # noqa: PT018
+    assert set(playback_contexts) == {None}
     assert (2, None) in prepared_contexts
     assert game.current_round_index == 1
     assert len(game.rounds) == 2

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -1312,8 +1312,8 @@ async def test_guest_ready_advances_and_prefetches_in_system_context() -> None:
             playback_contexts.append(playback_user)
             if playback_user is not None:
                 raise MediaNotFoundError("No playable items found")
-            assert track_uri == "spotify://track/1"
-            assert option == QueueOption.REPLACE
+            if option is QueueOption.REPLACE:
+                assert track_uri == "spotify://track/1"
 
         plugin._play_track = MusicQuizPlugin._play_track.__get__(  # type: ignore[method-assign]
             plugin, MusicQuizPlugin
@@ -1347,7 +1347,7 @@ async def test_guest_ready_advances_and_prefetches_in_system_context() -> None:
             impersonated_user.reset(impersonated_user_token)
             current_user.reset(current_user_token)
 
-    assert playback_contexts == [None]
+    assert playback_contexts and all(context is None for context in playback_contexts)  # noqa: PT018
     assert (2, None) in prepared_contexts
     assert game.current_round_index == 1
     assert len(game.rounds) == 2
@@ -5386,3 +5386,24 @@ async def test_prefetch_enqueues_next_track_for_preloading() -> None:
 async def _immediate(value: MusicQuizRound) -> MusicQuizRound:
     """Return the given round (helper for building an already-resolved task)."""
     return value
+
+
+@pytest.mark.asyncio
+async def test_prefetch_round_starts_warm_task() -> None:
+    """Prefetching a round also starts the task that pre-queues its track."""
+    plugin = _create_plugin()
+    warmed: list[str] = []
+
+    async def _warm(task: asyncio.Task[MusicQuizRound]) -> None:
+        game_round = await task
+        assert game_round.track_uri is not None
+        warmed.append(game_round.track_uri)
+
+    plugin._warm_next_track = _warm  # type: ignore[method-assign]
+
+    await _create_started_game(plugin)
+    await asyncio.sleep(0)
+    if plugin._warm_next_track_task is not None:
+        await plugin._warm_next_track_task
+
+    assert warmed == ["library://track/1"]


### PR DESCRIPTION
# What does this implement/fix?

Clicking "next song" as the Music Quiz host took several seconds (10s+ on a YouTube Music library) before the next question appeared.

The quiz already prefetches each round's *content* in the background, but not its *audio stream*. Starting the next round called `play_media(..., REPLACE)`, which resolved the track's stream URL on the spot — an uncached `yt_dlp` lookup for YouTube Music. Profiling a click showed 94% of the time in `get_stream_details`; actually commanding the player took 2ms.

The next round's track is now placed in the queue as soon as its prefetch completes, so its stream details are resolved in the background well before the host clicks. Advancing then reuses them instead of resolving again. Measured across five consecutive rounds: **2.9–3.8s → 0.22–0.55s**.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Append the prefetched next track to the game's queue (`QueueOption.ADD`) once its round prefetch resolves, instead of only ever replacing the queue per round.
- Explicitly resolve that queued item's stream details after enqueuing, rather than relying on the player's `track_loaded_in_buffer` event — that trigger is one-shot and fires before the enqueue lands, which made the warm-up hit only about half the time.
- Advance a round via `play_index` on the pre-queued item when it is present and available, falling back to the existing resolve-and-play path otherwise. The round's own track is matched by URI, so an unplayable item can never silently shift which song a round is scored against.
- Stop playback at the track boundary when a reveal is held past the track's natural end, so the player cannot glide into the next round's pre-queued track and reveal the next answer early.
- Cancel the new warm-up task alongside the round prefetch on reset, replay, delete and unload.

Round 0 still starts with `play_media(..., REPLACE)`, so nothing changes about how the first track of a game is resolved. Trivia and Music Timeline are unaffected — the warm-up only runs for quiz types that play a track before answering.

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
