### PR TITLE
Don't resume an unrelated track from the global playlog

### DIFF
--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -442,11 +442,16 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         """
         Try to resume playback from playlog when queue is empty.
 
-        Attempts to find user-initiated recently played items in the following order:
+        Attempts to find user-initiated recently played items for *this* queue
+        or its user, in the following order:
         1. By userid AND queue_id
         2. By queue_id only
         3. By userid only (if available)
-        4. Any recently played item
+
+        Only this queue's/user's own history is considered — a resume must never
+        start a track that was played elsewhere. The former global "any recent
+        item" fallback was removed because it resumed an unrelated track (e.g.
+        after an announcement on an idle player or sync group). See support #5913.
 
         :param queue: The queue to resume playback on.
         :return: True if playback was started, False otherwise.
@@ -459,7 +464,6 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         filter_attempts.append((None, queue.queue_id, "queue_id match"))
         if queue_data.userid:
             filter_attempts.append((queue_data.userid, None, "userid match"))
-        filter_attempts.append((None, None, "any recent item"))
 
         for userid, queue_id, match_type in filter_attempts:
             items = await self.mass.music.recently_played(

--- a/tests/controllers/player_queues/test_resume_from_playlog.py
+++ b/tests/controllers/player_queues/test_resume_from_playlog.py
@@ -1,0 +1,65 @@
+"""
+Tests for resuming an empty queue from the playlog.
+
+Covers the scope of the playlog fallback used when a queue is resumed while
+empty. A resume must only continue *this queue's/user's* own recently-played
+history. It must never pull a globally-recent item that was played elsewhere,
+which is how a restore after an announcement on an idle (sync group) player
+ended up starting an unrelated track. See support #5913.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+from music_assistant.controllers.player_queues import PlayerQueuesController
+
+
+def _make_controller() -> tuple[PlayerQueuesController, AsyncMock]:
+    """Bare controller instance with only the dependencies the resume path touches."""
+    controller = PlayerQueuesController.__new__(PlayerQueuesController)
+    controller.logger = Mock()
+    handle_play_media = AsyncMock()
+    controller._handle_play_media = handle_play_media  # type: ignore[method-assign]
+    return controller, handle_play_media
+
+
+async def test_resume_from_playlog_ignores_globally_recent_item() -> None:
+    """A resume must not start a track that only exists in the unscoped/global playlog."""
+    controller, handle_play_media = _make_controller()
+    foreign = Mock(uri="spotify://foreign", name="Foreign")
+
+    async def recently_played(**kwargs: object) -> list[Mock]:
+        # the track exists only in the global (unscoped) playlog,
+        # not in this queue's or user's own history
+        if kwargs.get("queue_id") is None and kwargs.get("userid") is None:
+            return [foreign]
+        return []
+
+    controller.mass = Mock()
+    controller.mass.music.recently_played = AsyncMock(side_effect=recently_played)
+
+    queue = Mock(queue_id="kitchen", display_name="Kitchen")
+    controller._queue_data = {"kitchen": Mock(userid=None)}
+
+    started = await controller._try_resume_from_playlog(queue)
+
+    assert started is False
+    handle_play_media.assert_not_called()
+
+
+async def test_resume_from_playlog_uses_queue_specific_item() -> None:
+    """A resume continues a track from this queue's own playlog history."""
+    controller, handle_play_media = _make_controller()
+    own = Mock(uri="spotify://own", name="Own")
+
+    controller.mass = Mock()
+    controller.mass.music.recently_played = AsyncMock(return_value=[own])
+
+    queue = Mock(queue_id="kitchen", display_name="Kitchen")
+    controller._queue_data = {"kitchen": Mock(userid=None)}
+
+    started = await controller._try_resume_from_playlog(queue)
+
+    assert started is True
+    handle_play_media.assert_called_once_with("kitchen", own)


### PR DESCRIPTION
Resuming an empty queue (e.g. after an announcement on an idle player/sync
group) fell through to an unscoped "any recently played item" fallback, which
started the most recent play from anywhere in the system.

Removed that global fallback so a resume only considers this queue's (and its
user's) own history. Adds two unit tests; queue/user-scoped lookups unchanged.

Closes music-assistant/support#5913.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`