### PR TITLE
Strip trailing NUL from MusicBrainz UFID recording MBID

### DIFF
--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -977,10 +977,7 @@ def _parse_id3_tags(tags: dict[str, Any]) -> dict[str, Any]:
     if (frame := tags.get("TXXX:MusicBrainz Release Group Id")) and frame.text:
         result["musicbrainzreleasegroupid"] = frame.text[0]
     if frame := tags.get("UFID:http://musicbrainz.org"):
-        # Some taggers (e.g. Picard) append a trailing NUL terminator to the
-        # UFID frame data; drop any stray NULs and surrounding whitespace so the
-        # recording MBID is a well-formed UUID instead of a malformed one that
-        # breaks import and MusicBrainz lookups. See support #5906.
+        # Strip NULs and whitespace from MusicBrainz UFID data (support #5906).
         result["musicbrainzrecordingid"] = frame.data.decode().replace("\x00", "").strip()
     if (frame := tags.get("TXXX:MusicBrainz Track Id")) and frame.text:
         result["musicbrainztrackid"] = frame.text[0]

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -977,7 +977,11 @@ def _parse_id3_tags(tags: dict[str, Any]) -> dict[str, Any]:
     if (frame := tags.get("TXXX:MusicBrainz Release Group Id")) and frame.text:
         result["musicbrainzreleasegroupid"] = frame.text[0]
     if frame := tags.get("UFID:http://musicbrainz.org"):
-        result["musicbrainzrecordingid"] = frame.data.decode()
+        # Some taggers (e.g. Picard) append a trailing NUL terminator to the
+        # UFID frame data; drop any stray NULs and surrounding whitespace so the
+        # recording MBID is a well-formed UUID instead of a malformed one that
+        # breaks import and MusicBrainz lookups. See support #5906.
+        result["musicbrainzrecordingid"] = frame.data.decode().replace("\x00", "").strip()
     if (frame := tags.get("TXXX:MusicBrainz Track Id")) and frame.text:
         result["musicbrainztrackid"] = frame.text[0]
 

--- a/tests/helpers/test_tags.py
+++ b/tests/helpers/test_tags.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import mutagen
 import pytest
 from music_assistant_models.errors import InvalidDataError
+from mutagen.id3 import UFID
 
 from music_assistant.constants import UNKNOWN_ARTIST
 from music_assistant.helpers import tags
@@ -166,6 +167,26 @@ def test_parse_metadata_from_apev2tags() -> None:
     assert result.get("artistsort") == ["MyArtist Sort"]
     assert result.get("albumsort") == "MyAlbum Sort"
     assert result.get("albumartistsort") == ["MyAlbumArtist Sort"]
+
+
+def test_id3_musicbrainz_ufid_strips_trailing_null() -> None:
+    """
+    Strip a trailing NUL terminator from the MusicBrainz UFID frame data.
+
+    Some taggers (e.g. Picard) append a NUL to the UFID data; without stripping
+    it the recording MBID is malformed and breaks import and MusicBrainz
+    lookups.
+
+    See https://github.com/music-assistant/support/issues/5906
+    """
+    ufid = UFID(  # type: ignore[no-untyped-call]
+        owner="http://musicbrainz.org",
+        data=b"1e74cd4c-cfa7-4bdb-99da-41869f5f1171\x00",
+    )
+
+    result = _parse_id3_tags({"UFID:http://musicbrainz.org": ufid})
+
+    assert result["musicbrainzrecordingid"] == "1e74cd4c-cfa7-4bdb-99da-41869f5f1171"
 
 
 async def test_parse_metadata_from_flac_with_multiple_artist_fields() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Picard writes the recording ID in an ID3 `UFID` frame with a trailing NUL. Decoded verbatim, this produced a malformed MBID (`<uuid>\x00`) that broke local file import/playback and MusicBrainz lookups ("Invalid MusicBrainz … ID"). Strip stray NUL/whitespace when decoding UFID data so the MBID is well-formed. Adds a red→green regression test. Refs #5906.
**Related issue (if applicable):**

- #5906

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
