### PR TITLE
Harden the setup flow engine

### DIFF
--- a/music_assistant/controllers/config/flows.py
+++ b/music_assistant/controllers/config/flows.py
@@ -305,10 +305,10 @@ class SetupFlowMixin:
         """
         Return the scope required to receive/interact with the given setup flow.
 
-        Also resolves recently finished flows: their terminal step can publish
-        just after the registry pop.
+        Also resolves recently finished flows (their terminal step can publish
+        just after the registry pop). Returns None when the flow is unknown.
 
-        :param flow_id: The id of the flow; None when the flow is unknown.
+        :param flow_id: The id of the flow.
         """
         if flow := self._setup_flows.get(flow_id):
             return flow.required_scope

--- a/music_assistant/controllers/config/flows.py
+++ b/music_assistant/controllers/config/flows.py
@@ -51,6 +51,8 @@ FLOW_SWEEP_INTERVAL = 60
 # how long start/submit wait for the flow coroutine to produce the (next) step;
 # generous because finish() may install requirements and load the provider
 NEXT_STEP_TIMEOUT = 120
+# bound on waiting for a cancelled flow's cleanup (author finally-blocks)
+FLOW_ABORT_CLEANUP_TIMEOUT = 10
 
 
 @dataclass
@@ -222,7 +224,8 @@ class SetupFlowMixin:
             return await self._start_flow(
                 flow_coro=child.run_setup_flow,
                 context=self._player_flow_context(child),
-                target_key=target_key,
+                # key on the child: a direct setup of the child must replace this flow
+                target_key=f"player_setup:{child.player_id}",
                 required_scope=Scope.CONFIG_PLAYERS_WRITE,
                 finish_handler=self._finish_player_setup,
             )
@@ -254,12 +257,22 @@ class SetupFlowMixin:
         self._check_flow_permission(flow)
         if (error_step := flow.session.handle_submit(values)) is not None:
             return error_step
-        # wait (bounded) for the coroutine to produce the next step; on the rare
-        # timeout the stored step is returned as-is and the client picks up the real
-        # next step from the SETUP_FLOW_UPDATED push event
+        # wait (bounded) for the coroutine to produce the next step
+        submitted_step = flow.session.current_step
         await flow.session.wait_for_step_change(NEXT_STEP_TIMEOUT)
         step = flow.session.current_step
         assert step is not None  # an accepted submit implies a published FORM step
+        if step is submitted_step:
+            # rare: the coroutine is still working on the next step. The submitted
+            # form's input future is already consumed, so re-serving the form would
+            # invite a doomed resubmit - hand back a transient progress step and let
+            # the SETUP_FLOW_UPDATED push deliver the real next step
+            return SetupFlowStep(
+                flow_id=flow_id,
+                step_id="working",
+                type=FlowStepType.PROGRESS,
+                translation_owner=step.translation_owner,
+            )
         return step
 
     @api_command("config/flows/get")
@@ -287,6 +300,16 @@ class SetupFlowMixin:
         self._check_flow_permission(flow)
         await self._abort_flow(flow, reason="aborted")
 
+    def get_setup_flow_required_scope(self, flow_id: str) -> Scope | None:
+        """
+        Return the scope required to interact with the given running setup flow.
+
+        :param flow_id: The id of the flow; None is returned when no such flow runs.
+        """
+        if flow := self._setup_flows.get(flow_id):
+            return flow.required_scope
+        return None
+
     async def _start_flow(
         self,
         *,
@@ -299,10 +322,13 @@ class SetupFlowMixin:
         ],
     ) -> SetupFlowStep:
         """Register and start a new flow, returning its first published step."""
-        # one flow per target: starting anew replaces (aborts) a lingering previous flow
-        for existing_flow in list(self._setup_flows.values()):
-            if existing_flow.target_key == target_key:
-                await self._abort_flow(existing_flow, reason="replaced")
+        # one flow per target: starting anew replaces (aborts) a lingering previous flow.
+        # re-scan after every await: the abort yields, so a concurrent start for the same
+        # target may have registered a new flow in the meantime
+        while existing_flow := next(
+            (f for f in self._setup_flows.values() if f.target_key == target_key), None
+        ):
+            await self._abort_flow(existing_flow, reason="replaced")
         flow_id = uuid4().hex
         session = SetupSession(self.mass, flow_id, context, finish_handler)
         flow = ActiveSetupFlow(
@@ -360,8 +386,16 @@ class SetupFlowMixin:
         if flow.task is not None and not flow.task.done():
             flow.task.cancel()
             # wait() shields us from the task's CancelledError without
-            # masking a cancellation of the caller itself
-            await asyncio.wait([flow.task])
+            # masking a cancellation of the caller itself; the timeout keeps a
+            # wedged author cleanup (e.g. a hanging pairing teardown) from
+            # stalling the abort and any replacement flow indefinitely
+            _, pending = await asyncio.wait([flow.task], timeout=FLOW_ABORT_CLEANUP_TIMEOUT)
+            if pending:
+                LOGGER.warning(
+                    "Setup flow for %s did not clean up within %ss after cancellation",
+                    flow.session.context.domain,
+                    FLOW_ABORT_CLEANUP_TIMEOUT,
+                )
         self._setup_flows.pop(flow.session.flow_id, None)
         current_step = flow.session.current_step
         if current_step is None or current_step.type not in (
@@ -622,6 +656,15 @@ class SetupFlowMixin:
             return
         now = time.monotonic()
         for flow in list(self._setup_flows.values()):
+            current_step = flow.session.current_step
+            if (
+                current_step is not None
+                and current_step.expires_at is not None
+                and current_step.expires_at > time.time()
+            ):
+                # the step advertises a (longer) countdown to the user; the step
+                # deadline machinery guarantees the flow terminates on its own
+                continue
             if now - flow.session.last_activity >= IDLE_FLOW_TTL:
                 self.mass.create_task(self._abort_flow(flow, "timed_out"))
         if self._setup_flows:

--- a/music_assistant/controllers/config/flows.py
+++ b/music_assistant/controllers/config/flows.py
@@ -74,6 +74,10 @@ class SetupFlowMixin:
     # registry of running flows, keyed by flow_id (lazily created per instance)
     _flows: dict[str, ActiveSetupFlow] | None = None
     _flow_sweep_handle: asyncio.TimerHandle | None = None
+    # required scopes of recently finished flows: terminal steps can publish after
+    # the registry pop (cancel-driven aborts), and the event-scope filter still
+    # needs to resolve them; bounded FIFO
+    _finished_flow_scopes: dict[str, Scope] | None = None
 
     # Type hints for attributes/methods provided by the class this mixin is used with
     if TYPE_CHECKING:
@@ -299,13 +303,28 @@ class SetupFlowMixin:
 
     def get_setup_flow_required_scope(self, flow_id: str) -> Scope | None:
         """
-        Return the scope required to interact with the given running setup flow.
+        Return the scope required to receive/interact with the given setup flow.
 
-        :param flow_id: The id of the flow; None is returned when no such flow runs.
+        Also resolves recently finished flows: their terminal step can publish
+        just after the registry pop.
+
+        :param flow_id: The id of the flow; None when the flow is unknown.
         """
         if flow := self._setup_flows.get(flow_id):
             return flow.required_scope
+        if self._finished_flow_scopes:
+            return self._finished_flow_scopes.get(flow_id)
         return None
+
+    def _pop_flow(self, flow: ActiveSetupFlow) -> None:
+        """Remove a flow from the registry, retaining its scope for late events."""
+        self._setup_flows.pop(flow.session.flow_id, None)
+        if self._finished_flow_scopes is None:
+            self._finished_flow_scopes = {}
+        finished = self._finished_flow_scopes
+        finished[flow.session.flow_id] = flow.required_scope
+        while len(finished) > 64:
+            finished.pop(next(iter(finished)))
 
     async def _start_flow(
         self,
@@ -370,7 +389,7 @@ class SetupFlowMixin:
                 session.publish_abort("internal_error")
         finally:
             session.close()
-            self._setup_flows.pop(session.flow_id, None)
+            self._pop_flow(flow)
 
     async def _abort_flow(self, flow: ActiveSetupFlow, reason: str) -> None:
         """
@@ -396,7 +415,7 @@ class SetupFlowMixin:
                 # the wedged task never reaches _run_flow's finally: close the
                 # session here so the unauthenticated callback route is dropped
                 flow.session.close()
-        self._setup_flows.pop(flow.session.flow_id, None)
+        self._pop_flow(flow)
         current_step = flow.session.current_step
         if current_step is None or current_step.type not in (
             FlowStepType.FINISH,

--- a/music_assistant/controllers/config/flows.py
+++ b/music_assistant/controllers/config/flows.py
@@ -265,14 +265,11 @@ class SetupFlowMixin:
         if step is submitted_step:
             # rare: the coroutine is still working on the next step. The submitted
             # form's input future is already consumed, so re-serving the form would
-            # invite a doomed resubmit - hand back a transient progress step and let
-            # the SETUP_FLOW_UPDATED push deliver the real next step
-            return SetupFlowStep(
-                flow_id=flow_id,
-                step_id="working",
-                type=FlowStepType.PROGRESS,
-                translation_owner=step.translation_owner,
-            )
+            # invite a doomed resubmit - publish a progress step (so flows/get agrees)
+            # and let the coroutine's next publish deliver the real step
+            flow.session.progress("working")
+            step = flow.session.current_step
+            assert step is not None
         return step
 
     @api_command("config/flows/get")
@@ -396,6 +393,9 @@ class SetupFlowMixin:
                     flow.session.context.domain,
                     FLOW_ABORT_CLEANUP_TIMEOUT,
                 )
+                # the wedged task never reaches _run_flow's finally: close the
+                # session here so the unauthenticated callback route is dropped
+                flow.session.close()
         self._setup_flows.pop(flow.session.flow_id, None)
         current_step = flow.session.current_step
         if current_step is None or current_step.type not in (

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -19,7 +19,7 @@ from music_assistant_models.api import (
     MessageType,
     SuccessResultMessage,
 )
-from music_assistant_models.auth import AuthProviderType, User
+from music_assistant_models.auth import AuthProviderType, Scope, User
 from music_assistant_models.enums import EventType
 from music_assistant_models.errors import (
     AuthenticationRequired,
@@ -544,6 +544,27 @@ class WebsocketClientHandler:
                 and event.object_id != self._sendspin_player_id
             ):
                 return
+
+            if event.event == EventType.SETUP_FLOW_UPDATED:
+                # setup flow steps carry prefilled values, OAuth urls and the
+                # flow_id guarding the unauthenticated callback route - only
+                # users who could interact with the flow may receive them
+                user = self._authenticated_user
+                if user is None:
+                    return
+                required = (
+                    self.mass.config.get_setup_flow_required_scope(event.object_id)
+                    if event.object_id
+                    else None
+                )
+                if required is None:
+                    # flow already popped (terminal step race): config rights required
+                    if not has_scope(user, Scope.CONFIG_PROVIDERS_WRITE) and not has_scope(
+                        user, Scope.CONFIG_PLAYERS_WRITE
+                    ):
+                        return
+                elif not has_scope(user, required):
+                    return
 
             if event.event == EventType.TASKS_UPDATED:
                 if self._authenticated_user is None:

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -558,8 +558,9 @@ class WebsocketClientHandler:
                     else None
                 )
                 if required is None:
-                    # flow already popped (terminal step race): config rights required
-                    if not has_scope(user, Scope.CONFIG_PROVIDERS_WRITE) and not has_scope(
+                    # flow already popped (terminal step race): the flow kind is no
+                    # longer known, so require both config scopes to be safe
+                    if not has_scope(user, Scope.CONFIG_PROVIDERS_WRITE) or not has_scope(
                         user, Scope.CONFIG_PLAYERS_WRITE
                     ):
                         return

--- a/music_assistant/models/setup_flow.py
+++ b/music_assistant/models/setup_flow.py
@@ -253,8 +253,10 @@ class SetupSession:
         Publish a progress step and wait for the given awaitable, deadline-enforced.
 
         Display and enforcement come from the single ``expires_in`` declaration: the
-        step's countdown and the engine deadline cannot drift. On the deadline the
-        awaitable is cancelled and StepExpiredError is raised here.
+        step's countdown and the engine deadline cannot drift. On the deadline
+        StepExpiredError is raised here and the awaitable is cancelled - note this
+        holds for a coroutine passed in directly; a pre-existing Task/Future keeps
+        running (shield semantics) and must be cancelled by the caller.
 
         :param awaitable: The work/wait to perform while the progress step shows.
         :param step_id: Stable slug identifying this step (also the i18n key segment).
@@ -279,6 +281,9 @@ class SetupSession:
 
         :param values: The values to persist as the target's setup_data.
         """
+        if self.finished:
+            msg = "Setup flow already finished"
+            raise RuntimeError(msg)
         result = await self._finish_handler(self, values)
         self.finished = True
         step = self._build_step(FlowStepType.FINISH, "finish", result=result)
@@ -392,8 +397,11 @@ class SetupSession:
                     params.update({key: str(val) for key, val in (await request.post()).items()})
             except Exception as err:
                 LOGGER.error("Failed to parse setup flow callback body: %s", err)
-        self.last_activity = time.monotonic()
         if self._callback_future is not None and not self._callback_future.done():
+            # only a callback that resolves a pending external step counts as
+            # activity: the route is unauthenticated, so bare requests must not
+            # be able to keep the flow alive past the idle TTL
+            self.last_activity = time.monotonic()
             self._callback_future.set_result(params)
         else:
             LOGGER.debug(

--- a/music_assistant/models/setup_flow.py
+++ b/music_assistant/models/setup_flow.py
@@ -254,9 +254,9 @@ class SetupSession:
 
         Display and enforcement come from the single ``expires_in`` declaration: the
         step's countdown and the engine deadline cannot drift. On the deadline
-        StepExpiredError is raised here and the awaitable is cancelled - note this
-        holds for a coroutine passed in directly; a pre-existing Task/Future keeps
-        running (shield semantics) and must be cancelled by the caller.
+        StepExpiredError is raised here and the awaitable is cancelled - this also
+        cancels a pre-existing Task (cancellation propagates through the await);
+        wrap work in ``asyncio.shield`` if it must survive the deadline.
 
         :param awaitable: The work/wait to perform while the progress step shows.
         :param step_id: Stable slug identifying this step (also the i18n key segment).

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -585,6 +585,33 @@ async def test_submit_timeout_returns_transient_progress(flow_mass: MusicAssista
         assert next_step.type == FlowStepType.FORM
 
 
+async def test_aborted_flow_scope_still_resolvable(flow_mass: MusicAssistant) -> None:
+    """A cancel-driven ABORT publishes after the pop; its scope must still resolve."""
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.form([USERNAME_ENTRY])
+        await session.finish({})
+
+    resolvable_at_publish: list[bool] = []
+
+    def on_event(event: MassEvent) -> None:
+        if event.data.type == FlowStepType.ABORT and event.object_id:
+            resolvable_at_publish.append(
+                flow_mass.config.get_setup_flow_required_scope(event.object_id) is not None
+            )
+
+    flow_mass.subscribe(on_event, EventType.SETUP_FLOW_UPDATED)
+    with _use_flow(flow_mass, run_setup):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        await flow_mass.config.abort_setup_flow(step.flow_id)
+    # event delivery is async (call_soon); wait for the callback to run
+    await _wait_for(lambda: resolvable_at_publish)
+    assert resolvable_at_publish == [True]
+    assert (
+        flow_mass.config.get_setup_flow_required_scope(step.flow_id) == Scope.CONFIG_PROVIDERS_WRITE
+    )
+
+
 async def test_setup_flow_required_scope_accessor(flow_mass: MusicAssistant) -> None:
     """The event filter's scope accessor reports the flow's scope while it runs."""
 

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -12,6 +12,7 @@ from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from aiohttp.test_utils import make_mocked_request
+from music_assistant_models.auth import Scope
 from music_assistant_models.config_entries import ConfigEntry, PlayerConfig
 from music_assistant_models.enums import (
     ConfigEntryType,
@@ -472,6 +473,132 @@ async def test_idle_flow_ttl_sweep(flow_mass: MusicAssistant, flow_events: list[
         await _wait_for(lambda: step.flow_id not in flow_mass.config._setup_flows)
     abort_step = await _wait_for(lambda: next(iter(_abort_events(flow_events)), None))
     assert abort_step.reason == "timed_out"
+
+
+async def test_idle_sweep_respects_live_step_deadline(
+    flow_mass: MusicAssistant, flow_events: list[MassEvent]
+) -> None:
+    """The sweeper must not abort a flow whose current step advertises a longer deadline."""
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.form([USERNAME_ENTRY], expires_in=3600)
+        await session.finish({})
+
+    with _use_flow(flow_mass, run_setup):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        flow = flow_mass.config._setup_flows[step.flow_id]
+        flow.session.last_activity = time.monotonic() - 16 * 60
+        flow_mass.config._sweep_idle_flows()
+        await asyncio.sleep(0.05)
+        # still alive: the step's own countdown is the authoritative deadline
+        assert step.flow_id in flow_mass.config._setup_flows
+        assert not _abort_events(flow_events)
+
+
+async def test_concurrent_starts_keep_single_flow(flow_mass: MusicAssistant) -> None:
+    """Two concurrent starts for the same target never leave two live flows behind."""
+
+    async def run_setup(session: SetupSession) -> None:
+        try:
+            await session.form([USERNAME_ENTRY])
+        finally:
+            # slow author cleanup: widens the abort window the re-scan protects against
+            await asyncio.sleep(0.05)
+        await session.finish({})
+
+    with _use_flow(flow_mass, run_setup):
+        await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        await asyncio.gather(
+            flow_mass.config.setup_provider(FAKE_DOMAIN),
+            flow_mass.config.setup_provider(FAKE_DOMAIN),
+        )
+        target_flows = [
+            flow
+            for flow in flow_mass.config._setup_flows.values()
+            if flow.target_key == f"provider_setup:{FAKE_DOMAIN}"
+        ]
+        assert len(target_flows) <= 1
+
+
+async def test_finish_twice_raises(flow_mass: MusicAssistant, flow_events: list[MassEvent]) -> None:
+    """A second finish() call is a flow-author bug and must not create a second target."""
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.finish({})
+        await session.finish({})
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        abort_step = await _wait_for(lambda: next(iter(_abort_events(flow_events)), None))
+    assert abort_step.reason == "internal_error"
+    # the first finish still created (exactly one) provider config
+    assert flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}")["domain"] == FAKE_DOMAIN
+
+
+async def test_bare_callback_does_not_extend_ttl(flow_mass: MusicAssistant) -> None:
+    """The unauthenticated callback route must not keep an idle flow alive (no pending external)."""
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.form([USERNAME_ENTRY])
+        await session.finish({})
+
+    with _use_flow(flow_mass, run_setup):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        flow = flow_mass.config._setup_flows[step.flow_id]
+        activity_before = flow.session.last_activity
+        # the callback route is only registered while an external step is pending,
+        # but the session handler itself must also not count a bare hit as activity
+        request = make_mocked_request("GET", f"/setup_flow/callback/{step.flow_id}?foo=bar")
+        await flow.session.handle_callback(request)
+        assert flow.session.last_activity == activity_before
+
+
+async def test_submit_timeout_returns_transient_progress(flow_mass: MusicAssistant) -> None:
+    """A submit whose next step is slow returns a progress step, not the consumed form."""
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.form([USERNAME_ENTRY])
+        await asyncio.sleep(0.3)
+        await session.form([PORT_ENTRY], step_id="second")
+        await session.finish({})
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch("music_assistant.controllers.config.flows.NEXT_STEP_TIMEOUT", 0.05),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        result = await flow_mass.config.submit_setup_flow(step.flow_id, {"username": "x"})
+        assert result.type == FlowStepType.PROGRESS
+        assert result.flow_id == step.flow_id
+
+        # the real next step still arrives (idempotent get picks it up)
+        def _second_form() -> SetupFlowStep | None:
+            current = flow_mass.config._setup_flows[step.flow_id].session.current_step
+            if current is not None and current.step_id == "second":
+                return current
+            return None
+
+        next_step = await _wait_for(_second_form)
+        assert next_step.type == FlowStepType.FORM
+
+
+async def test_setup_flow_required_scope_accessor(flow_mass: MusicAssistant) -> None:
+    """The event filter's scope accessor reports the flow's scope while it runs."""
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.form([USERNAME_ENTRY])
+        await session.finish({})
+
+    with _use_flow(flow_mass, run_setup):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        assert (
+            flow_mass.config.get_setup_flow_required_scope(step.flow_id)
+            == Scope.CONFIG_PROVIDERS_WRITE
+        )
+    assert flow_mass.config.get_setup_flow_required_scope("nonexistent") is None
 
 
 async def test_one_flow_per_target_replaces(


### PR DESCRIPTION
Follow-up hardening from a post-ship review of the setup flow engine.

- **Setup flow events are now scope-filtered.** `SETUP_FLOW_UPDATED` was broadcast to every authenticated connection, exposing step payloads (prefilled values, OAuth URLs) and the `flow_id` — which is the only secret guarding the unauthenticated callback route — to user/guest roles that cannot even start or read a flow. The websocket layer now drops these events for connections lacking the flow's required scope.
- A bare hit on the callback route no longer counts as flow activity, so it can't keep an idle flow (and its dynamic route) alive past the TTL.
- The idle sweeper no longer aborts a flow whose current step advertises a longer author-declared deadline — the on-screen countdown and the engine now agree.
- Starting a flow re-checks the one-flow-per-target invariant after every abort await, closing a race where two concurrent starts could both register.
- Waiting for a cancelled flow's cleanup is now bounded (10s + warning) so a wedged author teardown can't stall aborts and replacement flows indefinitely.
- A submit whose next step is slow returns a transient progress step instead of the already-consumed form (re-submitting that form could only fail).
- `session.finish()` raises on a second call instead of silently persisting twice; single-child player delegation now keys the flow on the child it actually configures.

Covered by six new engine tests.