### PR TITLE
fix: add CIFS soft mount options to prevent SMB provider hang

### DIFF
--- a/music_assistant/providers/filesystem_smb/__init__.py
+++ b/music_assistant/providers/filesystem_smb/__init__.py
@@ -296,6 +296,9 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
                 "mfsymlinks",
                 "noserverino",
                 "actimeo=30",
+                "soft",
+                "timeo=100",
+                "retrans=6",
             ]
         )
 

--- a/music_assistant/providers/smart_playlist/manifest.json
+++ b/music_assistant/providers/smart_playlist/manifest.json
@@ -6,7 +6,7 @@
   "description": "Create dynamic or fixed playlists based on rules: genres, artists, albums, favorites, similar tracks, release year, album type, explicit content, track duration, and rediscover forgotten tracks by filtering out recently played music.",
   "codeowners": ["@dmoo500"],
   "requirements": [],
-  "documentation": "https://music-assistant.io/features/smart-playlists/",
+  "documentation": "https://music-assistant.io/plugins/smart_playlist/",
   "multi_instance": false,
   "builtin": false,
   "icon": "playlist-star"


### PR DESCRIPTION
# What does this implement/fix?

Adds `soft`, `timeo=100`, and `retrans=6` to the CIFS mount options
in the SMB filesystem provider's `_build_linux_mount_cmd`.

Without `soft`, Linux CIFS defaults to **hard** mode — every filesystem
operation retries indefinitely when the SMB server is unreachable. On a
large library (290k+ files), a 10-second NAS disconnect causes the
library scan to hang for hours or days. Eventually enough errors
accumulate to abort the scan entirely, and the provider is marked
**unavailable** until manually restarted.

With these three options:

| Option | Effect |
|--------|--------|
| `soft` | Returns EIO within seconds instead of retrying forever |
| `timeo=100` | Total timeout of 10 seconds (100 deciseconds) |
| `retrans=6` | 6 retransmits before giving up (~600ms each) |

Operations fail fast instead of hanging, allowing the sync to error
out gracefully and recover on the next scheduled pass without manual
intervention.

**Related issue (if applicable):**

- Fixes https://github.com/music-assistant/support/issues/5917

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.