### PR TITLE
Bump music-assistant-models to 1.1.171

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "getmac==0.9.5",
   "mashumaro==3.20",
   "music-assistant-frontend==2.17.241",
-  "music-assistant-models==1.1.170",
+  "music-assistant-models==1.1.171",
   "mutagen==1.48.1",
   "orjson==3.11.6",
   "pillow==12.3.0",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -51,7 +51,7 @@ markdownify==1.2.3
 mashumaro==3.20
 modern_colorthief==0.2.1
 music-assistant-frontend==2.17.241
-music-assistant-models==1.1.170
+music-assistant-models==1.1.171
 mutagen==1.48.1
 niconico.py-ma==2.1.0.post2
 nnAudio==0.3.3


### PR DESCRIPTION
Brings in `ConfigEntryType.URL` and `Player.has_setup_flow` (music-assistant/models#330) for the setup-flows follow-up work.