### PR TITLE
Report per-provider search status in search results

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -19,6 +19,7 @@ from music_assistant_models.enums import (
     EventType,
     MediaType,
     ProviderFeature,
+    ProviderSearchStatus,
     ProviderType,
     TaskStatus,
 )
@@ -371,66 +372,24 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         results_per_provider: list[SearchResults] = []
         if include_library:
             results_per_provider.append(library_results)
-        all_results_complete = True
+        provider_search_statuses: dict[str, ProviderSearchStatus] = {}
+        if include_library:
+            provider_search_statuses["library"] = ProviderSearchStatus.COMPLETE
         if search_providers:
-            # create a set of all provider item ids already in library
-            # this way we can avoid returning duplicates in the search results
-            all_prov_item_ids = {
-                (item.media_type, prov_mapping.provider_domain, prov_mapping.item_id)
-                for items in (
-                    library_results.artists,
-                    library_results.albums,
-                    library_results.tracks,
-                    library_results.playlists,
-                    library_results.audiobooks,
-                    library_results.podcasts,
-                )
-                for item in items
-                for prov_mapping in cast("MediaItemType", item).provider_mappings
-            }
-            # only apply the exact match shortcut on a regular global search;
-            # an explicit providers selection must always search those providers
-            covered_media_types = (
-                self._get_covered_media_types(library_results, search_query)
-                if providers is None
-                else set()
+            # include results from all (unique) music providers; one failing or
+            # timed out provider must not break the entire search, its status is
+            # tracked instead so the caller can see which providers contributed
+            provider_results, search_statuses = await self._search_providers(
+                search_query, search_providers, media_types, limit, library_results, providers
             )
-            provider_searches: list[Coroutine[Any, Any, SearchResults | None]] = []
-            for provider_instance in search_providers:
-                if not (prov := self.mass.get_provider(provider_instance)):
-                    continue
-                # skip media types for which the library already holds a (near)
-                # exact match that is mapped to this provider: searching the
-                # provider again for that media type will not add anything new
-                prov_media_types = [
-                    mt
-                    for mt in media_types
-                    if (mt, prov.domain) not in covered_media_types
-                    and (mt, prov.instance_id) not in covered_media_types
-                ]
-                if not prov_media_types:
-                    continue
-                provider_searches.append(
-                    self._search_provider(
-                        search_query,
-                        provider_instance,
-                        prov_media_types,
-                        limit=limit,
-                        skip_item_ids=all_prov_item_ids,
-                    )
-                )
-            # include results from all (unique) music providers
-            # one failing provider must not break the entire search,
-            # so exceptions are logged and excluded from the results
-            gather_results = await asyncio.gather(*provider_searches, return_exceptions=True)
-            for res in gather_results:
-                if isinstance(res, SearchResults):
-                    results_per_provider.append(res)
-                    continue
-                # a provider that failed or timed out contributes no results
-                all_results_complete = False
-                if isinstance(res, BaseException):
-                    self.logger.error("Search on provider failed", exc_info=res)
+            results_per_provider.extend(provider_results)
+            provider_search_statuses.update(search_statuses)
+        # a combined result is only ever cached below when every searched
+        # provider completed, so cached combined payloads never carry a
+        # non-COMPLETE status
+        all_results_complete = all(
+            status is ProviderSearchStatus.COMPLETE for status in provider_search_statuses.values()
+        )
         # return result from all providers while keeping index
         # so the result is sorted as each provider delivered
         result = SearchResults(
@@ -488,6 +447,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 for item in sublist
                 if item is not None
             ][:limit],
+            provider_search_statuses=provider_search_statuses,
         )
 
         # the search results should already be sorted by relevance
@@ -2222,6 +2182,100 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             if p.type != ProviderType.MUSIC or p.instance_id in user_provider_filter
         ]
 
+    async def _search_providers(
+        self,
+        search_query: str,
+        search_providers: list[str],
+        media_types: list[MediaType],
+        limit: int,
+        library_results: SearchResults,
+        providers: list[str] | None,
+    ) -> tuple[list[SearchResults], dict[str, ProviderSearchStatus]]:
+        """
+        Search all given providers concurrently and collect their results and status.
+
+        :param search_query: Search query.
+        :param search_providers: instance_ids of the providers to search.
+        :param media_types: A list of media_types to include.
+        :param limit: number of items to return in the search (per type).
+        :param library_results: Library search results, used to deduplicate provider
+                                results and to apply the covered-media-types shortcut.
+        :param providers: The original ``providers`` argument passed to ``search()``,
+                          used to decide whether the covered-media-types shortcut applies.
+        :return: A tuple of the results contributed by the searched providers and a
+                 dict with the search status per provider instance_id.
+        """
+        # create a set of all provider item ids already in library
+        # this way we can avoid returning duplicates in the search results
+        all_prov_item_ids = {
+            (item.media_type, prov_mapping.provider_domain, prov_mapping.item_id)
+            for items in (
+                library_results.artists,
+                library_results.albums,
+                library_results.tracks,
+                library_results.playlists,
+                library_results.audiobooks,
+                library_results.podcasts,
+            )
+            for item in items
+            for prov_mapping in cast("MediaItemType", item).provider_mappings
+        }
+        # only apply the exact match shortcut on a regular global search;
+        # an explicit providers selection must always search those providers
+        covered_media_types = (
+            self._get_covered_media_types(library_results, search_query)
+            if providers is None
+            else set()
+        )
+        provider_searches: list[
+            Coroutine[Any, Any, tuple[SearchResults | None, ProviderSearchStatus]]
+        ] = []
+        provider_search_instance_ids: list[str] = []
+        provider_search_statuses: dict[str, ProviderSearchStatus] = {}
+        for provider_instance in search_providers:
+            if not (prov := self.mass.get_provider(provider_instance)):
+                continue
+            # skip media types for which the library already holds a (near)
+            # exact match that is mapped to this provider: searching the
+            # provider again for that media type will not add anything new
+            prov_media_types = [
+                mt
+                for mt in media_types
+                if (mt, prov.domain) not in covered_media_types
+                and (mt, prov.instance_id) not in covered_media_types
+            ]
+            if not prov_media_types:
+                # entirely covered by the library exact-match shortcut,
+                # so this provider is deliberately not searched
+                provider_search_statuses[provider_instance] = ProviderSearchStatus.COMPLETE
+                continue
+            provider_searches.append(
+                self._search_provider(
+                    search_query,
+                    provider_instance,
+                    prov_media_types,
+                    limit=limit,
+                    skip_item_ids=all_prov_item_ids,
+                )
+            )
+            provider_search_instance_ids.append(provider_instance)
+        # a failing or timed out provider must not break the entire search,
+        # so exceptions are logged and excluded from the results
+        gather_results = await asyncio.gather(*provider_searches, return_exceptions=True)
+        results: list[SearchResults] = []
+        for provider_instance, res in zip(
+            provider_search_instance_ids, gather_results, strict=True
+        ):
+            if isinstance(res, BaseException):
+                self.logger.error("Search on provider failed", exc_info=res)
+                provider_search_statuses[provider_instance] = ProviderSearchStatus.FAILED
+                continue
+            prov_results, status = res
+            provider_search_statuses[provider_instance] = status
+            if prov_results is not None:
+                results.append(prov_results)
+        return results, provider_search_statuses
+
     async def _search_shareable_url(self, search_query: str) -> SearchResults | None:
         """
         Handle a search query that is a streaming provider public shareable URL.
@@ -2269,9 +2323,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         media_types: list[MediaType],
         limit: int = 10,
         skip_item_ids: set[tuple[MediaType, str, str]] | None = None,
-    ) -> SearchResults | None:
+    ) -> tuple[SearchResults | None, ProviderSearchStatus]:
         """
-        Perform search on given provider, returns None if the search failed or timed out.
+        Perform search on given provider.
 
         :param search_query: Search query
         :param provider_instance_id_or_domain: instance_id or domain of the provider
@@ -2280,12 +2334,14 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param limit: number of items to return in the search (per type).
         :param skip_item_ids: Optional set of (media_type, provider_domain, item_id)
                               tuples to filter out of the results.
+        :return: A tuple of the search results (None if the search failed or timed
+                 out) and the status of the provider's contribution to the search.
         """
         prov = self.mass.get_provider(provider_instance_id_or_domain, provider_type=MusicProvider)
         if not prov:
-            return SearchResults()
+            return SearchResults(), ProviderSearchStatus.COMPLETE
         if ProviderFeature.SEARCH not in prov.supported_features:
-            return SearchResults()
+            return SearchResults(), ProviderSearchStatus.COMPLETE
 
         # create safe search string
         search_query = search_query.replace("/", " ").replace("'", "")
@@ -2300,7 +2356,10 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 base_class=SearchResults,
             )
         ) is not None:
-            return filter_search_results(cast("SearchResults", cache), prov.domain, skip_item_ids)
+            filtered = filter_search_results(
+                cast("SearchResults", cache), prov.domain, skip_item_ids
+            )
+            return filtered, ProviderSearchStatus.COMPLETE
         # run the provider search as a separate task (deduplicated by task_id so
         # identical concurrent searches share a single provider call) and wait for
         # it a limited amount of time only: a slow provider then contributes no
@@ -2319,10 +2378,11 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 "the search continues in the background",
                 prov.name,
             )
-            return None
+            return None, ProviderSearchStatus.TIMEOUT
         if prov_search_results is None:
-            return None
-        return filter_search_results(prov_search_results, prov.domain, skip_item_ids)
+            return None, ProviderSearchStatus.FAILED
+        filtered = filter_search_results(prov_search_results, prov.domain, skip_item_ids)
+        return filtered, ProviderSearchStatus.COMPLETE
 
     async def _execute_provider_search(
         self,

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -8,7 +8,7 @@ import time
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, Mock
 
-from music_assistant_models.enums import MediaType, ProviderFeature
+from music_assistant_models.enums import MediaType, ProviderFeature, ProviderSearchStatus
 from music_assistant_models.errors import MusicAssistantError
 from music_assistant_models.media_items import (
     Artist,
@@ -134,13 +134,14 @@ async def _wait_for(condition: Callable[[], bool], timeout: float = 1.0) -> None
 
 
 async def test_search_provider_returns_none_on_provider_error() -> None:
-    """A provider error during search yields None instead of raising."""
+    """A provider error during search yields (None, FAILED) instead of raising."""
     prov = _make_search_provider("prov_a")
     controller = _make_controller([prov])
     for error in (MusicAssistantError("rate limited"), ValueError("unexpected")):
         prov.search.side_effect = error
-        result = await controller._search_provider("query", "prov_a", [MediaType.TRACK])
+        result, status = await controller._search_provider("query", "prov_a", [MediaType.TRACK])
         assert result is None
+        assert status == ProviderSearchStatus.FAILED
 
 
 async def test_global_search_returns_partial_results_when_provider_fails() -> None:
@@ -159,6 +160,11 @@ async def test_global_search_returns_partial_results_when_provider_fails() -> No
     prov_bad.search.assert_awaited_once()
     # an incomplete result may not be cached so the failed provider is retried
     assert not _cache_writes(controller, "music")
+    assert result.provider_search_statuses == {
+        "library": ProviderSearchStatus.COMPLETE,
+        "prov_ok": ProviderSearchStatus.COMPLETE,
+        "prov_bad": ProviderSearchStatus.FAILED,
+    }
 
 
 async def test_global_search_soft_timeout_returns_partial_and_caches_late(
@@ -168,19 +174,19 @@ async def test_global_search_soft_timeout_returns_partial_and_caches_late(
     monkeypatch.setattr(
         "music_assistant.controllers.music.controller.SEARCH_PROVIDER_SOFT_TIMEOUT", 0.1
     )
-    prov_fast = _make_search_provider("prov_fast")
-    prov_fast.search.return_value = SearchResults(
-        tracks=[_make_track("track1", "prov_fast", "My Song")]
+    fast_provider = _make_search_provider("fast_provider")
+    fast_provider.search.return_value = SearchResults(
+        tracks=[_make_track("track1", "fast_provider", "My Song")]
     )
-    prov_slow = _make_search_provider("prov_slow")
-    slow_results = SearchResults(tracks=[_make_track("track2", "prov_slow", "My Song")])
+    slow_provider = _make_search_provider("slow_provider")
+    slow_results = SearchResults(tracks=[_make_track("track2", "slow_provider", "My Song")])
 
     async def _slow_search(*_args: Any, **_kwargs: Any) -> SearchResults:
         await asyncio.sleep(0.5)
         return slow_results
 
-    prov_slow.search.side_effect = _slow_search
-    controller = _make_controller([prov_fast, prov_slow])
+    slow_provider.search.side_effect = _slow_search
+    controller = _make_controller([fast_provider, slow_provider])
 
     start = time.monotonic()
     result = await controller.search("My Song", media_types=[MediaType.TRACK], limit=5)
@@ -190,9 +196,14 @@ async def test_global_search_soft_timeout_returns_partial_and_caches_late(
     assert duration < 0.4
     assert [track.item_id for track in result.tracks] == ["track1"]
     assert not _cache_writes(controller, "music")
+    assert result.provider_search_statuses == {
+        "library": ProviderSearchStatus.COMPLETE,
+        "fast_provider": ProviderSearchStatus.COMPLETE,
+        "slow_provider": ProviderSearchStatus.TIMEOUT,
+    }
     # the slow provider search completes in the background and caches its result
-    await _wait_for(lambda: bool(_cache_writes(controller, "prov_slow")))
-    late_writes = _cache_writes(controller, "prov_slow")
+    await _wait_for(lambda: bool(_cache_writes(controller, "slow_provider")))
+    late_writes = _cache_writes(controller, "slow_provider")
     assert len(late_writes) == 1
     assert late_writes[0].kwargs["data"] == slow_results.to_dict()
 
@@ -207,7 +218,7 @@ async def test_global_search_hard_timeout_aborts_provider_search(
     monkeypatch.setattr(
         "music_assistant.controllers.music.controller.SEARCH_PROVIDER_HARD_TIMEOUT", 0.1
     )
-    prov_hung = _make_search_provider("prov_hung")
+    hung_provider = _make_search_provider("hung_provider")
     search_aborted = asyncio.Event()
 
     async def _hung_search(*_args: Any, **_kwargs: Any) -> SearchResults:
@@ -217,16 +228,73 @@ async def test_global_search_hard_timeout_aborts_provider_search(
             search_aborted.set()
         return SearchResults()
 
-    prov_hung.search.side_effect = _hung_search
-    controller = _make_controller([prov_hung])
+    hung_provider.search.side_effect = _hung_search
+    controller = _make_controller([hung_provider])
 
     result = await controller.search("My Song", media_types=[MediaType.TRACK], limit=5)
 
     assert result.tracks == []
+    # the soft timeout (0.05s) elapses before the hard timeout (0.1s), so the
+    # caller-visible status is TIMEOUT; the hard timeout only aborts the
+    # still-running background task afterwards
+    assert result.provider_search_statuses == {
+        "library": ProviderSearchStatus.COMPLETE,
+        "hung_provider": ProviderSearchStatus.TIMEOUT,
+    }
     # the hard timeout cancels the provider search and nothing is cached
     await _wait_for(search_aborted.is_set)
     cache_set = cast("AsyncMock", controller.mass.cache.set)
     assert not cache_set.await_args_list
+
+
+async def test_global_search_hard_timeout_within_soft_window_reports_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hard timeout that fires before the soft timeout reports status FAILED."""
+    monkeypatch.setattr(
+        "music_assistant.controllers.music.controller.SEARCH_PROVIDER_SOFT_TIMEOUT", 1.0
+    )
+    monkeypatch.setattr(
+        "music_assistant.controllers.music.controller.SEARCH_PROVIDER_HARD_TIMEOUT", 0.05
+    )
+    hung_provider = _make_search_provider("hung_provider")
+
+    async def _hung_search(*_args: Any, **_kwargs: Any) -> SearchResults:
+        await asyncio.sleep(5)
+        return SearchResults()
+
+    hung_provider.search.side_effect = _hung_search
+    controller = _make_controller([hung_provider])
+
+    result = await controller.search("My Song", media_types=[MediaType.TRACK], limit=5)
+
+    assert result.tracks == []
+    # the hard timeout aborts the background task before the soft timeout would
+    # have fired, so _search_provider observes a completed task with a None
+    # result rather than raising its own TimeoutError
+    assert result.provider_search_statuses == {
+        "library": ProviderSearchStatus.COMPLETE,
+        "hung_provider": ProviderSearchStatus.FAILED,
+    }
+
+
+async def test_global_search_all_providers_succeed_reports_complete_and_caches_combined() -> None:
+    """When every provider (and the library) completes, all statuses are COMPLETE."""
+    prov_a = _make_search_provider("prov_a")
+    prov_a.search.return_value = SearchResults(tracks=[_make_track("track1", "prov_a", "My Song")])
+    prov_b = _make_search_provider("prov_b")
+    prov_b.search.return_value = SearchResults(tracks=[_make_track("track2", "prov_b", "My Song")])
+    controller = _make_controller([prov_a, prov_b])
+
+    result = await controller.search("My Song", media_types=[MediaType.TRACK], limit=5)
+
+    assert result.provider_search_statuses == {
+        "library": ProviderSearchStatus.COMPLETE,
+        "prov_a": ProviderSearchStatus.COMPLETE,
+        "prov_b": ProviderSearchStatus.COMPLETE,
+    }
+    # a fully complete search caches the combined result for a next identical search
+    assert _cache_writes(controller, "music")
 
 
 async def test_search_provider_cache_hit_avoids_provider_call() -> None:
@@ -376,6 +444,8 @@ async def test_search_providers_param_restricts_search() -> None:
     assert [track.item_id for track in result.tracks] == ["track1"]
     prov_a.search.assert_not_awaited()
     prov_b.search.assert_awaited_once()
+    # statuses only cover the actually targeted provider, no library/other entries
+    assert result.provider_search_statuses == {"spotify--abc": ProviderSearchStatus.COMPLETE}
 
     # the special value "library" selects the library only
     prov_b.search.reset_mock()
@@ -385,6 +455,7 @@ async def test_search_providers_param_restricts_search() -> None:
     assert [track.item_id for track in result.tracks] == ["lib1"]
     prov_a.search.assert_not_awaited()
     prov_b.search.assert_not_awaited()
+    assert result.provider_search_statuses == {"library": ProviderSearchStatus.COMPLETE}
 
 
 async def test_search_library_only_maps_to_library_provider() -> None:
@@ -415,6 +486,11 @@ async def test_search_exact_library_match_skips_provider_media_types() -> None:
     result = await controller.search("Nirvana", media_types=[MediaType.ARTIST], limit=5)
     assert [artist.item_id for artist in result.artists] == ["lib1"]
     prov.search.assert_not_awaited()
+    # a deliberately skipped provider still reports COMPLETE (nothing pending)
+    assert result.provider_search_statuses == {
+        "library": ProviderSearchStatus.COMPLETE,
+        "prov_a": ProviderSearchStatus.COMPLETE,
+    }
 
     # other media types are still searched on the provider
     await controller.search("Nirvana", media_types=[MediaType.ARTIST, MediaType.TRACK], limit=5)

--- a/tests/test_cross_type_features.py
+++ b/tests/test_cross_type_features.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock, patch
 
-from music_assistant_models.enums import MediaType, ProviderFeature, ProviderType
+from music_assistant_models.enums import (
+    MediaType,
+    ProviderFeature,
+    ProviderSearchStatus,
+    ProviderType,
+)
 from music_assistant_models.media_items import Artist, ProviderMapping, SearchResults
 
 from music_assistant.controllers.music import MusicController
@@ -231,7 +236,9 @@ async def test_global_search_includes_plugin_providers_with_search() -> None:
     controller.domain = "music"
     controller.get_unique_providers = Mock(return_value=["m_a"])  # type: ignore[method-assign]
     controller.search_library = AsyncMock(return_value=SearchResults())  # type: ignore[method-assign]
-    controller._search_provider = AsyncMock(return_value=SearchResults())  # type: ignore[method-assign]
+    controller._search_provider = AsyncMock(  # type: ignore[method-assign]
+        return_value=(SearchResults(), ProviderSearchStatus.COMPLETE)
+    )
 
     with patch(
         "music_assistant.controllers.music.controller.sort_search_result",


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Reports how each provider contributed to a global search, so clients can tell
"this provider found nothing" apart from "this provider timed out / errored"
instead of guessing from an empty result.

`SearchResults` now carries `provider_search_statuses` (per provider,
`complete` / `timeout` / `failed`). `_search_provider` returns its status
alongside its results; `search()` collects them (library and shortcut-skipped
providers are `complete`).
Caching is unchanged — combined results are still
only cached when every provider completed, so cached payloads only ever carry
`complete` statuses.

Companion PRs:
https://github.com/music-assistant/models/pull/331
https://github.com/music-assistant/frontend/pull/2207

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
