### PR TITLE
Fix AirPlay players being marked off while streaming

### DIFF
--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -252,7 +252,7 @@ class AirPlayControlPlayer(AirPlayPlayer):
     async def power(self, powered: bool) -> None:
         """Turn the controlled device on or off."""
         feature = FeatureName.TurnOn if powered else FeatureName.TurnOff
-        device = self._device_for_feature(feature)
+        device = self._device_for_power_feature(feature)
         if device is None:
             raise PlayerCommandFailed(f"Power control is unavailable for {self.display_name}")
         if powered:

--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -201,8 +201,8 @@ class AirPlayControlPlayer(AirPlayPlayer):
         # credentials (so the feature does not flap while (re)connecting).
         if (
             self.get_setup_value(CONF_COMPANION_CREDENTIALS)
-            or self._device_for_feature(FeatureName.TurnOn)
-            or self._device_for_feature(FeatureName.TurnOff)
+            or self._device_for_power_feature(FeatureName.TurnOn)
+            or self._device_for_power_feature(FeatureName.TurnOff)
         ):
             features.add(PlayerFeature.POWER)
         if not self._stream_active and not self._device_for_feature(FeatureName.SetVolume):
@@ -707,6 +707,28 @@ class AirPlayControlPlayer(AirPlayPlayer):
                 return device
         return None
 
+    def _device_for_power_feature(self, feature: FeatureName) -> AppleTV | None:
+        """
+        Return a connected device facade that can genuinely serve a power command.
+
+        pyatv reports the power commands as available on every MRP connection, but a
+        transient tunnel - the only control channel current HomePod firmware offers -
+        cannot act on them, and derives its power state from ``logicalDeviceCount``,
+        which does not count AirPlay audio sessions. Trusting it would leave a playing
+        HomePod stranded as "off".
+
+        :param feature: The power feature to look for.
+        """
+        if self._companion_device and self._feature_available(self._companion_device, feature):
+            return self._companion_device
+        if (
+            self._mrp_device
+            and not self._uses_transient_mrp
+            and self._feature_available(self._mrp_device, feature)
+        ):
+            return self._mrp_device
+        return None
+
     @staticmethod
     def _feature_available(device: AppleTV, feature: FeatureName) -> bool:
         """Return whether pyatv currently exposes a feature."""
@@ -716,7 +738,7 @@ class AirPlayControlPlayer(AirPlayPlayer):
         """Wake the device before starting or resuming playback."""
         if self.powered is True:
             return
-        device = self._device_for_feature(FeatureName.TurnOn)
+        device = self._device_for_power_feature(FeatureName.TurnOn)
         if device is None:
             return
         self._power_on_event.clear()
@@ -954,12 +976,18 @@ class AirPlayControlPlayer(AirPlayPlayer):
             self._attr_powered = True
             self._power_on_event.set()
         elif power_state == PowerState.Off:
+            # A device streaming from Music Assistant is not powered off, whatever the
+            # control channel claims: MRP derives the state from logicalDeviceCount,
+            # which does not count AirPlay audio sessions, and a Companion SystemStatus
+            # can briefly report sleep mid-stream. Acting on it would strand the player
+            # as "off" and trip the auto-ungroup in the players controller.
+            if self._stream_active:
+                return
             self._attr_powered = False
             self._power_on_event.clear()
-            if not self._stream_active:
-                self._attr_playback_state = PlaybackState.IDLE
-                self._attr_active_source = None
-                self._attr_current_media = None
+            self._attr_playback_state = PlaybackState.IDLE
+            self._attr_active_source = None
+            self._attr_current_media = None
         else:
             self._attr_powered = None
         self.update_state()
@@ -967,6 +995,12 @@ class AirPlayControlPlayer(AirPlayPlayer):
     def _handle_volume_update(self, source: str, volume: float) -> None:
         """Apply a pushed pyatv volume level."""
         if source == "mrp" and self._companion_device is not None:
+            return
+        # While Music Assistant streams, volume_set drives the stream volume and
+        # deliberately leaves the native device volume alone. The two are separate
+        # knobs on a different scale, so a report about the native one must not
+        # overwrite (or persist) the level the user just set on the stream.
+        if source != "command" and self._stream_active:
             return
         volume_level = max(0, min(100, round(volume)))
         if volume_level == 0:

--- a/tests/providers/airplay/test_control_player.py
+++ b/tests/providers/airplay/test_control_player.py
@@ -233,6 +233,19 @@ def test_power_feature_skips_transient_mrp_tunnels() -> None:
     assert PlayerFeature.POWER not in homepod.supported_features
 
 
+async def test_power_command_refuses_transient_mrp_tunnels() -> None:
+    """A power command never reaches a tunnel that cannot serve it."""
+    homepod = _make_control_player(model="HomePod Mini", companion_flags="0x62792")
+    device = MagicMock(spec=AppleTV)
+    device.features.in_state.side_effect = lambda _state, feature: feature == FeatureName.TurnOn
+    homepod._mrp_device = device
+
+    with pytest.raises(PlayerCommandFailed):
+        await homepod.power(True)
+
+    device.power.turn_on.assert_not_called()
+
+
 def test_native_transport_features_follow_live_capabilities() -> None:
     """External next/previous controls are advertised only while available."""
     player = _make_control_player()

--- a/tests/providers/airplay/test_control_player.py
+++ b/tests/providers/airplay/test_control_player.py
@@ -218,6 +218,21 @@ def test_power_feature_requires_credentials_or_connection() -> None:
     assert PlayerFeature.POWER in connected.supported_features
 
 
+def test_power_feature_skips_transient_mrp_tunnels() -> None:
+    """A transient MRP tunnel does not count as real power control."""
+    # pyatv reports TurnOn/TurnOff as available on every MRP connection, but a HomePod
+    # reached over the transient tunnel cannot act on them and derives its power state
+    # from logicalDeviceCount, which does not count AirPlay audio sessions.
+    homepod = _make_control_player(model="HomePod Mini", companion_flags="0x62792")
+    assert homepod._uses_transient_mrp is True
+
+    device = MagicMock(spec=AppleTV)
+    device.features.in_state.side_effect = lambda _state, feature: feature == FeatureName.TurnOn
+    homepod._mrp_device = device
+
+    assert PlayerFeature.POWER not in homepod.supported_features
+
+
 def test_native_transport_features_follow_live_capabilities() -> None:
     """External next/previous controls are advertised only while available."""
     player = _make_control_player()
@@ -300,6 +315,39 @@ def test_duplicate_native_volume_update_is_ignored() -> None:
 
     cast("MagicMock", player.mass.config).set_raw_player_config_value.assert_not_called()
     update_state.assert_not_called()
+
+
+def test_native_volume_update_ignored_while_streaming() -> None:
+    """Native volume reports never overwrite the volume of a running stream."""
+    # volume_set routes to the stream while streaming and leaves the native device
+    # volume alone, so a report about that separate knob must not clobber (or persist)
+    # the level the user just set.
+    player = _make_control_player(model="HomePod Mini", companion_flags="0x62792")
+    player.stream = MagicMock(running=True)
+    player._attr_volume_level = 62
+    player._attr_volume_muted = False
+
+    with patch.object(player, "update_state") as update_state:
+        player._handle_volume_update("mrp", 10)
+
+    assert player.volume_level == 62
+    assert player.volume_muted is False
+    cast("MagicMock", player.mass.config).set_raw_player_config_value.assert_not_called()
+    update_state.assert_not_called()
+
+
+def test_native_volume_update_applies_when_idle() -> None:
+    """Native volume reports still drive player state while no stream is running."""
+    player = _make_control_player()
+    player.stream = MagicMock(running=False)
+    player._attr_volume_level = 62
+    player._attr_volume_muted = False
+
+    with patch.object(player, "update_state") as update_state:
+        player._handle_volume_update("companion", 10)
+
+    assert player.volume_level == 10
+    update_state.assert_called_once()
 
 
 def test_control_pairing_is_optional_and_never_requires_setup() -> None:
@@ -401,6 +449,28 @@ def test_power_off_update_tracks_sleep_state() -> None:
         assert player.current_media is None
 
         update_state.assert_called_once()
+
+
+def test_power_off_update_ignored_while_streaming() -> None:
+    """A device streaming from Music Assistant is never marked powered off."""
+    # MRP derives power from logicalDeviceCount, which does not count AirPlay audio
+    # sessions, so a playing HomePod reports PowerState.Off. Acting on that would
+    # strand the player as "off" and trip the auto-ungroup in the players controller.
+    player = _make_control_player(model="HomePod Mini", companion_flags="0x62792")
+    player.stream = MagicMock(running=True)
+    player._attr_powered = True
+    player._power_on_event.set()
+    player._attr_playback_state = PlaybackState.PLAYING
+    player._attr_active_source = "airplay"
+
+    with patch.object(player, "update_state") as update_state:
+        player._handle_power_update("mrp", PowerState.Off)
+
+    assert player.powered is True
+    assert player._power_on_event.is_set()
+    assert player.playback_state == PlaybackState.PLAYING
+    assert player.active_source == "airplay"
+    update_state.assert_not_called()
 
 
 def test_power_on_update_tracks_awake_state() -> None:


### PR DESCRIPTION
# What does this implement/fix?

A speaker that is playing a Music Assistant stream could still be marked as powered off, because Apple's remote-control channel reports power based on its own activity and does not count AirPlay audio. While a player is marked off, its volume slider is disabled, playback commands wait ten seconds for a wake confirmation that never arrives, and sync groups can be dissolved automatically.

The same channel also reports the speaker's own volume back to Music Assistant. That volume is a separate setting from the stream volume, so it could overwrite — and save — the volume you just set.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Ignore power-off reports from a device while it is playing a Music Assistant stream.
- Only offer power control for devices that can actually act on it, and use that same check when sending a power command.
- Ignore the speaker's own volume reports while streaming, so they no longer overwrite (or save) the volume you set.
- Added tests covering all three.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
