### PR TITLE
Keep AirPlay protocol selection automatic

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -83,15 +83,6 @@ AIRPLAY_ARTWORK_SIZE: Final[int] = 512
 CONF_RAOP_CREDENTIALS: Final[str] = "raop_credentials"
 CONF_AIRPLAY_CREDENTIALS: Final[str] = "airplay_credentials"
 
-# Provider-level marker for the one-time reset of user-calibrated sync_adjust
-# values from before the unified cliairplay binary, whose different timing model
-# invalidates offsets calibrated against the old implementation.
-CONF_SYNC_ADJUST_RESET_MARKER: Final[str] = "unified_binary_sync_adjust_reset"
-# Legacy protocol preference used only to migrate explicit RAOP selections.
-CONF_LEGACY_AIRPLAY_PROTOCOL: Final[str] = "airplay_protocol"
-CONF_LEGACY_FORCE_RAOP: Final[str] = "legacy_force_raop"
-CONF_PROTOCOL_MIGRATION_MARKER: Final[str] = "unified_binary_protocol_migration"
-
 # AirPlay serves the shared sync-adjust control as a non-advanced (always visible)
 # setting: the binary handles lead/buffer automatically and does not apply
 # device-reported render latency, so sync_adjust is the primary way to compensate

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -42,7 +42,6 @@ from .constants import (
     CONF_FORCE_RAOP,
     CONF_HIRES_PLAYBACK,
     CONF_IGNORE_VOLUME,
-    CONF_LEGACY_FORCE_RAOP,
     CONF_PAIRING_PASSWORD,
     CONF_PAIRING_PIN,
     CONF_PASSWORD,
@@ -131,10 +130,9 @@ class AirPlayPlayer(Player):
 
         The only override a user can set is the "force RAOP" escape hatch (offered
         for AirPlay-2-capable non-Apple receivers whose AirPlay 2 implementation
-        misbehaves). Legacy RAOP preferences are also preserved for Apple devices.
-        Otherwise the cliairplay binary resolves the route itself from the mDNS TXT
-        records (--protocol auto) and the ``protocol`` property above only reflects
-        MA's own planning heuristic (timing, ports).
+        misbehaves). Otherwise the cliairplay binary resolves the route itself from
+        the mDNS TXT records (--protocol auto) and the ``protocol`` property above
+        only reflects MA's own planning heuristic (timing, ports).
         """
         return StreamingProtocol.RAOP if self._force_raop_active else None
 
@@ -767,9 +765,7 @@ class AirPlayPlayer(Player):
 
         Offered only for AirPlay-2-capable non-Apple receivers that also advertise
         a RAOP service to fall back to. Genuine Apple devices are always AirPlay 2,
-        so the toggle is never offered for them; only an explicitly migrated legacy
-        preference can still force RAOP there. RAOP-only and AirPlay-2-only devices
-        have nothing to force, so they are excluded as well.
+        while RAOP-only and AirPlay-2-only devices have nothing to force.
         """
         return (
             self._is_airplay2_capable
@@ -780,16 +776,7 @@ class AirPlayPlayer(Player):
     @property
     def _force_raop_active(self) -> bool:
         """Return whether RAOP is being forced through the escape-hatch toggle."""
-        if self._force_raop_available and self.config.get_value(CONF_FORCE_RAOP, False):
-            return True
-        return (
-            self.raop_discovery_info is not None
-            and is_apple_device(self.device_info.manufacturer, self.device_info.model)
-            and self.provider.mass.config.get_raw_player_config_value(
-                self.player_id, CONF_LEGACY_FORCE_RAOP, False
-            )
-            is True
-        )
+        return self._force_raop_available and bool(self.config.get_value(CONF_FORCE_RAOP, False))
 
     def _get_pairing_config_entries(
         self, values: dict[str, ConfigValueType] | None

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -18,9 +18,7 @@ from zeroconf.asyncio import AsyncServiceInfo
 
 from music_assistant.constants import (
     CONF_LOG_LEVEL,
-    CONF_PLAYERS,
     CONF_PROVIDERS,
-    CONF_SYNC_ADJUST,
     VERBOSE_LOG_LEVEL,
 )
 from music_assistant.helpers.datetime import utc
@@ -38,13 +36,8 @@ from .constants import (
     AIRPLAY_DISCOVERY_TYPE,
     AIRPLAY_VOLUME_MUTE,
     COMPANION_DISCOVERY_TYPE,
-    CONF_FORCE_RAOP,
     CONF_IGNORE_VOLUME,
-    CONF_LEGACY_AIRPLAY_PROTOCOL,
-    CONF_LEGACY_FORCE_RAOP,
-    CONF_PROTOCOL_MIGRATION_MARKER,
     CONF_STORED_VOLUME,
-    CONF_SYNC_ADJUST_RESET_MARKER,
     DACP_DISCOVERY_TYPE,
     FALLBACK_VOLUME,
     MRP_DISCOVERY_TYPE,
@@ -214,9 +207,6 @@ class AirPlayProvider(PlayerProvider):
             server=f"{socket.gethostname()}.local",
         )
         await self._register_dacp_service()
-
-        self._migrate_protocol_preferences()
-        self._migrate_sync_adjust()
 
         # Run one shared PTP clock daemon for the provider lifetime: all native
         # AirPlay 2 streams attach to it (--ptp-shared) so multi-room sync groups
@@ -683,62 +673,6 @@ class AirPlayProvider(PlayerProvider):
             if discovery_info is not None
             for address in discovery_info.parsed_addresses()
         }
-
-    def _migrate_sync_adjust(self) -> None:
-        """One-time reset of persisted sync_adjust values on this provider's players."""
-        # The unified cliairplay binary uses a different timing model than the old
-        # implementation, so offsets calibrated against it would now break sync
-        # instead of fixing it. Reset them once; a provider-level marker prevents
-        # wiping adjustments the user makes after the migration.
-        if self.mass.config.get_raw_provider_config_value(
-            self.instance_id, CONF_SYNC_ADJUST_RESET_MARKER, False
-        ):
-            return
-        for raw_conf in list(self.mass.config.get(CONF_PLAYERS, {}).values()):
-            if not isinstance(raw_conf, dict) or raw_conf.get("provider") != self.instance_id:
-                continue
-            if not (player_id := raw_conf.get("player_id")):
-                continue
-            stored = self.mass.config.get_raw_player_config_value(player_id, CONF_SYNC_ADJUST, 0)
-            if not stored:
-                continue
-            self.logger.warning(
-                "Resetting sync_adjust of %sms for player %s: the unified AirPlay engine "
-                "uses a different timing model, so corrections calibrated against the old "
-                "implementation no longer apply",
-                stored,
-                player_id,
-            )
-            self.mass.config.set_raw_player_config_value(player_id, CONF_SYNC_ADJUST, 0)
-        self.mass.config.set_raw_provider_config_value(
-            self.instance_id, CONF_SYNC_ADJUST_RESET_MARKER, True
-        )
-
-    def _migrate_protocol_preferences(self) -> None:
-        """Preserve explicit RAOP selections from the legacy protocol setting."""
-        if self.mass.config.get_raw_provider_config_value(
-            self.instance_id, CONF_PROTOCOL_MIGRATION_MARKER, False
-        ):
-            return
-        for raw_conf in list(self.mass.config.get(CONF_PLAYERS, {}).values()):
-            if not isinstance(raw_conf, dict) or raw_conf.get("provider") != self.instance_id:
-                continue
-            if not (player_id := raw_conf.get("player_id")):
-                continue
-            legacy_protocol = self.mass.config.get_raw_player_config_value(
-                player_id, CONF_LEGACY_AIRPLAY_PROTOCOL, 0
-            )
-            force_raop = self.mass.config.get_raw_player_config_value(
-                player_id, CONF_FORCE_RAOP, None
-            )
-            if legacy_protocol == StreamingProtocol.RAOP and force_raop is None:
-                self.mass.config.set_raw_player_config_value(player_id, CONF_FORCE_RAOP, True)
-                self.mass.config.set_raw_player_config_value(
-                    player_id, CONF_LEGACY_FORCE_RAOP, True
-                )
-        self.mass.config.set_raw_provider_config_value(
-            self.instance_id, CONF_PROTOCOL_MIGRATION_MARKER, True
-        )
 
     async def _register_dacp_service(self) -> None:
         """

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -506,25 +506,6 @@ def test_force_raop_ignored_on_apple_airplay2() -> None:
     assert player.protocol_override is None
 
 
-def test_migrated_force_raop_is_preserved_on_apple_airplay2() -> None:
-    """A migrated legacy RAOP preference remains effective without exposing the toggle."""
-    player = _make_apple_player()
-    _set_discovery_info(player, raop=True, airplay=True, airplay_features=AP2_FEATURES)
-    _configure_player(
-        player,
-        {
-            CONF_FORCE_RAOP: True,
-        },
-    )
-    with patch.object(
-        player.provider.mass.config,
-        "get_raw_player_config_value",
-        return_value=True,
-    ):
-        assert player.protocol == StreamingProtocol.RAOP
-        assert player.protocol_override == StreamingProtocol.RAOP
-
-
 @pytest.mark.parametrize(
     ("stored_config", "expected"),
     [

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -1,21 +1,16 @@
-"""Unit tests for the AirPlay provider (sync_adjust migration + PTP timing source)."""
+"""Unit tests for the AirPlay provider."""
 
 import asyncio
 import logging
 import time
 from contextlib import AbstractContextManager
 from typing import cast
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from music_assistant_models.enums import PlaybackState
 
-from music_assistant.constants import CONF_SYNC_ADJUST, VERBOSE_LOG_LEVEL
+from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.providers.airplay.constants import (
-    CONF_FORCE_RAOP,
-    CONF_LEGACY_AIRPLAY_PROTOCOL,
-    CONF_LEGACY_FORCE_RAOP,
-    CONF_PROTOCOL_MIGRATION_MARKER,
-    CONF_SYNC_ADJUST_RESET_MARKER,
     AirPlayRemoteCommand,
     StreamingProtocol,
 )
@@ -41,128 +36,19 @@ DAEMON_UP_LINE = (
 )
 
 
-def _make_provider(
-    marker_set: bool,
-    player_configs: dict[str, dict[str, object]],
-    stored_sync_adjust: dict[str, int],
-) -> AirPlayProvider:
-    """
-    Build a bare provider wired to a mocked config store.
-
-    :param marker_set: Whether the one-time migration already ran.
-    :param player_configs: Raw player config store contents.
-    :param stored_sync_adjust: Persisted sync_adjust value per player id.
-    """
+def _make_provider() -> AirPlayProvider:
+    """Build a bare provider wired to a mocked Music Assistant instance."""
     prov = AirPlayProvider.__new__(AirPlayProvider)
     prov.mass = MagicMock()
     prov.logger = logging.getLogger("test.airplay.provider")
     prov.config = MagicMock()
     prov.config.instance_id = INSTANCE_ID
-    prov.mass.config.get_raw_provider_config_value.return_value = marker_set
-    prov.mass.config.get.return_value = player_configs
-    prov.mass.config.get_raw_player_config_value.side_effect = lambda player_id, _key, default=0: (
-        stored_sync_adjust.get(player_id, default)
-    )
     return prov
-
-
-def test_sync_adjust_migration_resets_stored_values() -> None:
-    """Persisted sync_adjust values are reset once and the marker is written."""
-    player_configs: dict[str, dict[str, object]] = {
-        "apaaa": {"player_id": "apaaa", "provider": INSTANCE_ID},
-        "apbbb": {"player_id": "apbbb", "provider": INSTANCE_ID},
-        # player of another provider must be left alone
-        "sonos1": {"player_id": "sonos1", "provider": "sonos"},
-    }
-    prov = _make_provider(
-        marker_set=False,
-        player_configs=player_configs,
-        stored_sync_adjust={"apaaa": 120, "apbbb": 0, "sonos1": 250},
-    )
-
-    prov._migrate_sync_adjust()
-
-    # only the airplay player with a non-zero offset is reset
-    cast("MagicMock", prov.mass.config).set_raw_player_config_value.assert_called_once_with(
-        "apaaa", CONF_SYNC_ADJUST, 0
-    )
-    # the one-time marker is written afterwards
-    cast("MagicMock", prov.mass.config).set_raw_provider_config_value.assert_called_once_with(
-        INSTANCE_ID, CONF_SYNC_ADJUST_RESET_MARKER, True
-    )
-
-
-def test_sync_adjust_migration_runs_only_once() -> None:
-    """With the marker set, the migration must not touch player configs again."""
-    player_configs: dict[str, dict[str, object]] = {
-        "apaaa": {"player_id": "apaaa", "provider": INSTANCE_ID}
-    }
-    prov = _make_provider(
-        marker_set=True,
-        player_configs=player_configs,
-        stored_sync_adjust={"apaaa": 120},
-    )
-
-    prov._migrate_sync_adjust()
-
-    cast("MagicMock", prov.mass.config).set_raw_player_config_value.assert_not_called()
-    cast("MagicMock", prov.mass.config).set_raw_provider_config_value.assert_not_called()
-
-
-def test_protocol_migration_preserves_only_explicit_raop_preferences() -> None:
-    """Legacy forced RAOP values migrate without overriding newer toggle values."""
-    player_configs: dict[str, dict[str, object]] = {
-        "raop": {"player_id": "raop", "provider": INSTANCE_ID},
-        "airplay2": {"player_id": "airplay2", "provider": INSTANCE_ID},
-        "automatic": {"player_id": "automatic", "provider": INSTANCE_ID},
-        "new-toggle": {"player_id": "new-toggle", "provider": INSTANCE_ID},
-        "other": {"player_id": "other", "provider": "sonos"},
-    }
-    stored_values: dict[tuple[str, str], object] = {
-        ("raop", CONF_LEGACY_AIRPLAY_PROTOCOL): StreamingProtocol.RAOP,
-        ("airplay2", CONF_LEGACY_AIRPLAY_PROTOCOL): StreamingProtocol.AIRPLAY2,
-        ("automatic", CONF_LEGACY_AIRPLAY_PROTOCOL): 0,
-        ("new-toggle", CONF_LEGACY_AIRPLAY_PROTOCOL): StreamingProtocol.RAOP,
-        ("new-toggle", CONF_FORCE_RAOP): False,
-        ("other", CONF_LEGACY_AIRPLAY_PROTOCOL): StreamingProtocol.RAOP,
-    }
-    prov = _make_provider(False, player_configs, {})
-    config = cast("MagicMock", prov.mass.config)
-    config.get_raw_player_config_value.side_effect = lambda player_id, key, default=None: (
-        stored_values.get((player_id, key), default)
-    )
-
-    prov._migrate_protocol_preferences()
-
-    cast("MagicMock", prov.mass.config).set_raw_player_config_value.assert_has_calls(
-        [
-            call("raop", CONF_FORCE_RAOP, True),
-            call("raop", CONF_LEGACY_FORCE_RAOP, True),
-        ]
-    )
-    assert cast("MagicMock", prov.mass.config).set_raw_player_config_value.call_count == 2
-    cast("MagicMock", prov.mass.config).set_raw_provider_config_value.assert_called_once_with(
-        INSTANCE_ID, CONF_PROTOCOL_MIGRATION_MARKER, True
-    )
-
-
-def test_protocol_migration_runs_only_once() -> None:
-    """The protocol migration marker prevents a disabled toggle being restored later."""
-    prov = _make_provider(
-        True,
-        {"raop": {"player_id": "raop", "provider": INSTANCE_ID}},
-        {},
-    )
-
-    prov._migrate_protocol_preferences()
-
-    cast("MagicMock", prov.mass.config).set_raw_player_config_value.assert_not_called()
-    cast("MagicMock", prov.mass.config).set_raw_provider_config_value.assert_not_called()
 
 
 def test_remote_pause_routes_to_sendspin_session() -> None:
     """A bridged device pause targets the owning Sendspin session."""
-    prov = _make_provider(False, {}, {})
+    prov = _make_provider()
     players = cast("MagicMock", prov.mass.players)
     manager = SendspinBridgeManager(prov)
     prov._bridge_manager = manager
@@ -196,7 +82,7 @@ def test_remote_pause_routes_to_sendspin_session() -> None:
 
 def test_remote_pause_keeps_normal_airplay_routing() -> None:
     """An inactive bridge does not change normal AirPlay pause routing."""
-    prov = _make_provider(False, {}, {})
+    prov = _make_provider()
     players = cast("MagicMock", prov.mass.players)
     manager = SendspinBridgeManager(prov)
     prov._bridge_manager = manager


### PR DESCRIPTION
# What does this implement/fix?

Legacy AirPlay settings could silently force RAOP or reset sync adjustments after moving to the unified playback engine.

- Removes the old protocol and sync-adjust migrations.
- Keeps RAOP fallback available only when explicitly enabled on supported receivers.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.