### PR TITLE
Reject ACTION-type entries in setup flow forms

### DIFF
--- a/music_assistant/models/setup_flow.py
+++ b/music_assistant/models/setup_flow.py
@@ -494,7 +494,7 @@ class SetupSession:
         """Return copies of the form entries, validated and stamped for this flow."""
         prepared: list[ConfigEntry] = []
         for entry in entries:
-            if entry.action:
+            if entry.action or entry.type == ConfigEntryType.ACTION:
                 # actions are the pseudo-flow mechanism of the options surface;
                 # inside real flows they are structurally banned
                 msg = f"Config entry {entry.key} carries an action, not allowed in setup flows"

--- a/music_assistant/models/setup_flow.py
+++ b/music_assistant/models/setup_flow.py
@@ -497,7 +497,7 @@ class SetupSession:
             if entry.action or entry.type == ConfigEntryType.ACTION:
                 # actions are the pseudo-flow mechanism of the options surface;
                 # inside real flows they are structurally banned
-                msg = f"Config entry {entry.key} carries an action, not allowed in setup flows"
+                msg = f"Config entry {entry.key} is an action entry, not allowed in setup flows"
                 raise ValueError(msg)
             # replace() returns a copy so the (often module-level) entry definitions
             # are never mutated by submit-side value/owner stamping

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -703,6 +703,22 @@ async def test_form_entries_with_action_rejected(flow_mass: MusicAssistant) -> N
     assert step.reason == "internal_error"
 
 
+@pytest.mark.usefixtures("flow_events")
+async def test_form_entries_with_action_type_rejected(flow_mass: MusicAssistant) -> None:
+    """The engine rejects FORM entries of type ACTION (they render dead in the dialog)."""
+    action_entry = ConfigEntry(key="authenticate", type=ConfigEntryType.ACTION, required=False)
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.form([action_entry])
+        await session.finish({})
+
+    with _use_flow(flow_mass, run_setup):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+    # the ValueError ends the flow as an internal error
+    assert step.type == FlowStepType.ABORT
+    assert step.reason == "internal_error"
+
+
 async def test_reconfigure_prefill_and_success(flow_mass: MusicAssistant) -> None:
     """Reconfigure decrypts setup_data for prefill and merges the new values on finish."""
     instance_id = FAKE_DOMAIN


### PR DESCRIPTION
# What does this implement/fix?

`ConfigEntryType.ACTION` is an options-screen concept: those buttons are driven by the
dedicated `invoke_action` commands. Inside a setup-flow FORM step the dialog binds no
action events, so such a button renders dead.

The engine already rejected entries carrying an `action` string, but an entry declared
as `type=ACTION` without one slipped through. Reject that too, so the mistake surfaces
during development instead of as a dead button.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`
