### PR TITLE
Surface the player reconfigure flow

### DIFF
--- a/music_assistant/controllers/config/flows.py
+++ b/music_assistant/controllers/config/flows.py
@@ -202,6 +202,10 @@ class SetupFlowMixin:
         more than one does - via a form that lets the user pick which child to set up.
         The child's flow persists to the child's own config.
 
+        Also serves on-demand re-runs: when nothing needs setup (anymore), delegation
+        falls back to any child that merely has a flow, so a step the user skipped
+        earlier - an optional pairing, say - remains reachable.
+
         :param player_id: The player to set up.
         """
         # deliberately no raise_unavailable: a player that needs setup is serialized
@@ -212,7 +216,7 @@ class SetupFlowMixin:
             raise KeyError(msg)
         owner = f"provider.{player.provider.domain}"
         target_key = f"player_setup:{player_id}"
-        if type(player).run_setup_flow is not Player.run_setup_flow:
+        if player.implements_setup_flow:
             # the player implements its own setup flow: run it directly
             return await self._start_flow(
                 flow_coro=player.run_setup_flow,
@@ -221,8 +225,11 @@ class SetupFlowMixin:
                 required_scope=Scope.CONFIG_PLAYERS_WRITE,
                 finish_handler=self._finish_player_setup,
             )
-        # no direct setup: delegate to protocol child player(s) that need setup
-        children = self._protocol_children_needing_setup(player)
+        # no direct setup: delegate to protocol child player(s), preferring the ones
+        # that actually need setup and falling back to any that can re-run their flow
+        children = self._protocol_children_with_setup_flow(player, needing_only=True)
+        if not children:
+            children = self._protocol_children_with_setup_flow(player, needing_only=False)
         if len(children) == 1:
             child = children[0]
             return await self._start_flow(
@@ -503,13 +510,18 @@ class SetupFlowMixin:
             values=self._decrypt_values(raw_conf.get("values") or {}),
         )
 
-    def _protocol_children_needing_setup(self, player: Player) -> list[Player]:
+    def _protocol_children_with_setup_flow(
+        self, player: Player, *, needing_only: bool
+    ) -> list[Player]:
         """
-        Return the player's protocol child players that need (and implement) setup.
+        Return the player's protocol child players that implement a setup flow.
 
         Covers the wrapper case: a universal player, or a native player wrapping
         protocol children, whose own setup is a no-op but whose linked protocol
         outputs still require pairing/credentials.
+
+        :param player: The (wrapper) player whose protocol children to inspect.
+        :param needing_only: Only return children that currently need setup.
         """
         children: list[Player] = []
         seen: set[str] = set()
@@ -519,12 +531,11 @@ class SetupFlowMixin:
                 continue
             seen.add(child_id)
             child = self.mass.players.get_player(child_id)
-            if (
-                child is not None
-                and child.needs_setup
-                and type(child).run_setup_flow is not Player.run_setup_flow
-            ):
-                children.append(child)
+            if child is None or not child.implements_setup_flow:
+                continue
+            if needing_only and not child.needs_setup:
+                continue
+            children.append(child)
         return children
 
     async def _run_child_selection_flow(

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -255,6 +255,7 @@ def _state_fingerprint(state: PlayerState) -> dict[str, Any]:
         "active_output_protocol": state.active_output_protocol,
         "needs_setup": state.needs_setup,
         "setup_reason": state.setup_reason,
+        "has_setup_flow": state.has_setup_flow,
         "sleep_timer_expires_at": state.sleep_timer_expires_at,
         "supported_features": frozenset(state.supported_features),
         "sound_mode_list": tuple((m.id, m.name, m.passive) for m in state.sound_mode_list),
@@ -506,6 +507,33 @@ class Player(ABC):
         or "password_required"). Returns None when there is no specific reason.
         """
         return self._attr_setup_reason
+
+    @property
+    @final
+    def implements_setup_flow(self) -> bool:
+        """Return if this player implements its own interactive setup flow."""
+        return type(self).run_setup_flow is not Player.run_setup_flow
+
+    @property
+    @final
+    def has_setup_flow(self) -> bool:
+        """
+        Return if an interactive setup flow can be started for this player.
+
+        True when the player implements its own setup flow, or when it wraps a
+        (non-native) protocol child player that does. Unlike ``needs_setup`` this stays
+        True once setup completed, so the UI can offer to re-run the flow on demand
+        (e.g. to redo a pairing step that was skipped).
+        """
+        if self.implements_setup_flow:
+            return True
+        for output_protocol in self.output_protocols:
+            if output_protocol.is_native:
+                continue
+            child = self.mass.players.get_player(output_protocol.output_protocol_id)
+            if child is not None and child.implements_setup_flow:
+                return True
+        return False
 
     @property
     def powered(self) -> bool | None:
@@ -2186,6 +2214,7 @@ class Player(ABC):
             active_output_protocol=self.__attr_active_output_protocol,
             needs_setup=self.needs_setup,
             setup_reason=self.setup_reason,
+            has_setup_flow=self.has_setup_flow,
             sleep_timer_expires_at=self.sleep_timer_expires_at,
         )
         media_position_jumped = self.__reconcile_current_media_anchor(

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -1052,13 +1052,45 @@ async def test_player_setup_multi_child_selection(flow_mass: MusicAssistant) -> 
     assert flow_mass.config.decrypt_string(child_raw["setup_data"]["pin"]) == "9999"
 
 
-async def test_player_setup_no_children_needing_setup_aborts(flow_mass: MusicAssistant) -> None:
-    """A wrapper player whose children are all set up reports nothing to configure."""
+async def test_player_setup_reruns_child_flow_when_nothing_needs_setup(
+    flow_mass: MusicAssistant,
+) -> None:
+    """A wrapper player whose children are all set up still reaches the child's flow."""
     parent_provider = MockProvider("universal_player", instance_id="universal_player")
     child_provider = MockProvider("airplay", instance_id="airplay")
     parent = MockPlayer(parent_provider, "up_parent", "Bedroom")
     child = _ProtocolChildPlayer(child_provider, "ap_child", "Bedroom AirPlay")
-    child._attr_needs_setup = False  # already set up
+    child._attr_needs_setup = False  # already set up: this is an on-demand re-run
+    parent._cache["output_protocols"] = [_child_output_protocol(child)]
+    _set_player_conf(flow_mass, parent)
+    _set_player_conf(flow_mass, child)
+    players = {parent.player_id: parent, child.player_id: child}
+    child_config = PlayerConfig(
+        values={}, provider=child_provider.instance_id, player_id=child.player_id
+    )
+    with (
+        patch.object(
+            flow_mass.players, "get_player", side_effect=lambda pid, *_a, **_k: players.get(pid)
+        ),
+        patch.object(flow_mass.config, "get_player_config", AsyncMock(return_value=child_config)),
+    ):
+        step = await flow_mass.config.setup_player(parent.player_id)
+        assert step.type == FlowStepType.FORM
+        assert step.step_id == "user"
+        assert step.translation_owner == "provider.airplay"
+        finish_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"pin": "1234"})
+    assert finish_step.type == FlowStepType.FINISH
+    assert finish_step.result == {"player_id": child.player_id}
+
+
+async def test_player_setup_without_flow_capable_children_aborts(
+    flow_mass: MusicAssistant,
+) -> None:
+    """A wrapper player whose children offer no flow at all reports nothing to configure."""
+    parent_provider = MockProvider("universal_player", instance_id="universal_player")
+    child_provider = MockProvider("dlna", instance_id="dlna")
+    parent = MockPlayer(parent_provider, "up_parent", "Study")
+    child = MockPlayer(child_provider, "dlna_child", "Study DLNA", player_type=PlayerType.PROTOCOL)
     parent._cache["output_protocols"] = [_child_output_protocol(child)]
     _set_player_conf(flow_mass, parent)
     players = {parent.player_id: parent, child.player_id: child}
@@ -1081,6 +1113,41 @@ async def test_player_setup_reason_in_state_fingerprint() -> None:
     player_state = player.state
     player_state.setup_reason = "pairing_required"
     assert _state_fingerprint(player_state)["setup_reason"] == "pairing_required"
+
+
+async def test_has_setup_flow_serialized_for_own_flow() -> None:
+    """A player implementing its own flow serializes has_setup_flow (regardless of needs_setup)."""
+    provider = MockProvider("sendspin", instance_id="sendspin")
+    plain = MockPlayer(provider, "plain_player", "Plain Player")
+    player = _FlowPlayer(provider, "flow_player", "Flow Player")
+    assert plain.has_setup_flow is False
+    assert player.has_setup_flow is True
+    # not gated on needs_setup: the flow stays re-runnable once setup completed
+    assert player.needs_setup is False
+    player.update_state(force_update=True)
+    assert player.state.has_setup_flow is True
+    assert player.to_dict()["has_setup_flow"] is True
+    # tracked leaf of the fingerprint, so a late-binding protocol child drives an event
+    assert _state_fingerprint(player.state)["has_setup_flow"] is True
+
+
+async def test_has_setup_flow_serialized_for_protocol_child() -> None:
+    """A wrapper player inherits has_setup_flow from a linked protocol child with a flow."""
+    parent_provider = MockProvider("universal_player", instance_id="universal_player")
+    child_provider = MockProvider("airplay", instance_id="airplay")
+    parent = MockPlayer(parent_provider, "up_parent", "Hallway")
+    child = _ProtocolChildPlayer(child_provider, "ap_child", "Hallway AirPlay")
+    child._attr_needs_setup = False  # already set up, but its flow can be re-run
+    players = {parent.player_id: parent, child.player_id: child}
+    # link the child: set_linked_output_protocols survives the update_state cache flush
+    parent.set_linked_output_protocols([_child_output_protocol(child)])
+    with patch.object(
+        parent.mass.players, "get_player", side_effect=lambda pid, *_a, **_k: players.get(pid)
+    ):
+        assert parent.has_setup_flow is True
+        parent.update_state(force_update=True)
+    assert parent.to_dict()["has_setup_flow"] is True
+    assert _state_fingerprint(parent.state)["has_setup_flow"] is True
 
 
 async def test_secure_values_never_echoed_on_step(flow_mass: MusicAssistant) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Models 1.1.171 added `Player.has_setup_flow` and the frontend (2.17.242+) shows a "Reconfigure player" context-menu item when it is truthy — but the server never populated it, so the item stayed invisible. As a result an optional setup step that was dismissed (Apple TV Companion pairing, for example) had no way to be reached again.

- compute `has_setup_flow` on the `Player` base — true when the player implements `run_setup_flow` itself, or when it wraps a linked non-native protocol child that does — and serialize it on the player state
- track it in `_state_fingerprint`, so the flag flipping (a protocol child binding later) actually drives a player update event
- `setup_player` now falls back to protocol children that merely *have* a flow when none of them currently *needs* setup, so the flow is re-runnable on demand; the "Setup required" path keeps its existing preference for children that need setup

**Related issue (if applicable):**

- https://github.com/music-assistant/models/issues/330

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
