### PR TITLE
Align core-module config actions with invoke_action

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -39,7 +39,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 40
+API_SCHEMA_VERSION: Final[int] = 41
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/cache/controller.py
+++ b/music_assistant/controllers/cache/controller.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.background_task import TaskSchedule
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
+from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import ConfigEntryType
 
 from music_assistant.constants import (
@@ -58,28 +58,28 @@ class CacheController(CoreController):
         )
         self.manifest.icon = "memory"
 
-    async def get_config_entries(
-        self,
-        action: str | None = None,
-        values: dict[str, ConfigValueType] | None = None,
-    ) -> tuple[ConfigEntry, ...]:
+    async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return all Config Entries for this core module (if any)."""
-        if action == CONF_CLEAR_CACHE:
-            await self.clear()
-            return (
-                ConfigEntry(
-                    key=CONF_CLEAR_CACHE,
-                    type=ConfigEntryType.LABEL,
-                    # distinct key so the result label doesn't collide with the action's label
-                    translation_key="clear_cache_result",
-                ),
-            )
         return (
             ConfigEntry(
                 key=CONF_CLEAR_CACHE,
                 type=ConfigEntryType.ACTION,
             ),
         )
+
+    async def handle_config_action(self, action: str) -> tuple[ConfigEntry, ...]:
+        """Handle a one-shot action button press and re-render the config entries."""
+        if action == CONF_CLEAR_CACHE:
+            await self.clear()
+            return (
+                *await self.get_config_entries(),
+                # distinct key so the result label doesn't collide with the action's label
+                ConfigEntry(
+                    key="clear_cache_result",
+                    type=ConfigEntryType.LABEL,
+                ),
+            )
+        return await super().handle_config_action(action)
 
     async def setup(self, config: CoreConfig) -> None:
         """Async initialize of cache module."""

--- a/music_assistant/controllers/config/core.py
+++ b/music_assistant/controllers/config/core.py
@@ -137,32 +137,29 @@ class CoreConfigMixin:
         )
 
     @api_command("config/core/get_entries", required_scope=Scope.CONFIG_CORE_READ)
-    async def get_core_config_entries(
-        self,
-        domain: str,
-        action: str | None = None,
-        values: dict[str, ConfigValueType] | None = None,
-    ) -> list[ConfigEntry]:
+    async def get_core_config_entries(self, domain: str) -> list[ConfigEntry]:
         """
         Return Config entries to configure a core controller.
 
-        core_controller: name of the core controller
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+        :param domain: The core controller domain.
         """
         controller: CoreController = getattr(self.mass, domain)
-        all_entries = list(
-            await controller.get_config_entries(action=action, values=values)
-            + DEFAULT_CORE_CONFIG_ENTRIES
+        return await self._resolve_core_config_entries(
+            domain, await controller.get_config_entries()
         )
-        if domain == CONF_PLAYER_QUEUES:
-            # populate the global autoplay playlist dropdown for the UI here (not in get_core_config),
-            # so the config value/parse path stays free of a library lookup
-            playlist_options = await self.mass.config._library_playlist_options()
-            for entry in all_entries:
-                if entry.key == CONF_AUTOPLAY_PLAYLIST:
-                    entry.options = playlist_options
-        return _with_translation_owner(all_entries, f"core.{domain}")
+
+    @api_command("config/core/invoke_action", required_scope=Scope.CONFIG_CORE_WRITE)
+    async def invoke_core_config_action(self, domain: str, action: str) -> list[ConfigEntry]:
+        """
+        Run a one-shot action button from a core module's config and return the entries.
+
+        :param domain: The core controller domain.
+        :param action: The action id of the pressed button.
+        """
+        controller: CoreController = getattr(self.mass, domain)
+        return await self._resolve_core_config_entries(
+            domain, await controller.handle_config_action(action)
+        )
 
     @api_command("config/core/save", required_scope=Scope.CONFIG_CORE_WRITE)
     async def save_core_config(
@@ -243,3 +240,17 @@ class CoreConfigMixin:
         controller = getattr(self.mass, core_module, None)
         if (config := getattr(controller, "config", None)) and (entry := config.values.get(key)):
             entry.value = value
+
+    async def _resolve_core_config_entries(
+        self, domain: str, entries: tuple[ConfigEntry, ...]
+    ) -> list[ConfigEntry]:
+        """Append the server default entries, resolve dynamic options and stamp the owner."""
+        all_entries = list(entries + DEFAULT_CORE_CONFIG_ENTRIES)
+        if domain == CONF_PLAYER_QUEUES:
+            # populate the global autoplay playlist dropdown for the UI here (not in get_core_config),
+            # so the config value/parse path stays free of a library lookup
+            playlist_options = await self.mass.config._library_playlist_options()
+            for entry in all_entries:
+                if entry.key == CONF_AUTOPLAY_PLAYLIST:
+                    entry.options = playlist_options
+        return _with_translation_owner(all_entries, f"core.{domain}")

--- a/music_assistant/controllers/discovery/controller.py
+++ b/music_assistant/controllers/discovery/controller.py
@@ -13,7 +13,7 @@ from ipaddress import IPv4Address
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import ClientTimeout
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
+from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import ConfigEntryType
 from zeroconf import (
     NonUniqueNameException,
@@ -100,13 +100,8 @@ class DiscoveryController(CoreController):
             self._schedule_periodic_ha_announce()
         self._schedule_periodic_upnp_discovery()
 
-    async def get_config_entries(
-        self,
-        action: str | None = None,
-        values: dict[str, ConfigValueType] | None = None,
-    ) -> tuple[ConfigEntry, ...]:
+    async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return config entries for the discovery controller."""
-        del action, values
         return (
             CONF_ENTRY_ZEROCONF_INTERFACES,
             ConfigEntry(

--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -59,7 +59,7 @@ from .images import ImageProxyMixin
 from .radio import RadioArtworkMixin
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ConfigValueType, CoreConfig
+    from music_assistant_models.config_entries import CoreConfig
     from music_assistant_models.media_items import (
         Album,
         Artist,
@@ -114,11 +114,7 @@ class MetaDataController(
         # corrupt metadata rows found by the last scan pass, per table, for diagnostics
         self._corrupt_metadata_rows: dict[str, list[dict[str, str | int]]] = {}
 
-    async def get_config_entries(
-        self,
-        action: str | None = None,
-        values: dict[str, ConfigValueType] | None = None,
-    ) -> tuple[ConfigEntry, ...]:
+    async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return all Config Entries for this core module (if any)."""
         return (
             ConfigEntry(

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -157,13 +157,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             raise RuntimeError("Database not initialized")
         return self._database
 
-    async def get_config_entries(
-        self,
-        action: str | None = None,
-        values: dict[str, ConfigValueType] | None = None,
-    ) -> tuple[ConfigEntry, ...]:
+    async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return all Config Entries for this core module (if any)."""
-        entries: tuple[ConfigEntry, ...] = (
+        return (
             ConfigEntry(
                 key=CONF_RESET_DB,
                 type=ConfigEntryType.ACTION,
@@ -171,20 +167,24 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 advanced=True,
             ),
         )
+
+    async def handle_config_action(self, action: str) -> tuple[ConfigEntry, ...]:
+        """Handle a one-shot action button press and re-render the config entries."""
         if action == CONF_RESET_DB:
             await self._reset_database()
             await self.mass.cache.clear()
             await self.start_sync()
-            entries = (
-                *entries,
+            return (
+                *await self.get_config_entries(),
+                # distinct key so the result label doesn't collide with the action's label
                 ConfigEntry(
-                    key=CONF_RESET_DB,
+                    key="reset_db_result",
                     type=ConfigEntryType.LABEL,
-                    # distinct key so the result label doesn't collide with the action's label
-                    translation_key="reset_db_result",
+                    category="generic",
+                    advanced=True,
                 ),
             )
-        return entries
+        return await super().handle_config_action(action)
 
     async def setup(self, config: CoreConfig) -> None:
         """Async initialize of module."""

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -86,7 +86,6 @@ if TYPE_CHECKING:
     from music_assistant_models.config_entries import (
         ConfigEntry,
         ConfigValueOption,
-        ConfigValueType,
         CoreConfig,
     )
     from music_assistant_models.queue_item import QueueItem
@@ -163,11 +162,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             "total_items": sum(queue.items for queue in queues),
         }
 
-    async def get_config_entries(
-        self,
-        action: str | None = None,
-        values: dict[str, ConfigValueType] | None = None,
-    ) -> tuple[ConfigEntry, ...]:
+    async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return the core-module (global) config entries: the queue-controller defaults."""
         # kept cheap (no library lookup): the config controller populates the global autoplay
         # playlist dropdown for the UI, so this stays fast on the config value/parse path

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -123,7 +123,6 @@ if TYPE_CHECKING:
 
     from music_assistant_models.config_entries import (
         ConfigEntry,
-        ConfigValueType,
         CoreConfig,
         PlayerConfig,
     )
@@ -243,11 +242,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                         del self._task_held_locks[task]
                 lock.release()
 
-    async def get_config_entries(
-        self,
-        action: str | None = None,
-        values: dict[str, ConfigValueType] | None = None,
-    ) -> tuple[ConfigEntry, ...]:
+    async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config Entries for the Player Controller."""
         return ()
 

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -20,7 +20,7 @@ from uuid import uuid4
 from aiofiles.os import wrap
 from aiohttp import web
 from music_assistant_models.audio_processing import AudioQueueProcessing
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import (
     ConfigEntryType,
     ContentType,
@@ -251,9 +251,7 @@ class StreamsController(CoreController):
         """Return whether the queue's effective crossfade mode is smart crossfade."""
         return self.get_crossfade_mode(queue) == CrossfadeMode.SMART_CROSSFADE
 
-    async def get_config_entries(
-        self, action: str | None = None, values: dict[str, ConfigValueType] | None = None
-    ) -> tuple[ConfigEntry, ...]:
+    async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return all Config Entries for this core module (if any)."""
         ip_addresses = await get_ip_addresses(include_ipv6=True)
         return (

--- a/music_assistant/controllers/tasks/controller.py
+++ b/music_assistant/controllers/tasks/controller.py
@@ -64,7 +64,6 @@ from .models import ManagedTask
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import (
         ConfigEntry,
-        ConfigValueType,
         CoreConfig,
     )
 
@@ -100,11 +99,7 @@ class TasksController(CoreController):
             self._log_handler = TaskLogHandler(self.mass, self._append_task_log)
             logging.getLogger().addHandler(self._log_handler)
 
-    async def get_config_entries(
-        self,
-        action: str | None = None,
-        values: dict[str, ConfigValueType] | None = None,
-    ) -> tuple[ConfigEntry, ...]:
+    async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return all Config Entries for this core module (if any)."""
         return (CONF_ENTRY_MAX_CONCURRENT_TASKS,)
 

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -73,7 +73,7 @@ from .sendspin_proxy import SendspinProxyHandler
 from .websocket_client import WebsocketClientHandler
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ConfigValueType, CoreConfig
+    from music_assistant_models.config_entries import CoreConfig
 
     from music_assistant import MusicAssistant
     from music_assistant.helpers.api import APICommandHandler
@@ -163,96 +163,21 @@ class WebserverController(CoreController):
             return self._auto_base_url
         return base_url.removesuffix("/")
 
-    async def get_config_entries(
-        self,
-        action: str | None = None,
-        values: dict[str, ConfigValueType] | None = None,
-    ) -> tuple[ConfigEntry, ...]:
+    async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return all Config Entries for this core module (if any)."""
-        ip_addresses = await get_ip_addresses(include_ipv6=True)
+        return await self._build_config_entries()
 
-        # Handle verify SSL action
-        ssl_verify_result = ""
-        if action == CONF_ACTION_VERIFY_SSL and values:
+    async def handle_config_action(self, action: str) -> tuple[ConfigEntry, ...]:
+        """Handle a one-shot action button press and re-render the config entries."""
+        if action == CONF_ACTION_VERIFY_SSL:
+            # the certificate/key are read from the stored config, so they must be saved
+            # before verifying - the action no longer receives the (unsaved) form values
             cert_info = await verify_ssl_certificate(
-                str(values.get(CONF_SSL_CERTIFICATE, "")),
-                str(values.get(CONF_SSL_PRIVATE_KEY, "")),
+                str(self.get_config_value(CONF_SSL_CERTIFICATE, "")),
+                str(self.get_config_value(CONF_SSL_PRIVATE_KEY, "")),
             )
-            ssl_verify_result = format_certificate_info(cert_info)
-
-        return (
-            ConfigEntry(
-                key=CONF_AUTH_ALLOW_SELF_REGISTRATION,
-                type=ConfigEntryType.BOOLEAN,
-                default_value=True,
-                hidden=not any(provider.domain == "hass" for provider in self.mass.providers),
-                requires_reload=False,
-            ),
-            ConfigEntry(
-                key=CONF_BASE_URL,
-                type=ConfigEntryType.STRING,
-                default_value=CONF_VALUE_AUTO,
-                requires_reload=False,
-            ),
-            ConfigEntry(
-                key=CONF_BIND_PORT,
-                type=ConfigEntryType.INTEGER,
-                default_value=DEFAULT_SERVER_PORT,
-                requires_reload=True,
-            ),
-            ConfigEntry(
-                key="webserver_warn",
-                type=ConfigEntryType.ALERT,
-                required=False,
-                depends_on=CONF_ENABLE_SSL,
-                depends_on_value=False,
-                hidden=bool(values.get(CONF_ENABLE_SSL, False)) if values else False,
-            ),
-            ConfigEntry(
-                key=CONF_ENABLE_SSL,
-                type=ConfigEntryType.BOOLEAN,
-                default_value=False,
-                requires_reload=True,
-            ),
-            ConfigEntry(
-                key=CONF_SSL_CERTIFICATE,
-                type=ConfigEntryType.STRING,
-                required=False,
-                depends_on=CONF_ENABLE_SSL,
-                requires_reload=True,
-            ),
-            ConfigEntry(
-                key=CONF_SSL_PRIVATE_KEY,
-                type=ConfigEntryType.SECURE_STRING,
-                required=False,
-                depends_on=CONF_ENABLE_SSL,
-                requires_reload=True,
-            ),
-            ConfigEntry(
-                key=CONF_ACTION_VERIFY_SSL,
-                type=ConfigEntryType.ACTION,
-                action=CONF_ACTION_VERIFY_SSL,
-                depends_on=CONF_ENABLE_SSL,
-                required=False,
-            ),
-            ConfigEntry(
-                key="ssl_verify_result",
-                type=ConfigEntryType.LABEL,
-                label=ssl_verify_result,
-                hidden=not ssl_verify_result,
-                depends_on=CONF_ENABLE_SSL,
-                required=False,
-            ),
-            ConfigEntry(
-                key=CONF_BIND_IP,
-                type=ConfigEntryType.STRING,
-                default_value="0.0.0.0",
-                options=[ConfigValueOption(x, title=x) for x in {"0.0.0.0", *ip_addresses}],
-                category="generic",
-                advanced=True,
-                requires_reload=True,
-            ),
-        )
+            return await self._build_config_entries(format_certificate_info(cert_info))
+        return await super().handle_config_action(action)
 
     async def setup(self, config: CoreConfig) -> None:  # noqa: PLR0915
         """Async initialize of module."""
@@ -506,6 +431,82 @@ class WebserverController(CoreController):
             async for chunk in preview_stream:
                 await resp.write(chunk)
         return resp
+
+    async def _build_config_entries(self, ssl_verify_result: str = "") -> tuple[ConfigEntry, ...]:
+        """Build this module's config entries, optionally carrying an SSL verify result."""
+        ip_addresses = await get_ip_addresses(include_ipv6=True)
+        return (
+            ConfigEntry(
+                key=CONF_AUTH_ALLOW_SELF_REGISTRATION,
+                type=ConfigEntryType.BOOLEAN,
+                default_value=True,
+                hidden=not any(provider.domain == "hass" for provider in self.mass.providers),
+                requires_reload=False,
+            ),
+            ConfigEntry(
+                key=CONF_BASE_URL,
+                type=ConfigEntryType.STRING,
+                default_value=CONF_VALUE_AUTO,
+                requires_reload=False,
+            ),
+            ConfigEntry(
+                key=CONF_BIND_PORT,
+                type=ConfigEntryType.INTEGER,
+                default_value=DEFAULT_SERVER_PORT,
+                requires_reload=True,
+            ),
+            ConfigEntry(
+                key="webserver_warn",
+                type=ConfigEntryType.ALERT,
+                required=False,
+                depends_on=CONF_ENABLE_SSL,
+                depends_on_value=False,
+            ),
+            ConfigEntry(
+                key=CONF_ENABLE_SSL,
+                type=ConfigEntryType.BOOLEAN,
+                default_value=False,
+                requires_reload=True,
+            ),
+            ConfigEntry(
+                key=CONF_SSL_CERTIFICATE,
+                type=ConfigEntryType.STRING,
+                required=False,
+                depends_on=CONF_ENABLE_SSL,
+                requires_reload=True,
+            ),
+            ConfigEntry(
+                key=CONF_SSL_PRIVATE_KEY,
+                type=ConfigEntryType.SECURE_STRING,
+                required=False,
+                depends_on=CONF_ENABLE_SSL,
+                requires_reload=True,
+            ),
+            ConfigEntry(
+                key=CONF_ACTION_VERIFY_SSL,
+                type=ConfigEntryType.ACTION,
+                action=CONF_ACTION_VERIFY_SSL,
+                depends_on=CONF_ENABLE_SSL,
+                required=False,
+            ),
+            ConfigEntry(
+                key="ssl_verify_result",
+                type=ConfigEntryType.LABEL,
+                label=ssl_verify_result,
+                hidden=not ssl_verify_result,
+                depends_on=CONF_ENABLE_SSL,
+                required=False,
+            ),
+            ConfigEntry(
+                key=CONF_BIND_IP,
+                type=ConfigEntryType.STRING,
+                default_value="0.0.0.0",
+                options=[ConfigValueOption(x, title=x) for x in {"0.0.0.0", *ip_addresses}],
+                category="generic",
+                advanced=True,
+                requires_reload=True,
+            ),
+        )
 
     async def _handle_cors_preflight(self, request: web.Request) -> web.Response:
         """Handle CORS preflight OPTIONS request."""

--- a/music_assistant/models/core_controller.py
+++ b/music_assistant/models/core_controller.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, TypeVar, overload
 
 from music_assistant_models.config_entries import ConfigValueType
 from music_assistant_models.enums import ProviderStage, ProviderType
+from music_assistant_models.errors import ActionUnavailable
 from music_assistant_models.provider import ProviderManifest
 
 from music_assistant.constants import CONF_LOG_LEVEL, MASS_LOGGER_NAME
@@ -54,13 +55,25 @@ class CoreController:
         """Return the "core.<domain>" namespace this module's translation strings resolve under."""
         return f"core.{self.domain}"
 
-    async def get_config_entries(
-        self,
-        action: str | None = None,
-        values: dict[str, ConfigValueType] | None = None,
-    ) -> tuple[ConfigEntry, ...]:
-        """Return all Config Entries for this core module (if any)."""
+    async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
+        """
+        Return all Config Entries for this core module (if any).
+
+        Include ``ConfigEntryType.ACTION`` entries for one-shot buttons and handle
+        their presses in ``handle_config_action``.
+        """
         return ()
+
+    async def handle_config_action(self, action: str) -> tuple[ConfigEntry, ...]:
+        """
+        Handle a one-shot action button press from this module's config and re-render.
+
+        Override to run the side effect for each ``ConfigEntryType.ACTION`` entry this
+        module declares, then return the (possibly refreshed) config entries to display.
+
+        :param action: The action id of the pressed button (an entry's ``action`` key).
+        """
+        raise ActionUnavailable(f"Unknown action: {action}")
 
     @overload
     def get_config_value(

--- a/tests/controllers/config/test_core_invoke_action.py
+++ b/tests/controllers/config/test_core_invoke_action.py
@@ -1,0 +1,44 @@
+"""Tests for the core-module config action contract (config/core/invoke_action)."""
+
+import pytest
+from music_assistant_models.enums import ConfigEntryType
+from music_assistant_models.errors import ActionUnavailable
+
+from music_assistant.controllers.cache.constants import CONF_CLEAR_CACHE
+from music_assistant.mass import MusicAssistant
+
+
+async def test_get_entries_omits_action_results(mass: MusicAssistant) -> None:
+    """The plain options render only exposes the action button, never its result."""
+    entries = await mass.config.get_core_config_entries("cache")
+    by_key = {entry.key: entry for entry in entries}
+    assert by_key[CONF_CLEAR_CACHE].type == ConfigEntryType.ACTION
+    assert "clear_cache_result" not in by_key
+
+
+async def test_invoke_action_runs_side_effect_and_re_renders(mass: MusicAssistant) -> None:
+    """Invoking an action runs it and returns the re-rendered entries with its result."""
+    await mass.cache.set("some_key", "some_value")
+    assert await mass.cache.get("some_key") == "some_value"
+
+    entries = await mass.config.invoke_core_config_action("cache", CONF_CLEAR_CACHE)
+
+    assert await mass.cache.get("some_key") is None
+    by_key = {entry.key: entry for entry in entries}
+    # the action button is still there, alongside the result label
+    assert by_key[CONF_CLEAR_CACHE].type == ConfigEntryType.ACTION
+    assert by_key["clear_cache_result"].type == ConfigEntryType.LABEL
+    # the server default entries are appended for both commands
+    assert "log_level" in by_key
+
+
+async def test_invoke_unknown_action_raises(mass: MusicAssistant) -> None:
+    """An action a core module does not declare is rejected."""
+    with pytest.raises(ActionUnavailable):
+        await mass.config.invoke_core_config_action("cache", "no_such_action")
+
+
+async def test_invoke_action_on_module_without_actions_raises(mass: MusicAssistant) -> None:
+    """A core module that declares no actions at all falls through to the base handler."""
+    with pytest.raises(ActionUnavailable):
+        await mass.config.invoke_core_config_action("streams", "no_such_action")


### PR DESCRIPTION
Core modules now expose their config action buttons through a dedicated `config/core/invoke_action {domain, action}` command, matching the provider/player contract from #5017. `config/core/get_entries` takes only a `domain` and no longer tunnels action/values, and core controllers implement `handle_config_action(action)` alongside `get_config_entries()`.

One behaviour change worth calling out: the webserver's *Verify SSL Certificate* button now reads the certificate and private key from the **stored** config instead of the unsaved form values, so those have to be saved before verifying. The other two actions (clear cache, reset database) never used values.

Companion frontend PR: music-assistant/frontend#2209

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
