### PR TITLE
Fix server hanging on startup

### DIFF
--- a/music_assistant/__main__.py
+++ b/music_assistant/__main__.py
@@ -23,6 +23,7 @@ from music_assistant.constants import MASS_LOGGER_NAME, VERBOSE_LOG_LEVEL
 from music_assistant.helpers.diagnostics import install_diagnostics_log_handler
 from music_assistant.helpers.json import json_loads
 from music_assistant.helpers.logging import activate_log_queue_handler
+from music_assistant.helpers.util import cap_native_thread_pools
 from music_assistant.mass import MusicAssistant
 
 FORMAT_DATE: Final = "%Y-%m-%d"
@@ -239,6 +240,11 @@ def main() -> None:
 
     # setup logger
     logger = setup_logger(data_dir, log_level)
+
+    # Size the native BLAS/OpenMP pools before any provider imports a math library,
+    # because those pools read the environment once at load time.
+    blas_budget = cap_native_thread_pools()
+    LOGGER.debug("Native BLAS/OpenMP thread pools capped to %d thread(s)", blas_budget)
 
     # Raise the open-file soft limit to the hard limit so the concurrent provider
     # imports at startup can't exhaust it (default soft=1024 in HAOS add-on containers).

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -34,7 +34,7 @@ from music_assistant.controllers.streams.audio_buffer import AudioBufferDiscarde
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.datetime import local_clock_time_to_utc, utc_timestamp
 from music_assistant.helpers.json import json_dumps, json_loads
-from music_assistant.helpers.util import is_arm
+from music_assistant.helpers.util import inference_thread_budget, is_arm
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import (
     AudioAnalysisProvider,
@@ -223,9 +223,6 @@ class AudioAnalysisController:
         # per queue (concurrent queues don't evict each other's still-playing analysis).
         self._session_queues: dict[str, str] = {}
         self._inference_runtime_configured = False
-        # Kept alive to persist the process-wide native BLAS thread cap (set in
-        # ensure_inference_runtime_configured); never used as a context manager.
-        self._blas_limiter: object | None = None
         # Bounds how many analysis offloads run concurrently to half the cores; created in
         # ensure_inference_runtime_configured once the core count is known (None until then),
         # and honored by AudioAnalysisProvider._run_offloaded.
@@ -280,10 +277,9 @@ class AudioAnalysisController:
         """
         if self._inference_runtime_configured:
             return
-        # Lazy imports: only torch-backed providers call this, so a host running no such
-        # provider never imports torch/threadpoolctl. Running before the first model load
-        # also lets set_num_interop_threads take effect (only settable before the first op).
-        import threadpoolctl  # noqa: PLC0415
+        # Lazy import: only torch-backed providers call this, so a host running no such
+        # provider never imports torch. Running before the first model load also lets
+        # set_num_interop_threads take effect (only settable before the first op).
         import torch  # noqa: PLC0415
 
         budget = self._aa_thread_budget()
@@ -292,11 +288,9 @@ class AudioAnalysisController:
             # set_num_interop_threads can only be called before the first torch op
             torch.set_num_interop_threads(1)
         # torch.set_num_threads only governs torch's own ops. The per-block librosa/numpy
-        # feature extraction runs through the native BLAS pool (OpenBLAS), which otherwise
-        # spawns a thread per core per worker and, across concurrent sessions, saturates
-        # every core and starves playback. Cap it to the same budget; the limiter is kept
-        # alive on the controller so the cap persists for the process.
-        self._blas_limiter = threadpoolctl.threadpool_limits(limits=budget, user_api="blas")
+        # feature extraction runs through the native BLAS pool (OpenBLAS), which is capped to
+        # the same budget from the environment at process start (cap_native_thread_pools);
+        # it cannot be capped from here without deadlocking against a concurrent import.
         arm = is_arm()
         if arm:
             # NNPACK frequently fails to initialize on ARM SBCs (e.g. Raspberry Pi); torch
@@ -319,11 +313,11 @@ class AudioAnalysisController:
             initializer=_nice_analysis_worker,
         )
         self.logger.info(
-            "AudioAnalysis runtime: torch intra=%d interop=%d, blas<=%d, "
+            "AudioAnalysis runtime: torch intra=%d interop=%d, blas<=%s, "
             "analysis concurrency<=%d (1 while a player streams), nnpack=%s",
             torch.get_num_threads(),
             torch.get_num_interop_threads(),
-            budget,
+            os.environ.get("OPENBLAS_NUM_THREADS", "uncapped"),
             concurrency_cap,
             "off" if arm else "on",
         )
@@ -1523,7 +1517,8 @@ class AudioAnalysisController:
 
     def _aa_thread_budget(self) -> int:
         """Return the per-op PyTorch intra-op thread budget for inference (~25% of cpu_count)."""
-        return max(1, self._cpu_count() // 4)
+        # Shared with the native BLAS cap applied at process start, so torch and BLAS agree.
+        return inference_thread_budget()
 
     def _get_scan_concurrency(self) -> int:
         """Read background scan concurrency from config, clamped to [1, 16]."""

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -265,7 +265,15 @@ def is_arm() -> bool:
 
 
 def inference_thread_budget() -> int:
-    """Return the native thread budget for on-device inference (~25% of the available cores)."""
+    """
+    Return the native thread budget for on-device inference.
+
+    Defaults to ~25% of the available cores, or to an operator-supplied OMP_NUM_THREADS
+    when that is set, so the torch and native pool budgets stay in agreement.
+    """
+    override = os.environ.get("OMP_NUM_THREADS", "")
+    if override.isdigit() and (threads := int(override)) > 0:
+        return threads
     return max(1, (os.process_cpu_count() or os.cpu_count() or 4) // 4)
 
 

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -264,6 +264,38 @@ def is_arm() -> bool:
     return platform.machine().lower() in ("arm64", "aarch64", "armv8l", "armv7l")
 
 
+def inference_thread_budget() -> int:
+    """Return the native thread budget for on-device inference (~25% of the available cores)."""
+    return max(1, (os.process_cpu_count() or os.cpu_count() or 4) // 4)
+
+
+def cap_native_thread_pools() -> int:
+    """
+    Cap the native BLAS/OpenMP thread pools process-wide and return the applied budget.
+
+    Left uncapped, every one of these pools sizes itself to the full core count per worker
+    and, across concurrent analysis sessions, saturates the box and starves playback.
+
+    Must be called before any native math library is loaded, because these pools read their
+    size from the environment once, at library load time. Capping them after the fact means
+    walking the dynamic linker's loaded-library list (what threadpoolctl does), which
+    deadlocks against a concurrent import: the walk holds the loader lock while it needs the
+    GIL back for each callback, and an importing thread holds the GIL while it waits in
+    dlopen() for that same loader lock.
+    """
+    budget = inference_thread_budget()
+    for env_var in (
+        "OMP_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+    ):
+        # setdefault so an operator-supplied value always wins
+        os.environ.setdefault(env_var, str(budget))
+    return budget
+
+
 async def verify_system_meets_requirements(
     *,
     feature_name: str,

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -9,7 +9,8 @@ import os
 import pathlib
 import threading
 from base64 import b64encode
-from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Coroutine
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, Self, TypeGuard, TypeVar, cast, overload
 from uuid import uuid4
 
@@ -102,6 +103,11 @@ LOGGER = logging.getLogger(MASS_LOGGER_NAME)
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 PROVIDERS_PATH = os.path.join(BASE_DIR, "providers")
+PROVIDER_SETUP_TIMEOUT = 30
+# Generous enough for the slowest hosts to load their ML models, but bounded so a wedged
+# provider fails to load instead of holding up startup forever.
+PROVIDER_ASYNC_INIT_TIMEOUT = 300
+PROVIDER_LOAD_CONCURRENCY = 8
 
 _R = TypeVar("_R")
 _ProviderT = TypeVar("_ProviderT", bound=ProviderInstanceType)
@@ -136,6 +142,23 @@ def _provider_error_from_exc(exc: BaseException) -> ProviderError:
             translation_owner=exc.translation_owner,
         )
     return ProviderError(error_code=999, message=message)
+
+
+@asynccontextmanager
+async def _provider_load_step(domain: str, action: str, timeout: int) -> AsyncIterator[None]:
+    """
+    Bound a provider load step, surfacing a timeout as a regular setup failure.
+
+    :param domain: Domain of the provider being loaded, used in the error message.
+    :param action: Verb describing the step, used in the error message.
+    :param timeout: Seconds to allow the step before it is treated as failed.
+    """
+    try:
+        async with asyncio.timeout(timeout):
+            yield
+    except TimeoutError as err:
+        msg = f"Provider {domain} did not {action} within {timeout} seconds"
+        raise SetupFailedError(msg) from err
 
 
 class MusicAssistant:
@@ -1121,14 +1144,15 @@ class MusicAssistant:
                 or not manifest.builtin
             )
         ]
-        # load providers concurrently via tasks
-        async with TaskManager(self, 2) as tg:
+        # load providers concurrently via tasks, bounded so a host with many providers does
+        # not import every provider module at once (a torch-backed one costs hundreds of MB)
+        async with TaskManager(self, PROVIDER_LOAD_CONCURRENCY) as tg:
             for prov_conf in other_configs:
                 # Use a task so we can load multiple providers at once.
                 # If a provider fails, that will not block the loading of other providers.
                 # For providers just auto-set-up as a default, drop the config again if the
                 # host does not meet their requirements (rather than retry a broken provider).
-                tg.create_task(
+                await tg.create_task_with_limit(
                     self.load_provider(
                         prov_conf.instance_id,
                         allow_retry=True,
@@ -1174,12 +1198,8 @@ class MusicAssistant:
 
         # try to setup the module
         prov_mod = await load_provider_module(domain, prov_manifest.requirements)
-        try:
-            async with asyncio.timeout(30):
-                provider = await prov_mod.setup(self, prov_manifest, conf)
-        except TimeoutError as err:
-            msg = f"Provider {domain} did not load within 30 seconds"
-            raise SetupFailedError(msg) from err
+        async with _provider_load_step(domain, "load", PROVIDER_SETUP_TIMEOUT):
+            provider = await prov_mod.setup(self, prov_manifest, conf)
 
         # The instance now exists, so its full (options) config entries can be resolved
         # (get_config_entries is an instance method). Rehydrate the config values from
@@ -1193,7 +1213,8 @@ class MusicAssistant:
             raise SetupFailedError(msg) from err
 
         # run async setup
-        await provider.handle_async_init()
+        async with _provider_load_step(domain, "initialize", PROVIDER_ASYNC_INIT_TIMEOUT):
+            await provider.handle_async_init()
 
         # if we reach this point, the provider loaded successfully
         self._providers[provider.instance_id] = provider

--- a/music_assistant/providers/smart_fades/manifest.json
+++ b/music_assistant/providers/smart_fades/manifest.json
@@ -7,8 +7,7 @@
   "requirements": [
     "beat-this==1.1.0",
     "kaldi-native-fbank==1.22.3",
-    "nnAudio==0.3.3",
-    "threadpoolctl==3.6.0"
+    "nnAudio==0.3.3"
   ],
   "credits": [
     "[Beat This!](https://github.com/CPJKU/beat_this)",

--- a/music_assistant/providers/sonic_analysis/manifest.json
+++ b/music_assistant/providers/sonic_analysis/manifest.json
@@ -8,8 +8,7 @@
     "transformers==5.6.2",
     "huggingface-hub==1.22.0",
     "PyYAML==6.0.3",
-    "torchlibrosa==0.1.0",
-    "threadpoolctl==3.6.0"
+    "torchlibrosa==0.1.0"
   ],
   "credits": [
     "[Microsoft CLAP](https://github.com/microsoft/CLAP)",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -93,7 +93,6 @@ soco==0.31.1
 soundcloudpy==0.1.4
 sounddevice==0.5.5
 sxm==0.2.8
-threadpoolctl==3.6.0
 torch==2.13.0+cpu; sys_platform == 'linux' and platform_machine == 'x86_64'
 torch==2.13.0; sys_platform != 'linux' or platform_machine != 'x86_64'
 torchaudio==2.11.0+cpu; sys_platform == 'linux' and platform_machine == 'x86_64'

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -60,18 +60,16 @@ async def test_distribute_chunk_calls_all_providers() -> None:
 
 
 def test_ensure_inference_runtime_configured_is_idempotent() -> None:
-    """The inference runtime (torch + native BLAS caps) is configured once per controller."""
+    """The inference runtime (torch thread caps) is configured once per controller."""
     controller = _make_controller()
     with (
         patch("torch.set_num_threads") as set_threads,
         patch("torch.set_num_interop_threads"),
-        patch("threadpoolctl.threadpool_limits") as blas_limits,
         patch("torch.backends.nnpack.set_flags"),
     ):
         controller.ensure_inference_runtime_configured()
         controller.ensure_inference_runtime_configured()
     set_threads.assert_called_once()
-    blas_limits.assert_called_once()
     if controller.analysis_executor is not None:
         controller.analysis_executor.shutdown(wait=False)
 
@@ -82,7 +80,6 @@ def test_ensure_inference_runtime_creates_solo_lock_and_executor() -> None:
     with (
         patch("torch.set_num_threads"),
         patch("torch.set_num_interop_threads"),
-        patch("threadpoolctl.threadpool_limits"),
         patch("torch.backends.nnpack.set_flags"),
     ):
         controller.ensure_inference_runtime_configured()
@@ -120,7 +117,6 @@ async def test_analysis_concurrency_capped_at_half_cores(
         ),
         patch("torch.set_num_threads"),
         patch("torch.set_num_interop_threads"),
-        patch("threadpoolctl.threadpool_limits"),
         patch("torch.backends.nnpack.set_flags"),
     ):
         controller.ensure_inference_runtime_configured()

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -722,8 +722,21 @@ def test_is_arm(machine: str, expected: bool) -> None:
 )
 def test_inference_thread_budget(cpu_count: int, expected: int) -> None:
     """The inference thread budget is a quarter of the cores, never below one."""
-    with patch("music_assistant.helpers.util.os.process_cpu_count", return_value=cpu_count):
+    with (
+        patch("music_assistant.helpers.util.os.process_cpu_count", return_value=cpu_count),
+        patch.dict(os.environ, {}, clear=False),
+    ):
+        os.environ.pop("OMP_NUM_THREADS", None)
         assert util.inference_thread_budget() == expected
+
+
+def test_inference_thread_budget_follows_operator_override() -> None:
+    """An operator-supplied OMP_NUM_THREADS becomes the torch budget too, so the two agree."""
+    with (
+        patch("music_assistant.helpers.util.os.process_cpu_count", return_value=32),
+        patch.dict(os.environ, {"OMP_NUM_THREADS": "2"}, clear=False),
+    ):
+        assert util.inference_thread_budget() == 2
 
 
 def test_cap_native_thread_pools_sets_env() -> None:
@@ -747,13 +760,15 @@ def test_cap_native_thread_pools_sets_env() -> None:
 
 
 def test_cap_native_thread_pools_respects_operator_value() -> None:
-    """An operator-supplied thread cap is never overwritten."""
+    """An operator-supplied cap is kept, reported back, and applied to the other pools."""
     with (
         patch("music_assistant.helpers.util.os.process_cpu_count", return_value=8),
         patch.dict(os.environ, {"OMP_NUM_THREADS": "1"}, clear=False),
     ):
-        util.cap_native_thread_pools()
+        os.environ.pop("OPENBLAS_NUM_THREADS", None)
+        assert util.cap_native_thread_pools() == 1
         assert os.environ["OMP_NUM_THREADS"] == "1"
+        assert os.environ["OPENBLAS_NUM_THREADS"] == "1"
 
 
 # 4/8/2 GiB expressed in bytes, for cgroup fixture files.

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -1,5 +1,6 @@
 """Tests for utility/helper functions."""
 
+import os
 import signal
 import subprocess
 import sys
@@ -713,6 +714,46 @@ def test_is_arm(machine: str, expected: bool) -> None:
     """is_arm recognizes 32/64-bit ARM and rejects x86."""
     with patch("music_assistant.helpers.util.platform.machine", return_value=machine):
         assert util.is_arm() is expected
+
+
+@pytest.mark.parametrize(
+    ("cpu_count", "expected"),
+    [(1, 1), (2, 1), (4, 1), (8, 2), (12, 3), (32, 8)],
+)
+def test_inference_thread_budget(cpu_count: int, expected: int) -> None:
+    """The inference thread budget is a quarter of the cores, never below one."""
+    with patch("music_assistant.helpers.util.os.process_cpu_count", return_value=cpu_count):
+        assert util.inference_thread_budget() == expected
+
+
+def test_cap_native_thread_pools_sets_env() -> None:
+    """The native pool caps are published to the environment for load-time pickup."""
+    env_vars = (
+        "OMP_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+    )
+    with (
+        patch("music_assistant.helpers.util.os.process_cpu_count", return_value=8),
+        patch.dict(os.environ, dict.fromkeys(env_vars, ""), clear=False),
+    ):
+        for env_var in env_vars:
+            del os.environ[env_var]
+        assert util.cap_native_thread_pools() == 2
+        for env_var in env_vars:
+            assert os.environ[env_var] == "2"
+
+
+def test_cap_native_thread_pools_respects_operator_value() -> None:
+    """An operator-supplied thread cap is never overwritten."""
+    with (
+        patch("music_assistant.helpers.util.os.process_cpu_count", return_value=8),
+        patch.dict(os.environ, {"OMP_NUM_THREADS": "1"}, clear=False),
+    ):
+        util.cap_native_thread_pools()
+        assert os.environ["OMP_NUM_THREADS"] == "1"
 
 
 # 4/8/2 GiB expressed in bytes, for cgroup fixture files.


### PR DESCRIPTION
# What does this implement/fix?

The server could hang forever while starting up, right after the analysis providers began loading. The web UI stayed unreachable even though the port was open.

The audio analysis providers capped the native BLAS thread pools from the event loop. Doing that means walking the dynamic linker's list of loaded libraries, and if another provider happened to be importing a math library at that same moment, the two blocked on each other and the whole server froze. Recent changes moved provider imports into the concurrent load phase, which made the overlap likely enough to hit on every boot.

The thread caps are now applied from the environment at process start, so the pools are sized when the libraries load and nothing needs adjusting afterwards.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Set the native thread caps (`OMP`/`OPENBLAS`/`MKL`/`NUMEXPR`/`VECLIB`) at process start instead of adjusting them later; an operator-supplied value still wins
- Dropped the `threadpoolctl` dependency, which is no longer used
- Bounded how many providers load at the same time (the existing limit was never actually applied)
- Added a timeout to provider async init, so one stuck provider fails to load instead of blocking startup forever

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
