### PR TITLE
Fix bit-perfect AirPlay playback

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -176,11 +176,14 @@ class CrossfadeData:
 
 
 def _snap_supported_rate_up(target: int, supported_sample_rates: list[int]) -> int:
-    """Snap target up to the lowest supported rate >= target, falling back to max."""
+    """Snap target up, falling back to its highest supported divisor or the maximum."""
     if target in supported_sample_rates:
         return target
     higher = [r for r in supported_sample_rates if r > target]
-    return min(higher) if higher else max(supported_sample_rates)
+    if higher:
+        return min(higher)
+    same_family = [r for r in supported_sample_rates if target % r == 0]
+    return max(same_family) if same_family else max(supported_sample_rates)
 
 
 def _snap_supported_rate_down(target: int, supported_sample_rates: list[int]) -> int:
@@ -1309,7 +1312,7 @@ class StreamsAudio:
             default=min(supported_sample_rates),
         )
         content_type, bit_depth = self._pick_pcm_bit_depth(
-            player,
+            (player,),
             streamdetails,
             crossfade_enabled,
             overlay_active,
@@ -1330,6 +1333,8 @@ class StreamsAudio:
         start_streamdetails: StreamDetails | None = None,
         crossfade_enabled: bool = False,
         overlay_active: bool = False,
+        fallback_sample_rate: int | None = None,
+        output_players: Iterable[Player] | None = None,
     ) -> AudioFormat:
         """
         Select the internal PCM format for a Queue Flow Mode stream.
@@ -1352,12 +1357,31 @@ class StreamsAudio:
             omitted the bit depth defaults to F32.
         :param crossfade_enabled: Whether the queue will use crossfade transitions.
         :param overlay_active: Whether an audio overlay will be mixed into the stream.
+        :param fallback_sample_rate: Preferred rate when the first item format is unknown.
+        :param output_players: All players consuming the shared PCM stream. Their common
+            sample rates and processing requirements determine the session format.
         """
+        players = tuple(output_players) if output_players is not None else (player,)
+        if not players:
+            raise AudioError("At least one output player is required")
+        supported_sample_rates = sorted(
+            set.intersection(
+                *(
+                    {sample_rate for sample_rate, _ in item.get_supported_sample_rates()}
+                    for item in players
+                )
+            )
+        )
+        if not supported_sample_rates:
+            raise AudioError("Output players do not share a supported sample rate")
         if start_streamdetails is not None and (
             start_streamdetails.media_type == MediaType.AUDIO_SOURCE
         ):
-            return self._select_audio_source_pcm_format(player, start_streamdetails)
-        supported_sample_rates = sorted({sr for sr, _ in player.get_supported_sample_rates()})
+            return self._select_audio_source_pcm_format(
+                player,
+                start_streamdetails,
+                supported_sample_rates=supported_sample_rates,
+            )
         flow_mode_conf = cast(
             "str",
             player.config.get_value(CONF_FLOW_MODE_SAMPLE_RATE, FLOW_MODE_SAMPLE_RATE_SMART),
@@ -1378,12 +1402,16 @@ class StreamsAudio:
             target_rate = (
                 start_streamdetails.audio_format.sample_rate
                 if start_streamdetails
-                else max(supported_sample_rates)
+                else (
+                    fallback_sample_rate
+                    if fallback_sample_rate is not None
+                    else max(supported_sample_rates)
+                )
             )
             output_sample_rate = _snap_supported_rate_up(target_rate, supported_sample_rates)
 
         content_type, bit_depth = self._pick_pcm_bit_depth(
-            player, start_streamdetails, crossfade_enabled, overlay_active
+            players, start_streamdetails, crossfade_enabled, overlay_active
         )
         return AudioFormat(
             content_type=content_type,
@@ -3056,7 +3084,7 @@ class StreamsAudio:
 
     def _pick_pcm_bit_depth(
         self,
-        player: Player,
+        players: Iterable[Player],
         streamdetails: StreamDetails | None,
         crossfade_enabled: bool,
         overlay_active: bool = False,
@@ -3077,7 +3105,7 @@ class StreamsAudio:
             crossfade_enabled
             or overlay_active
             or streamdetails.volume_normalization_mode != VolumeNormalizationMode.DISABLED
-            or self._resolve_player_dsp_config(player).enabled
+            or any(self._resolve_player_dsp_config(player).enabled for player in players)
         )
         if needs_headroom:
             return INTERNAL_PCM_FORMAT.content_type, INTERNAL_PCM_FORMAT.bit_depth
@@ -3085,7 +3113,10 @@ class StreamsAudio:
         return ContentType.from_bit_depth(bit_depth), bit_depth
 
     def _select_audio_source_pcm_format(
-        self, player: Player, streamdetails: StreamDetails
+        self,
+        player: Player,
+        streamdetails: StreamDetails,
+        supported_sample_rates: Iterable[int] | None = None,
     ) -> AudioFormat:
         """
         Return a passthrough PCM format for a realtime AudioSource item.
@@ -3098,15 +3129,20 @@ class StreamsAudio:
 
         :param player: The player requesting the stream.
         :param streamdetails: Stream details for the AudioSource item.
+        :param supported_sample_rates: Rates shared by every output player, if applicable.
         """
-        supported_sample_rates = [sr for sr, _ in player.get_supported_sample_rates()]
+        resolved_sample_rates = (
+            list(supported_sample_rates)
+            if supported_sample_rates is not None
+            else [sample_rate for sample_rate, _ in player.get_supported_sample_rates()]
+        )
         source_rate = streamdetails.audio_format.sample_rate
-        if source_rate in supported_sample_rates:
+        if source_rate in resolved_sample_rates:
             output_sample_rate = source_rate
         else:
             output_sample_rate = max(
-                (r for r in supported_sample_rates if r <= source_rate),
-                default=min(supported_sample_rates),
+                (rate for rate in resolved_sample_rates if rate <= source_rate),
+                default=min(resolved_sample_rates),
             )
         bit_depth = streamdetails.audio_format.bit_depth
         return AudioFormat(

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -9,7 +9,7 @@ from typing import Final
 from music_assistant_models.enums import ContentType, PlayerFeature
 from music_assistant_models.media_items import AudioFormat
 
-from music_assistant.constants import CONF_ENTRY_SYNC_ADJUST, INTERNAL_PCM_FORMAT
+from music_assistant.constants import CONF_ENTRY_SYNC_ADJUST
 
 DOMAIN = "airplay"
 
@@ -103,11 +103,6 @@ BACKOFF_TIME_UPPER_LIMIT: Final[int] = 300  # Five minutes
 FALLBACK_VOLUME: Final[int] = 20
 AIRPLAY_VOLUME_MUTE: Final[float] = -144.0
 
-AIRPLAY_FLOW_PCM_FORMAT = AudioFormat(
-    content_type=INTERNAL_PCM_FORMAT.content_type,
-    sample_rate=44100,
-    bit_depth=INTERNAL_PCM_FORMAT.bit_depth,
-)
 AIRPLAY_PCM_FORMAT = AudioFormat(
     content_type=ContentType.from_bit_depth(16), sample_rate=44100, bit_depth=16
 )

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import ipaddress
 import time
+from dataclasses import replace
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
@@ -13,7 +14,9 @@ from music_assistant_models.constants import PLAYER_CONTROL_NATIVE
 from music_assistant_models.enums import (
     ConfigEntryType,
     ContentType,
+    CrossfadeMode,
     IdentifierType,
+    MediaType,
     PlaybackState,
     PlayerFeature,
     PlayerType,
@@ -21,6 +24,7 @@ from music_assistant_models.enums import (
 from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import AudioFormat
 
+from music_assistant.controllers.streams.audio import overlay_active
 from music_assistant.helpers.util import get_primary_ip_address_from_zeroconf, is_valid_mac_address
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
 from music_assistant.models.setup_flow import AbortFlow
@@ -28,7 +32,6 @@ from music_assistant.models.setup_flow import AbortFlow
 from .constants import (
     AIRPLAY_AP2_SETUP_LEAD_MS,
     AIRPLAY_DISCOVERY_TYPE,
-    AIRPLAY_FLOW_PCM_FORMAT,
     AIRPLAY_HIRES_SAMPLE_RATES,
     AIRPLAY_PCM_FORMAT,
     AIRPLAY_RAOP_SETUP_LEAD_MS,
@@ -360,7 +363,7 @@ class AirPlayPlayer(Player):
             self._attr_current_media = media
 
             sync_clients = self._get_sync_clients()
-            session_pcm_format = self._get_session_pcm_format(sync_clients, media)
+            session_pcm_format = await self._get_session_pcm_format(sync_clients, media)
 
             # Warm path: a live, compatible session absorbs the new media via a
             # flush-refill in place (seek/next never pays the reconnect cost).
@@ -921,41 +924,61 @@ class AirPlayPlayer(Player):
         progress = int(metadata.corrected_elapsed_time or 0)
         self.mass.create_task(self.stream.send_metadata(progress, metadata))
 
-    def _get_session_pcm_format(
+    async def _get_session_pcm_format(
         self, sync_clients: list[AirPlayPlayer], media: PlayerMedia
     ) -> AudioFormat:
         """
-        Select the session (flow) PCM format for a new stream session.
+        Select the shared PCM format for a new stream session.
 
         :param sync_clients: All players that will take part in the session.
         :param media: The media that is about to be played.
         """
+        queue = self.mass.player_queues.get(media.source_id) if media.source_id else None
+        queue_item = (
+            self.mass.player_queues.get_item(media.source_id, media.queue_item_id)
+            if media.source_id and media.queue_item_id
+            else None
+        )
+        streamdetails = queue_item.streamdetails if queue_item else None
+        crossfade_enabled = bool(
+            queue
+            and media.media_type == MediaType.TRACK
+            and self.mass.streams.get_crossfade_mode(queue) != CrossfadeMode.DISABLED
+        )
+        pcm_formats = await asyncio.gather(
+            *(
+                self.mass.streams.audio.select_flow_pcm_format(
+                    client,
+                    start_streamdetails=streamdetails,
+                    crossfade_enabled=crossfade_enabled,
+                    overlay_active=bool(queue and overlay_active(queue)),
+                )
+                for client in sync_clients
+            )
+        )
+        pcm_format = next(
+            (
+                candidate
+                for candidate in pcm_formats
+                if candidate.content_type == ContentType.PCM_F32LE
+            ),
+            pcm_formats[0],
+        )
+
         # The session runs at 48 kHz only when every member supports it (hi-res
         # enabled); any 16-bit/44.1 member pins the session to the 44.1 base.
         common_rates = set.intersection(
             *({sample_rate for sample_rate, _ in c.supported_sample_rates} for c in sync_clients)
         )
-        if 48000 not in common_rates:
-            return AIRPLAY_FLOW_PCM_FORMAT
         # Only lift the session to 48 kHz for 48k-family content; 44.1k(-family)
         # content stays at 44.1 to avoid a pointless resample for the common case.
-        content_rate = 0
-        if (
-            media.source_id
-            and media.queue_item_id
-            and (
-                queue_item := self.mass.player_queues.get_item(media.source_id, media.queue_item_id)
-            )
-            and queue_item.streamdetails
-        ):
-            content_rate = queue_item.streamdetails.audio_format.sample_rate
-        if content_rate and content_rate % 48000 == 0:
-            return AudioFormat(
-                content_type=AIRPLAY_FLOW_PCM_FORMAT.content_type,
-                sample_rate=48000,
-                bit_depth=AIRPLAY_FLOW_PCM_FORMAT.bit_depth,
-            )
-        return AIRPLAY_FLOW_PCM_FORMAT
+        content_rate = streamdetails.audio_format.sample_rate if streamdetails else 0
+        sample_rate = (
+            48000
+            if 48000 in common_rates and content_rate and content_rate % 48000 == 0
+            else AIRPLAY_PCM_FORMAT.sample_rate
+        )
+        return replace(pcm_format, sample_rate=sample_rate)
 
     def _get_sync_clients(self) -> list[AirPlayPlayer]:
         """Get all sync clients for a player."""

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -6,7 +6,6 @@ import asyncio
 import contextlib
 import ipaddress
 import time
-from dataclasses import replace
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
@@ -945,40 +944,14 @@ class AirPlayPlayer(Player):
             and media.media_type == MediaType.TRACK
             and self.mass.streams.get_crossfade_mode(queue) != CrossfadeMode.DISABLED
         )
-        pcm_formats = await asyncio.gather(
-            *(
-                self.mass.streams.audio.select_flow_pcm_format(
-                    client,
-                    start_streamdetails=streamdetails,
-                    crossfade_enabled=crossfade_enabled,
-                    overlay_active=bool(queue and overlay_active(queue)),
-                )
-                for client in sync_clients
-            )
+        return await self.mass.streams.audio.select_flow_pcm_format(
+            self,
+            start_streamdetails=streamdetails,
+            crossfade_enabled=crossfade_enabled,
+            overlay_active=bool(queue and overlay_active(queue)),
+            fallback_sample_rate=AIRPLAY_PCM_FORMAT.sample_rate,
+            output_players=sync_clients,
         )
-        pcm_format = next(
-            (
-                candidate
-                for candidate in pcm_formats
-                if candidate.content_type == ContentType.PCM_F32LE
-            ),
-            pcm_formats[0],
-        )
-
-        # The session runs at 48 kHz only when every member supports it (hi-res
-        # enabled); any 16-bit/44.1 member pins the session to the 44.1 base.
-        common_rates = set.intersection(
-            *({sample_rate for sample_rate, _ in c.supported_sample_rates} for c in sync_clients)
-        )
-        # Only lift the session to 48 kHz for 48k-family content; 44.1k(-family)
-        # content stays at 44.1 to avoid a pointless resample for the common case.
-        content_rate = streamdetails.audio_format.sample_rate if streamdetails else 0
-        sample_rate = (
-            48000
-            if 48000 in common_rates and content_rate and content_rate % 48000 == 0
-            else AIRPLAY_PCM_FORMAT.sample_rate
-        )
-        return replace(pcm_format, sample_rate=sample_rate)
 
     def _get_sync_clients(self) -> list[AirPlayPlayer]:
         """Get all sync clients for a player."""

--- a/tests/controllers/streams/test_flow_format.py
+++ b/tests/controllers/streams/test_flow_format.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import ContentType, MediaType, VolumeNormalizationMode
+from music_assistant_models.errors import AudioError
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.constants import (
@@ -31,11 +32,12 @@ from music_assistant.controllers.streams.audio import (
         (48000, [44100, 48000, 96000], 48000),  # exact match
         (50000, [44100, 48000, 96000], 96000),  # snap up to next higher
         (200000, [44100, 48000, 96000], 96000),  # no higher; fall back to max
+        (88200, [44100, 48000], 44100),  # preserve the source sample-rate family
         (40000, [44100, 48000], 44100),  # snap up to lowest higher
     ],
 )
 def test_snap_supported_rate_up(target: int, supported: list[int], expected: int) -> None:
-    """_snap_supported_rate_up picks the lowest supported >= target, else max."""
+    """_snap_supported_rate_up prefers a higher rate, then a source-family divisor."""
     assert _snap_supported_rate_up(target, supported) == expected
 
 
@@ -152,6 +154,90 @@ async def test_select_flow_pcm_format_smart_without_start_format_uses_max() -> N
     )
     fmt = await audio.select_flow_pcm_format(player)
     assert fmt.sample_rate == 96000
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_uses_fallback_rate_without_start_format() -> None:
+    """A caller-provided fallback rate is used when stream details are unavailable."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (48000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    fmt = await audio.select_flow_pcm_format(player, fallback_sample_rate=44100)
+    assert fmt.sample_rate == 44100
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_uses_common_output_rates() -> None:
+    """A shared flow only selects sample rates supported by every output player."""
+    audio = _make_streams_audio()
+    leader = _make_player(
+        supported=[(44100, 24), (48000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    member = _make_player(
+        supported=[(44100, 16)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    streamdetails = _make_streamdetails(sample_rate=48000, bit_depth=24)
+
+    fmt = await audio.select_flow_pcm_format(
+        leader,
+        start_streamdetails=streamdetails,
+        output_players=(leader, member),
+    )
+
+    assert fmt.sample_rate == 44100
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_rejects_outputs_without_common_rate() -> None:
+    """A shared flow requires at least one sample rate supported by every output."""
+    audio = _make_streams_audio()
+    leader = _make_player(
+        supported=[(48000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    member = _make_player(
+        supported=[(44100, 16)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+
+    with pytest.raises(AudioError, match="do not share"):
+        await audio.select_flow_pcm_format(
+            leader,
+            output_players=(leader, member),
+        )
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_uses_headroom_for_any_output_dsp() -> None:
+    """DSP on any shared output requires float headroom for the complete flow."""
+    audio = _make_streams_audio()
+    leader = _make_player(
+        supported=[(44100, 24), (48000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    member = _make_player(
+        supported=[(44100, 24), (48000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    streamdetails = _make_streamdetails(sample_rate=48000, bit_depth=24)
+
+    with patch.object(
+        audio,
+        "_resolve_player_dsp_config",
+        side_effect=(MagicMock(enabled=False), MagicMock(enabled=True)),
+    ):
+        fmt = await audio.select_flow_pcm_format(
+            leader,
+            start_streamdetails=streamdetails,
+            output_players=(leader, member),
+        )
+
+    assert fmt.content_type == ContentType.PCM_F32LE
+    assert fmt.bit_depth == 32
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -6,11 +6,19 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 from music_assistant_models.constants import PLAYER_CONTROL_NATIVE
-from music_assistant_models.enums import ConfigEntryType, ContentType, PlayerFeature
+from music_assistant_models.enums import (
+    ConfigEntryType,
+    ContentType,
+    CrossfadeMode,
+    MediaType,
+    PlayerFeature,
+    VolumeNormalizationMode,
+)
 from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.constants import CONF_SYNC_ADJUST
+from music_assistant.controllers.streams.audio import StreamsAudio
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_PCM_FORMAT,
     CONF_AIRPLAY_CREDENTIALS,
@@ -470,8 +478,18 @@ def test_get_stream_pcm_format_default(airplay_player: AirPlayPlayer) -> None:
     assert airplay_player.get_stream_pcm_format(session_format) == AIRPLAY_PCM_FORMAT
 
 
-def test_session_pcm_format_selection(airplay_player: AirPlayPlayer) -> None:
+@pytest.mark.asyncio
+async def test_session_pcm_format_selection(airplay_player: AirPlayPlayer) -> None:
     """The session runs at 48 kHz only for 48k content when every member supports it."""
+    streams_audio = cast("MagicMock", airplay_player.mass.streams.audio)
+    streams_audio.select_flow_pcm_format = AsyncMock(
+        return_value=AudioFormat(
+            content_type=ContentType.PCM_S24LE,
+            sample_rate=48000,
+            bit_depth=24,
+        )
+    )
+    cast("MagicMock", airplay_player.mass.player_queues.get).return_value = None
     hires_client = MagicMock()
     hires_client.supported_sample_rates = [(44100, 24), (48000, 24)]
     cd_client = MagicMock()
@@ -484,17 +502,63 @@ def test_session_pcm_format_selection(airplay_player: AirPlayPlayer) -> None:
     airplay_player.mass.player_queues.get_item.return_value = queue_item  # type: ignore[attr-defined]
 
     # all members hi-res capable + 48k-family content: session lifts to 48 kHz
-    fmt = airplay_player._get_session_pcm_format([hires_client, hires_client], media)
+    fmt = await airplay_player._get_session_pcm_format([hires_client, hires_client], media)
     assert fmt.sample_rate == 48000
 
     # a 16-bit member pins the session at the 44.1 kHz base
-    fmt = airplay_player._get_session_pcm_format([hires_client, cd_client], media)
+    fmt = await airplay_player._get_session_pcm_format([hires_client, cd_client], media)
     assert fmt.sample_rate == 44100
 
     # 44.1-family content stays at 44.1 kHz even for an all-hi-res group
     queue_item.streamdetails.audio_format.sample_rate = 88200
-    fmt = airplay_player._get_session_pcm_format([hires_client], media)
+    fmt = await airplay_player._get_session_pcm_format([hires_client], media)
     assert fmt.sample_rate == 44100
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("normalization_mode", "expected_content_type", "expected_bit_depth"),
+    [
+        (VolumeNormalizationMode.DISABLED, ContentType.PCM_S24LE, 24),
+        (VolumeNormalizationMode.MEASUREMENT_ONLY, ContentType.PCM_F32LE, 32),
+    ],
+)
+async def test_session_pcm_format_selects_processing_depth(
+    airplay_player: AirPlayPlayer,
+    normalization_mode: VolumeNormalizationMode,
+    expected_content_type: ContentType,
+    expected_bit_depth: int,
+) -> None:
+    """An AirPlay session only uses float PCM when processing needs headroom."""
+    _set_discovery_info(airplay_player, raop=True, airplay=True)
+    _configure_player(airplay_player, {CONF_HIRES_PLAYBACK: True, CONF_FORCE_RAOP: False})
+    airplay_player.mass.streams.audio = StreamsAudio(airplay_player.mass)
+    cast("MagicMock", airplay_player.mass.config.get_player_dsp_config).return_value = MagicMock(
+        enabled=False
+    )
+    cast(
+        "MagicMock", airplay_player.mass.streams.get_crossfade_mode
+    ).return_value = CrossfadeMode.DISABLED
+
+    streamdetails = MagicMock()
+    streamdetails.audio_format = AudioFormat(
+        content_type=ContentType.FLAC,
+        sample_rate=48000,
+        bit_depth=24,
+    )
+    streamdetails.media_type = MediaType.TRACK
+    streamdetails.volume_normalization_mode = normalization_mode
+    queue_item = MagicMock(streamdetails=streamdetails)
+    queue = MagicMock(crossfade_enabled=False, overlay_enabled=False, overlay_source=None)
+    cast("MagicMock", airplay_player.mass.player_queues.get).return_value = queue
+    cast("MagicMock", airplay_player.mass.player_queues.get_item).return_value = queue_item
+    media = MagicMock(source_id="queue1", queue_item_id="item1", media_type=MediaType.TRACK)
+
+    fmt = await airplay_player._get_session_pcm_format([airplay_player], media)
+
+    assert fmt.content_type == expected_content_type
+    assert fmt.sample_rate == 48000
+    assert fmt.bit_depth == expected_bit_depth
 
 
 # --- Volume and Mute tests ---

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -480,39 +480,34 @@ def test_get_stream_pcm_format_default(airplay_player: AirPlayPlayer) -> None:
 
 @pytest.mark.asyncio
 async def test_session_pcm_format_selection(airplay_player: AirPlayPlayer) -> None:
-    """The session runs at 48 kHz only for 48k content when every member supports it."""
-    streams_audio = cast("MagicMock", airplay_player.mass.streams.audio)
-    streams_audio.select_flow_pcm_format = AsyncMock(
-        return_value=AudioFormat(
-            content_type=ContentType.PCM_S24LE,
-            sample_rate=48000,
-            bit_depth=24,
-        )
+    """AirPlay delegates the complete session format decision to the shared selector."""
+    selected_format = AudioFormat(
+        content_type=ContentType.PCM_S24LE,
+        sample_rate=48000,
+        bit_depth=24,
     )
+    streams_audio = cast("MagicMock", airplay_player.mass.streams.audio)
+    streams_audio.select_flow_pcm_format = AsyncMock(return_value=selected_format)
     cast("MagicMock", airplay_player.mass.player_queues.get).return_value = None
-    hires_client = MagicMock()
-    hires_client.supported_sample_rates = [(44100, 24), (48000, 24)]
-    cd_client = MagicMock()
-    cd_client.supported_sample_rates = [(44100, 16)]
     media = MagicMock()
     media.source_id = "queue1"
     media.queue_item_id = "item1"
     queue_item = MagicMock()
     queue_item.streamdetails.audio_format.sample_rate = 48000
     airplay_player.mass.player_queues.get_item.return_value = queue_item  # type: ignore[attr-defined]
+    sync_clients = [airplay_player, airplay_player]
 
-    # all members hi-res capable + 48k-family content: session lifts to 48 kHz
-    fmt = await airplay_player._get_session_pcm_format([hires_client, hires_client], media)
-    assert fmt.sample_rate == 48000
+    fmt = await airplay_player._get_session_pcm_format(sync_clients, media)
 
-    # a 16-bit member pins the session at the 44.1 kHz base
-    fmt = await airplay_player._get_session_pcm_format([hires_client, cd_client], media)
-    assert fmt.sample_rate == 44100
-
-    # 44.1-family content stays at 44.1 kHz even for an all-hi-res group
-    queue_item.streamdetails.audio_format.sample_rate = 88200
-    fmt = await airplay_player._get_session_pcm_format([hires_client], media)
-    assert fmt.sample_rate == 44100
+    assert fmt is selected_format
+    streams_audio.select_flow_pcm_format.assert_awaited_once_with(
+        airplay_player,
+        start_streamdetails=queue_item.streamdetails,
+        crossfade_enabled=False,
+        overlay_active=False,
+        fallback_sample_rate=AIRPLAY_PCM_FORMAT.sample_rate,
+        output_players=sync_clients,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

AirPlay requested 32-bit float PCM even when the input and output formats matched and audio processing was disabled. This prevented playback from being bit-perfect.

- Route AirPlay through the shared PCM format selector.
- Preserve source depth and common group sample rates when no processing is active.
- Keep float headroom for normalization, fades, overlays, and DSP.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.