### PR TITLE
Update players immediately after setup

### DIFF
--- a/music_assistant/controllers/config/flows.py
+++ b/music_assistant/controllers/config/flows.py
@@ -476,7 +476,7 @@ class SetupFlowMixin:
     async def _finish_player_setup(
         self, session: SetupSession, values: dict[str, ConfigValueType]
     ) -> dict[str, str]:
-        """Finish handler for player setup flows: persist setup_data on the player config."""
+        """Finish handler for player setup flows: persist and apply the collected setup data."""
         player_id = session.context.player_id
         assert player_id is not None  # always set for player flows
         conf_key = f"{CONF_PLAYERS}/{player_id}"
@@ -487,13 +487,18 @@ class SetupFlowMixin:
         self.set(f"{conf_key}/setup_data", {**snapshot, **self._encrypt_values(values)})
         try:
             config = await self.get_player_config(player_id)
+            changed_keys = {f"setup_data/{key}" for key in values}
+            await self.mass.players.on_player_config_change(config, changed_keys)
         except asyncio.CancelledError:
             self.set(f"{conf_key}/setup_data", snapshot)
             raise
         except Exception as err:
-            # reading back the just-updated config failed: restore the previous setup_data
+            # reading back or applying the updated config failed: restore the previous setup_data
             self.set(f"{conf_key}/setup_data", snapshot)
-            raise SetupFlowError(str(err) or err.__class__.__name__) from err
+            raise SetupFlowError(
+                str(err) or err.__class__.__name__,
+                translation_key=getattr(err, "translation_key", None),
+            ) from err
         self.mass.signal_event(EventType.PLAYER_CONFIG_UPDATED, object_id=player_id, data=config)
         return {"player_id": player_id}
 

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -78,6 +78,7 @@ async def flow_mass(mass_minimal: MusicAssistant) -> AsyncGenerator[MusicAssista
     )
     mass_minimal.music = MagicMock()
     mass_minimal.players = MagicMock()
+    mass_minimal.players.on_player_config_change = AsyncMock()
     try:
         yield mass_minimal
     finally:
@@ -936,7 +937,7 @@ async def test_player_setup_reaches_unavailable_player(flow_mass: MusicAssistant
 
 
 async def test_player_setup_flow_finish(flow_mass: MusicAssistant) -> None:
-    """A player flow persists (encrypted) setup_data on the player config."""
+    """A player flow persists and applies encrypted setup_data to the active player."""
     events: list[MassEvent] = []
     flow_mass.subscribe(events.append, EventType.PLAYER_CONFIG_UPDATED)
     player_id = "test_player_1"
@@ -958,8 +959,44 @@ async def test_player_setup_flow_finish(flow_mass: MusicAssistant) -> None:
     assert finish_step.result == {"player_id": player_id}
     raw_conf = flow_mass.config.get(f"{CONF_PLAYERS}/{player_id}")
     assert flow_mass.config.decrypt_string(raw_conf["setup_data"]["pin"]) == "1234"
+    cast("AsyncMock", flow_mass.players.on_player_config_change).assert_awaited_once_with(
+        player_config, {"setup_data/pin"}
+    )
     config_event = await _wait_for(lambda: next(iter(events), None))
     assert config_event.object_id == player_id
+
+
+async def test_player_setup_apply_failure_restores_setup_data(
+    flow_mass: MusicAssistant,
+) -> None:
+    """A player setup failure restores the previous setup_data."""
+    player_id = "test_player_1"
+    provider = MockProvider("test_players", instance_id="test_players--1")
+    player = _FlowPlayer(provider, player_id, "Player One")
+    original_setup_data = {"pin": flow_mass.config.encrypt_string("0000")}
+    flow_mass.config.set(
+        f"{CONF_PLAYERS}/{player_id}",
+        {
+            "player_id": player_id,
+            "provider": provider.instance_id,
+            "enabled": True,
+            "setup_data": dict(original_setup_data),
+        },
+    )
+    player_config = PlayerConfig(values={}, provider=provider.instance_id, player_id=player_id)
+    cast("AsyncMock", flow_mass.players.on_player_config_change).side_effect = RuntimeError(
+        "apply failed"
+    )
+    with (
+        patch.object(flow_mass.players, "get_player", return_value=player),
+        patch.object(flow_mass.config, "get_player_config", AsyncMock(return_value=player_config)),
+    ):
+        step = await flow_mass.config.setup_player(player_id)
+        abort_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"pin": "1234"})
+    assert abort_step.type == FlowStepType.ABORT
+    assert abort_step.reason == "apply failed"
+    raw_conf = flow_mass.config.get(f"{CONF_PLAYERS}/{player_id}")
+    assert raw_conf["setup_data"] == original_setup_data
 
 
 class _ProtocolChildPlayer(MockPlayer):

--- a/tests/providers/fully_kiosk/test_setup_flow.py
+++ b/tests/providers/fully_kiosk/test_setup_flow.py
@@ -25,6 +25,7 @@ async def flow_mass(mass_minimal: MusicAssistant) -> AsyncGenerator[MusicAssista
     tests/controllers/config/test_setup_flows.py.
     """
     mass_minimal.players = MagicMock()
+    mass_minimal.players.on_player_config_change = AsyncMock()
     try:
         yield mass_minimal
     finally:

--- a/tests/providers/mpd/test_setup_flow.py
+++ b/tests/providers/mpd/test_setup_flow.py
@@ -26,6 +26,7 @@ async def flow_mass(mass_minimal: MusicAssistant) -> AsyncGenerator[MusicAssista
     tests/controllers/config/test_setup_flows.py.
     """
     mass_minimal.players = MagicMock()
+    mass_minimal.players.on_player_config_change = AsyncMock()
     try:
         yield mass_minimal
     finally:


### PR DESCRIPTION
# What does this implement/fix?

Player setup changes were saved but not applied to the running player, so a player could keep showing “Setup required” until a later refresh.

- Apply completed setup data to the running player immediately.
- Refresh linked player state without waiting for rediscovery.
- Restore the previous setup data if applying it fails.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (Not applicable)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (Not applicable)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (Not applicable)