### PR TITLE
Automatically enable 24-bit AirPlay playback on devices that support it

### DIFF
--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -10,7 +10,7 @@ The AirPlay provider enables Music Assistant to stream audio to AirPlay-enabled 
 - **Pairing**: Supports pairing with Apple devices (Apple TV, HomePod, Mac) using HAP/HomeKit pair-setup (via the cliairplay binary) or legacy RAOP pairing (native)
 - **Multi-Room Audio**: Synchronizes playback across multiple AirPlay devices from a single wall-clock start instant, with a shared PTP clock daemon for native AirPlay 2 timing
 - **Now-Playing Metadata**: Sends title/artist/album/artwork/progress — as DMAP over the stream for speakers, and additionally as MediaRemote over the native AirPlay 2 flow so an Apple TV renders the now-playing screen
-- **Hi-Res Audio**: Optional 24-bit playback (44.1/48 kHz) over the native AirPlay 2 flow (per-player opt-in)
+- **Hi-Res Audio**: 24-bit playback (44.1/48 kHz) over the AirPlay 2 flow, enabled automatically for receivers that advertise 24-bit ALAC
 - **DACP Remote Control**: Receives remote control commands (play/pause/volume/next/previous) from devices while streaming
 - **Late Join Support**: Allows adding players to an existing playback session without interrupting other players
 - **Flow Mode Streaming**: Provides gapless playback and crossfade support by streaming the queue as one continuous audio stream
@@ -92,7 +92,11 @@ airplay/
   - Better compatibility with newer devices
   - More robust protocol
   - Required for some devices that don't support RAOP
-  - 24-bit audio support (native AirPlay 2 flow)
+  - 24-bit audio support (native AirPlay 2 flow), enabled automatically from the
+    formats the receiver advertises in its `/info` response (`supportedAudioFormatsExtended`,
+    else the legacy `supportedFormats`). Both the realtime and buffered stream tables
+    count: receivers understate them, and an Apple TV lists 24-bit for its buffered
+    stream only while rendering it fine on the realtime stream.
 - **Binary**: `cliairplay --protocol airplay2` (native implementation, no OwnTone dependency)
 
 ### Automatic Selection
@@ -234,7 +238,7 @@ The `AirPlayStreamSession` class in [stream_session.py](stream_session.py) manag
 
 2. **Client Setup** (per player, `_start_client()` method)
    - Creates an `AirPlayStream` instance with the player's PCM format
-     (16-bit default, 24-bit s32le when hi-res is enabled)
+     (16-bit default, 24-bit s32le for a 24-bit capable receiver)
    - Starts the CLI process and connects to the receiver without anchoring playback
    - Configures FFmpeg for audio format conversion and optional DSP filters,
      feeding its output into the CLI's persistent stdin
@@ -530,7 +534,6 @@ keeps their exposed player id stable and their Universal Player merging intact.
 ### General
 - **`password`**: Device password if required (RAOP)
 - **`ignore_volume`**: Ignore device volume reports (default: false)
-- **`hires_playback`**: Advanced per-player opt-in for 24-bit playback over native AirPlay 2 (default: off; only shown for AirPlay 2-capable devices - some devices accept 24-bit and play silence, hence opt-in)
 - **`sync_adjust`**: Per-player audio synchronization delay correction in milliseconds (default: 0; negative = play earlier, e.g. to compensate for a TV/AV receiver that adds latency). The playback lead/buffer is handled automatically by the binary.
 
 ### Pairing

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -39,7 +39,6 @@ CONF_ENCRYPTION: Final[str] = "encryption"
 # AirPlay-2-capable receiver whose AirPlay 2 implementation misbehaves.
 CONF_FORCE_RAOP: Final[str] = "force_raop"
 CONF_STORED_VOLUME: Final[str] = "stored_volume"
-CONF_HIRES_PLAYBACK: Final[str] = "hires_playback"
 CONF_COMPANION_CREDENTIALS: Final[str] = "companion_credentials"
 CONF_MRP_CREDENTIALS: Final[str] = "mrp_credentials"
 CONF_NATIVE_MRP_CREDENTIALS: Final[str] = "native_mrp_credentials"
@@ -106,10 +105,17 @@ AIRPLAY_VOLUME_MUTE: Final[float] = -144.0
 AIRPLAY_PCM_FORMAT = AudioFormat(
     content_type=ContentType.from_bit_depth(16), sample_rate=44100, bit_depth=16
 )
-# Sample rates advertised when the per-player hi-res option is enabled (AirPlay 2
-# native flow only). At 24-bit the cliairplay binary expects raw s32le on stdin
-# and truncates to 24-bit ALAC internally.
+# Sample rates advertised for a receiver that supports 24-bit (AirPlay 2 flow
+# only). At 24-bit the cliairplay binary expects raw s32le on stdin and truncates
+# to 24-bit ALAC internally.
 AIRPLAY_HIRES_SAMPLE_RATES: Final[list[tuple[int, int]]] = [(44100, 24), (48000, 24)]
+
+# Bits in the audioFormat bit space (shared with the receiver's /info format
+# tables) that mark 24-bit ALAC: 44.1 kHz and 48 kHz respectively. Receivers
+# understate these - the Apple TV lists them for its buffered stream only, yet
+# renders them fine on the realtime stream - so a device advertising either bit
+# on either stream is treated as 24-bit capable.
+AIRPLAY_HIRES_AUDIO_FORMATS: Final[int] = (1 << 19) | (1 << 21)
 
 BASE_PLAYER_FEATURES: Final[set[PlayerFeature]] = {
     PlayerFeature.PLAY_MEDIA,

--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -135,7 +135,6 @@ class AirPlayControlPlayer(AirPlayPlayer):
         manufacturer: str,
         model: str,
         initial_volume: int,
-        advertised_audio_formats: int = 0,
     ) -> None:
         """Initialize a control-capable AirPlay player."""
         self.companion_discovery_info = companion_discovery_info
@@ -152,7 +151,6 @@ class AirPlayControlPlayer(AirPlayPlayer):
             manufacturer=manufacturer,
             model=model,
             initial_volume=initial_volume,
-            advertised_audio_formats=advertised_audio_formats,
         )
         self._companion_listener: _AirPlayStateListener | None = None
         self._mrp_state_listener: _AirPlayStateListener | None = None

--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -135,6 +135,7 @@ class AirPlayControlPlayer(AirPlayPlayer):
         manufacturer: str,
         model: str,
         initial_volume: int,
+        advertised_audio_formats: int = 0,
     ) -> None:
         """Initialize a control-capable AirPlay player."""
         self.companion_discovery_info = companion_discovery_info
@@ -151,6 +152,7 @@ class AirPlayControlPlayer(AirPlayPlayer):
             manufacturer=manufacturer,
             model=model,
             initial_volume=initial_volume,
+            advertised_audio_formats=advertised_audio_formats,
         )
         self._companion_listener: _AirPlayStateListener | None = None
         self._mrp_state_listener: _AirPlayStateListener | None = None

--- a/music_assistant/providers/airplay/helpers.py
+++ b/music_assistant/providers/airplay/helpers.py
@@ -5,15 +5,17 @@ from __future__ import annotations
 import logging
 import os
 import platform
+import plistlib
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from aiohttp import ClientError, ClientTimeout
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.constants import CONF_ZEROCONF_INTERFACES
 from music_assistant.helpers.process import check_output
-from music_assistant.helpers.util import get_source_ip_for_target
+from music_assistant.helpers.util import format_ip_for_url, get_source_ip_for_target
 
 if TYPE_CHECKING:
     from zeroconf.asyncio import AsyncServiceInfo
@@ -29,6 +31,9 @@ _COMPANION_PAIRING_WITH_PIN = 0x4000
 # of an unsigned download), and a wedged binary would otherwise block provider load or
 # a stream start indefinitely.
 _CLI_BINARY_CHECK_TIMEOUT = 15.0
+# Bound the /info capability probe: it runs in the discovery path, and a receiver
+# that is slow to answer must not hold up player registration.
+_INFO_PROBE_TIMEOUT = 5.0
 
 
 async def resolve_if_ip(mass: MusicAssistant, target_ip: str) -> str:
@@ -252,6 +257,31 @@ def supports_mrp_service(discovery_info: AsyncServiceInfo | None) -> bool:
     return match is None or int(match.group(1)) < 19
 
 
+async def probe_audio_formats(mass: MusicAssistant, host: str, port: int) -> int:
+    """
+    Return the audio formats an AirPlay 2 receiver advertises, as a bitmask.
+
+    Zero when the device is unreachable or publishes no format tables.
+
+    :param mass: The MusicAssistant instance.
+    :param host: Address of the receiver.
+    :param port: Port of the receiver's _airplay._tcp service.
+    """
+    # The tables live in the receiver's /info response, which is served
+    # unauthenticated, so this needs no pairing or credentials.
+    url = f"http://{format_ip_for_url(host)}:{port}/info"
+    try:
+        async with mass.http_session.get(
+            url, timeout=ClientTimeout(total=_INFO_PROBE_TIMEOUT)
+        ) as resp:
+            if resp.status != 200:
+                return 0
+            info = plistlib.loads(await resp.read())
+    except ClientError, TimeoutError, plistlib.InvalidFileException, ValueError:
+        return 0
+    return _parse_format_tables(info) if isinstance(info, dict) else 0
+
+
 async def get_cli_binary() -> str:
     """
     Find the cliairplay binary for the current platform.
@@ -350,6 +380,24 @@ def get_final_output_format(
         bit_depth=audio_format.bit_depth,
         channels=audio_format.channels,
     )
+
+
+def _parse_format_tables(info: dict[str, Any]) -> int:
+    """Return the union of the format tables in a receiver's /info response."""
+    # Each stream advertises its formats either as a list of bit indices in
+    # supportedAudioFormatsExtended, or as a plain mask in the older
+    # supportedFormats. A device can use a different shape per stream.
+    extended = info.get("supportedAudioFormatsExtended")
+    legacy = info.get("supportedFormats")
+    formats = 0
+    for stream in ("audioStream", "bufferStream"):
+        if isinstance(extended, dict) and isinstance(bits := extended.get(stream), list):
+            for bit in bits:
+                if isinstance(bit, int) and 0 <= bit < 64:
+                    formats |= 1 << bit
+        elif isinstance(legacy, dict) and isinstance(mask := legacy.get(stream), int):
+            formats |= mask
+    return formats
 
 
 def _get_cli_binary_name(system: str, machine: str) -> str | None:

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -31,6 +31,7 @@ from music_assistant.models.setup_flow import AbortFlow
 from .constants import (
     AIRPLAY_AP2_SETUP_LEAD_MS,
     AIRPLAY_DISCOVERY_TYPE,
+    AIRPLAY_HIRES_AUDIO_FORMATS,
     AIRPLAY_HIRES_SAMPLE_RATES,
     AIRPLAY_PCM_FORMAT,
     AIRPLAY_RAOP_SETUP_LEAD_MS,
@@ -39,7 +40,6 @@ from .constants import (
     CONF_ENCRYPTION,
     CONF_ENTRY_SYNC_ADJUST_AIRPLAY,
     CONF_FORCE_RAOP,
-    CONF_HIRES_PLAYBACK,
     CONF_IGNORE_VOLUME,
     CONF_PAIRING_PASSWORD,
     CONF_PAIRING_PIN,
@@ -87,10 +87,12 @@ class AirPlayPlayer(Player):
         manufacturer: str,
         model: str,
         initial_volume: int = FALLBACK_VOLUME,
+        advertised_audio_formats: int = 0,
     ) -> None:
         """Initialize AirPlayPlayer."""
         self.raop_discovery_info = raop_discovery_info
         self.airplay_discovery_info = airplay_discovery_info
+        self.advertised_audio_formats = advertised_audio_formats
         super().__init__(provider, player_id)
         self.address = address
         self.stream: AirPlayStream | None = None
@@ -138,12 +140,11 @@ class AirPlayPlayer(Player):
 
     @property
     def hires_playback_enabled(self) -> bool:
-        """Return if 24-bit hi-res playback is enabled (and possible) for this player."""
-        # 24-bit only works over the native AirPlay 2 flow, so the opt-in is
-        # only effective for AirPlay 2 capable devices that are not forced to RAOP.
+        """Return if 24-bit hi-res playback is possible for this player."""
+        # 24-bit only works over the AirPlay 2 flow, so a device that is forced
+        # to RAOP stays on the 16-bit base whatever it advertises.
         return (
-            bool(self.config.get_value(CONF_HIRES_PLAYBACK, False))
-            and self.airplay_discovery_info is not None
+            bool(self.advertised_audio_formats & AIRPLAY_HIRES_AUDIO_FORMATS)
             and self.protocol_override != StreamingProtocol.RAOP
         )
 
@@ -218,10 +219,9 @@ class AirPlayPlayer(Player):
         # interactive setup flow (run_setup_flow) and stored in the player's setup_data.
         base_entries: list[ConfigEntry] = []
 
-        # Effective RAOP state from the current (stored) force-RAOP setting, so the RAOP
-        # device password and the hi-res option show/hide consistently with it.
-        force_raop = self._force_raop_active
-        is_raop = force_raop or not self._is_airplay2_capable
+        # Effective RAOP state from the current (stored) force-RAOP setting, so the
+        # RAOP-only entries show/hide consistently with it.
+        is_raop = self._force_raop_active or not self._is_airplay2_capable
 
         # "Force RAOP" escape hatch: only for AirPlay-2-capable non-Apple receivers
         # (see _force_raop_available). Framed as a per-device workaround for a
@@ -262,16 +262,6 @@ class AirPlayPlayer(Player):
                 key=CONF_IGNORE_VOLUME,
                 type=ConfigEntryType.BOOLEAN,
                 default_value=False,
-                category="protocol_generic",
-                advanced=True,
-            ),
-            ConfigEntry(
-                key=CONF_HIRES_PLAYBACK,
-                type=ConfigEntryType.BOOLEAN,
-                default_value=False,
-                # 24-bit requires the native AirPlay 2 flow, so the option is only
-                # offered for AirPlay 2 capable devices that are not forced to RAOP
-                hidden=not self.airplay_discovery_info or is_raop,
                 category="protocol_generic",
                 advanced=True,
             ),

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -87,12 +87,13 @@ class AirPlayPlayer(Player):
         manufacturer: str,
         model: str,
         initial_volume: int = FALLBACK_VOLUME,
-        advertised_audio_formats: int = 0,
     ) -> None:
         """Initialize AirPlayPlayer."""
         self.raop_discovery_info = raop_discovery_info
         self.airplay_discovery_info = airplay_discovery_info
-        self.advertised_audio_formats = advertised_audio_formats
+        # Audio formats the receiver advertises, learned from its /info response;
+        # zero until that lands (or when the device publishes no format tables).
+        self.advertised_audio_formats = 0
         super().__init__(provider, player_id)
         self.address = address
         self.stream: AirPlayStream | None = None

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -142,11 +142,12 @@ class AirPlayPlayer(Player):
     @property
     def hires_playback_enabled(self) -> bool:
         """Return if 24-bit hi-res playback is possible for this player."""
-        # 24-bit only works over the AirPlay 2 flow, so a device that is forced
-        # to RAOP stays on the 16-bit base whatever it advertises.
+        # 24-bit only works over the AirPlay 2 flow, so a device that streams RAOP
+        # (a legacy receiver, or the force-RAOP escape hatch) stays on the 16-bit
+        # base whatever it advertises.
         return (
             bool(self.advertised_audio_formats & AIRPLAY_HIRES_AUDIO_FORMATS)
-            and self.protocol_override != StreamingProtocol.RAOP
+            and self.protocol == StreamingProtocol.AIRPLAY2
         )
 
     @property

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -52,6 +52,7 @@ from .helpers import (
     get_cli_binary,
     get_model_info,
     is_apple_device,
+    probe_audio_formats,
 )
 from .player import AirPlayPlayer, GenericAirPlayPlayer
 from .sendspin_bridge import SendspinBridgeManager
@@ -407,6 +408,15 @@ class AirPlayProvider(PlayerProvider):
             model,
         )
 
+        # A receiver only publishes its audio formats (and so whether it can do
+        # 24-bit) in its /info response, never in its mDNS records, so ask it
+        # directly. Unreachable devices simply stay on the 16-bit base.
+        advertised_audio_formats = (
+            await probe_audio_formats(self.mass, address, airplay_discovery_info.port)
+            if airplay_discovery_info and airplay_discovery_info.port
+            else 0
+        )
+
         player_addresses = self._get_discovery_addresses(
             airplay_discovery_info,
             raop_discovery_info,
@@ -452,6 +462,7 @@ class AirPlayProvider(PlayerProvider):
                 manufacturer=manufacturer,
                 model=model,
                 initial_volume=volume,
+                advertised_audio_formats=advertised_audio_formats,
             )
         else:
             player = GenericAirPlayPlayer(
@@ -464,6 +475,7 @@ class AirPlayProvider(PlayerProvider):
                 manufacturer=manufacturer,
                 model=model,
                 initial_volume=volume,
+                advertised_audio_formats=advertised_audio_formats,
             )
         await self.mass.players.register(player)
 

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -408,15 +408,6 @@ class AirPlayProvider(PlayerProvider):
             model,
         )
 
-        # A receiver only publishes its audio formats (and so whether it can do
-        # 24-bit) in its /info response, never in its mDNS records, so ask it
-        # directly. Unreachable devices simply stay on the 16-bit base.
-        advertised_audio_formats = (
-            await probe_audio_formats(self.mass, address, airplay_discovery_info.port)
-            if airplay_discovery_info and airplay_discovery_info.port
-            else 0
-        )
-
         player_addresses = self._get_discovery_addresses(
             airplay_discovery_info,
             raop_discovery_info,
@@ -462,7 +453,6 @@ class AirPlayProvider(PlayerProvider):
                 manufacturer=manufacturer,
                 model=model,
                 initial_volume=volume,
-                advertised_audio_formats=advertised_audio_formats,
             )
         else:
             player = GenericAirPlayPlayer(
@@ -475,9 +465,17 @@ class AirPlayProvider(PlayerProvider):
                 manufacturer=manufacturer,
                 model=model,
                 initial_volume=volume,
-                advertised_audio_formats=advertised_audio_formats,
             )
         await self.mass.players.register(player)
+
+        # A receiver only publishes its audio formats (and so whether it can do
+        # 24-bit) in its /info response, never in its mDNS records, so ask it
+        # directly. Off the discovery path: mdns callbacks are serialized per
+        # provider, so an unreachable device must not hold up the next player.
+        if airplay_discovery_info and airplay_discovery_info.port:
+            self.mass.create_task(
+                self._learn_audio_formats(player, address, airplay_discovery_info.port)
+            )
 
         # Set up Sendspin bridge for protocol linking (if Sendspin provider is available)
         await self._bridge_manager.evaluate_bridge(player)
@@ -485,6 +483,11 @@ class AirPlayProvider(PlayerProvider):
         # Track control players (Apple TVs) for dashboard eligibility
         if isinstance(player, AirPlayControlPlayer):
             self.dashboards.setup_player(player)
+
+    async def _learn_audio_formats(self, player: AirPlayPlayer, host: str, port: int) -> None:
+        """Read the audio formats a receiver advertises, so 24-bit can be auto-enabled."""
+        if formats := await probe_audio_formats(self.mass, host, port):
+            player.advertised_audio_formats = formats
 
     async def _is_own_airplay_receiver(
         self, display_name: str, discovery_info: AsyncServiceInfo

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -595,10 +595,13 @@ class AirPlayStream:
         Monitor stdout for the running cliairplay process.
 
         The binary reports its resolved route at startup, the effective lead
-        plus receiver-reported buffering window after connect, and the result
-        of MediaRemote now-playing pushes (Apple devices):
+        plus receiver-reported buffering window after connect, the audio formats
+        the receiver advertises, and the result of MediaRemote now-playing
+        pushes (Apple devices):
           [STATUS] route protocol=<raop|airplay2> flow=<...> timing=<ntp|ptp> buffered=<0|1>
           [STATUS] latency lead_ms=<int> device_min_frames=<int> device_max_frames=<int>
+          [STATUS] capabilities requested=<hex> realtime_formats=<hex> realtime_known=<0|1>
+            buffered_formats=<hex> buffered_known=<0|1>
           [STATUS] mrp path=<command> status=<http status>
           [EVENT] remote command=<play|pause|play_pause|next|previous>
         """
@@ -618,6 +621,8 @@ class AirPlayStream:
                     self._parse_mrp_status(line)
                 elif "[STATUS] latency" in line:
                     self._parse_latency_status(line)
+                elif "[STATUS] capabilities" in line:
+                    self._parse_capabilities_status(line)
                 elif line.startswith("[EVENT] remote command="):
                     self._parse_remote_event(line)
                 self.player.logger.log(VERBOSE_LOG_LEVEL, line)
@@ -644,6 +649,32 @@ class AirPlayStream:
             self.player.display_name,
             fields.get("status", "?"),
         )
+
+    def _parse_capabilities_status(self, line: str) -> None:
+        """Parse the [STATUS] capabilities line and refresh the player's audio formats."""
+        # The binary reports the format tables it read from the receiver's /info,
+        # which corrects a device that was unreachable when it was discovered.
+        # Only the native AirPlay 2 flow reads them; the other routes report
+        # zeroes with the known flags unset. A change applies to the next stream.
+        fields = dict(part.split("=", 1) for part in line.split() if "=" in part)
+        formats = 0
+        for mask_field, known_field in (
+            ("realtime_formats", "realtime_known"),
+            ("buffered_formats", "buffered_known"),
+        ):
+            if fields.get(known_field) != "1":
+                continue
+            try:
+                formats |= int(fields[mask_field], 16)
+            except KeyError, ValueError:
+                continue
+        if formats and formats != self.player.advertised_audio_formats:
+            self.player.logger.debug(
+                "Audio formats advertised by %s changed to 0x%x",
+                self.player.display_name,
+                formats,
+            )
+            self.player.advertised_audio_formats = formats
 
     def _parse_route_status(self, line: str) -> None:
         """Parse the [STATUS] route line and log which route this stream took."""

--- a/music_assistant/providers/airplay/strings.json
+++ b/music_assistant/providers/airplay/strings.json
@@ -16,10 +16,6 @@
       "label": "Ignore volume reports sent by the device itself",
       "description": "The AirPlay protocol allows devices to report their own volume level. \nFor some devices this is not reliable and can cause unexpected volume changes. \nEnable this option to ignore these reports."
     },
-    "hires_playback": {
-      "label": "Enable hi-res (24-bit) playback",
-      "description": "Stream 24-bit audio (44.1/48 kHz) to this device using the native AirPlay 2 flow. \nOnly enable if the device actually renders 24-bit — some devices accept the stream and then play silence. \nKnown to work on Apple TV and HomePod."
-    },
     "sync_adjust": {
       "label": "Audio synchronization delay correction",
       "description": "Shifts when audio is heard on this device relative to the other players in a synced group. \nNegative values make this device play earlier; positive values make it play later. \nUse a negative value when this device is connected to a TV, AV receiver or amplifier that adds a processing delay, which makes it play slightly behind the rest of the group. \nExample: if this device lags the group by about 100 ms, set it to -100 to pull it back into sync."

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -807,8 +807,6 @@
   "provider.airplay.config_entries.encryption.label": "Enable encryption",
   "provider.airplay.config_entries.force_raop.description": "Escape hatch for devices whose AirPlay 2 implementation misbehaves (e.g. dropouts, silence or failed playback). \nWhen enabled, this device is streamed to using the older AirPlay 1 (RAOP) protocol instead of AirPlay 2. \nLeave this off unless this device genuinely works better on RAOP.",
   "provider.airplay.config_entries.force_raop.label": "Force RAOP protocol",
-  "provider.airplay.config_entries.hires_playback.description": "Stream 24-bit audio (44.1/48 kHz) to this device using the native AirPlay 2 flow. \nOnly enable if the device actually renders 24-bit — some devices accept the stream and then play silence. \nKnown to work on Apple TV and HomePod.",
-  "provider.airplay.config_entries.hires_playback.label": "Enable hi-res (24-bit) playback",
   "provider.airplay.config_entries.ignore_volume.description": "The AirPlay protocol allows devices to report their own volume level. \nFor some devices this is not reliable and can cause unexpected volume changes. \nEnable this option to ignore these reports.",
   "provider.airplay.config_entries.ignore_volume.label": "Ignore volume reports sent by the device itself",
   "provider.airplay.config_entries.mrp_pairing_pin.label": "Enter the 4-digit PIN shown on the device",

--- a/tests/providers/airplay/test_helpers.py
+++ b/tests/providers/airplay/test_helpers.py
@@ -1,17 +1,24 @@
 """Unit tests for AirPlay provider helpers."""
 
+import plistlib
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiohttp import ClientError
 
 from music_assistant.providers.airplay.helpers import (
     _CLI_BINARY_CHECK_TIMEOUT,
     get_cli_binary,
     get_decoded_property,
+    probe_audio_formats,
     serialize_txt_records,
     supports_airplay2,
     supports_companion_pairing,
 )
+
+ALAC_44100_24 = 1 << 19
+ALAC_48000_24 = 1 << 21
 
 
 def test_get_decoded_property_matches_case_insensitively() -> None:
@@ -139,3 +146,96 @@ async def test_get_cli_binary_raises_when_check_times_out(monkeypatch: pytest.Mo
 
     with pytest.raises(RuntimeError, match="did not respond to --check"):
         await get_cli_binary()
+
+
+@pytest.mark.parametrize(
+    ("info", "expected_hires"),
+    [
+        # Apple TV: 24-bit listed for the buffered stream only
+        (
+            {
+                "supportedAudioFormatsExtended": {
+                    "audioStream": [11, 18, 22, 24],
+                    "bufferStream": [19, 21, 22, 23],
+                }
+            },
+            True,
+        ),
+        # Sonos: 16-bit only on both streams
+        (
+            {
+                "supportedAudioFormatsExtended": {
+                    "audioStream": [18, 22],
+                    "bufferStream": [18, 22],
+                }
+            },
+            False,
+        ),
+        # Mac: legacy mask for the realtime stream, extended table for the buffered one
+        (
+            {
+                "supportedFormats": {"audioStream": 0x1440800},
+                "supportedAudioFormatsExtended": {"bufferStream": [21, 22, 23]},
+            },
+            True,
+        ),
+        # receivers that publish no format tables at all
+        ({"deviceid": "AA:BB:CC:DD:EE:FF"}, False),
+    ],
+)
+async def test_probe_audio_formats(info: dict[str, Any], expected_hires: bool) -> None:
+    """The advertised formats are read from the union of both /info stream tables."""
+    mass = _mass_serving_info(info)
+
+    formats = await probe_audio_formats(mass, "10.0.0.5", 7000)
+
+    assert bool(formats & (ALAC_44100_24 | ALAC_48000_24)) is expected_hires
+    mass.http_session.get.assert_called_once()
+    assert mass.http_session.get.call_args.args[0] == "http://10.0.0.5:7000/info"
+
+
+async def test_probe_audio_formats_ipv6_address() -> None:
+    """An IPv6 receiver address is bracketed for the request URL."""
+    mass = _mass_serving_info({})
+
+    await probe_audio_formats(mass, "fe80::1", 7000)
+
+    assert mass.http_session.get.call_args.args[0] == "http://[fe80::1]:7000/info"
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        ClientError("unreachable"),
+        TimeoutError,
+        b"not-a-plist",
+        404,
+    ],
+)
+async def test_probe_audio_formats_failures(response: Any) -> None:
+    """An unreachable, slow or nonsensical receiver reports no formats instead of raising."""
+    if isinstance(response, int):
+        mass = _mass_serving_info({}, status=response)
+    elif isinstance(response, bytes):
+        mass = _mass_serving_info({})
+        mass.http_session.get.return_value.__aenter__.return_value.read = AsyncMock(
+            return_value=response
+        )
+    else:
+        mass = MagicMock()
+        mass.http_session.get = MagicMock(side_effect=response)
+
+    assert await probe_audio_formats(mass, "10.0.0.5", 7000) == 0
+
+
+def _mass_serving_info(info: dict[str, Any], status: int = 200) -> MagicMock:
+    """Build a mass mock whose http session serves the given /info plist."""
+    response = MagicMock()
+    response.status = status
+    response.read = AsyncMock(return_value=plistlib.dumps(info, fmt=plistlib.FMT_BINARY))
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=response)
+    context.__aexit__ = AsyncMock(return_value=False)
+    mass = MagicMock()
+    mass.http_session.get = MagicMock(return_value=context)
+    return mass

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -418,28 +418,36 @@ def _configure_player(player: AirPlayPlayer, values: dict[str, object]) -> None:
 
 
 @pytest.mark.parametrize(
-    ("advertised_audio_formats", "force_raop", "expected"),
+    ("advertised_audio_formats", "force_raop", "airplay2_capable", "expected"),
     [
         # 24-bit advertised on the realtime stream
-        (ALAC_44100_24, False, [(44100, 24), (48000, 24)]),
+        (ALAC_44100_24, False, True, [(44100, 24), (48000, 24)]),
         # the Apple TV advertises 24-bit for its buffered stream only
-        (ALAC_48000_24, False, [(44100, 24), (48000, 24)]),
+        (ALAC_48000_24, False, True, [(44100, 24), (48000, 24)]),
         # forced RAOP cannot do 24-bit: falls back to the 16-bit base
-        (ALAC_44100_24, True, [(44100, 16)]),
+        (ALAC_44100_24, True, True, [(44100, 16)]),
+        # a receiver that streams RAOP never gets 24-bit, whatever it advertises
+        (ALAC_44100_24, False, False, [(44100, 16)]),
         # only 16-bit advertised: the 16-bit default
-        (ALAC_44100_16, False, [(44100, 16)]),
+        (ALAC_44100_16, False, True, [(44100, 16)]),
         # nothing advertised (unreachable device or no format tables)
-        (0, False, [(44100, 16)]),
+        (0, False, True, [(44100, 16)]),
     ],
 )
 def test_hires_supported_sample_rates(
     airplay_player: AirPlayPlayer,
     advertised_audio_formats: int,
     force_raop: bool,
+    airplay2_capable: bool,
     expected: list[tuple[int, int]],
 ) -> None:
     """The formats the device advertises drive the advertised sample rates."""
-    _set_discovery_info(airplay_player, raop=True, airplay=True, airplay_features=AP2_FEATURES)
+    _set_discovery_info(
+        airplay_player,
+        raop=True,
+        airplay=True,
+        airplay_features=AP2_FEATURES if airplay2_capable else None,
+    )
     airplay_player.advertised_audio_formats = advertised_audio_formats
     _configure_player(airplay_player, {CONF_FORCE_RAOP: force_raop})
     assert airplay_player.supported_sample_rates == expected
@@ -447,7 +455,7 @@ def test_hires_supported_sample_rates(
 
 def test_get_stream_pcm_format_hires(airplay_player: AirPlayPlayer) -> None:
     """For a 24-bit capable device the stream format is 24-bit in a s32le container."""
-    _set_discovery_info(airplay_player, raop=True, airplay=True)
+    _set_discovery_info(airplay_player, raop=True, airplay=True, airplay_features=AP2_FEATURES)
     airplay_player.advertised_audio_formats = ALAC_44100_24
     _configure_player(airplay_player, {CONF_FORCE_RAOP: False})
 
@@ -526,8 +534,9 @@ async def test_session_pcm_format_selects_processing_depth(
     expected_bit_depth: int,
 ) -> None:
     """An AirPlay session only uses float PCM when processing needs headroom."""
-    _set_discovery_info(airplay_player, raop=True, airplay=True)
-    _configure_player(airplay_player, {CONF_HIRES_PLAYBACK: True, CONF_FORCE_RAOP: False})
+    _set_discovery_info(airplay_player, raop=True, airplay=True, airplay_features=AP2_FEATURES)
+    airplay_player.advertised_audio_formats = ALAC_48000_24
+    _configure_player(airplay_player, {CONF_FORCE_RAOP: False})
     airplay_player.mass.streams.audio = StreamsAudio(airplay_player.mass)
     cast("MagicMock", airplay_player.mass.config.get_player_dsp_config).return_value = MagicMock(
         enabled=False

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -24,7 +24,6 @@ from music_assistant.providers.airplay.constants import (
     CONF_AIRPLAY_CREDENTIALS,
     CONF_ENCRYPTION,
     CONF_FORCE_RAOP,
-    CONF_HIRES_PLAYBACK,
     CONF_IGNORE_VOLUME,
     CONF_RAOP_CREDENTIALS,
     CONF_STORED_VOLUME,
@@ -34,6 +33,10 @@ from music_assistant.providers.airplay.player import AirPlayPlayer
 
 # _airplay._tcp features bitmask with the AirPlay 2 feature bits set (bit 38/48).
 AP2_FEATURES = "0x4A7FDFD5,0x3C177FDE"
+# audioFormat bits as advertised in a receiver's /info format tables.
+ALAC_44100_16 = 1 << 18
+ALAC_44100_24 = 1 << 19
+ALAC_48000_24 = 1 << 21
 
 
 @pytest.fixture
@@ -415,40 +418,38 @@ def _configure_player(player: AirPlayPlayer, values: dict[str, object]) -> None:
 
 
 @pytest.mark.parametrize(
-    ("hires_enabled", "force_raop", "has_airplay_info", "expected"),
+    ("advertised_audio_formats", "force_raop", "expected"),
     [
-        # hi-res on an AirPlay 2 capable device advertises the 24-bit rates
-        (True, False, True, [(44100, 24), (48000, 24)]),
+        # 24-bit advertised on the realtime stream
+        (ALAC_44100_24, False, [(44100, 24), (48000, 24)]),
+        # the Apple TV advertises 24-bit for its buffered stream only
+        (ALAC_48000_24, False, [(44100, 24), (48000, 24)]),
         # forced RAOP cannot do 24-bit: falls back to the 16-bit base
-        (True, True, True, [(44100, 16)]),
-        # no _airplay._tcp service: hi-res not possible
-        (True, False, False, [(44100, 16)]),
-        # option disabled: the 16-bit default
-        (False, False, True, [(44100, 16)]),
+        (ALAC_44100_24, True, [(44100, 16)]),
+        # only 16-bit advertised: the 16-bit default
+        (ALAC_44100_16, False, [(44100, 16)]),
+        # nothing advertised (unreachable device or no format tables)
+        (0, False, [(44100, 16)]),
     ],
 )
 def test_hires_supported_sample_rates(
     airplay_player: AirPlayPlayer,
-    hires_enabled: bool,
+    advertised_audio_formats: int,
     force_raop: bool,
-    has_airplay_info: bool,
     expected: list[tuple[int, int]],
 ) -> None:
-    """The hi-res toggle drives the advertised sample rates (AirPlay 2, not forced to RAOP)."""
-    _set_discovery_info(
-        airplay_player, raop=True, airplay=has_airplay_info, airplay_features=AP2_FEATURES
-    )
-    _configure_player(
-        airplay_player,
-        {CONF_HIRES_PLAYBACK: hires_enabled, CONF_FORCE_RAOP: force_raop},
-    )
+    """The formats the device advertises drive the advertised sample rates."""
+    _set_discovery_info(airplay_player, raop=True, airplay=True, airplay_features=AP2_FEATURES)
+    airplay_player.advertised_audio_formats = advertised_audio_formats
+    _configure_player(airplay_player, {CONF_FORCE_RAOP: force_raop})
     assert airplay_player.supported_sample_rates == expected
 
 
 def test_get_stream_pcm_format_hires(airplay_player: AirPlayPlayer) -> None:
-    """With hi-res enabled the stream format is 24-bit in a s32le container."""
+    """For a 24-bit capable device the stream format is 24-bit in a s32le container."""
     _set_discovery_info(airplay_player, raop=True, airplay=True)
-    _configure_player(airplay_player, {CONF_HIRES_PLAYBACK: True, CONF_FORCE_RAOP: False})
+    airplay_player.advertised_audio_formats = ALAC_44100_24
+    _configure_player(airplay_player, {CONF_FORCE_RAOP: False})
 
     session_format = AudioFormat(
         content_type=ContentType.PCM_F32LE, sample_rate=48000, bit_depth=32
@@ -469,9 +470,9 @@ def test_get_stream_pcm_format_hires(airplay_player: AirPlayPlayer) -> None:
 
 
 def test_get_stream_pcm_format_default(airplay_player: AirPlayPlayer) -> None:
-    """Without hi-res the stream format is the 44.1/16 default."""
+    """Without a 24-bit capable device the stream format is the 44.1/16 default."""
     _set_discovery_info(airplay_player, raop=True, airplay=True)
-    _configure_player(airplay_player, {CONF_HIRES_PLAYBACK: False, CONF_FORCE_RAOP: False})
+    _configure_player(airplay_player, {CONF_FORCE_RAOP: False})
     session_format = AudioFormat(
         content_type=ContentType.PCM_F32LE, sample_rate=48000, bit_depth=32
     )

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -271,6 +271,51 @@ def test_parse_latency_status() -> None:
 
 
 @pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        # both tables published: the union is kept
+        (
+            "[STATUS] capabilities requested=0x80000 realtime_formats=0x40000 "
+            "realtime_known=1 buffered_formats=0x80000 buffered_known=1",
+            0xC0000,
+        ),
+        # the Apple TV publishes 24-bit for its buffered stream only
+        (
+            "[STATUS] capabilities requested=0x80000 realtime_formats=0x1440800 "
+            "realtime_known=1 buffered_formats=0xe80000 buffered_known=1",
+            0x1EC0800,
+        ),
+        # a table the device did not publish is ignored, even when non-zero
+        (
+            "[STATUS] capabilities requested=0x40000 realtime_formats=0x40000 "
+            "realtime_known=1 buffered_formats=0x80000 buffered_known=0",
+            0x40000,
+        ),
+        # RAOP-compat routes report nothing: the probed value survives
+        (
+            "[STATUS] capabilities requested=0x40000 realtime_formats=0x0 "
+            "realtime_known=0 buffered_formats=0x0 buffered_known=0",
+            0x1234,
+        ),
+        # a malformed mask is ignored rather than raising
+        (
+            "[STATUS] capabilities realtime_formats=nonsense realtime_known=1",
+            0x1234,
+        ),
+    ],
+)
+def test_parse_capabilities_status(line: str, expected: int) -> None:
+    """The [STATUS] capabilities line refreshes the formats the player advertises."""
+    player = _make_player()
+    player.advertised_audio_formats = 0x1234
+    stream = AirPlayStream(player)
+
+    stream._parse_capabilities_status(line)
+
+    assert player.advertised_audio_formats == expected
+
+
+@pytest.mark.parametrize(
     ("value", "command"),
     [
         ("play", AirPlayRemoteCommand.PLAY),


### PR DESCRIPTION
# What does this implement/fix?

AirPlay had an advanced per-player setting to enable 24-bit playback, which asked
users to guess something they cannot know: devices that support it just work, and
devices that don't either fall back to 16-bit or play silence. We can simply ask
the device instead.

Every AirPlay 2 receiver publishes the audio formats it accepts in its `/info`
response, which is served without pairing. Music Assistant now reads that at
discovery and enables 24-bit for the devices that advertise it - no setting to
find, and no way to switch it on for a device that will only play silence.

Both of the receiver's format tables count, because devices understate them: an
Apple TV lists 24-bit for its buffered stream only, yet renders it fine on the
stream we actually use.

## Changes

- Removed the `hires_playback` player setting; 24-bit is now decided per device
- Read the advertised formats from the receiver's `/info` response at discovery
- Refresh them from the streaming binary's own report, so a device that was
  asleep when it was discovered corrects itself
- Devices forced to RAOP keep streaming 16-bit as before

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
