### PR TITLE
Fix outdated Home Assistant token help text

### DIFF
--- a/music_assistant/providers/hass/strings.json
+++ b/music_assistant/providers/hass/strings.json
@@ -29,8 +29,7 @@
       "description": "Authenticate to your home assistant instance and generate the long lived token."
     },
     "token": {
-      "label": "Authentication token for HomeAssistant",
-      "description": "You can either paste a Long Lived Token here manually or use the 'authenticate' button to generate a token for you with logging in."
+      "label": "Authentication token for HomeAssistant"
     },
     "verify_ssl": {
       "label": "[%key:common::config_entries::verify_ssl::label%]",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1271,7 +1271,6 @@
   "provider.hass.config_entries.mute_controls.label": "Player Mute Control entities",
   "provider.hass.config_entries.power_controls.description": "Specify which Home Assistant entities you like to import as player Power controls in Music Assistant.",
   "provider.hass.config_entries.power_controls.label": "Player Power Control entities",
-  "provider.hass.config_entries.token.description": "You can either paste a Long Lived Token here manually or use the 'authenticate' button to generate a token for you with logging in.",
   "provider.hass.config_entries.token.label": "Authentication token for HomeAssistant",
   "provider.hass.config_entries.tts_entity.description": "Select which Home Assistant TTS entity you like to use for text-to-speech capabilities inside Music Assistant.",
   "provider.hass.config_entries.tts_entity.label": "Text-to-Speech entity",


### PR DESCRIPTION
## What does this implement/fix?

The Home Assistant token field's help text still referred to an old "authenticate" button that no longer exists in the setup flow, which could confuse users. The setup screen already explains how to get a token, so the outdated field description is removed.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

_Replaces #5047, which GitHub auto-closed when the source branch was renamed to `hass-token-help`._