### PR TITLE
Fix HomePods muting themselves and ignoring volume changes

### DIFF
--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -990,7 +990,12 @@ class AirPlayControlPlayer(AirPlayPlayer):
 
     def _handle_volume_update(self, source: str, volume: float) -> None:
         """Apply a pushed pyatv volume level."""
-        if source == "mrp" and self._companion_device is not None:
+        # MRP volume is ignored when Companion owns volume, and always on a transient
+        # tunnel: that only exposes the speaker's own volume, which Music Assistant
+        # never drives. Worse, a 0 from there latches a mute, and a muted player
+        # skips the stream volume command entirely - so every later volume change
+        # silently stops reaching the device.
+        if source == "mrp" and (self._companion_device is not None or self._uses_transient_mrp):
             return
         # While Music Assistant streams, volume_set drives the stream volume and
         # deliberately leaves the native device volume alone. The two are separate

--- a/tests/providers/airplay/test_control_player.py
+++ b/tests/providers/airplay/test_control_player.py
@@ -349,6 +349,25 @@ def test_native_volume_update_ignored_while_streaming() -> None:
     update_state.assert_not_called()
 
 
+def test_transient_mrp_volume_report_never_latches_mute() -> None:
+    """A transient MRP tunnel never mutes the player or rewrites its volume."""
+    # A muted player skips the stream volume command, so a phantom mute learned while
+    # idle would silently stop every later volume change from reaching the device.
+    player = _make_control_player(model="HomePod Mini", companion_flags="0x62792")
+    assert player._uses_transient_mrp is True
+    player.stream = MagicMock(running=False)
+    player._attr_volume_level = 62
+    player._attr_volume_muted = False
+
+    with patch.object(player, "update_state") as update_state:
+        player._handle_volume_update("mrp", 0)
+
+    assert player.volume_muted is False
+    assert player.volume_level == 62
+    cast("MagicMock", player.mass.config).set_raw_player_config_value.assert_not_called()
+    update_state.assert_not_called()
+
+
 def test_native_volume_update_applies_when_idle() -> None:
     """Native volume reports still drive player state while no stream is running."""
     player = _make_control_player()


### PR DESCRIPTION
# What does this implement/fix?

HomePods could mute themselves shortly after being unmuted, and once that happened, changing their volume appeared to work in the interface but never reached the speaker — so the volume had to be set over and over.

Apple's remote-control channel on a HomePod only exposes the speaker's own volume, which is a separate setting from the volume Music Assistant sends with the stream. Reports from it were still being applied whenever nothing was playing, and a reported volume of zero was taken as "muted". A muted player skips the stream volume command altogether, so that one wrong flag quietly blocked every later volume change. Leaving a group stopped the stream and reconnected the channel, which is what triggered it.

**Related issue (if applicable):**

- follow-up to #5029

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Ignore volume reports coming from a HomePod's remote-control channel, so they can no longer mute the player or overwrite its volume.
- Apple TVs keep their native volume and mute control, which works normally.
- Added a test covering it.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
