### PR TITLE
Fix AirPlay speakers drifting out of sync in a group

### DIFF
--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -711,7 +711,7 @@ class SendspinAirPlayBridge:
         drift_us = round(drift_frames * 1_000_000 / BRIDGE_SAMPLE_RATE)
         if abs(drift_us) > 1_000:
             self.logger.warning(
-                "Realigned a %d µs Sendspin timeline gap for %s",
+                "Realigned %d µs of Sendspin timeline drift for %s",
                 drift_us,
                 self.airplay_player.display_name,
             )

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -173,9 +173,11 @@ class SendspinAirPlayBridge:
         self._bridge_role: BridgePlayerRole | None = None
         self._airplay_stream: AirPlayStream | None = None
         self._is_streaming = False
-        self._next_expected_timestamp_us: int | None = None
+        # Frames handed to the CLI since the start anchor. Byte 0 of that stream is
+        # audible at _drop_until_us and the device plays on at a fixed rate, so this
+        # counter is also the write cursor's position on the Sendspin timeline.
+        self._queued_frames: int = 0
         self._drop_until_us: int = 0
-        self._start_aligned = False
         # Unix-epoch ms at which byte 0 written to the CLI is audible (0 = unset).
         # Used to pace writes so the device buffer stays bounded (see _cli_writer).
         self._start_unix_ms: int = 0
@@ -377,9 +379,8 @@ class SendspinAirPlayBridge:
             )
 
         self._is_streaming = True
-        self._next_expected_timestamp_us = None
+        self._queued_frames = 0
         self._drop_until_us = 0
-        self._start_aligned = False
         self._start_unix_ms = 0
         self._started = keep_stream
 
@@ -414,9 +415,8 @@ class SendspinAirPlayBridge:
 
         self._is_streaming = True
         self._airplay_stream_ready.clear()
-        self._next_expected_timestamp_us = None
+        self._queued_frames = 0
         self._drop_until_us = 0
-        self._start_aligned = False
         self._start_unix_ms = 0
         self._started = keep_stream
         # Drain stale audio data from the previous stream
@@ -590,7 +590,7 @@ class SendspinAirPlayBridge:
         kills the CLI so AirPlay stops instead of draining its buffer.
         """
         self._is_streaming = False
-        self._next_expected_timestamp_us = None
+        self._queued_frames = 0
         self.mass.call_later(
             BRIDGE_WARM_GRACE_SECONDS, self._schedule_cleanup, task_id=self._teardown_timer_id
         )
@@ -679,7 +679,6 @@ class SendspinAirPlayBridge:
             #   * late join     -> the first chunk is the catch-up target, i.e. the
             #     group's current playback position, so the joiner lands in sync.
             self._drop_until_us = chunk.timestamp_us
-            self._start_aligned = False
             self._airplay_stream_start_task = self.mass.create_task(
                 self._start_protocol_from_chunk()
             )
@@ -689,66 +688,47 @@ class SendspinAirPlayBridge:
         if self._drop_until_us and chunk_end_us <= self._drop_until_us:
             return
 
-        # Align the first written chunk so byte 0 of stdin matches the start time.
-        if not self._start_aligned:
-            if self._align_first_chunk(chunk):
-                self._start_aligned = True
-                self._next_expected_timestamp_us = chunk.timestamp_us + chunk.duration_us
-            return
+        self._align_chunk(chunk)
 
-        if self._next_expected_timestamp_us is not None:
-            gap_us = chunk.timestamp_us - self._next_expected_timestamp_us
-            if abs(gap_us) > 1_000:
-                self.logger.warning(
-                    "Unexpected timestamp gap of %d µs for %s",
-                    gap_us,
-                    self.airplay_player.display_name,
-                )
-
-        self._next_expected_timestamp_us = chunk.timestamp_us + chunk.duration_us
-        self._write_queue.put_nowait(chunk.data)
-
-    def _align_first_chunk(self, chunk: AudioChunk) -> bool:
+    def _align_chunk(self, chunk: AudioChunk) -> None:
         """
-        Align the first audio chunk so byte 0 of CLI stdin matches the start time.
+        Queue a chunk at the byte offset its timestamp claims on the CLI stream.
 
-        Inserts silence if the chunk starts after the target time, or trims
-        the beginning if the chunk straddles it.
+        The device plays the stream at a fixed rate from a start anchor that is
+        never revised, so a chunk only stays on the group's clock when it is
+        written at the offset matching its timestamp. A hole in the Sendspin
+        timeline is filled with silence and an overlapping head is trimmed;
+        without that, the device would run permanently ahead of (or behind) the
+        rest of the group by the size of the discontinuity.
 
-        :param chunk: The first audio chunk that overlaps with the start time.
-        :return: True if aligned audio was queued successfully.
+        :param chunk: The audio chunk to queue.
         """
         bytes_per_frame = BRIDGE_CHANNELS * BRIDGE_BYTES_PER_SAMPLE
+        target_frames = round(
+            (chunk.timestamp_us - self._drop_until_us) * BRIDGE_SAMPLE_RATE / 1_000_000
+        )
+        drift_frames = target_frames - self._queued_frames
+        drift_us = round(drift_frames * 1_000_000 / BRIDGE_SAMPLE_RATE)
+        if abs(drift_us) > 1_000:
+            self.logger.warning(
+                "Realigned a %d µs Sendspin timeline gap for %s",
+                drift_us,
+                self.airplay_player.display_name,
+            )
 
-        if chunk.timestamp_us > self._drop_until_us:
-            # Chunk starts after the start time — pad with silence
-            gap_us = chunk.timestamp_us - self._drop_until_us
-            silence_frames = int(gap_us * BRIDGE_SAMPLE_RATE / 1_000_000)
-            if silence_frames > 0:
-                self.logger.debug(
-                    "Inserting %d frames of silence to align start for %s",
-                    silence_frames,
-                    self.airplay_player.display_name,
-                )
-                self._write_queue.put_nowait(b"\x00" * (silence_frames * bytes_per_frame))
-            self._write_queue.put_nowait(chunk.data)
-            return True
-        if chunk.timestamp_us < self._drop_until_us:
-            # Chunk straddles the start time — trim the beginning
-            trim_us = self._drop_until_us - chunk.timestamp_us
-            trim_frames = int(trim_us * BRIDGE_SAMPLE_RATE / 1_000_000)
-            trim_bytes = trim_frames * bytes_per_frame
-            if trim_bytes < len(chunk.data):
-                self.logger.debug(
-                    "Trimming %d frames from first chunk for %s",
-                    trim_frames,
-                    self.airplay_player.display_name,
-                )
-                self._write_queue.put_nowait(chunk.data[trim_bytes:])
-                return True
-            return False
-        self._write_queue.put_nowait(chunk.data)
-        return True
+        data = chunk.data
+        if drift_frames < 0:
+            trim_bytes = -drift_frames * bytes_per_frame
+            if trim_bytes >= len(data):
+                # Fully covered by what was already written.
+                return
+            data = data[trim_bytes:]
+        elif drift_frames > 0:
+            self._write_queue.put_nowait(b"\x00" * (drift_frames * bytes_per_frame))
+            self._queued_frames += drift_frames
+
+        self._write_queue.put_nowait(data)
+        self._queued_frames += len(data) // bytes_per_frame
 
     async def _cli_writer(self) -> None:
         """
@@ -816,7 +796,7 @@ class SendspinAirPlayBridge:
     async def _stop_streaming(self) -> None:
         """Stop streaming (internal, called with lock held)."""
         self._is_streaming = False
-        self._next_expected_timestamp_us = None
+        self._queued_frames = 0
         self._airplay_stream_ready.clear()
         self._started = False
         if self._airplay_stream_start_task:

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -1,13 +1,16 @@
 """
 Unit tests for the Sendspin -> AirPlay bridge timing.
 
-Cover four things, with the Sendspin clock mocked via ``ManualClock`` so the
+Cover five things, with the Sendspin clock mocked via ``ManualClock`` so the
 tests are deterministic and independent of the host wall-clock:
 
 * the clock-domain conversion turning a Sendspin audible instant (Sendspin's own
   monotonic clock) into the unix epoch ms used by the START command;
 * the start anchor: byte 0 is anchored to the first chunk Sendspin delivers, so a
   fresh track keeps position 0 and a late joiner lands at the group's live position;
+* the timeline alignment that keeps every chunk at the byte offset its timestamp
+  claims, so a discontinuity in the Sendspin timeline does not shift the device
+  off the group's clock for the rest of the stream;
 * the write pacing that keeps the device buffered a bounded amount ahead of real
   time so a late-join catch-up backlog is not dumped into the CLI;
 * the warm handover: a running, connected stream is kept (not torn down) across
@@ -17,6 +20,7 @@ tests are deterministic and independent of the host wall-clock:
 """
 
 import asyncio
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -203,7 +207,6 @@ def test_fresh_start_anchors_to_first_chunk_and_keeps_intro() -> None:
         bridge._on_audio_chunk(_pcm_chunk(first_chunk_ts))
 
     assert bridge._drop_until_us == first_chunk_ts
-    assert bridge._start_aligned is True
     assert not bridge._write_queue.empty()  # opening audio queued, not discarded
 
 
@@ -225,6 +228,126 @@ def test_late_join_anchors_to_catchup_target_live_position() -> None:
     assert bridge._drop_until_us == catchup_target_ts
     # The anchor tracks the advanced playhead, not a fresh now+wait_start-from-zero.
     assert bridge._drop_until_us > SENDSPIN_EPOCH_US + AP2_LEAD_MS * 1_000
+
+
+# --- Timeline alignment: a discontinuity must not shift the device off the group clock ---
+
+
+def _drain_queued_bytes(bridge: SendspinAirPlayBridge) -> int:
+    """Return the number of audio bytes handed to the CLI writer, emptying the queue."""
+    total = 0
+    while not bridge._write_queue.empty():
+        data = bridge._write_queue.get_nowait()
+        if data is not None:
+            total += len(data)
+    return total
+
+
+def _start_stream_at(bridge: SendspinAirPlayBridge, first_chunk_ts: int) -> None:
+    """Feed the anchoring first chunk so the bridge is aligned and streaming."""
+    with patch.object(bridge, "_start_protocol_from_chunk", MagicMock()):
+        bridge._on_audio_chunk(_pcm_chunk(first_chunk_ts))
+    # The mocked task reports done() truthy by default, which the chunk handler
+    # reads as a failed protocol start; model a start still in flight instead.
+    cast("MagicMock", bridge._airplay_stream_start_task).done.return_value = False
+
+
+def _expected_frames(bridge: SendspinAirPlayBridge, timeline_end_us: int) -> int:
+    """Frames the CLI stream must hold for its cursor to sit at a timeline instant."""
+    return round((timeline_end_us - bridge._drop_until_us) * BRIDGE_SAMPLE_RATE / 1_000_000)
+
+
+def test_timeline_gap_is_padded_with_silence() -> None:
+    """
+    A hole in the Sendspin timeline is filled so the device stays on the group clock.
+
+    Sendspin rebases the shared timeline forward when audio production stalls,
+    delivering no audio for the skipped span. The CLI plays its byte stream at a
+    fixed rate from an anchor that is never revised, so writing the next chunk
+    straight after the previous one would leave this device permanently ahead of
+    the group by the size of the hole.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    first_ts = SENDSPIN_EPOCH_US + 250_000
+    _start_stream_at(bridge, first_ts)
+    _drain_queued_bytes(bridge)
+
+    gap_us = 415_711
+    next_ts = first_ts + 100_000 + gap_us
+    bridge._on_audio_chunk(_pcm_chunk(next_ts))
+
+    expected = _expected_frames(bridge, next_ts + 100_000)
+    assert bridge._queued_frames == expected
+    assert (
+        _drain_queued_bytes(bridge)
+        == (expected - _expected_frames(bridge, first_ts + 100_000))
+        * BRIDGE_CHANNELS
+        * BRIDGE_BYTES_PER_SAMPLE
+    )
+
+
+def test_overlapping_chunk_head_is_trimmed() -> None:
+    """A chunk reaching back behind the write cursor keeps only its unwritten tail."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    first_ts = SENDSPIN_EPOCH_US + 250_000
+    _start_stream_at(bridge, first_ts)
+    _drain_queued_bytes(bridge)
+
+    overlap_us = 40_000
+    next_ts = first_ts + 100_000 - overlap_us
+    bridge._on_audio_chunk(_pcm_chunk(next_ts))
+
+    assert bridge._queued_frames == _expected_frames(bridge, next_ts + 100_000)
+
+
+def test_chunk_entirely_behind_the_cursor_is_dropped() -> None:
+    """Audio already written is not queued a second time."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    first_ts = SENDSPIN_EPOCH_US + 250_000
+    _start_stream_at(bridge, first_ts)
+    _drain_queued_bytes(bridge)
+    cursor_frames = bridge._queued_frames
+
+    bridge._on_audio_chunk(_pcm_chunk(first_ts + 10_000, duration_us=50_000))
+
+    assert bridge._queued_frames == cursor_frames
+    assert _drain_queued_bytes(bridge) == 0
+
+
+@pytest.mark.parametrize("server_side", [False, True])
+def test_stream_start_resets_the_write_cursor(server_side: bool) -> None:
+    """
+    Both stream-start entry points rewind the cursor so the next chunk re-anchors byte 0.
+
+    A cursor carried over from the previous stream would place the first chunk of
+    the new one far behind the write position and get it trimmed away as already
+    written.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    _start_stream_at(bridge, SENDSPIN_EPOCH_US + 250_000)
+    assert bridge._queued_frames > 0
+
+    if server_side:
+        bridge._on_stream_start(MagicMock())
+    else:
+        bridge._on_bridge_stream_start()
+
+    assert bridge._queued_frames == 0
+    assert bridge._drop_until_us == 0
+
+
+def test_contiguous_chunks_are_written_untouched() -> None:
+    """Normal playback queues exactly its own audio -- no padding, no trimming."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    first_ts = SENDSPIN_EPOCH_US + 250_000
+    _start_stream_at(bridge, first_ts)
+    _drain_queued_bytes(bridge)
+
+    for index in range(1, 20):
+        bridge._on_audio_chunk(_pcm_chunk(first_ts + index * 100_000))
+
+    assert bridge._queued_frames == _expected_frames(bridge, first_ts + 20 * 100_000)
+    assert _drain_queued_bytes(bridge) == 19 * 100_000 * BRIDGE_BYTES_PER_SECOND // 1_000_000
 
 
 # --- Write pacing: bound the device buffer so a catch-up backlog is not dumped ---


### PR DESCRIPTION
# What does this implement/fix?

When Sendspin briefly skips ahead in its shared timeline (it does this whenever audio production stalls for a moment), the AirPlay bridge kept writing audio back to back. The speaker plays its stream at a fixed speed from a start point that is never adjusted afterwards, so every skipped moment left that speaker permanently ahead of the rest of the group and it only recovered on the next track. Reported gaps ranged from 0.4 to 1.2 seconds, which is very audible between rooms.

The bridge already handled this correctly for the first chunk of a stream; it now does so for every chunk.

- Put every audio chunk at the position its timestamp asks for: fill a gap with silence, trim audio that was already written
- Reset the write position on both stream-start paths, so a new track always re-anchors from the beginning
- Log the correction instead of only reporting the gap
- Add tests for gaps, overlaps, repeated audio and normal playback

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
