### PR TITLE
Fix providers that could no longer be added

### DIFF
--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -59,6 +59,9 @@ LEGACY_BOSE_PRESET_KEY_PREFIX = "preset_"
 # - hass "url"/"token"/"verify_ssl": on a Home Assistant add-on these come from fixed
 #   (hidden) config entries whose values equal what a stored copy would hold, so moving a
 #   stored copy is a harmless no-op there while restoring normal installs.
+# - plex_connect's "plex_provider_id"/"mass_player_id" are not secrets, but its setup flow
+#   collects them (the options are only known from live server state), so they live in
+#   setup_data like any other flow-collected value.
 # - spotify is deliberately absent: its own _migrate_legacy_token still reads the legacy
 #   "refresh_token" and "client_id" from `values`, so this migration must not move them.
 # TODO: remove after 2.13 release
@@ -105,6 +108,7 @@ PROVIDER_SETUP_FLOW_KEYS: dict[str, tuple[str, ...]] = {
     "hue_entertainment": ("bridge_host", "hue_username", "hue_clientkey", "bridge_id"),
     "ibroadcast": ("username", "password"),
     "jellyfin": ("url", "username", "password", "verify_ssl"),
+    "kion_music": ("token",),
     "lastfm_scrobble": ("_provider", "_api_session_key", "_username", "_api_key", "_api_secret"),
     "listenbrainz_scrobble": ("_user_token", "api_base_url"),
     "musicme": ("username", "password"),
@@ -112,6 +116,7 @@ PROVIDER_SETUP_FLOW_KEYS: dict[str, tuple[str, ...]] = {
     "nicovideo": ("mail", "password", "user_session"),
     "nugs": ("username", "password"),
     "opensubsonic": ("username", "password", "baseURL", "port", "path"),
+    "pandora": ("username", "password"),
     "plex": (
         "token",
         "local_server_ip",
@@ -121,6 +126,7 @@ PROVIDER_SETUP_FLOW_KEYS: dict[str, tuple[str, ...]] = {
         "library_id",
         "library_type",
     ),
+    "plex_connect": ("plex_provider_id", "mass_player_id"),
     "pocketcasts": ("username", "password"),
     "podcast_index": ("api_key", "api_secret"),
     "podcastfeed": ("feed_url",),
@@ -153,6 +159,7 @@ PROVIDER_SETUP_FLOW_KEYS: dict[str, tuple[str, ...]] = {
     "yandex_ynison": ("ym_instance", "token", "x_token"),
     "yousee": ("username", "password"),
     "ytmusic": ("username", "cookie", "po_token_server_url"),
+    "zvuk_music": ("token",),
 }
 
 

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -1209,7 +1209,9 @@ class MusicAssistant:
         try:
             provider.config.validate()
         except (KeyError, ValueError, AttributeError, TypeError) as err:
-            msg = "Configuration is invalid"
+            # name the offending entry: the generic message alone gives no clue which
+            # value is missing or malformed when a provider refuses to load
+            msg = f"Configuration is invalid: {err}"
             raise SetupFailedError(msg) from err
 
         # run async setup

--- a/music_assistant/providers/hass_players/provider.py
+++ b/music_assistant/providers/hass_players/provider.py
@@ -92,6 +92,9 @@ class HomeAssistantPlayerProvider(PlayerProvider):
                 type=ConfigEntryType.STRING,
                 multi_value=True,
                 required=True,
+                # the provider is added before any entity can be picked, so it starts out
+                # with an empty selection and the players are chosen in its options
+                default_value=[],
                 options=player_entities,
             ),
         )

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -63,6 +63,9 @@ CONF_LOCALE = "locale"
 CONF_EXPLICIT = "explicit"
 CONF_NUM_EPISODES = "num_episodes"
 
+# store to search when the server's language has no matching iTunes storefront
+DEFAULT_LOCALE = "us"
+
 CACHE_CATEGORY_PODCASTS = 0
 CACHE_CATEGORY_RECOMMENDATIONS = 1
 CACHE_KEY_TOP_PODCASTS = "top-podcasts"
@@ -106,6 +109,9 @@ class ITunesPodcastsProvider(MusicProvider):
         language_options = [
             ConfigValueOption(key.lower(), title=val) for key, val in country_codes.items()
         ]
+        # the store country decides which catalog is searched; default to the region of the
+        # server's language so the provider can be added without picking one first
+        region = self.mass.metadata.locale.split("_")[-1].upper()
         return (
             CONF_ENTRY_LIBRARY_SYNC_PODCASTS_HIDDEN,
             ConfigEntry(
@@ -113,6 +119,7 @@ class ITunesPodcastsProvider(MusicProvider):
                 type=ConfigEntryType.STRING,
                 required=True,
                 options=language_options,
+                default_value=region.lower() if region in country_codes else DEFAULT_LOCALE,
             ),
             ConfigEntry(
                 key=CONF_NUM_EPISODES,

--- a/music_assistant/providers/kion_music/constants.py
+++ b/music_assistant/providers/kion_music/constants.py
@@ -9,14 +9,6 @@ CONF_TOKEN = "token"
 CONF_QUALITY = "quality"
 CONF_BASE_URL = "base_url"
 
-# Actions
-CONF_ACTION_AUTH = "auth"
-CONF_ACTION_CLEAR_AUTH = "clear_auth"
-
-# Labels
-LABEL_TOKEN = "token_label"
-LABEL_AUTH_INSTRUCTIONS = "auth_instructions_label"
-
 # API defaults
 DEFAULT_LIMIT: Final[int] = 50
 DEFAULT_BASE_URL: Final[str] = "https://api.music.yandex.net"

--- a/music_assistant/providers/kion_music/provider.py
+++ b/music_assistant/providers/kion_music/provider.py
@@ -43,7 +43,6 @@ from .api_client import KionMusicClient
 from .constants import (
     BROWSE_INITIAL_TRACKS,
     COLLECTION_FOLDER_ID,
-    CONF_ACTION_CLEAR_AUTH,
     CONF_BASE_URL,
     CONF_CODECS,
     CONF_LIKED_TRACKS_MAX_TRACKS,
@@ -296,23 +295,14 @@ class KionMusicProvider(MusicProvider):
         return folder.items
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
-        """Return Config entries to configure this provider."""
-        is_authenticated = bool(self.get_config_value(CONF_TOKEN))
+        """
+        Return Config entries to configure this provider.
+
+        The token is collected by the interactive setup flow (see setup_flow.py); this
+        surface only exposes the genuine playback options.
+        """
         return (
             CONF_ENTRY_UNOFFICIAL_PROVIDER,
-            # Authentication
-            ConfigEntry(
-                key=CONF_TOKEN,
-                type=ConfigEntryType.SECURE_STRING,
-                required=True,
-                hidden=is_authenticated,
-            ),
-            ConfigEntry(
-                key=CONF_ACTION_CLEAR_AUTH,
-                type=ConfigEntryType.ACTION,
-                action=CONF_ACTION_CLEAR_AUTH,
-                hidden=not is_authenticated,
-            ),
             # Quality
             ConfigEntry(
                 key=CONF_QUALITY,
@@ -374,16 +364,9 @@ class KionMusicProvider(MusicProvider):
             ),
         )
 
-    async def handle_config_action(self, action: str) -> tuple[ConfigEntry, ...]:
-        """Handle a one-shot config action button press and re-render the entries."""
-        if action == CONF_ACTION_CLEAR_AUTH:
-            self._update_config_value(CONF_TOKEN, None, immediate=True)
-            return await self.get_config_entries()
-        return await super().handle_config_action(action)
-
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        token = self.config.get_value(CONF_TOKEN)
+        token = self.get_setup_value(CONF_TOKEN)
         if not token:
             raise LoginFailed("No KION Music token provided")
 

--- a/music_assistant/providers/kion_music/setup_flow.py
+++ b/music_assistant/providers/kion_music/setup_flow.py
@@ -1,0 +1,35 @@
+"""Setup flow for the KION Music provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.models.setup_flow import SetupFlowError
+
+from .constants import CONF_TOKEN
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (ConfigEntry(key=CONF_TOKEN, type=ConfigEntryType.SECURE_STRING, required=True),)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the KION Music token and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/kion_music/strings.json
+++ b/music_assistant/providers/kion_music/strings.json
@@ -4,10 +4,6 @@
       "label": "KION Music Token",
       "description": "Enter your KION Music OAuth token. See the documentation for how to obtain it."
     },
-    "clear_auth": {
-      "label": "[%key:common::config_entries::clear_auth::label%]",
-      "description": "[%key:common::config_entries::clear_auth::description%]"
-    },
     "quality": {
       "label": "Audio quality",
       "description": "Select preferred audio quality.",
@@ -41,6 +37,12 @@
     "base_url": {
       "label": "API Base URL",
       "description": "API endpoint base URL. Only change if KION Music changes their API endpoint. Default: {0}"
+    }
+  },
+  "setup_flow": {
+    "user": {
+      "title": "Connect to KION Music",
+      "description": "Music Assistant needs your personal KION Music OAuth token to reach your account and library."
     }
   },
   "media": {

--- a/music_assistant/providers/pandora/__init__.py
+++ b/music_assistant/providers/pandora/__init__.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import ProviderFeature
-from music_assistant_models.errors import SetupFailedError
-
-from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
 
 from .provider import PandoraProvider
 
@@ -29,22 +26,4 @@ async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
     """Initialize provider instance with given configuration."""
-    # read the stored values directly: the config's option entries are only resolved
-    # (and its values populated) once the instance exists, which is after this call.
-    # A non-empty (still-encrypted) password satisfies the presence check below; the
-    # provider decrypts it via get_config_value once loaded.
-    username = mass.config.get_raw_provider_config_value(config.instance_id, CONF_USERNAME)
-    password = mass.config.get_raw_provider_config_value(config.instance_id, CONF_PASSWORD)
-
-    # Type-safe validation
-    if (
-        not username
-        or not password
-        or not isinstance(username, str)
-        or not isinstance(password, str)
-        or not username.strip()
-        or not password.strip()
-    ):
-        raise SetupFailedError("Username and password are required")
-
     return PandoraProvider(mass, manifest, config, SUPPORTED_FEATURES)

--- a/music_assistant/providers/pandora/provider.py
+++ b/music_assistant/providers/pandora/provider.py
@@ -111,16 +111,6 @@ class PandoraProvider(MusicProvider):
         return (
             CONF_ENTRY_UNOFFICIAL_PROVIDER,
             ConfigEntry(
-                key=CONF_USERNAME,
-                type=ConfigEntryType.STRING,
-                required=True,
-            ),
-            ConfigEntry(
-                key=CONF_PASSWORD,
-                type=ConfigEntryType.SECURE_STRING,
-                required=True,
-            ),
-            ConfigEntry(
                 key=CONF_QUALITY,
                 type=ConfigEntryType.STRING,
                 required=True,
@@ -158,8 +148,10 @@ class PandoraProvider(MusicProvider):
         self._sessions = {}
 
         # Authenticate with Pandora
-        username = str(self.config.get_value(CONF_USERNAME))
-        password = str(self.config.get_value(CONF_PASSWORD))
+        username = str(self.get_setup_value(CONF_USERNAME) or "")
+        password = str(self.get_setup_value(CONF_PASSWORD) or "")
+        if not username.strip() or not password.strip():
+            raise LoginFailed("Username and password are required")
         socks_url = get_socks5_url(str(self.config.get_value(CONF_SOCKS_URL)))
 
         if socks_url:
@@ -269,8 +261,8 @@ class PandoraProvider(MusicProvider):
                 if response.status == 401:
                     if RETRY_REASON_AUTH not in exhausted_retry_reasons:
                         # Auth token expired, re-authenticate and retry once
-                        username = str(self.config.get_value(CONF_USERNAME))
-                        password = str(self.config.get_value(CONF_PASSWORD))
+                        username = str(self.get_setup_value(CONF_USERNAME) or "")
+                        password = str(self.get_setup_value(CONF_PASSWORD) or "")
                         await self._authenticate(username, password)
                         return await self._api_request(
                             method,

--- a/music_assistant/providers/pandora/setup_flow.py
+++ b/music_assistant/providers/pandora/setup_flow.py
@@ -1,0 +1,37 @@
+"""Setup flow for the Pandora provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowError
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    ConfigEntry(key=CONF_USERNAME, type=ConfigEntryType.STRING, required=True),
+    ConfigEntry(key=CONF_PASSWORD, type=ConfigEntryType.SECURE_STRING, required=True),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """Run the setup flow: collect the Pandora account credentials and create the provider."""
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/pandora/strings.json
+++ b/music_assistant/providers/pandora/strings.json
@@ -29,6 +29,12 @@
       "description": "Pandora only allows one active stream at a time per account. You can request that Pandora terminate any existing stream on other devices and allow streaming here. You must manually restart playback after performing this action."
     }
   },
+  "setup_flow": {
+    "user": {
+      "title": "Sign in to Pandora",
+      "description": "Enter the username (or email address) and password of your Pandora account."
+    }
+  },
   "media": {
     "radio": {
       "pandora_station": {

--- a/music_assistant/providers/plex_connect/__init__.py
+++ b/music_assistant/providers/plex_connect/__init__.py
@@ -66,8 +66,8 @@ class PlexConnectProvider(PluginProvider):
         :param config: Provider configuration.
         """
         super().__init__(mass, manifest, config, SUPPORTED_FEATURES)
-        self.mass_player_id = cast("str", self.config.get_value(CONF_MASS_PLAYER_ID))
-        self.plex_provider_id = cast("str", self.config.get_value(CONF_PLEX_PROVIDER_ID))
+        self.mass_player_id = cast("str", self.get_setup_value(CONF_MASS_PLAYER_ID))
+        self.plex_provider_id = cast("str", self.get_setup_value(CONF_PLEX_PROVIDER_ID))
         self.custom_player_name = cast("str | None", self.config.get_value(CONF_PLAYER_NAME))
         self.device_class = cast("str", self.config.get_value(CONF_DEVICE_CLASS)) or "speaker"
 
@@ -79,34 +79,7 @@ class PlexConnectProvider(PluginProvider):
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
-        # Get available Plex music providers
-        plex_providers = [
-            provider
-            for provider in self.mass.get_providers()
-            if provider.domain == "plex" and provider.type.value == "music"
-        ]
         return (
-            ConfigEntry(
-                key=CONF_PLEX_PROVIDER_ID,
-                type=ConfigEntryType.STRING,
-                required=True,
-                options=[
-                    ConfigValueOption(provider.instance_id, title=provider.name)
-                    for provider in plex_providers
-                ],
-            ),
-            ConfigEntry(
-                key=CONF_MASS_PLAYER_ID,
-                type=ConfigEntryType.STRING,
-                required=True,
-                options=[
-                    ConfigValueOption(x.player_id, title=x.display_name)
-                    for x in sorted(
-                        self.mass.players.all_players(False, False),
-                        key=lambda p: p.display_name.lower(),
-                    )
-                ],
-            ),
             ConfigEntry(
                 key=CONF_PLAYER_NAME,
                 type=ConfigEntryType.STRING,

--- a/music_assistant/providers/plex_connect/setup_flow.py
+++ b/music_assistant/providers/plex_connect/setup_flow.py
@@ -1,0 +1,110 @@
+"""
+Setup flow for the Plex Connect plugin.
+
+Each instance links one Music Assistant player to one configured Plex music provider.
+Both choices are derived from live runtime state (the loaded plex instances and the
+currently known players), so the form is built when the flow runs rather than declared
+as a static set of entries.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
+from music_assistant_models.enums import ConfigEntryType, ProviderType
+
+from music_assistant.models.setup_flow import AbortFlow, SetupFlowError
+
+from . import CONF_MASS_PLAYER_ID, CONF_PLEX_PROVIDER_ID
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ConfigValueType
+
+    from music_assistant.mass import MusicAssistant
+    from music_assistant.models.setup_flow import SetupSession
+
+PLEX_DOMAIN = "plex"
+
+
+async def run_setup(session: SetupSession) -> None:
+    """
+    Run the Plex Connect setup flow: pick the Plex provider and the player to expose.
+
+    :param session: The setup session driving the flow.
+    """
+    plex_options = _plex_provider_options(session.mass)
+    if not plex_options:
+        # the engine's depends_on check only guarantees an enabled plex config exists,
+        # not that the instance actually loaded
+        raise AbortFlow("no_plex_provider")
+    player_options = _player_options(session.mass)
+    if not player_options:
+        raise AbortFlow("no_players")
+    setup_data = dict(session.context.setup_data)
+    errors: dict[str, str] | None = None
+    while True:
+        # setup_data (reconfigure) wins over the instance's stored option values, which
+        # still hold the selection on installs made before this flow existed
+        prefill: dict[str, Any] = {**session.context.values, **setup_data}
+        submitted = await session.form(
+            [
+                _select_entry(
+                    CONF_PLEX_PROVIDER_ID, plex_options, prefill.get(CONF_PLEX_PROVIDER_ID)
+                ),
+                _select_entry(
+                    CONF_MASS_PLAYER_ID, player_options, prefill.get(CONF_MASS_PLAYER_ID)
+                ),
+            ],
+            step_id="user",
+            errors=errors,
+            last_step=True,
+        )
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": err.translation_key or str(err)}
+
+
+def _plex_provider_options(mass: MusicAssistant) -> list[ConfigValueOption]:
+    """Return a picker option for every loaded Plex music provider instance."""
+    return [
+        ConfigValueOption(provider.instance_id, title=provider.name)
+        for provider in mass.get_provider_instances(
+            PLEX_DOMAIN, return_unavailable=True, provider_type=ProviderType.MUSIC
+        )
+    ]
+
+
+def _player_options(mass: MusicAssistant) -> list[ConfigValueOption]:
+    """Return a picker option for every available and enabled Music Assistant player."""
+    return [
+        ConfigValueOption(player.player_id, title=player.display_name)
+        for player in sorted(
+            mass.players.all_players(False, False),
+            key=lambda player: player.display_name.lower(),
+        )
+    ]
+
+
+def _select_entry(
+    key: str, options: list[ConfigValueOption], prefill: ConfigValueType
+) -> ConfigEntry:
+    """
+    Build the required single-select form entry for the given key.
+
+    :param key: The setup data key the selection is collected under.
+    :param options: The available options (never empty).
+    :param prefill: Previously selected value, used when it is still a valid option.
+    """
+    selected = prefill if any(option.value == prefill for option in options) else options[0].value
+    return ConfigEntry(
+        key=key,
+        type=ConfigEntryType.STRING,
+        required=True,
+        options=options,
+        default_value=selected,
+        value=selected,
+    )

--- a/music_assistant/providers/plex_connect/strings.json
+++ b/music_assistant/providers/plex_connect/strings.json
@@ -30,6 +30,16 @@
       "description": "TCP port this player is advertised and reachable on in Plex apps. Leave empty to auto-assign a free port and remember it for this instance."
     }
   },
+  "setup_flow": {
+    "user": {
+      "title": "Choose what to expose to Plex",
+      "description": "Pick the Plex server this player should show up on, and the Music Assistant player to expose."
+    },
+    "abort": {
+      "no_plex_provider": "No Plex music provider is loaded. Make sure your Plex provider is set up and working, then try again.",
+      "no_players": "No players are available yet. Add a player to Music Assistant first, then try again."
+    }
+  },
   "manifest": {
     "description": "Makes a Music Assistant player appear as a device in the official Plex apps."
   }

--- a/music_assistant/providers/zvuk_music/constants.py
+++ b/music_assistant/providers/zvuk_music/constants.py
@@ -8,9 +8,6 @@ from typing import Final
 CONF_TOKEN: Final[str] = "token"
 CONF_QUALITY: Final[str] = "quality"
 
-# Actions
-CONF_ACTION_CLEAR_AUTH: Final[str] = "clear_auth"
-
 # API defaults
 DEFAULT_LIMIT: Final[int] = 50
 PLAYLIST_TRACKS_PAGE_SIZE: Final[int] = 50

--- a/music_assistant/providers/zvuk_music/provider.py
+++ b/music_assistant/providers/zvuk_music/provider.py
@@ -43,7 +43,6 @@ from music_assistant.models.music_provider import MusicProvider
 
 from .api_client import ZvukMusicClient
 from .constants import (
-    CONF_ACTION_CLEAR_AUTH,
     CONF_QUALITY,
     CONF_TOKEN,
     DEFAULT_LIMIT,
@@ -73,21 +72,8 @@ class ZvukMusicProvider(MusicProvider):
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
-        is_authenticated = bool(self.get_config_value(CONF_TOKEN))
         return (
             CONF_ENTRY_UNOFFICIAL_PROVIDER,
-            ConfigEntry(
-                key=CONF_TOKEN,
-                type=ConfigEntryType.SECURE_STRING,
-                required=True,
-                hidden=is_authenticated,
-            ),
-            ConfigEntry(
-                key=CONF_ACTION_CLEAR_AUTH,
-                type=ConfigEntryType.ACTION,
-                action=CONF_ACTION_CLEAR_AUTH,
-                hidden=not is_authenticated,
-            ),
             ConfigEntry(
                 key=CONF_QUALITY,
                 type=ConfigEntryType.STRING,
@@ -99,16 +85,9 @@ class ZvukMusicProvider(MusicProvider):
             ),
         )
 
-    async def handle_config_action(self, action: str) -> tuple[ConfigEntry, ...]:
-        """Handle a one-shot config action button press and re-render the entries."""
-        if action == CONF_ACTION_CLEAR_AUTH:
-            self._update_config_value(CONF_TOKEN, None, immediate=True)
-            return await self.get_config_entries()
-        return await super().handle_config_action(action)
-
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        token = self.config.get_value(CONF_TOKEN)
+        token = self.get_setup_value(CONF_TOKEN)
         if not token:
             raise LoginFailed("No Zvuk Music token provided")
 
@@ -657,7 +636,7 @@ class ZvukMusicProvider(MusicProvider):
             ),
         }
         if is_zvuk:
-            token = self.config.get_value(CONF_TOKEN)
+            token = self.get_setup_value(CONF_TOKEN)
             if not token:
                 return str(path)
             headers["X-Auth-Token"] = str(token)

--- a/music_assistant/providers/zvuk_music/setup_flow.py
+++ b/music_assistant/providers/zvuk_music/setup_flow.py
@@ -1,0 +1,43 @@
+"""Setup flow for the Zvuk Music provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
+from music_assistant.models.setup_flow import SetupFlowError
+
+from .constants import CONF_TOKEN
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    CONF_ENTRY_UNOFFICIAL_PROVIDER,
+    ConfigEntry(key=CONF_TOKEN, type=ConfigEntryType.SECURE_STRING, required=True),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """
+    Run the setup flow: collect the Zvuk auth token and create the provider.
+
+    :param session: The setup session driving the flow.
+    """
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": err.translation_key or str(err)}

--- a/music_assistant/providers/zvuk_music/strings.json
+++ b/music_assistant/providers/zvuk_music/strings.json
@@ -4,10 +4,6 @@
       "label": "Zvuk Music Token",
       "description": "Enter your Zvuk Music X-Auth-Token. See the documentation for how to obtain it."
     },
-    "clear_auth": {
-      "label": "[%key:common::config_entries::clear_auth::label%]",
-      "description": "[%key:common::config_entries::clear_auth::description%]"
-    },
     "quality": {
       "label": "Audio quality",
       "description": "Select preferred audio quality.",
@@ -15,6 +11,12 @@
         "high": "High (320 kbps)",
         "lossless": "Lossless (FLAC)"
       }
+    }
+  },
+  "setup_flow": {
+    "user": {
+      "title": "Connect to Zvuk",
+      "description": "Music Assistant needs your personal Zvuk X-Auth-Token to reach your account and library."
     }
   },
   "media": {

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1376,6 +1376,8 @@
   "provider.kion_music.media.recommendations.new_releases.name": "New Releases",
   "provider.kion_music.media.recommendations.seasonal_mix.name": "Seasonal: {0}",
   "provider.kion_music.media.recommendations.top_picks.name": "Top Picks",
+  "provider.kion_music.setup_flow.user.description": "Music Assistant needs your personal KION Music OAuth token to reach your account and library.",
+  "provider.kion_music.setup_flow.user.title": "Connect to KION Music",
   "provider.lastfm_recommendations.background_task.refresh_lastfm_recommendations": "Refresh Last.fm recommendations",
   "provider.lastfm_recommendations.config_entries.api_key.description": "Optional. Override the built-in API key.",
   "provider.lastfm_recommendations.config_entries.api_key.label": "Last.fm API Key",
@@ -1636,6 +1638,8 @@
   "provider.pandora.config_entries.username.description": "Your Pandora username or email address",
   "provider.pandora.manifest.description": "Pandora is a music and podcast streaming service that creates personalized radio stations based on your favorite songs and artists.",
   "provider.pandora.media.radio.pandora_station.name": "Pandora Station {0}",
+  "provider.pandora.setup_flow.user.description": "Enter the username (or email address) and password of your Pandora account.",
+  "provider.pandora.setup_flow.user.title": "Sign in to Pandora",
   "provider.party.config_categories.guest_features": "Guest Features",
   "provider.party.config_categories.karaoke": "Karaoke",
   "provider.party.config_entries.action_disable_guest_access.action_label": "Disable Guest Access",
@@ -1810,6 +1814,10 @@
   "provider.plex_connect.config_entries.port.description": "TCP port this player is advertised and reachable on in Plex apps. Leave empty to auto-assign a free port and remember it for this instance.",
   "provider.plex_connect.config_entries.port.label": "Network Port",
   "provider.plex_connect.manifest.description": "Makes a Music Assistant player appear as a device in the official Plex apps.",
+  "provider.plex_connect.setup_flow.abort.no_players": "No players are available yet. Add a player to Music Assistant first, then try again.",
+  "provider.plex_connect.setup_flow.abort.no_plex_provider": "No Plex music provider is loaded. Make sure your Plex provider is set up and working, then try again.",
+  "provider.plex_connect.setup_flow.user.description": "Pick the Plex server this player should show up on, and the Music Assistant player to expose.",
+  "provider.plex_connect.setup_flow.user.title": "Choose what to expose to Plex",
   "provider.pocketcasts.config_entries.password.description": "Your Pocket Casts password",
   "provider.pocketcasts.config_entries.password.label": "Password",
   "provider.pocketcasts.config_entries.username.description": "Your Pocket Casts email address",
@@ -2443,5 +2451,7 @@
   "provider.zvuk_music.media.folder.editorial.name": "Collections",
   "provider.zvuk_music.media.folder.made_for_you.name": "Made for you",
   "provider.zvuk_music.media.recommendations.editorial.name": "Collections",
-  "provider.zvuk_music.media.recommendations.editorial.subtitle": "Editorial playlists from Zvuk by genre"
+  "provider.zvuk_music.media.recommendations.editorial.subtitle": "Editorial playlists from Zvuk by genre",
+  "provider.zvuk_music.setup_flow.user.description": "Music Assistant needs your personal Zvuk X-Auth-Token to reach your account and library.",
+  "provider.zvuk_music.setup_flow.user.title": "Connect to Zvuk"
 }

--- a/scripts/check_config_entries.py
+++ b/scripts/check_config_entries.py
@@ -1,8 +1,14 @@
 """
-Guard against hardcoded config strings and invalid category keys in ConfigEntry/ConfigValueOption.
+Guard against invalid ConfigEntry/ConfigValueOption definitions.
 
 Fails when a ConfigEntry or ConfigValueOption hardcodes user-facing text instead of strings.json,
-or when a ConfigEntry.category value is not defined in any strings.json config_categories section.
+when a ConfigEntry.category value is not defined in any strings.json config_categories section,
+or when an entry returned by ``get_config_entries`` is required but has no default value.
+
+A provider instance is created with empty values (setup input is collected by the setup flow into
+``setup_data``), and its config is validated at load right after the instance is constructed. An
+options entry that is ``required`` without a ``default_value`` therefore has nothing to resolve to
+and fails that validation, so the provider can never be added at all.
 
 A ConfigEntry's ``label``/``description``/``action_label`` and a ConfigValueOption's ``title`` are
 localized at serialization from the owning provider's (or the common) ``strings.json`` — keyed by
@@ -47,9 +53,12 @@ _CHECKS: dict[str, tuple[tuple[str, ...], bool, str]] = {
     "ConfigValueOption": (("title",), False, "config_entries.<key>.options.<value>"),
 }
 
+# ConfigEntryType members that never hold a value (models: config_entries.UI_ONLY)
+_UI_ONLY_TYPES = frozenset({"LABEL", "DIVIDER", "ACTION", "ALERT", "IMAGE", "URL"})
+
 
 def find_violations() -> list[str]:
-    """Return a sorted list of ``path:line: message`` for every hardcoded config text field."""
+    """Return a sorted list of ``path:line: message`` for every invalid config entry field."""
     violations: list[str] = []
     valid_categories = _load_valid_categories()
     for path in _iter_python_files():
@@ -58,6 +67,7 @@ def find_violations() -> list[str]:
         except SyntaxError:
             continue
         rel = os.path.relpath(path, _REPO_ROOT)
+        options_entries = _options_entry_calls(tree)
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -86,19 +96,21 @@ def find_violations() -> list[str]:
                             f"{rel}:{keyword.value.lineno}: ConfigEntry category={cat!r} is not "
                             f"defined in any strings.json config_categories section"
                         )
+                if id(node) in options_entries and _is_required_without_value(node):
+                    violations.append(
+                        f"{rel}:{node.lineno}: ConfigEntry {_entry_key(node)} is required but has "
+                        f"no default_value; an options entry must resolve without user input "
+                        f"(collect setup input in the provider's setup_flow instead)"
+                    )
     return sorted(violations)
 
 
 def main() -> int:
-    """Print every hardcoded config text field; return 1 when any were found."""
+    """Print every invalid ConfigEntry/ConfigValueOption definition; return 1 when any were found."""
     violations = find_violations()
     if not violations:
         return 0
-    print(
-        "Hardcoded config strings found. Move them into the owner's strings.json "
-        "instead of passing them in code:",
-        file=sys.stderr,
-    )
+    print("Invalid ConfigEntry/ConfigValueOption definitions found:", file=sys.stderr)
     for violation in violations:
         print(f"  {violation}", file=sys.stderr)
     return 1
@@ -153,6 +165,65 @@ def _call_name(node: ast.Call) -> str:
     if isinstance(func, ast.Name):
         return func.id
     return func.attr if isinstance(func, ast.Attribute) else ""
+
+
+def _options_entry_calls(tree: ast.Module) -> set[int]:
+    """
+    Return the node ids of the ConfigEntry calls built inside a ``get_config_entries``.
+
+    Only those entries end up in a config's values and are validated at load; the entries a
+    setup flow builds for its forms are input fields and are required without a default by
+    design, so they must not be flagged.
+    """
+    result: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.name != "get_config_entries":
+            continue
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Call) and _call_name(inner) == "ConfigEntry":
+                result.add(id(inner))
+    return result
+
+
+def _is_required_without_value(node: ast.Call) -> bool:
+    """Return True when a required ConfigEntry has neither a default nor a preset value."""
+    keywords = {keyword.arg: keyword.value for keyword in node.keywords}
+    if (required := keywords.get("required")) is not None:
+        if not isinstance(required, ast.Constant):
+            # a computed flag can't be judged statically
+            return False
+        if required.value is not True:
+            return False
+    elif _entry_type(node) in _UI_ONLY_TYPES:
+        # ConfigEntry.required defaults to True, but __post_init__ clears it for UI-only types
+        return False
+    for arg in ("default_value", "value"):
+        if (given := keywords.get(arg)) is None:
+            continue
+        # a computed default can't be judged statically, so only a literal None counts as absent
+        if not (isinstance(given, ast.Constant) and given.value is None):
+            return False
+    return True
+
+
+def _entry_type(node: ast.Call) -> str:
+    """Return the name of a ConfigEntry's ConfigEntryType member, or ``""`` when not literal."""
+    entry_type = {keyword.arg: keyword.value for keyword in node.keywords}.get("type")
+    if entry_type is None and len(node.args) > 1:
+        entry_type = node.args[1]
+    return entry_type.attr if isinstance(entry_type, ast.Attribute) else ""
+
+
+def _entry_key(node: ast.Call) -> str:
+    """Return a readable rendering of a ConfigEntry's key argument for a violation message."""
+    key = {keyword.arg: keyword.value for keyword in node.keywords}.get("key")
+    if isinstance(key, ast.Constant):
+        return repr(key.value)
+    if isinstance(key, ast.Name):
+        return key.id
+    return key.attr if isinstance(key, ast.Attribute) else "<unknown>"
 
 
 def _is_hardcoded_text(node: ast.AST, flag_fstrings: bool) -> bool:

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -21,12 +21,18 @@ from music_assistant_models.enums import (
     PlayerType,
     ProviderType,
 )
-from music_assistant_models.errors import ActionUnavailable, LoginFailed, PlayerUnavailableError
+from music_assistant_models.errors import (
+    ActionUnavailable,
+    LoginFailed,
+    PlayerUnavailableError,
+    SetupFailedError,
+)
 from music_assistant_models.player import OutputProtocol
 from music_assistant_models.provider import ProviderManifest
 
 from music_assistant.constants import CONF_PLAYERS, CONF_PROVIDERS, ENCRYPT_SUFFIX
 from music_assistant.mass import MusicAssistant
+from music_assistant.models.music_provider import MusicProvider
 from music_assistant.models.player import Player, _state_fingerprint
 from music_assistant.models.setup_flow import AbortFlow, SetupSession, StepExpiredError
 from music_assistant.providers.filesystem_local.setup_flow import (
@@ -36,6 +42,7 @@ from music_assistant.providers.qobuz.setup_flow import run_setup as qobuz_run_se
 from tests.common import MockPlayer, MockProvider
 
 if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ProviderConfig
     from music_assistant_models.event import MassEvent
     from music_assistant_models.setup_flow import SetupFlowStep
 
@@ -44,6 +51,9 @@ FAKE_DOMAIN = "_setup_flow_test"
 USERNAME_ENTRY = ConfigEntry(key="username", type=ConfigEntryType.STRING, required=True)
 PORT_ENTRY = ConfigEntry(key="port", type=ConfigEntryType.INTEGER, required=False, default_value=80)
 PASSWORD_ENTRY = ConfigEntry(key="password", type=ConfigEntryType.SECURE_STRING, required=True)
+REGION_ENTRY = ConfigEntry(
+    key="region", type=ConfigEntryType.STRING, required=True, default_value="eu"
+)
 
 
 @pytest.fixture
@@ -77,6 +87,8 @@ async def flow_mass(mass_minimal: MusicAssistant) -> AsyncGenerator[MusicAssista
         routes=routes,
     )
     mass_minimal.music = MagicMock()
+    # awaited at the tail of the real provider load path
+    mass_minimal.music.on_provider_loaded = AsyncMock()
     mass_minimal.players = MagicMock()
     mass_minimal.players.on_player_config_change = AsyncMock()
     try:
@@ -161,6 +173,84 @@ async def test_zero_input_provider_immediate_finish(flow_mass: MusicAssistant) -
     assert raw_conf["setup_data"] == {}
     # no flow session was registered for the synthesized step
     assert not flow_mass.config._setup_flows
+
+
+class _FlowlessProvider(MusicProvider):
+    """
+    A genuine (minimal) provider for a domain that ships no setup_flow module.
+
+    Only get_config_entries is overridden so everything the load path does around it -
+    rehydrating the stored config against those entries, validating it and running async
+    init - behaves exactly as in production.
+    """
+
+    declared_entries: tuple[ConfigEntry, ...] = ()
+
+    async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
+        """Return the (options) config entries this provider declares."""
+        return self.declared_entries
+
+
+def _use_provider_module(entries: tuple[ConfigEntry, ...]) -> Any:
+    """
+    Patch the module loader so the fake domain really loads a provider instance.
+
+    The fake domain has no importable package, so the module loader ``_load_provider`` uses
+    is served a stub module whose ``setup`` returns a real provider declaring the given entries.
+
+    :param entries: The (options) config entries the loaded provider declares.
+    """
+
+    async def setup(
+        mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
+    ) -> _FlowlessProvider:
+        provider = _FlowlessProvider(mass, manifest, config)
+        provider.declared_entries = entries
+        return provider
+
+    return patch(
+        "music_assistant.mass.load_provider_module",
+        AsyncMock(return_value=SimpleNamespace(setup=setup)),
+    )
+
+
+async def test_flowless_provider_loads_with_resolvable_entries(flow_mass: MusicAssistant) -> None:
+    """A flow-less provider whose options entries all resolve is added and actually loads."""
+    with (
+        patch.object(flow_mass.config, "_get_setup_flow_module", AsyncMock(return_value=None)),
+        _use_provider_module((PORT_ENTRY, REGION_ENTRY)),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+    assert step.type == FlowStepType.FINISH
+    assert step.result == {"instance_id": FAKE_DOMAIN}
+    # the instance went through the real load path, not a stubbed one
+    provider = flow_mass.get_provider(FAKE_DOMAIN)
+    assert isinstance(provider, _FlowlessProvider)
+    assert provider.available
+    # it was created with values={}, yet the rehydrated config holds - and validates
+    # against - the provider's own entries
+    assert flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}")["values"] == {}
+    assert {"port", "region"} <= set(provider.config.values)
+    provider.config.validate()
+    assert provider.config.get_value("port") == 80
+    assert provider.config.get_value("region") == "eu"
+
+
+async def test_flowless_provider_required_entry_without_default_rolls_back(
+    flow_mass: MusicAssistant,
+) -> None:
+    """A flow-less provider declaring a required entry with no default can not be added."""
+    with (
+        patch.object(flow_mass.config, "_get_setup_flow_module", AsyncMock(return_value=None)),
+        _use_provider_module((USERNAME_ENTRY,)),
+        # created with values={}, so validation of the rehydrated config has nothing to
+        # resolve the required entry from
+        pytest.raises(SetupFailedError, match="Configuration is invalid: username is required"),
+    ):
+        await flow_mass.config.setup_provider(FAKE_DOMAIN)
+    # the config created before the load attempt is rolled back, leaving nothing half-created
+    assert flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}") is None
+    assert flow_mass.get_provider(FAKE_DOMAIN, return_unavailable=True) is None
 
 
 async def test_form_flow_finish_success(

--- a/tests/providers/itunes_podcasts/test_config_entries.py
+++ b/tests/providers/itunes_podcasts/test_config_entries.py
@@ -1,0 +1,54 @@
+"""Test the iTunes Podcasts config entries."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from music_assistant.providers.itunes_podcasts import (
+    CONF_LOCALE,
+    DEFAULT_LOCALE,
+    SUPPORTED_FEATURES,
+    ITunesPodcastsProvider,
+)
+
+
+def _provider(server_locale: str) -> ITunesPodcastsProvider:
+    """Return a provider whose server is configured with the given metadata locale."""
+    mass = Mock()
+    mass.metadata.locale = server_locale
+    manifest = Mock(domain="itunes_podcasts")
+    config = Mock(instance_id="itunes_podcasts", enabled=True)
+    config.get_value.side_effect = lambda key, default=None: (
+        "INFO" if key == "log_level" else default
+    )
+    return ITunesPodcastsProvider(mass, manifest, config, SUPPORTED_FEATURES)
+
+
+async def _locale_entry_default(server_locale: str) -> str:
+    """Return the default value of the locale entry for the given server locale."""
+    entries = await _provider(server_locale).get_config_entries()
+    entry = next(entry for entry in entries if entry.key == CONF_LOCALE)
+    assert isinstance(entry.default_value, str)
+    return entry.default_value
+
+
+@pytest.mark.parametrize(
+    ("server_locale", "expected"),
+    [("nl_NL", "nl"), ("en_GB", "gb"), ("de_DE", "de")],
+)
+async def test_locale_defaults_to_server_region(server_locale: str, expected: str) -> None:
+    """The store to search defaults to the region of the server's configured language."""
+    assert await _locale_entry_default(server_locale) == expected
+
+
+@pytest.mark.parametrize("server_locale", ["en", "en_XX"])
+async def test_locale_falls_back_when_region_has_no_storefront(server_locale: str) -> None:
+    """A language without a matching iTunes storefront falls back to the default store."""
+    assert await _locale_entry_default(server_locale) == DEFAULT_LOCALE
+
+
+async def test_locale_default_is_a_selectable_option() -> None:
+    """The resolved default is one of the offered options, so the picker shows it selected."""
+    entries = await _provider("nl_NL").get_config_entries()
+    entry = next(entry for entry in entries if entry.key == CONF_LOCALE)
+    assert entry.default_value in [option.value for option in entry.options]

--- a/tests/providers/kion_music/test_config_entries.py
+++ b/tests/providers/kion_music/test_config_entries.py
@@ -1,0 +1,51 @@
+"""Unit tests for the provider options surface (get_config_entries)."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from music_assistant_models.config_entries import UI_ONLY
+
+from music_assistant.providers.kion_music.constants import (
+    CONF_BASE_URL,
+    CONF_CODECS,
+    CONF_LIKED_TRACKS_MAX_TRACKS,
+    CONF_MY_WAVE_MAX_TRACKS,
+    CONF_QUALITY,
+    CONF_TRANSPORT,
+)
+from music_assistant.providers.kion_music.provider import KionMusicProvider
+
+# auth keys/actions that used to live on the options surface and now belong to the
+# interactive setup flow — none of these may reappear in get_config_entries
+_AUTH_KEYS = frozenset({"token", "auth", "clear_auth"})
+
+
+async def test_get_config_entries_has_no_auth_entries_or_actions() -> None:
+    """Authentication moved to the setup flow: no auth entries/actions are emitted."""
+    entries = await KionMusicProvider.get_config_entries(Mock(spec=KionMusicProvider))
+    assert {entry.key for entry in entries}.isdisjoint(_AUTH_KEYS)
+    assert not [entry for entry in entries if entry.action]
+
+
+async def test_get_config_entries_keeps_genuine_options() -> None:
+    """The genuine playback options remain on the options surface."""
+    entries = await KionMusicProvider.get_config_entries(Mock(spec=KionMusicProvider))
+    assert {
+        CONF_QUALITY,
+        CONF_MY_WAVE_MAX_TRACKS,
+        CONF_LIKED_TRACKS_MAX_TRACKS,
+        CONF_TRANSPORT,
+        CONF_CODECS,
+        CONF_BASE_URL,
+    } <= {entry.key for entry in entries}
+
+
+async def test_get_config_entries_resolve_without_user_input() -> None:
+    """Every options entry resolves on its own, so the instance loads with empty values."""
+    entries = await KionMusicProvider.get_config_entries(Mock(spec=KionMusicProvider))
+    assert not [
+        entry.key
+        for entry in entries
+        if entry.required and entry.default_value is None and entry.type not in UI_ONLY
+    ]

--- a/tests/providers/pandora/__init__.py
+++ b/tests/providers/pandora/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Pandora provider."""

--- a/tests/providers/pandora/test_setup_flow.py
+++ b/tests/providers/pandora/test_setup_flow.py
@@ -1,0 +1,159 @@
+"""Tests for the Pandora setup flow and the options surface it took over from."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+from unittest.mock import Mock
+
+from music_assistant_models.enums import ConfigEntryType, FlowStepType
+
+from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.models.setup_flow import SetupFlowContext, SetupFlowError, SetupSession
+from music_assistant.providers.pandora.constants import (
+    CONF_QUALITY,
+    CONF_TAKEOVER_ACTION,
+    QUALITY_STANDARD,
+)
+from music_assistant.providers.pandora.provider import PandoraProvider
+from music_assistant.providers.pandora.setup_flow import run_setup
+
+
+def _make_session(
+    finish_handler: Any, setup_data: dict[str, Any] | None = None
+) -> tuple[SetupSession, Mock]:
+    """Build a SetupSession backed by a Mock mass for driving run_setup directly."""
+    mass = Mock()
+    context = SetupFlowContext(
+        kind="setup", reason="user", domain="pandora", setup_data=setup_data or {}
+    )
+    session = SetupSession(mass, "flow-test", context, finish_handler)
+    return session, mass
+
+
+async def _wait_for(predicate: Any, timeout: float = 5.0) -> Any:
+    """Wait until the predicate returns truthy (or fail the test)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if result := predicate():
+            return result
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition not met within timeout")
+
+
+async def _wait_for_form(session: SetupSession, with_errors: bool = False) -> Any:
+    """Wait until the flow publishes a FORM step (optionally one carrying errors)."""
+    return await _wait_for(
+        lambda: (
+            session.current_step
+            if session.current_step
+            and session.current_step.type == FlowStepType.FORM
+            and (session.current_step.errors if with_errors else True)
+            else None
+        )
+    )
+
+
+async def test_get_config_entries_excludes_credentials() -> None:
+    """The credentials are flow-owned now and must not appear on the options surface."""
+    provider = PandoraProvider.__new__(PandoraProvider)
+    entries = await provider.get_config_entries()
+    keys = {entry.key for entry in entries}
+    assert CONF_USERNAME not in keys
+    assert CONF_PASSWORD not in keys
+    # the genuine options (and the takeover action) stay
+    assert {CONF_QUALITY, CONF_TAKEOVER_ACTION} <= keys
+    # every remaining options entry must resolve without user input, since the instance
+    # is created with empty values and its config is validated right after construction
+    assert all(
+        entry.default_value is not None or not entry.required
+        for entry in entries
+        if entry.type != ConfigEntryType.ACTION
+    )
+
+
+async def test_run_setup_collects_credentials() -> None:
+    """The flow shows a username/password form and persists both as setup data."""
+    collected: dict[str, Any] = {}
+
+    async def finish_handler(_session: SetupSession, values: dict[str, Any]) -> dict[str, str]:
+        collected.update(values)
+        return {"instance_id": "pandora--test"}
+
+    session, _mass = _make_session(finish_handler)
+    task = asyncio.create_task(run_setup(session))
+    step = await _wait_for_form(session)
+
+    assert step.step_id == "user"
+    assert step.last_step is True
+    entries = {entry.key: entry for entry in step.entries}
+    assert set(entries) == {CONF_USERNAME, CONF_PASSWORD}
+    assert entries[CONF_USERNAME].type == ConfigEntryType.STRING
+    assert entries[CONF_PASSWORD].type == ConfigEntryType.SECURE_STRING
+    assert all(entry.required for entry in entries.values())
+
+    session.handle_submit({CONF_USERNAME: "listener@example.com", CONF_PASSWORD: "hunter2"})
+    await _wait_for(lambda: session.finished)
+    await task
+
+    assert collected == {CONF_USERNAME: "listener@example.com", CONF_PASSWORD: "hunter2"}
+
+
+async def test_run_setup_prefills_username_but_not_password() -> None:
+    """A reconfigure re-shows the stored username; the secret is never echoed back."""
+
+    async def finish_handler(_session: SetupSession, _values: dict[str, Any]) -> dict[str, str]:
+        return {"instance_id": "pandora--test"}
+
+    session, _mass = _make_session(
+        finish_handler,
+        setup_data={CONF_USERNAME: "listener@example.com", CONF_PASSWORD: "old-secret"},
+    )
+    task = asyncio.create_task(run_setup(session))
+    step = await _wait_for_form(session)
+
+    entries = {entry.key: entry for entry in step.entries}
+    assert entries[CONF_USERNAME].value == "listener@example.com"
+    assert entries[CONF_PASSWORD].value is None
+
+    session.handle_submit({CONF_USERNAME: "listener@example.com", CONF_PASSWORD: "new-secret"})
+    await _wait_for(lambda: session.finished)
+    await task
+
+
+async def test_run_setup_retries_form_on_login_failure() -> None:
+    """A failed login re-renders the form with the error, then succeeds on retry."""
+    attempts: list[dict[str, Any]] = []
+
+    async def finish_handler(_session: SetupSession, values: dict[str, Any]) -> dict[str, str]:
+        # snapshot: the flow carries (and mutates) one setup_data dict across retries
+        attempts.append(dict(values))
+        if len(attempts) == 1:
+            raise SetupFlowError("Authentication failed", translation_key="login_failed")
+        return {"instance_id": "pandora--test"}
+
+    session, _mass = _make_session(finish_handler)
+    task = asyncio.create_task(run_setup(session))
+    await _wait_for_form(session)
+    session.handle_submit({CONF_USERNAME: "listener", CONF_PASSWORD: "wrong"})
+
+    error_form = await _wait_for_form(session, with_errors=True)
+    assert error_form.errors == {"base": "login_failed"}
+    # the rejected username is prefilled again so only the password has to be retyped
+    entries = {entry.key: entry for entry in error_form.entries}
+    assert entries[CONF_USERNAME].value == "listener"
+    assert entries[CONF_PASSWORD].value is None
+
+    session.handle_submit({CONF_USERNAME: "listener", CONF_PASSWORD: "right"})
+    await _wait_for(lambda: session.finished)
+    await task
+
+    assert [attempt[CONF_PASSWORD] for attempt in attempts] == ["wrong", "right"]
+
+
+async def test_default_quality_is_standard() -> None:
+    """The quality option keeps a default so the instance loads without user input."""
+    provider = PandoraProvider.__new__(PandoraProvider)
+    entries = {entry.key: entry for entry in await provider.get_config_entries()}
+    assert entries[CONF_QUALITY].default_value == QUALITY_STANDARD

--- a/tests/providers/plex_connect/test_setup_flow.py
+++ b/tests/providers/plex_connect/test_setup_flow.py
@@ -1,0 +1,176 @@
+"""Tests for the Plex Connect interactive setup flow (run_setup)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+from unittest import mock
+
+import pytest
+from music_assistant_models.enums import FlowStepType
+
+from music_assistant.models.setup_flow import AbortFlow, SetupFlowContext, SetupSession
+from music_assistant.providers.plex_connect import CONF_MASS_PLAYER_ID, CONF_PLEX_PROVIDER_ID
+from music_assistant.providers.plex_connect import setup_flow as pc_flow
+
+
+def _provider(instance_id: str, name: str) -> mock.Mock:
+    """Build a stand-in for a loaded plex provider instance."""
+    provider = mock.Mock()
+    provider.instance_id = instance_id
+    provider.name = name
+    return provider
+
+
+def _player(player_id: str, display_name: str) -> mock.Mock:
+    """Build a stand-in for a Music Assistant player."""
+    player = mock.Mock()
+    player.player_id = player_id
+    player.display_name = display_name
+    return player
+
+
+def _make_session(
+    finish_handler: Any,
+    plex_providers: list[mock.Mock] | None = None,
+    players: list[mock.Mock] | None = None,
+    setup_data: dict[str, Any] | None = None,
+    values: dict[str, Any] | None = None,
+) -> SetupSession:
+    """Build a real SetupSession backed by a Mock mass with the given live state."""
+    mass = mock.Mock()
+    mass.get_provider_instances = mock.Mock(
+        return_value=plex_providers
+        if plex_providers is not None
+        else [_provider("plex--1", "Plex")]
+    )
+    mass.players.all_players = mock.Mock(
+        return_value=players if players is not None else [_player("player1", "Kitchen")]
+    )
+    context = SetupFlowContext(
+        kind="setup",
+        reason="user",
+        domain="plex_connect",
+        setup_data=setup_data or {},
+        values=values or {},
+    )
+    return SetupSession(mass, "flow-test", context, finish_handler)
+
+
+async def _await_user_form(session: SetupSession) -> Any:
+    """Wait until the user form is presented and return the step."""
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        step = session.current_step
+        if step is not None and step.type == FlowStepType.FORM:
+            return step
+        await asyncio.sleep(0.01)
+    raise AssertionError("form step not published within timeout")
+
+
+async def _wait_for_finish(session: SetupSession) -> None:
+    """Wait until the flow finished."""
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if session.finished:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("flow did not finish within timeout")
+
+
+async def test_collects_plex_provider_and_player() -> None:
+    """The single form step collects both selections into setup_data."""
+    collected: dict[str, Any] = {}
+
+    async def finish(_s: SetupSession, values: dict[str, Any]) -> dict[str, str]:
+        collected.update(values)
+        return {"instance_id": "plex_connect--1"}
+
+    session = _make_session(
+        finish,
+        plex_providers=[_provider("plex--1", "Plex"), _provider("plex--2", "Plex Audiobooks")],
+        players=[_player("player2", "living room"), _player("player1", "Kitchen")],
+    )
+    task = asyncio.create_task(pc_flow.run_setup(session))
+    step = await _await_user_form(session)
+    # players are offered sorted case-insensitively by display name
+    assert [option.value for option in step.entries[1].options] == ["player1", "player2"]
+    session.handle_submit({CONF_PLEX_PROVIDER_ID: "plex--2", CONF_MASS_PLAYER_ID: "player2"})
+    await _wait_for_finish(session)
+    await task
+
+    assert collected == {CONF_PLEX_PROVIDER_ID: "plex--2", CONF_MASS_PLAYER_ID: "player2"}
+
+
+async def test_prefills_stored_selection() -> None:
+    """A reconfigure re-shows the stored selection, ignoring values that no longer exist."""
+
+    async def finish(_s: SetupSession, _values: dict[str, Any]) -> dict[str, str]:
+        return {"instance_id": "plex_connect--1"}
+
+    session = _make_session(
+        finish,
+        plex_providers=[_provider("plex--1", "Plex"), _provider("plex--2", "Plex Audiobooks")],
+        players=[_player("player1", "Kitchen"), _player("player2", "Living Room")],
+        setup_data={CONF_PLEX_PROVIDER_ID: "plex--2", CONF_MASS_PLAYER_ID: "gone"},
+    )
+    task = asyncio.create_task(pc_flow.run_setup(session))
+    step = await _await_user_form(session)
+
+    assert step.entries[0].value == "plex--2"
+    # the stored player disappeared: fall back to the first available option
+    assert step.entries[1].value == "player1"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+async def test_prefills_from_legacy_option_values() -> None:
+    """Installs made before this flow existed keep their selection from the config values."""
+
+    async def finish(_s: SetupSession, _values: dict[str, Any]) -> dict[str, str]:
+        return {"instance_id": "plex_connect--1"}
+
+    session = _make_session(
+        finish,
+        plex_providers=[_provider("plex--1", "Plex"), _provider("plex--2", "Plex Audiobooks")],
+        players=[_player("player1", "Kitchen"), _player("player2", "Living Room")],
+        values={CONF_PLEX_PROVIDER_ID: "plex--2", CONF_MASS_PLAYER_ID: "player2"},
+    )
+    task = asyncio.create_task(pc_flow.run_setup(session))
+    step = await _await_user_form(session)
+
+    assert step.entries[0].value == "plex--2"
+    assert step.entries[1].value == "player2"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+async def test_aborts_without_loaded_plex_provider() -> None:
+    """Nothing to pick from: the flow aborts instead of showing an empty dropdown."""
+
+    async def finish(_s: SetupSession, _values: dict[str, Any]) -> dict[str, str]:
+        raise AssertionError("finish must not be called")
+
+    session = _make_session(finish, plex_providers=[])
+    with pytest.raises(AbortFlow) as err:
+        await pc_flow.run_setup(session)
+
+    assert err.value.reason == "no_plex_provider"
+
+
+async def test_aborts_without_players() -> None:
+    """No player to expose: the flow aborts instead of showing an empty dropdown."""
+
+    async def finish(_s: SetupSession, _values: dict[str, Any]) -> dict[str, str]:
+        raise AssertionError("finish must not be called")
+
+    session = _make_session(finish, players=[])
+    with pytest.raises(AbortFlow) as err:
+        await pc_flow.run_setup(session)
+
+    assert err.value.reason == "no_players"

--- a/tests/scripts/test_check_config_entries.py
+++ b/tests/scripts/test_check_config_entries.py
@@ -1,0 +1,118 @@
+"""Tests for the ConfigEntry definition check."""
+
+import ast
+
+from scripts.check_config_entries import (
+    _entry_key,
+    _is_required_without_value,
+    _options_entry_calls,
+    main,
+)
+
+
+def _first_entry(source: str) -> ast.Call:
+    """Return the first ``ConfigEntry(...)`` call node in a source snippet."""
+    return next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "ConfigEntry"
+    )
+
+
+def _entry(*args: str) -> ast.Call:
+    """Return the ConfigEntry call node for a snippet built from the given keyword arguments."""
+    return _first_entry(f"ConfigEntry({', '.join(args)})")
+
+
+def test_required_without_default_is_flagged() -> None:
+    """An explicitly required entry without a default can never resolve to a value."""
+    assert _is_required_without_value(_entry("key=CONF_TOKEN", "required=True")) is True
+
+
+def test_implicitly_required_without_default_is_flagged() -> None:
+    """``required`` defaults to True in the model, so omitting it is still required."""
+    assert _is_required_without_value(_entry("key=CONF_TOKEN")) is True
+
+
+def test_default_value_satisfies_required() -> None:
+    """A required entry with a default resolves to that default."""
+    assert (
+        _is_required_without_value(_entry("key=CONF_LOCALE", "required=True", 'default_value="us"'))
+        is False
+    )
+    assert _is_required_without_value(_entry("key=CONF_PLAYERS", "default_value=[]")) is False
+
+
+def test_preset_value_satisfies_required() -> None:
+    """An entry carrying a preset value resolves to that value."""
+    assert _is_required_without_value(_entry("key=CONF_URL", 'value="http://localhost"')) is False
+
+
+def test_explicit_none_default_is_flagged() -> None:
+    """A literal ``None`` default leaves a required entry just as unresolvable."""
+    assert _is_required_without_value(_entry("key=CONF_TOKEN", "default_value=None")) is True
+
+
+def test_optional_entry_is_not_flagged() -> None:
+    """An entry that is not required may resolve to nothing."""
+    assert _is_required_without_value(_entry("key=CONF_PORT", "required=False")) is False
+
+
+def test_computed_flags_are_not_flagged() -> None:
+    """A computed ``required`` or ``default_value`` cannot be judged statically."""
+    assert _is_required_without_value(_entry("key=CONF_SECRET", "required=not stored")) is False
+    assert _is_required_without_value(_entry("key=CONF_TTS", "default_value=entities[0]")) is False
+
+
+def test_ui_only_types_are_not_flagged() -> None:
+    """UI-only entries hold no value: the model clears ``required`` for them."""
+    assert (
+        _is_required_without_value(_entry("key=CONF_ACTION", "type=ConfigEntryType.ACTION"))
+        is False
+    )
+    assert (
+        _is_required_without_value(_entry("key=CONF_NOTE", "type=ConfigEntryType.LABEL")) is False
+    )
+    # an explicit required=True on a UI-only type is honoured by the check, not silently ignored
+    assert (
+        _is_required_without_value(
+            _entry("key=CONF_ACTION", "type=ConfigEntryType.ACTION", "required=True")
+        )
+        is True
+    )
+
+
+def test_only_get_config_entries_calls_are_collected() -> None:
+    """Setup-flow form entries are required by design, so only options entries are collected."""
+    source = (
+        "_FORM = (ConfigEntry(key='token', type=ConfigEntryType.SECURE_STRING),)\n"
+        "class P:\n"
+        "    async def get_config_entries(self):\n"
+        "        return (ConfigEntry(key='quality', default_value='high'),)\n"
+        "    async def run_setup(self, session):\n"
+        "        return ConfigEntry(key='password')\n"
+    )
+    tree = ast.parse(source)
+    collected = _options_entry_calls(tree)
+    assert len(collected) == 1
+    keys = [
+        _entry_key(node)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and id(node) in collected
+    ]
+    assert keys == ["'quality'"]
+
+
+def test_entry_key_rendering() -> None:
+    """A key is rendered from a literal, a constant reference or an attribute access."""
+    assert _entry_key(_entry("key='locale'")) == "'locale'"
+    assert _entry_key(_entry("key=CONF_LOCALE")) == "CONF_LOCALE"
+    assert _entry_key(_entry("key=constants.CONF_LOCALE")) == "CONF_LOCALE"
+    assert _entry_key(_entry("type=ConfigEntryType.STRING")) == "<unknown>"
+
+
+def test_real_tree_is_clean() -> None:
+    """The shipped tree defines no invalid config entries."""
+    assert main() == 0


### PR DESCRIPTION
# What does this implement/fix?

Adding some providers failed right away with a "Setup failed" toast and no way to continue. It affected iTunes Podcast Search, Home Assistant MediaPlayers, Zvuk Music, KION Music, Pandora and Plex Connect.

These providers still asked for their details on the old options screen, which the new setup wizard replaced. Having no wizard of their own, they were created with nothing filled in and then refused to start, and because the half-created config is removed again there was no screen left to fill anything in.

The ones that need account details now have a proper setup step. The ones that only needed a preference start with a sensible default that can be changed afterwards. Existing setups keep working and their saved logins move along automatically.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Added a setup step to Pandora, KION Music, Zvuk Music and Plex Connect, which used to ask for their token, login or device choice on the options screen
- Saved logins and selections of existing setups are moved to the new setup storage automatically
- iTunes Podcast Search now picks its store country from the server language, so it can be added without choosing one first
- Home Assistant MediaPlayers can be added before any players are selected
- Replaced the "Clear authentication" buttons on KION Music and Zvuk Music with the Reconfigure flow, which now collects a new token
- A provider that fails to load now names the setting that is missing, instead of only reporting that the configuration is invalid
- Added a check that catches this kind of mistake for any provider before it ships

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
