### PR TITLE
Clean up a duplicated setting in the built-in provider

### DIFF
--- a/music_assistant/providers/builtin/constants.py
+++ b/music_assistant/providers/builtin/constants.py
@@ -94,13 +94,6 @@ CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS_HIDDEN = ConfigEntry.from_dict(
         "default_value": True,
     }
 )
-CONF_ENTRY_LIBRARY_SYNC_TRACKS_HIDDEN = ConfigEntry.from_dict(
-    {
-        **CONF_ENTRY_LIBRARY_SYNC_TRACKS.to_dict(),
-        "hidden": True,
-        "default_value": True,
-    }
-)
 CONF_ENTRY_LIBRARY_SYNC_RADIOS_HIDDEN = ConfigEntry.from_dict(
     {
         **CONF_ENTRY_LIBRARY_SYNC_RADIOS.to_dict(),


### PR DESCRIPTION
# What does this implement/fix?

The built-in provider set up the same hidden library setting twice, the second one immediately replacing the first. Both copies were identical, so nothing behaved differently, but the repeated block looked like a different setting was meant to be there and had been copied over wrong.

Checked against the library settings the server offers this provider, and it already hides all of them, so nothing was missing and the extra copy could simply go.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Removed a duplicated hidden library setting from the built-in provider

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
