### PR TITLE
Follow-up fixes and enhancements to author and narrator support

### DIFF
--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -95,8 +95,8 @@ class ArtistsController(MediaControllerBase[Artist]):
             required_scope=Scope.LIBRARY_READ,
         )
         self.mass.register_api_command(
-            f"music/{api_base}/supported_library_artist_types",
-            self.get_supported_library_artist_types,
+            f"music/{api_base}/library_artist_types",
+            self.get_library_artist_types,
             required_scope=Scope.LIBRARY_READ,
         )
 
@@ -841,7 +841,7 @@ class ArtistsController(MediaControllerBase[Artist]):
                 result.append(candidate)
         return result[:limit]
 
-    async def get_supported_library_artist_types(self) -> list[ArtistType]:
+    async def get_library_artist_types(self) -> list[ArtistType]:
         """Get all supported in-library artist types."""
         artist_types: list[ArtistType] = []
         query = f"SELECT DISTINCT artist_type FROM {DB_TABLE_ARTISTS}"

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -95,7 +95,7 @@ class ArtistsController(MediaControllerBase[Artist]):
             required_scope=Scope.LIBRARY_READ,
         )
         self.mass.register_api_command(
-            f"music/{api_base}/supported_artist_types",
+            f"music/{api_base}/supported_library_artist_types",
             self.get_supported_library_artist_types,
             required_scope=Scope.LIBRARY_READ,
         )

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -94,6 +94,11 @@ class ArtistsController(MediaControllerBase[Artist]):
             self.similar_artists,
             required_scope=Scope.LIBRARY_READ,
         )
+        self.mass.register_api_command(
+            f"music/{api_base}/supported_artist_types",
+            self.get_supported_artist_types,
+            required_scope=Scope.LIBRARY_READ,
+        )
 
     @property
     def summary_query(self) -> tuple[str, dict[str, Any]]:
@@ -835,6 +840,15 @@ class ArtistsController(MediaControllerBase[Artist]):
                     continue
                 result.append(candidate)
         return result[:limit]
+
+    async def get_supported_artist_types(self) -> list[ArtistType]:
+        """Return all supported artist types."""
+        artist_types: list[ArtistType] = []
+        query = f"SELECT DISTINCT artist_type FROM {DB_TABLE_ARTISTS}"
+        rows = await self.mass.music.database.get_rows_from_query(query)
+        for row in rows:
+            artist_types.append(ArtistType(row["artist_type"]))
+        return artist_types
 
     async def remove_item_from_library(self, item_id: str | int, recursive: bool = True) -> None:
         """Delete record from the database."""

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -96,7 +96,7 @@ class ArtistsController(MediaControllerBase[Artist]):
         )
         self.mass.register_api_command(
             f"music/{api_base}/supported_artist_types",
-            self.get_supported_artist_types,
+            self.get_supported_library_artist_types,
             required_scope=Scope.LIBRARY_READ,
         )
 
@@ -841,8 +841,8 @@ class ArtistsController(MediaControllerBase[Artist]):
                 result.append(candidate)
         return result[:limit]
 
-    async def get_supported_artist_types(self) -> list[ArtistType]:
-        """Return all supported artist types."""
+    async def get_supported_library_artist_types(self) -> list[ArtistType]:
+        """Get all supported in-library artist types."""
         artist_types: list[ArtistType] = []
         query = f"SELECT DISTINCT artist_type FROM {DB_TABLE_ARTISTS}"
         rows = await self.mass.music.database.get_rows_from_query(query)

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Final, cast
 
 from music_assistant_models.background_task import TaskSchedule
-from music_assistant_models.enums import MediaType, ProviderFeature
+from music_assistant_models.enums import ArtistType, MediaType, ProviderFeature
 from music_assistant_models.errors import (
     MediaNotFoundError,
     MusicAssistantError,
@@ -80,6 +80,16 @@ class MusicProvider(Provider):
         Setting this to False will query all instances of this provider for search and lookups.
         """
         return True
+
+    @property
+    def supported_artist_types(self) -> set[ArtistType]:
+        """
+        Return all supported artist types by this provider.
+
+        Note, that this property only is used, if an artist-related ProviderFeature like
+        ProviderFeature.LIBRARY_ARTISTS is supported by the provider.
+        """
+        return {ArtistType.SINGER}
 
     async def loaded_in_mass(self) -> None:
         """Call after the provider has been loaded."""
@@ -1053,32 +1063,34 @@ class MusicProvider(Provider):
 
     def _validate_audiobook_author_narrator_types(self, prov_item: Audiobook) -> None:
         """Validate that authors/narrators types match the provider's supported features."""
-        if ProviderFeature.AUTHOR_AUDIOBOOKS in self.supported_features and not all(
-            isinstance(author, Artist) for author in prov_item.authors
+        if ArtistType.AUTHOR in self.supported_artist_types and not all(
+            (isinstance(author, Artist) and author.artist_type == ArtistType.AUTHOR)
+            for author in prov_item.authors
         ):
             raise MusicAssistantError(
-                f"Provider {self.name} supports ProviderFeature.AUTHOR_AUDIOBOOKS, but"
+                f"Provider {self.name} supports ArtistType.AUTHOR, but"
                 f" item {prov_item.name} does not exclusively provide Artist instances."
             )
-        if ProviderFeature.NARRATOR_AUDIOBOOKS in self.supported_features and not all(
-            isinstance(narrator, Artist) for narrator in prov_item.narrators
+        if ArtistType.NARRATOR in self.supported_artist_types and not all(
+            (isinstance(narrator, Artist) and narrator.artist_type == ArtistType.NARRATOR)
+            for narrator in prov_item.narrators
         ):
             raise MusicAssistantError(
-                f"Provider {self.name} supports ProviderFeature.NARRATOR_AUDIOBOOKS, but"
+                f"Provider {self.name} supports ArtistType.NARRATOR, but"
                 f" item {prov_item.name} does not exclusively provide Artist instances."
             )
-        if ProviderFeature.AUTHOR_AUDIOBOOKS not in self.supported_features and not all(
+        if ArtistType.AUTHOR not in self.supported_artist_types and not all(
             isinstance(author, str) for author in prov_item.authors
         ):
             raise MusicAssistantError(
-                f"Provider {self.name} does not support ProviderFeature.AUTHOR_AUDIOBOOKS, but"
+                f"Provider {self.name} does not support artists of type author, but"
                 f" item {prov_item.name} does not exclusively provide strings."
             )
-        if ProviderFeature.NARRATOR_AUDIOBOOKS not in self.supported_features and not all(
+        if ArtistType.NARRATOR not in self.supported_artist_types and not all(
             isinstance(narrator, str) for narrator in prov_item.narrators
         ):
             raise MusicAssistantError(
-                f"Provider {self.name} does not support ProviderFeature.NARRATOR_AUDIOBOOKS, but"
+                f"Provider {self.name} does not support artists of type narrator, but"
                 f" item {prov_item.name} does not exclusively provide strings."
             )
 

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Final, cast
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.enums import ArtistType, MediaType, ProviderFeature
 from music_assistant_models.errors import (
+    InvalidDataError,
     MediaNotFoundError,
     MusicAssistantError,
     UnsupportedFeaturedException,
@@ -86,8 +87,8 @@ class MusicProvider(Provider):
         """
         Return all supported artist types by this provider.
 
-        Note, that this property only is used, if an artist-related ProviderFeature like
-        ProviderFeature.LIBRARY_ARTISTS is supported by the provider.
+        Note, that this property currently is only used, to verify support of artists with
+        ArtistType.AUTHOR or ArtistType.NARRATOR.
         """
         return {ArtistType.SINGER}
 
@@ -1062,34 +1063,41 @@ class MusicProvider(Provider):
                 self._report_sync_task_failure(MediaType.TRACK, prov_track.uri, err)
 
     def _validate_audiobook_author_narrator_types(self, prov_item: Audiobook) -> None:
-        """Validate that authors/narrators types match the provider's supported features."""
+        """
+        Validate of correct artist and artist types.
+
+        If a provider supports artists of type Author or Narrator, they have to be part of an audiobook instance.
+        Otherwise only strings are allowed.
+        """
         if ArtistType.AUTHOR in self.supported_artist_types and not all(
             (isinstance(author, Artist) and author.artist_type == ArtistType.AUTHOR)
             for author in prov_item.authors
         ):
-            raise MusicAssistantError(
+            raise InvalidDataError(
                 f"Provider {self.name} supports ArtistType.AUTHOR, but"
-                f" item {prov_item.name} does not exclusively provide Artist instances."
+                f" item {prov_item.name} does not exclusively provide Artist instances "
+                "with ArtistType.AUTHOR set."
             )
         if ArtistType.NARRATOR in self.supported_artist_types and not all(
             (isinstance(narrator, Artist) and narrator.artist_type == ArtistType.NARRATOR)
             for narrator in prov_item.narrators
         ):
-            raise MusicAssistantError(
+            raise InvalidDataError(
                 f"Provider {self.name} supports ArtistType.NARRATOR, but"
-                f" item {prov_item.name} does not exclusively provide Artist instances."
+                f" item {prov_item.name} does not exclusively provide Artist instances "
+                "with ArtistType.NARRATOR set."
             )
         if ArtistType.AUTHOR not in self.supported_artist_types and not all(
             isinstance(author, str) for author in prov_item.authors
         ):
-            raise MusicAssistantError(
+            raise InvalidDataError(
                 f"Provider {self.name} does not support artists of type author, but"
                 f" item {prov_item.name} does not exclusively provide strings."
             )
         if ArtistType.NARRATOR not in self.supported_artist_types and not all(
             isinstance(narrator, str) for narrator in prov_item.narrators
         ):
-            raise MusicAssistantError(
+            raise InvalidDataError(
                 f"Provider {self.name} does not support artists of type narrator, but"
                 f" item {prov_item.name} does not exclusively provide strings."
             )
@@ -1132,9 +1140,8 @@ class MusicProvider(Provider):
                         lib_fully_played = library_item.fully_played
                         lib_resume_position_ms = library_item.resume_position_ms
                     else:
-                        # detect a change in ProviderFeature
-                        # (stored authors/narrators are plain strings but the provider
-                        # now supplies full Artist objects)
+                        # Detect, if stored authors/narrators are plain strings but the provider
+                        # now supplies full Artist objects, i.e. artist support changed.
                         prov_author = prov_item.authors[0] if prov_item.authors else None
                         prov_narrator = prov_item.narrators[0] if prov_item.narrators else None
                         if (sync_details.author_is_str and not isinstance(prov_author, str)) or (

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -28,9 +28,6 @@ from aioaudiobookshelf.exceptions import (
 )
 from aioaudiobookshelf.schema.author import AuthorExpanded
 from aioaudiobookshelf.schema.calls_authors import (
-    AuthorWithItems as AbsAuthorWithItems,
-)
-from aioaudiobookshelf.schema.calls_authors import (
     AuthorWithItemsAndSeries as AbsAuthorWithItemsAndSeries,
 )
 from aioaudiobookshelf.schema.calls_items import (
@@ -82,6 +79,7 @@ from music_assistant_models.config_entries import (
     ProviderConfig,
 )
 from music_assistant_models.enums import (
+    ArtistType,
     ConfigEntryType,
     ContentType,
     MediaType,
@@ -152,8 +150,6 @@ SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_AUDIOBOOKS,
     ProviderFeature.LIBRARY_PLAYLISTS,
     ProviderFeature.LIBRARY_ARTISTS,  # authors/ narrators
-    ProviderFeature.AUTHOR_AUDIOBOOKS,
-    ProviderFeature.NARRATOR_AUDIOBOOKS,
     ProviderFeature.BROWSE,
     ProviderFeature.RECOMMENDATIONS,
 }
@@ -387,6 +383,11 @@ for more details.
             features.add(ProviderFeature.PLAYLIST_CREATE_PODCAST_EPISODES)
         return features
 
+    @property
+    def supported_artist_types(self) -> set[ArtistType]:
+        """Supported artist types."""
+        return {ArtistType.AUTHOR, ArtistType.NARRATOR}
+
     @handle_refresh_token
     async def sync_library(self, media_type: MediaType) -> None:
         """Obtain audiobook library ids and podcast library ids."""
@@ -452,43 +453,6 @@ for more details.
                 yield parse_narrator(
                     abs_narrator=abs_narrator, instance_id=self.instance_id, domain=self.domain
                 )
-
-    async def get_author_audiobooks(self, prov_artist_id: str) -> list[Audiobook]:
-        """Get audiobooks of author."""
-        abs_author = await self._client.get_author(
-            author_id=prov_artist_id, include_items=True, include_series=False
-        )
-        if not isinstance(abs_author, AbsAuthorWithItems):
-            raise TypeError("Unexpected type of author.")
-
-        book_ids = {x.id_ for x in abs_author.library_items}
-        audiobooks: list[Audiobook] = []
-        for book_id in book_ids:
-            mass_item = await self.mass.music.get_library_item_by_prov_id(
-                media_type=MediaType.AUDIOBOOK,
-                item_id=book_id,
-                provider_instance_id_or_domain=self.instance_id,
-            )
-            if mass_item is not None:
-                mass_item = cast("Audiobook", mass_item)
-                audiobooks.append(mass_item)
-        return audiobooks
-
-    async def get_narrator_audiobooks(self, prov_artist_id: str) -> list[Audiobook]:
-        """Get audiobooks of narrator."""
-        narrator_lib_id: str = ""
-        # get library of artist:
-        for lib_id, narrator_ids in self.libraries.narrators.items():
-            if prov_artist_id in narrator_ids:
-                narrator_lib_id = lib_id
-                break
-        if narrator_lib_id:
-            return list(
-                await self._browse_narrator_books(
-                    library_id=narrator_lib_id, narrator_filter_str=prov_artist_id
-                )
-            )
-        return []
 
     async def get_artist(self, prov_artist_id: str) -> Artist:
         """Get an author or narrator."""


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Follow up fixes to artist support of type ArtistType.AUTHOR / ArtistType.NARRATOR:
- ProviderFeature.LIBRARY_ARTIST doesn't indicate, what kind of artists are supported. Add an additional API endpoint giving all library-supported artist types
- ProviderFeature.AUTHOR_AUDIOBOOKS / ProviderFeature.NARRATOR_AUDIOBOOKS are for streaming providers, where the provider might have additional audiobooks of an author/ narrator not part of the library.
    - Remove from audiobookshelf, including methods. Doesn't make any sense, audiobookshelf is not a streaming provider, and we sync all artists to the library
    - Do not use these ProviderFeatures to check, if an audiobook.author/ narrator should be a string or Artist
- Introduce a new music model property supported_artist_types, which is instead used for verification. By default this is ArtistType.SINGER, but not used anywhere.

Nothing of this is breaking, the only provider using this until now was abs, and it is fix in this PR as well.

The frontend companion PR depends on these changes.
https://github.com/music-assistant/frontend/pull/2000

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
