### PR TITLE
Reduce repeated discovery logging

### DIFF
--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -78,6 +78,14 @@ _CAST_LOG_LEVEL_MAP: dict[str, int] = {
     "debug": logging.DEBUG,
 }
 
+_BRIDGE_POLICY_STATE_FIELDS = {
+    "device_info.identifiers",
+    "device_info.manufacturer",
+    "device_info.model",
+    "output_protocols",
+    "type",
+}
+
 
 class SendspinCastController(BaseController):
     """
@@ -676,7 +684,17 @@ class SendspinBridgeManager(SendspinBridgeManagerBase[SendspinChromecastBridge])
         super().__init__(provider)
         self._rebridge_unsubs: dict[str, Callable[[], None]] = {}
         self._claimed_clients: dict[str, str] = {}
-        self._unsubs.append(self.mass.subscribe(self._on_player_updated, EventType.PLAYER_UPDATED))
+        self._blocklist_log_state: dict[str, tuple[str, str]] = {}
+        self._pending_bridge_evaluations: set[str] = set()
+        self._unsubs.append(
+            self.mass.players.subscribe_player_state_update(self._on_player_state_updated)
+        )
+        self._unsubs.append(
+            self.mass.subscribe(
+                self._on_player_unregistered,
+                (EventType.PLAYER_UPDATED, EventType.PLAYER_REMOVED),
+            )
+        )
 
     async def remove_bridge(self, player_id: str, permanent: bool = False) -> None:
         """
@@ -708,6 +726,8 @@ class SendspinBridgeManager(SendspinBridgeManagerBase[SendspinChromecastBridge])
                 unsub()
         self._rebridge_unsubs.clear()
         self._claimed_clients.clear()
+        self._blocklist_log_state.clear()
+        self._pending_bridge_evaluations.clear()
         await super().close()
 
     def get_bridge_by_client_id(self, bridge_client_id: str) -> SendspinChromecastBridge | None:
@@ -761,13 +781,17 @@ class SendspinBridgeManager(SendspinBridgeManagerBase[SendspinChromecastBridge])
         manufacturer = cast_player.device_info.manufacturer or ""
         model = cast_player.device_info.model or ""
         if is_sendspin_cast_blocked(manufacturer, model):
-            self.logger.debug(
-                "Skipping Sendspin Cast bridge for %s (%s / %s) — device is blocklisted",
-                cast_player.display_name,
-                manufacturer,
-                model,
-            )
+            blocklist_state = (manufacturer, model)
+            if self._blocklist_log_state.get(cast_player.player_id) != blocklist_state:
+                self.logger.debug(
+                    "Skipping Sendspin Cast bridge for %s (%s / %s) — device is blocklisted",
+                    cast_player.display_name,
+                    manufacturer,
+                    model,
+                )
+                self._blocklist_log_state[cast_player.player_id] = blocklist_state
             return False
+        self._blocklist_log_state.pop(cast_player.player_id, None)
 
         # Prefer the airplay bridge over the cast bridge: the Cast receiver
         # pipeline is fragile on many (especially 3rd-party) devices. Hard-deny
@@ -935,20 +959,49 @@ class SendspinBridgeManager(SendspinBridgeManagerBase[SendspinChromecastBridge])
 
         self._rebridge_unsubs[client_id] = _combined_unsub
 
-    async def _on_player_updated(self, event: MassEvent) -> None:
-        """Re-evaluate bridge state for cast players affected by a player update."""
-        if not event.object_id:
+    def _on_player_state_updated(
+        self, updated_player: Player, changed_values: dict[str, tuple[Any, Any]]
+    ) -> None:
+        """Re-evaluate bridge state after a relevant player state change."""
+        if not changed_values.keys() & _BRIDGE_POLICY_STATE_FIELDS:
             return
-        updated_player = self.mass.players.get_player(event.object_id)
-        match_ids = {event.object_id}
-        if updated_player and updated_player.protocol_parent_id:
+        match_ids = {updated_player.player_id}
+        if updated_player.protocol_parent_id:
             match_ids.add(updated_player.protocol_parent_id)
+        self._schedule_bridge_evaluations(match_ids)
+
+    def _on_player_unregistered(self, event: MassEvent) -> None:
+        """Re-evaluate Cast bridges after a possible parent is unregistered."""
+        if not event.object_id or self.mass.players.get_player(event.object_id):
+            return
+        self._schedule_bridge_evaluations({event.object_id})
+
+    def _schedule_bridge_evaluations(self, match_ids: set[str]) -> None:
+        """Schedule reconciliation for Cast bridges matching a player ID."""
         for player in self.provider.players:
             cast_player = cast("ChromecastPlayer", player)
             if cast_player.player_id in match_ids or (
                 cast_player.protocol_parent_id and cast_player.protocol_parent_id in match_ids
             ):
-                await self.evaluate_bridge(cast_player)
+                self._pending_bridge_evaluations.add(cast_player.player_id)
+                self.mass.create_task(
+                    self._process_pending_bridge_evaluations,
+                    cast_player.player_id,
+                    task_id=f"evaluate_chromecast_sendspin_bridge_{cast_player.player_id}",
+                )
+
+    async def _process_pending_bridge_evaluations(self, player_id: str) -> None:
+        """
+        Reconcile all bridge policy updates queued for a Chromecast player.
+
+        :param player_id: The Chromecast player ID to reconcile.
+        """
+        while player_id in self._pending_bridge_evaluations:
+            self._pending_bridge_evaluations.discard(player_id)
+            player = self.mass.players.get_player(player_id)
+            if player is None or player.provider is not self.provider:
+                return
+            await self.evaluate_bridge(player)
 
     async def _on_player_config_updated(self, event: MassEvent) -> None:
         """Re-evaluate bridges and push runtime config updates to active Cast apps."""

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -39,12 +39,15 @@ if TYPE_CHECKING:
 class SonosPlayerProvider(PlayerProvider):
     """Sonos Player provider."""
 
+    _ignored_disabled_players: set[str]
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to setup this provider."""
         return (CONF_ENTRY_MANUAL_DISCOVERY_IPS,)
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
+        self._ignored_disabled_players = set()
         self._set_aiosonos_log_level()
         self.mass.streams.register_dynamic_route(
             "/sonos_queue/*", self._handle_sonos_cloud_queue_request
@@ -138,6 +141,8 @@ class SonosPlayerProvider(PlayerProvider):
                 sonos_player.reconnect()
             self.mass.players.trigger_player_update(player_id)
             return
+        if self._ignore_disabled_discovery(player_id, name):
+            return
         # handle new player setup in a delayed task because mdns announcements
         # can arrive in (duplicated) bursts
         task_id = f"setup_sonos_{player_id}"
@@ -157,11 +162,10 @@ class SonosPlayerProvider(PlayerProvider):
         if self.mass.players.get_player(player_id):
             msg = f"Player {player_id} already exists"
             raise ValueError(msg)
+        if self._ignore_disabled_discovery(player_id, name):
+            return
         address = get_primary_ip_address(info)
         if address is None:
-            return
-        if not self.mass.config.get_raw_player_config_value(player_id, "enabled", True):
-            self.logger.debug("Ignoring %s in discovery as it is disabled.", name)
             return
         try:
             discovery_info = await get_discovery_info(self.mass.http_session_no_ssl, address)
@@ -179,6 +183,21 @@ class SonosPlayerProvider(PlayerProvider):
         sonos_player = SonosPlayer(self, player_id, discovery_info=discovery_info)
         sonos_player.device_info.add_identifier(IdentifierType.IP_ADDRESS, address)
         await sonos_player.setup()
+
+    def _ignore_disabled_discovery(self, player_id: str, name: str) -> bool:
+        """
+        Return whether discovery should ignore a disabled player.
+
+        :param player_id: The discovered Sonos player ID.
+        :param name: The discovered Sonos service name.
+        """
+        if self.mass.config.get_raw_player_config_value(player_id, "enabled", True):
+            self._ignored_disabled_players.discard(player_id)
+            return False
+        if player_id not in self._ignored_disabled_players:
+            self.logger.debug("Ignoring %s in discovery as it is disabled.", name)
+            self._ignored_disabled_players.add(player_id)
+        return True
 
     async def _handle_sonos_cloud_queue_request(self, request: web.Request) -> web.Response:
         """

--- a/tests/providers/sendspin/test_bridge_manager.py
+++ b/tests/providers/sendspin/test_bridge_manager.py
@@ -264,6 +264,8 @@ class TestCastBridgePolicy:
         """
         mass = MagicMock()
         mass.subscribe = MagicMock(return_value=MagicMock())
+        mass.players.subscribe_player_state_update = MagicMock(return_value=MagicMock())
+        mass.create_task = MagicMock()
         provider = MagicMock()
         provider.mass = mass
         provider.logger = logging.getLogger("test.cast_bridge_manager")
@@ -277,6 +279,8 @@ class TestCastBridgePolicy:
         cast_player.device_info.manufacturer = "TestCo"
         cast_player.device_info.model = "TestSpeaker"
         cast_player.protocol_parent_id = "parent_1"
+        cast_player.provider = provider
+        provider.players = [cast_player]
 
         manager = CastSendspinBridgeManager(provider)
         return manager, mass, cast_player
@@ -315,6 +319,104 @@ class TestCastBridgePolicy:
         mass.players.get_player = MagicMock(return_value=parent)
 
         assert manager._should_have_bridge(cast_player) is True
+
+    def test_blocklist_message_only_repeats_after_policy_change(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test repeated blocklist checks only log when the policy result changes."""
+        manager, _, cast_player = self._make_cast_environment()
+        cast_player.device_info.manufacturer = "Harman Luxury Audio"
+        cast_player.protocol_parent_id = None
+
+        with caplog.at_level(logging.DEBUG, logger=manager.logger.name):
+            assert manager._should_have_bridge(cast_player) is False
+            assert manager._should_have_bridge(cast_player) is False
+            cast_player.device_info.manufacturer = "TestCo"
+            assert manager._should_have_bridge(cast_player) is True
+            cast_player.device_info.manufacturer = "Harman Luxury Audio"
+            assert manager._should_have_bridge(cast_player) is False
+
+        blocklist_records = [
+            record for record in caplog.records if "device is blocklisted" in record.message
+        ]
+        assert len(blocklist_records) == 2
+
+    def test_irrelevant_state_update_does_not_schedule_evaluation(self) -> None:
+        """Test playback state updates do not re-evaluate bridge policy."""
+        manager, mass, cast_player = self._make_cast_environment()
+
+        manager._on_player_state_updated(cast_player, {"volume_level": (20, 30)})
+
+        mass.create_task.assert_not_called()
+
+    def test_relevant_cast_state_update_schedules_evaluation(self) -> None:
+        """Test device policy changes re-evaluate the affected Cast bridge."""
+        manager, mass, cast_player = self._make_cast_environment()
+
+        manager._on_player_state_updated(
+            cast_player, {"device_info.model": ("Old Model", "New Model")}
+        )
+
+        mass.create_task.assert_called_once_with(
+            manager._process_pending_bridge_evaluations,
+            cast_player.player_id,
+            task_id="evaluate_chromecast_sendspin_bridge_cc_player",
+        )
+
+    def test_parent_protocol_update_schedules_evaluation(self) -> None:
+        """Test protocol changes on a parent re-evaluate its Cast bridge."""
+        manager, mass, _ = self._make_cast_environment()
+        parent = MagicMock()
+        parent.player_id = "parent_1"
+        parent.protocol_parent_id = None
+
+        manager._on_player_state_updated(parent, {"output_protocols": ((), ("airplay",))})
+
+        mass.create_task.assert_called_once()
+
+    def test_unregistered_parent_schedules_evaluation(self) -> None:
+        """Test removal of a protocol parent re-evaluates its Cast bridge."""
+        manager, mass, _ = self._make_cast_environment()
+        mass.players.get_player.return_value = None
+        event = MagicMock()
+        event.object_id = "parent_1"
+
+        manager._on_player_unregistered(event)
+
+        mass.create_task.assert_called_once()
+
+    def test_registered_player_event_does_not_duplicate_evaluation(self) -> None:
+        """Test regular player events remain on the filtered state-update path."""
+        manager, mass, _ = self._make_cast_environment()
+        mass.players.get_player.return_value = MagicMock()
+        event = MagicMock()
+        event.object_id = "parent_1"
+
+        manager._on_player_unregistered(event)
+
+        mass.create_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_during_evaluation_triggers_trailing_reconciliation(self) -> None:
+        """Test a policy update during reconciliation is processed afterward."""
+        manager, mass, cast_player = self._make_cast_environment()
+        mass.players.get_player.return_value = cast_player
+        evaluation_count = 0
+
+        async def evaluate_bridge(player: Any) -> None:
+            nonlocal evaluation_count
+            evaluation_count += 1
+            if evaluation_count == 1:
+                manager._pending_bridge_evaluations.add(player.player_id)
+
+        evaluate_mock = AsyncMock(side_effect=evaluate_bridge)
+        manager.evaluate_bridge = evaluate_mock  # type: ignore[method-assign]
+        manager._pending_bridge_evaluations.add(cast_player.player_id)
+
+        await manager._process_pending_bridge_evaluations(cast_player.player_id)
+
+        assert evaluate_mock.await_count == 2
+        assert not manager._pending_bridge_evaluations
 
 
 class TestLocalAudioBridgeManager:

--- a/tests/providers/sonos/__init__.py
+++ b/tests/providers/sonos/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Sonos provider."""

--- a/tests/providers/sonos/test_provider.py
+++ b/tests/providers/sonos/test_provider.py
@@ -1,0 +1,79 @@
+"""Tests for Sonos provider discovery."""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from zeroconf import ServiceStateChange
+
+from music_assistant.providers.sonos.provider import SonosPlayerProvider
+
+
+def _make_provider(enabled: bool = False) -> tuple[SonosPlayerProvider, MagicMock]:
+    """Create a Sonos provider with mocked discovery dependencies."""
+    provider = SonosPlayerProvider.__new__(SonosPlayerProvider)
+    mass = MagicMock()
+    provider.mass = mass
+    provider.logger = logging.getLogger("test.sonos.discovery")
+    provider._ignored_disabled_players = set()
+    mass.config.get_raw_player_config_value.return_value = enabled
+    mass.players.get_player.return_value = None
+    return provider, mass
+
+
+def _make_discovery_info(player_id: str = "sonos_player") -> MagicMock:
+    """Create minimal Sonos mDNS discovery information."""
+    info = MagicMock()
+    info.decoded_properties = {"uuid": player_id}
+    return info
+
+
+@pytest.mark.asyncio
+async def test_disabled_discovery_is_not_scheduled_repeatedly(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test repeated announcements for a disabled player are ignored once."""
+    provider, mass = _make_provider()
+    info = _make_discovery_info()
+
+    with caplog.at_level(logging.DEBUG, logger=provider.logger.name):
+        await provider.on_mdns_service_state_change(
+            "Toilet._sonos._tcp.local.", ServiceStateChange.Added, info
+        )
+        await provider.on_mdns_service_state_change(
+            "Toilet._sonos._tcp.local.", ServiceStateChange.Updated, info
+        )
+
+    mass.call_later.assert_not_called()
+    ignored_records = [
+        record for record in caplog.records if "in discovery as it is disabled" in record.message
+    ]
+    assert len(ignored_records) == 1
+
+
+@pytest.mark.asyncio
+async def test_disabled_discovery_logs_again_after_reenable(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a new disabled period produces a new discovery diagnostic."""
+    provider, mass = _make_provider()
+    info = _make_discovery_info()
+
+    with caplog.at_level(logging.DEBUG, logger=provider.logger.name):
+        await provider.on_mdns_service_state_change(
+            "Toilet._sonos._tcp.local.", ServiceStateChange.Added, info
+        )
+        mass.config.get_raw_player_config_value.return_value = True
+        await provider.on_mdns_service_state_change(
+            "Toilet._sonos._tcp.local.", ServiceStateChange.Updated, info
+        )
+        mass.config.get_raw_player_config_value.return_value = False
+        await provider.on_mdns_service_state_change(
+            "Toilet._sonos._tcp.local.", ServiceStateChange.Updated, info
+        )
+
+    mass.call_later.assert_called_once()
+    ignored_records = [
+        record for record in caplog.records if "in discovery as it is disabled" in record.message
+    ]
+    assert len(ignored_records) == 2


### PR DESCRIPTION
# What does this implement/fix?

Reduces repeated discovery messages and unnecessary work caused by recurring player and mDNS updates.

- Reconcile Chromecast Sendspin bridges only for relevant state changes.
- Log unchanged Chromecast blocklist and disabled Sonos decisions once.
- Skip delayed Sonos setup for disabled players.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.