### PR TITLE
Fix playback on devices whose AirPlay output still needs pairing

### DIFF
--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -720,7 +720,7 @@ class PlayerConfigMixin:
             if has_native_volume_control:
                 break
             protocol_player = self.mass.players.get_player(linked_protocol.output_protocol_id)
-            if not protocol_player or not protocol_player.available:
+            if not protocol_player or not protocol_player.available_for_playback:
                 continue
             if protocol_player.supports_feature(PlayerFeature.VOLUME_SET):
                 if auto_option not in volume_options:

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1723,7 +1723,9 @@ class ProtocolLinkingMixin:
         # 1. Check if any output protocol is currently grouped
         for linked in player.linked_output_protocols:
             if protocol_player := self.get_player(linked.output_protocol_id):
-                if protocol_player.available and self._is_protocol_grouped(protocol_player):
+                if protocol_player.available_for_playback and self._is_protocol_grouped(
+                    protocol_player
+                ):
                     self.logger.log(
                         VERBOSE_LOG_LEVEL,
                         "Selected protocol for %s: %s (grouped)",
@@ -1749,7 +1751,7 @@ class ProtocolLinkingMixin:
                 for linked in player.linked_output_protocols:
                     if linked.output_protocol_id == preferred:
                         if protocol_player := self.get_player(linked.output_protocol_id):
-                            if protocol_player.available:
+                            if protocol_player.available_for_playback:
                                 self.logger.log(
                                     VERBOSE_LOG_LEVEL,
                                     "Selected protocol for %s: %s (user preference)",
@@ -1769,7 +1771,7 @@ class ProtocolLinkingMixin:
         # 4. Fall back to best protocol by priority
         for linked in sorted(player.linked_output_protocols, key=lambda x: x.priority):
             if protocol_player := self.get_player(linked.output_protocol_id):
-                if protocol_player.available:
+                if protocol_player.available_for_playback:
                     self.logger.log(
                         VERBOSE_LOG_LEVEL,
                         "Selected protocol for %s: %s (priority-based)",
@@ -1819,7 +1821,7 @@ class ProtocolLinkingMixin:
         for linked in player.linked_output_protocols:
             if (
                 (protocol_player := self.mass.players.get_player(linked.output_protocol_id))
-                and protocol_player.available
+                and protocol_player.available_for_playback
                 and required_feature in protocol_player.supported_features
             ):
                 return protocol_player
@@ -1953,11 +1955,11 @@ class ProtocolLinkingMixin:
         if not child_preferred or child_preferred in {"auto", "native"}:
             return None, None
 
-        # Find child's preferred protocol in linked protocols
+        # Find child's preferred protocol, with its current availability
         child_protocol = None
-        for linked in child_player.linked_output_protocols:
-            if linked.output_protocol_id == child_preferred:
-                child_protocol = linked
+        for output_protocol in child_player.output_protocols:
+            if output_protocol.output_protocol_id == child_preferred:
+                child_protocol = output_protocol
                 break
 
         if not child_protocol or not child_protocol.available:

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -510,6 +510,18 @@ class Player(ABC):
 
     @property
     @final
+    def available_for_playback(self) -> bool:
+        """
+        Return if the player can currently be used to play (or control) audio.
+
+        A device that is reachable but still needs setup - an unpaired AirPlay
+        receiver, for example - can not accept a stream, so it must never be
+        picked as an output protocol or command target.
+        """
+        return self.available and not self.needs_setup
+
+    @property
+    @final
     def implements_setup_flow(self) -> bool:
         """Return if this player implements its own interactive setup flow."""
         return type(self).run_setup_flow is not Player.run_setup_flow
@@ -1534,7 +1546,7 @@ class Player(ABC):
                     name=self.provider.name,
                     protocol_domain=self.provider.domain,
                     priority=0,  # Native is always highest priority
-                    available=self.available,
+                    available=self.available_for_playback,
                     is_native=True,
                 )
             )
@@ -1549,7 +1561,7 @@ class Player(ABC):
                     name=self.provider.name,
                     protocol_domain=self.provider.domain,
                     priority=PROTOCOL_PRIORITY[self.provider.domain],
-                    available=self.available,
+                    available=self.available_for_playback,
                     is_native=True,
                 )
             )
@@ -1560,7 +1572,7 @@ class Player(ABC):
             active_ids.add(linked.output_protocol_id)
             # Check if the protocol player is actually available
             protocol_player = self.mass.players.get_player(linked.output_protocol_id)
-            is_available = protocol_player.available if protocol_player else False
+            is_available = protocol_player.available_for_playback if protocol_player else False
             # Use provider name if available, else domain title
             if protocol_player:
                 name = protocol_player.provider.name
@@ -1700,7 +1712,9 @@ class Player(ABC):
         for linked in self.__attr_linked_protocols:
             if linked.protocol_domain == protocol_domain:
                 protocol_player = self.mass.players.get_player(linked.output_protocol_id)
-                current_available = protocol_player.available if protocol_player else False
+                current_available = (
+                    protocol_player.available_for_playback if protocol_player else False
+                )
                 return OutputProtocol(
                     output_protocol_id=linked.output_protocol_id,
                     name=protocol_player.provider.name
@@ -1741,7 +1755,7 @@ class Player(ABC):
         """Get the best available protocol player by priority."""
         for linked in sorted(self.__attr_linked_protocols, key=lambda x: x.priority):
             if protocol_player := self.mass.players.get_player(linked.output_protocol_id):
-                if protocol_player.available:
+                if protocol_player.available_for_playback:
                     return protocol_player
         return None
 
@@ -2004,7 +2018,7 @@ class Player(ABC):
             protocol_player = self.mass.players.get_player(active_protocol)
             if (
                 protocol_player
-                and protocol_player.available
+                and protocol_player.available_for_playback
                 and feature in protocol_player.supported_features
             ):
                 return protocol_player
@@ -2021,7 +2035,7 @@ class Player(ABC):
             preferred_protocol = str(preferred_conf)
             if (
                 (_player := self.mass.players.get_player(preferred_protocol))
-                and _player.available
+                and _player.available_for_playback
                 and feature in _player.supported_features
             ):
                 return _player
@@ -2036,7 +2050,7 @@ class Player(ABC):
         ):
             if (
                 (protocol_player := self.mass.players.get_player(linked.output_protocol_id))
-                and protocol_player.available
+                and protocol_player.available_for_playback
                 and feature in protocol_player.supported_features
             ):
                 return protocol_player

--- a/music_assistant/providers/universal_player/player.py
+++ b/music_assistant/providers/universal_player/player.py
@@ -75,7 +75,7 @@ class UniversalPlayer(Player):
     def available(self) -> bool:
         """Return if the player is currently available."""
         return any(
-            (p := self.mass.players.get_player(pid)) and p.available and not p.needs_setup
+            (p := self.mass.players.get_player(pid)) and p.available_for_playback
             for pid in self._protocol_player_ids
         )
 
@@ -84,10 +84,16 @@ class UniversalPlayer(Player):
         """Return if the player needs setup (a protocol is connected but not set up)."""
         if self.available:
             return False
-        return any(
-            (p := self.mass.players.get_player(pid)) and p.available and p.needs_setup
-            for pid in self._protocol_player_ids
-        )
+        return self._get_protocol_player_needing_setup() is not None
+
+    @property
+    def setup_reason(self) -> str | None:
+        """Return why the player needs setup, or None when it is ready to use."""
+        if self.available:
+            return None
+        if protocol_player := self._get_protocol_player_needing_setup():
+            return protocol_player.setup_reason
+        return None
 
     @property
     def supported_features(self) -> set[PlayerFeature]:
@@ -185,6 +191,14 @@ class UniversalPlayer(Player):
         """Remove a protocol player from this universal player."""
         if protocol_player_id in self._protocol_player_ids:
             self._protocol_player_ids.remove(protocol_player_id)
+
+    def _get_protocol_player_needing_setup(self) -> Player | None:
+        """Return the first connected protocol player that still needs setup, if any."""
+        for pid in self._protocol_player_ids:
+            protocol_player = self.mass.players.get_player(pid)
+            if protocol_player and protocol_player.available and protocol_player.needs_setup:
+                return protocol_player
+        return None
 
     def _get_active_output_protocol_player(self) -> Player | None:
         """Return the protocol player currently selected as this player's output, if any."""

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -1292,6 +1292,83 @@ class TestSelectBestOutputProtocol:
         assert selected_player == native_player
         assert output_protocol is None  # None means native playback
 
+    def test_skip_protocol_that_needs_setup(self, mock_mass: MagicMock) -> None:
+        """Test that a protocol player which still needs setup is never selected."""
+        controller = PlayerController(mock_mass)
+
+        # Universal player wrapping the protocols of a device without native playback
+        universal_provider = MockProvider("universal_player", mass=mock_mass)
+        universal_player = MockPlayer(
+            universal_provider,
+            "up_AABBCCDDEEFF",
+            "Living Room TV",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+
+        # AirPlay protocol player that is discovered but still awaits pairing
+        airplay_provider = MockProvider("airplay", mass=mock_mass)
+        airplay_player = MockPlayer(
+            airplay_provider,
+            "airplay_AABBCCDDEEFF",
+            "Living Room TV AirPlay",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        airplay_player._attr_needs_setup = True
+
+        dlna_provider = MockProvider("dlna", mass=mock_mass)
+        dlna_player = MockPlayer(
+            dlna_provider,
+            "dlna_AABBCCDDEEFF",
+            "Living Room TV DLNA",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+
+        # Wire up mock_mass.players to controller
+        mock_mass.players = controller
+
+        # Register players
+        controller._players = {
+            "up_AABBCCDDEEFF": universal_player,
+            "airplay_AABBCCDDEEFF": airplay_player,
+            "dlna_AABBCCDDEEFF": dlna_player,
+        }
+
+        # Link both protocols, AirPlay with the better priority
+        universal_player.set_linked_output_protocols(
+            [
+                OutputProtocol(
+                    output_protocol_id="airplay_AABBCCDDEEFF",
+                    name="AirPlay",
+                    protocol_domain="airplay",
+                    priority=10,
+                ),
+                OutputProtocol(
+                    output_protocol_id="dlna_AABBCCDDEEFF",
+                    name="DLNA",
+                    protocol_domain="dlna",
+                    priority=50,
+                ),
+            ]
+        )
+
+        selected_player, output_protocol = controller._select_best_output_protocol(universal_player)
+
+        # Should skip the unpaired AirPlay output and fall through to DLNA
+        assert selected_player == dlna_player
+        assert output_protocol is not None
+        assert output_protocol.output_protocol_id == "dlna_AABBCCDDEEFF"
+
+        # and the unpaired output must be reported as unavailable
+        universal_player.update_state(signal_event=False)
+        airplay_output = next(
+            protocol
+            for protocol in universal_player.output_protocols
+            if protocol.output_protocol_id == "airplay_AABBCCDDEEFF"
+        )
+        assert airplay_output.available is False
+
 
 class TestPlayerGrouping:
     """Tests for player grouping scenarios."""

--- a/tests/providers/universal_player/test_player.py
+++ b/tests/providers/universal_player/test_player.py
@@ -1,4 +1,4 @@
-"""Regression tests for universal player external-source delegation (#5443)."""
+"""Tests for the universal player."""
 
 from __future__ import annotations
 
@@ -78,6 +78,32 @@ def _make_chromecast_player(
     player.seek = AsyncMock()
     mass.players.get_player = MagicMock(return_value=player)
     return player
+
+
+def _make_protocol_player(
+    player_id: str,
+    domain: str,
+    *,
+    needs_setup: bool = False,
+    setup_reason: str | None = None,
+) -> MagicMock:
+    """Return a reachable protocol player, optionally still awaiting its setup."""
+    player = MagicMock(spec=Player)
+    player.player_id = player_id
+    player.available = True
+    player.available_for_playback = not needs_setup
+    player.needs_setup = needs_setup
+    player.setup_reason = setup_reason
+    provider = MagicMock()
+    provider.domain = domain
+    player.provider = provider
+    return player
+
+
+def _register_players(mass: MagicMock, *players: MagicMock) -> None:
+    """Make the given players resolvable by id on the mass mock."""
+    registry = {player.player_id: player for player in players}
+    mass.players.get_player = MagicMock(side_effect=lambda pid, *_a, **_kw: registry.get(pid))
 
 
 def _make_universal_player(mass: MagicMock, protocol_player_ids: list[str]) -> UniversalPlayer:
@@ -168,3 +194,30 @@ def test_no_features_without_external_source() -> None:
     )
     universal = _make_universal_player(mass, ["cc_1"])
     assert universal.supported_features == set()
+
+
+def test_setup_needed_when_only_protocol_awaits_setup() -> None:
+    """A wrapper whose only protocol still needs setup reports it, including the reason."""
+    mass = _make_mock_mass()
+    airplay = _make_protocol_player(
+        "ap_1", "airplay", needs_setup=True, setup_reason="pairing_required"
+    )
+    _register_players(mass, airplay)
+    universal = _make_universal_player(mass, ["ap_1"])
+    assert universal.available is False
+    assert universal.needs_setup is True
+    assert universal.setup_reason == "pairing_required"
+
+
+def test_no_setup_needed_while_another_protocol_is_usable() -> None:
+    """A wrapper that can play through another protocol does not ask for setup."""
+    mass = _make_mock_mass()
+    airplay = _make_protocol_player(
+        "ap_1", "airplay", needs_setup=True, setup_reason="pairing_required"
+    )
+    chromecast = _make_protocol_player("cc_1", "chromecast")
+    _register_players(mass, airplay, chromecast)
+    universal = _make_universal_player(mass, ["ap_1", "cc_1"])
+    assert universal.available is True
+    assert universal.needs_setup is False
+    assert universal.setup_reason is None

--- a/tests/providers/universal_player/test_player.py
+++ b/tests/providers/universal_player/test_player.py
@@ -53,33 +53,6 @@ def _make_universal_provider(mock_mass: MagicMock) -> UniversalPlayerProvider:
     return provider
 
 
-def _make_chromecast_player(
-    mass: MagicMock,
-    player_id: str,
-    *,
-    active_source: str | None,
-    features: set[PlayerFeature],
-) -> MagicMock:
-    """Return a chromecast-domain protocol player with the given active source and features."""
-    player = MagicMock(spec=Player)
-    player.player_id = player_id
-    player.available = True
-    player.active_source = active_source
-    player.playback_state = PlaybackState.PLAYING
-    player.supported_features = features
-    provider = MagicMock()
-    provider.domain = "chromecast"
-    player.provider = provider
-    player.play = AsyncMock()
-    player.pause = AsyncMock()
-    player.stop = AsyncMock()
-    player.next_track = AsyncMock()
-    player.previous_track = AsyncMock()
-    player.seek = AsyncMock()
-    mass.players.get_player = MagicMock(return_value=player)
-    return player
-
-
 def _make_protocol_player(
     player_id: str,
     domain: str,
@@ -104,6 +77,28 @@ def _register_players(mass: MagicMock, *players: MagicMock) -> None:
     """Make the given players resolvable by id on the mass mock."""
     registry = {player.player_id: player for player in players}
     mass.players.get_player = MagicMock(side_effect=lambda pid, *_a, **_kw: registry.get(pid))
+
+
+def _make_chromecast_player(
+    mass: MagicMock,
+    player_id: str,
+    *,
+    active_source: str | None,
+    features: set[PlayerFeature],
+) -> MagicMock:
+    """Return a chromecast-domain protocol player with the given active source and features."""
+    player = _make_protocol_player(player_id, "chromecast")
+    player.active_source = active_source
+    player.playback_state = PlaybackState.PLAYING
+    player.supported_features = features
+    player.play = AsyncMock()
+    player.pause = AsyncMock()
+    player.stop = AsyncMock()
+    player.next_track = AsyncMock()
+    player.previous_track = AsyncMock()
+    player.seek = AsyncMock()
+    _register_players(mass, player)
+    return player
 
 
 def _make_universal_player(mass: MagicMock, protocol_player_ids: list[str]) -> UniversalPlayer:


### PR DESCRIPTION
# What does this implement/fix?

Some devices only accept AirPlay after entering a PIN on screen, an LG TV for example. Music Assistant lists that AirPlay as an output of the player, but it can not be used until the pairing is done. It was still picked to play to, because AirPlay is the most preferred output of all, so playback failed on devices that had another output that worked fine. And when a device had nothing but that one output, the player asked for setup without saying why.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- An output that still needs setup is no longer offered or picked for playback, volume control or grouping
- A player that bundles the outputs of a device now also passes on why setup is needed (pairing required, for example)

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
