### PR TITLE
Promote LRC formatted text in the plain lyrics tag to lrc_lyrics

### DIFF
--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -33,7 +33,7 @@ from music_assistant.controllers.tasks.context import (
 )
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.images import cleanup_thumb_cache
-from music_assistant.helpers.lyrics import normalize_lrc_lyrics
+from music_assistant.helpers.lyrics import extract_lrc_lyrics, normalize_lrc_lyrics
 from music_assistant.helpers.throttle_retry import Throttler
 from music_assistant.helpers.util import try_parse_int
 from music_assistant.models.core_controller import CoreController
@@ -317,7 +317,8 @@ class MetaDataController(
         """
         lyrics, lrc_lyrics = await self._get_track_lyrics(track)
         # on-demand lookups are not stored in the library db, so normalize on the way out
-        return lyrics, normalize_lrc_lyrics(lrc_lyrics)
+        # promoting LRC formatted text stored in the plain lyrics tag
+        return lyrics, normalize_lrc_lyrics(lrc_lyrics or extract_lrc_lyrics(lyrics))
 
     async def get_diagnostics(self) -> dict[str, SerializableType] | None:
         """Return diagnostics info for this controller to include in diagnostics reports."""

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -48,7 +48,7 @@ from music_assistant.helpers.compare import (
 )
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.json import json_loads, serialize_to_json
-from music_assistant.helpers.lyrics import normalize_lrc_lyrics
+from music_assistant.helpers.lyrics import extract_lrc_lyrics, normalize_lrc_lyrics
 from music_assistant.models.music_provider import MusicProvider
 
 from .base import MediaControllerBase, TrackSyncDetails
@@ -683,7 +683,10 @@ class TracksController(MediaControllerBase[Track]):
             msg = "Track is missing artist(s)"
             raise InvalidDataError(msg)
         # normalize synced lyrics so clients only need a minimal single-timestamp LRC parser
-        item.metadata.lrc_lyrics = normalize_lrc_lyrics(item.metadata.lrc_lyrics)
+        # promoting LRC formatted text stored in the plain lyrics tag
+        item.metadata.lrc_lyrics = normalize_lrc_lyrics(
+            item.metadata.lrc_lyrics or extract_lrc_lyrics(item.metadata.lyrics)
+        )
         db_id = await self.mass.music.database.insert(
             self.db_table,
             {
@@ -722,7 +725,9 @@ class TracksController(MediaControllerBase[Track]):
         db_id = int(item_id)  # ensure integer
         cur_item = await self.get_library_item(db_id)
         metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
-        metadata.lrc_lyrics = normalize_lrc_lyrics(metadata.lrc_lyrics)
+        metadata.lrc_lyrics = normalize_lrc_lyrics(
+            metadata.lrc_lyrics or extract_lrc_lyrics(metadata.lyrics)
+        )
         cur_item.external_ids.update(update.external_ids)
         name = update.name if overwrite else cur_item.name
         sort_name = update.sort_name if overwrite else cur_item.sort_name or update.sort_name

--- a/music_assistant/helpers/lyrics.py
+++ b/music_assistant/helpers/lyrics.py
@@ -45,6 +45,26 @@ def normalize_lrc_lyrics(lrc_lyrics: str | None) -> str | None:
     return "\n".join(entry[1] for entry in entries).strip("\n") or None
 
 
+def extract_lrc_lyrics(lyrics: str | None) -> str | None:
+    """
+    Return the given plain lyrics text if it is LRC formatted, None otherwise.
+
+    :param lyrics: The plain lyrics text to inspect, may be None.
+    """
+    if not lyrics:
+        return None
+    stripped_lines = (line.strip() for line in lyrics.splitlines())
+    content_lines = [line for line in stripped_lines if line and not _LRC_ID_TAG_RE.match(line)]
+    if not content_lines:
+        return None
+    timestamped = sum(1 for line in content_lines if _LRC_TIMESTAMP_BLOCK_RE.match(line))
+    # require most lines to carry a leading timestamp to avoid false positives on
+    # plain lyrics that merely mention something like [2:30] somewhere in the text
+    if timestamped * 2 < len(content_lines):
+        return None
+    return lyrics
+
+
 def _expand_line(line: str) -> list[tuple[float | None, str]]:
     """Expand a lyric line into (time, line) entries, one per leading timestamp."""
     block_match = _LRC_TIMESTAMP_BLOCK_RE.match(line)

--- a/tests/helpers/test_lyrics.py
+++ b/tests/helpers/test_lyrics.py
@@ -1,6 +1,10 @@
 """Tests for the lyrics helpers."""
 
-from music_assistant.helpers.lyrics import convert_to_lrc_lyrics, normalize_lrc_lyrics
+from music_assistant.helpers.lyrics import (
+    convert_to_lrc_lyrics,
+    extract_lrc_lyrics,
+    normalize_lrc_lyrics,
+)
 
 LRC_WITH_ID_TAGS = """[ar:Chubby Checker oppure  Beatles, The]
 [al:Hits Of The 60's - Vol. 2 - Oldies]
@@ -164,3 +168,34 @@ def test_convert_multiple_lines_partially_invalid() -> None:
     assert convert_to_lrc_lyrics(lyrics) == (
         "[00:00.00]First line\n[00:01.00]Second line\n[00:02.00]Third line"
     )
+
+
+def test_extract_detects_lrc_content() -> None:
+    """Test that LRC formatted text in the plain lyrics tag is detected as-is."""
+    assert extract_lrc_lyrics(LRC_CLEAN) == LRC_CLEAN
+    assert extract_lrc_lyrics(LRC_WITH_ID_TAGS) == LRC_WITH_ID_TAGS
+    assert extract_lrc_lyrics("[2:30]Short timestamp style") == "[2:30]Short timestamp style"
+
+
+def test_extract_rejects_plain_lyrics() -> None:
+    """Test that regular unsynced lyrics text is not detected as LRC."""
+    assert extract_lrc_lyrics("Just some lyrics\nspread over\nmultiple lines") is None
+    assert extract_lrc_lyrics(None) is None
+    assert extract_lrc_lyrics("") is None
+    assert extract_lrc_lyrics("\n\n") is None
+    # ID tag lines alone do not count as synced lyrics content
+    assert extract_lrc_lyrics("[ar:Some Artist]\n[ti:Some Title]") is None
+
+
+def test_extract_rejects_timestamp_mention_in_text() -> None:
+    """Test that a timestamp-like mention within plain lyrics does not trigger detection."""
+    lyrics = (
+        "First plain line\nat [2:30] the beat drops\nanother plain line\nand yet another plain line"
+    )
+    assert extract_lrc_lyrics(lyrics) is None
+
+
+def test_extract_tolerates_some_untimed_lines() -> None:
+    """Test that LRC content with a minority of untimed lines is still detected."""
+    lyrics = "[00:12.00]First line\n[00:15.30]Second line\nuntimed line"
+    assert extract_lrc_lyrics(lyrics) == lyrics


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Tagging tools can store synced lyrics as LRC formatted text inside the regular (unsynced) lyrics tag. Until now only the frontend detected this, bypassing server-side LRC normalization. This PR detects such content server-side and serves it as `lrc_lyrics` so it flows through the same normalization path as .lrc files and provider-supplied lyrics.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
