### PR TITLE
⬆️ Update music-assistant-models to 1.1.173

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "getmac==0.9.5",
   "mashumaro==3.20",
   "music-assistant-frontend==2.17.245",
-  "music-assistant-models==1.1.172",
+  "music-assistant-models==1.1.173",
   "mutagen==1.48.1",
   "orjson==3.11.6",
   "pillow==12.3.0",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -51,7 +51,7 @@ markdownify==1.2.3
 mashumaro==3.20
 modern_colorthief==0.2.1
 music-assistant-frontend==2.17.245
-music-assistant-models==1.1.172
+music-assistant-models==1.1.173
 mutagen==1.48.1
 niconico.py-ma==2.1.0.post2
 nnAudio==0.3.3


### PR DESCRIPTION
Update music-assistant-models to version [1.1.173](https://github.com/music-assistant/models/releases/tag/1.1.173)


- Let a config option name the slug used for its translations (by @marcelveldt in [#333](https://github.com/music-assistant/models/pull/333))


## :bow: Contributors

@marcelveldt