### PR TITLE
Don't start playing music after an announcement when nothing was playing

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2798,6 +2798,14 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         prev_source = player.state.active_source
         prev_media = player.state.current_media
         prev_media_name = prev_media.title or prev_media.uri if prev_media else None
+        # An announcement is transient: a player that is still busy with an earlier
+        # announcement holds no user content, so there is nothing to restore for it.
+        # The raw media attribute is read here (instead of state.current_media, which
+        # reports the active queue item) since it tells what the device is playing.
+        restore_playback = prev_state == PlaybackState.PLAYING and not (
+            player.current_media is not None
+            and player.current_media.media_type == MediaType.ANNOUNCEMENT
+        )
         if prev_synced_to:
             # ungroup player if its currently synced
             self.logger.debug(
@@ -2935,7 +2943,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                     prev_group.display_name,
                 )
                 await prev_group.set_members(player_ids_to_add=[player.player_id])
-            elif prev_state == PlaybackState.PLAYING:
+            elif restore_playback:
                 # if the player is part of a group player that does not support set_members,
                 # we need to restart the groupplayer
                 self.logger.debug(
@@ -2944,7 +2952,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                     prev_group.display_name,
                 )
                 await self.cmd_play(prev_group.player_id)
-        elif prev_state == PlaybackState.PLAYING:
+        elif restore_playback:
             # player was playing something before the announcement - try to resume that here
             await self._handle_cmd_resume(player.player_id, prev_source, prev_media)
 

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -24,13 +24,19 @@ from music_assistant_models.constants import (
     PLAYER_CONTROL_NATIVE,
     PLAYER_CONTROL_NONE,
 )
-from music_assistant_models.enums import EventType, PlaybackState, PlayerFeature, PlayerType
+from music_assistant_models.enums import (
+    EventType,
+    MediaType,
+    PlaybackState,
+    PlayerFeature,
+    PlayerType,
+)
 from music_assistant_models.errors import (
     InvalidDataError,
     PlayerCommandFailed,
     UnsupportedFeaturedException,
 )
-from music_assistant_models.player import PlayerSource
+from music_assistant_models.player import PlayerMedia, PlayerSource
 
 from music_assistant.constants import ATTR_PREVIOUS_VOLUME, CONF_MUTE_CONTROL
 from music_assistant.controllers.players import PlayerController
@@ -1354,6 +1360,62 @@ class TestPlayAnnouncementCleanup:
             await controller.play_announcement("player_1", "http://test/announcement.mp3")
 
         assert announcements == {}
+
+
+class TestPlayAnnouncementRestore:
+    """Test the playback restore of the default (fallback) announcement implementation."""
+
+    def _make_player(
+        self, mock_mass: MagicMock, prev_media: PlayerMedia
+    ) -> tuple[PlayerController, MockPlayer, AsyncMock]:
+        """Create a controller and a playing player, returning the patched resume handler."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+        player._attr_playback_state = PlaybackState.PLAYING
+        player._attr_current_media = prev_media
+        player._cache.clear()
+        controller._players = {"player_1": player}
+        mock_mass.players = controller
+        resume_mock = AsyncMock()
+        controller._handle_cmd_resume = resume_mock  # type: ignore[method-assign]
+        controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
+        controller._handle_play_media = AsyncMock()  # type: ignore[method-assign]
+        controller._wait_for_playback_state = AsyncMock()  # type: ignore[method-assign]
+        controller.get_announcement_volume = MagicMock(return_value=None)  # type: ignore[method-assign]
+        player.update_state(signal_event=False)
+        return controller, player, resume_mock
+
+    @staticmethod
+    def _announcement() -> PlayerMedia:
+        """Return the announcement to play."""
+        return PlayerMedia(
+            uri="http://ma/announcement/player_1.mp3",
+            media_type=MediaType.ANNOUNCEMENT,
+            title="Announcement",
+            duration=3,
+        )
+
+    async def test_previous_playback_is_restored(self, mock_mass: MagicMock) -> None:
+        """Content that was playing before the announcement is resumed afterwards."""
+        controller, player, resume_mock = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+
+        await controller._play_announcement(player, self._announcement())
+
+        resume_mock.assert_awaited_once()
+
+    async def test_previous_announcement_is_not_restored(self, mock_mass: MagicMock) -> None:
+        """A player still busy with an earlier announcement has no playback to restore."""
+        controller, player, resume_mock = self._make_player(
+            mock_mass,
+            PlayerMedia(uri="http://ma/announcement/x.mp3", media_type=MediaType.ANNOUNCEMENT),
+        )
+
+        await controller._play_announcement(player, self._announcement())
+
+        resume_mock.assert_not_awaited()
 
 
 class TestScheduleActiveOutputProtocolClear:


### PR DESCRIPTION
# What does this implement/fix?

When a player has no built-in announcement support, we snapshot what it was playing, play the announcement, and then put things back the way they were. That snapshot did not tell an announcement apart from real music, so a player that was still busy with a previous announcement looked like it was "playing something". Once our announcement finished, we tried to resume that - and since there was nothing left in the queue, playback fell back to a recently played track, often from a completely different room.

Announcements are temporary by nature, so there is never anything to resume from one.

**Related issue (if applicable):**

- fixes https://github.com/music-assistant/support/issues/5913

Changes:

- Only restore playback after an announcement if the player was playing actual media, not another announcement.
- Added tests covering both cases.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
