### PR TITLE
Fix Spotify Connect multiple instances

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -1046,13 +1046,24 @@ async def get_primary_ip_address() -> str | None:
     """Return the primary IP address of the system."""
 
 
-async def is_port_in_use(port: int) -> bool:
-    """Check if port is in use."""
+async def is_port_in_use(port: int, host: str | None = None) -> bool:
+    """
+    Check if a port is in use.
+
+    :param port: Port number to check.
+    :param host: Optional bind address to probe. When omitted, both IPv4 and IPv6
+        wildcard addresses are checked.
+    """
 
     def _is_port_in_use() -> bool:
-        # Try both IPv4 and IPv6 to support single-stack and dual-stack systems.
-        # A port is considered free if it can be bound on at least one address family.
-        for family, addr in ((socket.AF_INET, "0.0.0.0"), (socket.AF_INET6, "::")):
+        candidates: tuple[tuple[socket.AddressFamily, str], ...]
+        if host is not None:
+            candidates = ((socket.AF_INET6 if ":" in host else socket.AF_INET, host),)
+        else:
+            # Try both IPv4 and IPv6 to support single-stack and dual-stack systems.
+            # A port is considered free if it can be bound on at least one address family.
+            candidates = ((socket.AF_INET, "0.0.0.0"), (socket.AF_INET6, "::"))
+        for family, addr in candidates:
             try:
                 with socket.socket(family, socket.SOCK_STREAM) as _sock:
                     # Set SO_REUSEADDR to match asyncio.start_server behavior
@@ -1079,7 +1090,7 @@ _reserved_ports: dict[int, float] = {}
 _select_free_port_lock = asyncio.Lock()
 
 
-async def select_free_port(range_start: int, range_end: int) -> int:
+async def select_free_port(range_start: int, range_end: int, host: str | None = None) -> int:
     """
     Find and reserve a free port within the given range.
 
@@ -1088,6 +1099,7 @@ async def select_free_port(range_start: int, range_end: int) -> int:
 
     :param range_start: First port (inclusive) of the range to search.
     :param range_end: Port to stop before (exclusive) when searching the range.
+    :param host: Optional bind address to probe for availability.
     """
     async with _select_free_port_lock:
         now = time.monotonic()
@@ -1098,7 +1110,7 @@ async def select_free_port(range_start: int, range_end: int) -> int:
         for port in range(range_start, range_end):
             if port in _reserved_ports:
                 continue
-            if not await is_port_in_use(port):
+            if not await is_port_in_use(port, host=host):
                 _reserved_ports[port] = now + _PORT_RESERVATION_TTL
                 return port
     msg = "No free port available"

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -194,7 +194,7 @@ class Provider:
             # default implementation - simply use the instance number/index
             instance_name_postfix = str(instances.index(self.instance_id) + 1)
         # append instance name to provider name
-        return f"{self.manifest.name} [{self.instance_name_postfix}]"
+        return f"{self.manifest.name} [{instance_name_postfix}]"
 
     @property
     def instance_name_postfix(self) -> str | None:

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -218,7 +218,9 @@ class SpotifyConnectProvider(PluginProvider):
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
         self._binary = get_go_librespot_binary()
-        self._api_port = await select_free_port(API_PORT_RANGE_START, API_PORT_RANGE_END)
+        self._api_port = await select_free_port(
+            API_PORT_RANGE_START, API_PORT_RANGE_END, host="127.0.0.1"
+        )
         self._client = GoLibrespotClient(
             self.mass, f"http://127.0.0.1:{self._api_port}", self.logger
         )

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -1,6 +1,7 @@
 """Tests for music_assistant.helpers.util helpers."""
 
 import asyncio
+import socket
 import time
 from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
@@ -10,6 +11,7 @@ import pytest
 from music_assistant.helpers import util
 from music_assistant.helpers.util import (
     get_source_ip_for_target,
+    is_port_in_use,
     load_provider_module,
     sanitize_http_header_value,
     select_free_port,
@@ -86,6 +88,39 @@ class TestSelectFreePort:
             util._reserved_ports[first] = 0.0
             second = await select_free_port(38800, 38900)
         assert first == second
+
+    @pytest.mark.asyncio
+    async def test_host_is_passed_to_port_probe(self) -> None:
+        """A bind address is forwarded to the availability probe."""
+        with patch("music_assistant.helpers.util.is_port_in_use", return_value=False) as probe:
+            port = await select_free_port(38800, 38900, host="127.0.0.1")
+        probe.assert_awaited_once_with(port, host="127.0.0.1")
+
+
+class TestIsPortInUse:
+    """is_port_in_use can probe the exact address a server will bind."""
+
+    @pytest.mark.asyncio
+    async def test_bound_loopback_port_is_in_use(self) -> None:
+        """An active IPv4 loopback listener is detected on that same address."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            sock.listen(1)
+            assert await is_port_in_use(sock.getsockname()[1], host="127.0.0.1")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("host", "family"),
+        [("127.0.0.1", socket.AF_INET), ("::1", socket.AF_INET6)],
+    )
+    async def test_host_selects_matching_address_family(
+        self, host: str, family: socket.AddressFamily
+    ) -> None:
+        """A specific bind address is probed with its matching socket family."""
+        with patch("music_assistant.helpers.util.socket.socket") as socket_mock:
+            await is_port_in_use(38800, host=host)
+        socket_mock.assert_called_once_with(family, socket.SOCK_STREAM)
+        socket_mock.return_value.__enter__.return_value.bind.assert_called_once_with((host, 38800))
 
 
 class TestLoadProviderModule:

--- a/tests/models/test_provider.py
+++ b/tests/models/test_provider.py
@@ -34,6 +34,26 @@ def test_to_dict_matches_provider_instance_schema() -> None:
     ProviderInstance.from_dict(result)
 
 
+def test_default_name_uses_instance_number_fallback() -> None:
+    """A multi-instance provider without a custom postfix uses its instance number."""
+    provider = _make_base_provider()
+    provider.config.name = None
+    provider.config.instance_id = "test_instance_2"
+    provider.manifest.name = "Test Provider"
+    cast("MagicMock", provider.mass.config.get).return_value = {
+        "test_instance_1": {
+            "domain": "test_provider",
+            "instance_id": "test_instance_1",
+        },
+        "test_instance_2": {
+            "domain": "test_provider",
+            "instance_id": "test_instance_2",
+        },
+    }
+
+    assert provider.default_name == "Test Provider [2]"
+
+
 def test_signal_provider_event() -> None:
     """signal_provider_event() emits a PROVIDER_EVENT with the instance_id as object_id."""
     provider = _make_base_provider()

--- a/tests/providers/spotify_connect/__init__.py
+++ b/tests/providers/spotify_connect/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spotify Connect provider."""

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -1,0 +1,33 @@
+"""Tests for the Spotify Connect provider."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from music_assistant.providers.spotify_connect import (
+    API_PORT_RANGE_END,
+    API_PORT_RANGE_START,
+    SpotifyConnectProvider,
+)
+
+
+async def test_async_init_probes_api_port_on_ipv4_loopback() -> None:
+    """The daemon API port is selected on the address go-librespot binds."""
+    provider = object.__new__(SpotifyConnectProvider)
+    provider.mass = MagicMock()
+    provider.logger = MagicMock()
+    provider.mass.create_task.side_effect = lambda coroutine: coroutine.close()
+
+    with (
+        patch(
+            "music_assistant.providers.spotify_connect.get_go_librespot_binary",
+            return_value="/usr/bin/go-librespot",
+        ),
+        patch(
+            "music_assistant.providers.spotify_connect.select_free_port",
+            new=AsyncMock(return_value=38801),
+        ) as select_port,
+    ):
+        await provider.handle_async_init()
+
+    select_port.assert_awaited_once_with(API_PORT_RANGE_START, API_PORT_RANGE_END, host="127.0.0.1")
+    assert provider._client is not None
+    assert provider._client.base_url == "http://127.0.0.1:38801"


### PR DESCRIPTION
# What does this implement/fix?

Spotify Connect could fail when adding a second instance because both background services selected the same local port.

- Assign each instance a free port on the correct local address.
- Use numbered instance names instead of `[None]`.
- Add regression coverage for port allocation and instance naming.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.