### PR TITLE
Handle invalid MusicBrainz identifiers in file tags gracefully

### DIFF
--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -12,6 +12,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any
+from uuid import UUID
 
 from music_assistant_models.enums import AlbumType
 from music_assistant_models.errors import InvalidDataError
@@ -42,6 +43,26 @@ TAG_SPLITTER = ";"
 def clean_tuple(values: Iterable[str]) -> tuple[str, ...]:
     """Return a tuple with all empty values removed."""
     return tuple(x.strip() for x in values if x not in (None, "", " "))
+
+
+def clean_mbid(value: str | None, source: str | None = None) -> str | None:
+    """
+    Return a MusicBrainz identifier in canonical (lowercase UUID) form, or None if invalid.
+
+    :param value: The raw MusicBrainz identifier value from the file tags.
+    :param source: Origin of the value (e.g. filename), included in the log when invalid.
+    """
+    if not value:
+        return None
+    # taggers may write NUL-terminated or padded values (e.g. in a UFID frame)
+    try:
+        return str(UUID(value.strip("\x00 \t\r\n")))
+    except ValueError, TypeError, AttributeError:
+        if source:
+            LOGGER.warning("Ignoring invalid MusicBrainz identifier %r in %s", value, source)
+        else:
+            LOGGER.warning("Ignoring invalid MusicBrainz identifier %r", value)
+        return None
 
 
 def split_items(
@@ -450,10 +471,6 @@ class AudioTags:
     @property
     def musicbrainz_recordingid(self) -> str | None:
         """Return musicbrainz_recordingid tag if present."""
-        if tag := self.tags.get("UFID:http://musicbrainz.org"):
-            return str(tag)
-        if tag := self.tags.get("musicbrainz.org"):
-            return str(tag)
         if tag := self.tags.get("musicbrainzrecordingid"):
             return str(tag)
         if tag := self.tags.get("musicbrainztrackid"):
@@ -1003,7 +1020,10 @@ def _parse_id3_tags(tags: ID3Tags) -> dict[str, Any]:
         result["musicbrainzreleasegroupid"] = releasegroupid[0]
     if frame := tags.get("UFID:http://musicbrainz.org"):  # type: ignore[no-untyped-call]
         # Strip NULs and whitespace from MusicBrainz UFID data (support #5906).
-        result["musicbrainzrecordingid"] = frame.data.decode().replace("\x00", "").strip()
+        # UFID data is binary per the ID3 spec; a decode error here would discard all mutagen tags.
+        result["musicbrainzrecordingid"] = (
+            frame.data.decode("utf-8", errors="replace").replace("\x00", "").strip()
+        )
     if trackid := _id3_get_tag_text(tags, "TXXX:MusicBrainz Track Id"):
         result["musicbrainztrackid"] = trackid[0]
 

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -79,7 +79,7 @@ from music_assistant.helpers import lyrics
 from music_assistant.helpers.compare import compare_strings, create_safe_string
 from music_assistant.helpers.json import SerializableType, json_loads
 from music_assistant.helpers.playlists import parse_m3u, parse_pls
-from music_assistant.helpers.tags import AudioTags, async_parse_tags, split_items
+from music_assistant.helpers.tags import AudioTags, async_parse_tags, clean_mbid, split_items
 from music_assistant.helpers.util import (
     TaskManager,
     detect_charset,
@@ -1466,8 +1466,8 @@ class LocalFileSystemProvider(MusicProvider):
         explicit_tag = tags.get("itunesadvisory")
         if explicit_tag is not None:
             track.metadata.explicit = explicit_tag == "1"
-        if tags.musicbrainz_recordingid:
-            track.mbid = tags.musicbrainz_recordingid
+        if recording_mbid := clean_mbid(tags.musicbrainz_recordingid, tags.filename):
+            track.mbid = recording_mbid
 
         # handle (optional) loudness measurement tag(s)
         if tags.track_loudness is not None:
@@ -1657,7 +1657,7 @@ class LocalFileSystemProvider(MusicProvider):
                 )
             },
         )
-        if mbid:
+        if mbid := clean_mbid(mbid, f"tags of artist {name}"):
             artist.mbid = mbid
         if not artist_path or not await self.exists(artist_path):
             return artist
@@ -1674,7 +1674,7 @@ class LocalFileSystemProvider(MusicProvider):
                 artist.name = info.get("title", info.get("name", name))
                 if sort_name := info.get("sortname"):
                     artist.sort_name = sort_name
-                if mbid := info.get("musicbrainzartistid"):
+                if mbid := clean_mbid(info.get("musicbrainzartistid"), nfo_file):
                     artist.mbid = mbid
                 if description := info.get("biography"):
                     artist.metadata.description = description
@@ -1794,8 +1794,8 @@ class LocalFileSystemProvider(MusicProvider):
         explicit_tag = tags.get("itunesadvisory")
         if explicit_tag is not None:
             audio_book.metadata.explicit = explicit_tag == "1"
-        if tags.musicbrainz_recordingid:
-            audio_book.mbid = tags.musicbrainz_recordingid
+        if recording_mbid := clean_mbid(tags.musicbrainz_recordingid, tags.filename):
+            audio_book.mbid = recording_mbid
 
         # try to fetch additional metadata from the folder
         if not audio_book.image or not audio_book.metadata.description:
@@ -2140,10 +2140,12 @@ class LocalFileSystemProvider(MusicProvider):
         if track_tags.barcode:
             album.external_ids.add((ExternalID.BARCODE, track_tags.barcode))
 
-        if track_tags.musicbrainz_albumid:
-            album.mbid = track_tags.musicbrainz_albumid
-        if track_tags.musicbrainz_releasegroupid:
-            album.add_external_id(ExternalID.MB_RELEASEGROUP, track_tags.musicbrainz_releasegroupid)
+        if album_mbid := clean_mbid(track_tags.musicbrainz_albumid, track_tags.filename):
+            album.mbid = album_mbid
+        if releasegroup_mbid := clean_mbid(
+            track_tags.musicbrainz_releasegroupid, track_tags.filename
+        ):
+            album.add_external_id(ExternalID.MB_RELEASEGROUP, releasegroup_mbid)
         if track_tags.year:
             album.year = track_tags.year
         album.album_type = track_tags.album_type
@@ -2162,7 +2164,7 @@ class LocalFileSystemProvider(MusicProvider):
                 try:
                     data = (await self._read_file(nfo_file)).decode("utf-8")
                     info = await asyncio.to_thread(xmltodict.parse, data)
-                    parse_album_nfo(album, info["album"])
+                    parse_album_nfo(album, info["album"], nfo_file)
                 except (ExpatError, KeyError) as err:
                     self.logger.warning(
                         "Failed to parse album NFO file %s: %s",

--- a/music_assistant/providers/filesystem_local/cue.py
+++ b/music_assistant/providers/filesystem_local/cue.py
@@ -41,7 +41,7 @@ from music_assistant_models.streamdetails import StreamDetails
 from music_assistant.constants import UNKNOWN_ARTIST, UNKNOWN_ARTIST_ID_MBID
 from music_assistant.helpers.cue_sheet import CueSheet, CueTrack, parse_cue_sheet
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
-from music_assistant.helpers.tags import AudioTags, async_parse_tags
+from music_assistant.helpers.tags import AudioTags, async_parse_tags, clean_mbid
 from music_assistant.helpers.util import detect_charset
 
 from .constants import CACHE_CATEGORY_CUE_SHEETS, TRACK_EXTENSIONS
@@ -495,9 +495,9 @@ class CueSheetHandler:
             track.album = ctx.album
         for isrc in cue_track.isrcs:
             track.external_ids.add((ExternalID.ISRC, isrc))
-        if cue_track.musicbrainz_recordingid:
-            # the setter runs UUID validation and keeps external_ids in sync
-            track.mbid = cue_track.musicbrainz_recordingid
+        if recording_mbid := clean_mbid(cue_track.musicbrainz_recordingid, cue_item.relative_path):
+            # the setter keeps external_ids in sync
+            track.mbid = recording_mbid
         if cue_track.musicbrainz_releasetrackid:
             track.external_ids.add((ExternalID.MB_TRACK, cue_track.musicbrainz_releasetrackid))
         if ctx.embedded_image is not None:

--- a/music_assistant/providers/filesystem_local/parsers.py
+++ b/music_assistant/providers/filesystem_local/parsers.py
@@ -4,24 +4,30 @@ from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import ExternalID
 
-from music_assistant.helpers.tags import split_items
+from music_assistant.helpers.tags import clean_mbid, split_items
 from music_assistant.helpers.util import parse_title_and_version
 
 if TYPE_CHECKING:
     from music_assistant_models.media_items import Album
 
 
-def parse_album_nfo(album: Album, nfo_album: dict[Any, Any]) -> None:
-    """Enrich album metadata from NFO file."""
+def parse_album_nfo(album: Album, nfo_album: dict[Any, Any], source: str | None = None) -> None:
+    """
+    Enrich album metadata from NFO file.
+
+    :param album: The album to enrich.
+    :param nfo_album: The parsed 'album' element from the NFO file.
+    :param source: Origin of the NFO data (e.g. file path), included in log messages.
+    """
     if title := nfo_album.get("title") or nfo_album.get("name"):
         album.name, album.version = parse_title_and_version(title)
     if sort_name := nfo_album.get("sortname"):
         album.sort_name = sort_name
-    if releasegroup_id := nfo_album.get("musicbrainzreleasegroupid"):
+    if releasegroup_id := clean_mbid(nfo_album.get("musicbrainzreleasegroupid"), source):
         album.add_external_id(ExternalID.MB_RELEASEGROUP, releasegroup_id)
-    if album_id := nfo_album.get("musicbrainzalbumid"):
+    if album_id := clean_mbid(nfo_album.get("musicbrainzalbumid"), source):
         album.add_external_id(ExternalID.MB_ALBUM, album_id)
-    if mb_artist_id := nfo_album.get("musicbrainzalbumartistid"):
+    if mb_artist_id := clean_mbid(nfo_album.get("musicbrainzalbumartistid"), source):
         if album.artists and not album.artists[0].mbid:
             album.artists[0].mbid = mb_artist_id
     if description := nfo_album.get("review"):

--- a/tests/helpers/test_tags.py
+++ b/tests/helpers/test_tags.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import mutagen
 import pytest
 from music_assistant_models.errors import InvalidDataError
-from mutagen.id3 import UFID
+from mutagen.id3 import ID3, UFID
 
 from music_assistant.constants import UNKNOWN_ARTIST
 from music_assistant.helpers import tags
@@ -17,6 +17,7 @@ from music_assistant.helpers.tags import (
     _parse_id3_tags,
     _parse_mp4_tags,
     _parse_vorbis_tags,
+    clean_mbid,
     parse_tags_mutagen,
     split_artists,
     write_replaygain_track_gain,
@@ -859,3 +860,61 @@ async def test_write_replaygain_track_gain_read_only(tmp_path: pathlib.Path) -> 
     finally:
         # restore permissions so tmp_path cleanup can remove the file
         dest.chmod(0o644)
+
+
+VALID_MBID = "73c69a4b-1f9e-4c8c-b8bb-3ba903af1c3f"
+
+
+def test_clean_mbid() -> None:
+    """Test cleaning/canonicalizing MusicBrainz identifiers from file tags."""
+    assert clean_mbid(VALID_MBID) == VALID_MBID
+    # uppercase hex digits are canonicalized to lowercase
+    assert clean_mbid(VALID_MBID.upper()) == VALID_MBID
+    # trailing NUL bytes and surrounding whitespace are stripped
+    assert clean_mbid(f"{VALID_MBID}\x00") == VALID_MBID
+    assert clean_mbid(f"  {VALID_MBID} \n") == VALID_MBID
+    # non-UUID values are rejected
+    assert clean_mbid("CAAE0466 1G4B0N3 07800NE1") is None
+    assert clean_mbid("abcdefg") is None
+    assert clean_mbid("") is None
+    assert clean_mbid(None) is None
+    # non-string values (e.g. repeated NFO elements parsed as a list) are rejected
+    assert clean_mbid([VALID_MBID, VALID_MBID]) is None  # type: ignore[arg-type]
+
+
+def test_parse_id3_ufid_frame_binary_data() -> None:
+    """A UFID frame with non-UTF-8 binary data must not break parsing of other tags."""
+    ufid = UFID(  # type: ignore[no-untyped-call]
+        owner="http://musicbrainz.org",
+        data=bytes.fromhex("73c69a4b1f9e4c8cb8bb3ba903af1c3f"),
+    )
+    title_frame = MagicMock()
+    title_frame.text = ["MyTitle"]
+    frames = {"UFID:http://musicbrainz.org": ufid, "TIT2": title_frame}
+
+    mock_tags = MagicMock()
+    mock_tags.get = frames.get
+    result = _parse_id3_tags(mock_tags)
+
+    assert result.get("title") == "MyTitle"
+    # the garbled identifier is rejected downstream by clean_mbid
+    assert clean_mbid(result.get("musicbrainzrecordingid")) is None
+
+
+async def test_parse_ufid_frame_with_dirty_payload(tmp_path: pathlib.Path) -> None:
+    """
+    A UFID payload with a NUL terminator must still yield a usable recording id.
+
+    Regression test for https://github.com/music-assistant/support/issues/5906
+    where such files failed to import with "Invalid MusicBrainz identifier".
+    """
+    dest = tmp_path / "ufid.mp3"
+    shutil.copy(FILE_MP3, dest)
+    id3 = ID3(str(dest))  # type: ignore[no-untyped-call]
+    id3.add(  # type: ignore[no-untyped-call]
+        UFID(owner="http://musicbrainz.org", data=f"{VALID_MBID}\x00".encode("ascii"))  # type: ignore[no-untyped-call]
+    )
+    id3.save()
+
+    _tags = await tags.async_parse_tags(str(dest))
+    assert clean_mbid(_tags.musicbrainz_recordingid) == VALID_MBID


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Files with a UFID frame (or any MusicBrainz tag) containing a value that is not a strictly valid lowercase UUID - e.g. a NUL-terminated payload, uppercase hex digits, or a foreign identifier written under the http://musicbrainz.org owner - failed to import entirely with 'Invalid MusicBrainz identifier'.

- add `clean_mbid()` helper that canonicalizes MusicBrainz ids from tags (strips NUL bytes/whitespace, lowercases) and rejects non-UUID values with a warning that includes the originating file
- apply it at all MusicBrainz id assignment sites in the filesystem provider (tracks, albums, artists, audiobooks, CUE sheets, NFO files) so a bad tag value can no longer abort the import of a file
- decode UFID frame data with `errors='replace'` so binary payloads no longer discard all other mutagen-parsed tags via `UnicodeDecodeError`
- remove dead UFID key lookups in `AudioTags.musicbrainz_recordingid` (ffprobe tag keys are normalized to lowercase, so they never matched)

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5906

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
