### PR TITLE
Keep playback controls loading until the player really starts

### DIFF
--- a/music_assistant/controllers/player_queues/base.py
+++ b/music_assistant/controllers/player_queues/base.py
@@ -10,7 +10,7 @@ type-checks on its own while the real implementations live on PlayerQueuesContro
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from music_assistant.models.core_controller import CoreController
 
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from music_assistant.controllers.player_queues.media_resolver import MediaResolver
     from music_assistant.controllers.player_queues.smart_shuffle import SmartShuffle
     from music_assistant.controllers.player_queues.state import PlayerQueueData
-    from music_assistant.models.player import PlayerMedia
+    from music_assistant.models.player import Player, PlayerMedia
 
 
 class _PlayerQueuesBase(CoreController):
@@ -54,6 +54,9 @@ class _PlayerQueuesBase(CoreController):
         def get_next_item(self, queue_id: str, cur_index: int | str) -> QueueItem | None: ...
         def clear(self, queue_id: str, skip_stop: bool = False) -> None: ...
         def signal_update(self, queue_id: str, items_changed: bool = False) -> None: ...
+        def on_player_update(
+            self, player: Player, changed_values: dict[str, tuple[Any, Any]]
+        ) -> None: ...
         def is_smart_shuffle_active(self, queue: PlayerQueue) -> bool: ...
         def store_sources(self, queue: PlayerQueue, items: list[MediaItemType]) -> None: ...
         async def load(

--- a/music_assistant/controllers/player_queues/constants.py
+++ b/music_assistant/controllers/player_queues/constants.py
@@ -66,6 +66,13 @@ MANAGED_POOL_SOURCE_CAP = 250
 CACHE_CATEGORY_PLAYER_QUEUE_STATE = 0
 CACHE_CATEGORY_PLAYER_QUEUE_ITEMS = 1
 
+# A play command is only complete once the player actually reports playback: several player
+# implementations return from play_media as soon as the start command is out while the device
+# needs another moment to connect and start (AirPlay anchors its audible start in the future).
+# The play action - and with it the UI's in-progress indication - is held until the player
+# reports PLAYING, capped by this timeout so a player that never reports state can't block.
+PLAYBACK_START_TIMEOUT = 5.0
+
 # The queue's cached state/items are written through a debounced timer, so a burst of updates (or
 # the per-track updates during playback) collapses into a single write instead of hitting the cache
 # db on every signal_update.

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1003,7 +1003,8 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             player_media = await self.player_media_from_queue_item(queue_item)
             # Hold the play action until the player confirms playback so the UI keeps
             # showing the command as in progress instead of falling back to a play button
-            # for the time the player still needs to connect and start.
+            # for the time the player still needs to connect and start. The queue update
+            # for the new item goes out first, so the item shows while it is starting.
             async with self.mass.players.wait_for_player_update(
                 queue_id,
                 attribute_name="playback_state",
@@ -1011,9 +1012,9 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                 timeout=PLAYBACK_START_TIMEOUT,
             ):
                 await self.mass.players.play_media(queue_id, player_media)
-            queue.current_index = index
-            queue.current_item = queue_item
-            self.signal_update(queue_id)
+                queue.current_index = index
+                queue.current_item = queue_item
+                self.signal_update(queue_id)
         finally:
             self._set_transitioning(queue_id, False)
 

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -62,6 +62,7 @@ from music_assistant.controllers.player_queues.config import (
 from music_assistant.controllers.player_queues.constants import (
     CACHE_CATEGORY_PLAYER_QUEUE_ITEMS,
     CACHE_CATEGORY_PLAYER_QUEUE_STATE,
+    PLAYBACK_START_TIMEOUT,
     QUEUE_CACHE_SAVE_DELAY,
 )
 from music_assistant.controllers.player_queues.helpers import (
@@ -999,10 +1000,19 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
 
             # Reset flow_mode - the streams controller will set it if flow mode is used.
             queue.flow_mode = False
-            await self.mass.players.play_media(
+            # Hold the play action until the player confirms playback so the UI keeps
+            # showing the command as in progress instead of falling back to a play button
+            # for the time the player still needs to connect and start.
+            async with self.mass.players.wait_for_player_update(
                 queue_id,
-                await self.player_media_from_queue_item(queue_item),
-            )
+                attribute_name="playback_state",
+                attribute_value=PlaybackState.PLAYING,
+                timeout=PLAYBACK_START_TIMEOUT,
+            ):
+                await self.mass.players.play_media(
+                    queue_id,
+                    await self.player_media_from_queue_item(queue_item),
+                )
             queue.current_index = index
             queue.current_item = queue_item
             self.signal_update(queue_id)
@@ -1669,8 +1679,15 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         if queue_player is None:
             raise PlayerUnavailableError(f"Player {queue_id} is not available")
         if (queue := self.get(queue_id)) and queue.active and queue.state == PlaybackState.PAUSED:
-            # forward the actual play/unpause command to the player
-            await queue_player.play()
+            # forward the actual play/unpause command to the player,
+            # holding the action until the player confirms it resumed playback
+            async with self.mass.players.wait_for_player_update(
+                queue_id,
+                attribute_name="playback_state",
+                attribute_value=PlaybackState.PLAYING,
+                timeout=PLAYBACK_START_TIMEOUT,
+            ):
+                await queue_player.play()
             return
         # player is not paused, perform resume instead
         await self.resume(queue_id)

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1000,6 +1000,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
 
             # Reset flow_mode - the streams controller will set it if flow mode is used.
             queue.flow_mode = False
+            player_media = await self.player_media_from_queue_item(queue_item)
             # Hold the play action until the player confirms playback so the UI keeps
             # showing the command as in progress instead of falling back to a play button
             # for the time the player still needs to connect and start.
@@ -1009,10 +1010,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                 attribute_value=PlaybackState.PLAYING,
                 timeout=PLAYBACK_START_TIMEOUT,
             ):
-                await self.mass.players.play_media(
-                    queue_id,
-                    await self.player_media_from_queue_item(queue_item),
-                )
+                await self.mass.players.play_media(queue_id, player_media)
             queue.current_index = index
             queue.current_item = queue_item
             self.signal_update(queue_id)

--- a/music_assistant/controllers/player_queues/helpers.py
+++ b/music_assistant/controllers/player_queues/helpers.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
     from music_assistant import MusicAssistant
     from music_assistant.controllers.player_queues.state import PlayerQueueData
+    from music_assistant.models.player import Player
 
 _SortableT = TypeVar("_SortableT", bound=PlaylistPlayableItem)
 
@@ -58,6 +59,10 @@ class _PlayActionHost(Protocol):
 
     def signal_update(self, queue_id: str, items_changed: bool = False) -> None: ...
 
+    def on_player_update(
+        self, player: Player, changed_values: dict[str, tuple[Any, Any]]
+    ) -> None: ...
+
 
 def handle_play_action[PlayActionHostT: _PlayActionHost, **P, R](
     func: Callable[Concatenate[PlayActionHostT, P], Awaitable[R]],
@@ -94,6 +99,11 @@ def handle_play_action[PlayActionHostT: _PlayActionHost, **P, R](
                 if queue_data.play_action_refcount <= 0:
                     queue_data.play_action_refcount = 0
                     queue.extra_attributes[ATTR_PLAY_ACTION_IN_PROGRESS] = False
+                    # the queue follows the player through a debounced update, which is also
+                    # suppressed while an action is transitioning; recalculate it here so the
+                    # update that clears the flag already carries the action's resulting state
+                    if (player := self.mass.players.get_player(queue_id)) is not None:
+                        self.on_player_update(player, {})
                     self.signal_update(queue_id)
 
     return wrapper

--- a/tests/controllers/player_queues/test_player_queues_helpers.py
+++ b/tests/controllers/player_queues/test_player_queues_helpers.py
@@ -146,14 +146,25 @@ class _FakeLock:
         return False
 
 
+class _FakePlayer:
+    def __init__(self, player_id: str) -> None:
+        self.player_id = player_id
+
+
 class _FakePlayers:
+    def __init__(self, player_ids: set[str]) -> None:
+        self._players = {player_id: _FakePlayer(player_id) for player_id in player_ids}
+
     def get_player_lock(self, queue_id: str, purpose: object) -> _FakeLock:
         return _FakeLock()
 
+    def get_player(self, player_id: str) -> _FakePlayer | None:
+        return self._players.get(player_id)
+
 
 class _FakeMass:
-    def __init__(self) -> None:
-        self.players = _FakePlayers()
+    def __init__(self, player_ids: set[str]) -> None:
+        self.players = _FakePlayers(player_ids)
 
 
 class _FakeQueue:
@@ -164,16 +175,21 @@ class _FakeQueue:
 class _FakeController:
     """Minimal stand-in exposing only what handle_play_action touches."""
 
-    def __init__(self, queues: dict[str, _FakeQueue]) -> None:
-        self.mass = _FakeMass()
+    def __init__(self, queues: dict[str, _FakeQueue], with_players: bool = True) -> None:
+        self.mass = _FakeMass(set(queues) if with_players else set())
         self._queue_data = {
             queue_id: PlayerQueueData(queue=cast("PlayerQueue", queue))
             for queue_id, queue in queues.items()
         }
-        self.signal_calls: list[str] = []
+        self.calls: list[str] = []
 
     def signal_update(self, queue_id: str, items_changed: bool = False) -> None:
-        self.signal_calls.append(queue_id)
+        self.calls.append(f"signal:{queue_id}")
+
+    def on_player_update(
+        self, player: _FakePlayer, changed_values: dict[str, tuple[Any, Any]]
+    ) -> None:
+        self.calls.append(f"refresh:{player.player_id}")
 
 
 def _flag_value(ctrl: PlayerQueuesController, queue_id: str) -> bool:
@@ -214,7 +230,7 @@ class TestHandlePlayAction:
         sink: list[bool] = []
         assert await _flag_during(cast("PlayerQueuesController", ctrl), "missing", sink) == "done"
         assert sink == [False]
-        assert ctrl.signal_calls == []
+        assert ctrl.calls == []
 
     async def test_sets_and_clears_flag(self) -> None:
         """The in-progress flag is set during the action and cleared afterwards."""
@@ -224,9 +240,19 @@ class TestHandlePlayAction:
         assert await _flag_during(cast("PlayerQueuesController", ctrl), "q1", sink) == "done"
         assert sink == [True]
         assert queue.extra_attributes[ATTR_PLAY_ACTION_IN_PROGRESS] is False
-        # signalled once on entry and once on exit
-        assert ctrl.signal_calls == ["q1", "q1"]
+        # signalled once on entry and once on exit, with the queue recalculated
+        # from the player in between so the exit signal carries the result
+        assert ctrl.calls == ["signal:q1", "refresh:q1", "signal:q1"]
         assert ctrl._queue_data["q1"].play_action_refcount == 0
+
+    async def test_clears_flag_without_player(self) -> None:
+        """A queue without a registered player still clears and signals."""
+        queue = _FakeQueue()
+        ctrl = _FakeController({"q1": queue}, with_players=False)
+        sink: list[bool] = []
+        assert await _flag_during(cast("PlayerQueuesController", ctrl), "q1", sink) == "done"
+        assert queue.extra_attributes[ATTR_PLAY_ACTION_IN_PROGRESS] is False
+        assert ctrl.calls == ["signal:q1", "signal:q1"]
 
     async def test_nested_actions_refcount(self) -> None:
         """Nested actions keep the flag set until the outermost one finishes."""
@@ -238,7 +264,7 @@ class TestHandlePlayAction:
         assert sink == [True, True]
         assert queue.extra_attributes[ATTR_PLAY_ACTION_IN_PROGRESS] is False
         # only the outermost entry/exit signal an update (inner sees it already in progress)
-        assert ctrl.signal_calls == ["q1", "q1"]
+        assert ctrl.calls == ["signal:q1", "refresh:q1", "signal:q1"]
         assert ctrl._queue_data["q1"].play_action_refcount == 0
 
     async def test_flag_cleared_on_exception(self) -> None:


### PR DESCRIPTION
# What does this implement/fix?

When you hit play, the interface shows the controls as busy (spinner) until the queue has handed the command to the player. Some players need a moment after that to connect and actually start — AirPlay is the clearest example. The spinner would disappear and a play button would come back for a few seconds, as if nothing had happened, right before the music started.

The queue now keeps the command marked as in progress until the player reports that it is playing, so the controls stay in their loading state for the whole start-up instead of briefly falling back.

## Changes

- Play and resume wait (up to 5 seconds) for the player to report playback before the queue marks the command as done.
- The queue's state is refreshed from the player right before that, so the update that ends the command already shows the player as playing.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
