### PR TITLE
ariacast_receiver: fix tests

### DIFF
--- a/tests/providers/receiver_setup_flows/test_receiver_setup_flows.py
+++ b/tests/providers/receiver_setup_flows/test_receiver_setup_flows.py
@@ -22,6 +22,9 @@ from music_assistant.providers.airplay_receiver import setup_flow as airplay_flo
 from music_assistant.providers.ariacast_receiver import (
     CONF_ARIACAST_NAME,
 )
+from music_assistant.providers.ariacast_receiver import (
+    CONF_MASS_PLAYER_ID as ARIACAST_PLAYER_ID,
+)
 from music_assistant.providers.ariacast_receiver import setup_flow as ariacast_flow
 from music_assistant.providers.spotify_connect import (
     CONF_MASS_PLAYER_ID as SPOTIFY_PLAYER_ID,
@@ -123,7 +126,7 @@ async def _wait_finished(session: SetupSession) -> None:
             "ariacast_receiver",
             ariacast_flow,
             {
-                AIRPLAY_PLAYER_ID: "kitchen",
+                ARIACAST_PLAYER_ID: "kitchen",
                 CONF_ARIACAST_NAME: "Kitchen AriaCast",
             },
         ),


### PR DESCRIPTION
# What does this implement/fix?

- update tests, fixes PR https://github.com/music-assistant/server/pull/4922

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
