### PR TITLE
Fix podcast playback on feeds that list a cover image before the audio

### DIFF
--- a/music_assistant/helpers/podcast_parsers.py
+++ b/music_assistant/helpers/podcast_parsers.py
@@ -127,7 +127,9 @@ def parse_podcast(
 
 def get_stream_url_from_episode(*, episode: dict[str, Any]) -> str | None:
     """
-    Give the url of the episode's audio enclosure, or None if the episode has none.
+    Give the url of the episode's playable enclosure, or None if the episode has none.
+
+    Prefers the first audio or video enclosure, falling back to any non-image one.
 
     :param episode: A single episode dict as returned by podcastparser.
     """

--- a/music_assistant/helpers/podcast_parsers.py
+++ b/music_assistant/helpers/podcast_parsers.py
@@ -125,22 +125,41 @@ def parse_podcast(
     return mass_podcast
 
 
+def get_stream_url_from_episode(*, episode: dict[str, Any]) -> str | None:
+    """
+    Give the url of the episode's audio enclosure, or None if the episode has none.
+
+    :param episode: A single episode dict as returned by podcastparser.
+    """
+    fallback: str | None = None
+    for enclosure in episode.get("enclosures", []):
+        url = enclosure.get("url")
+        if not url:
+            continue
+        mime_type = str(enclosure.get("mime_type") or "")
+        if mime_type.startswith(("audio/", "video/")):
+            return str(url)
+        # feeds do declare bogus mime types (e.g. type="file") for real audio, so anything
+        # that is not an image stays a candidate in case no audio enclosure is declared
+        if fallback is None and not mime_type.startswith("image/"):
+            fallback = str(url)
+    return fallback
+
+
 def get_stream_url_and_guid_from_episode(*, episode: dict[str, Any]) -> tuple[str, str | None]:
     """Give episode's stream url and guid, if it exists."""
-    episode_enclosures = episode.get("enclosures", [])
-    if len(episode_enclosures) < 1:
-        raise ValueError("Episode enclosure is missing")
-    if stream_url := episode_enclosures[0].get("url"):
-        guid = episode.get("guid")
-        if guid is not None:
-            # The media's item_id is {prov_podcast_id} {guid_or_stream_url}
-            # see parse_podcast_episode.
-            # However, the guid must not contain a space, otherwise it is invalid.
-            # We cannot check, if it is a proper guid (uuid.UUID4(...)), as some podcast feeds
-            # do not follow the standard.
-            guid = None if len(guid.split(" ")) > 1 else guid
-        return stream_url, guid
-    raise ValueError("Stream URL is missing.")
+    stream_url = get_stream_url_from_episode(episode=episode)
+    if stream_url is None:
+        raise ValueError("Episode has no playable enclosure")
+    guid = episode.get("guid")
+    if guid is not None:
+        # The media's item_id is {prov_podcast_id} {guid_or_stream_url}
+        # see parse_podcast_episode.
+        # However, the guid must not contain a space, otherwise it is invalid.
+        # We cannot check, if it is a proper guid (uuid.UUID4(...)), as some podcast feeds
+        # do not follow the standard.
+        guid = None if len(guid.split(" ")) > 1 else guid
+    return stream_url, guid
 
 
 def parse_podcast_episode(

--- a/music_assistant/providers/gpodder/__init__.py
+++ b/music_assistant/providers/gpodder/__init__.py
@@ -40,6 +40,7 @@ from music_assistant.helpers.podcast_parsers import (
     enrich_episode_chapters,
     get_podcastparser_dict,
     get_stream_url_and_guid_from_episode,
+    get_stream_url_from_episode,
     parse_podcast,
     parse_podcast_episode,
 )
@@ -479,12 +480,11 @@ class GPodder(MusicProvider):
         podcast = await self._cache_get_podcast(podcast_id)
         episodes = podcast.get("episodes", [])
         for episode in episodes:
-            episode_enclosures = episode.get("enclosures", [])
-            if len(episode_enclosures) < 1:
-                # episode without an enclosure carries no stream; skip it instead of
+            stream_url = get_stream_url_from_episode(episode=episode)
+            if stream_url is None:
+                # episode without a playable enclosure carries no stream; skip it instead of
                 # aborting the lookup for the (potentially later) requested episode
                 continue
-            stream_url: str | None = episode_enclosures[0].get("url", None)
             guid = episode.get("guid")
             if guid is not None and len(guid.split(" ")) == 1:
                 _guid_or_stream_url_compare = guid

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -39,6 +39,7 @@ from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.podcast_parsers import (
     enrich_episode_chapters,
     get_podcastparser_dict,
+    get_stream_url_from_episode,
     parse_podcast,
     parse_podcast_episode,
 )
@@ -364,12 +365,11 @@ class ITunesPodcastsProvider(MusicProvider):
         podcast = await self._cache_get_podcast(podcast_id)
         episodes = podcast.get("episodes", [])
         for episode in episodes:
-            episode_enclosures = episode.get("enclosures", [])
-            if len(episode_enclosures) < 1:
-                # episode without an enclosure carries no stream; skip it instead of
+            stream_url = get_stream_url_from_episode(episode=episode)
+            if stream_url is None:
+                # episode without a playable enclosure carries no stream; skip it instead of
                 # aborting the lookup for the (potentially later) requested episode
                 continue
-            stream_url: str | None = episode_enclosures[0].get("url", None)
             guid = episode.get("guid")
             if guid is not None and len(guid.split(" ")) == 1:
                 _guid_or_stream_url_compare = guid

--- a/music_assistant/providers/podcastfeed/__init__.py
+++ b/music_assistant/providers/podcastfeed/__init__.py
@@ -35,6 +35,7 @@ from music_assistant.helpers.compare import create_safe_string
 from music_assistant.helpers.podcast_parsers import (
     enrich_episode_chapters,
     get_podcastparser_dict,
+    get_stream_url_from_episode,
     parse_podcast,
     parse_podcast_episode,
 )
@@ -159,7 +160,9 @@ class PodcastMusicprovider(MusicProvider):
         """Get streamdetails for a track/radio."""
         for episode in self.parsed_podcast["episodes"]:
             if item_id == episode["guid"]:
-                stream_url = episode["enclosures"][0]["url"]
+                stream_url = get_stream_url_from_episode(episode=episode)
+                if stream_url is None:
+                    break
                 return StreamDetails(
                     provider=self.instance_id,
                     item_id=item_id,

--- a/music_assistant/providers/podcastfeed/__init__.py
+++ b/music_assistant/providers/podcastfeed/__init__.py
@@ -162,7 +162,7 @@ class PodcastMusicprovider(MusicProvider):
             if item_id == episode["guid"]:
                 stream_url = get_stream_url_from_episode(episode=episode)
                 if stream_url is None:
-                    break
+                    raise MediaNotFoundError(f"Episode {item_id} has no playable stream")
                 return StreamDetails(
                     provider=self.instance_id,
                     item_id=item_id,

--- a/tests/helpers/test_podcast_parsers.py
+++ b/tests/helpers/test_podcast_parsers.py
@@ -9,6 +9,7 @@ from music_assistant_models.enums import LinkType
 
 from music_assistant.helpers.podcast_parsers import (
     enrich_episode_chapters,
+    get_stream_url_from_episode,
     parse_chapters_from_json,
     parse_podcast_episode,
     parse_podcast_persons,
@@ -83,6 +84,74 @@ class _FakeSession:
         self.calls += 1
         self.last_url = url
         return _FakeGetContext(self)
+
+
+# --- enclosure / stream url selection ---------------------------------------------------------
+
+
+def test_stream_url_prefers_audio_over_leading_image() -> None:
+    """A leading image media:content enclosure is skipped in favor of the audio one (#5920)."""
+    audio_url = "https://rss.wbur.org/the-midnight-rebellion/ep1.mp3"
+    cover_url = "https://rss.wbur.org/the-midnight-rebellion/cover.jpg"
+    episode = _episode(
+        enclosures=[
+            {"url": cover_url, "mime_type": "image/jpeg"},
+            {"url": audio_url, "mime_type": "audio/mpeg"},
+            {"url": audio_url, "mime_type": "audio/mpeg"},
+        ]
+    )
+    assert get_stream_url_from_episode(episode=episode) == audio_url
+
+
+def test_stream_url_accepts_bogus_mime_type() -> None:
+    """A real audio enclosure with a bogus declared mime type is still used (#5692)."""
+    episode = _episode(
+        enclosures=[{"url": "https://example.com/ep1.mp3", "mime_type": "application/octet-stream"}]
+    )
+    assert get_stream_url_from_episode(episode=episode) == "https://example.com/ep1.mp3"
+
+
+def test_stream_url_accepts_video_enclosure() -> None:
+    """A video/mp4 enclosure is accepted as a playable stream."""
+    video_url = "https://example.com/ep1.mp4"
+    episode = _episode(enclosures=[{"url": video_url, "mime_type": "video/mp4"}])
+    assert get_stream_url_from_episode(episode=episode) == video_url
+
+
+def test_stream_url_skips_enclosures_without_url() -> None:
+    """An enclosure missing a url is skipped in favor of a later usable one."""
+    episode = _episode(
+        enclosures=[
+            {"mime_type": "audio/mpeg"},
+            {"url": "https://example.com/ep1.mp3", "mime_type": "audio/mpeg"},
+        ]
+    )
+    assert get_stream_url_from_episode(episode=episode) == "https://example.com/ep1.mp3"
+
+
+def test_stream_url_image_only_returns_none() -> None:
+    """An episode whose only enclosure is an image has no playable stream."""
+    episode = _episode(
+        enclosures=[{"url": "https://example.com/cover.jpg", "mime_type": "image/jpeg"}]
+    )
+    assert get_stream_url_from_episode(episode=episode) is None
+    assert _parse(episode) is None
+
+
+def test_stream_url_first_audio_enclosure_wins() -> None:
+    """When several audio enclosures are declared, the first one wins."""
+    episode = _episode(
+        enclosures=[
+            {"url": "https://example.com/ep1-first.mp3", "mime_type": "audio/mpeg"},
+            {"url": "https://example.com/ep1-second.mp3", "mime_type": "audio/mpeg"},
+        ]
+    )
+    assert get_stream_url_from_episode(episode=episode) == "https://example.com/ep1-first.mp3"
+
+
+def test_stream_url_missing_mime_type_falls_back_to_url() -> None:
+    """The default `_episode()` enclosure has no mime_type key and still resolves (fallback)."""
+    assert get_stream_url_from_episode(episode=_episode()) == "https://example.com/ep1.mp3"
 
 
 # --- description -----------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Podcast feeds that list a cover image as a `<media:content>` before the audio one made
every podcast provider hand the cover JPG to ffmpeg instead of the episode audio, so
playback produced nothing. `podcastparser` merges `<media:content>` and `<enclosure>`
into a single `enclosures` list in document order, and we always indexed it at `[0]`.

On WBUR's feeds (e.g. The Midnight Rebellion, Circle Round) this hits every single
episode — all 27 in the reported feed resolve to a `.jpg`.

Now we select the first `audio/*` or `video/*` enclosure, falling back to any non-image
enclosure so feeds that declare a bogus mime type (`type="file"`, see #5692) keep working.

- Add `get_stream_url_from_episode()` to `helpers/podcast_parsers.py` and use it from
  `get_stream_url_and_guid_from_episode()`
- Use it in the `podcastfeed`, `gpodder` and `itunes_podcasts` providers instead of
  `enclosures[0]`
- Episodes with no playable enclosure are skipped rather than yielding an image URL
- Add tests covering the image-first, bogus-mime-type, video and image-only cases

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/5920

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
