### PR TITLE
Disable Mac AirPlay players by default

### DIFF
--- a/music_assistant/providers/airplay/helpers.py
+++ b/music_assistant/providers/airplay/helpers.py
@@ -177,6 +177,11 @@ def is_apple_device(manufacturer: str, model: str) -> bool:
     )
 
 
+def is_macos_device(manufacturer: str, model: str) -> bool:
+    """Return whether an AirPlay device identifies as a Mac."""
+    return manufacturer.lower().startswith("apple") and model.lower().startswith(("mac", "imac"))
+
+
 def is_apple_tv(manufacturer: str, model: str) -> bool:
     """
     Check if a device identifies as an Apple TV (and not a HomePod).

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -55,6 +55,7 @@ from .constants import (
 )
 from .helpers import (
     is_apple_device,
+    is_macos_device,
     player_id_to_mac_address,
     supports_airplay2,
 )
@@ -94,6 +95,7 @@ class AirPlayPlayer(Player):
         # Audio formats the receiver advertises, learned from its /info response;
         # zero until that lands (or when the device publishes no format tables).
         self.advertised_audio_formats = 0
+        self._attr_enabled_by_default = not is_macos_device(manufacturer, model)
         super().__init__(provider, player_id)
         self.address = address
         self.stream: AirPlayStream | None = None
@@ -115,7 +117,6 @@ class AirPlayPlayer(Player):
         self._attr_device_info.add_identifier(IdentifierType.AIRPLAY_ID, player_id)
         self._attr_volume_level = initial_volume
         self._attr_can_group_with = {provider.instance_id}
-        self._attr_enabled_by_default = True
 
     @property
     def protocol(self) -> StreamingProtocol:

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -55,6 +55,40 @@ def airplay_player() -> AirPlayPlayer:
 
 
 @pytest.mark.parametrize(
+    ("manufacturer", "model", "expected"),
+    [
+        ("Apple", "MacBookPro18,3", False),
+        ("Apple Inc.", "MacBook Air (MacBookAir10,1)", False),
+        ("Apple", "iMac (iMac21,1)", False),
+        ("Apple", "Mac mini (Mac16,11)", False),
+        ("Apple", "Mac Pro (MacPro7,1)", False),
+        ("Apple", "Mac Studio (Mac14,13)", False),
+        ("Apple", "HomePod Mini", True),
+        ("Apple", "Apple TV 4K", True),
+        ("Acme", "Mac-compatible receiver", True),
+    ],
+)
+def test_macos_devices_are_disabled_by_default(
+    manufacturer: str, model: str, expected: bool
+) -> None:
+    """Macs are disabled by default without affecting other AirPlay receivers."""
+    provider = MagicMock()
+    player = AirPlayPlayer(
+        provider=provider,
+        player_id="test_player",
+        display_name="Test Player",
+        address="127.0.0.1",
+        manufacturer=manufacturer,
+        model=model,
+        raop_discovery_info=None,
+        airplay_discovery_info=None,
+    )
+
+    assert player.enabled_by_default is expected
+    assert provider.mass.config.create_default_player_config.call_args.args[-1] is expected
+
+
+@pytest.mark.parametrize(
     ("aiplay_properties", "raop_properties", "expected"),
     [
         ({b"flags": b"0x200"}, None, True),


### PR DESCRIPTION
# What does this implement/fix?

Mac computers discovered through AirPlay are now disabled by default because they can be temporary endpoints and often require pairing.

- Detect Mac AirPlay devices from their manufacturer and model.
- Keep other AirPlay receivers enabled by default.
- Preserve existing player settings.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
