### PR TITLE
Show Apple TV external playback artwork

### DIFF
--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -31,6 +31,7 @@ from music_assistant.helpers.security import is_safe_path
 from music_assistant.helpers.tags import get_embedded_image
 from music_assistant.models.metadata_provider import MetadataProvider
 from music_assistant.models.music_provider import MusicProvider
+from music_assistant.models.player_provider import PlayerProvider
 from music_assistant.models.plugin import PluginProvider
 
 if TYPE_CHECKING:
@@ -397,7 +398,7 @@ async def _fetch_source_image(
     :param depth: Recursion depth of the originating get_image_data call.
     """
     if prov := mass.get_provider(provider):
-        assert isinstance(prov, MusicProvider | MetadataProvider | PluginProvider)
+        assert isinstance(prov, MusicProvider | MetadataProvider | PlayerProvider | PluginProvider)
         if resolved_image := await prov.resolve_image(path_or_url):
             if isinstance(resolved_image, bytes):
                 return resolved_image, True

--- a/music_assistant/models/player_provider.py
+++ b/music_assistant/models/player_provider.py
@@ -68,6 +68,15 @@ class PlayerProvider(Provider):
         # For providers that support dynamic discovery of players via mdns,
         # there is no need to implement this method.
 
+    async def resolve_image(self, path: str) -> str | bytes:
+        """
+        Resolve an image from an image path.
+
+        :param path: Provider-specific image path.
+        :return: Raw image bytes or a URL/local path accessible from the server.
+        """
+        return path
+
     @property
     def players(self) -> list[Player]:
         """Return all players belonging to this provider."""

--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -560,9 +560,10 @@ Some devices have known broken AirPlay implementations (see `BROKEN_AIRPLAY_MODE
 2. **Pause while synced**: Not supported; uses stop instead
 3. **HomePod power control**: Current HomePod firmware does not advertise
    Companion PIN pairing, so explicit power/wake control is unavailable
-4. **External artwork**: MRP exposes external playback metadata but its artwork
-   is not currently published through the Music Assistant image proxy
-5. **Apple TV artwork for non-public images**: Cover art only reachable through the imageproxy (e.g. filesystem-provider images with no public URL) does not currently render on the Apple TV's now-playing screen, while externally-hosted art does
+4. **Apple TV artwork for non-public images**: Cover art only reachable through
+   the imageproxy (e.g. filesystem-provider images with no public URL) does not
+   currently render on the Apple TV's now-playing screen, while externally-hosted
+   art does
 
 ## Development Notes
 

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -76,6 +76,7 @@ AIRPLAY_GROUP_START_LEAD_MS: Final[int] = 500
 # does not fetch URLs). 512px keeps the SET_PARAMETER payload small while still
 # looking sharp on speaker apps and the Apple TV now-playing screen.
 AIRPLAY_ARTWORK_SIZE: Final[int] = 512
+EXTERNAL_ARTWORK_PATH_PREFIX: Final[str] = "external_artwork"
 
 # Per-protocol credential storage keys
 CONF_RAOP_CREDENTIALS: Final[str] = "raop_credentials"

--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -13,12 +13,14 @@ import pyatv
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import (
     ConfigEntryType,
+    ImageType,
     MediaType,
     PlaybackState,
     PlayerFeature,
     PlayerType,
 )
-from music_assistant_models.errors import PlayerCommandFailed
+from music_assistant_models.errors import MediaNotFoundError, PlayerCommandFailed
+from music_assistant_models.media_items import MediaItemImage
 from music_assistant_models.player import PlayerSource
 from pyatv import exceptions as pyatv_exceptions
 from pyatv.conf import AppleTV as AppleTVConfig
@@ -58,6 +60,7 @@ from .constants import (
     CONF_NATIVE_MRP_CREDENTIALS,
     CONF_PAIR_NOW,
     CONF_STORED_VOLUME,
+    EXTERNAL_ARTWORK_PATH_PREFIX,
     FALLBACK_VOLUME,
 )
 from .helpers import (
@@ -394,6 +397,35 @@ class AirPlayControlPlayer(AirPlayPlayer):
         if device is None:
             raise PlayerCommandFailed(f"App launching is unavailable for {self.display_name}")
         await self._run_control_command(device.apps.launch_app(bundle_id_or_url), "launch app")
+
+    async def async_get_external_artwork(self, artwork_id: str) -> bytes:
+        """
+        Return artwork bytes for the current externally playing item.
+
+        :param artwork_id: Identifier of the artwork requested by the image proxy.
+        :raises MediaNotFoundError: If the artwork is stale or unavailable.
+        """
+        device = self._mrp_device
+        if (
+            device is None
+            or self._stream_active
+            or not self._feature_available(device, FeatureName.Artwork)
+            or device.metadata.artwork_id != artwork_id
+        ):
+            raise MediaNotFoundError("External AirPlay artwork is unavailable")
+        try:
+            artwork = await device.metadata.artwork()
+        except _COMMAND_ERRORS as err:
+            raise MediaNotFoundError("Unable to retrieve external AirPlay artwork") from err
+        if (
+            artwork is None
+            or not artwork.bytes
+            or self._mrp_device is not device
+            or self._stream_active
+            or device.metadata.artwork_id != artwork_id
+        ):
+            raise MediaNotFoundError("External AirPlay artwork is no longer current")
+        return artwork.bytes
 
     def set_discovery_info(self, discovery_info: AsyncServiceInfo, display_name: str) -> None:
         """Update AirPlay discovery data and reconnect device control if needed."""
@@ -1071,6 +1103,14 @@ class AirPlayControlPlayer(AirPlayPlayer):
         self._ensure_source(source_id, source_name)
         self._attr_elapsed_time = float(playing.position or 0)
         self._attr_elapsed_time_last_updated = time.time()
+        image_url: str | None = None
+        if (
+            self._mrp_device
+            and self._feature_available(self._mrp_device, FeatureName.Artwork)
+            and isinstance(artwork_id := self._mrp_device.metadata.artwork_id, str)
+            and artwork_id
+        ):
+            image_url = self._get_external_artwork_url(artwork_id)
         media_type = (
             MediaType.TRACK if playing.media_type == PyatvMediaType.Music else MediaType.UNKNOWN
         )
@@ -1080,6 +1120,7 @@ class AirPlayControlPlayer(AirPlayPlayer):
             title=playing.title or source_name,
             artist=playing.artist,
             album=playing.album,
+            image_url=image_url,
             duration=playing.total_time,
             source_id=source_id,
             elapsed_time=playing.position,
@@ -1089,24 +1130,41 @@ class AirPlayControlPlayer(AirPlayPlayer):
 
     def _ensure_source(self, source_id: str, source_name: str) -> None:
         """Add a passive source reported by MRP playback monitoring."""
-        if any(source.id == source_id for source in self._attr_source_list):
+        can_play_pause = bool(
+            self._device_for_feature(FeatureName.Play)
+            or self._device_for_feature(FeatureName.Pause)
+        )
+        can_next_previous = bool(
+            self._device_for_feature(FeatureName.Next)
+            or self._device_for_feature(FeatureName.Previous)
+        )
+        for source in self._attr_source_list:
+            if source.id != source_id:
+                continue
+            source.name = source_name
+            source.can_play_pause = can_play_pause
+            source.can_next_previous = can_next_previous
             return
         self._attr_source_list.append(
             PlayerSource(
                 id=source_id,
                 name=source_name,
                 passive=True,
-                can_play_pause=bool(
-                    self._device_for_feature(FeatureName.Play)
-                    or self._device_for_feature(FeatureName.Pause)
-                ),
+                can_play_pause=can_play_pause,
                 can_seek=False,
-                can_next_previous=bool(
-                    self._device_for_feature(FeatureName.Next)
-                    or self._device_for_feature(FeatureName.Previous)
-                ),
+                can_next_previous=can_next_previous,
             )
         )
+
+    def _get_external_artwork_url(self, artwork_id: str) -> str:
+        """Return the image-proxy URL for external MRP artwork."""
+        image = MediaItemImage(
+            type=ImageType.THUMB,
+            path=f"{EXTERNAL_ARTWORK_PATH_PREFIX}/{self.player_id}/{artwork_id}",
+            provider=self.provider_id,
+            remotely_accessible=False,
+        )
+        return self.mass.metadata.get_image_url(image)
 
     def _handle_connection_closed(
         self,

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -13,6 +13,7 @@ from ipaddress import IPv4Address, IPv6Address, ip_address
 from typing import TYPE_CHECKING, Final, cast
 
 from music_assistant_models.enums import PlaybackState
+from music_assistant_models.errors import MediaNotFoundError
 from zeroconf import NonUniqueNameException, ServiceStateChange
 from zeroconf.asyncio import AsyncServiceInfo
 
@@ -39,6 +40,7 @@ from .constants import (
     CONF_IGNORE_VOLUME,
     CONF_STORED_VOLUME,
     DACP_DISCOVERY_TYPE,
+    EXTERNAL_ARTWORK_PATH_PREFIX,
     FALLBACK_VOLUME,
     MRP_DISCOVERY_TYPE,
     RAOP_DISCOVERY_TYPE,
@@ -326,6 +328,27 @@ class AirPlayProvider(PlayerProvider):
     def get_player(self, player_id: str) -> AirPlayPlayer | None:
         """Return AirplayPlayer by id."""
         return cast("AirPlayPlayer | None", self.mass.players.get_player(player_id))
+
+    async def resolve_image(self, path: str) -> bytes:
+        """
+        Resolve artwork for the current external media on an Apple device.
+
+        :param path: AirPlay artwork path produced for the image proxy.
+        :return: Raw artwork bytes.
+        :raises MediaNotFoundError: If the artwork is invalid, stale, or unavailable.
+        """
+        try:
+            prefix, player_id, artwork_id = path.split("/", 2)
+        except ValueError as err:
+            raise MediaNotFoundError("Invalid AirPlay artwork path") from err
+        player = self.get_player(player_id)
+        if (
+            prefix != EXTERNAL_ARTWORK_PATH_PREFIX
+            or not artwork_id
+            or not isinstance(player, AirPlayControlPlayer)
+        ):
+            raise MediaNotFoundError("AirPlay artwork is unavailable")
+        return await player.async_get_external_artwork(artwork_id)
 
     def _set_pyatv_log_level(self) -> None:
         """Keep pyatv's (very chatty) logging quiet unless verbose logging is enabled."""

--- a/tests/helpers/test_images.py
+++ b/tests/helpers/test_images.py
@@ -29,6 +29,7 @@ from music_assistant.helpers.images import (
     load_provider_icon,
 )
 from music_assistant.models.metadata_provider import MetadataProvider
+from music_assistant.models.player_provider import PlayerProvider
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -209,6 +210,21 @@ async def test_provider_bytes_use_disk_cache_across_restart(
     data = await get_image_data(mass_minimal, "some/prov/path.jpg", "fake--1")
     assert data == b"expensive-image-bytes"
     assert len(fetch_calls) == 1
+
+
+async def test_player_provider_can_resolve_image_bytes(
+    mass_minimal: MusicAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Player-provider images use the shared image retrieval pipeline."""
+    fake_provider = MagicMock(spec=PlayerProvider)
+    fake_provider.resolve_image = AsyncMock(return_value=b"player-image-bytes")
+    monkeypatch.setattr(mass_minimal, "get_provider", lambda _prov: fake_provider)
+
+    data = await get_image_data(mass_minimal, "player/artwork", "player--1")
+
+    assert data == b"player-image-bytes"
+    fake_provider.resolve_image.assert_awaited_once_with("player/artwork")
 
 
 async def test_local_file_read_cached_on_disk(

--- a/tests/providers/airplay/test_control_player.py
+++ b/tests/providers/airplay/test_control_player.py
@@ -7,8 +7,15 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import MediaType, PlaybackState, PlayerFeature, PlayerType
-from music_assistant_models.errors import PlayerCommandFailed
+from music_assistant_models.enums import (
+    ImageType,
+    MediaType,
+    PlaybackState,
+    PlayerFeature,
+    PlayerType,
+)
+from music_assistant_models.errors import MediaNotFoundError, PlayerCommandFailed
+from music_assistant_models.media_items import MediaItemImage
 from pyatv import exceptions as pyatv_exceptions
 from pyatv.const import (
     DeviceState,
@@ -18,7 +25,7 @@ from pyatv.const import (
     Protocol,
 )
 from pyatv.const import MediaType as PyatvMediaType
-from pyatv.interface import App, AppleTV, Playing
+from pyatv.interface import App, AppleTV, ArtworkInfo, Playing
 from pyatv.settings import MrpTunnel
 from zeroconf import ServiceStateChange
 
@@ -29,6 +36,7 @@ from music_assistant.providers.airplay.constants import (
     CONF_COMPANION_CREDENTIALS,
     CONF_MRP_CREDENTIALS,
     CONF_NATIVE_MRP_CREDENTIALS,
+    EXTERNAL_ARTWORK_PATH_PREFIX,
     MRP_DISCOVERY_TYPE,
 )
 from music_assistant.providers.airplay.control_player import AirPlayControlPlayer
@@ -544,6 +552,80 @@ def test_mrp_updates_external_source_and_media() -> None:
     assert player.current_media.title == "External track"
     assert player.current_media.elapsed_time == 12
     assert player.source_list[0].name == "Music"
+
+
+def test_mrp_update_publishes_external_artwork() -> None:
+    """MRP artwork is exposed as a cached Music Assistant image-proxy URL."""
+    player = _make_control_player()
+    device = MagicMock(spec=AppleTV)
+    device.features.in_state.side_effect = lambda _state, feature: feature == FeatureName.Artwork
+    device.metadata.app = App("NLZIET", "nl.nlziet")
+    artwork_id = "https://artwork.example/{w}x{h}/cover"
+    device.metadata.artwork_id = artwork_id
+    player._mrp_device = device
+
+    with (
+        patch.object(player, "update_state"),
+        patch.object(
+            player.mass.metadata,
+            "get_image_url",
+            return_value="http://mass/imageproxy/artwork",
+        ) as get_image_url,
+    ):
+        player._handle_playing_update(
+            Playing(device_state=DeviceState.Playing, title="De Eindmusical")
+        )
+
+    assert player.current_media is not None
+    assert player.current_media.image_url == "http://mass/imageproxy/artwork"
+    image = get_image_url.call_args.args[0]
+    assert image == MediaItemImage(
+        type=ImageType.THUMB,
+        path=f"{EXTERNAL_ARTWORK_PATH_PREFIX}/{PLAYER_ID}/{artwork_id}",
+        provider="airplay",
+        remotely_accessible=False,
+    )
+
+
+def test_mrp_update_refreshes_existing_app_name() -> None:
+    """A late app name replaces the bundle id on an existing source."""
+    player = _make_control_player()
+    device = MagicMock(spec=AppleTV)
+    device.features.in_state.return_value = False
+    device.metadata.app = App(None, "nl.nlziet")
+    player._mrp_device = device
+    playing = Playing(device_state=DeviceState.Playing, title="De Eindmusical")
+
+    with patch.object(player, "update_state"):
+        player._handle_playing_update(playing)
+        device.metadata.app = App("NLZIET", "nl.nlziet")
+        player._handle_playing_update(playing)
+
+    assert len(player.source_list) == 1
+    assert player.source_list[0].name == "NLZIET"
+
+
+async def test_airplay_provider_resolves_only_current_external_artwork() -> None:
+    """The image proxy can retrieve current MRP artwork but not stale artwork."""
+    player = _make_control_player()
+    device = MagicMock(spec=AppleTV)
+    device.features.in_state.side_effect = lambda _state, feature: feature == FeatureName.Artwork
+    artwork_id = "https://artwork.example/{w}x{h}/cover"
+    device.metadata.artwork_id = artwork_id
+    device.metadata.artwork = AsyncMock(
+        return_value=ArtworkInfo(b"artwork-bytes", "image/jpeg", 512, 288)
+    )
+    player._mrp_device = device
+    provider = AirPlayProvider.__new__(AirPlayProvider)
+    provider.mass = MagicMock()
+    provider.mass.players.get_player.return_value = player
+    artwork_path = f"{EXTERNAL_ARTWORK_PATH_PREFIX}/{PLAYER_ID}/{artwork_id}"
+
+    assert await provider.resolve_image(artwork_path) == b"artwork-bytes"
+
+    device.metadata.artwork_id = "replacement-artwork"
+    with pytest.raises(MediaNotFoundError):
+        await provider.resolve_image(artwork_path)
 
 
 def test_mrp_update_without_app_uses_generic_source() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Apple TV content playing outside Music Assistant only showed partial details.

- Show external playback artwork in Music Assistant.
- Keep the active app name up to date.
- Ignore outdated artwork after the content changes.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.