### PR TITLE
Fix pause failing on Cast devices streaming via Sendspin

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -4132,15 +4132,16 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             ):
                 await target_player.play()
                 return
-            # No active protocol target: if the player natively supports pause and the active
-            # (external) source can be paused, unpause the player directly instead of
+            # No active protocol target: if the player rendering the audio supports pause and
+            # the active (external) source can be paused, unpause it directly instead of
             # restarting the source.
+            output_player = player.resolve_output_player()
             if (
                 active_source
                 and active_source.can_play_pause
-                and PlayerFeature.PAUSE in player.state.supported_features
+                and PlayerFeature.PAUSE in output_player.supported_features
             ):
-                await player.play()
+                await output_player.play()
                 return
 
         # player is not paused: try to resume the player
@@ -4197,15 +4198,16 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         ):
             await target_player.pause()
             return
-        # No active protocol target: if the player natively supports pause and the active
-        # (external) source can be paused, forward the command to the player itself instead
-        # of stopping it (mirrors the external-source handling in cmd_seek/cmd_next_track).
+        # No active protocol target: if the player rendering the audio supports pause and the
+        # active (external) source can be paused, forward the command to it instead of stopping
+        # it (mirrors the external-source handling in cmd_seek/cmd_next_track).
+        output_player = player.resolve_output_player()
         if (
             active_source
             and active_source.can_play_pause
-            and PlayerFeature.PAUSE in player.state.supported_features
+            and PlayerFeature.PAUSE in output_player.supported_features
         ):
-            await player.pause()
+            await output_player.pause()
             return
         # player/protocol does not support pause: fall back to stop
         self.logger.debug(

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -36,7 +36,7 @@ from music_assistant_models.errors import (
     PlayerCommandFailed,
     UnsupportedFeaturedException,
 )
-from music_assistant_models.player import PlayerMedia, PlayerSource
+from music_assistant_models.player import OutputProtocol, PlayerMedia, PlayerSource
 
 from music_assistant.constants import ATTR_PREVIOUS_VOLUME, CONF_MUTE_CONTROL
 from music_assistant.controllers.players import PlayerController
@@ -981,6 +981,81 @@ class TestExternalSourcePlayPause:
 
         controller._handle_cmd_stop.assert_awaited_once()
         player.pause.assert_not_called()
+
+
+class TestProtocolOutputPlayPause:
+    """Play/pause on a player rendering through a linked output protocol."""
+
+    @staticmethod
+    def _make_player_on_protocol(
+        mock_mass: MagicMock,
+        controller: PlayerController,
+        *,
+        playback_state: PlaybackState,
+    ) -> MockPlayer:
+        """Build a player playing the MA queue through a protocol that cannot pause."""
+        native_provider = MockProvider("chromecast", mass=mock_mass)
+        player = MockPlayer(native_provider, "player_1", "Test Player")
+        player._attr_supported_features.add(PlayerFeature.PAUSE)
+        player._attr_playback_state = playback_state
+
+        protocol_provider = MockProvider("sendspin", mass=mock_mass)
+        protocol_player = MockPlayer(
+            protocol_provider, "proto_1", "Test Protocol", player_type=PlayerType.PROTOCOL
+        )
+        protocol_player._attr_playback_state = playback_state
+
+        controller._players = {"player_1": player, "proto_1": protocol_player}
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        mock_mass.player_queues.get = MagicMock(return_value=None)
+        player.set_linked_output_protocols(
+            [
+                OutputProtocol(
+                    output_protocol_id="proto_1",
+                    name="Sendspin",
+                    protocol_domain="sendspin",
+                    priority=40,
+                )
+            ]
+        )
+        player.set_active_output_protocol("proto_1")
+        player.set_active_mass_source("player_1")
+        protocol_player.update_state(signal_event=False)
+        player.refresh_state(signal_event=False)
+        return player
+
+    async def test_pause_on_protocol_without_pause_falls_back_to_stop(
+        self, mock_mass: MagicMock, controller: PlayerController
+    ) -> None:
+        """The native transport has no session to pause while a protocol renders the audio."""
+        player = self._make_player_on_protocol(
+            mock_mass, controller, playback_state=PlaybackState.PLAYING
+        )
+        player.pause = AsyncMock()  # type: ignore[method-assign]
+        controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._handle_cmd_pause("player_1")
+
+        player.pause.assert_not_called()
+        # STOP goes to the visible player, not the protocol player
+        controller._handle_cmd_stop.assert_awaited_once_with("player_1")
+
+    async def test_play_on_protocol_without_pause_does_not_unpause_natively(
+        self, mock_mass: MagicMock, controller: PlayerController
+    ) -> None:
+        """Unpausing must not hit the native transport either; the source is restarted."""
+        player = self._make_player_on_protocol(
+            mock_mass, controller, playback_state=PlaybackState.PAUSED
+        )
+        player.play = AsyncMock()  # type: ignore[method-assign]
+        controller._handle_select_source = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._handle_cmd_play("player_1")
+
+        player.play.assert_not_called()
+        # the MA queue source is restarted, not some other source
+        controller._handle_select_source.assert_awaited_once_with("player_1", "player_1")
 
 
 class TestMirrorsParentMedia:


### PR DESCRIPTION
# What does this implement/fix?

Pausing a player that streams through a linked output protocol failed with "The command to the player failed", and playback continued. Most visible on Google Cast devices playing via Sendspin: the Cast device runs the Sendspin receiver app, so there is no Cast media session and `media_controller.pause()` is rejected with `PAUSE command requested but no session is active`.

The external-source pause/unpause fallback forwarded the command to the native player whenever the active source reported `can_play_pause`. The MA queue source always reports that, and `state.supported_features` unions the native player's PAUSE with the active protocol's, so with a protocol active (which has no pause of its own) the command hit the native transport instead of falling back to STOP.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/5902

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Resolve the player that actually renders the output (`Player.resolve_output_player()`) and decide on its own capabilities, forwarding the command there; a protocol that cannot pause now falls back to STOP as before.
- Applied to both `_handle_cmd_pause` and the mirrored unpause path in `_handle_cmd_play`.
- Added tests covering pause and unpause on a player with an active protocol that does not support pause.

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
