### PR TITLE
Fix bit-perfect status for lossy sources

### DIFF
--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -577,8 +577,6 @@ def _is_bit_perfect(
         return None
     if item.alters_audio:
         return False
-    if get_audio_quality(source_format) not in (AudioQuality.LOSSLESS, AudioQuality.HI_RES):
-        return False
     if get_audio_quality(output_format) not in (AudioQuality.LOSSLESS, AudioQuality.HI_RES):
         return False
     formats = [source_format]

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -137,6 +137,65 @@ def test_audio_processing_manager_attaches_grouped_chain() -> None:
     )
 
 
+def test_lossy_source_can_have_bit_perfect_lossless_output() -> None:
+    """Lossy source quality does not prevent preserving its decoded PCM samples."""
+    manager, _mass, _queue_data, streamdetails, lossless_plan, lossy_plan = _manager_context()
+    streamdetails.audio_format = AudioFormat(
+        content_type=ContentType.OGG,
+        codec_type=ContentType.VORBIS,
+        sample_rate=44100,
+        bit_depth=16,
+        channels=2,
+        bit_rate=320,
+    )
+    pcm_format = _format(ContentType.PCM_S16LE)
+    manager.update_item_runtime(
+        "queue-1",
+        "session-1",
+        "item-1",
+        input_format=pcm_format,
+        pcm_format=pcm_format,
+        normalization=None,
+        playback_speed=1.0,
+    )
+    lossless_plan.input_format = pcm_format
+    lossless_plan.output_details.output_format = _format(ContentType.FLAC)
+    lossy_plan.input_format = pcm_format
+    lossy_plan.output_details.output_format = _format(ContentType.MP3, bit_rate=320)
+
+    manager.update_output(
+        "lossless-player",
+        lossless_plan,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+    manager.update_output(
+        "lossy-player",
+        lossy_plan,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+
+    chain = cast("AudioProcessingChain", streamdetails.audio_processing)
+    outputs = {output.player_ids[0]: output for output in chain.outputs}
+    assert chain.input_fidelity.quality == AudioQuality.STANDARD
+    assert outputs["lossless-player"].fidelity == AudioFidelity(
+        quality=AudioQuality.STANDARD,
+        bit_perfect=True,
+    )
+    assert outputs["lossy-player"].fidelity == AudioFidelity(
+        quality=AudioQuality.STANDARD,
+        bit_perfect=False,
+    )
+    serialized = streamdetails.to_dict()
+    serialized_outputs = {
+        output["player_ids"][0]: output for output in serialized["audio_processing"]["outputs"]
+    }
+    assert serialized_outputs["lossless-player"]["fidelity"]["bit_perfect"] is True
+
+
 def test_shared_output_destinations_are_registered_atomically() -> None:
     """One shared output publishes all destinations in a single queue update."""
     manager, mass, _queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()


### PR DESCRIPTION
# What does this implement/fix?

Lossy sources were always marked non-bit-perfect after decoding, even when their PCM samples passed unchanged to a lossless output.

- Keep lossy source quality classified as standard while allowing unchanged decoded PCM to be bit-perfect
- Keep lossy outputs and sample-altering processing non-bit-perfect
- Add regression coverage for Vorbis input and the serialized stream-details payload

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (N/A: no shared model changes)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked: music-assistant/frontend#2224.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (N/A: no documentation changes are needed)