### PR TITLE
Fix Audiobookshelf configuration loading

### DIFF
--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -175,6 +175,17 @@ class Audiobookshelf(RecommendationPayloadMixin, MusicProvider):
 
     _on_unload_callbacks: list[Callable[[], None]]
 
+    def __init__(
+        self,
+        mass: MusicAssistant,
+        manifest: ProviderManifest,
+        config: ProviderConfig,
+        supported_features: set[ProviderFeature] | None = None,
+    ) -> None:
+        """Initialize the Audiobookshelf provider."""
+        super().__init__(mass, manifest, config, supported_features)
+        self.libraries = LibrariesHelper()
+
     @staticmethod
     def handle_refresh_token(
         method: Callable[P, Coroutine[Any, Any, R]],

--- a/tests/providers/audiobookshelf/conftest.py
+++ b/tests/providers/audiobookshelf/conftest.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 import pytest
 
 from music_assistant.providers.audiobookshelf import SUPPORTED_FEATURES, Audiobookshelf
-from music_assistant.providers.audiobookshelf.helpers import LibrariesHelper, LibraryHelper
+from music_assistant.providers.audiobookshelf.helpers import LibraryHelper
 
 
 @pytest.fixture
@@ -24,8 +24,6 @@ def provider() -> Audiobookshelf:
         "log_level": "GLOBAL",
     }.get(key, default)
     provider = Audiobookshelf(mass, manifest, config, SUPPORTED_FEATURES)
-    # attributes normally set in handle_async_init
-    provider.libraries = LibrariesHelper()
     provider.libraries.audiobooks["lib1"] = LibraryHelper(name="Audiobooks")
     provider._client = Mock()
     return provider

--- a/tests/providers/audiobookshelf/test_init.py
+++ b/tests/providers/audiobookshelf/test_init.py
@@ -1,0 +1,10 @@
+"""Tests for Audiobookshelf provider initialization."""
+
+from music_assistant_models.enums import ProviderFeature
+
+from music_assistant.providers.audiobookshelf import Audiobookshelf
+
+
+def test_supported_features_before_async_init(provider: Audiobookshelf) -> None:
+    """Provider features are available before asynchronous initialization."""
+    assert ProviderFeature.PLAYLIST_CREATE_AUDIOBOOKS in provider.supported_features


### PR DESCRIPTION
# What does this implement/fix?

Audiobookshelf could fail to load or save its configuration because its library state was unavailable while determining provider capabilities.

- Initialize library state when the provider is created.
- Add coverage for capability detection before connection setup.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.