### PR TITLE
Play the track you selected when shuffle is on

### DIFF
--- a/music_assistant/controllers/player_queues/media_resolver.py
+++ b/music_assistant/controllers/player_queues/media_resolver.py
@@ -151,9 +151,21 @@ class MediaResolver:
         return result
 
     async def get_album_tracks(
-        self, album: Album, start_item: str | None, sort_by: str | None = None
+        self,
+        album: Album,
+        start_item: str | None,
+        sort_by: str | None = None,
+        keep_preceding_items: bool = False,
     ) -> list[Track]:
-        """Return tracks for given album, based on user preference."""
+        """
+        Return tracks for given album, based on user preference.
+
+        :param album: The album to fetch the tracks for.
+        :param start_item: Optional item_id/uri of the track to start from.
+        :param sort_by: Optional sort key to order the tracks by before applying start_item.
+        :param keep_preceding_items: Move the tracks before start_item behind the rest instead
+            of dropping them, so the full album is returned with start_item first.
+        """
         album_items_conf = self.mass.config.get_raw_core_config_value(
             self.queues.domain,
             CONF_DEFAULT_ENQUEUE_SELECT_ALBUM,
@@ -177,7 +189,7 @@ class MediaResolver:
         if start_item is not None:
             for idx, track in enumerate(result):
                 if start_item in (track.item_id, track.uri):
-                    return result[idx:]
+                    return result[idx:] + result[:idx] if keep_preceding_items else result[idx:]
             return []
         return result
 
@@ -226,8 +238,17 @@ class MediaResolver:
         playlist: Playlist,
         start_item: str | None,
         sort_by: str | None = None,
+        keep_preceding_items: bool = False,
     ) -> list[PlaylistPlayableItem]:
-        """Return tracks for given playlist, based on user preference."""
+        """
+        Return tracks for given playlist, based on user preference.
+
+        :param playlist: The playlist to fetch the tracks for.
+        :param start_item: Optional item_id/uri/name of the track to start from.
+        :param sort_by: Optional sort key to order the tracks by before applying start_item.
+        :param keep_preceding_items: Move the tracks before start_item behind the rest instead
+            of dropping them, so the full playlist is returned with start_item first.
+        """
         result: list[PlaylistPlayableItem] = []
         self.logger.info(
             "Fetching tracks to play for playlist %s",
@@ -235,9 +256,10 @@ class MediaResolver:
         )
         force_refresh = playlist.is_dynamic
         needs_sort = sort_by is not None and sort_by != "position"
-        # Fast path: no re-sort needed, skip-until-found in a single pass
-        # so we don't materialize huge playlists when starting near the end.
-        if not needs_sort:
+        # Fast path: no re-sort needed and the preceding tracks are dropped anyway, so
+        # skip-until-found in a single pass and never materialize huge playlists when
+        # starting near the end.
+        if not needs_sort and not keep_preceding_items:
             start_item_found = False
             async for playlist_track in self.mass.music.playlists.tracks(
                 playlist.item_id,
@@ -253,7 +275,7 @@ class MediaResolver:
                     continue
                 result.append(playlist_track)
             return result
-        # Sort path: must materialize all tracks before sorting, then slice.
+        # Sort/rotate path: must materialize all tracks before sorting or rotating, then slice.
         async for playlist_track in self.mass.music.playlists.tracks(
             playlist.item_id,
             playlist.provider,
@@ -263,11 +285,12 @@ class MediaResolver:
             if not playlist_track.available:
                 continue
             result.append(playlist_track)
-        result = sort_tracks(result, cast("str", sort_by))
+        if needs_sort:
+            result = sort_tracks(result, cast("str", sort_by))
         if start_item is not None:
             for idx, track in enumerate(result):
                 if _start_item_matches(start_item, track):
-                    return result[idx:]
+                    return result[idx:] + result[:idx] if keep_preceding_items else result[idx:]
             return []
         return result
 
@@ -462,8 +485,22 @@ class MediaResolver:
         queue_id: str | None = None,
         sort_by: str | None = None,
         start_from_beginning: bool = False,
+        keep_preceding_items: bool = False,
     ) -> list[MediaItemType]:
-        """Resolve/unwrap media items to enqueue."""
+        """
+        Resolve/unwrap media items to enqueue.
+
+        :param media_item: The media item to resolve into playable items.
+        :param start_item: Optional item to start a playlist/album/genre from, or the chapter
+            to start an audiobook/podcast episode at.
+        :param userid: Optional user the playback is attributed to.
+        :param queue_id: Optional queue the playback is requested for.
+        :param sort_by: Optional sort key to order tracks by before applying start_item.
+        :param start_from_beginning: Ignore any saved resume position for a podcast episode.
+        :param keep_preceding_items: For a playlist/album, move the tracks before start_item
+            behind the rest instead of dropping them, so the full item is returned with
+            start_item first.
+        """
         # resolve Itemmapping to full media item
         if isinstance(media_item, ItemMapping):
             if media_item.uri is None:
@@ -476,7 +513,14 @@ class MediaResolver:
                     media_item, userid=userid, queue_id=queue_id, user_initiated=True
                 )
             )
-            return list(await self.get_playlist_tracks(media_item, start_item, sort_by=sort_by))
+            return list(
+                await self.get_playlist_tracks(
+                    media_item,
+                    start_item,
+                    sort_by=sort_by,
+                    keep_preceding_items=keep_preceding_items,
+                )
+            )
         if media_item.media_type == MediaType.ARTIST:
             media_item = cast("Artist", media_item)
             self.mass.create_task(
@@ -487,7 +531,14 @@ class MediaResolver:
             return list(await self.get_artist_tracks(media_item))
         if media_item.media_type == MediaType.ALBUM:
             media_item = cast("Album", media_item)
-            return list(await self.get_album_tracks(media_item, start_item, sort_by=sort_by))
+            return list(
+                await self.get_album_tracks(
+                    media_item,
+                    start_item,
+                    sort_by=sort_by,
+                    keep_preceding_items=keep_preceding_items,
+                )
+            )
         if media_item.media_type == MediaType.GENRE:
             media_item = cast("Genre", media_item)
             self.mass.create_task(

--- a/music_assistant/controllers/player_queues/media_resolver.py
+++ b/music_assistant/controllers/player_queues/media_resolver.py
@@ -189,7 +189,7 @@ class MediaResolver:
         if start_item is not None:
             for idx, track in enumerate(result):
                 if start_item in (track.item_id, track.uri):
-                    return result[idx:] + result[:idx] if keep_preceding_items else result[idx:]
+                    return result[idx:] + (result[:idx] if keep_preceding_items else [])
             return []
         return result
 
@@ -290,7 +290,7 @@ class MediaResolver:
         if start_item is not None:
             for idx, track in enumerate(result):
                 if _start_item_matches(start_item, track):
-                    return result[idx:] + result[:idx] if keep_preceding_items else result[idx:]
+                    return result[idx:] + (result[:idx] if keep_preceding_items else [])
             return []
         return result
 

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -75,8 +75,17 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         queue_id: str,
         queue_items: list[QueueItem],
         option: QueueOption | None,
+        pin_first: bool = False,
     ) -> None:
-        """Load queue items into the queue according to the given enqueue option."""
+        """
+        Load queue items into the queue according to the given enqueue option.
+
+        :param queue_id: The queue to load the items into.
+        :param queue_items: The items to load.
+        :param option: The enqueue option to apply.
+        :param pin_first: The first item was explicitly picked by the user (a start_item), so it
+            must keep its position when the batch is shuffled instead of being moved at random.
+        """
         queue = self._queue_data[queue_id].queue
         if queue.state in (PlaybackState.PLAYING, PlaybackState.PAUSED):
             cur_index = (
@@ -88,16 +97,28 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             cur_index = queue.current_index or 0
         insert_at_index = cur_index + 1
         shuffle = queue.shuffle_enabled and len(queue_items) > 1
+        # a user-picked start item must be the one that actually starts playing, so keep it in
+        # front of the shuffled rest instead of letting the shuffle move it to a random slot
+        pin_first = pin_first and shuffle
 
         # handle replace: clear all items and replace with the new items
         if option == QueueOption.REPLACE:
-            await self.load(
-                queue_id,
-                queue_items=queue_items,
-                keep_remaining=False,
-                keep_played=False,
-                shuffle=shuffle,
-            )
+            if pin_first:
+                await self._load_pinned_first(
+                    queue_id,
+                    queue_items,
+                    insert_at_index=0,
+                    keep_remaining=False,
+                    keep_played=False,
+                )
+            else:
+                await self.load(
+                    queue_id,
+                    queue_items=queue_items,
+                    keep_remaining=False,
+                    keep_played=False,
+                    shuffle=shuffle,
+                )
             await self.play_index(queue_id, 0)
             return
         # handle next: add item(s) in the index next to the playing/loaded/buffered index
@@ -107,17 +128,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                 # buffered index so it plays next, the rest of the batch is shuffled into the tail
                 # behind it. insert_at_index is the first un-buffered slot, so the track the player
                 # already prepared for crossfade is left untouched.
-                await self.load(
-                    queue_id,
-                    queue_items=queue_items[:1],
-                    insert_at_index=insert_at_index,
-                )
-                await self.load(
-                    queue_id,
-                    queue_items=queue_items[1:],
-                    insert_at_index=insert_at_index + 1,
-                    shuffle=True,
-                )
+                await self._load_pinned_first(queue_id, queue_items, insert_at_index)
             else:
                 await self.load(
                     queue_id,
@@ -128,13 +139,18 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             self._ensure_current_index(queue_id)
             return
         if option == QueueOption.REPLACE_NEXT:
-            await self.load(
-                queue_id,
-                queue_items=queue_items,
-                insert_at_index=insert_at_index,
-                keep_remaining=False,
-                shuffle=shuffle,
-            )
+            if pin_first:
+                await self._load_pinned_first(
+                    queue_id, queue_items, insert_at_index, keep_remaining=False
+                )
+            else:
+                await self.load(
+                    queue_id,
+                    queue_items=queue_items,
+                    insert_at_index=insert_at_index,
+                    keep_remaining=False,
+                    shuffle=shuffle,
+                )
             self._ensure_current_index(queue_id)
             return
         # handle play: replace current loaded/playing index with new item(s)
@@ -142,12 +158,15 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             # an idle/empty queue has no current item to insert after, so insert at and
             # start from the very first index instead of skipping past it
             play_at_index = 0 if queue.current_index is None else insert_at_index
-            await self.load(
-                queue_id,
-                queue_items=queue_items,
-                insert_at_index=play_at_index,
-                shuffle=shuffle,
-            )
+            if pin_first:
+                await self._load_pinned_first(queue_id, queue_items, play_at_index)
+            else:
+                await self.load(
+                    queue_id,
+                    queue_items=queue_items,
+                    insert_at_index=play_at_index,
+                    shuffle=shuffle,
+                )
             next_index = min(play_at_index, len(self._queue_data[queue_id].items) - 1)
             await self.play_index(queue_id, next_index)
             return
@@ -170,6 +189,37 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                 shuffle=queue.shuffle_enabled,
             )
             self._ensure_current_index(queue_id)
+
+    async def _load_pinned_first(
+        self,
+        queue_id: str,
+        queue_items: list[QueueItem],
+        insert_at_index: int,
+        keep_remaining: bool = True,
+        keep_played: bool = True,
+    ) -> None:
+        """
+        Insert the first item at the given index and shuffle the rest of the batch behind it.
+
+        :param queue_id: The queue to load the items into.
+        :param queue_items: The items to load; the first one keeps the given index.
+        :param insert_at_index: The index to place the first item at.
+        :param keep_remaining: Keep the queue's existing items from the insert index onwards.
+        :param keep_played: Keep the queue's existing items before the insert index.
+        """
+        await self.load(
+            queue_id,
+            queue_items=queue_items[:1],
+            insert_at_index=insert_at_index,
+            keep_remaining=keep_remaining,
+            keep_played=keep_played,
+        )
+        await self.load(
+            queue_id,
+            queue_items=queue_items[1:],
+            insert_at_index=insert_at_index + 1,
+            shuffle=True,
+        )
 
     def _ensure_current_index(self, queue_id: str) -> None:
         """
@@ -661,6 +711,10 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                         queue_id=queue_id,
                         sort_by=sort_by,
                         start_from_beginning=start_from_beginning,
+                        # under shuffle "start here and play forward" has no meaning, so keep the
+                        # whole playlist/album (chosen track first) instead of dropping everything
+                        # before it - the chosen track is pinned in front of the shuffled rest
+                        keep_preceding_items=queue.shuffle_enabled,
                     )
 
             except MusicAssistantError as err:
@@ -695,7 +749,9 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         if not queue_items:
             raise MediaNotFoundError("No playable items found")
 
-        await self._enqueue_with_option(queue_id, queue_items, option)
+        await self._enqueue_with_option(
+            queue_id, queue_items, option, pin_first=start_item is not None
+        )
 
     async def _enter_dynamic_mode(self, queue_id: str, option: QueueOption | None) -> None:
         """

--- a/tests/controllers/player_queues/test_enqueue_options.py
+++ b/tests/controllers/player_queues/test_enqueue_options.py
@@ -430,3 +430,85 @@ def test_store_sources_keeps_only_container_types_on_wire() -> None:
     assert ctrl._queue_data["q1"].source_items == items
     # but only the container sources are shown to clients, in original order
     assert [mapping.uri for mapping in queue.sources] == [album.uri, podcast.uri]
+
+
+def _shuffled_queue(ctrl: PlayerQueuesController) -> PlayerQueue:
+    """Set up an idle queue with shuffle on and a deterministic (reversing) shuffle."""
+    ctrl._smart_shuffle = Mock()
+    ctrl._smart_shuffle.is_enabled = Mock(return_value=True)
+    ctrl._smart_shuffle.arrange = AsyncMock(
+        side_effect=lambda _queue, items: list(items)[::-1],
+    )
+    queue = PlayerQueue(
+        queue_id="q1",
+        active=True,
+        display_name="Q1",
+        available=True,
+        items=0,
+        shuffle_enabled=True,
+    )
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue)}
+    return queue
+
+
+async def test_play_with_start_item_pins_chosen_track_under_shuffle() -> None:
+    """PLAY from a chosen track keeps that track first when shuffle is on."""
+    ctrl = _controller()
+    play_index = AsyncMock()
+    ctrl.play_index = play_index  # type: ignore[method-assign]
+    _shuffled_queue(ctrl)
+    items = _items("q1", ["chosen", "b", "c", "d"])
+
+    await ctrl._enqueue_with_option("q1", items, QueueOption.PLAY, pin_first=True)
+
+    queue_items = ctrl._queue_data["q1"].items
+    # the track the user picked starts playing; the rest is shuffled behind it
+    assert queue_items[0] is items[0]
+    assert {item.queue_item_id for item in queue_items[1:]} == {"b", "c", "d"}
+    play_index.assert_awaited_once_with("q1", 0)
+
+
+async def test_replace_with_start_item_pins_chosen_track_under_shuffle() -> None:
+    """REPLACE from a chosen track keeps that track first when shuffle is on."""
+    ctrl = _controller()
+    play_index = AsyncMock()
+    ctrl.play_index = play_index  # type: ignore[method-assign]
+    _shuffled_queue(ctrl)
+    items = _items("q1", ["chosen", "b", "c", "d"])
+
+    await ctrl._enqueue_with_option("q1", items, QueueOption.REPLACE, pin_first=True)
+
+    queue_items = ctrl._queue_data["q1"].items
+    assert queue_items[0] is items[0]
+    assert {item.queue_item_id for item in queue_items[1:]} == {"b", "c", "d"}
+    play_index.assert_awaited_once_with("q1", 0)
+
+
+async def test_play_without_start_item_shuffles_the_whole_batch() -> None:
+    """PLAY of a whole playlist under shuffle still randomises which track starts."""
+    ctrl = _controller()
+    play_index = AsyncMock()
+    ctrl.play_index = play_index  # type: ignore[method-assign]
+    _shuffled_queue(ctrl)
+    items = _items("q1", ["a", "b", "c", "d"])
+
+    await ctrl._enqueue_with_option("q1", items, QueueOption.PLAY)
+
+    # nothing is pinned: the deterministic reversal moves the last item to the front
+    assert ctrl._queue_data["q1"].items[0] is items[-1]
+    play_index.assert_awaited_once_with("q1", 0)
+
+
+async def test_play_with_start_item_keeps_order_when_shuffle_is_off() -> None:
+    """With shuffle off, PLAY from a chosen track plays it and keeps the rest in order."""
+    ctrl = _controller()
+    play_index = AsyncMock()
+    ctrl.play_index = play_index  # type: ignore[method-assign]
+    queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue)}
+    items = _items("q1", ["chosen", "b", "c"])
+
+    await ctrl._enqueue_with_option("q1", items, QueueOption.PLAY, pin_first=True)
+
+    assert [item.queue_item_id for item in ctrl._queue_data["q1"].items] == ["chosen", "b", "c"]
+    play_index.assert_awaited_once_with("q1", 0)

--- a/tests/controllers/player_queues/test_start_item_rotation.py
+++ b/tests/controllers/player_queues/test_start_item_rotation.py
@@ -1,0 +1,149 @@
+"""
+Tests for the ``keep_preceding_items`` handling of ``start_item`` in the media resolver.
+
+Playing a playlist/album from a chosen track normally drops everything before that track
+("play from here onwards"). With shuffle on that has no meaning, so the preceding tracks are
+moved behind the rest instead of being dropped and the chosen track is returned first.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.media_items import Album, Playlist, ProviderMapping, Track
+
+from music_assistant.controllers.player_queues.media_resolver import MediaResolver
+
+
+def _track(item_id: str) -> Track:
+    """Build an available Track on the 'test' provider."""
+    return Track(
+        item_id=item_id,
+        provider="test",
+        name=f"Track {item_id}",
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")
+        },
+    )
+
+
+def _resolver() -> tuple[MediaResolver, MagicMock]:
+    """Create a bare resolver, plus the mock standing in for the `mass` instance."""
+    resolver = MediaResolver.__new__(MediaResolver)
+    mass = MagicMock()
+    mass.config.get_raw_core_config_value = MagicMock(return_value="all_tracks")
+    resolver.mass = mass
+    resolver.queues = MagicMock()
+    resolver.logger = MagicMock()
+    return resolver, mass
+
+
+def _album_resolver(tracks: list[Track]) -> MediaResolver:
+    """Create a resolver whose album track listing returns the given tracks."""
+    resolver, mass = _resolver()
+    mass.music.albums.tracks = AsyncMock(return_value=tracks)
+    return resolver
+
+
+def _playlist_resolver(tracks: list[Track]) -> MediaResolver:
+    """Create a resolver whose playlist track listing yields the given tracks."""
+    resolver, mass = _resolver()
+
+    async def _tracks(*_args: Any, **_kwargs: Any) -> AsyncIterator[Track]:
+        for track in tracks:
+            yield track
+
+    mass.music.playlists.tracks = _tracks
+    return resolver
+
+
+def _album() -> Album:
+    """Build an Album on the 'test' provider."""
+    return Album(
+        item_id="al",
+        provider="test",
+        name="Album",
+        provider_mappings={
+            ProviderMapping(item_id="al", provider_domain="test", provider_instance="test")
+        },
+    )
+
+
+def _playlist() -> Playlist:
+    """Build a non-dynamic Playlist on the 'test' provider."""
+    return Playlist(
+        item_id="pl",
+        provider="test",
+        name="Playlist",
+        provider_mappings={
+            ProviderMapping(item_id="pl", provider_domain="test", provider_instance="test")
+        },
+    )
+
+
+async def test_album_start_item_drops_preceding_tracks_by_default() -> None:
+    """Without the flag an album starts at the chosen track and the earlier ones are dropped."""
+    tracks = [_track(x) for x in ("a", "b", "c", "d")]
+    resolver = _album_resolver(tracks)
+
+    result = await resolver.get_album_tracks(_album(), start_item="c")
+
+    assert [track.item_id for track in result] == ["c", "d"]
+
+
+async def test_album_start_item_keeps_preceding_tracks_behind_the_rest() -> None:
+    """With the flag the whole album is returned, rotated so the chosen track comes first."""
+    tracks = [_track(x) for x in ("a", "b", "c", "d")]
+    resolver = _album_resolver(tracks)
+
+    result = await resolver.get_album_tracks(_album(), start_item="c", keep_preceding_items=True)
+
+    assert [track.item_id for track in result] == ["c", "d", "a", "b"]
+
+
+async def test_playlist_start_item_drops_preceding_tracks_by_default() -> None:
+    """Without the flag a playlist starts at the chosen track and the earlier ones are dropped."""
+    tracks = [_track(x) for x in ("a", "b", "c", "d")]
+    resolver = _playlist_resolver(tracks)
+
+    result = await resolver.get_playlist_tracks(_playlist(), start_item="c")
+
+    assert [track.item_id for track in result] == ["c", "d"]
+
+
+async def test_playlist_start_item_keeps_preceding_tracks_behind_the_rest() -> None:
+    """With the flag the whole playlist is returned, rotated so the chosen track comes first."""
+    tracks = [_track(x) for x in ("a", "b", "c", "d")]
+    resolver = _playlist_resolver(tracks)
+
+    result = await resolver.get_playlist_tracks(
+        _playlist(), start_item="c", keep_preceding_items=True
+    )
+
+    assert [track.item_id for track in result] == ["c", "d", "a", "b"]
+
+
+async def test_playlist_without_start_item_keeps_full_order() -> None:
+    """The flag is a no-op when no start item is given: the playlist keeps its own order."""
+    tracks = [_track(x) for x in ("a", "b", "c")]
+    resolver = _playlist_resolver(tracks)
+
+    result = await resolver.get_playlist_tracks(
+        _playlist(), start_item=None, keep_preceding_items=True
+    )
+
+    assert [track.item_id for track in result] == ["a", "b", "c"]
+
+
+async def test_playlist_unknown_start_item_yields_nothing() -> None:
+    """An unmatched start item still yields no tracks, so the caller can fall back."""
+    tracks = [_track(x) for x in ("a", "b", "c")]
+    resolver = _playlist_resolver(tracks)
+
+    result = await resolver.get_playlist_tracks(
+        _playlist(), start_item="zz", keep_preceding_items=True
+    )
+
+    assert result == []


### PR DESCRIPTION
# What does this implement/fix?

With shuffle turned on, pressing play on a track inside a playlist or album started a random other track instead of the one you picked, because the selected track got thrown into the shuffle along with everything else.

The track you pick now always starts playing and the shuffle applies to the rest of the queue behind it. Shuffling from a selected track also no longer throws away the tracks before it: picking track 18 of 20 used to leave you with a 3 track queue that ended almost immediately.

- Keep the selected track in place when the queue gets shuffled, for play, replace and replace-next
- Keep the full playlist/album when shuffling from a selected track, instead of only the tracks that follow it
- Reuse the pinning the "play next" option already did, instead of a second copy of it
- Tests for the new behaviour

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
