### PR TITLE
Play the track you selected when shuffle is on

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1497,7 +1497,9 @@ class PlayerQueuesController(CoreController):
             raise MediaNotFoundError("No playable items found")
 
         # load the items into the queue
-        await self._enqueue_with_option(queue_id, queue_items, option, radio_mode)
+        await self._enqueue_with_option(
+            queue_id, queue_items, option, radio_mode, pin_first=start_item is not None
+        )
 
     async def _enqueue_with_option(
         self,
@@ -1505,8 +1507,18 @@ class PlayerQueuesController(CoreController):
         queue_items: list[QueueItem],
         option: QueueOption | None,
         radio_mode: bool,
+        pin_first: bool = False,
     ) -> None:
-        """Load queue items into the queue according to the given enqueue option."""
+        """
+        Load queue items into the queue according to the given enqueue option.
+
+        :param queue_id: The queue to load the items into.
+        :param queue_items: The items to load.
+        :param option: The enqueue option to apply.
+        :param radio_mode: Whether the items come from radio mode.
+        :param pin_first: The first item was explicitly picked by the user (a start_item), so it
+            must keep its position when the batch is shuffled instead of being moved at random.
+        """
         queue = self._queues[queue_id]
         if queue.state in (PlaybackState.PLAYING, PlaybackState.PAUSED):
             cur_index = (
@@ -1519,16 +1531,28 @@ class PlayerQueuesController(CoreController):
         insert_at_index = cur_index + 1
         # Radio modes are already shuffled in a pattern we would like to keep.
         shuffle = queue.shuffle_enabled and len(queue_items) > 1 and not radio_mode
+        # a user-picked start item must be the one that actually starts playing, so keep it in
+        # front of the shuffled rest instead of letting the shuffle move it to a random slot
+        pin_first = pin_first and shuffle
 
         # handle replace: clear all items and replace with the new items
         if option == QueueOption.REPLACE:
-            await self.load(
-                queue_id,
-                queue_items=queue_items,
-                keep_remaining=False,
-                keep_played=False,
-                shuffle=shuffle,
-            )
+            if pin_first:
+                await self._load_pinned_first(
+                    queue_id,
+                    queue_items,
+                    insert_at_index=0,
+                    keep_remaining=False,
+                    keep_played=False,
+                )
+            else:
+                await self.load(
+                    queue_id,
+                    queue_items=queue_items,
+                    keep_remaining=False,
+                    keep_played=False,
+                    shuffle=shuffle,
+                )
             await self.play_index(queue_id, 0)
             return
         # handle next: add item(s) in the index next to the playing/loaded/buffered index
@@ -1554,12 +1578,15 @@ class PlayerQueuesController(CoreController):
             # an idle/empty queue has no current item to insert after, so insert at and
             # start from the very first index instead of skipping past it
             play_at_index = 0 if queue.current_index is None else insert_at_index
-            await self.load(
-                queue_id,
-                queue_items=queue_items,
-                insert_at_index=play_at_index,
-                shuffle=shuffle,
-            )
+            if pin_first:
+                await self._load_pinned_first(queue_id, queue_items, play_at_index)
+            else:
+                await self.load(
+                    queue_id,
+                    queue_items=queue_items,
+                    insert_at_index=play_at_index,
+                    shuffle=shuffle,
+                )
             next_index = min(play_at_index, len(self._queue_items[queue_id]) - 1)
             await self.play_index(queue_id, next_index)
             return
@@ -1580,6 +1607,37 @@ class PlayerQueuesController(CoreController):
                 queue.current_item = self.get_item(queue_id, 0)
                 queue.items = len(queue_items)
                 self.signal_update(queue_id)
+
+    async def _load_pinned_first(
+        self,
+        queue_id: str,
+        queue_items: list[QueueItem],
+        insert_at_index: int,
+        keep_remaining: bool = True,
+        keep_played: bool = True,
+    ) -> None:
+        """
+        Insert the first item at the given index and shuffle the rest of the batch behind it.
+
+        :param queue_id: The queue to load the items into.
+        :param queue_items: The items to load; the first one keeps the given index.
+        :param insert_at_index: The index to place the first item at.
+        :param keep_remaining: Keep the queue's existing items from the insert index onwards.
+        :param keep_played: Keep the queue's existing items before the insert index.
+        """
+        await self.load(
+            queue_id,
+            queue_items=queue_items[:1],
+            insert_at_index=insert_at_index,
+            keep_remaining=keep_remaining,
+            keep_played=keep_played,
+        )
+        await self.load(
+            queue_id,
+            queue_items=queue_items[1:],
+            insert_at_index=insert_at_index + 1,
+            shuffle=True,
+        )
 
     @handle_play_action
     async def _handle_play(self, queue_id: str) -> None:

--- a/tests/core/test_player_queues_enqueue_options.py
+++ b/tests/core/test_player_queues_enqueue_options.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
+import pytest
 from music_assistant_models.enums import PlaybackState, QueueOption
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
 
+from music_assistant.controllers import player_queues
 from music_assistant.controllers.player_queues import PlayerQueuesController
 
 
@@ -75,3 +77,83 @@ async def test_play_on_active_queue_inserts_after_current() -> None:
     # inserted right after the current/buffered index (2) and playback jumps there
     assert ctrl._queue_items["q1"][3] is new_items[0]
     play_index.assert_awaited_once_with("q1", 3)
+
+
+def _reversing_shuffle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the smart shuffle deterministic: reverse the batch instead of randomising it."""
+
+    async def _reverse(items: list[QueueItem]) -> list[QueueItem]:
+        return list(items)[::-1]
+
+    monkeypatch.setattr(player_queues, "_smart_shuffle", _reverse)
+
+
+def _shuffled_queue(ctrl: PlayerQueuesController) -> None:
+    """Point the controller at an idle, empty queue with shuffle enabled."""
+    queue = PlayerQueue(
+        queue_id="q1",
+        active=True,
+        display_name="Q1",
+        available=True,
+        items=0,
+        shuffle_enabled=True,
+    )
+    ctrl._queues = {"q1": queue}
+    ctrl._queue_items = {"q1": []}
+
+
+async def test_play_with_start_item_pins_chosen_track_under_shuffle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PLAY from a chosen track keeps that track first when shuffle is on."""
+    ctrl = _controller()
+    play_index = AsyncMock()
+    ctrl.play_index = play_index  # type: ignore[method-assign]
+    _reversing_shuffle(monkeypatch)
+    _shuffled_queue(ctrl)
+    items = _items("q1", ["chosen", "b", "c", "d"])
+
+    await ctrl._enqueue_with_option("q1", items, QueueOption.PLAY, radio_mode=False, pin_first=True)
+
+    # the track the user picked starts playing; the rest is shuffled behind it
+    assert ctrl._queue_items["q1"][0] is items[0]
+    assert {item.queue_item_id for item in ctrl._queue_items["q1"][1:]} == {"b", "c", "d"}
+    play_index.assert_awaited_once_with("q1", 0)
+
+
+async def test_replace_with_start_item_pins_chosen_track_under_shuffle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REPLACE from a chosen track keeps that track first when shuffle is on."""
+    ctrl = _controller()
+    play_index = AsyncMock()
+    ctrl.play_index = play_index  # type: ignore[method-assign]
+    _reversing_shuffle(monkeypatch)
+    _shuffled_queue(ctrl)
+    items = _items("q1", ["chosen", "b", "c", "d"])
+
+    await ctrl._enqueue_with_option(
+        "q1", items, QueueOption.REPLACE, radio_mode=False, pin_first=True
+    )
+
+    assert ctrl._queue_items["q1"][0] is items[0]
+    assert {item.queue_item_id for item in ctrl._queue_items["q1"][1:]} == {"b", "c", "d"}
+    play_index.assert_awaited_once_with("q1", 0)
+
+
+async def test_play_without_start_item_shuffles_the_whole_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PLAY of a whole playlist under shuffle still randomises which track starts."""
+    ctrl = _controller()
+    play_index = AsyncMock()
+    ctrl.play_index = play_index  # type: ignore[method-assign]
+    _reversing_shuffle(monkeypatch)
+    _shuffled_queue(ctrl)
+    items = _items("q1", ["a", "b", "c", "d"])
+
+    await ctrl._enqueue_with_option("q1", items, QueueOption.PLAY, radio_mode=False)
+
+    # nothing is pinned: the deterministic reversal moves the last item to the front
+    assert ctrl._queue_items["q1"][0] is items[-1]
+    play_index.assert_awaited_once_with("q1", 0)


### PR DESCRIPTION
# What does this implement/fix?

Manual backport of #5092 to `stable` (the automatic backport does not apply, `stable` still has the single-module player queues controller).

With shuffle turned on, pressing play on a track inside a playlist or album started a random other track instead of the one you picked, because the selected track got thrown into the shuffle along with everything else. The track you pick now always starts playing, and the shuffle applies to the rest of the queue behind it.

- Keep the selected track in place when the queue gets shuffled, for play and replace
- Tests for the new behaviour

Kept deliberately small for a patch release: this only fixes which track starts playing. The other half of #5092, keeping the tracks *before* the selected one instead of dropping them, is a behaviour change and stays on `dev`.

**Related issue (if applicable):**

- backport of #5092

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
