### PR TITLE
Align PR review instructions with current context engineering guidance

### DIFF
--- a/.claude/skills/review-pr/REVIEW_STANDARDS.md
+++ b/.claude/skills/review-pr/REVIEW_STANDARDS.md
@@ -1,72 +1,39 @@
 # PR Review Standards
 
-## Review Philosophy
-- Only comment when confident an issue exists
-- Be concise: one sentence per comment when possible
-- Focus on actionable feedback, not observations
-- When reviewing text, only comment on clarity issues if the text is genuinely confusing or could lead to errors
+## Philosophy
 
-## What to Analyze
+Comment only where you're confident there's a real issue. Actionable feedback, not observations. One sentence where one sentence does the job. On documentation or user-facing text, flag wording only when it's genuinely confusing or could mislead someone into an error.
 
-Review all code changes for:
-- Code quality and style consistency with the existing codebase
-- Potential bugs or issues
-- Performance implications
-- Blocking IO in async code
-- Security concerns
-- Test coverage
-- Documentation updates if needed
+## What to review
 
-## New Provider Reviews
+Correctness and bugs, blocking IO in async code, security, performance, test coverage, docs the change makes wrong, and consistency with the surrounding code. `CLAUDE.md` holds the project standards — deviations from it are at least `[PROBLEM]`.
 
-When the PR adds a new provider (new files under `music_assistant/providers/`), use the relevant demo provider as ground truth:
+## Linked issues
 
-| Provider type | Demo reference |
-|---|---|
-| Music source | `_demo_music_provider` |
-| Player | `_demo_player_provider` |
-| Plugin | `_demo_plugin_provider` |
-| Audio analysis | `_demo_audio_analysis_provider` |
+If the PR references an issue, read it (`gh issue view`) before reviewing the diff. Then judge two things: whether the change actually resolves the reported problem, and whether it does so in the most elegant way available. A fix that works but patches a symptom, sits at the wrong layer, or adds a special case where the existing design already had a seam for it is a `[PROBLEM]` — say which approach would be cleaner and why. A change that leaves part of the issue unaddressed, or addresses something else entirely, is `[CRITICAL]`.
 
-- Flag any deviations from the requirements and patterns outlined in the demo provider as `[PROBLEM]` or `[CRITICAL]` depending on severity.
-- Provider icons (e.g. icon.svg) are allowed to be 5KB max. If larger, flag as a critical.
+## Reuse over reimplementation
 
-## Project standards
-Respect the project standards as outlined in CLAUDE.md. Any deviations must be raised as `[PROBLEM]`.
+Check whether `music_assistant/helpers/` already covers what new code does; providers are expected to use the shared helpers rather than reimplement. A music provider parsing PLS itself instead of calling `parse_pls` from `music_assistant.helpers.playlists` is a `[PROBLEM]`.
 
-## Helper Function Reuse
+## New providers
 
-Check if existing helper functions in `music_assistant/helpers/` cover what new code is doing. Providers should use shared helpers instead of reimplementing logic. Example: if a music provider does PLS parsing, it should use `parse_pls` from `music_assistant.helpers.playlists` instead of writing its own.
+If the PR adds files under `music_assistant/providers/`, read `references/new-provider.md`.
 
-## PR Title
+## Don't duplicate CI
 
-The PR title must be a functional description of the change. It must NOT contain conventional commit prefixes such as `feat:`, `fix:`, `refactor:`, `chore:`, etc. Labels categorize PRs, not the title. Flag as `[PROBLEM]` if the title uses such prefixes.
+Reviews happen before CI finishes, which makes it tempting to flag what CI will catch on its own — formatting, lint, test failures, missing dependencies. Those comments cost the author a round trip and tell them nothing they won't hear from CI a minute later; `.pre-commit-config.yaml` and `.github/workflows/test.yml` are the authority on that class of problem. Spend the review on what CI can't see.
 
-## Existing Review Comments
+## PR title
 
-Check if existing review comments on the PR have been addressed. Flag unaddressed comments.
+A functional description of the change, with no conventional-commit prefix (`feat:`, `fix:`, `refactor:`, `chore:`, ...) — labels do the categorizing. A prefixed title is a `[PROBLEM]`.
 
-## CI Context
+## Existing review comments
 
-You review PRs immediately, before CI completes. Do not flag issues that CI will catch.
+Flag earlier review comments on the PR that haven't been addressed.
 
-### What CI Checks (`.github/workflows/test.yml`)
-**Lint:** `SKIP=no-commit-to-branch pre-commit run --all-files` (see `.pre-commit-config.yaml` for full list)
-**Tests:** `pytest --durations 10 --cov-report term-missing --cov=music_assistant --cov-report=xml tests/`
+## Severity
 
-## Skip These (Low Value)
-
-Do not comment on:
-- Style/formatting (pre-commit handles this)
-- Test failures (CI catches this)
-- Missing dependencies (CI catches this)
-- Minor naming suggestions
-- Suggestions to add comments
-- Logging suggestions unless security-related
-
-## Issue Categories
-
-Categorize every issue as:
-- `[CRITICAL]` — must fix before merging (bugs, security issues, broken functionality)
-- `[PROBLEM]` — should fix (code quality, bad patterns, missing tests)
-- `[SUGGESTION]` — optional improvement (style, minor refactors, nice-to-haves)
+- `[CRITICAL]` — must fix before merge: bugs, security issues, broken functionality
+- `[PROBLEM]` — should fix: bad patterns, missing tests, standards deviations
+- `[SUGGESTION]` — optional: minor refactors, nice-to-haves

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -7,42 +7,24 @@ description: Use when asked to review a GitHub pull request, PR link is shared, 
 
 Review the GitHub pull request: $ARGUMENTS.
 
+This is a read-only review. Report findings in the console — never post comments, approve, or request changes on GitHub, and never modify the code under review.
+
 ## Steps
 
-1. Run `gh pr view` to get PR details and description.
-2. Run `gh pr diff` to see all changes.
-3. Compare the local commit hash with the remote PR head commit.
-   - Make sure to do your work in a git worktree to avoid affecting the checked out branch of the reviewer.
-   - If they don't match, run `gh pr checkout` to check out the PR locally.
-   - **HARD STOP**: If `gh pr checkout` fails for ANY reason, STOP immediately. Do NOT attempt workarounds (git fetch, alternative methods). Do NOT proceed with the review using only diffs. Alert about the failure and wait for instructions.
-   - After checkout, verify the local commit hash matches the remote one. If they still don't match, STOP.
-4. Run `gh pr checks` to see CI status.
-5. Apply the review standards defined in `REVIEW_STANDARDS.md` (located in the same directory as this skill).
-6. Output review feedback to the CONSOLE only. DO NOT act on GitHub (no posting comments, no approving, no requesting changes).
+1. `gh pr view` for the PR details and description.
+2. Create a git worktree and do everything below inside it, so the reviewer's checked-out branch stays untouched (`git worktree add --detach <path>`).
+3. `gh pr checkout` in the worktree, then confirm the local commit hash matches the remote PR head.
+   - **HARD STOP**: if the checkout fails, or the hashes still differ afterwards, stop and report it. No workarounds — not `git fetch`, not reviewing from the diff alone. Wait for instructions.
+4. `gh pr checks` for CI status.
+5. `gh pr diff` for the changes, then read the surrounding code for anything the diff alone can't settle.
+6. Apply `REVIEW_STANDARDS.md`, in the same directory as this skill.
+
+Running tests or linters isn't part of this — CI does that.
 
 ## Output Format
 
-List specific comments per file/line that need attention. Do not list things that are already correct.
+Comments per file and line that need attention. Skip what's already fine.
 
-Each comment:
-1. State the severity ([CRITICAL], [PROBLEM], [SUGGESTION])
-2. State the problem (1 sentence)
-3. Why it matters (1 sentence, if needed)
-4. Suggested fix (snippet or specific action)
+Each comment carries a severity (`[CRITICAL]`, `[PROBLEM]`, `[SUGGESTION]`), states the problem in a sentence, says why it matters when that isn't self-evident, and gives a concrete fix or snippet.
 
-Example:
-> This could generate a `KeyError` if `"name"` does not exist in the `dict`. Consider using `.get("name")` or adding a check.
-
-End with an overall assessment and summary:
-
-```
-Overall assessment: <approve | request changes | comment>
-- [CRITICAL] <issue>
-- [PROBLEM] <issue>
-- [SUGGESTION] <improvement>
-```
-
-## Constraints
-
-- DO NOT make any changes to the code.
-- No need to run tests or linters, just review the code changes.
+Close with an overall assessment — `approve`, `request changes`, or `comment` — followed by the findings grouped by severity.

--- a/.claude/skills/review-pr/references/new-provider.md
+++ b/.claude/skills/review-pr/references/new-provider.md
@@ -1,0 +1,14 @@
+# Reviewing a new provider
+
+The matching demo provider is the ground truth — it's the annotated template that encodes the required structure, lifecycle and config schema:
+
+| Provider type | Reference |
+|---|---|
+| Music source | `music_assistant/providers/_demo_music_provider` |
+| Player | `music_assistant/providers/_demo_player_provider` |
+| Plugin | `music_assistant/providers/_demo_plugin_provider` |
+| Audio analysis | `music_assistant/providers/_demo_audio_analysis_provider` |
+
+Read the demo provider alongside the new one, then flag deviations from its requirements and patterns as `[PROBLEM]` or `[CRITICAL]` depending on what breaks.
+
+Provider icons (`icon.svg`) are capped at 5KB — anything larger is `[CRITICAL]`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,89 +1,54 @@
 # PR Review Standards
 
-## Review Philosophy
-- Only comment when confident an issue exists
-- Be concise: one sentence per comment when possible
-- Focus on actionable feedback, not observations
-- When reviewing text, only comment on clarity issues if the text is genuinely confusing or could lead to errors
-- If you're uncertain whether something is an issue, don't comment
+## Philosophy
 
-## What to Analyze
+Comment only where you're confident there's a real issue — if you're uncertain whether something is a problem, don't raise it. Actionable feedback, not observations. One sentence where one sentence does the job. On documentation or user-facing text, flag wording only when it's genuinely confusing or could mislead someone into an error.
 
-Review all code changes for:
-- Code quality and style consistency with the existing codebase
-- Potential bugs or issues
-- Performance implications
-- Blocking IO in async code
-- Security concerns
-- Test coverage
-- Documentation updates if needed
+## What to review
 
-## New Provider Reviews
+Correctness and bugs, blocking IO in async code, security, performance, test coverage, docs the change makes wrong, and consistency with the surrounding code. `AGENTS.md` holds the project standards — deviations from it are at least `[PROBLEM]`.
 
-When the PR adds a new provider (new files under `music_assistant/providers/`), use the relevant demo provider as ground truth:
+## Linked issues
 
-| Provider type | Demo reference |
+If the PR references an issue, read it before reviewing the diff. Then judge two things: whether the change actually resolves the reported problem, and whether it does so in the most elegant way available. A fix that works but patches a symptom, sits at the wrong layer, or adds a special case where the existing design already had a seam for it is a `[PROBLEM]` — say which approach would be cleaner and why. A change that leaves part of the issue unaddressed, or addresses something else entirely, is `[CRITICAL]`.
+
+## Reuse over reimplementation
+
+Check whether `music_assistant/helpers/` already covers what new code does; providers are expected to use the shared helpers rather than reimplement. A music provider parsing PLS itself instead of calling `parse_pls` from `music_assistant.helpers.playlists` is a `[PROBLEM]`.
+
+## New providers
+
+When the PR adds files under `music_assistant/providers/`, the matching demo provider is the ground truth — it's the annotated template that encodes the required structure, lifecycle and config schema:
+
+| Provider type | Reference |
 |---|---|
-| Music source | `_demo_music_provider` |
-| Player | `_demo_player_provider` |
-| Plugin | `_demo_plugin_provider` |
-| Audio analysis | `_demo_audio_analysis_provider` |
+| Music source | `music_assistant/providers/_demo_music_provider` |
+| Player | `music_assistant/providers/_demo_player_provider` |
+| Plugin | `music_assistant/providers/_demo_plugin_provider` |
+| Audio analysis | `music_assistant/providers/_demo_audio_analysis_provider` |
 
-- Flag any deviations from the requirements and patterns outlined in the demo provider as `[PROBLEM]` or `[CRITICAL]` depending on severity.
-- Provider icons (e.g. icon.svg) are allowed to be 5KB max. If larger, flag as a critical.
+Read the demo provider alongside the new one, then flag deviations from its requirements and patterns as `[PROBLEM]` or `[CRITICAL]` depending on what breaks. Provider icons (`icon.svg`) are capped at 5KB — anything larger is `[CRITICAL]`.
 
-## Project standards
-Respect the project standards as outlined in AGENTS.md. Any deviations must be raised as `[PROBLEM]`.
+## Don't duplicate CI
 
-## Helper Function Reuse
+Reviews happen before CI finishes, which makes it tempting to flag what CI will catch on its own — formatting, lint, test failures, missing dependencies. Those comments cost the author a round trip and tell them nothing they won't hear from CI a minute later; `.pre-commit-config.yaml` and `.github/workflows/test.yml` are the authority on that class of problem. Spend the review on what CI can't see.
 
-Check if existing helper functions in `music_assistant/helpers/` cover what new code is doing. Providers should use shared helpers instead of reimplementing logic. Example: if a music provider does PLS parsing, it should use `parse_pls` from `music_assistant.helpers.playlists` instead of writing its own.
+## PR title
 
-## PR Title
+A functional description of the change, with no conventional-commit prefix (`feat:`, `fix:`, `refactor:`, `chore:`, ...) — labels do the categorizing. A prefixed title is a `[PROBLEM]`.
 
-The PR title must be a functional description of the change. It must NOT contain conventional commit prefixes such as `feat:`, `fix:`, `refactor:`, `chore:`, etc. Labels categorize PRs, not the title. Flag as `[PROBLEM]` if the title uses such prefixes.
+## Existing review comments
 
-## Existing Review Comments
+Flag earlier review comments on the PR that haven't been addressed.
 
-Check if existing review comments on the PR have been addressed. Flag unaddressed comments.
+## Severity
 
-## CI Context
-
-You review PRs immediately, before CI completes. Do not flag issues that CI will catch.
-
-### What CI Checks (`.github/workflows/test.yml`)
-**Lint:** `SKIP=no-commit-to-branch pre-commit run --all-files` (see `.pre-commit-config.yaml` for full list)
-**Tests:** `pytest --durations 10 --cov-report term-missing --cov=music_assistant --cov-report=xml tests/`
-
-## Skip These (Low Value)
-
-Do not comment on:
-- Style/formatting (pre-commit handles this)
-- Test failures (CI catches this)
-- Missing dependencies (CI catches this)
-- Minor naming suggestions
-- Suggestions to add comments
-- Logging suggestions unless security-related
-
-## Issue Categories
-
-Categorize every issue as:
-- `[CRITICAL]` — must fix before merging (bugs, security issues, broken functionality)
-- `[PROBLEM]` — should fix (code quality, bad patterns, missing tests)
-- `[SUGGESTION]` — optional improvement (style, minor refactors, nice-to-haves)
+- `[CRITICAL]` — must fix before merge: bugs, security issues, broken functionality
+- `[PROBLEM]` — should fix: bad patterns, missing tests, standards deviations
+- `[SUGGESTION]` — optional: minor refactors, nice-to-haves
 
 ## Output
 
-- Post inline comments on GitHub for every `[CRITICAL]` and `[PROBLEM]` issue found.
-- Do NOT post `[SUGGESTION]` items to GitHub.
-- Do not list things that are already correct.
+Post an inline comment on GitHub for every `[CRITICAL]` and `[PROBLEM]`. Do not post `[SUGGESTION]` items, and don't comment on what's already fine.
 
-## Output Comment Format
-
-1. State the severity ([CRITICAL], [PROBLEM], [SUGGESTION])
-2. State the problem (1 sentence)
-3. Why it matters (1 sentence, if needed)
-4. Suggested fix (snippet or specific action)
-
-Example:
-This could generate a `KeyError` if `"name"` does not exist in the `dict`. Consider using `.get("name")` or adding a check.
+Each comment carries its severity, states the problem in a sentence, says why it matters when that isn't self-evident, and gives a concrete fix or snippet.


### PR DESCRIPTION
# What does this implement/fix?

Our PR review instructions — the `review-pr` skill and the Copilot review instructions — were written for older models and had drifted apart. Both leaned on prohibition lists and restated things the repo already defines, which suppresses judgement on findings that happen to be shaped like a forbidden category, and goes stale. Anthropic's context engineering guidance for the Claude 5 generation recommends the opposite: fewer hard rules, progressive disclosure, and pointing at real artifacts rather than paraphrasing them.

Both files are now rewritten from the same wording so they stop diverging, while keeping the differences that matter (Copilot posts inline comments, the skill is read-only and has the worktree/checkout guardrails).

- Replaced the "Skip These (Low Value)" list with one paragraph explaining *why* duplicating CI is noise, instead of banning categories like naming or logging outright
- Point at `.pre-commit-config.yaml` and `.github/workflows/test.yml` rather than inlining their commands, which had already gone stale
- Added a linked-issue check: verify the PR actually resolves the referenced issue, and does so in the most elegant way rather than patching a symptom or landing at the wrong layer
- Moved the new-provider rules into `references/new-provider.md`, which the skill loads only when the diff touches `music_assistant/providers/`
- Fixed the step order in the skill so the worktree is created *before* `gh pr checkout`, which is the point of having one
- Dropped the worked example output, which anchored reviewers toward the findings it happened to illustrate

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

<!-- No runtime code is touched: these are agent instruction files, so the test/pre-commit items below don't apply. -->

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
