### PR TITLE
Fix AirPlay players joining a playing group out of sync

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -318,7 +318,11 @@ class AirPlayPlayer(Player):
             return
         async with self._lock:
             if self.stream and self.stream.running:
-                await self.stream.send_cli_command("ACTION=PLAY")
+                if await self.stream.send_cli_command("ACTION=PLAY"):
+                    # Resuming re-anchors playout; the binary zeroes its own
+                    # re-anchor total on resume, so drop the tracked shift to
+                    # keep the server and binary baselines aligned.
+                    self.stream.reset_reanchor_shift()
 
     async def pause(self) -> None:
         """Send PAUSE command to player."""

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import logging
+import re
 import time
 from contextlib import suppress
 from typing import TYPE_CHECKING, cast
@@ -109,6 +110,16 @@ class AirPlayStream:
         # Route the binary resolved for this stream (empty until reported),
         # e.g. "AirPlay 2 (native, PTP)" or "RAOP"
         self.active_route: str = ""
+        # Cumulative playout shift (seconds) this process reported after PCM
+        # starvation re-anchors (AP2 only). The stream session adds the
+        # reference member's shift so a late joiner anchors to the group's real
+        # timeline. Reset per process (and on every re-anchoring START/resume);
+        # a new cliairplay re-anchors from scratch.
+        self.cumulative_shift_seconds: float = 0.0
+        # Set once the machine-readable [STATUS] REANCHOR line is seen: newer
+        # binaries emit it alongside the legacy warn for the same event, so the
+        # warn line is then ignored to avoid double counting.
+        self._reanchor_status_seen: bool = False
 
     @property
     def running(self) -> bool:
@@ -142,6 +153,9 @@ class AirPlayStream:
             NTP timing. None (single-stream callers) falls back to the daemon's
             live state.
         """
+        # A fresh cliairplay process re-anchors from scratch, so drop any shift
+        # (and its status-line supersession flag) carried on this stream object.
+        self.reset_reanchor_shift()
         args = await self._build_cli_args(use_shared_ptp)
         self.player.logger.debug("Starting cliairplay for player %s", self.player.player_id)
         self._cli_proc = AsyncProcess(args, stdin=True, stdout=True, stderr=True, name="cliairplay")
@@ -312,6 +326,11 @@ class AirPlayStream:
         """
         if not self.running or not self.connected:
             raise RuntimeError("Cannot start playback without a connected cliairplay process")
+        # A START re-anchors playout from scratch — the binary zeroes its own
+        # re-anchor total on start/resume — so drop any shift accumulated against
+        # the previous anchor (this also covers the warm-seek FLUSH->refill->START
+        # path) to keep the server and binary baselines aligned.
+        self.reset_reanchor_shift()
         self._start_position = position_ms / 1000
         # Stamp the player's elapsed onto the new anchor's base right away: until
         # the binary's first status arrives, interpolation would otherwise keep
@@ -334,6 +353,11 @@ class AirPlayStream:
             task_id=f"airplay_metadata_after_start_{self._stream_id}",
             abort_existing=True,
         )
+
+    def reset_reanchor_shift(self) -> None:
+        """Clear the accumulated re-anchor shift and its status-line supersession flag."""
+        self.cumulative_shift_seconds = 0.0
+        self._reanchor_status_seen = False
 
     async def send_metadata(
         self,
@@ -780,6 +804,10 @@ class AirPlayStream:
         elif "[STATUS] eof" in line:
             player.logger.debug("End of stream reached")
             return True
+        elif "[STATUS] REANCHOR" in line:
+            self._parse_reanchor_status(line)
+        elif "Re-anchored" in line and "shifted_frames=" in line:
+            self._parse_reanchor_shift(line)
         elif "[ERROR]" in line:
             player.logger.error("cliairplay: %s", line.strip())
         return False
@@ -793,6 +821,69 @@ class AirPlayStream:
         self.player.set_state_from_stream(
             state=PlaybackState.PLAYING, elapsed_time=elapsed_time, stream=self
         )
+
+    def _parse_reanchor_status(self, line: str) -> None:
+        """
+        Parse the machine-readable [STATUS] REANCHOR line from newer binaries.
+
+        Newer cliairplay builds report the shift cumulative since the last
+        start/resume directly, so this SETS the tracked shift (using the sample
+        rate carried on the line when present) and marks the legacy warn line as
+        superseded, since both fire for the same event and would otherwise be
+        double counted.
+
+        :param line: The status line, e.g. ``[STATUS] REANCHOR shifted_frames=67870
+            total_shifted_frames=135740 sample_rate=44100``.
+        """
+        fields = dict(part.split("=", 1) for part in line.split() if "=" in part)
+        try:
+            total_frames = int(fields["total_shifted_frames"])
+        except KeyError, ValueError:
+            return
+        self._reanchor_status_seen = True
+        self.cumulative_shift_seconds = total_frames / self._reanchor_sample_rate(
+            fields.get("sample_rate")
+        )
+        self.player.logger.debug(
+            "cliairplay re-anchored %s after PCM starvation: cumulative shift %.3fs",
+            self.player.display_name,
+            self.cumulative_shift_seconds,
+        )
+
+    def _parse_reanchor_shift(self, line: str) -> None:
+        """
+        Track a legacy cliairplay PCM-starvation re-anchor warning on stderr.
+
+        The warn line reports the per-event shift in frames, so it is accumulated
+        at the session PCM rate. Ignored once the machine-readable [STATUS]
+        REANCHOR line has been seen: newer binaries emit both for the same event
+        and the status line carries the authoritative cumulative total.
+
+        :param line: The raw stderr line, e.g. ``[AP2] Re-anchored after PCM
+            starvation: shifted_frames=67870 lead_frames=77175 count=1``.
+        """
+        if self._reanchor_status_seen:
+            return
+        match = re.search(r"shifted_frames=(\d+)", line)
+        if not match:
+            return
+        self.cumulative_shift_seconds += int(match.group(1)) / self._reanchor_sample_rate(None)
+        self.player.logger.debug(
+            "cliairplay re-anchored %s after PCM starvation: cumulative shift %.3fs",
+            self.player.display_name,
+            self.cumulative_shift_seconds,
+        )
+
+    def _reanchor_sample_rate(self, reported: str | None) -> int:
+        """Return the frame->seconds rate, preferring a valid rate reported on the line."""
+        if reported is not None:
+            try:
+                rate = int(reported)
+            except ValueError:
+                rate = 0
+            if rate > 0:
+                return rate
+        return self.pcm_format.sample_rate or 44100
 
     async def _prepare_artwork(self, image_url: str, _generation: int) -> str | None:
         """

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -79,6 +79,31 @@ class AirPlayStreamSession:
         # with enough slack left to prime the joiner.
         self._pcm_buffer = bytearray()
         self._pcm_buffer_max = pcm_format.pcm_sample_size * 10  # 10 seconds
+        # Bytes still to skip off the head of the live feed for a late joiner
+        # whose anchor lands ahead of the current write head, keyed by player id.
+        self._client_skip_bytes: dict[str, int] = {}
+
+    @property
+    def effective_start_time(self) -> float:
+        """
+        Return the session anchor adjusted for the reference member's clock shift.
+
+        ``start_time`` is the wall-clock anchor set at the last group (re)start.
+        A member's cliairplay can re-anchor its playout LATER after recovering
+        from a PCM starvation, shifting the group's real timeline; that shift is
+        tracked per member. The first sync client is taken as the reference and
+        its accumulated shift is added, so a late joiner maps its first sample to
+        where the group actually plays. Divergent per-member shifts make any
+        single reference imperfect; the current first client is the best
+        available choice and the reference transfers to the new first client when
+        the old one is removed.
+        """
+        if not self.sync_clients:
+            return self.start_time
+        reference_stream = self.sync_clients[0].stream
+        if reference_stream is None:
+            return self.start_time
+        return self.start_time + reference_stream.cumulative_shift_seconds
 
     async def start(self, audio_source: AsyncGenerator[bytes]) -> None:
         """
@@ -177,6 +202,11 @@ class AirPlayStreamSession:
             # describe the OLD timeline; restart them before the new source pumps.
             self.seconds_streamed = 0
             self._pcm_buffer.clear()
+            # The shared START below re-establishes start_time, so the per-client
+            # late-join skip counters and every member's accumulated starvation
+            # shift describe a timeline that no longer exists: reset them.
+            self._client_skip_bytes.clear()
+            self._reset_member_shifts()
             self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
             # Anchor only after every member confirms the new audio flowing;
             # the live connection and clock survive the flush, so a short
@@ -233,6 +263,8 @@ class AirPlayStreamSession:
         # a parked session has no live timeline; the resume re-anchors it
         self.seconds_streamed = 0
         self._pcm_buffer.clear()
+        self._client_skip_bytes.clear()
+        self._reset_member_shifts()
         return True
 
     async def stop(self) -> None:
@@ -275,40 +307,35 @@ class AirPlayStreamSession:
             airplay_player.player_id,
             reason,
         )
+        self._client_skip_bytes.pop(airplay_player.player_id, None)
         ffmpeg = self._player_ffmpeg.pop(airplay_player.player_id, None)
         # note that we use kill instead of graceful close here,
         # because otherwise it can take a very long time for the process to exit.
         if ffmpeg and not ffmpeg.closed:
             await ffmpeg.kill()
         if airplay_player.stream and airplay_player.stream.session == self:
+            airplay_player.stream.reset_reanchor_shift()
             await airplay_player.stream.stop(force=True)
 
     async def add_client(self, airplay_player: AirPlayPlayer) -> None:  # noqa: PLR0915
         """
         Add a sync client to the session as a late joiner.
 
-        Uses the PCM ring buffer to prime the late joiner's pipeline so it
-        starts playing quickly. Timing-source readiness is resolved before the
-        session lock; buffer calculations and writes stay under the lock so
-        ``seconds_streamed`` and the buffer remain consistent.
+        The joiner cannot honour an anchor in the past — cliairplay makes the
+        first post-START stdin byte audible exactly at the commanded instant and
+        then freezes the anchor, with no catch-up. So the anchor is chosen a
+        fixed headroom into the future and the stream position due at that
+        instant is derived from the group's effective (shift-adjusted) timeline.
+        Depending on where that position falls relative to the ring buffer the
+        joiner is either primed from the ring tail (position at or behind the
+        write head) or has the leading bytes of the live feed skipped (position
+        ahead of the write head), so its first audible sample lands exactly where
+        the group is playing.
 
-        Devices generally cannot honour a start anchor that is in the
-        past — they just play whatever the pipe gives them, trailing the
-        group by the deficit. To stay in sync we therefore push the late
-        joiner's ``start_at`` into the future (at least ``wait_start`` ahead
-        of now) and trim the corresponding amount from the head of the
-        buffered PCM, so the first sample we send maps to the correct future
-        stream position.
-
-        1. Connect the new client without anchoring playback.
-        2. Snapshot the ring buffer and map its first byte to its stream
-           position; if the
-           resulting start anchor is in the past, shift it forward to
-           ``now + min_headroom`` and trim that many seconds from the buffer
-           head so timing stays aligned with the rest of the group.
-        3. Anchor the joiner with a single START at the computed group-aligned
-           time, then feed the (possibly trimmed) buffer into its stdin and add
-           the client so the live stream continues priming it.
+        Timing-source readiness is resolved before the session lock; all buffer
+        and anchor math stays under the lock so ``seconds_streamed``, the ring
+        buffer and the per-client skip counter stay consistent with the live
+        feed.
         """
         await self._resolve_late_joiner_ptp(airplay_player)
         async with self._lock:
@@ -345,72 +372,77 @@ class AirPlayStreamSession:
             now = time.time()
             pcm_sample_size = self.pcm_format.pcm_sample_size
             frame_size = (self.pcm_format.bit_depth // 8) * self.pcm_format.channels
-            # Snapshot the buffer and calculate its duration
+            # Snapshot the ring buffer and map its span onto stream positions:
+            # it covers [seconds_streamed - buffer_seconds, seconds_streamed].
             buffered_pcm = bytes(self._pcm_buffer)
             buffer_seconds = len(buffered_pcm) / pcm_sample_size
-            # The first byte in the buffer corresponds to this stream position
-            first_byte_pos = self.seconds_streamed - buffer_seconds
-            first_sample_pos = first_byte_pos
-            start_at = self.start_time + first_byte_pos
+            ring_floor = self.seconds_streamed - buffer_seconds
 
-            # The audio we hand to ffmpeg → cliairplay must be bit-aligned with
-            # ``start_at``: the first sample sent should be the one that should
-            # play at ``start_at``. cliairplay buffers ``wait_start`` seconds of
-            # audio before starting playback, so we keep ``start_at`` at least
-            # that far in the future (using the larger of the session's
-            # existing wait_start, the late joiner's own and the late-join
-            # floor, which is more conservative than the plain session lead).
+            # cliairplay makes the first post-START stdin byte audible exactly at
+            # the anchor and then freezes it (no catch-up), so pick the anchor
+            # first — far enough ahead that the device can connect and prime —
+            # then derive which stream position the group plays at that instant.
+            # min_headroom is the most conservative of the session lead, the
+            # joiner's own lead and the late-join floor.
             min_headroom = max(
                 self.wait_start,
                 airplay_player.wait_start / 1000,
                 AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000,
             )
-            target_start_at = now + min_headroom
-            trim_seconds = 0.0
-            if start_at < target_start_at:
-                # Shift start_at forward so the device has time to prep, and
-                # trim the buffer head by the same amount so the first sample
-                # we send is the one that should play at the new start_at.
-                trim_seconds = target_start_at - start_at
-                trim_bytes = int(trim_seconds * pcm_sample_size)
-                trim_bytes -= trim_bytes % frame_size
-                if trim_bytes >= len(buffered_pcm):
-                    # Nothing left of the buffer after the trim. Drop it and
-                    # let the audio_streamer feed the late joiner from the
-                    # next chunk. Set start_at to the current live position;
-                    # the clamp below may still move it later to preserve
-                    # the required headroom.
-                    buffered_pcm = b""
-                    first_sample_pos = self.seconds_streamed
-                    start_at = self.start_time + self.seconds_streamed
-                else:
-                    buffered_pcm = buffered_pcm[trim_bytes:]
-                    # Advance start_at by exactly the trimmed duration so the
-                    # NTP anchor matches the first sample we actually send.
-                    trimmed_seconds = trim_bytes / pcm_sample_size
-                    first_sample_pos += trimmed_seconds
-                    start_at += trimmed_seconds
-                # Make sure start_at still leaves enough lead time for slow
-                # connections / very-far-behind joiners.
-                start_at = max(start_at, target_start_at)
+            start_at = now + min_headroom
+            effective_start_time = self.effective_start_time
+            fed_pos_due = start_at - effective_start_time
+
+            skip_bytes = 0
+            prime = b""
+            if fed_pos_due <= self.seconds_streamed:
+                # The due position is at or behind the write head: prime the
+                # joiner from the ring so the live feed then continues seamlessly.
+                if fed_pos_due < ring_floor:
+                    # The due position predates the ring (an unusually large
+                    # lead). Cap the prime at the whole buffer and grow the
+                    # headroom so the anchor still maps to the prime's first
+                    # sample exactly.
+                    self.prov.logger.debug(
+                        "Late joiner %s: due position %.2fs predates the %.2fs ring; "
+                        "capping prime at the whole buffer",
+                        airplay_player.player_id,
+                        fed_pos_due,
+                        buffer_seconds,
+                    )
+                    fed_pos_due = ring_floor
+                    start_at = effective_start_time + fed_pos_due
+                keep_bytes = int((self.seconds_streamed - fed_pos_due) * pcm_sample_size)
+                keep_bytes -= keep_bytes % frame_size
+                if keep_bytes:
+                    prime = buffered_pcm[len(buffered_pcm) - keep_bytes :]
+            else:
+                # The due position is ahead of the write head: skip that many
+                # bytes off the head of the live feed so the joiner's first
+                # delivered byte is the sample due at the anchor.
+                skip_bytes = int((fed_pos_due - self.seconds_streamed) * pcm_sample_size)
+                skip_bytes -= skip_bytes % frame_size
+
+            self._client_skip_bytes[airplay_player.player_id] = skip_bytes
 
             start_unix_ms = int(start_at * 1000)
             sync_adjust = airplay_player.config.get_value(CONF_SYNC_ADJUST, 0)
             if isinstance(sync_adjust, int):
                 start_unix_ms += sync_adjust
-            position_ms = int(((self.media.elapsed_time or 0) + first_sample_pos) * 1000)
+            position_ms = int(((self.media.elapsed_time or 0) + fed_pos_due) * 1000)
 
             self.prov.logger.debug(
-                "Late joiner %s: sending %.2fs of buffered audio, "
-                "stream_pos=%.2fs, first_byte_pos=%.2fs, "
-                "start_at is %.2fs from now (min_headroom=%.2fs, trimmed=%.2fs)",
+                "Late joiner %s: priming %.2fs, skipping %.2fs, stream_pos=%.2fs, "
+                "fed_pos_due=%.2fs, start_at is %.2fs from now "
+                "(min_headroom=%.2fs, effective_shift=%.2fs)",
                 airplay_player.player_id,
-                len(buffered_pcm) / pcm_sample_size,
+                len(prime) / pcm_sample_size,
+                skip_bytes / pcm_sample_size,
                 self.seconds_streamed,
-                first_byte_pos,
+                fed_pos_due,
                 start_at - now,
                 min_headroom,
-                trim_seconds,
+                effective_start_time - self.start_time,
             )
 
             try:
@@ -422,8 +454,8 @@ class AirPlayStreamSession:
                 # streams in. The START does not re-anchor the session
                 # timeline (the group keeps playing).
                 await stream.start(start_unix_ms, position_ms)
-                if buffered_pcm:
-                    await self._write_chunk_to_player(airplay_player, buffered_pcm)
+                if prime:
+                    await self._write_chunk_to_player(airplay_player, prime)
             except asyncio.CancelledError:
                 await self.stop_client(airplay_player, reason="late joiner start cancelled")
                 raise
@@ -631,6 +663,15 @@ class AirPlayStreamSession:
     async def _write_chunk_to_player(self, airplay_player: AirPlayPlayer, chunk: bytes) -> None:
         """Write audio chunk to a player's ffmpeg process."""
         player_id = airplay_player.player_id
+        # Drain any pending late-join skip first: a joiner anchored ahead of the
+        # write head must drop that many leading bytes of the live feed so its
+        # first delivered byte is the sample due at its anchor.
+        if skip := self._client_skip_bytes.get(player_id, 0):
+            if skip >= len(chunk):
+                self._client_skip_bytes[player_id] = skip - len(chunk)
+                return
+            chunk = chunk[skip:]
+            self._client_skip_bytes[player_id] = 0
         if ffmpeg := self._player_ffmpeg.get(player_id):
             if ffmpeg.closed:
                 return
@@ -711,6 +752,12 @@ class AirPlayStreamSession:
         if stream is None:
             return False
         return await stream.flush()
+
+    def _reset_member_shifts(self) -> None:
+        """Zero every member's accumulated starvation shift for a fresh anchor."""
+        for player in self.sync_clients:
+            if player.stream is not None:
+                player.stream.reset_reanchor_shift()
 
     async def _start_player_ffmpeg(self, player: AirPlayPlayer, media: PlayerMedia) -> None:
         """

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -751,10 +751,28 @@ async def test_single_player_play_sends_action_play(airplay_player: AirPlayPlaye
     """An unsynced player resumes its paused stream in place with ACTION=PLAY."""
     airplay_player._attr_group_members = []
     send_cmd = _setup_running_stream(airplay_player)
+    send_cmd.return_value = True
 
     await airplay_player.play()
 
     send_cmd.assert_awaited_once_with("ACTION=PLAY")
+    # resume re-anchors the binary, so the tracked re-anchor shift is reset to match
+    cast("MagicMock", airplay_player.stream).reset_reanchor_shift.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_single_player_play_keeps_shift_when_resume_not_delivered(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """An undelivered ACTION=PLAY leaves the tracked re-anchor shift untouched."""
+    airplay_player._attr_group_members = []
+    send_cmd = _setup_running_stream(airplay_player)
+    send_cmd.return_value = False
+
+    await airplay_player.play()
+
+    send_cmd.assert_awaited_once_with("ACTION=PLAY")
+    cast("MagicMock", airplay_player.stream).reset_reanchor_shift.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -471,6 +471,7 @@ async def test_raop_session_resolves_ptp_for_first_ap2_late_joiner() -> None:
     raop_player.player_id = "raop"
     raop_player.stream = MagicMock()
     raop_player.stream.running = True
+    raop_player.stream.cumulative_shift_seconds = 0.0
     ap2_player = _ap2_player()
     ap2_player.player_id = "airplay2"
     ap2_player.stream = None

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -887,6 +887,138 @@ def test_elapsed_includes_start_position() -> None:
     )
 
 
+def test_legacy_reanchor_warns_accumulate_per_event() -> None:
+    """The legacy warn line reports a per-event shift, so successive events accumulate."""
+    stream = AirPlayStream(_make_player())
+    assert stream.cumulative_shift_seconds == 0.0
+
+    for _event in range(2):
+        assert (
+            stream._handle_status_line(
+                "[AP2] Re-anchored after PCM starvation: "
+                "shifted_frames=67870 lead_frames=77175 count=1"
+            )
+            is False
+        )
+
+    # two +1.539s events accumulate to ~3.078s
+    assert stream.cumulative_shift_seconds == pytest.approx(2 * 67870 / 44100)
+
+
+def test_reanchor_status_supersedes_legacy_warn() -> None:
+    """The [STATUS] REANCHOR total is authoritative and stops the legacy warn double count."""
+    stream = AirPlayStream(_make_player())
+
+    # a first legacy warn accumulates until the status line arrives
+    stream._handle_status_line(
+        "[AP2] Re-anchored after PCM starvation: shifted_frames=67870 lead_frames=77175 count=1"
+    )
+    # the machine-readable line SETS from the cumulative total and supersedes the warn
+    assert (
+        stream._handle_status_line(
+            "[STATUS] REANCHOR shifted_frames=67870 total_shifted_frames=67870 sample_rate=44100"
+        )
+        is False
+    )
+    assert stream._reanchor_status_seen is True
+    assert stream.cumulative_shift_seconds == pytest.approx(67870 / 44100)
+
+    # both lines fire per event for new binaries: the warn that follows is ignored,
+    # only the status line's cumulative total is tracked (no double count)
+    stream._handle_status_line(
+        "[AP2] Re-anchored after PCM starvation: shifted_frames=67870 lead_frames=77175 count=2"
+    )
+    assert stream.cumulative_shift_seconds == pytest.approx(67870 / 44100)
+    stream._handle_status_line(
+        "[STATUS] REANCHOR shifted_frames=67870 total_shifted_frames=135740 sample_rate=44100"
+    )
+    assert stream.cumulative_shift_seconds == pytest.approx(135740 / 44100)
+
+
+def test_reanchor_status_prefers_line_sample_rate() -> None:
+    """The sample rate carried on the [STATUS] REANCHOR line wins over the stream format."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    stream.pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=48000, bit_depth=16
+    )
+
+    stream._handle_status_line(
+        "[STATUS] REANCHOR shifted_frames=44100 total_shifted_frames=44100 sample_rate=44100"
+    )
+
+    # converts at 44100 (from the line), not 48000 (the stream format) -> exactly 1.0s
+    assert stream.cumulative_shift_seconds == pytest.approx(1.0)
+
+
+def test_reanchor_status_ignores_line_without_total() -> None:
+    """A [STATUS] REANCHOR line missing the total leaves the shift unchanged."""
+    stream = AirPlayStream(_make_player())
+    stream.cumulative_shift_seconds = 1.5
+
+    stream._handle_status_line("[STATUS] REANCHOR shifted_frames=67870 sample_rate=44100")
+
+    assert stream.cumulative_shift_seconds == 1.5
+    assert stream._reanchor_status_seen is False
+
+
+def test_reanchor_shift_ignores_line_without_frames() -> None:
+    """A malformed legacy re-anchor line leaves the tracked shift unchanged."""
+    stream = AirPlayStream(_make_player())
+    stream.cumulative_shift_seconds = 1.5
+
+    ended = stream._handle_status_line("[AP2] Re-anchored after PCM starvation: shifted_frames=")
+
+    assert ended is False
+    assert stream.cumulative_shift_seconds == 1.5
+
+
+@pytest.mark.asyncio
+async def test_start_resets_reanchor_shift() -> None:
+    """A START re-anchors from scratch, clearing the shift and the status flag."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+    stream.cumulative_shift_seconds = 3.078
+    stream._reanchor_status_seen = True
+
+    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True):
+        await stream.start(START_UNIX_MS, 0)
+
+    assert stream.cumulative_shift_seconds == 0.0
+    assert stream._reanchor_status_seen is False
+
+
+@pytest.mark.asyncio
+async def test_connect_resets_accumulated_shift() -> None:
+    """A fresh cliairplay process starts from a zero playout shift and cleared flag."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    stream.cumulative_shift_seconds = 5.0
+    stream._reanchor_status_seen = True
+    player.current_media = MagicMock(corrected_elapsed_time=0)
+    process = MagicMock(closed=False)
+    process.start = AsyncMock()
+
+    def consume_task(awaitable: Any) -> MagicMock:
+        awaitable.close()
+        task = MagicMock()
+        task.done.return_value = True
+        return task
+
+    player.provider.mass.create_task.side_effect = consume_task
+    with (
+        patch.object(stream, "_build_cli_args", new_callable=AsyncMock, return_value=["binary"]),
+        patch("music_assistant.providers.airplay.stream.AsyncProcess", return_value=process),
+        patch.object(stream.commands_pipe, "create", new_callable=AsyncMock),
+        patch.object(stream, "send_metadata", new_callable=AsyncMock),
+    ):
+        await stream.connect()
+
+    assert stream.cumulative_shift_seconds == 0.0
+    assert stream._reanchor_status_seen is False
+
+
 @pytest.mark.asyncio
 async def test_initial_metadata_skips_artwork() -> None:
     """The pre-connect metadata push cannot delay setup on artwork rendering."""

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -40,6 +40,7 @@ def _make_session(
     leader.stream.running = True
     leader.stream.connected = True
     leader.stream.wait_audio_present = AsyncMock(return_value=True)
+    leader.stream.cumulative_shift_seconds = 0.0
     leader.config.get_value = MagicMock(return_value=0)
 
     session = AirPlayStreamSession(prov, [leader], pcm_format, MagicMock(elapsed_time=0))
@@ -74,6 +75,7 @@ def _setup_stream(player: MagicMock) -> Any:
         player.stream.wait_audio_present = AsyncMock(return_value=True)
         player.stream.flush = AsyncMock(return_value=True)
         player.stream.start = AsyncMock()
+        player.stream.cumulative_shift_seconds = 0.0
 
     return _side_effect
 
@@ -667,32 +669,40 @@ async def test_late_join_empty_buffer() -> None:
 
 
 @pytest.mark.asyncio
-async def test_late_join_with_buffered_pcm_in_future() -> None:
-    """Late join with start_at already in the future leaves start_at unmodified."""
-    now = time.time()
-    # Place start_at well in the future: start_time = now + 5, buffer = 0 →
-    # start_at = now + 5 + (seconds_streamed - 0) = now + 17.5 (>> min_headroom)
-    start_time = now + 5
+async def test_late_join_caps_prime_at_whole_ring_when_position_predates_it() -> None:
+    """A due position older than the ring caps the prime at the whole buffer."""
+    now = 1_000_000.0
+    # Synthetic anchor in the future forces the due position behind the oldest
+    # buffered sample: only the whole ring can prime and the anchor is pulled
+    # to the ring's first sample so content and anchor stay exactly aligned.
     seconds_streamed = 12.5
+    buffer_seconds = 3
+    start_time = now + 5.0
     session = _make_session(start_time, seconds_streamed)
-    # Fill the ring buffer with 3 seconds of PCM
-    session._pcm_buffer = bytearray(b"\x00" * PCM_SAMPLE_SIZE * 3)
+    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * buffer_seconds)
     player = _make_late_joiner(wait_start_ms=2000)
+
+    written_chunks: list[bytes] = []
+
+    async def capture_write(_player: Any, chunk: bytes) -> None:
+        written_chunks.append(chunk)
 
     with (
         patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start,
-        patch.object(session, "_write_chunk_to_player", new_callable=AsyncMock),
+        patch.object(session, "_write_chunk_to_player", side_effect=capture_write),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
     ):
         mock_start.side_effect = _setup_stream(player)
         await session.add_client(player)
 
     assert mock_start.called, "_start_client was never called"
-    # start_at should remain at start_time + (seconds_streamed - 3.0) — already in future
-    expected = start_time + (seconds_streamed - 3.0)
-    captured = _captured_start_at(player)
-    assert abs(captured - expected) < 0.1, (
-        f"start_at should match buffer position, expected {expected}, got {captured}"
-    )
+    # the whole ring is primed, nothing is skipped, and the anchor maps to the
+    # ring's first sample: start_at = start_time + (seconds_streamed - buffer)
+    assert session._client_skip_bytes[player.player_id] == 0
+    assert written_chunks, "expected the whole ring to be primed"
+    assert len(written_chunks[0]) / PCM_SAMPLE_SIZE == pytest.approx(buffer_seconds, abs=0.01)
+    expected = start_time + (seconds_streamed - buffer_seconds)
+    assert _captured_start_at(player) == pytest.approx(expected, abs=0.02)
 
 
 @pytest.mark.asyncio
@@ -750,14 +760,14 @@ async def test_late_join_no_running_session() -> None:
 
 
 @pytest.mark.asyncio
-async def test_late_join_trims_and_shifts_when_start_at_in_past() -> None:
-    """When start_at would be in the past, trim from buffer head and shift start_at forward."""
+async def test_late_join_primes_from_ring_tail_at_headroom() -> None:
+    """A due position inside the ring primes from the tail and anchors at now + headroom."""
     # Freeze time so both the test and the code under test agree on `now`.
     now = 1_000_000.0
     start_time = now - 0.5
     seconds_streamed = 5.0
     session = _make_session(start_time, seconds_streamed)
-    # Fill ring buffer with 5 seconds of non-silent PCM (so trim has something to take)
+    # Fill ring buffer with 5 seconds of non-silent PCM.
     session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 5)
     player = _make_late_joiner(wait_start_ms=2000)
 
@@ -774,33 +784,34 @@ async def test_late_join_trims_and_shifts_when_start_at_in_past() -> None:
         mock_start.side_effect = _setup_stream(player)
         await session.add_client(player)
 
-    # start_at should be pushed to now + min_headroom (session.wait_start = 2.0)
+    # start_at is now + min_headroom (session.wait_start = 2.0); fed_pos_due = 2.5s
     assert mock_start.called, "_start_client was never called"
     assert _captured_start_at(player) - now == pytest.approx(2.0, abs=0.01), (
         f"start_at should be at now + min_headroom, "
         f"got offset {_captured_start_at(player) - now:.4f}s"
     )
 
-    # Buffer should have been trimmed: 2.5s out of 5s (start_at shifted from -0.5 to +2.0)
+    # The last 2.5s of the ring is primed (positions 2.5s..5.0s), nothing skipped.
+    assert session._client_skip_bytes[player.player_id] == 0
     assert written_chunks, "No data was written to the player"
-    written = written_chunks[0]
-    remaining_seconds = len(written) / PCM_SAMPLE_SIZE
+    remaining_seconds = len(written_chunks[0]) / PCM_SAMPLE_SIZE
     assert remaining_seconds == pytest.approx(2.5, abs=0.01), (
-        f"expected 2.5s remaining, got {remaining_seconds:.4f}s"
+        f"expected 2.5s primed, got {remaining_seconds:.4f}s"
     )
 
 
 @pytest.mark.asyncio
-async def test_late_join_drops_buffer_when_trim_exceeds_buffer() -> None:
-    """When the required trim exceeds the buffer, the buffer is dropped entirely."""
+async def test_late_join_skips_live_feed_when_anchor_ahead_of_write_head() -> None:
+    """When the due position is ahead of the write head, skip that many live bytes."""
     # Freeze time so both the test and the code under test agree on `now`.
     now = 1_000_000.0
-    # start_at = now - 4.0 (way in the past). With 3s buffer the required trim
-    # is 6s but buffer only holds 3s → buffer fully consumed.
-    start_time = now - 4.0
-    seconds_streamed = 3.0
+    # Diagnosed clamp case: now - start_time = 8.84s, seconds_streamed = 10.0s,
+    # min_headroom = 2.5s and no group shift -> fed_pos_due = 11.34s > 10.0s.
+    start_time = now - 8.84
+    seconds_streamed = 10.0
     session = _make_session(start_time, seconds_streamed)
-    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 3)
+    session.wait_start = 2.5
+    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 10)
     player = _make_late_joiner(wait_start_ms=2000)
 
     written_chunks: list[bytes] = []
@@ -816,11 +827,132 @@ async def test_late_join_drops_buffer_when_trim_exceeds_buffer() -> None:
         mock_start.side_effect = _setup_stream(player)
         await session.add_client(player)
 
-    # No bytes should be written (buffer fully trimmed)
-    assert written_chunks == [], "Buffer should have been dropped entirely"
-    # start_at should be exactly now + min_headroom (since the next-chunk anchor would
-    # have landed at now - 1.0, which is below the target).
-    assert _captured_start_at(player) - now == pytest.approx(2.0, abs=0.01)
+    # anchor is now + min_headroom and nothing is primed (position past the head)
+    assert _captured_start_at(player) - now == pytest.approx(2.5, abs=0.01)
+    assert written_chunks == []
+    skip_seconds = session._client_skip_bytes[player.player_id] / PCM_SAMPLE_SIZE
+    assert skip_seconds == pytest.approx(1.34, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_late_join_primes_from_ring_under_group_shift() -> None:
+    """A reference member that re-anchored later pulls the due position back into the ring."""
+    # Freeze time so both the test and the code under test agree on `now`.
+    now = 1_000_000.0
+    # Same base as the clamp case, but the reference member accumulated a
+    # +1.539s starvation shift (67870 frames @44100) so the group's effective
+    # anchor is later: fed_pos_due = 9.80s, back inside the ring. The joiner is
+    # primed with ~0.2s from the ring tail and skips nothing.
+    start_time = now - 8.84
+    seconds_streamed = 10.0
+    session = _make_session(start_time, seconds_streamed)
+    session.wait_start = 2.5
+    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 10)
+    reference: Any = session.sync_clients[0]
+    reference.stream.cumulative_shift_seconds = 67870 / 44100
+    player = _make_late_joiner(wait_start_ms=2000)
+
+    written_chunks: list[bytes] = []
+
+    async def capture_write(_player: Any, chunk: bytes) -> None:
+        written_chunks.append(chunk)
+
+    with (
+        patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start,
+        patch.object(session, "_write_chunk_to_player", side_effect=capture_write),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
+    ):
+        mock_start.side_effect = _setup_stream(player)
+        await session.add_client(player)
+
+    assert _captured_start_at(player) - now == pytest.approx(2.5, abs=0.01)
+    assert session._client_skip_bytes[player.player_id] == 0
+    assert written_chunks, "expected a prime write from the ring tail"
+    primed_seconds = len(written_chunks[0]) / PCM_SAMPLE_SIZE
+    assert primed_seconds == pytest.approx(0.199, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_write_chunk_drains_skip_counter_across_chunks() -> None:
+    """A per-client skip is consumed across chunks, slicing the partial one."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    ffmpeg = MagicMock(closed=False)
+    ffmpeg.write = AsyncMock()
+    session._player_ffmpeg[player.player_id] = ffmpeg
+    # skip 1.5s of a 1s-per-chunk feed
+    session._client_skip_bytes[player.player_id] = PCM_SAMPLE_SIZE * 3 // 2
+
+    chunk_one = b"\x01" * PCM_SAMPLE_SIZE
+    chunk_two = b"\x02" * PCM_SAMPLE_SIZE
+    chunk_three = b"\x03" * PCM_SAMPLE_SIZE
+    for chunk in (chunk_one, chunk_two, chunk_three):
+        await session._write_chunk_to_player(player, chunk)
+
+    written = [call_args.args[0] for call_args in ffmpeg.write.await_args_list]
+    # first chunk fully consumed, second chunk sliced in half, third whole
+    assert written == [b"\x02" * (PCM_SAMPLE_SIZE // 2), chunk_three]
+    assert session._client_skip_bytes[player.player_id] == 0
+
+
+def test_effective_start_time_adds_reference_member_shift() -> None:
+    """The effective anchor adds the first sync client's accumulated shift."""
+    session = _make_session(100.0, 0)
+    reference: Any = session.sync_clients[0]
+    reference.stream.cumulative_shift_seconds = 1.539
+    assert session.effective_start_time == pytest.approx(101.539)
+
+    # the reference transfers to whichever client is first
+    other = MagicMock()
+    other.stream.cumulative_shift_seconds = 0.5
+    session.sync_clients.insert(0, other)
+    assert session.effective_start_time == pytest.approx(100.5)
+
+    # a missing stream falls back to the raw anchor
+    other.stream = None
+    assert session.effective_start_time == pytest.approx(100.0)
+
+
+@pytest.mark.asyncio
+async def test_stop_client_clears_skip_and_shift_state() -> None:
+    """Tearing a client down drops its skip counter and resets its playout shift."""
+    session = _make_session(0, 0)
+    player = _make_late_joiner()
+    player.stream = MagicMock()
+    player.stream.session = session
+    player.stream.stop = AsyncMock()
+    session._client_skip_bytes[player.player_id] = 12_345
+
+    await session.stop_client(player)
+
+    assert player.player_id not in session._client_skip_bytes
+    player.stream.reset_reanchor_shift.assert_called_once_with()
+    player.stream.stop.assert_awaited_once_with(force=True)
+
+
+@pytest.mark.asyncio
+async def test_replace_clears_skip_and_shift_state() -> None:
+    """A warm replace re-anchors everyone, so skip counters and shifts reset."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.config.get_value = MagicMock(return_value=0)
+    stream = player.stream
+    stream.running = True
+    stream.connected = True
+    stream.flush = AsyncMock(return_value=True)
+    stream.wait_audio_present = AsyncMock(return_value=True)
+    stream.start = AsyncMock()
+    session._client_skip_bytes[player.player_id] = 999
+
+    with (
+        patch.object(session, "_start_player_ffmpeg", new_callable=AsyncMock),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0),
+    ):
+        assert await session.replace(MagicMock(), MagicMock(elapsed_time=0))
+
+    assert session._client_skip_bytes == {}
+    stream.reset_reanchor_shift.assert_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Players added to an already-playing AirPlay group ended up with a constant, audible offset (an echo) that never healed — only stopping and starting playback fresh fixed it.

Two causes, both addressed:
- The late joiner's start anchor was pushed forward to give the device connection headroom, but the corresponding audio was not skipped — so the first delivered sample no longer matched the anchor, and cliairplay freezes the anchor (no catch-up).
- When a member's cliairplay re-anchors itself after PCM input starvation, its playout shifts later, but the session's timeline bookkeeping never learned of it. Late joiners were anchored to a timeline the group had already left (e.g. Player A shifts +1.5s early in a session; Player B joining later lands 1.5s off).

The late-join path now picks the anchor first, derives the exact stream position due at that instant from the group's effective (shift-adjusted) timeline, and either primes from the PCM ring buffer (position behind the write head) or skips the leading live bytes (position ahead). Member re-anchor shifts are tracked from the binary's existing stderr report; a companion cliairplay change adds a machine-readable `[STATUS] REANCHOR` event as the long-term source.

The exact numbers from the field logs that surfaced this are reproduced in the unit tests.