### PR TITLE
Fix lyrics and other optional values breaking on cached empty results

### DIFF
--- a/music_assistant/helpers/api.py
+++ b/music_assistant/helpers/api.py
@@ -519,9 +519,10 @@ def parse_value(  # noqa: PLR0911
     if origin is Union or origin is UnionType:
         # try all possible types
         sub_value_types = get_args(value_type)
+        if value is None and NoneType in sub_value_types:
+            # an optional annotation with no value needs no further parsing
+            return None
         for sub_arg_type in sub_value_types:
-            if value is NoneType and sub_arg_type is NoneType:
-                return value
             # try them all until one succeeds
             try:
                 return parse_value(

--- a/tests/helpers/test_parse_value_collections.py
+++ b/tests/helpers/test_parse_value_collections.py
@@ -2,9 +2,29 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from music_assistant_models.enums import DashboardType
 
 from music_assistant.helpers.api import parse_value
+
+
+def test_parse_value_none_for_optional_dict() -> None:
+    """A None value is returned as-is when the annotation is dict[str, Any] | None."""
+    result = parse_value("supported_types", None, dict[str, Any] | None)
+    assert result is None
+
+
+def test_parse_value_none_for_optional_list() -> None:
+    """A None value is returned as-is when the annotation is list[str] | None."""
+    result = parse_value("values", None, list[str] | None)
+    assert result is None
+
+
+def test_parse_value_dict_for_optional_dict() -> None:
+    """A real dict is still parsed correctly when the annotation is dict[str, Any] | None."""
+    result = parse_value("supported_types", {"a": 1}, dict[str, Any] | None)
+    assert result == {"a": 1}
 
 
 def test_parse_value_set_of_enum() -> None:


### PR DESCRIPTION
# What does this implement/fix?

`parse_value` crashed with `AttributeError: 'NoneType' object has no attribute 'items'` whenever it received `None` for an optional dict annotation such as `dict[str, Any] | None`.

In the union branch the guard meant to catch this compared `value` against the `NoneType` *type object* rather than `None`, so it never matched. `None` then fell through to the `dict` branch, which called `.items()` on it. `AttributeError` is not in that branch's `except` list, so the error escaped to the caller.

The practical impact is on the cache-reconstruct path: any `@use_cache` function whose return hint is `X | None` raises as soon as its cached value is `None`. Spotted on a nightly instance where every LRCLIB lyrics lookup for a track with no lyrics failed permanently — the negative result is cached, and reconstructing that cached `None` raised on every subsequent request.

The fix short-circuits `None` before the union loop, so it never reaches the dict/collection branches.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
