### PR TITLE
Prevent volume normalization from clipping quiet, peaky tracks

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -249,6 +249,10 @@ VACUUM_MIN_RECLAIM_RATIO: Final[float] = 0.2
 # audio (e.g. when a stream was cancelled early).
 LOUDNESS_MEASUREMENT_MIN_LUFS: Final[float] = -50.0
 
+# Ceiling (dBTP) a positive normalization gain may push a measured true peak to. Keeps
+# headroom for inter-sample peaks that appear after resampling in the output stage.
+NORMALIZATION_MAX_TRUE_PEAK_DBTP: Final[float] = -1.0
+
 
 def load_genre_mapping(mapping_file: pathlib.Path) -> list[dict[str, Any]]:
     """

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -103,6 +103,7 @@ from music_assistant.helpers.audio import (
     HTTP_HEADERS_ICY,
     build_concat_filelist,
     calculate_content_length,
+    clamp_gain_to_true_peak,
     get_bit_rate,
     get_normalization_mode,
     get_parts_from_position,
@@ -1586,6 +1587,12 @@ class StreamsAudio:
                 gain_correct = target_loudness - float(streamdetails.loudness)
             else:
                 gain_correct = 0.0
+            if gain_correct > 0:
+                # a positive gain on a peaky master overshoots 0 dBFS and hard-clips in the
+                # output stage, so cap it at the headroom the measured true peak leaves
+                gain_correct = clamp_gain_to_true_peak(
+                    gain_correct, await self._get_measured_true_peak(streamdetails)
+                )
             gain_correct = round(gain_correct, 2)
             filter_params.append(f"volume={gain_correct}dB")
         streamdetails.volume_normalization_gain_correct = gain_correct
@@ -2744,6 +2751,16 @@ class StreamsAudio:
         return VolumeNormalizationMode(
             self.mass.streams.get_config_value(conf_key, return_type=str)
         )
+
+    async def _get_measured_true_peak(self, streamdetails: StreamDetails) -> float | None:
+        """Return the stored EBU R128 true peak (dBTP) for this item, if it was measured."""
+        analysis = await self.mass.streams.audio_analysis.get_audio_analysis(
+            streamdetails.item_id,
+            streamdetails.provider,
+            media_type=streamdetails.media_type,
+            priority=(LOUDNESS_ANALYSIS_DOMAIN,),
+        )
+        return analysis.true_peak if analysis else None
 
     def _update_radio_stream_metadata(
         self,

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -24,6 +24,7 @@ from music_assistant_models.streamdetails import MultiPartPath
 
 from music_assistant.constants import (
     MASS_LOGGER_NAME,
+    NORMALIZATION_MAX_TRUE_PEAK_DBTP,
     VERBOSE_LOG_LEVEL,
 )
 from music_assistant.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads
@@ -775,3 +776,19 @@ def get_normalization_mode(
 
     # simply return the preference
     return preference
+
+
+def clamp_gain_to_true_peak(gain_db: float, true_peak_dbtp: float | None) -> float:
+    """
+    Limit a positive normalization gain to the headroom the measured true peak allows.
+
+    Returns the gain unchanged when it is not positive or no true peak was measured. The
+    result is never negative: content already above the ceiling keeps its own level instead
+    of being attenuated.
+
+    :param gain_db: Gain the normalization target asks for.
+    :param true_peak_dbtp: Measured true peak in dBTP, or None when unknown.
+    """
+    if gain_db <= 0 or true_peak_dbtp is None:
+        return gain_db
+    return min(gain_db, max(0.0, NORMALIZATION_MAX_TRUE_PEAK_DBTP - true_peak_dbtp))

--- a/music_assistant/providers/loudness_analysis/provider.py
+++ b/music_assistant/providers/loudness_analysis/provider.py
@@ -33,7 +33,7 @@ CONF_WRITE_REPLAYGAIN_TAGS = "write_replaygain_tags"
 
 _INTEGRATED_RE = re.compile(r"Integrated loudness:.*?I:\s*(-?\d+(?:\.\d+)?)\s*LUFS", re.DOTALL)
 _LRA_RE = re.compile(r"Loudness range:.*?LRA:\s*(-?\d+(?:\.\d+)?)\s*LU", re.DOTALL)
-_TRUE_PEAK_RE = re.compile(r"True peak:.*?Peak:\s*(-?\d+(?:\.\d+)?)\s*dBTP", re.DOTALL)
+_TRUE_PEAK_RE = re.compile(r"True peak:.*?Peak:\s*(-?\d+(?:\.\d+)?)\s*dB(?:TP|FS)", re.DOTALL)
 
 
 @dataclass
@@ -133,7 +133,8 @@ class LoudnessAnalysisProvider(AudioAnalysisProvider):
             input_format=audio_format,
             output_format=audio_format,
             audio_output="NULL",
-            filter_params=["ebur128=framelog=verbose"],
+            # peak=true is what makes ffmpeg emit the (4x oversampled) true-peak block
+            filter_params=["ebur128=framelog=verbose:peak=true"],
             collect_log_history=True,
             loglevel="info",
         )

--- a/tests/controllers/streams/test_normalization_override.py
+++ b/tests/controllers/streams/test_normalization_override.py
@@ -155,3 +155,27 @@ async def test_no_override_reevaluates_to_measurement_only(
     cast(
         "MagicMock", controller.mass
     ).streams.audio_analysis.get_audio_analysis.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_measurement_only_gain_clamped_to_true_peak(
+    audio: tuple[StreamsAudio, dict[str, list[str]]],
+) -> None:
+    """
+    A quiet-but-peaky measurement is clamped instead of hard-clipping.
+
+    With TARGET_LOUDNESS = -17.0 and loudness_integrated = -20.3, the raw gain would be
+    +3.3 dB. Applying that unclamped to a track whose true peak already sits at -0.5 dBTP
+    would push it to +2.8 dBTP and clip when converted to 16/24-bit for the player.
+    """
+    controller, captured = audio
+    queue_item = _make_queue_item()
+    mass = cast("MagicMock", controller.mass)
+    mass.streams.audio_analysis.get_audio_analysis = AsyncMock(
+        return_value=SimpleNamespace(loudness_integrated=-20.3, loudness_album=None, true_peak=-0.5)
+    )
+
+    await _drain(controller.get_queue_item_stream(queue_item, PCM_FORMAT))
+
+    assert "volume=0.0dB" in captured["filter_params"]
+    assert not any(p.startswith("loudnorm") for p in captured["filter_params"])

--- a/tests/helpers/test_audio.py
+++ b/tests/helpers/test_audio.py
@@ -11,6 +11,7 @@ from music_assistant_models.media_items import AudioFormat
 from music_assistant.helpers.audio import (
     build_concat_filelist,
     calculate_content_length,
+    clamp_gain_to_true_peak,
     resolve_output_player_ids,
 )
 from music_assistant.helpers.ffmpeg import DEFAULT_MP3_BIT_RATE
@@ -70,3 +71,24 @@ def test_build_concat_filelist_escapes_multiple_apostrophes() -> None:
     """Every apostrophe in a path is escaped, not just the first."""
     result = build_concat_filelist(["/x/it's a, b's & c's.mp3"])
     assert result == "file '/x/it'\\''s a, b'\\''s & c'\\''s.mp3'\n"
+
+
+def test_clamp_gain_to_true_peak_ignores_non_positive_gain() -> None:
+    """A negative or zero gain is returned unchanged, regardless of true peak."""
+    assert clamp_gain_to_true_peak(-3.0, -1.0) == -3.0
+    assert clamp_gain_to_true_peak(0.0, -1.0) == 0.0
+
+
+def test_clamp_gain_to_true_peak_ignores_unknown_true_peak() -> None:
+    """A positive gain is returned unchanged when no true peak was measured."""
+    assert clamp_gain_to_true_peak(6.0, None) == 6.0
+
+
+def test_clamp_gain_to_true_peak_limits_to_available_headroom() -> None:
+    """A positive gain is capped to the headroom the measured true peak leaves."""
+    assert clamp_gain_to_true_peak(6.0, -3.0) == 2.0
+
+
+def test_clamp_gain_to_true_peak_never_goes_negative() -> None:
+    """A true peak already at or above the ceiling clamps the gain to unity, not below."""
+    assert clamp_gain_to_true_peak(6.0, -0.1) == 0.0

--- a/tests/providers/loudness_analysis/test_provider.py
+++ b/tests/providers/loudness_analysis/test_provider.py
@@ -15,7 +15,36 @@ from music_assistant.providers.loudness_analysis.provider import (
     MIN_DURATION_SECONDS,
     LoudnessAnalysisProvider,
     LoudnessSessionData,
+    _parse_ebur128_metrics,
 )
+
+# ---------------------------------------------------------------------------
+# _parse_ebur128_metrics tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_ebur128_metrics_reads_true_peak_labeled_dbfs() -> None:
+    """Verbatim ebur128=framelog=verbose:peak=true output labels true peak in dBFS, not dBTP."""
+    log = """[Parsed_ebur128_0 @ 0xa7902c900] Summary:
+
+  Integrated loudness:
+    I:         -20.3 LUFS
+    Threshold: -30.6 LUFS
+
+  Loudness range:
+    LRA:         1.1 LU
+    Threshold: -40.7 LUFS
+    LRA low:   -21.3 LUFS
+    LRA high:  -20.1 LUFS
+
+  True peak:
+    Peak:       -3.4 dBFS
+"""
+    integrated, lra, true_peak = _parse_ebur128_metrics(log.splitlines())
+
+    assert integrated == -20.3
+    assert lra == 1.1
+    assert true_peak == -3.4
 
 
 def _make_provider() -> LoudnessAnalysisProvider:


### PR DESCRIPTION
# What does this implement/fix?

Two related defects that together mean volume normalization can clip, and nothing stops it.

**1. A positive normalization gain is unbounded.** In `MEASUREMENT_ONLY` mode the gain is applied as a raw ffmpeg `volume=<x>dB` with no limiter or clamp anywhere in the chain. When a track measures quieter than the configured target, the resulting positive gain pushes peaks past 0 dBFS: the internal F32 PCM preserves the overshoot, and it hard-clips when converted to 16/24-bit for the player. Measured on one file: source peak -3.52 dBFS, after `volume=+6.3dB` the F32 stage sits at +2.78 dBFS, and the 16-bit output comes out at 0.000 dBFS with a flat factor of 9.54.

On a 424-track library measured with the default -14 LUFS target, 18.9% of tracks ask for a positive gain — median +3.1 dB, p90 +9.7 dB, up to +13.4 dB. Any of those peaking above -13.4 dBFS clips today.

**2. The true peak was never actually measured.** `loudness_analysis` ran `ebur128=framelog=verbose` without a `peak=` option, so ffmpeg emitted no peak block at all; and `_TRUE_PEAK_RE` required the literal unit `dBTP`, which ffmpeg does not use (it labels the value `dBFS` even in true-peak mode). Both had to be fixed or the clamp below would never engage — 0 of the 424 stored measurements in that library have a true peak. The existing tests all monkeypatched `_parse_ebur128_metrics`, so the unit mismatch was never exercised.

The gain is now capped at the headroom the measured true peak leaves, keeping 1 dBTP spare for inter-sample peaks and for the stages that run after this one (resampling, per-player DSP, mixing, lossy output codecs). Tracks with no stored true peak and any negative gain are unaffected, and the clamp never turns a positive gain into an attenuation, so content already above the ceiling keeps its own level.

- Measure the true peak: add `peak=true` to the ebur128 filter and accept ffmpeg's `dBFS` unit label
- Add `NORMALIZATION_MAX_TRUE_PEAK_DBTP` (-1.0 dBTP) ceiling constant
- Add `clamp_gain_to_true_peak()` and apply it to the `MEASUREMENT_ONLY` gain
- Look up the stored true peak when the gain is positive
- Test the helper, the streaming path, and the ebur128 parser against verbatim ffmpeg output

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.