### PR TITLE
Fix volume limit enforcement for players with redirected volume control

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2565,19 +2565,14 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         min_volume, max_volume = self._get_volume_limits(player_id)
         if min_volume == 0 and max_volume == 100:
             return
-        # The state's volume_level holds the logical (0-100) volume resolved from
-        # whatever volume control this player uses (native, protocol player or
-        # external playercontrol) - unlike the raw volume_level attribute, which is
-        # None for players that redirect their volume control (e.g. universal players).
-        # scale_volume_from_device deliberately does not clamp, so a device volume
-        # outside the configured range surfaces here as a logical value outside 0-100.
+        # state.volume_level is the resolved logical volume, available for all
+        # volume control types; a device volume outside the configured range
+        # surfaces here as a value outside 0-100 (scaling does not clamp)
         logical_volume = player.state.volume_level
         if logical_volume is None or 0 <= logical_volume <= 100:
             return
         clamped = max(0, min(100, logical_volume))
-        # Route the correction through the regular volume-set handling so it follows
-        # the same scaling and redirection (protocol player / playercontrol) as a
-        # user-issued volume command.
+        # correct via the regular volume-set path so scaling and redirection apply
         self.mass.create_task(self._handle_cmd_volume_set(player_id, clamped))
 
     def _forward_state_update(

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2561,17 +2561,24 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
     def _enforce_volume_limits(self, player: Player) -> None:
         """Clamp device volume to min/max range when changed externally."""
-        if player.volume_level is None:
-            return
         player_id = player.player_id
         min_volume, max_volume = self._get_volume_limits(player_id)
         if min_volume == 0 and max_volume == 100:
             return
-        device_volume = player.volume_level
-        clamped = max(min_volume, min(max_volume, device_volume))
-        if clamped != device_volume:
-            # Device volume is outside allowed range, correct it
-            self.mass.create_task(player.volume_set(clamped))
+        # The state's volume_level holds the logical (0-100) volume resolved from
+        # whatever volume control this player uses (native, protocol player or
+        # external playercontrol) - unlike the raw volume_level attribute, which is
+        # None for players that redirect their volume control (e.g. universal players).
+        # scale_volume_from_device deliberately does not clamp, so a device volume
+        # outside the configured range surfaces here as a logical value outside 0-100.
+        logical_volume = player.state.volume_level
+        if logical_volume is None or 0 <= logical_volume <= 100:
+            return
+        clamped = max(0, min(100, logical_volume))
+        # Route the correction through the regular volume-set handling so it follows
+        # the same scaling and redirection (protocol player / playercontrol) as a
+        # user-issued volume command.
+        self.mass.create_task(self._handle_cmd_volume_set(player_id, clamped))
 
     def _forward_state_update(
         self, player: Player, changed_values: dict[str, tuple[Any, Any]]

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -623,10 +623,13 @@ class SpotifyConnectProvider(PluginProvider):
         os.makedirs(self.cache_dir, exist_ok=True)
         initial_volume = 50
         if self._default_player_id != PLAYER_ID_AUTO:
+            # use the state's logical (0-100) volume: it matches the Spotify volume
+            # scale and is also resolved for players that redirect their volume
+            # control (e.g. universal players), where the raw attribute is None
             if (player := self.mass.players.get_player(self._default_player_id)) and (
-                player.volume_level is not None
+                player.state.volume_level is not None
             ):
-                initial_volume = player.volume_level
+                initial_volume = player.state.volume_level
         config: dict[str, Any] = {
             "device_name": self._publish_name,
             "device_type": "speaker",

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -623,9 +623,7 @@ class SpotifyConnectProvider(PluginProvider):
         os.makedirs(self.cache_dir, exist_ok=True)
         initial_volume = 50
         if self._default_player_id != PLAYER_ID_AUTO:
-            # use the state's logical (0-100) volume: it matches the Spotify volume
-            # scale and is also resolved for players that redirect their volume
-            # control (e.g. universal players), where the raw attribute is None
+            # the resolved logical (0-100) volume matches the Spotify volume scale
             if (player := self.mass.players.get_player(self._default_player_id)) and (
                 player.state.volume_level is not None
             ):

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -623,11 +623,12 @@ class SpotifyConnectProvider(PluginProvider):
         os.makedirs(self.cache_dir, exist_ok=True)
         initial_volume = 50
         if self._default_player_id != PLAYER_ID_AUTO:
-            # the resolved logical (0-100) volume matches the Spotify volume scale
+            # the resolved logical (0-100) volume matches the Spotify volume scale;
+            # clamp it as it can be out of range until volume limit enforcement runs
             if (player := self.mass.players.get_player(self._default_player_id)) and (
                 player.state.volume_level is not None
             ):
-                initial_volume = player.state.volume_level
+                initial_volume = max(0, min(100, player.state.volume_level))
         config: dict[str, Any] = {
             "device_name": self._publish_name,
             "device_type": "speaker",

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1114,6 +1114,81 @@ class TestVolumeScalingOnRedirect:
         control.volume_set.assert_awaited_once_with(50)
 
 
+class TestEnforceVolumeLimits:
+    """External volume changes outside the min/max range must be corrected."""
+
+    @staticmethod
+    def _set_limits(mock_mass: MagicMock, min_volume: int, max_volume: int) -> None:
+        def _conf(_player_id: str, key: str, default: object = None) -> object:
+            if key == "min_volume":
+                return min_volume
+            if key == "max_volume":
+                return max_volume
+            return default if default is not None else "auto"
+
+        mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_conf)
+
+    @staticmethod
+    def _player(logical_volume: int | None) -> SimpleNamespace:
+        return SimpleNamespace(
+            player_id="user_player",
+            state=SimpleNamespace(volume_level=logical_volume),
+        )
+
+    def test_out_of_range_volume_is_corrected(
+        self, controller: PlayerController, mock_mass: MagicMock
+    ) -> None:
+        """A device volume above max_volume (logical > 100) is clamped back to logical 100."""
+        self._set_limits(mock_mass, 0, 80)
+        # device volume 100 with max 80 resolves to logical 125
+        player = self._player(125)
+        with patch.object(controller, "_handle_cmd_volume_set", MagicMock()) as cmd:
+            controller._enforce_volume_limits(cast("MockPlayer", player))
+        cmd.assert_called_once_with("user_player", 100)
+        mock_mass.create_task.assert_called_once()
+
+    def test_below_min_volume_is_corrected(
+        self, controller: PlayerController, mock_mass: MagicMock
+    ) -> None:
+        """A device volume below min_volume (logical < 0) is clamped back to logical 0."""
+        self._set_limits(mock_mass, 20, 100)
+        # device volume 10 with min 20 resolves to a negative logical volume
+        player = self._player(-13)
+        with patch.object(controller, "_handle_cmd_volume_set", MagicMock()) as cmd:
+            controller._enforce_volume_limits(cast("MockPlayer", player))
+        cmd.assert_called_once_with("user_player", 0)
+
+    def test_in_range_volume_is_untouched(
+        self, controller: PlayerController, mock_mass: MagicMock
+    ) -> None:
+        """A logical volume within 0-100 needs no correction."""
+        self._set_limits(mock_mass, 0, 80)
+        player = self._player(100)
+        with patch.object(controller, "_handle_cmd_volume_set", MagicMock()) as cmd:
+            controller._enforce_volume_limits(cast("MockPlayer", player))
+        cmd.assert_not_called()
+
+    def test_no_limits_configured_is_noop(
+        self, controller: PlayerController, mock_mass: MagicMock
+    ) -> None:
+        """Default 0-100 limits skip enforcement entirely."""
+        self._set_limits(mock_mass, 0, 100)
+        player = self._player(100)
+        with patch.object(controller, "_handle_cmd_volume_set", MagicMock()) as cmd:
+            controller._enforce_volume_limits(cast("MockPlayer", player))
+        cmd.assert_not_called()
+
+    def test_unknown_volume_is_noop(
+        self, controller: PlayerController, mock_mass: MagicMock
+    ) -> None:
+        """A player without a resolved volume level is left alone."""
+        self._set_limits(mock_mass, 0, 80)
+        player = self._player(None)
+        with patch.object(controller, "_handle_cmd_volume_set", MagicMock()) as cmd:
+            controller._enforce_volume_limits(cast("MockPlayer", player))
+        cmd.assert_not_called()
+
+
 class TestFakeMuteControl:
     """Fake mute must report the muted state and restore the volume on unmute."""
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Volume limits (min/max) were only enforced against external volume changes for players with native volume control. Players that resolve volume through a protocol player or external control (e.g. universal players wrapping AirPlay/Sendspin/Chromecast devices) were never corrected, so they could sit at full volume and a Spotify Connect session would start playing at true 100% regardless of the limit.

Enforcement now uses the resolved volume from the player state (works for all control types) and corrects through the regular volume-set path. Also seeds Spotify Connect's initial volume from the resolved volume instead of the raw attribute (which is None for universal players).

Players without volume limits configured are unaffected.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5845

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
