### PR TITLE
Show protocol-connected speakers in the Music Quiz speaker picker

### DIFF
--- a/music_assistant/helpers/shared_playback.py
+++ b/music_assistant/helpers/shared_playback.py
@@ -53,6 +53,17 @@ class SharedPlaybackMode(StrEnum):
     REMOTE = "remote"
 
 
+def is_remote_session_host(mass: MusicAssistant, player_id: str) -> bool:
+    """
+    Return whether the given player is the virtual host of a REMOTE session.
+
+    :param mass: MusicAssistant instance.
+    :param player_id: Player to inspect.
+    """
+    sendspin = cast("SendspinProvider | None", mass.get_provider(SENDSPIN_DOMAIN))
+    return sendspin is not None and sendspin.is_virtual_player(player_id)
+
+
 class SharedPlaybackSession:
     """
     A player/queue that hosts a shared listening experience.

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -84,6 +84,7 @@ from music_assistant.helpers.shared_playback import (
     SENDSPIN_DOMAIN,
     SharedPlaybackMode,
     SharedPlaybackSession,
+    is_remote_session_host,
 )
 from music_assistant.helpers.uri import parse_uri
 from music_assistant.models.plugin import PluginProvider
@@ -1716,8 +1717,7 @@ class MusicQuizPlugin(PluginProvider):
         player = self.mass.players.get_player(player_id)
         return player is not None and self._is_eligible_venue_player(player)
 
-    @staticmethod
-    def _is_eligible_venue_player(player: Player) -> bool:
+    def _is_eligible_venue_player(self, player: Player) -> bool:
         """
         Return whether a player is a real venue playback target.
 
@@ -1732,8 +1732,11 @@ class MusicQuizPlugin(PluginProvider):
             and state.synced_to is None
             and state.active_group is None
             and state.type in (PlayerType.PLAYER, PlayerType.STEREO_PAIR, PlayerType.GROUP)
-            and player.is_native_player
-            and player.provider.domain != SENDSPIN_DOMAIN
+            # a universal player has no native playback of its own but plays through
+            # its protocol children, so ask for any usable output instead of native playback
+            and any(protocol.available for protocol in state.output_protocols)
+            # the virtual host of a remote session is not a speaker in the room
+            and not is_remote_session_host(self.mass, player.player_id)
         )
 
     def _remote_playback_available(self) -> bool:

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -1732,10 +1732,7 @@ class MusicQuizPlugin(PluginProvider):
             and state.synced_to is None
             and state.active_group is None
             and state.type in (PlayerType.PLAYER, PlayerType.STEREO_PAIR, PlayerType.GROUP)
-            # a universal player has no native playback of its own but plays through
-            # its protocol children, so ask for any usable output instead of native playback
             and any(protocol.available for protocol in state.output_protocols)
-            # the virtual host of a remote session is not a speaker in the room
             and not is_remote_session_host(self.mass, player.player_id)
         )
 

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -130,7 +130,6 @@ def _make_venue_player(
         and player_type != PlayerType.PROTOCOL
         and provider_domain != "universal_player"
     )
-    # a native player offers its own output, a universal player only the ones it wraps
     output_protocols = (
         [SimpleNamespace(available=True)] if is_native_player or linked_protocol else []
     )

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -121,6 +121,7 @@ def _make_venue_player(
     features: set[PlayerFeature] | None = None,
     provider_domain: str = "test_player",
     playback_state: PlaybackState = PlaybackState.IDLE,
+    linked_protocol: bool = False,
 ) -> SimpleNamespace:
     """Return a player-shaped venue target for tests."""
     supported_features = features if features is not None else {PlayerFeature.PLAY_MEDIA}
@@ -128,6 +129,10 @@ def _make_venue_player(
         PlayerFeature.PLAY_MEDIA in supported_features
         and player_type != PlayerType.PROTOCOL
         and provider_domain != "universal_player"
+    )
+    # a native player offers its own output, a universal player only the ones it wraps
+    output_protocols = (
+        [SimpleNamespace(available=True)] if is_native_player or linked_protocol else []
     )
     return SimpleNamespace(
         player_id=player_id,
@@ -145,6 +150,7 @@ def _make_venue_player(
             group_members=[],
             type=player_type,
             supported_features=supported_features,
+            output_protocols=output_protocols,
         ),
         extra_data={},
     )
@@ -296,7 +302,9 @@ def _create_plugin(
     plugin._unregister_handles = []
     plugin.mass.cache.get = AsyncMock(return_value=None)
     plugin.mass.cache.set = AsyncMock()
-    plugin.mass.get_provider.return_value = MagicMock()
+    sendspin_provider = MagicMock()
+    sendspin_provider.is_virtual_player.return_value = False
+    plugin.mass.get_provider.return_value = sendspin_provider
     plugin.mass.players.all_players.return_value = (
         [_make_venue_player(player, "Venue Player")] if player and player != "__auto__" else []
     )
@@ -673,6 +681,13 @@ async def test_playback_options_filter_and_stably_rank_venue_players() -> None:
     active_group_member = _make_venue_player("group-member", "Active Group Member")
     active_group_member.state.active_group = "group"
     group.state.group_members = ["group-member"]
+    universal = _make_venue_player(
+        "universal", "Universal", provider_domain="universal_player", linked_protocol=True
+    )
+    session_host = _make_venue_player("virtual", "Quiz Session", provider_domain="sendspin")
+    cast(
+        "MagicMock", plugin.mass.get_provider.return_value
+    ).is_virtual_player.side_effect = lambda player_id: player_id == "virtual"
     excluded = [
         _make_venue_player("unavailable", "Unavailable", available=False),
         _make_venue_player("disabled", "Disabled", enabled=False),
@@ -683,13 +698,14 @@ async def test_playback_options_filter_and_stably_rank_venue_players() -> None:
         _make_venue_player("protocol", "Protocol", player_type=PlayerType.PROTOCOL),
         _make_venue_player("display", "Display", player_type=PlayerType.DISPLAY),
         _make_venue_player("no-play", "No Playback", features=set()),
-        _make_venue_player("browser", "Browser", provider_domain="sendspin"),
-        _make_venue_player("universal", "Universal", provider_domain="universal_player"),
+        _make_venue_player("browser", "Browser", provider_domain="sendspin", hidden=True),
+        session_host,
     ]
     cast("MagicMock", plugin.mass.players.all_players).return_value = [
         playing_bathroom,
         *excluded,
         group,
+        universal,
         alpha,
     ]
 
@@ -713,12 +729,32 @@ async def test_playback_options_filter_and_stably_rank_venue_players() -> None:
         "venue_players": [
             {"player_id": "alpha", "name": "Alpha Room"},
             {"player_id": "group", "name": "House Group"},
+            {"player_id": "universal", "name": "Universal"},
             {"player_id": "bathroom", "name": "Z Bathroom"},
         ],
     }
     create_venue.assert_not_awaited()
     create_remote.assert_not_awaited()
     assert cast("MagicMock", plugin.mass.player_queues).mock_calls == []
+
+
+@pytest.mark.asyncio
+async def test_playback_options_include_protocol_wrapped_speakers() -> None:
+    """Offer speakers that play through a linked protocol, such as a Sendspin CLI client."""
+    plugin = _create_plugin(player="__auto__")
+    cli_speaker = _make_venue_player(
+        "universal_kitchen",
+        "Kitchen",
+        provider_domain="universal_player",
+        linked_protocol=True,
+    )
+    cast("MagicMock", plugin.mass.players.all_players).return_value = [cli_speaker]
+
+    options = await plugin.playback_options()
+
+    assert options["venue_available"] is True
+    assert options["default_venue_player_id"] == "universal_kitchen"
+    assert options["venue_players"] == [{"player_id": "universal_kitchen", "name": "Kitchen"}]
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -109,7 +109,7 @@ LISTEN_IN_COMMANDS = (
 )
 
 
-def _make_venue_player(
+def _make_venue_player(  # noqa: PLR0913
     player_id: str,
     name: str,
     *,
@@ -684,9 +684,8 @@ async def test_playback_options_filter_and_stably_rank_venue_players() -> None:
         "universal", "Universal", provider_domain="universal_player", linked_protocol=True
     )
     session_host = _make_venue_player("virtual", "Quiz Session", provider_domain="sendspin")
-    cast(
-        "MagicMock", plugin.mass.get_provider.return_value
-    ).is_virtual_player.side_effect = lambda player_id: player_id == "virtual"
+    sendspin_provider = cast("MagicMock", plugin.mass.get_provider).return_value
+    sendspin_provider.is_virtual_player.side_effect = lambda player_id: player_id == "virtual"
     excluded = [
         _make_venue_player("unavailable", "Unavailable", available=False),
         _make_venue_player("disabled", "Disabled", enabled=False),


### PR DESCRIPTION
# What does this implement/fix?

Speakers that play through a linked protocol never appeared in the Music Quiz speaker dropdown. A Sendspin CLI client registers as a protocol player and is surfaced as a universal player wrapper, but the venue filter required `is_native_player`, which excludes universal players (they have no playback capability of their own and delegate to their protocol children). The same filter also dropped every Sendspin player by domain, which is broader than intended — the case it needs to guard is the virtual host player of a remote session, not real speakers.

**Related issue (if applicable):**

- Reported on [Discord:](https://discord.com/channels/753947050995089438/1531576131138879488)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Accept any venue player that has an available output protocol, instead of requiring native playback, so universal player wrappers qualify.
- Replace the blanket Sendspin domain exclusion with a check on the virtual host player of a remote session, added as `is_remote_session_host` in the shared playback helper.
- Hidden web and app players stay out of the list through the existing `hide_in_ui` check.

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
