### PR TITLE
Keep AI Radio segments in order and add a shuffle toggle

### DIFF
--- a/music_assistant/providers/ai_radio/runtime.py
+++ b/music_assistant/providers/ai_radio/runtime.py
@@ -24,7 +24,7 @@ from music_assistant_models.enums import (
     QueueOption,
     TaskStatus,
 )
-from music_assistant_models.errors import InvalidDataError, MusicAssistantError
+from music_assistant_models.errors import InvalidCommand, InvalidDataError, MusicAssistantError
 from music_assistant_models.media_items import (
     MediaItemImage,
     ProviderMapping,
@@ -161,6 +161,7 @@ class AIRadioRuntimeMixin:
         self._set_session_progress(session, "fetch_source_tracks")
         runtime_tokens = await self._prepare_runtime_tokens(station)
         tracks, playlist_name = await self._fetch_source_tracks(station)
+        tracks = self._apply_source_shuffle(tracks, station)
         tracks = self._apply_track_duration_limit(tracks, station)
         if not tracks:
             raise MusicAssistantError("No source tracks available after applying station limits")
@@ -276,6 +277,7 @@ class AIRadioRuntimeMixin:
             raise MusicAssistantError(f"Unknown target player: {player_id}")
 
         tracks, playlist_name = await self._fetch_source_tracks(station)
+        tracks = self._apply_source_shuffle(tracks, station)
         tracks = self._apply_track_duration_limit(tracks, station)
         if not tracks:
             raise MusicAssistantError("No source tracks available after applying station limits")
@@ -322,6 +324,15 @@ class AIRadioRuntimeMixin:
                 PlaybackState.PLAYING,
                 PlaybackState.PAUSED,
             )
+
+        # a shuffled queue reorders each batch, scattering sections away from their tracks
+        try:
+            await self.mass.player_queues.set_shuffle(queue_id, False)
+        except InvalidCommand as err:
+            raise MusicAssistantError(
+                f"Queue {queue_id} is in dynamic mode, which reorders the queue. Disable dynamic "
+                "mode on the player or enable 'clear queue on start' for this station."
+            ) from err
 
         cumulative_minutes = [0.0]
         for track in tracks:
@@ -577,20 +588,34 @@ class AIRadioRuntimeMixin:
             return create_uri(MediaType.TRACK, mapping.provider_instance, mapping.item_id)
         return ""
 
+    def _apply_source_shuffle(
+        self, tracks: list[dict[str, Any]], station: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Return the source tracks in random order when the station asks for it."""
+        if not station.get("shuffle_source_tracks", True) or not tracks:
+            return tracks
+        indices = list(range(len(tracks)))
+        random.Random().shuffle(indices)
+        result: list[dict[str, Any]] = []
+        for new_index, old_index in enumerate(indices):
+            updated = deepcopy(tracks[old_index])
+            updated["index"] = new_index
+            updated["source_index"] = old_index
+            result.append(updated)
+        self.logger.info("Shuffled %d source tracks", len(result))
+        return result
+
     def _apply_track_duration_limit(
         self, tracks: list[dict[str, Any]], station: dict[str, Any]
     ) -> list[dict[str, Any]]:
-        """Apply random max duration truncation if configured."""
+        """Truncate the given tracks to the configured playtime cap, preserving their order."""
         max_duration = float(station.get("max_duration_minutes", 0) or 0)
         if max_duration <= 0 or not tracks:
             return tracks
-        indices = list(range(len(tracks)))
-        rng = random.Random()
-        rng.shuffle(indices)
         chosen: list[int] = []
         total_minutes = 0.0
-        for index in indices:
-            duration = tracks[index].get("duration")
+        for index, track in enumerate(tracks):
+            duration = track.get("duration")
             seconds = (
                 float(duration) if isinstance(duration, (int, float)) and duration > 0 else 210.0
             )
@@ -599,7 +624,7 @@ class AIRadioRuntimeMixin:
             if total_minutes > max_duration:
                 break
         result: list[dict[str, Any]] = []
-        for new_index, old_index in enumerate(sorted(chosen)):
+        for new_index, old_index in enumerate(chosen):
             updated = deepcopy(tracks[old_index])
             updated["index"] = new_index
             updated["source_index"] = old_index

--- a/music_assistant/providers/ai_radio/storage.py
+++ b/music_assistant/providers/ai_radio/storage.py
@@ -322,6 +322,7 @@ class AIRadioStorageMixin:
                     "max_duration_minutes", station.get("max_duration_minutes"), 0.0, float
                 ),
             ),
+            "shuffle_source_tracks": bool(station.get("shuffle_source_tracks", True)),
             "dynamic_batch_size": max(
                 1,
                 _require_number("dynamic_batch_size", station.get("dynamic_batch_size"), 3, int),
@@ -525,6 +526,7 @@ class AIRadioStorageMixin:
             "target_playlist_provider": "builtin",
             "default_player_id": "",
             "max_duration_minutes": 0,
+            "shuffle_source_tracks": True,
             "dynamic_batch_size": 3,
             "dynamic_poll_seconds": 5,
             "dynamic_prefetch_remaining_tracks": 2,

--- a/tests/providers/ai_radio/test_runtime.py
+++ b/tests/providers/ai_radio/test_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
 from contextlib import suppress
 from types import SimpleNamespace
 from typing import Any, cast
@@ -19,7 +20,7 @@ from music_assistant_models.enums import (
     QueueOption,
     TaskStatus,
 )
-from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.errors import InvalidCommand, MusicAssistantError
 from music_assistant_models.media_items import SoundEffect
 
 from music_assistant.helpers.datetime import now as host_now
@@ -794,6 +795,9 @@ async def test_run_dynamic_mode_has_watchdog_for_stalled_playback(
         def clear(self, queue_id: str) -> None:
             return None
 
+        async def set_shuffle(self, queue_id: str, shuffle_enabled: bool) -> None:
+            return None
+
         async def play_media(self, **kwargs: Any) -> None:
             return None
 
@@ -964,6 +968,9 @@ def _make_watchdog_runtime_classes() -> tuple[type, type]:
         def clear(self, queue_id: str) -> None:
             return None
 
+        async def set_shuffle(self, queue_id: str, shuffle_enabled: bool) -> None:
+            return None
+
         async def play_media(self, **kwargs: Any) -> None:
             return None
 
@@ -1044,16 +1051,26 @@ class RecordingPlayerQueues:
         """Initialize recorder around one fake queue object."""
         self.queue = queue
         self.clear_calls: list[str] = []
+        self.set_shuffle_calls: list[tuple[str, bool]] = []
         self.play_media_calls: list[tuple[Any, int]] = []
         self.play_index_calls: list[tuple[str, int]] = []
+        # combined call order across the methods below, for ordering assertions
+        self.call_order: list[str] = []
 
     def clear(self, queue_id: str) -> None:
         """Record a queue clear call."""
         self.clear_calls.append(queue_id)
+        self.call_order.append("clear")
+
+    async def set_shuffle(self, queue_id: str, shuffle_enabled: bool) -> None:
+        """Record a set_shuffle call."""
+        self.set_shuffle_calls.append((queue_id, shuffle_enabled))
+        self.call_order.append("set_shuffle")
 
     async def play_media(self, **kwargs: Any) -> None:
         """Record a play_media call with the poll count at call time."""
         self.play_media_calls.append((kwargs.get("option"), self.queue.polls))
+        self.call_order.append("play_media")
 
     async def play_index(self, queue_id: str, index: int) -> None:
         """Record a play_index call and mark the queue as started."""
@@ -1210,6 +1227,10 @@ async def test_dynamic_mode_targets_active_group_queue(
         def clear(self, queue_id: str) -> None:
             """Record a queue clear call."""
             self.clear_calls.append(queue_id)
+
+        async def set_shuffle(self, queue_id: str, shuffle_enabled: bool) -> None:
+            """No-op shuffle toggle for the group queue."""
+            return
 
         async def play_media(self, **kwargs: Any) -> None:
             """Record the queue targeted by a play_media call."""
@@ -1370,3 +1391,162 @@ async def test_fetch_source_tracks_skips_tracks_with_no_resolvable_uri(caplog: A
     assert [track["item_id"] for track in tracks] == ["1", "3"]
     assert [track["index"] for track in tracks] == [0, 1]
     assert any("Track Two" in record.message for record in caplog.records)
+
+
+def test_apply_source_shuffle_returns_unchanged_when_disabled() -> None:
+    """Leave the source list untouched when the station does not request shuffling."""
+    runtime = DummyRuntime()
+    tracks = [{"index": 0, "uri": "a"}, {"index": 1, "uri": "b"}]
+    station = {"shuffle_source_tracks": False}
+
+    result = runtime._apply_source_shuffle(tracks, station)
+
+    assert result is tracks
+
+
+def test_apply_source_shuffle_reorders_and_records_source_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shuffle every track into a new order while keeping all of them and their origin."""
+    # capture the real class before patching it away: runtime.random is the same shared
+    # stdlib module object, so the lambda below would otherwise re-look-up itself
+    original_random_cls = random.Random
+    monkeypatch.setattr(
+        "music_assistant.providers.ai_radio.runtime.random.Random",
+        lambda: original_random_cls(1234),
+    )
+    runtime = DummyRuntime()
+    tracks = [{"uri": f"track/{i}"} for i in range(5)]
+    station = {"shuffle_source_tracks": True}
+
+    result = runtime._apply_source_shuffle(tracks, station)
+
+    assert [track["index"] for track in result] == list(range(len(tracks)))
+    assert {track["uri"] for track in result} == {track["uri"] for track in tracks}
+    for track in result:
+        assert tracks[track["source_index"]]["uri"] == track["uri"]
+    # a seeded shuffle must actually reorder, not silently pass through in place
+    assert [track["source_index"] for track in result] != list(range(len(tracks)))
+
+
+def test_apply_track_duration_limit_keeps_prefix_of_given_order() -> None:
+    """Truncate to the playtime cap by walking the given order, no shuffling."""
+    runtime = DummyRuntime()
+    tracks = [
+        {"uri": "a", "duration": 120},
+        {"uri": "b", "duration": 120},
+        {"uri": "c", "duration": 120},
+        {"uri": "d", "duration": 120},
+    ]
+    station = {"max_duration_minutes": 3}
+
+    result = runtime._apply_track_duration_limit(tracks, station)
+
+    assert [track["uri"] for track in result] == ["a", "b"]
+    assert [track["index"] for track in result] == [0, 1]
+    assert [track["source_index"] for track in result] == [0, 1]
+
+
+def test_apply_track_duration_limit_zero_cap_is_noop() -> None:
+    """A cap of 0 disables truncation entirely."""
+    runtime = DummyRuntime()
+    tracks = [{"uri": "a", "duration": 120}, {"uri": "b", "duration": 120}]
+    station = {"max_duration_minutes": 0}
+
+    result = runtime._apply_track_duration_limit(tracks, station)
+
+    assert result is tracks
+
+
+async def test_dynamic_mode_disables_shuffle_before_first_play_media(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Disable queue shuffle before the first batch is queued, so batches keep their order."""
+    monkeypatch.setattr(
+        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
+        0.2,
+    )
+    watchdog_runtime_cls, _ = _make_watchdog_runtime_classes()
+
+    class BusyQueue:
+        """Queue already playing 3 pre-existing items."""
+
+        polls = 0
+        items = 3
+        state = PlaybackState.PLAYING
+        started = False
+
+        @property
+        def current_index(self) -> int:
+            return 2 if self.polls < 4 else 4
+
+        @property
+        def elapsed_time(self) -> float:
+            return float(self.polls * 10)
+
+    class DummyPlayers:
+        def get_player(self, player_id: str) -> Any:
+            return object()
+
+    player_queues = RecordingPlayerQueues(BusyQueue())
+
+    class DummyMass:
+        def __init__(self) -> None:
+            self.players = DummyPlayers()
+            self.player_queues = player_queues
+
+    mass = DummyMass()
+    runtime = watchdog_runtime_cls()
+    _set_runtime_mass(runtime, mass)
+    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
+    runtime._sessions[session.session_id] = session
+
+    await asyncio.wait_for(runtime._run_dynamic_mode(session, _watchdog_station()), timeout=10.0)
+
+    assert player_queues.set_shuffle_calls == [("living_room", False)]
+    assert player_queues.call_order.index("set_shuffle") < player_queues.call_order.index(
+        "play_media"
+    )
+
+
+async def test_dynamic_mode_raises_when_set_shuffle_rejects_dynamic_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Translate a dynamic-mode queue's InvalidCommand into an actionable MusicAssistantError."""
+    monkeypatch.setattr(
+        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
+        0.2,
+    )
+    watchdog_runtime_cls, _ = _make_watchdog_runtime_classes()
+
+    class RaisingPlayerQueues(RecordingPlayerQueues):
+        """Player queues stub whose queue is stuck in dynamic (smart-mix) mode."""
+
+        async def set_shuffle(self, queue_id: str, shuffle_enabled: bool) -> None:
+            await super().set_shuffle(queue_id, shuffle_enabled)
+            raise InvalidCommand("Cannot change shuffle while the queue is in dynamic mode")
+
+    class DummyPlayers:
+        def get_player(self, player_id: str) -> Any:
+            return object()
+
+    class DummyQueue:
+        items = 0
+        state = PlaybackState.IDLE
+
+    player_queues = RaisingPlayerQueues(DummyQueue())
+
+    class DummyMass:
+        def __init__(self) -> None:
+            self.players = DummyPlayers()
+            self.player_queues = player_queues
+
+    mass = DummyMass()
+    runtime = watchdog_runtime_cls()
+    _set_runtime_mass(runtime, mass)
+    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
+    runtime._sessions[session.session_id] = session
+    station = {**_watchdog_station(), "clear_queue_on_start": True}
+
+    with pytest.raises(MusicAssistantError, match="dynamic mode"):
+        await runtime._run_dynamic_mode(session, station)


### PR DESCRIPTION
# What does this implement/fix?

Two things reported on the AI Radio beta.

**Segments end up in the wrong place when the queue has shuffle on.** A dynamic run pushes each batch in with `play_media`, and the queue controller shuffles the incoming batch — and on every `ADD` it also re-shuffles the whole un-played tail. So the intro lands in the middle, and a "the next track is…" segment ends up next to a track it was not written for. A run now switches shuffle off on its target queue before the first batch, and leaves it off. A queue in dynamic (smart-mix) mode cannot hold a fixed order at all — the managed pool rebuilds the tail and discards the segments — so that case fails with an actionable error instead of producing nonsense.

**Shuffling the source playlist was a side effect of the playtime cap.** The cap picked tracks at random until it was full and then sorted them back into playlist order, so it silently meant "random selection", and there was no way to shuffle a playlist without capping it. The two are separate now: a new "shuffle playlist tracks" station option (default on, matching what cap users effectively had) decides between playlist order and random order, and the cap only truncates whatever order it is given.

Both run before segment planning, so the "previous/next track" lines match the order that actually plays.

**Related issue (if applicable):**

- related issue n/a

**Companion frontend PR:** music-assistant/frontend#2227

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
