### PR TITLE
Map episode description in audiobookshelf provider

### DIFF
--- a/music_assistant/providers/audiobookshelf/parsers.py
+++ b/music_assistant/providers/audiobookshelf/parsers.py
@@ -242,6 +242,7 @@ def parse_podcast_episode(
     )
 
     mass_episode.metadata.release_date = release_date
+    mass_episode.metadata.description = episode.description
 
     # cover image
     if token is not None and cover_path:


### PR DESCRIPTION
# What does this implement/fix?

The audiobookshelf provider parses the show-level description into `metadata.description` for podcasts, but the episode-level parser (`parse_podcast_episode`) never maps the episode description. This means MA serves an empty `metadata.description` for podcast episodes even though ABS has the data in its API response.

This adds the one missing assignment, following the same pattern already used for the show-level parser and for `release_date` on the line immediately above.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.