### PR TITLE
Automatically re-join AirPlay group members after a brief connection loss

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -72,6 +72,14 @@ AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 2000
 AIRPLAY_START_LEAD_MS: Final[int] = 250
 AIRPLAY_GROUP_START_LEAD_MS: Final[int] = 500
 
+# Delay (seconds) before automatically re-joining a group member whose
+# cliairplay process died unexpectedly mid-session (e.g. the device rode out a
+# network blackout longer than the binary's own keepalive tolerance). A single
+# attempt keeps the behaviour predictable: it waits long enough for a short
+# blackout to clear, and if the device is still gone the player is left idle.
+# Staged retries can be reintroduced by adding entries to the tuple.
+AIRPLAY_REJOIN_ATTEMPT_DELAYS: Final[tuple[int, ...]] = (5,)
+
 # Cover art is rendered to a local JPEG for the binary to embed (the binary
 # does not fetch URLs). 512px keeps the SET_PARAMETER payload small while still
 # looking sharp on speaker apps and the Apple TV now-playing screen.

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -35,6 +35,7 @@ from .constants import (
     AIRPLAY_HIRES_SAMPLE_RATES,
     AIRPLAY_PCM_FORMAT,
     AIRPLAY_RAOP_SETUP_LEAD_MS,
+    AIRPLAY_REJOIN_ATTEMPT_DELAYS,
     BASE_PLAYER_FEATURES,
     CONF_AIRPLAY_CREDENTIALS,
     CONF_ENCRYPTION,
@@ -102,6 +103,7 @@ class AirPlayPlayer(Player):
         self.last_command_sent = 0.0
         self._lock = asyncio.Lock()
         self._transitioning = False  # Set during stream replacement to ignore stale DACP messages
+        self._rejoin_task: asyncio.Task[None] | None = None
         # Set (static) player attributes
         self._attr_name = display_name
         self._attr_available = True
@@ -284,6 +286,9 @@ class AirPlayPlayer(Player):
 
     async def stop(self) -> None:
         """Send STOP command to player."""
+        # an explicit stop (including power-off routed as stop) is user intent:
+        # drop any pending automatic re-join
+        self.cancel_group_rejoin()
         async with self._lock:
             if self.stream and self.stream.session:
                 # forward stop to the entire stream session
@@ -352,6 +357,9 @@ class AirPlayPlayer(Player):
 
     async def play_media(self, media: PlayerMedia) -> None:
         """Handle PLAY MEDIA on given player."""
+        # the player is being (re)purposed on purpose: drop any pending
+        # automatic re-join left over from an unexpected stream loss
+        self.cancel_group_rejoin()
         async with self._lock:
             if self.synced_to:
                 # this should not happen, but guard anyways
@@ -671,11 +679,44 @@ class AirPlayPlayer(Player):
     async def on_unload(self) -> None:
         """Handle logic when the player is unloaded from the Player controller."""
         await super().on_unload()
+        self.cancel_group_rejoin()
         if self.stream:
             # remove this player from the stream session if it is running
             if self.stream.running and self.stream.session:
                 await self.stream.session.remove_client(self, reason="player unloaded")
             self.stream = None
+
+    def schedule_group_rejoin(self, candidate_ids: list[str]) -> None:
+        """
+        Schedule a bounded automatic re-join of this player to its still-active group.
+
+        Used when this player's stream process died unexpectedly while it was part
+        of a playing sync group (e.g. the device rode out a network blackout): the
+        player is re-added to the group's live session through the regular
+        late-join path after a short backoff. Any user action on the player (or it
+        joining a session by other means) cancels the re-join; when the group is
+        no longer playing, its membership was changed meanwhile or the device is
+        offline, the re-join is abandoned and the player simply stays idle.
+
+        :param candidate_ids: Player ids that led or shared the group at the
+            moment the stream was lost, used to resolve the re-join target (the
+            leadership may transfer while the backoff runs).
+        """
+        self.cancel_group_rejoin()
+        self.logger.info(
+            "Scheduling automatic re-join of %s to its group after unexpected stream loss",
+            self.display_name,
+        )
+        self._rejoin_task = self.mass.create_task(self._group_rejoin_attempts(candidate_ids))
+
+    def cancel_group_rejoin(self) -> None:
+        """Cancel any pending automatic group re-join attempts for this player."""
+        rejoin_task = self._rejoin_task
+        self._rejoin_task = None
+        # never self-cancel: the re-join attempt itself flows through the same
+        # session (re)start paths that call this to clear stale schedules
+        if rejoin_task and not rejoin_task.done() and rejoin_task is not asyncio.current_task():
+            rejoin_task.cancel()
 
     @property
     def _has_native_protocol_parent(self) -> bool:
@@ -960,6 +1001,125 @@ class AirPlayPlayer(Player):
             if client := cast("AirPlayPlayer | None", self.mass.players.get_player(child_id)):
                 sync_clients.append(client)
         return sync_clients
+
+    async def _group_rejoin_attempts(self, candidate_ids: list[str]) -> None:
+        """Re-join this player to its group's live session after a bounded backoff."""
+        max_attempts = len(AIRPLAY_REJOIN_ATTEMPT_DELAYS)
+        for attempt, delay in enumerate(AIRPLAY_REJOIN_ATTEMPT_DELAYS, start=1):
+            await asyncio.sleep(delay)
+            if (
+                self.group_members
+                or (self.stream and self.stream.running)
+                or self.playback_state != PlaybackState.IDLE
+                # synced into a group outside the original one = deliberate regroup.
+                # Still pointing at an original candidate is fine: a static group
+                # keeps the sync membership while only the session lost this player.
+                or (self.synced_to and self.synced_to not in candidate_ids)
+            ):
+                # the player was grouped or repurposed by other means meanwhile
+                self.logger.debug(
+                    "Automatic group re-join for %s cancelled: player is active again",
+                    self.display_name,
+                )
+                return
+            if not self.available:
+                # the device is offline: an attempt cannot succeed and the user
+                # may well have switched it off on purpose
+                self.logger.debug(
+                    "Automatic group re-join for %s cancelled: player is unavailable",
+                    self.display_name,
+                )
+                return
+            target = self._resolve_rejoin_target(candidate_ids)
+            if target is None:
+                # the group may be between sessions (e.g. a track change); keep
+                # trying until the attempts run out
+                self.logger.debug(
+                    "Automatic group re-join attempt %d/%d for %s: no playing group found",
+                    attempt,
+                    max_attempts,
+                    self.display_name,
+                )
+                continue
+            # When the sync membership survived the stream loss (a static group,
+            # where membership is configuration), only the running session needs
+            # healing; a group command would no-op on the existing membership.
+            heal_session = (
+                target.stream.session
+                if self.player_id in target.group_members and target.stream is not None
+                else None
+            )
+            try:
+                if heal_session is not None:
+                    await heal_session.add_client(self)
+                else:
+                    await self.mass.players.cmd_group(self.player_id, target.player_id)
+            except Exception as err:
+                self.logger.warning(
+                    "Automatic re-join of %s to group of %s failed (attempt %d/%d): %s",
+                    self.display_name,
+                    target.display_name,
+                    attempt,
+                    max_attempts,
+                    err,
+                )
+                continue
+            # A failed late-join is swallowed inside the grouping path (the player
+            # then holds group membership without a live stream), so verify the
+            # session actually carries this player before declaring success.
+            if (
+                self.stream
+                and self.stream.running
+                and self.stream.session
+                and self in self.stream.session.sync_clients
+            ):
+                self.logger.info(
+                    "Automatically re-joined %s to the group of %s after stream loss",
+                    self.display_name,
+                    target.display_name,
+                )
+                return
+            self.logger.warning(
+                "Automatic re-join of %s did not produce a running stream (attempt %d/%d)",
+                self.display_name,
+                attempt,
+                max_attempts,
+            )
+            if heal_session is None:
+                # undo the group membership this attempt created so a retry (or
+                # a manual regroup) starts from a clean join
+                await self.mass.players.cmd_ungroup(self.player_id)
+        self.logger.warning(
+            "Giving up on automatic group re-join for %s after %d attempt(s); "
+            "the player stays idle",
+            self.display_name,
+            max_attempts,
+        )
+
+    def _resolve_rejoin_target(self, candidate_ids: list[str]) -> AirPlayPlayer | None:
+        """Resolve which player now carries the group's actively playing session."""
+        for candidate_id in candidate_ids:
+            candidate = self.mass.players.get_player(candidate_id)
+            if candidate is None or candidate is self:
+                continue
+            if not isinstance(candidate, AirPlayPlayer):
+                continue
+            if candidate.synced_to:
+                # the candidate was absorbed into another group since the loss
+                # (user intent): never follow the old group's players elsewhere.
+                # A leadership transfer inside the original group is still found:
+                # the promoted member is itself one of the candidates.
+                continue
+            if not candidate.available:
+                continue
+            # only a PLAYING session can absorb a late joiner: a parked (paused)
+            # session has no live timeline to anchor against
+            if candidate.playback_state != PlaybackState.PLAYING:
+                continue
+            if not (candidate.stream and candidate.stream.running and candidate.stream.session):
+                continue
+            return candidate
+        return None
 
 
 class GenericAirPlayPlayer(AirPlayPlayer):

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -795,7 +795,9 @@ class AirPlayStream:
                     # unjoining a static member as releasing the whole group (HA unjoin
                     # semantics), which would silence every room over one dead transport.
                     # Its membership is configuration; drop only this member from the
-                    # leader's live session instead.
+                    # leader's live session instead. The set_members call cannot bounce
+                    # back to the group player: the controller only redirects it when
+                    # the group advertises SET_MEMBERS, which a static group never does.
                     static_member_of = self._static_group_membership(player)
                     if static_member_of and player.synced_to:
                         self.mass.create_task(

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -765,6 +765,25 @@ class AirPlayStream:
                     logger.warning(
                         "cliairplay process stopped unexpectedly for %s", player.display_name
                     )
+                    # Candidates for the automatic re-join: the leader this member
+                    # was synced to (plus its other members, in case leadership
+                    # transfers while the backoff runs), or - when this was the
+                    # leader itself - the members that survive it. Captured before
+                    # the ungroup below mutates the group state (create_task
+                    # starts eagerly).
+                    was_leader = bool(player.group_members)
+                    if player.synced_to:
+                        rejoin_candidates = [player.synced_to]
+                        if leader := self.mass.players.get_player(player.synced_to):
+                            rejoin_candidates += [
+                                member_id
+                                for member_id in leader.group_members
+                                if member_id not in (player.player_id, player.synced_to)
+                            ]
+                    else:
+                        rejoin_candidates = [
+                            m for m in player.group_members if m != player.player_id
+                        ]
                     # Hand off to the player controller so it drops just this member, or
                     # transfers leadership to a healthy member, instead of dissolving the
                     # whole group over a single dead transport. A sync leader is left in
@@ -772,7 +791,11 @@ class AirPlayStream:
                     # leadership while the queue still looks active, and transfer_queue or
                     # dissolve sets the final state.
                     self.mass.create_task(self.mass.players.cmd_ungroup(player.player_id))
-                    if player.group_members:
+                    if rejoin_candidates:
+                        # the group (or its successor) may still be playing:
+                        # schedule bounded attempts to re-join it
+                        player.schedule_group_rejoin(rejoin_candidates)
+                    if was_leader:
                         return
                 player.set_state_from_stream(state=PlaybackState.IDLE, elapsed_time=0, stream=self)
             finally:

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -790,7 +790,21 @@ class AirPlayStream:
                     # its current state here on purpose: the controller only transfers
                     # leadership while the queue still looks active, and transfer_queue or
                     # dissolve sets the final state.
-                    self.mass.create_task(self.mass.players.cmd_ungroup(player.player_id))
+                    # One exception: a member that is a STATIC member of an active group
+                    # player must not go through cmd_ungroup - the controller interprets
+                    # unjoining a static member as releasing the whole group (HA unjoin
+                    # semantics), which would silence every room over one dead transport.
+                    # Its membership is configuration; drop only this member from the
+                    # leader's live session instead.
+                    static_member_of = self._static_group_membership(player)
+                    if static_member_of and player.synced_to:
+                        self.mass.create_task(
+                            self.mass.players.cmd_set_members(
+                                player.synced_to, player_ids_to_remove=[player.player_id]
+                            )
+                        )
+                    else:
+                        self.mass.create_task(self.mass.players.cmd_ungroup(player.player_id))
                     if rejoin_candidates:
                         # the group (or its successor) may still be playing:
                         # schedule bounded attempts to re-join it
@@ -800,6 +814,16 @@ class AirPlayStream:
                 player.set_state_from_stream(state=PlaybackState.IDLE, elapsed_time=0, stream=self)
             finally:
                 await self.commands_pipe.remove()
+
+    def _static_group_membership(self, player: AirPlayPlayer) -> str | None:
+        """Return the active group player id the player is a static member of, if any."""
+        active_group_id = player.state.active_group
+        if not active_group_id:
+            return None
+        group_player = self.mass.players.get_player(active_group_id)
+        if group_player and player.player_id in group_player.static_group_members:
+            return active_group_id
+        return None
 
     def _handle_status_line(self, line: str) -> bool:
         """Dispatch one cliairplay status line; True ends the stderr loop."""

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -693,6 +693,8 @@ class AirPlayStreamSession:
         :param use_shared_ptp: The session-wide shared-PTP decision applied to
             this member so the whole group shares one timing source.
         """
+        # joining a session supersedes any pending automatic group re-join
+        airplay_player.cancel_group_rejoin()
         # sync volume from parent player if needed
         airplay_player.sync_volume_level()
         if airplay_player.stream and airplay_player.stream.running:

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -1,5 +1,6 @@
 """Unit tests for AirPlay player."""
 
+import asyncio
 import time
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
@@ -11,6 +12,7 @@ from music_assistant_models.enums import (
     ContentType,
     CrossfadeMode,
     MediaType,
+    PlaybackState,
     PlayerFeature,
     VolumeNormalizationMode,
 )
@@ -862,3 +864,346 @@ async def test_synced_child_pause_parks_session(airplay_player: AirPlayPlayer) -
     session.standby.assert_awaited_once()
     mock_stop.assert_not_called()
     send_cmd.assert_not_called()
+
+
+# --- Automatic group re-join after unexpected stream loss ---
+
+
+def _make_idle_player(player_id: str = "test_player") -> AirPlayPlayer:
+    """Create an idle, ungrouped AirPlayPlayer wired for the re-join tests."""
+    player = AirPlayPlayer(
+        provider=MagicMock(),
+        player_id=player_id,
+        display_name=f"Player {player_id}",
+        address="127.0.0.1",
+        manufacturer="Test Manufacturer",
+        model="Test Model",
+        raop_discovery_info=None,
+        airplay_discovery_info=None,
+    )
+    # the synced_to property scans all players of the provider
+    _players_mock(player).all_players.return_value = []
+    player._attr_group_members = []
+    player._attr_playback_state = PlaybackState.IDLE
+    player.stream = None
+    return player
+
+
+def _make_playing_leader(player_id: str = "leader") -> AirPlayPlayer:
+    """Create an AirPlayPlayer that looks like the playing leader of a live session."""
+    leader = _make_idle_player(player_id)
+    leader._attr_playback_state = PlaybackState.PLAYING
+    stream = MagicMock()
+    stream.running = True
+    stream.session = MagicMock()
+    leader.stream = stream
+    return leader
+
+
+def _players_mock(player: AirPlayPlayer) -> MagicMock:
+    """Return the mocked players controller of the given player."""
+    return cast("MagicMock", player.mass.players)
+
+
+def _attach_running_session(player: AirPlayPlayer, sync_clients: list[AirPlayPlayer]) -> None:
+    """Attach a mock running stream whose session carries the given members."""
+    stream = MagicMock()
+    stream.running = True
+    stream.session = MagicMock()
+    stream.session.sync_clients = sync_clients
+    player.stream = stream
+
+
+_NO_DELAYS = "music_assistant.providers.airplay.player.AIRPLAY_REJOIN_ATTEMPT_DELAYS"
+
+
+@pytest.mark.asyncio
+async def test_rejoin_succeeds_on_first_attempt() -> None:
+    """A re-join attempt joins the player back to the playing leader's session."""
+    player = _make_idle_player()
+    leader = _make_playing_leader()
+    players_mock = _players_mock(player)
+    players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
+
+    async def cmd_group(player_id: str, target_id: str) -> None:
+        assert player_id == player.player_id
+        assert target_id == leader.player_id
+        _attach_running_session(player, [leader, player])
+
+    players_mock.cmd_group = AsyncMock(side_effect=cmd_group)
+    players_mock.cmd_ungroup = AsyncMock()
+
+    with patch(_NO_DELAYS, (0, 0, 0)):
+        await player._group_rejoin_attempts(["leader"])
+
+    assert players_mock.cmd_group.await_count == 1
+    players_mock.cmd_ungroup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rejoin_retries_after_failure_then_succeeds() -> None:
+    """A failed attempt (device still unreachable) is retried with backoff."""
+    player = _make_idle_player()
+    leader = _make_playing_leader()
+    players_mock = _players_mock(player)
+    players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
+    attempts: list[int] = []
+
+    async def cmd_group(_player_id: str, _target_id: str) -> None:
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise PlayerCommandFailed("device unreachable")
+        _attach_running_session(player, [leader, player])
+
+    players_mock.cmd_group = AsyncMock(side_effect=cmd_group)
+
+    with patch(_NO_DELAYS, (0, 0, 0)):
+        await player._group_rejoin_attempts(["leader"])
+
+    assert len(attempts) == 2
+
+
+@pytest.mark.asyncio
+async def test_rejoin_gives_up_after_all_attempts() -> None:
+    """Without a playing group to re-join, the attempts run out and stop cleanly."""
+    player = _make_idle_player()
+    players_mock = _players_mock(player)
+    players_mock.get_player.return_value = None
+    players_mock.cmd_group = AsyncMock()
+
+    with patch(_NO_DELAYS, (0, 0, 0)):
+        await player._group_rejoin_attempts(["leader"])
+
+    players_mock.cmd_group.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rejoin_aborts_when_player_used_meanwhile() -> None:
+    """A player that was grouped or repurposed meanwhile is left alone."""
+    player = _make_idle_player()
+    leader = _make_playing_leader()
+    players_mock = _players_mock(player)
+    players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
+    players_mock.cmd_group = AsyncMock()
+    # the user started something else on the player during the backoff
+    stream = MagicMock()
+    stream.running = True
+    player.stream = stream
+
+    with patch(_NO_DELAYS, (0, 0, 0)):
+        await player._group_rejoin_attempts(["leader"])
+
+    players_mock.cmd_group.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rejoin_undoes_dangling_membership() -> None:
+    """A join that yields no running stream is rolled back before the next attempt."""
+    player = _make_idle_player()
+    leader = _make_playing_leader()
+    players_mock = _players_mock(player)
+    players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
+    # cmd_group "succeeds" but the late-join failed internally: no stream appears
+    players_mock.cmd_group = AsyncMock()
+    players_mock.cmd_ungroup = AsyncMock()
+
+    with patch(_NO_DELAYS, (0, 0, 0)):
+        await player._group_rejoin_attempts(["leader"])
+
+    # every attempt rolled its dangling membership back
+    assert players_mock.cmd_group.await_count == 3
+    assert players_mock.cmd_ungroup.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_rejoin_cancelled_when_player_unavailable() -> None:
+    """An offline player abandons the re-join right away instead of attempting."""
+    player = _make_idle_player()
+    leader = _make_playing_leader()
+    players_mock = _players_mock(player)
+    players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
+    players_mock.cmd_group = AsyncMock()
+    player._attr_available = False
+
+    # the later long delays prove the loop returns on the first pass
+    with patch(_NO_DELAYS, (0, 60, 60)):
+        await asyncio.wait_for(player._group_rejoin_attempts(["leader"]), timeout=5)
+
+    players_mock.cmd_group.assert_not_awaited()
+    players_mock.get_player.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rejoin_aborts_when_synced_into_foreign_group() -> None:
+    """A player the user grouped elsewhere meanwhile is left alone."""
+    player = _make_idle_player()
+    leader = _make_playing_leader()
+    foreign_leader = MagicMock()
+    foreign_leader.player_id = "other"
+    foreign_leader.group_members = ["other", player.player_id]
+    # the player reports it is now synced to a leader outside the original group
+    _players_mock(player).all_players.return_value = [foreign_leader]
+    players_mock = _players_mock(player)
+    players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
+    players_mock.cmd_group = AsyncMock()
+
+    with patch(_NO_DELAYS, (0, 60, 60)):
+        await asyncio.wait_for(player._group_rejoin_attempts(["leader"]), timeout=5)
+
+    players_mock.cmd_group.assert_not_awaited()
+
+
+def test_resolve_rejoin_target_finds_promoted_sibling() -> None:
+    """When the old leader is gone, a promoted (now leading) sibling is the target."""
+    player = _make_idle_player()
+    sibling = _make_playing_leader("sibling")
+    sibling._attr_group_members = ["sibling", "other_member"]
+    _players_mock(player).get_player.side_effect = lambda player_id: {"sibling": sibling}.get(
+        player_id
+    )
+
+    assert player._resolve_rejoin_target(["old_leader", "sibling"]) is sibling
+
+
+def test_resolve_rejoin_target_skips_candidate_in_foreign_group() -> None:
+    """A candidate absorbed into another group is never followed there."""
+    player = _make_idle_player()
+    foreign_leader = _make_playing_leader("foreign")
+    foreign_leader._attr_group_members = ["foreign", "old_leader"]
+    old_leader = _make_playing_leader("old_leader")
+    # the old leader reports it is now synced to the foreign leader
+    _players_mock(old_leader).all_players.return_value = [foreign_leader]
+    _players_mock(player).get_player.side_effect = lambda player_id: {
+        "old_leader": old_leader,
+        "foreign": foreign_leader,
+    }.get(player_id)
+
+    assert player._resolve_rejoin_target(["old_leader"]) is None
+
+
+@pytest.mark.parametrize(
+    ("playback_state", "stream_running", "available", "expected"),
+    [
+        (PlaybackState.PLAYING, True, True, True),
+        # a parked (paused) session has no live timeline to late-join
+        (PlaybackState.PAUSED, True, True, False),
+        (PlaybackState.IDLE, False, True, False),
+        # target device itself dropped off the network
+        (PlaybackState.PLAYING, True, False, False),
+    ],
+)
+def test_resolve_rejoin_target_requires_playing_session(
+    playback_state: PlaybackState, stream_running: bool, available: bool, expected: bool
+) -> None:
+    """Only an available target with an actively playing session is accepted."""
+    player = _make_idle_player()
+    leader = _make_playing_leader()
+    leader._attr_playback_state = playback_state
+    cast("MagicMock", leader.stream).running = stream_running
+    leader._attr_available = available
+    _players_mock(player).get_player.side_effect = lambda player_id: {"leader": leader}.get(
+        player_id
+    )
+
+    target = player._resolve_rejoin_target(["leader"])
+    assert (target is leader) is expected
+
+
+@pytest.mark.asyncio
+async def test_rejoin_heals_session_when_membership_survived() -> None:
+    """A player still holding sync membership (static group) heals the session only."""
+    player = _make_idle_player()
+    leader = _make_playing_leader()
+    # the sync membership survived the stream loss: the player is still listed
+    # as a member of (and synced to) the leader
+    leader._attr_group_members = ["leader", player.player_id]
+    _players_mock(player).all_players.return_value = [leader]
+    players_mock = _players_mock(player)
+    players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
+    players_mock.cmd_group = AsyncMock()
+    players_mock.cmd_ungroup = AsyncMock()
+    session = cast("MagicMock", leader.stream).session
+
+    async def add_client(joiner: AirPlayPlayer) -> None:
+        assert joiner is player
+        _attach_running_session(player, [leader, player])
+
+    session.add_client = AsyncMock(side_effect=add_client)
+
+    with patch(_NO_DELAYS, (0,)):
+        await player._group_rejoin_attempts(["leader"])
+
+    session.add_client.assert_awaited_once()
+    players_mock.cmd_group.assert_not_awaited()
+    players_mock.cmd_ungroup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rejoin_session_heal_failure_keeps_membership() -> None:
+    """A failed session heal never touches the (configured) group membership."""
+    player = _make_idle_player()
+    leader = _make_playing_leader()
+    leader._attr_group_members = ["leader", player.player_id]
+    _players_mock(player).all_players.return_value = [leader]
+    players_mock = _players_mock(player)
+    players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
+    players_mock.cmd_group = AsyncMock()
+    players_mock.cmd_ungroup = AsyncMock()
+    session = cast("MagicMock", leader.stream).session
+    # the late-join fails internally: no stream appears on the player
+    session.add_client = AsyncMock()
+
+    with patch(_NO_DELAYS, (0,)):
+        await player._group_rejoin_attempts(["leader"])
+
+    session.add_client.assert_awaited_once()
+    players_mock.cmd_ungroup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_schedule_and_cancel_group_rejoin() -> None:
+    """Scheduling replaces a pending task and cancelling stops it."""
+    player = _make_idle_player()
+    _players_mock(player).get_player.return_value = None
+    cast("MagicMock", player.mass).create_task = lambda coro: (
+        asyncio.get_running_loop().create_task(coro)
+    )
+
+    with patch(_NO_DELAYS, (60, 60, 60)):
+        player.schedule_group_rejoin(["leader"])
+        first_task = player._rejoin_task
+        assert first_task is not None
+        # a second death replaces the pending schedule
+        player.schedule_group_rejoin(["leader"])
+        second_task = player._rejoin_task
+        assert second_task is not None
+        assert second_task is not first_task
+        await asyncio.sleep(0)
+        assert first_task.cancelled()
+        # any deliberate use of the player cancels the pending re-join
+        player.cancel_group_rejoin()
+        assert player._rejoin_task is None
+        await asyncio.sleep(0)
+        assert second_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_pending_rejoin() -> None:
+    """An explicit stop command on the player drops the pending re-join."""
+    player = _make_idle_player()
+    _players_mock(player).get_player.return_value = None
+    cast("MagicMock", player.mass).create_task = lambda coro: (
+        asyncio.get_running_loop().create_task(coro)
+    )
+
+    with (
+        patch(_NO_DELAYS, (60,)),
+        patch.object(AirPlayPlayer, "update_state"),
+    ):
+        player.schedule_group_rejoin(["leader"])
+        rejoin_task = player._rejoin_task
+        assert rejoin_task is not None
+        await player.stop()
+        assert player._rejoin_task is None
+        await asyncio.sleep(0)
+        assert rejoin_task.cancelled()

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -1232,6 +1232,73 @@ async def test_process_eof_cleans_up_command_pipe() -> None:
 
     assert stream._stopped is True
     remove_pipe.assert_awaited_once()
+    player.schedule_group_rejoin.assert_not_called()
+
+
+async def _run_unexpected_process_death(player: MagicMock) -> AirPlayStream:
+    """Drive the stderr reader through an unexpected process exit."""
+    stream = AirPlayStream(player)
+    process = MagicMock()
+    stream._cli_proc = process
+
+    async def _stderr_lines() -> AsyncGenerator[str]:
+        yield "some final log line"
+
+    with (
+        patch.object(process, "iter_stderr", return_value=_stderr_lines()),
+        patch.object(stream.commands_pipe, "remove", new_callable=AsyncMock),
+    ):
+        await stream._stderr_reader()
+    return stream
+
+
+@pytest.mark.asyncio
+async def test_unexpected_death_of_synced_child_schedules_rejoin() -> None:
+    """A grouped member whose process dies unexpectedly gets a re-join scheduled."""
+    player = _make_player()
+    player.synced_to = "leader"
+    player.group_members = []
+    # the leader's other members are captured as fallback candidates in case
+    # leadership transfers while the re-join backoff runs
+    leader = MagicMock()
+    leader.group_members = ["leader", player.player_id, "sibling"]
+    player.provider.mass.players.get_player.return_value = leader
+
+    stream = await _run_unexpected_process_death(player)
+
+    player.schedule_group_rejoin.assert_called_once_with(["leader", "sibling"])
+    player.set_state_from_stream.assert_called_once_with(
+        state=PlaybackState.IDLE, elapsed_time=0, stream=stream
+    )
+
+
+@pytest.mark.asyncio
+async def test_unexpected_death_of_leader_schedules_rejoin_to_members() -> None:
+    """A dying leader re-joins towards its surviving members (leadership transfers)."""
+    player = _make_player()
+    player.synced_to = None
+    player.group_members = [player.player_id, "child1", "child2"]
+
+    await _run_unexpected_process_death(player)
+
+    player.schedule_group_rejoin.assert_called_once_with(["child1", "child2"])
+    # the controller sets the leader's final state (transfer or dissolve)
+    player.set_state_from_stream.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_death_of_solo_player_schedules_no_rejoin() -> None:
+    """An ungrouped player's process death only marks the player idle."""
+    player = _make_player()
+    player.synced_to = None
+    player.group_members = []
+
+    stream = await _run_unexpected_process_death(player)
+
+    player.schedule_group_rejoin.assert_not_called()
+    player.set_state_from_stream.assert_called_once_with(
+        state=PlaybackState.IDLE, elapsed_time=0, stream=stream
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -41,6 +41,7 @@ def _make_player() -> MagicMock:
     player.device_info.ip_address = "192.168.1.50"
     player.logger = logging.getLogger("test.airplay.player")
     player.config.get_value = MagicMock(side_effect=lambda _key, default=None: default)
+    player.state.active_group = None
 
     airplay_info = MagicMock()
     airplay_info.port = 7000
@@ -1299,6 +1300,34 @@ async def test_unexpected_death_of_solo_player_schedules_no_rejoin() -> None:
     player.set_state_from_stream.assert_called_once_with(
         state=PlaybackState.IDLE, elapsed_time=0, stream=stream
     )
+
+
+@pytest.mark.asyncio
+async def test_unexpected_death_of_static_group_member_drops_member_only() -> None:
+    """A static group member's death drops just that member, never the whole group."""
+    player = _make_player()
+    player.synced_to = "leader"
+    player.group_members = []
+    # the player is a static member of an actively playing group player, for
+    # which cmd_ungroup would release (stop) the WHOLE group
+    player.state.active_group = "syncgroup1"
+    group_player = MagicMock()
+    group_player.static_group_members = ["leader", player.player_id]
+    leader = MagicMock()
+    leader.group_members = ["leader", player.player_id]
+    player.provider.mass.players.get_player.side_effect = lambda player_id: {
+        "syncgroup1": group_player,
+        "leader": leader,
+    }.get(player_id)
+
+    await _run_unexpected_process_death(player)
+
+    players_controller = player.provider.mass.players
+    players_controller.cmd_set_members.assert_called_once_with(
+        "leader", player_ids_to_remove=[player.player_id]
+    )
+    players_controller.cmd_ungroup.assert_not_called()
+    player.schedule_group_rejoin.assert_called_once_with(["leader"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

When a grouped AirPlay speaker suffered a brief network hiccup (a wifi roam, a few seconds of dropout), its stream process could die and the speaker was silently removed from the group until the user re-added it by hand. For a member of a static group this could even stop playback in every room.

- When a grouped member's stream dies unexpectedly, the server now automatically re-joins it to the still playing group after a short delay, using the regular late-join path so it comes back in sync.
- The re-join is skipped or cancelled when the user meanwhile stopped, re-grouped or repurposed the player, when the device is offline, or when the group is no longer playing — the player then simply stays idle.
- A static group member is now dropped from the running session only, so the rest of the group keeps playing (previously one dead member could stop the whole group).

Pairs with music-assistant/airplay-cli#22, which makes the player process itself ride out short dropouts so most hiccups never even reach this path.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
