### PR TITLE
Don't render announcements twice when a player sends a HEAD request

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1079,8 +1079,7 @@ class StreamsController(CoreController):
         """Stream announcement audio to a player."""
         self._log_request(request)
         player_id = request.match_info["player_id"]
-        player = self.mass.player_queues.get(player_id)
-        if not player:
+        if not (player := self.mass.players.get_player(player_id)):
             raise web.HTTPNotFound(reason=f"Unknown Player: {player_id}")
         if not (announce_data := self.announcements.get(player_id)):
             raise web.HTTPNotFound(reason=f"No pending announcements for Player: {player_id}")
@@ -1090,6 +1089,19 @@ class StreamsController(CoreController):
         audio_format = AudioFormat(content_type=ContentType.try_parse(fmt))
 
         http_profile = self._get_announcement_http_profile(player_id, announce_data)
+
+        # return early if this is not a GET request:
+        # players often probe the url with a HEAD request before fetching it and
+        # rendering the announcement for such a probe would run the entire (costly)
+        # TTS/ffmpeg chain twice for a single announcement.
+        if request.method != "GET":
+            resp = web.StreamResponse(status=200, reason="OK", headers=DEFAULT_STREAM_HEADERS)
+            resp.content_type = get_mime_type(audio_format.output_format_str)
+            if http_profile == "chunked":
+                resp.enable_chunked_encoding()
+            await resp.prepare(request)
+            return resp
+
         if http_profile == "forced_content_length":
             # given the fact that an announcement is just a short audio clip,
             # just send it over completely at once so we have a fixed content length
@@ -1119,15 +1131,11 @@ class StreamsController(CoreController):
 
         await resp.prepare(request)
 
-        # return early if this is not a GET request
-        if request.method != "GET":
-            return resp
-
         # all checks passed, start streaming!
         self.logger.debug(
             "Start serving audio stream for Announcement %s to %s",
             announce_data["announcement_url"],
-            player.state.name,
+            player.display_name,
         )
         announcement_stream = self.get_announcement_stream(
             announcement_url=announce_data["announcement_url"],
@@ -1149,7 +1157,7 @@ class StreamsController(CoreController):
         self.logger.debug(
             "Finished serving audio stream for Announcement %s to %s",
             announce_data["announcement_url"],
-            player.state.name,
+            player.display_name,
         )
 
         return resp

--- a/tests/controllers/streams/test_announcement_stream.py
+++ b/tests/controllers/streams/test_announcement_stream.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncGenerator
+import logging
+from collections.abc import AsyncGenerator, Iterator
 from contextlib import aclosing
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 
@@ -107,3 +110,102 @@ def test_announcement_http_profile_prefers_fetching_player() -> None:
     # unknown player resolves to the safe default
     profile = controller._get_announcement_http_profile("unknown", _announce_data(None))
     assert profile == "default"
+
+
+ANNOUNCEMENT_AUDIO = b"announcement-audio"
+
+
+def _fake_announcement_stream(*_args: Any, **_kwargs: Any) -> AsyncGenerator[bytes]:
+    async def _stream() -> AsyncGenerator[bytes]:
+        yield ANNOUNCEMENT_AUDIO
+
+    return _stream()
+
+
+@pytest.fixture(name="render_mock")
+def render_mock_fixture() -> Iterator[MagicMock]:
+    """Replace the announcement render chain with a stub that yields a single chunk."""
+    with patch.object(
+        StreamsController, "get_announcement_stream", side_effect=_fake_announcement_stream
+    ) as mocked:
+        yield mocked
+
+
+def _announcement_controller(http_profile: str) -> tuple[StreamsController, MagicMock]:
+    """Build a controller serving one pending announcement for player 'player1'."""
+    controller = StreamsController.__new__(StreamsController)
+    controller.mass = mass = MagicMock()
+    controller.logger = logging.getLogger("test.streams.announcement")
+    controller.announcements = {"player1": _announce_data(None)}
+    player = MagicMock()
+    player.display_name = "Player A"
+    player.get_output_config_value.return_value = http_profile
+    mass.players.get_player = MagicMock(
+        side_effect=lambda pid, *_args, **_kwargs: player if pid == "player1" else None
+    )
+    # no queue is registered for this player: announcements must be served regardless
+    mass.player_queues.get = MagicMock(return_value=None)
+    return controller, mass
+
+
+def _mocked_request(method: str, player_id: str = "player1") -> web.Request:
+    return make_mocked_request(
+        method,
+        f"/announcement/{player_id}.mp3",
+        match_info={"player_id": player_id, "fmt": "mp3"},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("http_profile", ["forced_content_length", "chunked", "default"])
+async def test_head_request_does_not_render_announcement(
+    render_mock: MagicMock, http_profile: str
+) -> None:
+    """A HEAD probe answers with headers only, without running the render chain."""
+    controller, _ = _announcement_controller(http_profile)
+
+    resp = await controller.serve_announcement_stream(_mocked_request("HEAD"))
+
+    assert resp.status == 200
+    assert resp.content_type == "audio/mpeg"
+    render_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_request_renders_announcement_once(render_mock: MagicMock) -> None:
+    """A GET on the forced_content_length profile renders the announcement exactly once."""
+    controller, _ = _announcement_controller("forced_content_length")
+
+    resp = await controller.serve_announcement_stream(_mocked_request("GET"))
+
+    assert isinstance(resp, web.Response)
+    assert resp.body == ANNOUNCEMENT_AUDIO
+    render_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_announcement_served_to_player_without_queue(
+    render_mock: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The stream resolves the player itself, so a player without a queue is still served."""
+    controller, mass = _announcement_controller("default")
+
+    with caplog.at_level(logging.DEBUG, logger="test.streams.announcement"):
+        resp = await controller.serve_announcement_stream(_mocked_request("GET"))
+
+    assert resp.status == 200
+    mass.player_queues.get.assert_not_called()
+    render_mock.assert_called_once()
+    # the player is logged by name, not by its playback state
+    assert "Player A" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_unknown_player_raises_not_found(render_mock: MagicMock) -> None:
+    """An announcement request for an unknown player is rejected."""
+    controller, _ = _announcement_controller("default")
+
+    with pytest.raises(web.HTTPNotFound):
+        await controller.serve_announcement_stream(_mocked_request("GET", player_id="ghost"))
+
+    render_mock.assert_not_called()


### PR DESCRIPTION
The announcement route is registered for all HTTP methods, but the "return early if this is not a GET request" check sat *below* the `forced_content_length` branch. Players that probe the url with a HEAD request before fetching it therefore ran the entire announcement through the TTS/ffmpeg chain, buffered it and threw it away — and then rendered it all over again on the follow-up GET. Moved the method check above both branches so a HEAD probe only gets the headers back.

While in there: the handler resolved the player through `player_queues.get()`, which returns a `PlayerQueue`. That made the endpoint 404 for any player without a registered queue, and made the debug log print the playback state ("PLAYING") instead of the player name.
