### PR TITLE
Restore player state when an announcement fails

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2768,7 +2768,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
     # Protocol linking methods are provided by ProtocolLinkingMixin (protocol_linking.py)
 
-    async def _play_announcement(  # noqa: PLR0915
+    async def _play_announcement(
         self,
         player: Player,
         announcement: PlayerMedia,
@@ -2790,7 +2790,14 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         (provider) has no native support for the PLAY_ANNOUNCEMENT feature.
         """
         prev_state = player.state.playback_state
-        prev_power = player.state.powered or prev_state != PlaybackState.IDLE
+        # A player without power control has no power state to restore, so it counts as
+        # powered here - otherwise the restore below would be skipped altogether for it,
+        # leaving the player ungrouped from its (sync)group.
+        prev_power = (
+            player.state.power_control == PLAYER_CONTROL_NONE
+            or bool(player.state.powered)
+            or prev_state != PlaybackState.IDLE
+        )
         prev_synced_to = player.state.synced_to
         prev_group = (
             self.get_player(player.state.active_group) if player.state.active_group else None
@@ -2806,155 +2813,57 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             player.current_media is not None
             and player.current_media.media_type == MediaType.ANNOUNCEMENT
         )
-        if prev_synced_to:
-            # ungroup player if its currently synced
-            self.logger.debug(
-                "Announcement to player %s - ungrouping player from %s...",
-                player.state.name,
-                prev_synced_to,
-            )
-            await self.cmd_ungroup(player.player_id)
-        elif prev_group:
-            # if the player is part of a group player, we need to ungroup it
-            if PlayerFeature.SET_MEMBERS in prev_group.supported_features:
-                self.logger.debug(
-                    "Announcement to player %s - ungrouping from group player %s...",
-                    player.state.name,
-                    prev_group.display_name,
-                )
-                await prev_group.set_members(player_ids_to_remove=[player.player_id])
-            else:
-                # if the player is part of a group player that does not support ungrouping,
-                # we need to power off the groupplayer instead
-                self.logger.debug(
-                    "Announcement to player %s - turning off group player %s...",
-                    player.state.name,
-                    prev_group.display_name,
-                )
-                await self._handle_cmd_power(player.player_id, False)
-        elif prev_state in (PlaybackState.PLAYING, PlaybackState.PAUSED):
-            # normal/standalone player: stop player if its currently playing
-            self.logger.debug(
-                "Announcement to player %s - stop existing content (%s)...",
-                player.state.name,
-                prev_media_name,
-            )
-            await self._handle_cmd_stop(player.player_id)
-            # wait for the player to stop
-            await self._wait_for_playback_state(player, PlaybackState.IDLE, 10, 0.4)
-        # adjust volume if needed
-        # in case of a (sync) group, we need to do this for all child players
+        # filled while the temporary announcement volume is applied below
         prev_volumes: dict[str, int] = {}
-        async with TaskManager(self.mass) as tg:
-            for volume_player_id in player.state.group_members or (player.player_id,):
-                if not (volume_player := self.get_player(volume_player_id)):
-                    continue
-                # catch any players that have a different source active
-                if (
-                    volume_player.state.active_source
-                    not in (
-                        player.state.active_source,
-                        volume_player.player_id,
-                        None,
-                    )
-                    and volume_player.state.playback_state == PlaybackState.PLAYING
-                ):
-                    self.logger.warning(
-                        "Detected announcement to playergroup %s while group member %s is playing "
-                        "other content, this may lead to unexpected behavior.",
-                        player.state.name,
-                        volume_player.state.name,
-                    )
-                    tg.create_task(self._handle_cmd_stop(volume_player.player_id))
-                if volume_player.state.volume_control == PLAYER_CONTROL_NONE:
-                    continue
-                if (prev_volume := volume_player.state.volume_level) is None:
-                    continue
-                announcement_volume = self.get_announcement_volume(volume_player_id, volume_level)
-                if announcement_volume is None:
-                    continue
-                temp_volume = announcement_volume or player.state.volume_level
-                if temp_volume != prev_volume:
-                    prev_volumes[volume_player_id] = prev_volume
-                    self.logger.debug(
-                        "Announcement to player %s - setting temporary volume (%s)...",
-                        volume_player.state.name,
-                        announcement_volume,
-                    )
-                    tg.create_task(
-                        self._handle_cmd_volume_set(volume_player.player_id, announcement_volume)
-                    )
-        # play the announcement
-        self.logger.debug(
-            "Announcement to player %s - playing the announcement on the player...",
-            player.state.name,
-        )
-        await self._handle_play_media(player.player_id, announcement)
-        # wait for the player(s) to play
-        await self._wait_for_playback_state(player, PlaybackState.PLAYING, 10, minimal_time=0.1)
-        # wait for the player to stop playing
-        if not announcement.duration:
-            if not announcement.custom_data:
-                raise ValueError("Announcement missing duration and custom_data")
-            media_info = await async_parse_tags(
-                announcement.custom_data["announcement_url"], require_duration=True
+        # everything from here on alters the player state, so the restore in the finally
+        # block must run even when the announcement itself fails halfway through
+        try:
+            await self._prepare_for_announcement(
+                player,
+                volume_level=volume_level,
+                prev_state=prev_state,
+                prev_synced_to=prev_synced_to,
+                prev_group=prev_group,
+                prev_media_name=prev_media_name,
+                prev_volumes=prev_volumes,
             )
-            announcement.duration = int(media_info.duration) if media_info.duration else None
-
-        if announcement.duration is None:
-            raise ValueError("Announcement duration could not be determined")
-
-        await self._wait_for_playback_state(
-            player,
-            PlaybackState.IDLE,
-            timeout=announcement.duration + 10,
-            minimal_time=float(announcement.duration) + 2,
-        )
-        self.logger.debug(
-            "Announcement to player %s - restore previous state...", player.state.name
-        )
-        # restore volume
-        async with TaskManager(self.mass) as tg:
-            for volume_player_id, prev_volume in prev_volumes.items():
-                tg.create_task(self._handle_cmd_volume_set(volume_player_id, prev_volume))
-        await asyncio.sleep(0.2)
-        # either power off the player or resume playing
-        if not prev_power:
-            if player.state.power_control != PLAYER_CONTROL_NONE:
-                self.logger.debug(
-                    "Announcement to player %s - turning player off again...", player.state.name
-                )
-                await self._handle_cmd_power(player.player_id, False)
-            # nothing to do anymore, player was not previously powered
-            # and does not support power control
-            return
-        if prev_synced_to:
+            # play the announcement
             self.logger.debug(
-                "Announcement to player %s - syncing back to %s...",
+                "Announcement to player %s - playing the announcement on the player...",
                 player.state.name,
-                prev_synced_to,
             )
-            await self.cmd_set_members(prev_synced_to, player_ids_to_add=[player.player_id])
-        elif prev_group:
-            if PlayerFeature.SET_MEMBERS in prev_group.supported_features:
-                self.logger.debug(
-                    "Announcement to player %s - grouping back to group player %s...",
-                    player.state.name,
-                    prev_group.display_name,
+            await self._handle_play_media(player.player_id, announcement)
+            # wait for the player(s) to play
+            await self._wait_for_playback_state(player, PlaybackState.PLAYING, 10, minimal_time=0.1)
+            # wait for the player to stop playing
+            if not announcement.duration:
+                if not announcement.custom_data:
+                    raise ValueError("Announcement missing duration and custom_data")
+                media_info = await async_parse_tags(
+                    announcement.custom_data["announcement_url"], require_duration=True
                 )
-                await prev_group.set_members(player_ids_to_add=[player.player_id])
-            elif restore_playback:
-                # if the player is part of a group player that does not support set_members,
-                # we need to restart the groupplayer
-                self.logger.debug(
-                    "Announcement to player %s - restarting playback on group player %s...",
-                    player.state.name,
-                    prev_group.display_name,
-                )
-                await self.cmd_play(prev_group.player_id)
-        elif restore_playback:
-            # player was playing something before the announcement - try to resume that here
-            await self._handle_cmd_resume(player.player_id, prev_source, prev_media)
+                announcement.duration = int(media_info.duration) if media_info.duration else None
+
+            if announcement.duration is None:
+                raise ValueError("Announcement duration could not be determined")
+
+            await self._wait_for_playback_state(
+                player,
+                PlaybackState.IDLE,
+                timeout=announcement.duration + 10,
+                minimal_time=float(announcement.duration) + 2,
+            )
+        finally:
+            await self._restore_after_announcement(
+                player,
+                prev_power=prev_power,
+                prev_volumes=prev_volumes,
+                prev_synced_to=prev_synced_to,
+                prev_group=prev_group,
+                prev_source=prev_source,
+                prev_media=prev_media,
+                restore_playback=restore_playback,
+            )
 
     def _repair_protocol_parent_links(self) -> None:
         """
@@ -4213,3 +4122,183 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             player.state.name,
         )
         await self._handle_cmd_stop(player.player_id)
+
+    async def _prepare_for_announcement(
+        self,
+        player: Player,
+        *,
+        volume_level: int | None,
+        prev_state: PlaybackState,
+        prev_synced_to: str | None,
+        prev_group: Player | None,
+        prev_media_name: str | None,
+        prev_volumes: dict[str, int],
+    ) -> None:
+        """
+        Free up the player for an announcement and apply the temporary announcement volume.
+
+        :param player: The player the announcement will be played on.
+        :param volume_level: Optional volume level override for the announcement.
+        :param prev_state: The playback state the player had before the announcement.
+        :param prev_synced_to: Player ID of the sync leader the player is synced to (if any).
+        :param prev_group: The group player the player is a member of (if any).
+        :param prev_media_name: Name of the media the player was playing (for logging).
+        :param prev_volumes: Mapping that is filled in-place with the previous volume level
+            per player id, so the caller can restore the volumes even if this call fails.
+        """
+        if prev_synced_to:
+            # ungroup player if its currently synced
+            self.logger.debug(
+                "Announcement to player %s - ungrouping player from %s...",
+                player.state.name,
+                prev_synced_to,
+            )
+            await self.cmd_ungroup(player.player_id)
+        elif prev_group:
+            # if the player is part of a group player, we need to ungroup it
+            if PlayerFeature.SET_MEMBERS in prev_group.supported_features:
+                self.logger.debug(
+                    "Announcement to player %s - ungrouping from group player %s...",
+                    player.state.name,
+                    prev_group.display_name,
+                )
+                await prev_group.set_members(player_ids_to_remove=[player.player_id])
+            else:
+                # if the player is part of a group player that does not support ungrouping,
+                # we need to power off the groupplayer instead
+                self.logger.debug(
+                    "Announcement to player %s - turning off group player %s...",
+                    player.state.name,
+                    prev_group.display_name,
+                )
+                await self._handle_cmd_power(prev_group.player_id, False)
+        elif prev_state in (PlaybackState.PLAYING, PlaybackState.PAUSED):
+            # normal/standalone player: stop player if its currently playing
+            self.logger.debug(
+                "Announcement to player %s - stop existing content (%s)...",
+                player.state.name,
+                prev_media_name,
+            )
+            await self._handle_cmd_stop(player.player_id)
+            # wait for the player to stop
+            await self._wait_for_playback_state(player, PlaybackState.IDLE, 10, 0.4)
+        # adjust volume if needed
+        # in case of a (sync) group, we need to do this for all child players
+        async with TaskManager(self.mass) as tg:
+            for volume_player_id in player.state.group_members or (player.player_id,):
+                if not (volume_player := self.get_player(volume_player_id)):
+                    continue
+                # catch any players that have a different source active
+                if (
+                    volume_player.state.active_source
+                    not in (
+                        player.state.active_source,
+                        volume_player.player_id,
+                        None,
+                    )
+                    and volume_player.state.playback_state == PlaybackState.PLAYING
+                ):
+                    self.logger.warning(
+                        "Detected announcement to playergroup %s while group member %s is playing "
+                        "other content, this may lead to unexpected behavior.",
+                        player.state.name,
+                        volume_player.state.name,
+                    )
+                    tg.create_task(self._handle_cmd_stop(volume_player.player_id))
+                if volume_player.state.volume_control == PLAYER_CONTROL_NONE:
+                    continue
+                if (prev_volume := volume_player.state.volume_level) is None:
+                    continue
+                announcement_volume = self.get_announcement_volume(volume_player_id, volume_level)
+                if announcement_volume is None:
+                    continue
+                temp_volume = announcement_volume or player.state.volume_level
+                if temp_volume != prev_volume:
+                    prev_volumes[volume_player_id] = prev_volume
+                    self.logger.debug(
+                        "Announcement to player %s - setting temporary volume (%s)...",
+                        volume_player.state.name,
+                        announcement_volume,
+                    )
+                    tg.create_task(
+                        self._handle_cmd_volume_set(volume_player.player_id, announcement_volume)
+                    )
+
+    async def _restore_after_announcement(
+        self,
+        player: Player,
+        *,
+        prev_power: bool,
+        prev_volumes: dict[str, int],
+        prev_synced_to: str | None,
+        prev_group: Player | None,
+        prev_source: str | None,
+        prev_media: PlayerMedia | None,
+        restore_playback: bool,
+    ) -> None:
+        """
+        Restore the player state that was captured before an announcement was played.
+
+        This also runs when the announcement failed halfway through, so a failing restore
+        step is logged instead of raised: it may never mask the error that caused it.
+
+        :param player: The player the announcement was played on.
+        :param prev_power: Whether the player was powered before the announcement.
+        :param prev_volumes: The previous volume level per player id.
+        :param prev_synced_to: Player ID of the sync leader the player was synced to (if any).
+        :param prev_group: The group player the player was a member of (if any).
+        :param prev_source: The source that was active before the announcement.
+        :param prev_media: The media that was loaded before the announcement.
+        :param restore_playback: Whether playback needs to be resumed.
+        """
+        self.logger.debug(
+            "Announcement to player %s - restore previous state...", player.state.name
+        )
+        # restore volume
+        async with TaskManager(self.mass) as tg:
+            for volume_player_id, prev_volume in prev_volumes.items():
+                tg.create_task(self._handle_cmd_volume_set(volume_player_id, prev_volume))
+        await asyncio.sleep(0.2)
+        try:
+            # either power off the player or resume playing
+            if not prev_power:
+                # prev_power is always True for a player without power control,
+                # so there is an actual power control to switch off here
+                self.logger.debug(
+                    "Announcement to player %s - turning player off again...", player.state.name
+                )
+                await self._handle_cmd_power(player.player_id, False)
+                return
+            if prev_synced_to:
+                self.logger.debug(
+                    "Announcement to player %s - syncing back to %s...",
+                    player.state.name,
+                    prev_synced_to,
+                )
+                await self.cmd_set_members(prev_synced_to, player_ids_to_add=[player.player_id])
+            elif prev_group:
+                if PlayerFeature.SET_MEMBERS in prev_group.supported_features:
+                    self.logger.debug(
+                        "Announcement to player %s - grouping back to group player %s...",
+                        player.state.name,
+                        prev_group.display_name,
+                    )
+                    await prev_group.set_members(player_ids_to_add=[player.player_id])
+                elif restore_playback:
+                    # if the player is part of a group player that does not support set_members,
+                    # we need to restart the groupplayer
+                    self.logger.debug(
+                        "Announcement to player %s - restarting playback on group player %s...",
+                        player.state.name,
+                        prev_group.display_name,
+                    )
+                    await self.cmd_play(prev_group.player_id)
+            elif restore_playback:
+                # player was playing something before the announcement - try to resume that here
+                await self._handle_cmd_resume(player.player_id, prev_source, prev_media)
+        except MusicAssistantError as err:
+            self.logger.warning(
+                "Announcement to player %s - restoring the previous state failed: %s",
+                player.state.name,
+                err,
+            )

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -4210,10 +4210,12 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 if (prev_volume := volume_player.state.volume_level) is None:
                     continue
                 announcement_volume = self.get_announcement_volume(volume_player_id, volume_level)
+                # get_announcement_volume already returns None when the volume must be left
+                # alone, so any number it does return is the volume to announce at - including
+                # 0, which must not be mistaken for 'no volume configured'
                 if announcement_volume is None:
                     continue
-                temp_volume = announcement_volume or player.state.volume_level
-                if temp_volume != prev_volume:
+                if announcement_volume != prev_volume:
                     prev_volumes[volume_player_id] = prev_volume
                     self.logger.debug(
                         "Announcement to player %s - setting temporary volume (%s)...",

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -4298,7 +4298,10 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             elif restore_playback:
                 # player was playing something before the announcement - try to resume that here
                 await self._handle_cmd_resume(player.player_id, prev_source, prev_media)
-        except MusicAssistantError as err:
+        except Exception as err:
+            # deliberately broad: set_members is a raw provider call that is not wrapped
+            # into a MusicAssistantError, so it can surface anything its client library
+            # raises. CancelledError is a BaseException and still propagates.
             self.logger.warning(
                 "Announcement to player %s - restoring the previous state failed: %s",
                 player.state.name,

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1469,6 +1469,24 @@ class TestPlayAnnouncementRestore:
 
         assert volume_mock.call_args_list == [call("player_1", 80), call("player_1", 20)]
 
+    async def test_zero_announcement_volume_is_applied_and_restored(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """An announcement volume of 0 is a real volume, not an 'unset' fallback."""
+        controller, player, _ = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+        player._attr_volume_level = 20
+        player._cache.clear()
+        player.update_state(force_update=True, signal_event=False)
+        controller.get_announcement_volume = MagicMock(return_value=0)  # type: ignore[method-assign]
+        volume_mock = AsyncMock()
+        controller._handle_cmd_volume_set = volume_mock  # type: ignore[method-assign]
+
+        await controller._play_announcement(player, self._announcement())
+
+        assert volume_mock.call_args_list == [call("player_1", 0), call("player_1", 20)]
+
     async def test_playback_is_restored_when_duration_lookup_fails(
         self, mock_mass: MagicMock
     ) -> None:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1523,6 +1523,26 @@ class TestPlayAnnouncementRestore:
             call(player_ids_to_add=["player_1"]),
         ]
 
+    async def test_restore_failure_does_not_mask_the_announcement_error(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A provider blowing up during the restore must not hide why the announcement failed."""
+        controller, player, _ = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+        group = self._add_group(controller, player, supports_set_members=True)
+        # set_members is a raw provider call: whatever its client library raises comes
+        # through unwrapped, so the ungroup succeeds and the regroup times out
+        group.set_members = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[None, TimeoutError("provider timeout")]
+        )
+        controller._handle_play_media = AsyncMock(  # type: ignore[method-assign]
+            side_effect=PlayerCommandFailed("player went away")
+        )
+
+        with pytest.raises(PlayerCommandFailed, match="player went away"):
+            await controller._play_announcement(player, self._announcement())
+
     async def test_group_without_set_members_is_the_one_powered_off(
         self, mock_mass: MagicMock
     ) -> None:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -16,7 +16,7 @@ import time
 from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from music_assistant_models.constants import (
@@ -1363,7 +1363,7 @@ class TestPlayAnnouncementCleanup:
 
 
 class TestPlayAnnouncementRestore:
-    """Test the playback restore of the default (fallback) announcement implementation."""
+    """Test the state restore of the default (fallback) announcement implementation."""
 
     def _make_player(
         self, mock_mass: MagicMock, prev_media: PlayerMedia
@@ -1377,14 +1377,46 @@ class TestPlayAnnouncementRestore:
         player._cache.clear()
         controller._players = {"player_1": player}
         mock_mass.players = controller
+        # the (temporary and restored) volume commands are dispatched through the
+        # TaskManager, so background tasks must actually run in these tests
+        mock_mass.create_task = MagicMock(
+            side_effect=lambda coro, **_kwargs: asyncio.ensure_future(coro)
+        )
         resume_mock = AsyncMock()
         controller._handle_cmd_resume = resume_mock  # type: ignore[method-assign]
         controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
         controller._handle_play_media = AsyncMock()  # type: ignore[method-assign]
         controller._wait_for_playback_state = AsyncMock()  # type: ignore[method-assign]
         controller.get_announcement_volume = MagicMock(return_value=None)  # type: ignore[method-assign]
+        player.set_initialized()
         player.update_state(signal_event=False)
         return controller, player, resume_mock
+
+    @staticmethod
+    def _add_group(
+        controller: PlayerController, player: MockPlayer, *, supports_set_members: bool
+    ) -> MockPlayer:
+        """Register a powered group player that holds the given player as its member."""
+        group = MockPlayer(
+            cast("MockProvider", player.provider),
+            "group_1",
+            "Group 1",
+            player_type=PlayerType.GROUP,
+        )
+        group._attr_powered = True
+        group._attr_group_members = [player.player_id]
+        if supports_set_members:
+            group._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        controller._players[group.player_id] = group
+        group.set_initialized()
+        group._cache.clear()
+        group.update_state(signal_event=False)
+        # the member has no own input change to trigger a recalculation of its
+        # (group derived) state, so force it here - just like register() does
+        player._cache.clear()
+        player.update_state(force_update=True, signal_event=False)
+        assert player.state.active_group == group.player_id
+        return group
 
     @staticmethod
     def _announcement() -> PlayerMedia:
@@ -1416,6 +1448,101 @@ class TestPlayAnnouncementRestore:
         await controller._play_announcement(player, self._announcement())
 
         resume_mock.assert_not_awaited()
+
+    async def test_volume_is_restored_when_playback_fails(self, mock_mass: MagicMock) -> None:
+        """A failing announcement never leaves the player at the raised volume."""
+        controller, player, _ = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+        player._attr_volume_level = 20
+        player._cache.clear()
+        player.update_state(force_update=True, signal_event=False)
+        controller.get_announcement_volume = MagicMock(return_value=80)  # type: ignore[method-assign]
+        volume_mock = AsyncMock()
+        controller._handle_cmd_volume_set = volume_mock  # type: ignore[method-assign]
+        controller._handle_play_media = AsyncMock(  # type: ignore[method-assign]
+            side_effect=PlayerCommandFailed("player went away")
+        )
+
+        with pytest.raises(PlayerCommandFailed):
+            await controller._play_announcement(player, self._announcement())
+
+        assert volume_mock.call_args_list == [call("player_1", 80), call("player_1", 20)]
+
+    async def test_playback_is_restored_when_duration_lookup_fails(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """An announcement of unknown length still hands the player back to its content."""
+        controller, player, resume_mock = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+        announcement = self._announcement()
+        announcement.duration = None
+
+        with pytest.raises(ValueError, match="custom_data"):
+            await controller._play_announcement(player, announcement)
+
+        resume_mock.assert_awaited_once()
+
+    async def test_group_membership_is_restored_when_playback_fails(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A failing announcement never leaves the player out of its group player."""
+        controller, player, _ = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+        group = self._add_group(controller, player, supports_set_members=True)
+        group.set_members = AsyncMock()  # type: ignore[method-assign]
+        controller._handle_play_media = AsyncMock(  # type: ignore[method-assign]
+            side_effect=PlayerCommandFailed("player went away")
+        )
+
+        with pytest.raises(PlayerCommandFailed):
+            await controller._play_announcement(player, self._announcement())
+
+        assert group.set_members.await_args_list == [
+            call(player_ids_to_remove=["player_1"]),
+            call(player_ids_to_add=["player_1"]),
+        ]
+
+    async def test_group_without_set_members_is_the_one_powered_off(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A group that can not release members is powered off, not the announcement target."""
+        controller, player, _ = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+        self._add_group(controller, player, supports_set_members=False)
+        power_mock = AsyncMock()
+        controller._handle_cmd_power = power_mock  # type: ignore[method-assign]
+        play_mock = AsyncMock()
+        controller.cmd_play = play_mock  # type: ignore[method-assign]
+
+        await controller._play_announcement(player, self._announcement())
+
+        # the group is switched off for the announcement and restarted afterwards
+        power_mock.assert_awaited_once_with("group_1", False)
+        play_mock.assert_awaited_once_with("group_1")
+
+    async def test_idle_player_without_power_control_is_regrouped(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """An idle player that has no power state to restore is still put back in its group."""
+        controller, player, _ = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+        player._attr_playback_state = PlaybackState.IDLE
+        player._attr_powered = None
+        group = self._add_group(controller, player, supports_set_members=True)
+        assert player.state.power_control == PLAYER_CONTROL_NONE
+        group.set_members = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._play_announcement(player, self._announcement())
+
+        assert group.set_members.await_args_list == [
+            call(player_ids_to_remove=["player_1"]),
+            call(player_ids_to_add=["player_1"]),
+        ]
 
 
 class TestScheduleActiveOutputProtocolClear:


### PR DESCRIPTION
The fallback announcement implementation raises the volume and pulls the player out of its (sync)group before playing, but only restored that state on the happy path. If anything failed after that - the player went away, or the announcement had no determinable duration - Player A was left loud and out of its group, with nothing resuming playback. The restore now runs from a `finally` block, so it also happens when the announcement fails halfway through.

Two smaller defects in the same flow:

- A group player that can not release its members was supposed to be powered off for the duration of the announcement (that is what the comment, the log line and the symmetric restore all say), but the code powered off the announcement target instead - which `play_media` then immediately powered back on, while Group B kept playing over the announcement.
- `prev_power` was `False` for an idle player without power control, which made the restore return early and never group the player back.