### PR TITLE
Announcements start faster and no longer get cut off

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -22,6 +22,7 @@ import time
 import weakref
 from collections.abc import AsyncIterator
 from contextlib import suppress
+from math import ceil
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import Scope
@@ -95,6 +96,7 @@ from music_assistant.constants import (
     CONF_REPORTED_MAC,
     VERBOSE_LOG_LEVEL,
 )
+from music_assistant.controllers.streams.announcements import MAX_CLIP_SECONDS
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_current_user,
     get_sendspin_player_id,
@@ -102,7 +104,6 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
 )
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.colors import get_palette_for_url
-from music_assistant.helpers.tags import async_parse_tags
 from music_assistant.helpers.util import (
     TaskManager,
     enrich_device_mac_address,
@@ -1010,27 +1011,38 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             and not validate_announcement_chime_url(pre_announce_url)
         ):
             raise PlayerCommandFailed("Invalid pre-announce chime URL specified.")
+        # determine pre-announce from (group)player config
+        if pre_announce is None and "tts" in url:
+            conf_pre_announce = self.mass.config.get_raw_player_config_value(
+                player_id,
+                CONF_ENTRY_TTS_PRE_ANNOUNCE.key,
+                CONF_ENTRY_TTS_PRE_ANNOUNCE.default_value,
+            )
+            pre_announce = cast("bool", conf_pre_announce)
+        if pre_announce_url is None:
+            if conf_pre_announce_url := self.mass.config.get_raw_player_config_value(
+                player_id,
+                CONF_PRE_ANNOUNCE_CHIME_URL,
+            ):
+                # player default custom chime url
+                pre_announce_url = cast("str", conf_pre_announce_url)
+            else:
+                # use global default chime url
+                pre_announce_url = ANNOUNCE_ALERT_FILE
+        announce_data = AnnounceData(
+            announcement_url=url,
+            pre_announce=bool(pre_announce),
+            pre_announce_url=pre_announce_url,
+            # filled in below, once we know which player fetches the stream
+            announce_player_id=None,
+        )
+        # Start rendering the audio right away, so it is (nearly always fully) buffered
+        # by the time the player is ready for it. The render is shared by everything
+        # that consumes this announcement, including all members of a group.
+        render = self.mass.streams.announcement_renderer.acquire(announce_data)
         try:
             # mark announcement_in_progress on player
             player.extra_data[ATTR_ANNOUNCEMENT_IN_PROGRESS] = True
-            # determine pre-announce from (group)player config
-            if pre_announce is None and "tts" in url:
-                conf_pre_announce = self.mass.config.get_raw_player_config_value(
-                    player_id,
-                    CONF_ENTRY_TTS_PRE_ANNOUNCE.key,
-                    CONF_ENTRY_TTS_PRE_ANNOUNCE.default_value,
-                )
-                pre_announce = cast("bool", conf_pre_announce)
-            if pre_announce_url is None:
-                if conf_pre_announce_url := self.mass.config.get_raw_player_config_value(
-                    player_id,
-                    CONF_PRE_ANNOUNCE_CHIME_URL,
-                ):
-                    # player default custom chime url
-                    pre_announce_url = cast("str", conf_pre_announce_url)
-                else:
-                    # use global default chime url
-                    pre_announce_url = ANNOUNCE_ALERT_FILE
             # if player type is group with all members supporting announcements,
             # we forward the request to each individual player
             if player.state.type == PlayerType.GROUP and (
@@ -1071,11 +1083,8 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 announce_player = player
             # create a PlayerMedia object for the announcement so
             # we can send a regular play-media call downstream
-            announce_data = AnnounceData(
-                announcement_url=url,
-                pre_announce=bool(pre_announce),
-                pre_announce_url=pre_announce_url,
-                announce_player_id=(announce_player.player_id if native_announce_support else None),
+            announce_data["announce_player_id"] = (
+                announce_player.player_id if native_announce_support else None
             )
             announcement = PlayerMedia(
                 uri=self.mass.streams.get_announcement_url(player_id, announce_data=announce_data),
@@ -1085,6 +1094,14 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             )
             # handle native announce support (player or linked protocol)
             if native_announce_support:
+                # hand the url to the player as soon as there is audio to serve from;
+                # its exact length is resolved further downstream, while it plays
+                if not await render.wait_ready():
+                    self.logger.warning(
+                        "Announcement to player %s - no audio available for %s",
+                        player.state.name,
+                        url,
+                    )
                 announcement_volume = self.get_announcement_volume(player_id, volume_level)
                 await announce_player.play_announcement(announcement, announcement_volume)
                 return
@@ -1094,6 +1111,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             player.extra_data[ATTR_ANNOUNCEMENT_IN_PROGRESS] = False
             # release the announcement data registered by get_announcement_url
             self.mass.streams.announcements.pop(player_id, None)
+            await self.mass.streams.announcement_renderer.release(render)
 
     @handle_player_command
     async def play_media(self, player_id: str, media: PlayerMedia) -> None:
@@ -2832,27 +2850,47 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 "Announcement to player %s - playing the announcement on the player...",
                 player.state.name,
             )
+            render = (
+                self.mass.streams.announcement_renderer.get(
+                    cast("AnnounceData", announcement.custom_data)
+                )
+                if announcement.custom_data
+                else None
+            )
+            if render is not None and not await render.wait_ready():
+                # the render has been filling while the player was prepared above; play on
+                # regardless when it came up empty, so the restore still runs
+                self.logger.warning(
+                    "Announcement to player %s - no audio available for %s",
+                    player.state.name,
+                    announcement.uri,
+                )
             await self._handle_play_media(player.player_id, announcement)
             # wait for the player(s) to play
             await self._wait_for_playback_state(player, PlaybackState.PLAYING, 10, minimal_time=0.1)
+            playback_started = time.time()
             # wait for the player to stop playing
-            if not announcement.duration:
-                if not announcement.custom_data:
-                    raise ValueError("Announcement missing duration and custom_data")
-                media_info = await async_parse_tags(
-                    announcement.custom_data["announcement_url"], require_duration=True
+            duration = float(announcement.duration) if announcement.duration else None
+            if duration is None and render is not None:
+                # the render knows the exact length of the audio it produced
+                duration = await render.wait_finished()
+                if duration:
+                    announcement.duration = ceil(duration)
+            if duration is None:
+                # length unknown (e.g. the source stalled): wait for the player to report it
+                # finished, bounded by the longest clip an announcement can produce
+                await self._wait_for_playback_state(
+                    player, PlaybackState.IDLE, timeout=MAX_CLIP_SECONDS + 10
                 )
-                announcement.duration = int(media_info.duration) if media_info.duration else None
-
-            if announcement.duration is None:
-                raise ValueError("Announcement duration could not be determined")
-
-            await self._wait_for_playback_state(
-                player,
-                PlaybackState.IDLE,
-                timeout=announcement.duration + 10,
-                minimal_time=float(announcement.duration) + 2,
-            )
+            else:
+                # waiting for the length above already consumed part of the announcement
+                elapsed = time.time() - playback_started
+                await self._wait_for_playback_state(
+                    player,
+                    PlaybackState.IDLE,
+                    timeout=max(duration + 10 - elapsed, 1),
+                    minimal_time=max(duration + 2 - elapsed, 0),
+                )
         finally:
             await self._restore_after_announcement(
                 player,

--- a/music_assistant/controllers/streams/README.md
+++ b/music_assistant/controllers/streams/README.md
@@ -180,7 +180,7 @@ audio stream:
 |------|-------------|-------------|
 | Queue tracks | Yes (SEEKABLE) | Regular track playback with full buffering |
 | Radio streams | Yes (ROLLING) | Short rolling buffer, non-seekable |
-| Announcements | No | Short one-off audio (TTS), streamed directly |
+| Announcements | Yes (SEEKABLE) | Short one-off audio (TTS), rendered once and shared by all consumers |
 | Plugin sources | No | Real-time audio (microphone, aux), streamed directly |
 
 ## Configuration

--- a/music_assistant/controllers/streams/announcements.py
+++ b/music_assistant/controllers/streams/announcements.py
@@ -1,0 +1,295 @@
+"""
+Rendering of announcement audio (optional pre-announce chime + announcement).
+
+A single announcement is regularly consumed more than once: by the player's own http
+fetch, by a HEAD probe preceding it, and by every member of a group announcement. An
+AnnouncementRender decodes the audio once and keeps the whole clip in memory, so every
+one of those readers is served from there, each in the format it needs. Because the
+clip is complete, its exact duration is known without probing the source again.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncGenerator
+from contextlib import aclosing, suppress
+from typing import TYPE_CHECKING
+
+from music_assistant_models.enums import ContentType
+from music_assistant_models.errors import AudioError
+from music_assistant_models.media_items import AudioFormat
+
+from music_assistant.constants import MASS_LOGGER_NAME, VERBOSE_LOG_LEVEL
+from music_assistant.helpers.audio import calculate_content_length
+from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
+
+if TYPE_CHECKING:
+    from music_assistant.controllers.players.helpers import AnnounceData
+
+LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.announcements")
+
+# Announcements are always rendered to this format; readers that need something else
+# (an encoded http stream, a different sample rate) convert from it per reader.
+ANNOUNCEMENT_PCM_FORMAT = AudioFormat(
+    content_type=ContentType.PCM_S16LE,
+    sample_rate=44100,
+    bit_depth=16,
+    channels=2,
+)
+
+# Upper bounds on the audio taken from each source. Announcements are short by nature;
+# these only guard against a source that never ends (e.g. a radio stream handed to the
+# announcement api, or an endless custom chime), which would otherwise render forever.
+MAX_CHIME_SECONDS = 30
+MAX_ANNOUNCEMENT_SECONDS = 300
+
+# The longest clip a render can produce, for callers that need to bound a wait on an
+# announcement whose length is not known.
+MAX_CLIP_SECONDS = MAX_CHIME_SECONDS + MAX_ANNOUNCEMENT_SECONDS
+
+# Maximum time to wait for a (slow) announcement source.
+DEFAULT_RENDER_TIMEOUT = 30
+
+
+class AnnouncementRender:
+    """
+    A single announcement clip (pre-announce chime + announcement), held in memory.
+
+    Announcement clips are short and are read by several consumers at once, each from
+    the start, so the clip is kept whole until the render is closed.
+    """
+
+    def __init__(self, announcement_url: str, pre_announce: bool, pre_announce_url: str) -> None:
+        """
+        Initialize the render. Call start() to begin rendering.
+
+        :param announcement_url: URL of the announcement audio.
+        :param pre_announce: Whether to prepend the pre-announce chime.
+        :param pre_announce_url: URL of the pre-announce chime.
+        """
+        self.announcement_url = announcement_url
+        self.pre_announce = pre_announce
+        self.pre_announce_url = pre_announce_url
+        self.ref_count = 0
+        self._chunks: list[bytes] = []
+        self._total_bytes = 0
+        self._closed = False
+        self._task: asyncio.Task[None] | None = None
+        self._audio_added = asyncio.Condition()
+        self._ready = asyncio.Event()
+        self._finished = asyncio.Event()
+
+    @property
+    def duration(self) -> float:
+        """Return the duration (in seconds) of the audio rendered so far."""
+        return self._total_bytes / ANNOUNCEMENT_PCM_FORMAT.pcm_sample_size
+
+    @property
+    def key(self) -> str:
+        """Return the key that identifies the audio of this render."""
+        return _render_key(self.announcement_url, self.pre_announce, self.pre_announce_url)
+
+    def start(self) -> None:
+        """Start rendering the announcement audio."""
+        self._task = asyncio.get_running_loop().create_task(self._render())
+
+    async def get_stream(self, output_format: AudioFormat) -> AsyncGenerator[bytes]:
+        """
+        Stream the announcement audio in the given output format.
+
+        Starts at the beginning of the clip and waits for audio that is still being
+        rendered, so any number of consumers can read it at the same time.
+
+        :param output_format: The format to deliver the audio in.
+        """
+        if output_format == ANNOUNCEMENT_PCM_FORMAT:
+            async for chunk in self._read():
+                yield chunk
+            return
+        async for chunk in get_ffmpeg_stream(
+            audio_input=self._read(),
+            input_format=ANNOUNCEMENT_PCM_FORMAT,
+            output_format=output_format,
+        ):
+            yield chunk
+
+    async def wait_ready(self, timeout: float = DEFAULT_RENDER_TIMEOUT) -> bool:
+        """
+        Wait until there is audio available to start playback with.
+
+        Returns False if the source did not deliver any audio within the timeout.
+
+        :param timeout: Maximum time to wait for the first audio.
+        """
+        try:
+            await asyncio.wait_for(self._ready.wait(), timeout)
+        except TimeoutError:
+            LOGGER.warning("Timeout waiting for announcement audio from %s", self.announcement_url)
+            return False
+        return self._total_bytes > 0
+
+    async def wait_finished(self, timeout: float = DEFAULT_RENDER_TIMEOUT) -> float | None:
+        """
+        Wait for the render to finish and return the exact duration in seconds.
+
+        Returns None if the render did not finish within the timeout.
+
+        :param timeout: Maximum time to wait for the render to finish.
+        """
+        try:
+            await asyncio.wait_for(self._finished.wait(), timeout)
+        except TimeoutError:
+            LOGGER.warning(
+                "Timeout waiting for announcement %s to be rendered", self.announcement_url
+            )
+            return None
+        return self.duration
+
+    async def close(self) -> None:
+        """Discard the rendered audio and stop reading from the source."""
+        if self._task and not self._task.done():
+            self._task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._task
+        async with self._audio_added:
+            self._closed = True
+            self._chunks.clear()
+            self._ready.set()
+            self._finished.set()
+            self._audio_added.notify_all()
+
+    async def _render(self) -> None:
+        """Decode the chime and the announcement into the clip."""
+        try:
+            if self.pre_announce:
+                await self._decode(self.pre_announce_url, MAX_CHIME_SECONDS)
+            # only the announcement itself marks the clip ready to play: a player
+            # started on the chime alone would run dry waiting for a slow source
+            await self._decode(self.announcement_url, MAX_ANNOUNCEMENT_SECONDS, signal_ready=True)
+        except AudioError as err:
+            # a failed source ends the clip instead of propagating to every reader:
+            # they receive whatever was rendered so far (possibly nothing) and stop
+            LOGGER.warning(
+                "Failed to fetch announcement audio from %s: %s", self.announcement_url, err
+            )
+        except Exception:
+            # same reasoning, for anything the ffmpeg helper did not wrap in an AudioError
+            LOGGER.exception("Error rendering announcement audio from %s", self.announcement_url)
+        finally:
+            async with self._audio_added:
+                self._ready.set()
+                self._finished.set()
+                self._audio_added.notify_all()
+            LOGGER.log(
+                VERBOSE_LOG_LEVEL,
+                "Rendered %.2f seconds of announcement audio for %s",
+                self.duration,
+                self.announcement_url,
+            )
+
+    async def _decode(self, url: str, max_seconds: int, signal_ready: bool = False) -> None:
+        """Decode one source url and add it to the clip."""
+        fmt = url.rsplit(".", maxsplit=1)[-1]
+        stream = get_ffmpeg_stream(
+            audio_input=url,
+            input_format=AudioFormat(content_type=ContentType.try_parse(fmt)),
+            output_format=ANNOUNCEMENT_PCM_FORMAT,
+            chunk_size=calculate_content_length(ANNOUNCEMENT_PCM_FORMAT, 1),
+            extra_input_args=["-t", str(max_seconds)],
+        )
+        # aclosing guarantees the ffmpeg process is torn down immediately when the
+        # render is cancelled, instead of lingering until garbage collection
+        # finalizes the abandoned generator.
+        async with aclosing(stream):
+            async for chunk in stream:
+                async with self._audio_added:
+                    self._chunks.append(chunk)
+                    self._total_bytes += len(chunk)
+                    if signal_ready:
+                        self._ready.set()
+                    self._audio_added.notify_all()
+
+    async def _read(self) -> AsyncGenerator[bytes]:
+        """Yield the clip from the start, waiting for audio that is still rendering."""
+        index = 0
+        while True:
+            async with self._audio_added:
+                while index >= len(self._chunks):
+                    if self._closed or self._finished.is_set():
+                        return
+                    await self._audio_added.wait()
+                chunk = self._chunks[index]
+            index += 1
+            # yielded outside the lock, so a slow reader never holds up the render
+            yield chunk
+
+
+class AnnouncementRenderer:
+    """Registry of the announcement renders that are currently in use."""
+
+    def __init__(self) -> None:
+        """Initialize the renderer."""
+        self._renders: dict[str, AnnouncementRender] = {}
+
+    @property
+    def active_renders(self) -> int:
+        """Return the number of announcement renders currently in use."""
+        return len(self._renders)
+
+    def acquire(self, announce_data: AnnounceData) -> AnnouncementRender:
+        """
+        Get the render for the given announcement, starting it if it is not running yet.
+
+        Every acquire must be paired with a release.
+
+        :param announce_data: The announcement to render.
+        """
+        key = _announce_data_key(announce_data)
+        if (render := self._renders.get(key)) is None:
+            render = AnnouncementRender(
+                announce_data["announcement_url"],
+                announce_data["pre_announce"],
+                announce_data["pre_announce_url"],
+            )
+            self._renders[key] = render
+            render.start()
+        render.ref_count += 1
+        return render
+
+    def get(self, announce_data: AnnounceData) -> AnnouncementRender | None:
+        """
+        Return the active render for the given announcement, if there is one.
+
+        :param announce_data: The announcement to look up.
+        """
+        return self._renders.get(_announce_data_key(announce_data))
+
+    async def release(self, render: AnnouncementRender) -> None:
+        """
+        Release a reference to a render, tearing it down when it was the last one.
+
+        :param render: The render previously obtained from acquire().
+        """
+        render.ref_count -= 1
+        if render.ref_count > 0:
+            return
+        if self._renders.get(render.key) is render:
+            del self._renders[render.key]
+        await render.close()
+
+
+def _render_key(announcement_url: str, pre_announce: bool, pre_announce_url: str) -> str:
+    """Return the key that identifies the audio of an announcement."""
+    # The key covers the audio only - not which player fetches it - so all players
+    # (and probes) that want this exact audio are served from a single render.
+    return f"{announcement_url}|{pre_announce_url if pre_announce else ''}"
+
+
+def _announce_data_key(announce_data: AnnounceData) -> str:
+    """Return the render key for the given announcement."""
+    return _render_key(
+        announce_data["announcement_url"],
+        announce_data["pre_announce"],
+        announce_data["pre_announce_url"],
+    )

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -7,13 +7,13 @@ purely to stream audio packets to players.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import struct
 import time
 from collections.abc import AsyncGenerator
 from contextlib import aclosing
+from math import ceil
 from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
@@ -40,7 +40,6 @@ from music_assistant_models.helpers import get_global_cache_value
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.constants import (
-    ANNOUNCE_ALERT_FILE,
     CONF_BACKGROUND_SCAN_CONCURRENCY,
     CONF_BIND_IP,
     CONF_BIND_PORT,
@@ -67,6 +66,10 @@ from music_assistant.constants import (
     VERBOSE_LOG_LEVEL,
 )
 from music_assistant.controllers.players.helpers import AnnounceData
+from music_assistant.controllers.streams.announcements import (
+    DEFAULT_RENDER_TIMEOUT,
+    AnnouncementRenderer,
+)
 from music_assistant.controllers.streams.audio import StreamsAudio, overlay_active
 from music_assistant.controllers.streams.audio_analysis import AudioAnalysisController
 from music_assistant.controllers.streams.audio_processing import (
@@ -170,6 +173,7 @@ class StreamsController(CoreController):
         )
         self.manifest.icon = "cast-audio"
         self.announcements: dict[str, AnnounceData] = {}
+        self.announcement_renderer = AnnouncementRenderer()
         self._bind_ip: str = "0.0.0.0"
         self.audio = StreamsAudio(mass)
         self.audio_processing = AudioProcessingManager(mass)
@@ -195,6 +199,7 @@ class StreamsController(CoreController):
             "libsoxr_support": get_global_cache_value(CACHE_ATTR_LIBSOXR_PRESENT),
             "active_output_streams": self._active_output_streams,
             "active_announcements": len(self.announcements),
+            "active_announcement_renders": self.announcement_renderer.active_renders,
         }
 
     @property
@@ -1105,13 +1110,8 @@ class StreamsController(CoreController):
         if http_profile == "forced_content_length":
             # given the fact that an announcement is just a short audio clip,
             # just send it over completely at once so we have a fixed content length
-            data = b""
-            announcement_stream = self.get_announcement_stream(
-                announcement_url=announce_data["announcement_url"],
-                output_format=audio_format,
-                pre_announce=announce_data["pre_announce"],
-                pre_announce_url=announce_data["pre_announce_url"],
-            )
+            data = bytearray()
+            announcement_stream = self.get_announcement_stream(announce_data, audio_format)
             # aclosing guarantees the stream (and thus the ffmpeg process chain behind
             # it) is torn down immediately when the request is cancelled, instead of
             # lingering until garbage collection finalizes the abandoned generator.
@@ -1119,7 +1119,7 @@ class StreamsController(CoreController):
                 async for chunk in announcement_stream:
                     data += chunk
             return web.Response(
-                body=data,
+                body=bytes(data),
                 content_type=get_mime_type(audio_format.output_format_str),
                 headers=DEFAULT_STREAM_HEADERS,
             )
@@ -1137,12 +1137,7 @@ class StreamsController(CoreController):
             announce_data["announcement_url"],
             player.display_name,
         )
-        announcement_stream = self.get_announcement_stream(
-            announcement_url=announce_data["announcement_url"],
-            output_format=audio_format,
-            pre_announce=announce_data["pre_announce"],
-            pre_announce_url=announce_data["pre_announce_url"],
-        )
+        announcement_stream = self.get_announcement_stream(announce_data, audio_format)
         # aclosing guarantees the stream (and thus the ffmpeg process chain behind
         # it) is torn down immediately when the player disconnects mid-stream,
         # instead of lingering until garbage collection finalizes the abandoned
@@ -1207,12 +1202,7 @@ class StreamsController(CoreController):
         if media.media_type == MediaType.ANNOUNCEMENT:
             # special case: stream announcement
             assert media.custom_data
-            return self.get_announcement_stream(
-                media.custom_data["announcement_url"],
-                output_format=pcm_format,
-                pre_announce=media.custom_data["pre_announce"],
-                pre_announce_url=media.custom_data["pre_announce_url"],
-            )
+            return self.get_announcement_stream(cast("AnnounceData", media.custom_data), pcm_format)
         if (
             media.source_id
             and media.source_id.startswith(UGP_PREFIX)
@@ -1390,106 +1380,53 @@ class StreamsController(CoreController):
             yield chunk
 
     async def get_announcement_stream(
-        self,
-        announcement_url: str,
-        output_format: AudioFormat,
-        pre_announce: bool | str = False,
-        pre_announce_url: str = ANNOUNCE_ALERT_FILE,
+        self, announce_data: AnnounceData, output_format: AudioFormat
     ) -> AsyncGenerator[bytes]:
-        """Get the special announcement stream."""
-        announcement_data: asyncio.Queue[bytes | None] = asyncio.Queue(10)
-        # we are doing announcement in PCM first to avoid multiple encodings
-        # when mixing pre-announce and announcement
-        # also we have to deal with some TTS sources being super slow in delivering audio
-        # so we take an approach where we start fetching the announcement in the background
-        # while we can already start playing the pre-announce sound (if any)
+        """
+        Get the audio of an announcement (pre-announce chime + announcement).
 
-        pcm_format = (
-            output_format
-            if output_format.content_type.is_pcm()
-            else AudioFormat(
-                sample_rate=output_format.sample_rate,
-                content_type=ContentType.PCM_S16LE,
-                bit_depth=16,
-                channels=output_format.channels,
-            )
-        )
+        Any number of consumers may stream the same announcement at once; its source is
+        fetched and decoded only once. The audio stays available while the stream is
+        held open.
 
-        async def fetch_announcement() -> None:
-            fmt = announcement_url.rsplit(".", maxsplit=1)[-1]
-            eof_pending = True
-            stream = get_ffmpeg_stream(
-                audio_input=announcement_url,
-                input_format=AudioFormat(content_type=ContentType.try_parse(fmt)),
-                output_format=pcm_format,
-                chunk_size=calculate_content_length(pcm_format, 1),
-            )
-            try:
-                # aclosing guarantees the ffmpeg stream is torn down immediately
-                # when this task gets cancelled while blocked on the queue put.
-                async with aclosing(stream):
-                    async for chunk in stream:
-                        await announcement_data.put(chunk)
-            except asyncio.CancelledError:
-                # consumer is gone: skip the end-of-stream sentinel because the
-                # queue may be full and nobody will drain it anymore
-                eof_pending = False
-                raise
-            except AudioError as err:
-                self.logger.warning(
-                    "Failed to fetch announcement audio from %s: %s", announcement_url, err
-                )
-            finally:
-                if eof_pending:
-                    await announcement_data.put(None)  # always signal end of stream
-
-        fetch_task = self.mass.create_task(fetch_announcement())
-
-        async def _announcement_stream() -> AsyncGenerator[bytes]:
-            """Generate the PCM audio stream for the announcement + optional pre-announce."""
-            if pre_announce:
-                async for chunk in get_ffmpeg_stream(
-                    audio_input=pre_announce_url,
-                    input_format=AudioFormat(content_type=ContentType.try_parse(pre_announce_url)),
-                    output_format=pcm_format,
-                    chunk_size=calculate_content_length(pcm_format, 1),
-                ):
-                    yield chunk
-            # pad silence while we're waiting for the announcement to be ready
-            while announcement_data.empty():
-                yield b"\0" * int(
-                    pcm_format.sample_rate * (pcm_format.bit_depth / 8) * pcm_format.channels * 0.1
-                )
-                await asyncio.sleep(0.1)
-            # stream announcement
-            while True:
-                announcement_chunk = await announcement_data.get()
-                if announcement_chunk is None:
-                    break
-                yield announcement_chunk
-
+        :param announce_data: The announcement to stream.
+        :param output_format: The format to deliver the audio in.
+        """
+        render = self.announcement_renderer.acquire(announce_data)
         try:
-            if output_format == pcm_format:
-                # no need to re-encode, just yield the raw PCM stream
-                raw_stream = _announcement_stream()
-                async with aclosing(raw_stream):
-                    async for chunk in raw_stream:
-                        yield chunk
-                return
-
-            # stream final announcement in requested output format
-            encoded_stream = get_ffmpeg_stream(
-                audio_input=_announcement_stream(),
-                input_format=pcm_format,
-                output_format=output_format,
-            )
-            async with aclosing(encoded_stream):
-                async for chunk in encoded_stream:
+            # aclosing guarantees this consumer's ffmpeg encoder is torn down
+            # immediately when it goes away, instead of lingering until garbage
+            # collection finalizes the abandoned generator.
+            stream = render.get_stream(output_format)
+            async with aclosing(stream):
+                async for chunk in stream:
                     yield chunk
         finally:
-            # stop fetching when the consumer goes away early (e.g. player
-            # disconnected); no-op when the fetch already completed normally
-            fetch_task.cancel()
+            await self.announcement_renderer.release(render)
+
+    async def get_announcement_duration(
+        self, announcement: PlayerMedia, timeout: float = DEFAULT_RENDER_TIMEOUT
+    ) -> int | None:
+        """
+        Get the exact duration (in seconds) of an announcement, once it finished rendering.
+
+        Waits for the audio to be rendered in full, so call this while the announcement
+        plays rather than before handing it to a player. Returns None when the length can
+        not be determined, e.g. the announcement is no longer playing or its source did
+        not deliver in time.
+
+        :param announcement: The announcement to return the duration for.
+        :param timeout: Maximum time to wait for the audio to finish rendering.
+        """
+        if announcement.duration:
+            return announcement.duration
+        if not announcement.custom_data:
+            return None
+        render = self.announcement_renderer.get(cast("AnnounceData", announcement.custom_data))
+        if render is None:
+            return None
+        duration = await render.wait_finished(timeout)
+        return ceil(duration) if duration else None
 
     async def _wrap_with_audio_source_lifecycle(
         self,

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -38,7 +38,6 @@ from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.json import SerializableType
-from music_assistant.helpers.tags import async_parse_tags
 from music_assistant.helpers.util import try_parse_int
 from music_assistant.models.plugin import PluginProvider
 
@@ -50,6 +49,7 @@ if TYPE_CHECKING:
     from aiohttp import ClientSession
     from hass_client.models import CompressedState, Device, EntityStateEvent, State
     from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.player import PlayerMedia
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -575,7 +575,7 @@ class HomeAssistantProvider(PluginProvider):
             raise MusicAssistantError(msg)
         return str(data)
 
-    async def play_announcement_on_entity(self, entity_id: str, announcement_url: str) -> None:
+    async def play_announcement_on_entity(self, entity_id: str, announcement: PlayerMedia) -> None:
         """
         Play an announcement on a Home Assistant media_player entity.
 
@@ -584,13 +584,13 @@ class HomeAssistantProvider(PluginProvider):
         announcement has finished playing (approximated by its duration).
 
         :param entity_id: The media_player entity to play the announcement on.
-        :param announcement_url: URL of the announcement audio to play.
+        :param announcement: The announcement to play.
         """
         await self.hass.call_service(
             domain="media_player",
             service="play_media",
             service_data={
-                "media_content_id": announcement_url,
+                "media_content_id": announcement.uri,
                 "media_content_type": "music",
                 "announce": True,
             },
@@ -598,8 +598,8 @@ class HomeAssistantProvider(PluginProvider):
         )
         # Wait until the announcement is finished playing so callers can play
         # announcements in a sequence; HA gives no completion signal for announcements.
-        media_info = await async_parse_tags(announcement_url, require_duration=True)
-        await asyncio.sleep(media_info.duration or 5)
+        duration = await self.mass.streams.get_announcement_duration(announcement)
+        await asyncio.sleep(duration or 5)
 
     async def get_tts_message(self, message: str, language: str | None = None) -> StreamDetails:
         """Handle text-to-speech via Home Assistant's REST API."""

--- a/music_assistant/providers/hass_players/player.py
+++ b/music_assistant/providers/hass_players/player.py
@@ -311,7 +311,7 @@ class HomeAssistantPlayer(Player):
                 self.display_name,
             )
         hass_prov = cast("HomeAssistantPlayerProvider", self.provider).hass_prov
-        await hass_prov.play_announcement_on_entity(self.player_id, announcement.uri)
+        await hass_prov.play_announcement_on_entity(self.player_id, announcement)
         self.logger.debug(
             "Playing announcement on %s completed",
             self.display_name,

--- a/music_assistant/providers/samsung_wam/player.py
+++ b/music_assistant/providers/samsung_wam/player.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -11,7 +10,6 @@ from music_assistant_models.enums import IdentifierType, PlaybackState
 from music_assistant_models.player import DeviceInfo, PlayerMedia
 
 from music_assistant.constants import CONF_ENTRY_ENABLE_ICY_METADATA_HIDDEN
-from music_assistant.helpers.tags import async_parse_tags
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import Player
 
@@ -187,20 +185,15 @@ class WamPlayer(Player):
         if volume_level is not None and prev_volume is not None and volume_level != prev_volume:
             await self.volume.set_volume(volume_level)
 
-        # Samsung speakers auto-resume after a URL stream ends rather than going idle,
-        # so we stop the stream manually at the expected end of the announcement
-        duration: float | None = None
-        with contextlib.suppress(Exception):
-            media_info = await async_parse_tags(announcement.uri, require_duration=True)
-            if media_info.duration:
-                duration = float(media_info.duration)
-
         await self.playback.play_media(announcement)
         await self.await_state_change(
             lambda: self.playback_state == PlaybackState.PLAYING,
             timeout=10.0,
         )
 
+        # Samsung speakers auto-resume after a URL stream ends rather than going idle,
+        # so we stop the stream manually at the expected end of the announcement
+        duration = await self.mass.streams.get_announcement_duration(announcement)
         if duration is not None:
             await asyncio.sleep(duration + 1.0)
         else:

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -1078,7 +1078,7 @@ class SendspinPlayer(SendspinBasePlayer):
             # the device's announcement pipeline plays at its own volume;
             # the announce volume config entries are hidden for this player
             self.logger.debug("Ignoring announcement volume level for player %s", self.display_name)
-        await hass.play_announcement_on_entity(entity_id, announcement.uri)
+        await hass.play_announcement_on_entity(entity_id, announcement)
         self.logger.debug("Playing announcement on %s completed", self.display_name)
 
     def restore_bridge_identity(

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -34,7 +34,6 @@ from music_assistant.constants import (
     CONF_ENTRY_HTTP_PROFILE_DEFAULT_2,
     VERBOSE_LOG_LEVEL,
 )
-from music_assistant.helpers.tags import async_parse_tags
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import Player
 from music_assistant.providers.sonos.const import (
@@ -325,10 +324,7 @@ class SonosPlayer(Player):
         if media.media_type == MediaType.ANNOUNCEMENT:
             # We cannot use play_stream_url for announcements because Sonos treats those
             # as duration less radio streams and will retry/loop them.
-            if not media.duration and media.custom_data:
-                announcement_url = media.custom_data.get("announcement_url", media.uri)
-                media_info = await async_parse_tags(announcement_url, require_duration=True)
-                media.duration = int(media_info.duration) if media_info.duration else None
+            media.duration = await self.mass.streams.get_announcement_duration(media)
             media.queue_item_id = "announcement"
             self.sonos_queue.items = [media]
             self.sonos_queue.last_updated = time.time()
@@ -471,9 +467,8 @@ class SonosPlayer(Player):
         # Wait until the announcement is finished playing
         # This is helpful for people who want to play announcements in a sequence
         # yeah we can also setup a subscription on the sonos player for this, but this is easier
-        media_info = await async_parse_tags(announcement.uri, require_duration=True)
-        duration = media_info.duration or 10
-        await asyncio.sleep(duration)
+        duration = await self.mass.streams.get_announcement_duration(announcement)
+        await asyncio.sleep(duration or 10)
 
     def on_player_event(self, event: SonosEvent | None) -> None:
         """Handle incoming event from player."""

--- a/music_assistant/providers/yandex_station/player.py
+++ b/music_assistant/providers/yandex_station/player.py
@@ -446,7 +446,7 @@ class YandexStationPlayer(Player):
             _raise_if_failed(result, "Audio announcement")
             # externalCommandBypass playback doesn't update state.playing,
             # so we can't observe completion — wait by known duration instead.
-            duration = announcement.duration
+            duration = await self.mass.streams.get_announcement_duration(announcement)
             wait_time = (
                 min(duration + 1, announcement_timeout)
                 if duration and duration > 0

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1331,6 +1331,11 @@ class TestPlayAnnouncementCleanup:
 
         mock_mass.streams.announcements = announcements
         mock_mass.streams.get_announcement_url = MagicMock(side_effect=_get_announcement_url)
+        render = MagicMock()
+        render.wait_ready = AsyncMock(return_value=True)
+        render.wait_finished = AsyncMock(return_value=3.0)
+        mock_mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
+        mock_mass.streams.announcement_renderer.release = AsyncMock()
         player.update_state(signal_event=False)
         return controller, player
 
@@ -1349,6 +1354,7 @@ class TestPlayAnnouncementCleanup:
 
         player.play_announcement.assert_awaited_once()
         assert announcements == {}
+        mock_mass.streams.announcement_renderer.release.assert_awaited_once()
 
     async def test_announcement_data_removed_on_error(self, mock_mass: MagicMock) -> None:
         """The registered announcement data is released even when playback fails."""
@@ -1360,6 +1366,22 @@ class TestPlayAnnouncementCleanup:
             await controller.play_announcement("player_1", "http://test/announcement.mp3")
 
         assert announcements == {}
+        mock_mass.streams.announcement_renderer.release.assert_awaited_once()
+
+    async def test_native_announcement_starts_on_first_audio(self, mock_mass: MagicMock) -> None:
+        """A native implementation is handed the url as soon as there is audio to serve."""
+        announcements: dict[str, object] = {}
+        controller, player = self._make_player(mock_mass, announcements)
+        render = mock_mass.streams.announcement_renderer.acquire.return_value
+        player.play_announcement = AsyncMock()  # type: ignore[method-assign]
+
+        await controller.play_announcement("player_1", "http://test/announcement.mp3")
+
+        player.play_announcement.assert_awaited_once()
+        # waiting for the whole clip here would delay the player for a slow source;
+        # the length is resolved downstream while it plays
+        render.wait_ready.assert_awaited_once()
+        render.wait_finished.assert_not_awaited()
 
 
 class TestPlayAnnouncementRestore:
@@ -1487,7 +1509,7 @@ class TestPlayAnnouncementRestore:
 
         assert volume_mock.call_args_list == [call("player_1", 0), call("player_1", 20)]
 
-    async def test_playback_is_restored_when_duration_lookup_fails(
+    async def test_playback_is_restored_when_duration_is_unknown(
         self, mock_mass: MagicMock
     ) -> None:
         """An announcement of unknown length still hands the player back to its content."""
@@ -1497,8 +1519,8 @@ class TestPlayAnnouncementRestore:
         announcement = self._announcement()
         announcement.duration = None
 
-        with pytest.raises(ValueError, match="custom_data"):
-            await controller._play_announcement(player, announcement)
+        # an unknown length waits for the player to report it finished instead of failing
+        await controller._play_announcement(player, announcement)
 
         resume_mock.assert_awaited_once()
 

--- a/tests/controllers/streams/test_announcement_stream.py
+++ b/tests/controllers/streams/test_announcement_stream.py
@@ -6,16 +6,21 @@ import asyncio
 import logging
 from collections.abc import AsyncGenerator, Iterator
 from contextlib import aclosing
-from typing import Any, cast
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import make_mocked_request
-from music_assistant_models.enums import ContentType
+from music_assistant_models.enums import ContentType, MediaType
 from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.player import PlayerMedia
 
 from music_assistant.controllers.players.helpers import AnnounceData
+from music_assistant.controllers.streams.announcements import (
+    ANNOUNCEMENT_PCM_FORMAT,
+    AnnouncementRenderer,
+)
 from music_assistant.controllers.streams.controller import StreamsController
 
 PCM_FORMAT = AudioFormat(
@@ -24,64 +29,232 @@ PCM_FORMAT = AudioFormat(
     bit_depth=16,
     channels=2,
 )
+ONE_SECOND_CHUNK = b"\x00" * ANNOUNCEMENT_PCM_FORMAT.pcm_sample_size
+
+
+def _announce_data(
+    announce_player_id: str | None = None, pre_announce: bool = False
+) -> AnnounceData:
+    return AnnounceData(
+        announcement_url="http://test/announcement.mp3",
+        pre_announce=pre_announce,
+        pre_announce_url="http://test/chime.mp3",
+        announce_player_id=announce_player_id,
+    )
+
+
+def _announcement(pre_announce: bool = False) -> PlayerMedia:
+    """Return the PlayerMedia a player is handed for an announcement."""
+    return PlayerMedia(
+        uri="http://ma/announcement/player_1.mp3",
+        media_type=MediaType.ANNOUNCEMENT,
+        custom_data=dict(_announce_data(pre_announce=pre_announce)),
+    )
+
+
+def _fake_ffmpeg_stream(chunks: int) -> Any:
+    """Return a get_ffmpeg_stream stand-in yielding the given number of 1-second chunks."""
+
+    def _factory(*_args: Any, **_kwargs: Any) -> AsyncGenerator[bytes]:
+        async def _stream() -> AsyncGenerator[bytes]:
+            for _ in range(chunks):
+                yield ONE_SECOND_CHUNK
+
+        return _stream()
+
+    return _factory
+
+
+def _controller(renderer: AnnouncementRenderer) -> StreamsController:
+    """Return a StreamsController stub that only knows about announcements."""
+    controller = StreamsController.__new__(StreamsController)
+    controller.announcement_renderer = renderer
+    return controller
 
 
 @pytest.mark.asyncio
-async def test_fetch_task_cancelled_when_consumer_abandons() -> None:
-    """The background fetch task and its ffmpeg stream stop when the consumer goes away."""
-    ffmpeg_stream_closed = asyncio.Event()
-    fetch_tasks: list[asyncio.Task[None]] = []
+async def test_source_is_rendered_once_for_all_consumers() -> None:
+    """Every consumer of the same announcement is served from a single render."""
+    renderer = AnnouncementRenderer()
+    controller = _controller(renderer)
+    factory = MagicMock(side_effect=_fake_ffmpeg_stream(3))
 
-    def _fake_ffmpeg_stream(*_args: Any, **_kwargs: Any) -> AsyncGenerator[bytes]:
+    async def _read() -> list[bytes]:
+        return [
+            chunk
+            async for chunk in controller.get_announcement_stream(_announce_data(), PCM_FORMAT)
+        ]
+
+    with patch("music_assistant.controllers.streams.announcements.get_ffmpeg_stream", factory):
+        # play_announcement holds a reference for the duration of the announcement
+        owner_render = renderer.acquire(_announce_data())
+        # two group members read at the same time, a HEAD probe read before them
+        sequential = await _read()
+        concurrent = await asyncio.gather(_read(), _read())
+        await renderer.release(owner_render)
+
+    # the source is fetched/decoded once, yet every consumer got the full audio
+    assert factory.call_count == 1
+    assert all(len(chunks) == 3 for chunks in [sequential, *concurrent])
+    assert renderer.active_renders == 0
+
+
+@pytest.mark.asyncio
+async def test_render_is_kept_alive_while_a_consumer_reads() -> None:
+    """A render survives its owner releasing it as long as a consumer is still reading."""
+    renderer = AnnouncementRenderer()
+    controller = _controller(renderer)
+
+    with patch(
+        "music_assistant.controllers.streams.announcements.get_ffmpeg_stream",
+        side_effect=_fake_ffmpeg_stream(2),
+    ):
+        owner_render = renderer.acquire(_announce_data())
+        stream = controller.get_announcement_stream(_announce_data(), PCM_FORMAT)
+        async with aclosing(stream):
+            assert await anext(stream) == ONE_SECOND_CHUNK
+            # the owner (play_announcement) is done, the consumer is not
+            await renderer.release(owner_render)
+            assert renderer.active_renders == 1
+            assert await anext(stream) == ONE_SECOND_CHUNK
+
+    assert renderer.active_renders == 0
+
+
+@pytest.mark.asyncio
+async def test_duration_is_exact_without_probing_the_source() -> None:
+    """The rendered audio yields the exact announcement duration."""
+    renderer = AnnouncementRenderer()
+    controller = _controller(renderer)
+
+    with patch(
+        "music_assistant.controllers.streams.announcements.get_ffmpeg_stream",
+        side_effect=_fake_ffmpeg_stream(4),
+    ):
+        render = renderer.acquire(_announce_data())
+        assert await controller.get_announcement_duration(_announcement()) == 4
+        assert render.duration == 4.0
+        await renderer.release(render)
+
+    # without an active render there is nothing to report
+    assert await controller.get_announcement_duration(_announcement()) is None
+
+
+@pytest.mark.asyncio
+async def test_pre_announce_is_part_of_the_render() -> None:
+    """The pre-announce chime is decoded into the same render as the announcement."""
+    renderer = AnnouncementRenderer()
+    controller = _controller(renderer)
+    factory = MagicMock(side_effect=_fake_ffmpeg_stream(1))
+
+    with patch("music_assistant.controllers.streams.announcements.get_ffmpeg_stream", factory):
+        render = renderer.acquire(_announce_data(pre_announce=True))
+        duration = await render.wait_finished()
+        await renderer.release(render)
+
+    # chime and announcement are decoded separately but land in one render
+    assert factory.call_count == 2
+    assert duration == 2.0
+    # an announcement with a chime is a different render than the one without
+    assert await controller.get_announcement_duration(_announcement()) is None
+
+
+@pytest.mark.asyncio
+async def test_render_is_cancelled_when_released() -> None:
+    """Releasing the last reference tears the render (and its ffmpeg chain) down."""
+    ffmpeg_stream_closed = asyncio.Event()
+
+    def _endless_stream(*_args: Any, **_kwargs: Any) -> AsyncGenerator[bytes]:
         async def _stream() -> AsyncGenerator[bytes]:
             try:
                 while True:
-                    yield b"\x00" * 1024
+                    yield ONE_SECOND_CHUNK
+                    await asyncio.sleep(0)
             finally:
                 ffmpeg_stream_closed.set()
 
         return _stream()
 
-    def _create_task(coro: Any) -> asyncio.Task[None]:
-        task = asyncio.get_running_loop().create_task(coro)
-        fetch_tasks.append(task)
-        return task
-
-    fake_self = MagicMock()
-    fake_self.mass.create_task = MagicMock(side_effect=_create_task)
-
+    renderer = AnnouncementRenderer()
     with patch(
-        "music_assistant.controllers.streams.controller.get_ffmpeg_stream",
-        side_effect=_fake_ffmpeg_stream,
+        "music_assistant.controllers.streams.announcements.get_ffmpeg_stream",
+        side_effect=_endless_stream,
     ):
-        stream = StreamsController.get_announcement_stream(
-            cast("StreamsController", fake_self),
-            announcement_url="http://test/announcement.mp3",
-            output_format=PCM_FORMAT,
-            pre_announce=False,
-        )
-        # consume a few chunks, then abandon the stream (player disconnected)
-        async with aclosing(stream):
-            chunk_count = 0
-            async for _chunk in stream:
-                chunk_count += 1
-                if chunk_count == 3:
-                    break
+        render = renderer.acquire(_announce_data())
+        await render.wait_ready()
+        await renderer.release(render)
 
-    assert len(fetch_tasks) == 1
-    # closing the consumer must cancel the fetch task and finalize the ffmpeg stream
     await asyncio.wait_for(ffmpeg_stream_closed.wait(), timeout=1)
-    with pytest.raises(asyncio.CancelledError):
-        await fetch_tasks[0]
+    assert renderer.active_renders == 0
 
 
-def _announce_data(announce_player_id: str | None) -> AnnounceData:
-    return AnnounceData(
-        announcement_url="http://test/announcement.mp3",
-        pre_announce=False,
-        pre_announce_url="",
-        announce_player_id=announce_player_id,
-    )
+@pytest.mark.asyncio
+async def test_the_chime_alone_does_not_make_the_clip_ready() -> None:
+    """Playback waits for announcement audio, not just the pre-announce chime."""
+    tts_answered = asyncio.Event()
+
+    def _fast_chime_slow_tts(*_args: Any, **kwargs: Any) -> AsyncGenerator[bytes]:
+        is_chime = "chime" in kwargs["audio_input"]
+
+        async def _stream() -> AsyncGenerator[bytes]:
+            if is_chime:
+                yield ONE_SECOND_CHUNK
+                return
+            await tts_answered.wait()
+            yield ONE_SECOND_CHUNK
+
+        return _stream()
+
+    renderer = AnnouncementRenderer()
+    with patch(
+        "music_assistant.controllers.streams.announcements.get_ffmpeg_stream",
+        side_effect=_fast_chime_slow_tts,
+    ):
+        render = renderer.acquire(_announce_data(pre_announce=True))
+        waiter = asyncio.ensure_future(render.wait_ready())
+        await asyncio.sleep(0)
+        # the chime is buffered, but a player started on it would run dry
+        assert render.duration == 1.0
+        assert not waiter.done()
+
+        tts_answered.set()
+        assert await asyncio.wait_for(waiter, timeout=1) is True
+        assert render.duration == 2.0
+        await renderer.release(render)
+
+
+@pytest.mark.asyncio
+async def test_a_reader_can_start_before_the_render_finished() -> None:
+    """A reader that catches up with the render waits for the rest of the clip."""
+    released = asyncio.Event()
+
+    def _slow_stream(*_args: Any, **_kwargs: Any) -> AsyncGenerator[bytes]:
+        async def _stream() -> AsyncGenerator[bytes]:
+            yield ONE_SECOND_CHUNK
+            await released.wait()
+            yield ONE_SECOND_CHUNK
+
+        return _stream()
+
+    renderer = AnnouncementRenderer()
+    controller = _controller(renderer)
+    with patch(
+        "music_assistant.controllers.streams.announcements.get_ffmpeg_stream",
+        side_effect=_slow_stream,
+    ):
+        render = renderer.acquire(_announce_data())
+        stream = controller.get_announcement_stream(_announce_data(), PCM_FORMAT)
+        async with aclosing(stream):
+            # the reader catches up with the render and has to wait for the rest
+            assert await anext(stream) == ONE_SECOND_CHUNK
+            reader = asyncio.ensure_future(anext(stream))
+            await asyncio.sleep(0)
+            assert not reader.done()
+            released.set()
+            assert await asyncio.wait_for(reader, timeout=1) == ONE_SECOND_CHUNK
+        await renderer.release(render)
+
+    assert renderer.active_renders == 0
 
 
 def test_announcement_http_profile_prefers_fetching_player() -> None:

--- a/tests/providers/hass/test_device_correlation.py
+++ b/tests/providers/hass/test_device_correlation.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from music_assistant_models.player import PlayerMedia
 
 from music_assistant.providers.hass import HomeAssistantProvider
 
@@ -108,13 +110,11 @@ async def test_play_announcement_on_entity() -> None:
     """An announcement is played via HA's announce feature and awaited for its duration."""
     provider = HomeAssistantProvider.__new__(HomeAssistantProvider)
     provider.hass = SimpleNamespace(call_service=AsyncMock())
-    with patch(
-        "music_assistant.providers.hass.async_parse_tags",
-        AsyncMock(return_value=SimpleNamespace(duration=0.01)),
-    ) as parse_tags:
-        await provider.play_announcement_on_entity(
-            "media_player.kitchen", "http://mass.local/announcement.mp3"
-        )
+    provider.mass = MagicMock()
+    provider.mass.streams.get_announcement_duration = AsyncMock(return_value=7)
+    announcement = PlayerMedia(uri="http://mass.local/announcement.mp3")
+    with patch("music_assistant.providers.hass.asyncio.sleep", AsyncMock()) as sleep:
+        await provider.play_announcement_on_entity("media_player.kitchen", announcement)
     provider.hass.call_service.assert_awaited_once_with(
         domain="media_player",
         service="play_media",
@@ -125,4 +125,6 @@ async def test_play_announcement_on_entity() -> None:
         },
         target={"entity_id": "media_player.kitchen"},
     )
-    parse_tags.assert_awaited_once_with("http://mass.local/announcement.mp3", require_duration=True)
+    # the length is resolved after the announcement was handed to the entity
+    provider.mass.streams.get_announcement_duration.assert_awaited_once_with(announcement)
+    sleep.assert_awaited_once_with(7)

--- a/tests/providers/sendspin/test_hass_announce.py
+++ b/tests/providers/sendspin/test_hass_announce.py
@@ -128,11 +128,9 @@ async def test_play_announcement_relays_via_hass() -> None:
     player = _player()
     player.mass = cast("MusicAssistant", SimpleNamespace(get_provider=lambda _domain: hass))
     player.set_hass_announce_entity(ENTITY_ID)
-    announcement = PlayerMedia(uri="http://mass.local/announcement.mp3")
+    announcement = PlayerMedia(uri="http://mass.local/announcement.mp3", duration=4)
     await player.play_announcement(announcement, volume_level=50)
-    hass.play_announcement_on_entity.assert_awaited_once_with(
-        ENTITY_ID, "http://mass.local/announcement.mp3"
-    )
+    hass.play_announcement_on_entity.assert_awaited_once_with(ENTITY_ID, announcement)
 
 
 @pytest.mark.parametrize("hass_provider", [None, SimpleNamespace(available=False)])


### PR DESCRIPTION
# What does this implement/fix?

Announcements were sent to the player before their audio was ready. The player got a
stream that started with silence, padded for as long as the text-to-speech service took
to answer, and how long the announcement would last was only worked out afterwards by
downloading and decoding it a second time. That guess was made against the wrong audio,
so the wait could run out while the announcement was still playing, dropping the volume
back down and resuming music over the top of it.

Announcements are now prepared up front and held in memory, so playback starts on real
audio and the exact length is known.

- The audio is prepared the moment the announcement is requested, while the player is
  still being stopped and turned up, instead of afterwards
- The chime and the announcement are fetched and decoded once and shared, so a group
  announcement no longer downloads the same audio again for every speaker
- No more silence in front of the announcement: playback starts as soon as there is
  audio to play
- The volume and the previous music are restored when the announcement actually ends,
  instead of at a guessed moment that could land in the middle of it
- An announcement that never ends (a radio stream, say) is now cut off instead of
  playing forever

**Related issue (if applicable):**

- related issue n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
