### PR TITLE
Measure true peak during loudness analysis

### DIFF
--- a/music_assistant/providers/loudness_analysis/provider.py
+++ b/music_assistant/providers/loudness_analysis/provider.py
@@ -33,7 +33,7 @@ CONF_WRITE_REPLAYGAIN_TAGS = "write_replaygain_tags"
 
 _INTEGRATED_RE = re.compile(r"Integrated loudness:.*?I:\s*(-?\d+(?:\.\d+)?)\s*LUFS", re.DOTALL)
 _LRA_RE = re.compile(r"Loudness range:.*?LRA:\s*(-?\d+(?:\.\d+)?)\s*LU", re.DOTALL)
-_TRUE_PEAK_RE = re.compile(r"True peak:.*?Peak:\s*(-?\d+(?:\.\d+)?)\s*dBTP", re.DOTALL)
+_TRUE_PEAK_RE = re.compile(r"True peak:.*?Peak:\s*(-?\d+(?:\.\d+)?)\s*dBFS", re.DOTALL)
 
 
 @dataclass
@@ -48,7 +48,7 @@ class LoudnessSessionData:
 class LoudnessAnalysisProvider(AudioAnalysisProvider):
     """Audio analysis provider that measures EBU R128 integrated loudness."""
 
-    analysis_version: int = 1
+    analysis_version: int = 2
 
     def __init__(
         self,
@@ -133,7 +133,8 @@ class LoudnessAnalysisProvider(AudioAnalysisProvider):
             input_format=audio_format,
             output_format=audio_format,
             audio_output="NULL",
-            filter_params=["ebur128=framelog=verbose"],
+            # ebur128 measures no peak unless asked
+            filter_params=["ebur128=framelog=verbose:peak=true"],
             collect_log_history=True,
             loglevel="info",
         )

--- a/music_assistant/providers/loudness_analysis/provider.py
+++ b/music_assistant/providers/loudness_analysis/provider.py
@@ -133,7 +133,6 @@ class LoudnessAnalysisProvider(AudioAnalysisProvider):
             input_format=audio_format,
             output_format=audio_format,
             audio_output="NULL",
-            # ebur128 measures no peak unless asked
             filter_params=["ebur128=framelog=verbose:peak=true"],
             collect_log_history=True,
             loglevel="info",

--- a/tests/providers/loudness_analysis/test_provider.py
+++ b/tests/providers/loudness_analysis/test_provider.py
@@ -15,6 +15,7 @@ from music_assistant.providers.loudness_analysis.provider import (
     MIN_DURATION_SECONDS,
     LoudnessAnalysisProvider,
     LoudnessSessionData,
+    _parse_ebur128_metrics,
 )
 
 
@@ -229,3 +230,55 @@ async def test_post_analysis_skips_when_loudness_missing(
     await provider.post_analysis(streamdetails, analysis)
 
     write_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# true peak measurement tests
+# ---------------------------------------------------------------------------
+
+# verbatim ffmpeg output, do not hand-edit
+_FFMPEG_SUMMARY_WITH_PEAK = [
+    "[Parsed_ebur128_0 @ 0x8b8c05080] Summary:",
+    "",
+    "  Integrated loudness:",
+    "    I:         -21.8 LUFS",
+    "    Threshold: -31.8 LUFS",
+    "",
+    "  Loudness range:",
+    "    LRA:         0.0 LU",
+    "    Threshold: -41.8 LUFS",
+    "    LRA low:   -21.8 LUFS",
+    "    LRA high:  -21.8 LUFS",
+    "",
+    "  True peak:",
+    "    Peak:      -18.1 dBFS",
+]
+
+
+def test_parse_metrics_extracts_true_peak_from_ffmpeg_summary() -> None:
+    """All three metrics must be parsed from a real ebur128 summary."""
+    integrated, lra, true_peak = _parse_ebur128_metrics(_FFMPEG_SUMMARY_WITH_PEAK)
+
+    assert integrated == -21.8
+    assert lra == 0.0
+    assert true_peak == -18.1
+
+
+@pytest.mark.asyncio
+async def test_start_analysis_requests_peak_measurement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ebur128 only reports true peak when explicitly asked, so the filter must request it."""
+    provider = _make_provider()
+    streamdetails = MagicMock()
+    streamdetails.volume_normalization_mode = None
+
+    fake_ffmpeg = MagicMock()
+    fake_ffmpeg.start = AsyncMock()
+    ffmpeg_cls = MagicMock(return_value=fake_ffmpeg)
+    monkeypatch.setattr("music_assistant.providers.loudness_analysis.provider.FFMpeg", ffmpeg_cls)
+
+    assert await provider._start_analysis("session-peak", streamdetails, MagicMock()) is True
+
+    filter_params = ffmpeg_cls.call_args.kwargs["filter_params"]
+    assert any("peak=true" in param for param in filter_params)


### PR DESCRIPTION
# What does this implement/fix?

`AudioAnalysisData.true_peak` has always been stored as NULL. Two independent problems, either one enough on its own:

- The `ebur128` filter ran without `peak=true`. ffmpeg measures no peak unless asked, so the summary contains no `True peak:` section at all.
- `_TRUE_PEAK_RE` expected `dBTP`, but ffmpeg prints the peak in `dBFS` — the value would have been dropped even when present.

Neither surfaced, because `_finalize` guards with `if true_peak is not None`, so a permanently missing peak looks exactly like "this file had no peak data", and no consumer reads the field. On a real library, all 428 stored `loudness_analysis` rows had an integrated loudness and no peak.

This matters for peak-limited normalization: without a peak, static gain can push a quiet-but-hot item past full scale, and there is no measurement to clamp against.

- Request `peak=true` on the `ebur128` filter.
- Match the unit ffmpeg actually prints (`dBFS`).
- Bump `analysis_version` to 2 so v1 rows are re-measured instead of keeping their NULL peak forever.
- Add regression tests: one parses a verbatim ffmpeg summary, one asserts the filter requests peak measurement.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
