### PR TITLE
fix: skip ABS library types that don't support personalized views

### DIFF
--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -2066,9 +2066,12 @@ for more details.
         limit_items_per_lib = 1 if limit_items_per_lib == 0 else limit_items_per_lib
 
         for library_id in all_libraries:
-            shelves = await self._client.get_library_personalized_view(
-                library_id=library_id, limit=limit_items_per_lib
-            )
+            try:
+                shelves = await self._client.get_library_personalized_view(
+                    library_id=library_id, limit=limit_items_per_lib
+                )
+            except AbsNotFoundError:
+                continue
             await self._recommendations_iter_shelves(shelves, library_id, items_by_shelf_id)
 
         folders: list[RecommendationFolder] = []

--- a/tests/providers/audiobookshelf/test_recommendations.py
+++ b/tests/providers/audiobookshelf/test_recommendations.py
@@ -7,12 +7,14 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from aioaudiobookshelf.exceptions import NotFoundError as AbsNotFoundError
 from aioaudiobookshelf.schema.shelf import ShelfBook, ShelfLibraryItemMinified
 from aioaudiobookshelf.schema.shelf import ShelfId as AbsShelfId
 from aioaudiobookshelf.schema.shelf import ShelfType as AbsShelfType
 from music_assistant_models.media_items import BrowseFolder, UniqueList
 
 from music_assistant.providers.audiobookshelf import Audiobookshelf
+from music_assistant.providers.audiobookshelf.helpers import LibraryHelper
 
 
 def _make_shelf() -> Mock:
@@ -164,3 +166,21 @@ async def test_get_recommendation_items_unknown_id_returns_empty(
 
     assert isinstance(items, UniqueList)
     assert len(items) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_recommendations_skips_unsupported_libraries(
+    provider: Audiobookshelf,
+) -> None:
+    """A podcast library returning 404 is skipped; the audiobook lib still yields rows."""
+    _install_cache_mocks(provider)
+    view_mock = AsyncMock()
+    view_mock.side_effect = [AbsNotFoundError(""), [_make_shelf()]]
+    provider._client.get_library_personalized_view = view_mock  # type: ignore[method-assign]
+    provider.mass.music.get_library_item_by_prov_id = AsyncMock(return_value=Mock())  # type: ignore[method-assign]
+    provider.libraries.podcasts["pod_lib1"] = LibraryHelper(name="Podcasts")
+
+    rows = await provider.get_recommendations()
+
+    assert view_mock.await_count == 2
+    assert any(f.item_id == "recently-added" for f in rows)


### PR DESCRIPTION
# What does this implement/fix?

Audiobookshelf's _fetch_recommendation_payload() calls get_library_personalized_view() for all libraries including podcast libraries, but ABS returns HTTP 404 (NotFoundError) for podcast libraries on the /api/libraries/{id}/personalized endpoint.

This unhandled exception kills the entire recommendation payload, silently dropping all recommendation rows for users with podcast libraries.

Catch AbsNotFoundError per-library and skip unsupported libraries instead of failing the entire fetch.

**Related issue (if applicable):**

- None tracked, experienced on my local instance -

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
