### PR TITLE
Remove stale Audiobookshelf playback sessions to avoid repeated sync failures

### DIFF
--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -1240,12 +1240,19 @@ for more details.
                     ),
                 )
                 session_helper.last_sync_time = now
+                session_helper.failed_sync_count = 0
                 self.logger.debug("Synced playback session, position %s s.", position)
                 return True
             except AbsSessionSyncError:
-                self.logger.debug(
-                    "Was unable to sync session. Falling back to non-session approach."
-                )
+                session_helper.failed_sync_count += 1
+                if session_helper.failed_sync_count >= 5:
+                    self.logger.warning(
+                        "Unable to sync session %s after %s attempts - "
+                        "falling back to non-session approach.",
+                        session_helper.abs_session_id,
+                        session_helper.failed_sync_count,
+                    )
+                    self.sessions.pop(prov_item_id, None)
             return False
 
         if media_type == MediaType.PODCAST_EPISODE:

--- a/music_assistant/providers/audiobookshelf/helpers.py
+++ b/music_assistant/providers/audiobookshelf/helpers.py
@@ -54,6 +54,7 @@ class SessionHelper:
 
     abs_session_id: str
     last_sync_time: float
+    failed_sync_count: int = 0
 
 
 @dataclass(kw_only=True)

--- a/tests/providers/audiobookshelf/test_session_sync.py
+++ b/tests/providers/audiobookshelf/test_session_sync.py
@@ -1,0 +1,97 @@
+"""Tests for the Audiobookshelf session sync retry logic."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, Mock
+
+from aioaudiobookshelf.exceptions import SessionSyncError as AbsSessionSyncError
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import PodcastEpisode
+
+from music_assistant.providers.audiobookshelf import Audiobookshelf
+from music_assistant.providers.audiobookshelf.helpers import SessionHelper
+
+
+def _make_episode() -> Mock:
+    """Create a minimal podcast episode as returned by the provider."""
+    episode = Mock(spec=PodcastEpisode)
+    episode.duration = 600
+    episode.name = "Test Episode"
+    return episode
+
+
+def _install_session(provider: Audiobookshelf) -> SessionHelper:
+    """Add a session helper to the provider, keyed by mass item id."""
+    # handle_async_init() normally initializes these, but the fixture skips it.
+    # The progress guard would throttle rapid test calls, so bypass it.
+    provider.sessions = {}
+    provider.progress_guard = Mock()
+    provider.progress_guard.guard_ok_mass.return_value = True
+    # the non-session fallback path also updates media progress
+    provider._client.update_my_media_progress = AsyncMock()  # type: ignore[method-assign]
+    session = SessionHelper(abs_session_id="abs_session_1", last_sync_time=time.time())
+    provider.sessions["pod1 ep1"] = session
+    return session
+
+
+async def _play(provider: Audiobookshelf) -> None:
+    """Invoke on_played for a podcast episode at position 100."""
+    await provider.on_played(
+        media_type=MediaType.PODCAST_EPISODE,
+        prov_item_id="pod1 ep1",
+        fully_played=False,
+        position=100,
+        media_item=_make_episode(),
+    )
+
+
+async def test_session_kept_below_failure_threshold(
+    provider: Audiobookshelf,
+) -> None:
+    """A session survives consecutive failures below the threshold."""
+    _install_session(provider)
+    provider._client.sync_open_session = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AbsSessionSyncError()
+    )
+
+    for _ in range(4):
+        await _play(provider)
+
+    assert "pod1 ep1" in provider.sessions
+    session = provider.sessions["pod1 ep1"]
+    assert session.failed_sync_count == 4
+
+
+async def test_session_removed_at_failure_threshold(
+    provider: Audiobookshelf,
+) -> None:
+    """A session is removed after the 5th consecutive failure."""
+    _install_session(provider)
+    provider._client.sync_open_session = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AbsSessionSyncError()
+    )
+
+    for _ in range(5):
+        await _play(provider)
+
+    assert "pod1 ep1" not in provider.sessions
+
+
+async def test_failed_sync_count_reset_on_success(
+    provider: Audiobookshelf,
+) -> None:
+    """A successful sync resets the consecutive failure counter."""
+    session = _install_session(provider)
+    # fail twice, then succeed
+    provider._client.sync_open_session = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[AbsSessionSyncError(), AbsSessionSyncError(), Mock()]
+    )
+
+    for _ in range(2):
+        await _play(provider)
+    assert session.failed_sync_count == 2
+
+    await _play(provider)
+    assert session.failed_sync_count == 0
+    assert "pod1 ep1" in provider.sessions


### PR DESCRIPTION
# What does this implement/fix?

## Problem
When ABS closes an idle playback session, sync_open_session() raises AbsSessionSyncError. The on_played() callback (fired every 30s during playback) catches it and falls back to direct progress updates, but keeps the stale session in self.sessions — so every subsequent report cycle retries the dead session and fails again, generating repeated log spam.
Problem with the naive fix
Removing the stale session on the first failure permanently demotes the user to the non-session fallback (update_my_media_progress). That fallback only updates the play position — it does not feed into Audiobookshelf's listening statistics (time listened, session history). For users who care about those stats, a transient sync failure (e.g. ABS briefly unreachable, or a session that times out but could be recreated) would silently disable stats for the rest of the playback.

## Fix
Track consecutive sync failures on the SessionHelper via a new failed_sync_count field, reset on success:
- Success → failed_sync_count = 0
- AbsSessionSyncError → increment the counter
- 5 consecutive failures → remove the session from self.sessions and log a warning with the attempt count
This way transient errors don't permanently disable ABS listening stats — only genuinely dead sessions (5 consecutive failures over ~2.5 minutes of 30s reporting) are dropped. A fresh session is automatically created when a new stream starts via _get_playback_session().
## Testing
Added test_session_sync.py with three cases:
- Session survives 4 consecutive failures (failed_sync_count == 4, still in sessions)
- Session removed on the 5th consecutive failure
- A successful sync resets the failure counter

All existing Audiobookshelf provider tests pass.

**Related issue (if applicable):**

_None_

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
