### PR TITLE
Reduce deezer-python-gql log verbosity to match provider level

### DIFF
--- a/music_assistant/providers/deezer/provider.py
+++ b/music_assistant/providers/deezer/provider.py
@@ -9,6 +9,7 @@ Thin facade that delegates to specialized manager classes:
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncGenerator, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -102,6 +103,7 @@ class DeezerProvider(RecommendationPayloadMixin, MusicProvider):
 
         try:
             self.gql_client = DeezerGQLClient(arl=arl_token, session=self.mass.http_session)
+            logging.getLogger("deezer_python_gql").setLevel(self.logger.level + 10)
             me = await self.gql_client.get_me()
             if not me:
                 msg = "Authentication returned no user data"


### PR DESCRIPTION
# What does this implement/fix?

The deezer-python-gql library logs all GraphQL errors at WARNING, but operations like check_audiobook_ids produce errors as part of normal operation (Deezer's API returns errors for album IDs that aren't audiobooks). For users with many albums and no audiobooks, this generates hundreds of WARNING lines at startup.

Follow the established pattern used by 37 other providers — set the library logger's level relative to the provider's own log level.

**Related issue (if applicable):**

_None_

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
