### PR TITLE
Apple Music: signing in a second account no longer breaks the first

### DIFF
--- a/music_assistant/providers/apple_music/api_client.py
+++ b/music_assistant/providers/apple_music/api_client.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Concatenate, cast
 from aiohttp import ClientConnectionError, ClientPayloadError, ClientTimeout
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import (
+    LoginFailed,
     MediaNotFoundError,
     RateLimited,
     ResourceTemporarilyUnavailable,
@@ -53,6 +54,22 @@ def _retry_transient_transport_errors[ClientT, **P, R](
     return wrapper
 
 
+def _raise_on_auth_error(status: int, endpoint: str) -> None:
+    """
+    Raise LoginFailed when Apple rejected our credentials.
+
+    Apple answers a revoked or expired music user token with 401/403 on every endpoint,
+    so this surfaces as an auth error the user can act on instead of a bare HTTP error.
+
+    :param status: The HTTP status code returned by Apple.
+    :param endpoint: The endpoint that was called, used in the error message.
+    """
+    if status in (401, 403):
+        raise LoginFailed(
+            f"Apple Music denied access to {endpoint}: the account needs to be signed in again"
+        )
+
+
 class AppleMusicAPIClient:
     """Handles all HTTP communication with the Apple Music API."""
 
@@ -86,6 +103,7 @@ class AppleMusicAPIClient:
                 timeout=ClientTimeout(total=120),
             ) as response,
         ):
+            _raise_on_auth_error(response.status, endpoint)
             if response.status == 404 and "limit" in kwargs and "offset" in kwargs:
                 return {}
             if response.status == 404:
@@ -125,6 +143,7 @@ class AppleMusicAPIClient:
                 timeout=ClientTimeout(total=120),
             ) as response,
         ):
+            _raise_on_auth_error(response.status, endpoint)
             if response.status == 404:
                 raise MediaNotFoundError(f"{endpoint} not found")
             if response.status == 429:
@@ -148,6 +167,7 @@ class AppleMusicAPIClient:
                 timeout=ClientTimeout(total=120),
             ) as response,
         ):
+            _raise_on_auth_error(response.status, endpoint)
             if response.status == 404:
                 raise MediaNotFoundError(f"{endpoint} not found")
             if response.status == 429:
@@ -174,6 +194,7 @@ class AppleMusicAPIClient:
                 timeout=ClientTimeout(total=120),
             ) as response,
         ):
+            _raise_on_auth_error(response.status, endpoint)
             if response.status == 404:
                 raise MediaNotFoundError(f"{endpoint} not found")
             if response.status == 429:

--- a/music_assistant/providers/apple_music/musickit_auth/musickit_wrapper.html
+++ b/music_assistant/providers/apple_music/musickit_auth/musickit_wrapper.html
@@ -129,6 +129,10 @@
         }
       }
       xmlHttp.open(callback_method, url, true);
+      if (data !== null) {
+        // without this the browser labels the JSON body text/plain and the flow drops it
+        xmlHttp.setRequestHeader('Content-Type', 'application/json');
+      }
       xmlHttp.onreadystatechange = () => {
         if (xmlHttp.readyState === XMLHttpRequest.DONE) {
           callbackConsumed = true;

--- a/music_assistant/providers/apple_music/musickit_auth/musickit_wrapper.html
+++ b/music_assistant/providers/apple_music/musickit_auth/musickit_wrapper.html
@@ -15,6 +15,15 @@
     var music_user_token_timestamp = (typeof user_token_timestamp !== 'undefined' ) ? user_token_timestamp : 0;
     var callbackConsumed = false;
     var closing = false;
+    var reloading = false;
+    // token MusicKit already held on page load - may belong to another provider instance
+    var browser_token = "";
+
+    // MusicKit's authorization lives in localStorage, shared by every provider instance on
+    // this origin. Dropping these keys forgets it locally; unauthorize() revokes it at Apple.
+    const MUSICKIT_STORAGE_PREFIX = 'music.';
+    // marks a reload that already dropped the shared session, so we never loop on it
+    const FRESH_SESSION_MARKER = '#new-account';
 
     // The underlying MA auth helper times-out after fixed period so this window can no longer pass back any data so just close it.
     // Self closing windows is anti-pattern user experience but better than leaving non-functioning UI presented
@@ -37,8 +46,19 @@
         }
       }).then(() => {
         music = MusicKit.getInstance();
+        browser_token = (typeof music.musicUserToken === 'string') ? music.musicUserToken : "";
         document.getElementById('signin_button').disabled = false;
-        if (music.isAuthorized) {
+        if (isForeignSession()) {
+          // another instance's session: never hand its token to this one
+          if (!sessionForgotten()) {
+            forgetSessionAndReload();
+            return;
+          }
+          document.getElementById('message').innerHTML = "Not signed in";
+          document.getElementById('sub-message').innerHTML = "Sign in with the Apple Account you want to use for this provider.";
+          document.getElementById('signin_button').style.display = "inline-block";
+          document.getElementById('signout_button').style.display = "none";
+        } else if (music.isAuthorized) {
           // user token must have been issued in last 6 months
           music_user_token_timestamp = Math.max(music_user_token_timestamp, (Date.now() / 1000) - (3600 * 24 * 180));
           document.getElementById('message').innerHTML = "Already signed in";
@@ -59,9 +79,37 @@
       }
     });
 
+    // True when MusicKit is signed in with a session this instance cannot claim as its own.
+    function isForeignSession() {
+      if (!music || !music.isAuthorized) {
+        return false;
+      }
+      return !music_user_token || (browser_token !== "" && browser_token !== music_user_token);
+    }
+
+    function sessionForgotten() {
+      return window.location.hash === FRESH_SESSION_MARKER;
+    }
+
+    // Forget the session locally, leaving the token valid at Apple for other instances.
+    function forgetSessionAndReload() {
+      reloading = true;
+      try {
+        for (const key of Object.keys(window.localStorage)) {
+          if (key.startsWith(MUSICKIT_STORAGE_PREFIX)) {
+            window.localStorage.removeItem(key);
+          }
+        }
+      } catch (error) {
+        console.error("Could not clear the stored MusicKit session: ", error);
+      }
+      window.location.hash = FRESH_SESSION_MARKER;
+      window.location.reload();
+    }
+
     function sendTokenAndCloseWindow() {
-      if (closing) {
-        // anti race condition
+      if (reloading || closing) {
+        // anti race condition; a reload must not end the flow with an empty token
         return;
       }
       closing = true;
@@ -109,7 +157,15 @@
       document.getElementById('signin_button').disabled = true;
       document.getElementById('message').innerHTML = "Apple Signin window should open…";
       document.getElementById('sub-message').innerHTML = "If the Apple Music authentication window does not open, please check the MusicKit token and try again.";
+      const foreign_session = isForeignSession();
       music.authorize().then(function (token) {
+        if (foreign_session && token === browser_token) {
+          // MusicKit reused the session we could not clear: that is another instance's account
+          document.getElementById('message').innerHTML = "Could not start a new Apple Music sign-in";
+          document.getElementById('sub-message').innerHTML = "This browser is still signed in with another Apple Account. Please open this page in a private browser window and sign in there.";
+          document.getElementById('signin_button').disabled = false;
+          return;
+        }
         music_user_token = token;
         music_user_token_timestamp = Math.floor(Date.now() / 1000);
         document.getElementById('message').innerHTML = "Successfully signed in to Apple Music";
@@ -126,6 +182,7 @@
     }
 
     function mkSignOutButton() {
+      // only offered for this instance's own session, so revoking at Apple is intended here
       music.unauthorize();
       music_user_token = "";
       music_user_token_timestamp = 0;
@@ -140,14 +197,9 @@
     }
 
     function mkSwitchAccountButton() {
-      music.unauthorize()
       music_user_token = "";
       music_user_token_timestamp = 0;
-      document.getElementById('message').innerHTML = "Not signed in";
-      document.getElementById('sub-message').innerHTML = "Sign in with Apple to allow Music Assistant to access your Apple Music account.";
-      document.getElementById('signin_button').innerHTML = "Sign In";
-      document.getElementById('signin_button').style.display = "inline-block";
-      document.getElementById('signout_button').style.display = "none";
+      forgetSessionAndReload();
     }
   </script>
 </head>
@@ -209,7 +261,7 @@
       </section>
       <div class="privacy-summary__link-container">
         <a class="privacy-summary__link-text privacy-summary__link-text--margin-top typography-caption"
-          onclick="mkSwitchAccountButton();" href="#">Use a different Apple&nbsp;Account</a>
+          onclick="mkSwitchAccountButton(); return false;" href="#">Use a different Apple&nbsp;Account</a>
       </div>
       <footer class="base-footer">
         <p class="base-footer__copyright">© 2025 Music Assistant <span id="mass_version"></span>- Part of the

--- a/tests/providers/apple_music/test_api_client.py
+++ b/tests/providers/apple_music/test_api_client.py
@@ -8,7 +8,11 @@ import pytest
 from aiohttp import ClientPayloadError, ClientResponseError, ServerDisconnectedError
 from aiohttp.client_reqrep import RequestInfo
 from multidict import CIMultiDict, CIMultiDictProxy
-from music_assistant_models.errors import ResourceTemporarilyUnavailable, RetriesExhausted
+from music_assistant_models.errors import (
+    LoginFailed,
+    ResourceTemporarilyUnavailable,
+    RetriesExhausted,
+)
 from yarl import URL
 
 from music_assistant.providers.apple_music.api_client import (
@@ -257,3 +261,42 @@ async def test_get_all_items_persistent_truncation_raises() -> None:
     )
     with pytest.raises(ResourceTemporarilyUnavailable):
         await client.get_all_items("me/library/songs")
+
+
+# ---------------------------------------------------------------------------
+# P4: a rejected music user token surfaces as an auth error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", [401, 403])
+@pytest.mark.asyncio
+async def test_get_data_auth_error_raises_login_failed(status: int) -> None:
+    """A revoked/expired user token surfaces as LoginFailed, not a bare HTTP error."""
+    client, provider = _make_client()
+    provider.mass.http_session.get = MagicMock(
+        return_value=_FakeRequestCtx(_make_response(status=status))
+    )
+    with patch(_SLEEP_TARGET, new=AsyncMock()), pytest.raises(LoginFailed):
+        await client.get_data("me/storefront")
+    # the token will not become valid on its own, so this must not be retried
+    assert provider.mass.http_session.get.call_count == 1
+
+
+@pytest.mark.parametrize("status", [401, 403])
+@pytest.mark.asyncio
+async def test_write_requests_auth_error_raises_login_failed(status: int) -> None:
+    """Library mutations report a rejected user token as LoginFailed too."""
+    client, provider = _make_client()
+    for method in ("put", "post", "delete"):
+        setattr(
+            provider.mass.http_session,
+            method,
+            MagicMock(return_value=_FakeRequestCtx(_make_response(status=status))),
+        )
+    with patch(_SLEEP_TARGET, new=AsyncMock()):
+        with pytest.raises(LoginFailed):
+            await client.put_data("me/ratings/library-playlists/p.1")
+        with pytest.raises(LoginFailed):
+            await client.post_data("me/library")
+        with pytest.raises(LoginFailed):
+            await client.delete_data("me/library/playlists/p.1")


### PR DESCRIPTION
# What does this implement/fix?

With two Apple Music accounts configured as separate provider instances, authenticating one of them made the other return 403 on every request, and only one instance could ever be signed in at a time.

The MusicKit sign-in page is served from the MA origin, and MusicKit keeps its authorization in `localStorage`, which is scoped per origin — not per flow. So every Apple Music instance shares one browser session. "Use a different Apple Account" called `music.unauthorize()`, which is `revokeUserToken()` under the hood: it revokes that token *at Apple*, killing whichever other instance was still using it. The other route, "Continue", handed the first account's token to the second instance.

- Switching account now forgets the session locally (drops MusicKit's `music.*` keys and reloads) instead of revoking it at Apple
- A provider instance never adopts a session it cannot claim as its own, so a second instance can no longer end up configured with the first account's token
- If the session cannot be cleared, sign-in refuses the foreign token and explains the private-window workaround rather than misconfiguring the instance
- Explicit "Sign Out" still revokes — that is the instance's own session
- The auth callback now sets `Content-Type: application/json`; `XMLHttpRequest` labels a string body `text/plain`, so the setup flow saw no token and aborted the sign-in as cancelled
- A 401/403 from Apple now raises `LoginFailed` instead of a bare `ClientResponseError`, so a revoked token tells the user to sign in again instead of failing provider load with an opaque error

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/5933

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
