### PR TITLE
Setup flow: don't drop a callback body the browser labelled text/plain

### DIFF
--- a/music_assistant/models/setup_flow.py
+++ b/music_assistant/models/setup_flow.py
@@ -40,6 +40,8 @@ LOGGER = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
 
+_FORM_CONTENT_TYPES = ("application/x-www-form-urlencoded", "multipart/form-data")
+
 FlowKind = Literal["setup", "reconfigure"]
 FlowReason = Literal["user", "auth", "error"]
 
@@ -393,7 +395,11 @@ class SetupSession:
         params: dict[str, str] = dict(request.query)
         if request.method == "POST" and request.can_read_body:
             try:
-                if request.content_type == "application/json":
+                if request.content_type in _FORM_CONTENT_TYPES:
+                    params.update({key: str(val) for key, val in (await request.post()).items()})
+                else:
+                    # a browser XHR posting a JSON string labels it text/plain unless the
+                    # page sets the header, so anything not form encoded is parsed as JSON
                     body = json_loads(await request.read())
                     if isinstance(body, dict):
                         # coerce to str so the declared params contract holds for
@@ -401,8 +407,6 @@ class SetupSession:
                         params.update({str(key): str(val) for key, val in body.items()})
                     else:
                         LOGGER.error("Ignoring non-object JSON setup flow callback body")
-                else:
-                    params.update({key: str(val) for key, val in (await request.post()).items()})
             except Exception as err:
                 LOGGER.error("Failed to parse setup flow callback body: %s", err)
         if self._callback_future is not None and not self._callback_future.done():

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -473,6 +473,36 @@ async def test_external_callback_json_body_coerced(flow_mass: MusicAssistant) ->
     assert received == {"state": "xyz", "code": "123", "granted": "True"}
 
 
+async def test_external_callback_json_body_without_content_type(
+    flow_mass: MusicAssistant,
+) -> None:
+    """A JSON body a browser labelled text/plain still resolves the external step."""
+    received: dict[str, str] = {}
+
+    async def run_setup(session: SetupSession) -> None:
+        received.update(await session.external("https://example.com/authorize"))
+        await session.finish({})
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        session = flow_mass.config._setup_flows[step.flow_id].session
+        # XMLHttpRequest.send(<string>) defaults to this content type
+        request = SimpleNamespace(
+            query={},
+            method="POST",
+            can_read_body=True,
+            content_type="text/plain",
+            read=AsyncMock(return_value=b'{"music-user-token": "abc", "timestamp": 1}'),
+        )
+        response = await session.handle_callback(cast("Any", request))
+        assert response.status == 200
+        await _wait_for(lambda: session.finished)
+    assert received == {"music-user-token": "abc", "timestamp": "1"}
+
+
 async def test_form_expiry_aborts_flow(
     flow_mass: MusicAssistant, flow_events: list[MassEvent]
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

A setup flow's external-step callback dropped any POST body that was not labelled `application/json`. A browser XHR or `sendBeacon` posting a JSON string labels it `text/plain` unless the page sets the header, so the body was form-decoded into nothing: the external step resolved with no params while still answering 200. The flow then aborted (the page reported success and closed itself), which is how the Apple Music browser sign-in ended in "setup cancelled" on `dev` while `helpers/auth.py` on `stable` parsed the same body fine.

- Parse a callback body as JSON unless it is explicitly form encoded, matching what `handle_callback` already documents
- Regression test for a JSON body labelled `text/plain`

`dev` only — the setup flow engine does not exist on `stable`, so this must not be backported.

**Related issue (if applicable):**

- Found while fixing https://github.com/music-assistant/support/issues/5933 (see music-assistant/server#5122)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
