### PR TITLE
Fix remote access flooding the log with ICE and TURN warnings

### DIFF
--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -15,19 +15,20 @@ import json
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Final
 from urllib.parse import urlparse
 
 import aiohttp
 from aiolibdatachannel import (
     ConnectionClosedError,
     IceServer,
+    LogLevel,
     PeerConnection,
     RTCConfiguration,
     RTCError,
     RTCState,
     StateChangeEvent,
-    install_python_logger,
+    init_logger,
 )
 
 from music_assistant.constants import MASS_LOGGER_NAME, VERBOSE_LOG_LEVEL
@@ -43,6 +44,16 @@ HTTP_PROXY_CONCURRENCY = 6
 
 # Chunk ma-api messages larger than this; libdatachannel caps data-channel messages at 256 KiB.
 MA_API_CHUNK_SIZE = 64 * 1024
+
+# Failing candidates, paths and permissions is how ICE converges, so native warnings drop to INFO.
+_RTC_LOG_LEVELS: Final[dict[int, int]] = {
+    int(LogLevel.FATAL): logging.CRITICAL,
+    int(LogLevel.ERROR): logging.ERROR,
+    int(LogLevel.WARNING): logging.INFO,
+    int(LogLevel.INFO): logging.DEBUG,
+    int(LogLevel.DEBUG): VERBOSE_LOG_LEVEL,
+    int(LogLevel.VERBOSE): VERBOSE_LOG_LEVEL,
+}
 
 
 @dataclass
@@ -153,7 +164,7 @@ class WebRTCGateway:
         if self._running:
             self.logger.warning("WebRTC Gateway already running, skipping start")
             return
-        install_python_logger(self.logger)
+        _install_native_logger(self.logger)
         self.logger.info("Starting WebRTC Gateway")
         self.logger.debug("Signaling URL: %s", self.signaling_url)
         self.logger.debug("Local WS URL: %s", self.local_ws_url)
@@ -822,6 +833,32 @@ class WebRTCGateway:
                     self._set_sendspin_player_callback(session.session_id, client_id)
         except json.JSONDecodeError, TypeError:
             pass  # Not valid JSON, ignore
+
+
+def _install_native_logger(logger: logging.Logger) -> None:
+    """
+    Route libdatachannel's own logging onto the given logger.
+
+    :param logger: Logger to emit native lines on, using :data:`_RTC_LOG_LEVELS` for severity.
+    """
+
+    def forward(rtc_level: int, message: str) -> None:
+        # libdatachannel terminates its lines, so strip it and let the formatter own linebreaks
+        logger.log(_RTC_LOG_LEVELS.get(rtc_level, logging.DEBUG), "%s", message.rstrip())
+
+    init_logger(_rtc_log_level_for(logger), forward)
+
+
+def _rtc_log_level_for(logger: logging.Logger) -> LogLevel:
+    """
+    Return the most detailed rtcLogLevel whose mapped records the logger would still emit.
+
+    :param logger: Logger the native lines are forwarded to.
+    """
+    for rtc_level, py_level in sorted(_RTC_LOG_LEVELS.items(), reverse=True):
+        if logger.isEnabledFor(py_level):
+            return LogLevel(rtc_level)
+    return LogLevel.NONE
 
 
 def _is_usable_ice_url(url: str) -> bool:

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -15,7 +15,7 @@ import json
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar, Final
+from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import urlparse
 
 import aiohttp
@@ -28,7 +28,7 @@ from aiolibdatachannel import (
     RTCError,
     RTCState,
     StateChangeEvent,
-    init_logger,
+    install_python_logger,
 )
 
 from music_assistant.constants import MASS_LOGGER_NAME, VERBOSE_LOG_LEVEL
@@ -44,16 +44,6 @@ HTTP_PROXY_CONCURRENCY = 6
 
 # Chunk ma-api messages larger than this; libdatachannel caps data-channel messages at 256 KiB.
 MA_API_CHUNK_SIZE = 64 * 1024
-
-# Failing candidates, paths and permissions is how ICE converges, so native warnings drop to INFO.
-_RTC_LOG_LEVELS: Final[dict[int, int]] = {
-    int(LogLevel.FATAL): logging.CRITICAL,
-    int(LogLevel.ERROR): logging.ERROR,
-    int(LogLevel.WARNING): logging.INFO,
-    int(LogLevel.INFO): logging.DEBUG,
-    int(LogLevel.DEBUG): VERBOSE_LOG_LEVEL,
-    int(LogLevel.VERBOSE): VERBOSE_LOG_LEVEL,
-}
 
 
 @dataclass
@@ -164,7 +154,15 @@ class WebRTCGateway:
         if self._running:
             self.logger.warning("WebRTC Gateway already running, skipping start")
             return
-        _install_native_logger(self.logger)
+        # Failing candidates, paths and permissions is how ICE converges, so below DEBUG
+        # we only take errors from libdatachannel's native logging.
+        if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+            rtc_log_level = LogLevel.VERBOSE
+        elif self.logger.isEnabledFor(logging.DEBUG):
+            rtc_log_level = LogLevel.DEBUG
+        else:
+            rtc_log_level = LogLevel.ERROR
+        install_python_logger(self.logger, level=rtc_log_level)
         self.logger.info("Starting WebRTC Gateway")
         self.logger.debug("Signaling URL: %s", self.signaling_url)
         self.logger.debug("Local WS URL: %s", self.local_ws_url)
@@ -835,32 +833,6 @@ class WebRTCGateway:
             pass  # Not valid JSON, ignore
 
 
-def _install_native_logger(logger: logging.Logger) -> None:
-    """
-    Route libdatachannel's own logging onto the given logger.
-
-    :param logger: Logger to emit native lines on, using :data:`_RTC_LOG_LEVELS` for severity.
-    """
-
-    def forward(rtc_level: int, message: str) -> None:
-        # libdatachannel terminates its lines, so strip it and let the formatter own linebreaks
-        logger.log(_RTC_LOG_LEVELS.get(rtc_level, logging.DEBUG), "%s", message.rstrip())
-
-    init_logger(_rtc_log_level_for(logger), forward)
-
-
-def _rtc_log_level_for(logger: logging.Logger) -> LogLevel:
-    """
-    Return the most detailed rtcLogLevel whose mapped records the logger would still emit.
-
-    :param logger: Logger the native lines are forwarded to.
-    """
-    for rtc_level, py_level in sorted(_RTC_LOG_LEVELS.items(), reverse=True):
-        if logger.isEnabledFor(py_level):
-            return LogLevel(rtc_level)
-    return LogLevel.NONE
-
-
 def _is_usable_ice_url(url: str) -> bool:
     """
     Return whether libdatachannel's ICE backend (libjuice) can use this ICE server url.
@@ -873,7 +845,7 @@ def _is_usable_ice_url(url: str) -> bool:
         return True
     if scheme not in ("turn", "turns"):
         return False
-    # mirrors rtc::IceServer url parsing, where the transport parameter wins over the scheme
+    # like rtc::IceServer url parsing, the transport parameter wins over the scheme
     query = remainder.partition("?")[2].lower()
     if "transport=udp" in query:
         return True

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -763,15 +763,21 @@ class WebRTCGateway:
     # ---- Helpers -------------------------------------------------------------
 
     def _build_ice_servers(self, servers: list[dict[str, Any]]) -> list[IceServer]:
-        """Build IceServer entries (one per url) from ICE server config dicts."""
+        """Build IceServer entries (one per url) for our own peer connection."""
         ice_servers: list[IceServer] = []
+        skipped: list[str] = []
         for server in servers:
             urls = server.get("urls")
             username = server.get("username")
             credential = server.get("credential")
             url_list = [urls] if isinstance(urls, str) else (urls or [])
             for url in url_list:
+                if not _is_usable_ice_url(url):
+                    skipped.append(url)
+                    continue
                 ice_servers.append(IceServer(url=url, username=username, credential=credential))
+        if skipped:
+            self.logger.debug("Skipping ICE server urls unusable by libjuice: %s", skipped)
         return ice_servers
 
     def _schedule_close(self, session_id: str) -> None:
@@ -816,3 +822,22 @@ class WebRTCGateway:
                     self._set_sendspin_player_callback(session.session_id, client_id)
         except json.JSONDecodeError, TypeError:
             pass  # Not valid JSON, ignore
+
+
+def _is_usable_ice_url(url: str) -> bool:
+    """
+    Return whether libdatachannel's ICE backend (libjuice) can use this ICE server url.
+
+    :param url: ICE server url, e.g. ``turn:turn.example.com:3478?transport=tcp``.
+    """
+    scheme, _, remainder = url.partition(":")
+    scheme = scheme.lower()
+    if scheme == "stun":
+        return True
+    if scheme not in ("turn", "turns"):
+        return False
+    # mirrors rtc::IceServer url parsing, where the transport parameter wins over the scheme
+    query = remainder.partition("?")[2].lower()
+    if "transport=udp" in query:
+        return True
+    return scheme == "turn" and not ("transport=tcp" in query or "transport=tls" in query)

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -25,6 +25,7 @@ from music_assistant.controllers.webserver.remote_access.gateway import (
     MA_API_CHUNK_SIZE,
     WebRTCGateway,
     WebRTCSession,
+    _is_usable_ice_url,
 )
 from music_assistant.helpers.webrtc_certificate import (
     _generate_certificate,
@@ -226,6 +227,58 @@ async def test_webrtc_gateway_custom_ice_servers(cert_pems: tuple[str, str]) -> 
     )
 
     assert gateway.ice_servers == custom_ice_servers
+
+
+async def test_webrtc_gateway_local_ice_servers_skip_non_udp_turn(
+    cert_pems: tuple[str, str],
+) -> None:
+    """Test the local peer connection only gets ICE servers libjuice can use."""
+    cert_pem, key_pem = cert_pems
+    # shape of what HA Cloud hands us: one UDP TURN url plus TCP/TLS variants
+    ha_cloud_ice_servers = [
+        {"urls": "stun:stun.cloudflare.com:3478"},
+        {"urls": "turn:turn.cloudflare.com:3478?transport=udp", "username": "u", "credential": "p"},
+        {"urls": "turn:turn.cloudflare.com:53", "username": "u", "credential": "p"},
+        {"urls": "turn:turn.cloudflare.com:3478?transport=tcp", "username": "u", "credential": "p"},
+        {"urls": "turns:turn.cloudflare.com:5349?transport=tcp", "username": "u", "credential": "p"},
+        {"urls": "turns:turn.cloudflare.com:443?transport=tcp", "username": "u", "credential": "p"},
+    ]
+
+    gateway = WebRTCGateway(
+        http_session=Mock(),
+        remote_id="TEST-REMOTE-ID",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+        ice_servers=ha_cloud_ice_servers,
+    )
+
+    assert [server.url for server in gateway._build_ice_servers(ha_cloud_ice_servers)] == [
+        "stun:stun.cloudflare.com:3478",
+        "turn:turn.cloudflare.com:3478?transport=udp",
+        "turn:turn.cloudflare.com:53",
+    ]
+    # the unfiltered list stays what we advertise to remote clients, whose browsers do support
+    # TCP/TLS TURN
+    assert gateway.ice_servers == ha_cloud_ice_servers
+
+
+@pytest.mark.parametrize(
+    ("url", "usable"),
+    [
+        ("stun:stun.example.com:3478", True),
+        ("turn:turn.example.com:3478", True),
+        ("turn:turn.example.com:3478?transport=udp", True),
+        # the transport parameter wins over the scheme, matching rtc::IceServer
+        ("turns:turn.example.com:5349?transport=udp", True),
+        ("turn:turn.example.com:3478?transport=tcp", False),
+        ("turns:turn.example.com:5349", False),
+        ("turn:turn.example.com:3478?transport=tls", False),
+        ("https://turn.example.com", False),
+    ],
+)
+def test_is_usable_ice_url(url: str, usable: bool) -> None:
+    """Test only ICE server urls libjuice can actually use are kept."""
+    assert _is_usable_ice_url(url) is usable
 
 
 async def test_webrtc_gateway_start_stop(cert_pems: tuple[str, str]) -> None:

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -234,14 +234,15 @@ async def test_webrtc_gateway_local_ice_servers_skip_non_udp_turn(
 ) -> None:
     """Test the local peer connection only gets ICE servers libjuice can use."""
     cert_pem, key_pem = cert_pems
+    cred = {"username": "u", "credential": "p"}
     # shape of what HA Cloud hands us: one UDP TURN url plus TCP/TLS variants
     ha_cloud_ice_servers = [
         {"urls": "stun:stun.cloudflare.com:3478"},
-        {"urls": "turn:turn.cloudflare.com:3478?transport=udp", "username": "u", "credential": "p"},
-        {"urls": "turn:turn.cloudflare.com:53", "username": "u", "credential": "p"},
-        {"urls": "turn:turn.cloudflare.com:3478?transport=tcp", "username": "u", "credential": "p"},
-        {"urls": "turns:turn.cloudflare.com:5349?transport=tcp", "username": "u", "credential": "p"},
-        {"urls": "turns:turn.cloudflare.com:443?transport=tcp", "username": "u", "credential": "p"},
+        {"urls": "turn:turn.cloudflare.com:3478?transport=udp", **cred},
+        {"urls": "turn:turn.cloudflare.com:53", **cred},
+        {"urls": "turn:turn.cloudflare.com:3478?transport=tcp", **cred},
+        {"urls": "turns:turn.cloudflare.com:5349?transport=tcp", **cred},
+        {"urls": "turns:turn.cloudflare.com:443?transport=tcp", **cred},
     ]
 
     gateway = WebRTCGateway(
@@ -257,8 +258,7 @@ async def test_webrtc_gateway_local_ice_servers_skip_non_udp_turn(
         "turn:turn.cloudflare.com:3478?transport=udp",
         "turn:turn.cloudflare.com:53",
     ]
-    # the unfiltered list stays what we advertise to remote clients, whose browsers do support
-    # TCP/TLS TURN
+    # remote clients still get the unfiltered list, since browsers do support TCP/TLS TURN
     assert gateway.ice_servers == ha_cloud_ice_servers
 
 

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import hashlib
 import json
+import logging
 from collections.abc import AsyncIterator, Callable, Coroutine
 from types import SimpleNamespace
 from typing import Any, cast
@@ -12,9 +13,10 @@ from urllib.parse import urlparse
 
 import aiohttp
 import pytest
-from aiolibdatachannel import DataChannel, IceServer, PeerConnection, RTCConfiguration
+from aiolibdatachannel import DataChannel, IceServer, LogLevel, PeerConnection, RTCConfiguration
 from cryptography.hazmat.primitives import serialization
 
+from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.controllers.webserver.remote_access import (
     STARTUP_DELAY,
     TASK_ID_START_GATEWAY,
@@ -300,6 +302,41 @@ async def test_webrtc_gateway_start_stop(cert_pems: tuple[str, str]) -> None:
 
         await gateway.stop()
         assert gateway.is_running is False
+
+
+@pytest.mark.parametrize(
+    ("logger_level", "expected_rtc_level"),
+    [
+        (VERBOSE_LOG_LEVEL, LogLevel.VERBOSE),
+        (logging.DEBUG, LogLevel.DEBUG),
+        (logging.INFO, LogLevel.ERROR),
+        (logging.WARNING, LogLevel.ERROR),
+    ],
+)
+async def test_webrtc_gateway_native_log_level(
+    cert_pems: tuple[str, str], logger_level: int, expected_rtc_level: LogLevel
+) -> None:
+    """Test native libdatachannel logging is capped at ERROR unless debugging."""
+    cert_pem, key_pem = cert_pems
+    gateway = WebRTCGateway(
+        http_session=Mock(),
+        remote_id="TEST-REMOTE-ID",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+    )
+    gateway.logger = logging.getLogger("test_webrtc_native_log_level")
+    gateway.logger.setLevel(logger_level)
+
+    with (
+        patch.object(gateway, "_run", new_callable=AsyncMock),
+        patch(
+            "music_assistant.controllers.webserver.remote_access.gateway.install_python_logger"
+        ) as install_logger,
+    ):
+        await gateway.start()
+        await gateway.stop()
+
+    install_logger.assert_called_once_with(gateway.logger, level=expected_rtc_level)
 
 
 async def test_webrtc_gateway_handle_registration_message(cert_pems: tuple[str, str]) -> None:


### PR DESCRIPTION
# What does this implement/fix?

On an instance with remote access enabled, `music_assistant.remote_access` was responsible for 85% of all WARNING output (1244 of 1468 in a 24h window), burying every other warning in the log.

Two causes, neither of them an actual fault:

- We handed libdatachannel the full ICE server list from HA Cloud, including its four TCP/TLS TURN urls. Its ICE backend (libjuice) only speaks TURN over UDP, so it rejected each one with a warning on every peer connection — 364 per day.
- libdatachannel and libjuice warn about routine ICE outcomes. Candidates, paths and TURN permissions failing is how ICE converges on a working pair, so forwarding all of that at WARNING was never right. The largest single source was Cloudflare's TURN refusing `CreatePermission` for the remote peer's private LAN candidates. That was verified harmless before being quietened: permission *is* granted for the peer's public candidate, and forcing relay-only ICE (no direct path to fall back to) connects end to end.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- `_build_ice_servers` now keeps only the ICE urls libjuice can actually use (STUN, and TURN over UDP), mirroring how `rtc::IceServer` parses them so nothing libdatachannel would have accepted gets dropped. The unfiltered list is still what we advertise to remote clients over signaling — browsers do support TCP/TLS TURN.
- Cap libdatachannel's native log level at ERROR unless the server runs at `--log-level debug` or `verbose`, where the full native detail comes through at its true severities. Native faults still arrive at ERROR and above, and the gateway's own warnings on the same logger are unaffected.

Net effect: `remote_access` drops from 85% of WARNING output to none at the default log level, while the ICE detail needed to debug these paths stays available at `--log-level debug` and `--log-level verbose`.

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

