### PR TITLE
Don't show the dashboard keepalive as active playback on cast players

### DIFF
--- a/music_assistant/providers/chromecast/constants.py
+++ b/music_assistant/providers/chromecast/constants.py
@@ -19,6 +19,9 @@ SENDSPIN_CAST_NAMESPACE = "urn:x-cast:sendspin"
 CONF_USE_MASS_APP = "use_mass_app"
 DASHBOARD_NAMESPACE = "urn:x-cast:io.music-assistant.cast"
 
+# keepalive media the cast receiver plays while showing a dashboard
+DASHBOARD_KEEPALIVE_SUFFIXES = ("/dashboard-keepalive.mp4", "/keepalive.png")
+
 # Interval (seconds) before an unavailable player is re-evaluated as a possible
 # passive multichannel endpoint that should be removed from the setup.
 MULTICHANNEL_RECHECK_INTERVAL = 600

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -499,6 +499,8 @@ class ChromecastPlayer(Player):
             self._attr_playback_state = PlaybackState.IDLE
             self._attr_current_media = None
             self._attr_active_source = None
+            self._attr_elapsed_time = 0
+            self._attr_elapsed_time_last_updated = time.time()
             self.update_state()
             return
 

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -35,6 +35,7 @@ from .constants import (
     CONF_ENTRY_SAMPLE_RATES_CAST,
     CONF_ENTRY_SAMPLE_RATES_CAST_GROUP,
     CONF_USE_MASS_APP,
+    DASHBOARD_KEEPALIVE_SUFFIXES,
     MASS_APP_ID,
     SENDSPIN_CAST_APP_ID,
 )
@@ -492,6 +493,14 @@ class ChromecastPlayer(Player):
                 return
             group_player = player_obj
             status = group_player.cc.media_controller.status
+
+        # never surface the receiver's dashboard keepalive as actual playback
+        if status.content_id and status.content_id.endswith(DASHBOARD_KEEPALIVE_SUFFIXES):
+            self._attr_playback_state = PlaybackState.IDLE
+            self._attr_current_media = None
+            self._attr_active_source = None
+            self.update_state()
+            return
 
         # player state
         # pychromecast reports BUFFERING as 'playing', so a Cast group that underruns the

--- a/tests/providers/chromecast/test_media_status_keepalive.py
+++ b/tests/providers/chromecast/test_media_status_keepalive.py
@@ -1,0 +1,71 @@
+"""
+Tests for ChromecastPlayer dashboard keepalive media-status handling.
+
+The cast receiver app plays a keepalive media item (currently a paused
+``keepalive.png``, soon a looping ``dashboard-keepalive.mp4``) while showing a
+dashboard. That media is an implementation detail of the receiver and must
+never leak into MA player state - otherwise a Nest Hub showing a dashboard
+appears in MA as "playing dashboard-keepalive.mp4".
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import MagicMock
+
+from music_assistant_models.enums import PlaybackState
+
+from music_assistant.providers.chromecast.player import ChromecastPlayer
+
+
+def _handle_media_status(fake: MagicMock, status: MagicMock) -> None:
+    ChromecastPlayer._handle_media_status(cast("ChromecastPlayer", fake), status)
+
+
+def _fake_player() -> MagicMock:
+    """Build a MagicMock standing in for a ChromecastPlayer with no active cast group."""
+    fake = MagicMock()
+    fake.active_cast_group = None
+    return fake
+
+
+def _media_status(content_id: str, *, player_is_playing: bool, player_is_paused: bool) -> MagicMock:
+    status = MagicMock()
+    status.content_id = content_id
+    status.player_is_playing = player_is_playing
+    status.player_is_paused = player_is_paused
+    return status
+
+
+def test_dashboard_keepalive_video_treated_as_idle() -> None:
+    """A playing dashboard-keepalive.mp4 status must not surface as MA playback."""
+    fake = _fake_player()
+    status = _media_status(
+        "https://cast.music-assistant.io/dashboard-keepalive.mp4",
+        player_is_playing=True,
+        player_is_paused=False,
+    )
+
+    _handle_media_status(fake, status)
+
+    assert fake._attr_playback_state == PlaybackState.IDLE
+    assert fake._attr_current_media is None
+    assert fake._attr_active_source is None
+    fake.update_state.assert_called_once()
+
+
+def test_legacy_keepalive_image_treated_as_idle() -> None:
+    """The legacy paused keepalive.png status must also not surface as MA playback."""
+    fake = _fake_player()
+    status = _media_status(
+        "https://cast.music-assistant.io/keepalive.png",
+        player_is_playing=False,
+        player_is_paused=True,
+    )
+
+    _handle_media_status(fake, status)
+
+    assert fake._attr_playback_state == PlaybackState.IDLE
+    assert fake._attr_current_media is None
+    assert fake._attr_active_source is None
+    fake.update_state.assert_called_once()

--- a/tests/providers/chromecast/test_media_status_keepalive.py
+++ b/tests/providers/chromecast/test_media_status_keepalive.py
@@ -40,6 +40,7 @@ def _media_status(content_id: str, *, player_is_playing: bool, player_is_paused:
 def test_dashboard_keepalive_video_treated_as_idle() -> None:
     """A playing dashboard-keepalive.mp4 status must not surface as MA playback."""
     fake = _fake_player()
+    fake._attr_elapsed_time = 123.0
     status = _media_status(
         "https://cast.music-assistant.io/dashboard-keepalive.mp4",
         player_is_playing=True,
@@ -51,12 +52,15 @@ def test_dashboard_keepalive_video_treated_as_idle() -> None:
     assert fake._attr_playback_state == PlaybackState.IDLE
     assert fake._attr_current_media is None
     assert fake._attr_active_source is None
+    assert fake._attr_elapsed_time == 0
+    assert isinstance(fake._attr_elapsed_time_last_updated, float)
     fake.update_state.assert_called_once()
 
 
 def test_legacy_keepalive_image_treated_as_idle() -> None:
     """The legacy paused keepalive.png status must also not surface as MA playback."""
     fake = _fake_player()
+    fake._attr_elapsed_time = 123.0
     status = _media_status(
         "https://cast.music-assistant.io/keepalive.png",
         player_is_playing=False,
@@ -68,4 +72,6 @@ def test_legacy_keepalive_image_treated_as_idle() -> None:
     assert fake._attr_playback_state == PlaybackState.IDLE
     assert fake._attr_current_media is None
     assert fake._attr_active_source is None
+    assert fake._attr_elapsed_time == 0
+    assert isinstance(fake._attr_elapsed_time_last_updated, float)
     fake.update_state.assert_called_once()


### PR DESCRIPTION
# What does this implement/fix?

The cast receiver plays a "keepalive" media item on smart displays while a dashboard is shown (previously a paused image; with music-assistant/cast-receiver#3 a silent looping video in PLAYING state, to stop Nest Hubs from dropping the dashboard back to the screensaver). This keepalive leaked into MA player state: a Hub showing a dashboard reported as paused today, and would report as *playing* the keepalive file with the receiver fix.

- Treat media status for known keepalive content ids as idle / no media in the chromecast provider
- Add regression tests for both the new video and legacy image keepalive

Should land in the same release window as music-assistant/cast-receiver#3 (which deploys to all users on merge).

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
