### PR TITLE
Sendspin: freeze playback progress before tearing down the push stream

### DIFF
--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -1334,8 +1334,16 @@ class SendspinPlayer(SendspinBasePlayer):
         self._attr_elapsed_time = 0
         self._attr_elapsed_time_last_updated = time.time()
         self.update_state()
-        await self.playback_session.cancel("stop command")
+        # Order matters: group.stop() snapshots the live playback position into the
+        # metadata role before stopping transport, and can only extrapolate it while
+        # the group still has an active stream. Cancelling the session first stops the
+        # push stream, degrading that snapshot into a re-emit of the last pushed anchor
+        # - so progress jumps backwards on pause, which for Sendspin falls back to STOP.
         await self.api.group.stop()
+        # Keep adjacent to the call above: the STOPPED event it emits already cancels
+        # this session inline (create_task is eager-start), so an await in between would
+        # let that cancel interleave with this one and abort pipeline teardown mid-way.
+        await self.playback_session.cancel("stop command")
 
     def _get_cast_bridge_manager(self) -> SendspinBridgeManager | None:
         """Return the Chromecast provider's Sendspin bridge manager, if loaded."""

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -1334,15 +1334,11 @@ class SendspinPlayer(SendspinBasePlayer):
         self._attr_elapsed_time = 0
         self._attr_elapsed_time_last_updated = time.time()
         self.update_state()
-        # Order matters: group.stop() snapshots the live playback position into the
-        # metadata role before stopping transport, and can only extrapolate it while
-        # the group still has an active stream. Cancelling the session first stops the
-        # push stream, degrading that snapshot into a re-emit of the last pushed anchor
-        # - so progress jumps backwards on pause, which for Sendspin falls back to STOP.
+        # group.stop() snapshots the live position, which it can only do while the push
+        # stream is up - cancelling first leaves it re-emitting a stale anchor. Keep the
+        # two adjacent: the STOPPED event already cancels this session inline, so an await
+        # between them would interleave the two cancels and cut pipeline teardown short.
         await self.api.group.stop()
-        # Keep adjacent to the call above: the STOPPED event it emits already cancels
-        # this session inline (create_task is eager-start), so an await in between would
-        # let that cancel interleave with this one and abort pipeline teardown mid-way.
         await self.playback_session.cancel("stop command")
 
     def _get_cast_bridge_manager(self) -> SendspinBridgeManager | None:

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -1335,11 +1335,14 @@ class SendspinPlayer(SendspinBasePlayer):
         self._attr_elapsed_time_last_updated = time.time()
         self.update_state()
         # group.stop() snapshots the live position, which it can only do while the push
-        # stream is up - cancelling first leaves it re-emitting a stale anchor. Keep the
-        # two adjacent: the STOPPED event already cancels this session inline, so an await
-        # between them would interleave the two cancels and cut pipeline teardown short.
-        await self.api.group.stop()
-        await self.playback_session.cancel("stop command")
+        # stream is up - cancelling first leaves it re-emitting a stale anchor. Teardown
+        # goes in finally so a failing group stop can't strand the session, and nothing
+        # may await between the two: the STOPPED event cancels this session inline, and a
+        # suspension in between would let that cancel cut pipeline teardown short.
+        try:
+            await self.api.group.stop()
+        finally:
+            await self.playback_session.cancel("stop command")
 
     def _get_cast_bridge_manager(self) -> SendspinBridgeManager | None:
         """Return the Chromecast provider's Sendspin bridge manager, if loaded."""

--- a/tests/providers/sendspin/test_stop_progress_freeze.py
+++ b/tests/providers/sendspin/test_stop_progress_freeze.py
@@ -1,0 +1,53 @@
+"""
+Tests for progress being frozen before the push stream is torn down (support#5813).
+
+Pausing a Sendspin group falls back to STOP, and group.stop() can only snapshot
+the live position while the group still has an active stream. See the ordering
+comment in SendspinPlayer.stop() for why cancelling the session first breaks it.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant.providers.sendspin.player import SendspinPlayer
+
+
+def _player_mock() -> MagicMock:
+    """Create a mock with the real method under test bound to it."""
+    mock = MagicMock()
+    mock.playback_session.cancel = AsyncMock()
+    mock.api.group.stop = AsyncMock()
+    return mock
+
+
+async def test_stop_freezes_progress_while_transport_is_still_live() -> None:
+    """group.stop() must be awaited before the push stream is torn down."""
+    mock = _player_mock()
+    transport = SimpleNamespace(stream_active=True)
+    stream_active_at_freeze: list[bool] = []
+
+    async def group_stop() -> None:
+        stream_active_at_freeze.append(transport.stream_active)
+        transport.stream_active = False
+
+    async def session_cancel(_reason: str) -> None:
+        transport.stream_active = False
+
+    mock.api.group.stop = group_stop
+    mock.playback_session.cancel = session_cancel
+
+    await SendspinPlayer.stop(mock)
+
+    assert stream_active_at_freeze == [True]
+
+
+async def test_stop_still_cancels_the_playback_session() -> None:
+    """Freezing first must not drop the session teardown."""
+    mock = _player_mock()
+
+    await SendspinPlayer.stop(mock)
+
+    mock.playback_session.cancel.assert_awaited_once_with("stop command")
+    mock.api.group.stop.assert_awaited_once()

--- a/tests/providers/sendspin/test_stop_progress_freeze.py
+++ b/tests/providers/sendspin/test_stop_progress_freeze.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from music_assistant.providers.sendspin.player import SendspinPlayer
 
 
@@ -51,3 +53,14 @@ async def test_stop_still_cancels_the_playback_session() -> None:
 
     mock.playback_session.cancel.assert_awaited_once_with("stop command")
     mock.api.group.stop.assert_awaited_once()
+
+
+async def test_session_is_cancelled_even_if_the_group_stop_fails() -> None:
+    """A failing group stop must not strand the playback task and its pipelines."""
+    mock = _player_mock()
+    mock.api.group.stop = AsyncMock(side_effect=RuntimeError("transport gone"))
+
+    with pytest.raises(RuntimeError):
+        await SendspinPlayer.stop(mock)
+
+    mock.playback_session.cancel.assert_awaited_once_with("stop command")


### PR DESCRIPTION
# What does this implement/fix?

Pausing a Sendspin group made the progress bar jump backwards: the first `server/state` after pausing carried a `track_progress` from several seconds earlier, corrected only ~2s later.

Sendspin declares no PAUSE feature, so pausing falls back to STOP. `SendspinGroup.stop()` snapshots the live playback position into the metadata role before it stops transport, but can only do so while the group still has an active stream. `SendspinPlayer.stop()` cancelled the playback session first, which tears that stream down — so the snapshot fell back to re-emitting the last pushed anchor. Swapping the two calls lets it capture the real position.

The two awaits have to stay adjacent: `group.stop()`'s STOPPED event already cancels the session inline, so an await between them would let the two cancels interleave and cut member-pipeline teardown short.

`PlaybackSession._run_playback()` has the same inverted ordering on its natural-EOF path. It needs a different fix there — hoisting `group.stop()` would cancel the playback task from inside its own `finally` — so it is left to a separate change.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/5813

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
