### PR TITLE
Keep an AI Radio show and its queue in sync when either one stops

### DIFF
--- a/music_assistant/providers/ai_radio/models.py
+++ b/music_assistant/providers/ai_radio/models.py
@@ -60,6 +60,16 @@ class AudioSection:
 
 
 @dataclass(slots=True)
+class QueueBinding:
+    """The player queue a dynamic run plays on."""
+
+    queue_id: str
+    # False when the run appended to a queue that already had items
+    owned: bool
+    first_index: int
+
+
+@dataclass(slots=True)
 class SessionState:
     """State container for an AI Radio run."""
 
@@ -74,6 +84,7 @@ class SessionState:
     result: dict[str, Any] = field(default_factory=dict)
     error: str | None = None
     task: asyncio.Task[Any] | None = field(default=None, repr=False, compare=False)
+    queue: QueueBinding | None = field(default=None, repr=False, compare=False)
 
     def as_dict(self) -> dict[str, Any]:
         """Return session as a serializable dictionary."""

--- a/music_assistant/providers/ai_radio/models.py
+++ b/music_assistant/providers/ai_radio/models.py
@@ -60,16 +60,6 @@ class AudioSection:
 
 
 @dataclass(slots=True)
-class QueueBinding:
-    """The player queue a dynamic run plays on."""
-
-    queue_id: str
-    # False when the run appended to a queue that already had items
-    owned: bool
-    first_index: int
-
-
-@dataclass(slots=True)
 class SessionState:
     """State container for an AI Radio run."""
 
@@ -84,7 +74,7 @@ class SessionState:
     result: dict[str, Any] = field(default_factory=dict)
     error: str | None = None
     task: asyncio.Task[Any] | None = field(default=None, repr=False, compare=False)
-    queue: QueueBinding | None = field(default=None, repr=False, compare=False)
+    queue_id: str | None = field(default=None, repr=False, compare=False)
 
     def as_dict(self) -> dict[str, Any]:
         """Return session as a serializable dictionary."""

--- a/music_assistant/providers/ai_radio/provider.py
+++ b/music_assistant/providers/ai_radio/provider.py
@@ -322,10 +322,12 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioStorageMixin, PluginProvider):
         """Stop an active run."""
         selected = self._resolve_session_for_stop(session_id=session_id, station_id=station_id)
 
+        # cancel first so the run cannot queue another batch after playback stopped
         if selected.task and not selected.task.done():
             selected.task.cancel()
         selected.status = "stopped"
         selected.ended_at = utc_now_iso()
+        await self._stop_session_queue(selected)
         self.logger.info(
             "AI Radio session stopped: session=%s station=%s mode=%s",
             selected.session_id,

--- a/music_assistant/providers/ai_radio/runtime.py
+++ b/music_assistant/providers/ai_radio/runtime.py
@@ -24,7 +24,7 @@ from music_assistant_models.enums import (
     QueueOption,
     TaskStatus,
 )
-from music_assistant_models.errors import InvalidCommand, InvalidDataError, MusicAssistantError
+from music_assistant_models.errors import InvalidDataError, MusicAssistantError
 from music_assistant_models.media_items import (
     MediaItemImage,
     ProviderMapping,
@@ -72,7 +72,6 @@ from .models import (
     AudioSection,
     GeneratedSection,
     PlannedSection,
-    QueueBinding,
     SessionState,
     Slot,
 )
@@ -299,7 +298,6 @@ class AIRadioRuntimeMixin:
             poll_seconds,
             prefetch_remaining_tracks,
         )
-        clear_queue = bool(station.get("clear_queue_on_start", True))
         # a grouped player plays from the group leader's queue, so resolve the
         # active queue up front and target that one for queueing and polling
         queue_id = player_id
@@ -314,30 +312,11 @@ class AIRadioRuntimeMixin:
             prefetch_remaining_tracks=prefetch_remaining_tracks,
             queue_id=queue_id,
         )
-        # without clearing, batches are appended after the existing queue items,
-        # so all trigger index math below must be offset by the current queue size
-        base_offset = 0
-        queue_was_active = False
-        if clear_queue:
-            self.mass.player_queues.clear(queue_id)
-        else:
-            existing_queue = self.mass.player_queues.get(queue_id)
-            base_offset = int(getattr(existing_queue, "items", 0) or 0)
-            queue_was_active = getattr(existing_queue, "state", None) in (
-                PlaybackState.PLAYING,
-                PlaybackState.PAUSED,
-            )
-        # bind the run to its queue so stopping the show can stop playback too
-        session.queue = QueueBinding(queue_id=queue_id, owned=clear_queue, first_index=base_offset)
+        self.mass.player_queues.clear(queue_id)
+        session.queue_id = queue_id
 
         # a shuffled queue reorders each batch, scattering sections away from their tracks
-        try:
-            await self.mass.player_queues.set_shuffle(queue_id, False)
-        except InvalidCommand as err:
-            raise MusicAssistantError(
-                f"Queue {queue_id} is in dynamic mode, which reorders the queue. Disable dynamic "
-                "mode on the player or enable 'clear queue on start' for this station."
-            ) from err
+        await self.mass.player_queues.set_shuffle(queue_id, False)
 
         cumulative_minutes = [0.0]
         for track in tracks:
@@ -351,7 +330,6 @@ class AIRadioRuntimeMixin:
         batch_index = 0
         total_entries_queued = 0
         wait_trigger_global_index = -1
-        # only once playback has been observed can an idle queue mean "user stopped it"
         playback_seen = False
         queue_stopped = False
         history_state: dict[str, list[tuple[int, float]]] = {}
@@ -443,17 +421,13 @@ class AIRadioRuntimeMixin:
                 else entry
                 for entry in entries
             ]
-            option = QueueOption.REPLACE if is_first and clear_queue else QueueOption.ADD
+            option = QueueOption.REPLACE if is_first else QueueOption.ADD
             await self.mass.player_queues.play_media(
                 queue_id=queue_id,
                 media=media_entries,
                 option=option,
             )
-            if is_first and not clear_queue and not queue_was_active:
-                # ADD does not start playback on an idle queue
-                await self.mass.player_queues.play_index(queue_id, base_offset)
-
-            batch_start_global = base_offset + total_entries_queued
+            batch_start_global = total_entries_queued
             total_entries_queued += len(entries)
             if source_positions:
                 trigger_position = max(0, len(source_positions) - prefetch_remaining_tracks)
@@ -518,7 +492,6 @@ class AIRadioRuntimeMixin:
                     playback_seen = True
                 if playback_alive:
                     inactivity_deadline = asyncio.get_running_loop().time() + stall_timeout
-                # a stopped queue means the radio was turned off, not that it stalled
                 if playback_seen and queue_state == PlaybackState.IDLE:
                     self.logger.info(
                         "Queue %s was stopped, ending dynamic run (last_index=%s)",
@@ -1687,21 +1660,16 @@ class AIRadioRuntimeMixin:
 
     async def _stop_session_queue(self, session: SessionState) -> None:
         """Stop playback of the queue a run was playing on."""
-        binding = session.queue
-        if binding is None:
+        queue_id = session.queue_id
+        if queue_id is None:
             return
-        queue = self.mass.player_queues.get(binding.queue_id)
+        queue = self.mass.player_queues.get(queue_id)
         if queue is None or getattr(queue, "state", None) == PlaybackState.IDLE:
             return
-        if not binding.owned:
-            # an appended run shares the queue, so only stop once it reached the show
-            current_index = queue.current_index
-            if current_index is None or current_index < binding.first_index:
-                return
         try:
-            await self.mass.player_queues.stop(binding.queue_id)
+            await self.mass.player_queues.stop(queue_id)
         except MusicAssistantError as err:
-            self.logger.debug("Could not stop queue %s: %s", binding.queue_id, err)
+            self.logger.debug("Could not stop queue %s: %s", queue_id, err)
 
     def _get_tts_plugin(self) -> PluginProvider:
         """Return the plugin used for TTS tasks."""

--- a/music_assistant/providers/ai_radio/runtime.py
+++ b/music_assistant/providers/ai_radio/runtime.py
@@ -72,6 +72,7 @@ from .models import (
     AudioSection,
     GeneratedSection,
     PlannedSection,
+    QueueBinding,
     SessionState,
     Slot,
 )
@@ -123,9 +124,11 @@ class AIRadioRuntimeMixin:
             else:
                 result = await self._run_dynamic_mode(session, station)
             session.result = result
-            session.status = "completed"
+            queue_stopped = result.get("ended_reason") == "queue_stopped"
+            session.status = "stopped" if queue_stopped else "completed"
             self.logger.info(
-                "AI Radio run completed: session=%s station=%s mode=%s",
+                "AI Radio run %s: session=%s station=%s mode=%s",
+                session.status,
                 session.session_id,
                 session.station_id,
                 session.mode,
@@ -324,6 +327,8 @@ class AIRadioRuntimeMixin:
                 PlaybackState.PLAYING,
                 PlaybackState.PAUSED,
             )
+        # bind the run to its queue so stopping the show can stop playback too
+        session.queue = QueueBinding(queue_id=queue_id, owned=clear_queue, first_index=base_offset)
 
         # a shuffled queue reorders each batch, scattering sections away from their tracks
         try:
@@ -346,6 +351,9 @@ class AIRadioRuntimeMixin:
         batch_index = 0
         total_entries_queued = 0
         wait_trigger_global_index = -1
+        # only once playback has been observed can an idle queue mean "user stopped it"
+        playback_seen = False
+        queue_stopped = False
         history_state: dict[str, list[tuple[int, float]]] = {}
         self._set_session_progress(
             session,
@@ -505,8 +513,20 @@ class AIRadioRuntimeMixin:
                 elif elapsed_time is not None and elapsed_time != last_elapsed_time:
                     last_elapsed_time = elapsed_time
                     playback_alive = True
+                # elapsed_time also "moves" on the first poll of an idle queue
+                if queue_state in (PlaybackState.PLAYING, PlaybackState.PAUSED):
+                    playback_seen = True
                 if playback_alive:
                     inactivity_deadline = asyncio.get_running_loop().time() + stall_timeout
+                # a stopped queue means the radio was turned off, not that it stalled
+                if playback_seen and queue_state == PlaybackState.IDLE:
+                    self.logger.info(
+                        "Queue %s was stopped, ending dynamic run (last_index=%s)",
+                        queue_id,
+                        last_seen_index,
+                    )
+                    queue_stopped = True
+                    break
                 if asyncio.get_running_loop().time() >= inactivity_deadline:
                     raise MusicAssistantError(
                         f"Queue {queue_id} stopped advancing for {stall_timeout}s "
@@ -514,8 +534,12 @@ class AIRadioRuntimeMixin:
                     )
                 await asyncio.sleep(poll_seconds)
 
+            if queue_stopped:
+                break
+
         return {
             "mode": "dynamic",
+            "ended_reason": "queue_stopped" if queue_stopped else "source_exhausted",
             "source_playlist_name": playlist_name,
             "source_tracks": len(tracks),
             "queued_tracks": cursor,
@@ -1660,6 +1684,24 @@ class AIRadioRuntimeMixin:
                 "(for example Home Assistant with an ai_task entity)."
             )
         return plugins[0]
+
+    async def _stop_session_queue(self, session: SessionState) -> None:
+        """Stop playback of the queue a run was playing on."""
+        binding = session.queue
+        if binding is None:
+            return
+        queue = self.mass.player_queues.get(binding.queue_id)
+        if queue is None or getattr(queue, "state", None) == PlaybackState.IDLE:
+            return
+        if not binding.owned:
+            # an appended run shares the queue, so only stop once it reached the show
+            current_index = queue.current_index
+            if current_index is None or current_index < binding.first_index:
+                return
+        try:
+            await self.mass.player_queues.stop(binding.queue_id)
+        except MusicAssistantError as err:
+            self.logger.debug("Could not stop queue %s: %s", binding.queue_id, err)
 
     def _get_tts_plugin(self) -> PluginProvider:
         """Return the plugin used for TTS tasks."""

--- a/music_assistant/providers/ai_radio/storage.py
+++ b/music_assistant/providers/ai_radio/storage.py
@@ -342,7 +342,6 @@ class AIRadioStorageMixin:
                     int,
                 ),
             ),
-            "clear_queue_on_start": bool(station.get("clear_queue_on_start", True)),
             "merge_section_id": merge_section_id,
             "general": general,
             "section_ids": section_ids,
@@ -530,7 +529,6 @@ class AIRadioStorageMixin:
             "dynamic_batch_size": 3,
             "dynamic_poll_seconds": 5,
             "dynamic_prefetch_remaining_tracks": 2,
-            "clear_queue_on_start": True,
             "merge_section_id": "Between_Songs_Smoother",
             "general": {
                 "instructions": DEFAULT_LLM_INSTRUCTIONS,

--- a/tests/providers/ai_radio/test_provider.py
+++ b/tests/providers/ai_radio/test_provider.py
@@ -8,16 +8,26 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
-from music_assistant_models.errors import InvalidDataError
+from music_assistant_models.enums import PlaybackState
+from music_assistant_models.errors import InvalidDataError, PlayerUnavailableError
 
 from music_assistant.providers.ai_radio.constants import MAX_FINISHED_SESSIONS
-from music_assistant.providers.ai_radio.models import SessionState
+from music_assistant.providers.ai_radio.models import QueueBinding, SessionState
 from music_assistant.providers.ai_radio.provider import AIRadioProvider
 
 
 def _close(coro: Any) -> None:
     """Close an un-awaited coroutine so the test does not warn."""
     coro.close()
+
+
+def _recording_stop(recorder: list[str]) -> Any:
+    """Return an async queue-stop stub that records the queue ids it was called with."""
+
+    async def _stop(queue_id: str) -> None:
+        recorder.append(queue_id)
+
+    return _stop
 
 
 def _make_provider() -> AIRadioProvider:
@@ -330,3 +340,100 @@ async def test_concurrent_start_run_calls_respect_the_run_limit() -> None:
     assert len(started) == 1
     assert len(rejected) == 1
     assert "Max concurrent runs reached" in str(rejected[0])
+
+
+@pytest.mark.asyncio
+async def test_stop_run_stops_the_queue_it_owns() -> None:
+    """Stop playback on the target queue when the show is stopped from the UI."""
+    provider = _make_provider()
+    provider.logger = cast(
+        "Any",
+        SimpleNamespace(debug=lambda *_a, **_kw: None, info=lambda *_a, **_kw: None),
+    )
+    stopped: list[str] = []
+    provider.mass = cast(
+        "Any",
+        SimpleNamespace(
+            player_queues=SimpleNamespace(
+                get=lambda _queue_id: SimpleNamespace(state=PlaybackState.PLAYING, current_index=3),
+                stop=_recording_stop(stopped),
+            )
+        ),
+    )
+    provider._sessions["s_run"] = SessionState(
+        session_id="s_run",
+        station_id="st",
+        mode="dynamic",
+        status="running",
+        queue=QueueBinding(queue_id="living_room", owned=True, first_index=0),
+    )
+
+    result = await provider.stop_run(session_id="s_run")
+
+    assert result["status"] == "stopped"
+    assert stopped == ["living_room"]
+
+
+@pytest.mark.asyncio
+async def test_stop_run_leaves_a_shared_queue_alone_before_the_show_starts() -> None:
+    """Keep the user's own music playing when the appended show has not started yet."""
+    provider = _make_provider()
+    provider.logger = cast(
+        "Any",
+        SimpleNamespace(debug=lambda *_a, **_kw: None, info=lambda *_a, **_kw: None),
+    )
+    stopped: list[str] = []
+    provider.mass = cast(
+        "Any",
+        SimpleNamespace(
+            player_queues=SimpleNamespace(
+                get=lambda _queue_id: SimpleNamespace(state=PlaybackState.PLAYING, current_index=1),
+                stop=_recording_stop(stopped),
+            )
+        ),
+    )
+    provider._sessions["s_run"] = SessionState(
+        session_id="s_run",
+        station_id="st",
+        mode="dynamic",
+        status="running",
+        queue=QueueBinding(queue_id="living_room", owned=False, first_index=5),
+    )
+
+    await provider.stop_run(session_id="s_run")
+
+    assert stopped == []
+
+
+@pytest.mark.asyncio
+async def test_stop_run_survives_an_unavailable_player() -> None:
+    """Still mark the session stopped when the target player has gone away."""
+    provider = _make_provider()
+    provider.logger = cast(
+        "Any",
+        SimpleNamespace(debug=lambda *_a, **_kw: None, info=lambda *_a, **_kw: None),
+    )
+
+    async def _raise(queue_id: str) -> None:
+        raise PlayerUnavailableError(f"Player {queue_id} is not available")
+
+    provider.mass = cast(
+        "Any",
+        SimpleNamespace(
+            player_queues=SimpleNamespace(
+                get=lambda _queue_id: SimpleNamespace(state=PlaybackState.PLAYING, current_index=3),
+                stop=_raise,
+            )
+        ),
+    )
+    provider._sessions["s_run"] = SessionState(
+        session_id="s_run",
+        station_id="st",
+        mode="dynamic",
+        status="running",
+        queue=QueueBinding(queue_id="living_room", owned=True, first_index=0),
+    )
+
+    result = await provider.stop_run(session_id="s_run")
+
+    assert result["status"] == "stopped"

--- a/tests/providers/ai_radio/test_provider.py
+++ b/tests/providers/ai_radio/test_provider.py
@@ -12,7 +12,7 @@ from music_assistant_models.enums import PlaybackState
 from music_assistant_models.errors import InvalidDataError, PlayerUnavailableError
 
 from music_assistant.providers.ai_radio.constants import MAX_FINISHED_SESSIONS
-from music_assistant.providers.ai_radio.models import QueueBinding, SessionState
+from music_assistant.providers.ai_radio.models import SessionState
 from music_assistant.providers.ai_radio.provider import AIRadioProvider
 
 
@@ -365,44 +365,13 @@ async def test_stop_run_stops_the_queue_it_owns() -> None:
         station_id="st",
         mode="dynamic",
         status="running",
-        queue=QueueBinding(queue_id="living_room", owned=True, first_index=0),
+        queue_id="living_room",
     )
 
     result = await provider.stop_run(session_id="s_run")
 
     assert result["status"] == "stopped"
     assert stopped == ["living_room"]
-
-
-@pytest.mark.asyncio
-async def test_stop_run_leaves_a_shared_queue_alone_before_the_show_starts() -> None:
-    """Keep the user's own music playing when the appended show has not started yet."""
-    provider = _make_provider()
-    provider.logger = cast(
-        "Any",
-        SimpleNamespace(debug=lambda *_a, **_kw: None, info=lambda *_a, **_kw: None),
-    )
-    stopped: list[str] = []
-    provider.mass = cast(
-        "Any",
-        SimpleNamespace(
-            player_queues=SimpleNamespace(
-                get=lambda _queue_id: SimpleNamespace(state=PlaybackState.PLAYING, current_index=1),
-                stop=_recording_stop(stopped),
-            )
-        ),
-    )
-    provider._sessions["s_run"] = SessionState(
-        session_id="s_run",
-        station_id="st",
-        mode="dynamic",
-        status="running",
-        queue=QueueBinding(queue_id="living_room", owned=False, first_index=5),
-    )
-
-    await provider.stop_run(session_id="s_run")
-
-    assert stopped == []
 
 
 @pytest.mark.asyncio
@@ -431,7 +400,7 @@ async def test_stop_run_survives_an_unavailable_player() -> None:
         station_id="st",
         mode="dynamic",
         status="running",
-        queue=QueueBinding(queue_id="living_room", owned=True, first_index=0),
+        queue_id="living_room",
     )
 
     result = await provider.stop_run(session_id="s_run")

--- a/tests/providers/ai_radio/test_runtime.py
+++ b/tests/providers/ai_radio/test_runtime.py
@@ -1550,3 +1550,159 @@ async def test_dynamic_mode_raises_when_set_shuffle_rejects_dynamic_queue(
 
     with pytest.raises(MusicAssistantError, match="dynamic mode"):
         await runtime._run_dynamic_mode(session, station)
+
+
+async def test_dynamic_mode_ends_run_when_user_stops_the_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End the run right away when the target queue is stopped after playing."""
+    monkeypatch.setattr(
+        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
+        30.0,
+    )
+    watchdog_runtime_cls, stepping_queues_cls = _make_watchdog_runtime_classes()
+
+    class StoppedQueue:
+        """Queue that plays index 0 and is then stopped by the user."""
+
+        polls = 0
+        elapsed_time = 12.0
+
+        @property
+        def state(self) -> PlaybackState:
+            return PlaybackState.PLAYING if self.polls < 4 else PlaybackState.IDLE
+
+        @property
+        def current_index(self) -> int:
+            return 0
+
+    class DummyPlayers:
+        def get_player(self, player_id: str) -> Any:
+            return object()
+
+    class DummyMass:
+        players = DummyPlayers()
+        player_queues = stepping_queues_cls(StoppedQueue())
+
+    runtime = watchdog_runtime_cls()
+    _set_runtime_mass(runtime, DummyMass())
+    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
+    runtime._sessions[session.session_id] = session
+
+    result = await asyncio.wait_for(
+        runtime._run_dynamic_mode(session, _watchdog_station()), timeout=10.0
+    )
+
+    assert result["ended_reason"] == "queue_stopped"
+    # only the first batch was queued; the run did not wait out the stall timeout
+    assert result["queued_tracks"] == 2
+
+
+async def test_dynamic_mode_ignores_idle_queue_before_playback_starts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Do not treat a not-yet-started queue as a user stop."""
+    monkeypatch.setattr(
+        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
+        30.0,
+    )
+    watchdog_runtime_cls, _ = _make_watchdog_runtime_classes()
+
+    class SlowStartQueue:
+        """Queue that stays idle for a few polls before playback starts."""
+
+        polls = 0
+        elapsed_time = 0.0
+
+        @property
+        def state(self) -> PlaybackState:
+            return PlaybackState.IDLE if self.polls < 3 else PlaybackState.PLAYING
+
+        @property
+        def current_index(self) -> int | None:
+            return None if self.polls < 3 else 2
+
+    class DummyPlayers:
+        def get_player(self, player_id: str) -> Any:
+            return object()
+
+    class DummyMass:
+        players = DummyPlayers()
+        player_queues = RecordingPlayerQueues(SlowStartQueue())
+
+    runtime = watchdog_runtime_cls()
+    _set_runtime_mass(runtime, DummyMass())
+    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
+    runtime._sessions[session.session_id] = session
+
+    result = await asyncio.wait_for(
+        runtime._run_dynamic_mode(session, _watchdog_station()), timeout=10.0
+    )
+
+    assert result["queued_tracks"] == 3
+    assert result["ended_reason"] == "source_exhausted"
+
+
+async def test_dynamic_mode_binds_the_session_to_the_target_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Record the queue a dynamic run plays on so stopping the show can stop it."""
+    monkeypatch.setattr(
+        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
+        30.0,
+    )
+    watchdog_runtime_cls, stepping_queues_cls = _make_watchdog_runtime_classes()
+
+    class PlayingQueue:
+        polls = 0
+        items = 4
+        elapsed_time = 1.0
+        state = PlaybackState.PLAYING
+
+        @property
+        def current_index(self) -> int:
+            return 9
+
+    class DummyPlayers:
+        def get_player(self, player_id: str) -> Any:
+            return object()
+
+    class DummyMass:
+        players = DummyPlayers()
+        player_queues = stepping_queues_cls(PlayingQueue())
+
+    runtime = watchdog_runtime_cls()
+    _set_runtime_mass(runtime, DummyMass())
+    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
+    runtime._sessions[session.session_id] = session
+
+    await asyncio.wait_for(runtime._run_dynamic_mode(session, _watchdog_station()), timeout=10.0)
+
+    assert session.queue is not None
+    assert session.queue.queue_id == "living_room"
+    # clear_queue_on_start is off in the watchdog station, so the run appends
+    assert session.queue.owned is False
+    assert session.queue.first_index == 4
+
+
+async def test_run_session_reports_a_queue_stop_as_stopped() -> None:
+    """Report a run that ended because the queue was stopped as stopped, not completed."""
+
+    class QueueStoppedRuntime(AIRadioRuntimeMixin):
+        def __init__(self) -> None:
+            self.logger = logging.getLogger("tests.ai_radio.runtime.queue_stopped")
+            self._sessions: dict[str, SessionState] = {}
+
+        async def _run_dynamic_mode(
+            self, session: SessionState, station: dict[str, Any]
+        ) -> dict[str, Any]:
+            return {"mode": "dynamic", "ended_reason": "queue_stopped"}
+
+    runtime = QueueStoppedRuntime()
+    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
+    runtime._sessions[session.session_id] = session
+
+    await runtime._run_session(session.session_id, {"id": "st"})
+
+    assert session.status == "stopped"
+    assert session.ended_at is not None

--- a/tests/providers/ai_radio/test_runtime.py
+++ b/tests/providers/ai_radio/test_runtime.py
@@ -17,10 +17,9 @@ from music_assistant_models.enums import (
     PlaybackState,
     ProviderFeature,
     ProviderType,
-    QueueOption,
     TaskStatus,
 )
-from music_assistant_models.errors import InvalidCommand, MusicAssistantError
+from music_assistant_models.errors import MusicAssistantError
 from music_assistant_models.media_items import SoundEffect
 
 from music_assistant.helpers.datetime import now as host_now
@@ -825,7 +824,6 @@ async def test_run_dynamic_mode_has_watchdog_for_stalled_playback(
         "dynamic_batch_size": 1,
         "dynamic_poll_seconds": 1,
         "dynamic_prefetch_remaining_tracks": 1,
-        "clear_queue_on_start": False,
         "general": {"timezone": "UTC"},
         "sections": [],
         "section_order": [],
@@ -993,7 +991,6 @@ def _watchdog_station() -> dict[str, Any]:
         "dynamic_batch_size": 2,
         "dynamic_poll_seconds": 1,
         "dynamic_prefetch_remaining_tracks": 1,
-        "clear_queue_on_start": False,
         "general": {"timezone": "UTC"},
         "sections": [],
         "section_order": [],
@@ -1087,113 +1084,6 @@ class RecordingPlayerQueues:
         return self.queue
 
 
-async def test_dynamic_mode_appends_to_playing_queue_when_clear_disabled(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Append batches after the existing items when clear_queue_on_start is off."""
-    monkeypatch.setattr(
-        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
-        0.2,
-    )
-    watchdog_runtime_cls, _ = _make_watchdog_runtime_classes()
-
-    class BusyQueue:
-        """Queue already playing 3 pre-existing items."""
-
-        polls = 0
-        items = 3
-        state = PlaybackState.PLAYING
-        started = False
-
-        @property
-        def current_index(self) -> int:
-            # trigger for the first radio batch sits at global index 4
-            # (3 existing items + 1); stay on the old items for a few polls
-            return 2 if self.polls < 4 else 4
-
-        @property
-        def elapsed_time(self) -> float:
-            return float(self.polls * 10)
-
-    class DummyPlayers:
-        def get_player(self, player_id: str) -> Any:
-            return object()
-
-    player_queues = RecordingPlayerQueues(BusyQueue())
-
-    class DummyMass:
-        def __init__(self) -> None:
-            self.players = DummyPlayers()
-            self.player_queues = player_queues
-
-    mass = DummyMass()
-    runtime = watchdog_runtime_cls()
-    _set_runtime_mass(runtime, mass)
-    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
-    runtime._sessions[session.session_id] = session
-
-    result = await asyncio.wait_for(
-        runtime._run_dynamic_mode(session, _watchdog_station()), timeout=10.0
-    )
-
-    assert result["queued_tracks"] == 3
-    assert player_queues.clear_calls == []
-    options = [option for option, _ in player_queues.play_media_calls]
-    assert options == [QueueOption.ADD, QueueOption.ADD]
-    # second batch must wait for the trigger beyond the pre-existing items
-    assert player_queues.play_media_calls[1][1] >= 4
-    # queue was already playing: no forced playback start
-    assert player_queues.play_index_calls == []
-
-
-async def test_dynamic_mode_starts_playback_on_idle_queue_when_clear_disabled(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Start playback at the first appended entry when the target queue is idle."""
-    monkeypatch.setattr(
-        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
-        0.2,
-    )
-    watchdog_runtime_cls, _ = _make_watchdog_runtime_classes()
-
-    class IdleQueue:
-        """Idle queue with 3 leftover items and playback starting on demand."""
-
-        polls = 0
-        items = 3
-        state = PlaybackState.IDLE
-        elapsed_time = 0.0
-        started = False
-
-        @property
-        def current_index(self) -> int | None:
-            return 4 if self.started else None
-
-    class DummyPlayers:
-        def get_player(self, player_id: str) -> Any:
-            return object()
-
-    player_queues = RecordingPlayerQueues(IdleQueue())
-
-    class DummyMass:
-        def __init__(self) -> None:
-            self.players = DummyPlayers()
-            self.player_queues = player_queues
-
-    mass = DummyMass()
-    runtime = watchdog_runtime_cls()
-    _set_runtime_mass(runtime, mass)
-    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
-    runtime._sessions[session.session_id] = session
-
-    result = await asyncio.wait_for(
-        runtime._run_dynamic_mode(session, _watchdog_station()), timeout=10.0
-    )
-
-    assert result["queued_tracks"] == 3
-    assert player_queues.play_index_calls == [("living_room", 3)]
-
-
 async def test_dynamic_mode_targets_active_group_queue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1265,7 +1155,7 @@ async def test_dynamic_mode_targets_active_group_queue(
     _set_runtime_mass(runtime, mass)
     session = SessionState(session_id="s1", station_id="st", mode="dynamic")
     runtime._sessions[session.session_id] = session
-    station = {**_watchdog_station(), "clear_queue_on_start": True}
+    station = _watchdog_station()
 
     result = await asyncio.wait_for(runtime._run_dynamic_mode(session, station), timeout=10.0)
 
@@ -1509,49 +1399,6 @@ async def test_dynamic_mode_disables_shuffle_before_first_play_media(
     )
 
 
-async def test_dynamic_mode_raises_when_set_shuffle_rejects_dynamic_queue(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Translate a dynamic-mode queue's InvalidCommand into an actionable MusicAssistantError."""
-    monkeypatch.setattr(
-        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
-        0.2,
-    )
-    watchdog_runtime_cls, _ = _make_watchdog_runtime_classes()
-
-    class RaisingPlayerQueues(RecordingPlayerQueues):
-        """Player queues stub whose queue is stuck in dynamic (smart-mix) mode."""
-
-        async def set_shuffle(self, queue_id: str, shuffle_enabled: bool) -> None:
-            await super().set_shuffle(queue_id, shuffle_enabled)
-            raise InvalidCommand("Cannot change shuffle while the queue is in dynamic mode")
-
-    class DummyPlayers:
-        def get_player(self, player_id: str) -> Any:
-            return object()
-
-    class DummyQueue:
-        items = 0
-        state = PlaybackState.IDLE
-
-    player_queues = RaisingPlayerQueues(DummyQueue())
-
-    class DummyMass:
-        def __init__(self) -> None:
-            self.players = DummyPlayers()
-            self.player_queues = player_queues
-
-    mass = DummyMass()
-    runtime = watchdog_runtime_cls()
-    _set_runtime_mass(runtime, mass)
-    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
-    runtime._sessions[session.session_id] = session
-    station = {**_watchdog_station(), "clear_queue_on_start": True}
-
-    with pytest.raises(MusicAssistantError, match="dynamic mode"):
-        await runtime._run_dynamic_mode(session, station)
-
-
 async def test_dynamic_mode_ends_run_when_user_stops_the_queue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1678,11 +1525,7 @@ async def test_dynamic_mode_binds_the_session_to_the_target_queue(
 
     await asyncio.wait_for(runtime._run_dynamic_mode(session, _watchdog_station()), timeout=10.0)
 
-    assert session.queue is not None
-    assert session.queue.queue_id == "living_room"
-    # clear_queue_on_start is off in the watchdog station, so the run appends
-    assert session.queue.owned is False
-    assert session.queue.first_index == 4
+    assert session.queue_id == "living_room"
 
 
 async def test_run_session_reports_a_queue_stop_as_stopped() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Two related changes to how a dynamic AI Radio run and its queue relate to each other.

**Stopping a show and stopping playback were unrelated actions, in both directions.** Stopping the show only cancelled the generation task, so nothing stopped the queue: the already-queued tracks and clips kept playing with no host, while the UI showed nothing on air. And a stop on the player side was indistinguishable from a stall, so the run sat in its wait loop until the 300s watchdog fired and the session died with `Queue … stopped advancing for 300s`. That is worse on players without pause support, where `cmd_pause` falls back to STOP — an intentional pause killed the show five minutes later with an error. Now a stop in either place ends both, while a pause keeps the show on air. On a player that has no pause and stops instead, the show ends, because that is what the queue actually did.

**A dynamic run now always replaces the target queue**, and the `clear_queue_on_start` option is gone. A show takes over the speaker, so appending it behind whatever was already queued was never useful — the host intro landed after unrelated music — and on a queue in smart-mix mode the generated clips were discarded outright. Removing the option also removes the offset bookkeeping it needed and lets a run own its queue outright, which is what makes the stop handling above simple.

- stop the queue a dynamic run plays on when the show is stopped
- end the run cleanly with status `stopped` as soon as its queue is stopped, instead of waiting out the stall timeout and failing
- keep a paused queue on air, and never mistake a queue that has not started yet for one that was stopped
- always `REPLACE` on the first batch and drop the `clear_queue_on_start` option, so `base_offset`, `queue_was_active` and the `play_index` kick-start branch all go away
- track only the queue id on the session, now that a run always owns its queue
- drop the `set_shuffle` guard: `clear()` resets dynamic mode immediately above it, so its `InvalidCommand` can no longer be raised

Stations saved with the option off need no migration: `_normalize_station` drops the key on the next save. The one behaviour change for those users is that starting a show replaces the queue instead of appending to it.

Removed three tests whose behaviour no longer exists: the two covering the append path, and the one covering the `set_shuffle` rejection that `clear()` now prevents.

**Related issue (if applicable):**

- diagnosed from user logs on 2.10.0b9; no issue filed

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked: music-assistant/frontend#2230
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

Verification so far: `pytest tests/providers/ai_radio` passes (91 tests, 5 new covering both stop directions and the pause exemption), and `ruff format`/`ruff check` are clean. Not yet exercised end to end against a live player, and `pre-commit` was not run in this worktree (no env), so those two boxes are left for a maintainer.
