### PR TITLE
Snapshot Sendspin playback progress at natural end of stream

### DIFF
--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -941,7 +941,11 @@ class SendspinPlaybackSession:
                     # and let the new playback handle the transition.
                     producer_stopped_cleanly = False
             with suppress(Exception):
-                self._stop_push_stream()
+                # Same condition as the group.stop() below, so we snapshot on exactly the
+                # paths where a group STOP - and therefore a freeze - is already emitted.
+                self._stop_push_stream(
+                    snapshot_progress=producer_stopped_cleanly and not self._cancel_requested
+                )
             await self._clear_join_catchup()
             await self._clear_member_pipelines()
             async with self._state_lock:
@@ -1425,11 +1429,21 @@ class SendspinPlaybackSession:
                 break
         self.player.logger.debug("Client buffer drain complete")
 
-    def _stop_push_stream(self) -> None:
-        """Stop the active PushStream."""
+    def _stop_push_stream(self, *, snapshot_progress: bool = False) -> None:
+        """
+        Stop the active PushStream.
+
+        :param snapshot_progress: Freeze the group's playback progress first. Pass this
+            only for a natural end of stream, never for one being superseded.
+        """
         ps = self._push_stream
-        if ps is not None and not ps.is_stopped:
-            ps.stop()
+        if ps is None or ps.is_stopped:
+            return
+        if snapshot_progress and (metadata_role := self.player._metadata_role) is not None:
+            # The group can only resolve the live position while the stream is up; once
+            # it is down the freeze can just re-emit the last anchor that was pushed.
+            metadata_role.freeze_progress()
+        ps.stop()
 
     def _resolve_channel_for_player(self, player_id: str) -> UUID:
         """Channel resolver callback for per-player routing."""

--- a/tests/providers/sendspin/test_eof_progress_freeze.py
+++ b/tests/providers/sendspin/test_eof_progress_freeze.py
@@ -1,0 +1,65 @@
+"""
+Tests for snapshotting progress at a natural end of stream (support#5813).
+
+The group can only resolve the live playback position while its push stream is
+up; the group.stop() that follows teardown would otherwise re-emit whatever
+anchor was last pushed. Freezing is limited to a clean end of stream - doing it
+for a superseded stream would flash a paused position between tracks.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from music_assistant.providers.sendspin.playback import SendspinPlaybackSession
+
+
+def _session_mock() -> tuple[MagicMock, list[str]]:
+    """Create a session mock recording the order of progress freeze vs transport stop."""
+    session = MagicMock()
+    calls: list[str] = []
+    push_stream = MagicMock()
+    push_stream.is_stopped = False
+    push_stream.stop.side_effect = lambda: calls.append("stream_stop")
+    session._push_stream = push_stream
+    metadata_role = session.player._metadata_role
+    metadata_role.freeze_progress.side_effect = lambda: calls.append("freeze")
+    return session, calls
+
+
+def test_clean_eof_snapshots_progress_before_stopping_transport() -> None:
+    """The snapshot must happen while the push stream is still live."""
+    session, calls = _session_mock()
+
+    SendspinPlaybackSession._stop_push_stream(session, snapshot_progress=True)
+
+    assert calls == ["freeze", "stream_stop"]
+
+
+def test_superseded_stream_is_not_snapshotted() -> None:
+    """A stream torn down for a transition must not freeze clients at a paused position."""
+    session, calls = _session_mock()
+
+    SendspinPlaybackSession._stop_push_stream(session, snapshot_progress=False)
+
+    assert calls == ["stream_stop"]
+
+
+def test_snapshot_without_metadata_role_still_stops_transport() -> None:
+    """A group with no metadata role has nothing to freeze, but must still stop."""
+    session, calls = _session_mock()
+    session.player._metadata_role = None
+
+    SendspinPlaybackSession._stop_push_stream(session, snapshot_progress=True)
+
+    assert calls == ["stream_stop"]
+
+
+def test_already_stopped_stream_is_not_snapshotted() -> None:
+    """Nothing to freeze or stop once the stream is already down."""
+    session, calls = _session_mock()
+    session._push_stream.is_stopped = True
+
+    SendspinPlaybackSession._stop_push_stream(session, snapshot_progress=True)
+
+    assert calls == []


### PR DESCRIPTION
# What does this implement/fix?

`SendspinGroup.stop()` freezes the group's playback progress before it stops transport, but can only resolve the live position while the push stream is still up. On a natural end of stream `SendspinPlaybackSession` stops the push stream first, so that freeze re-emits whatever anchor was last pushed rather than the real end position. When another track follows, the next metadata push masks it.

Snapshotting at the point transport actually stops fixes it without reordering anything. `group.stop()` already calls `freeze_progress()` on every path it runs, so this adds no new metadata emission — it makes the existing one carry a real position. `snapshot_progress` is gated on the same condition as the `group.stop()` call below it, and the `is_stopped` guard means a stream that was already torn down can never be frozen.

The decision stays in the provider rather than the library because only the caller knows whether a teardown is final: `SendspinGroup.stop_stream()` exists for stopping transport mid-transition and deliberately preserves `PLAYING`, which is exactly the case where freezing would be wrong. A `stop_stream(snapshot_progress=...)` upstream in aiosendspin would be cleaner and would drop the reach into `player._metadata_role`, but it needs a library release against the pinned `aiosendspin[server]==7.0.0`, so it is deferred.

This is the same defect as #5129 at a second site. The two touch different files and are independent in either merge order — `SendspinPlayer.stop()` cancels the playback session before calling `group.stop()`, so this snapshot is inert on the user-STOP path. The condition is deliberately expressed at both sites rather than extracted, since each has its own answer to whether the teardown is a transition.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/5813

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
