### PR TITLE
Reconfiguring an AirPlay player can now redo or reset its pairing

### DIFF
--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -58,7 +58,6 @@ from .constants import (
     CONF_MRP_CREDENTIALS,
     CONF_MRP_PAIRING_PIN,
     CONF_NATIVE_MRP_CREDENTIALS,
-    CONF_PAIR_NOW,
     CONF_STORED_VOLUME,
     EXTERNAL_ARTWORK_PATH_PREFIX,
     FALLBACK_VOLUME,
@@ -230,8 +229,8 @@ class AirPlayControlPlayer(AirPlayPlayer):
         The streaming pairing (if any) is the required "device code" that gates
         ``needs_setup``; the optional Companion (remote control) and MRP (playback
         monitoring) pairings are offered afterwards as sequential, skippable steps.
-        Re-launching from the player settings with streaming already paired goes
-        straight to those optional offers.
+        Re-launching from the player settings re-offers every pairing, so a stored
+        pairing can be redone (replaced) when it went stale.
 
         :param session: The setup flow session used to interact with the user.
         """
@@ -814,17 +813,17 @@ class AirPlayControlPlayer(AirPlayPlayer):
         self, session: SetupSession, collected: dict[str, ConfigValueType]
     ) -> None:
         """
-        Offer optional Companion (remote control) pairing, when supported and unpaired.
+        Offer optional Companion (remote control) pairing, when supported.
 
         Shows a skippable choice; on "set up now" it drives the PIN pairing and adds
-        the resulting credentials to ``collected``.
+        the resulting credentials to ``collected`` (replacing any stored ones).
 
         :param session: The setup flow session used to interact with the user.
         :param collected: The values collected so far; updated in place.
         """
-        if self.get_setup_value(CONF_COMPANION_CREDENTIALS) or not self.companion_pairing_supported:
+        if not self.companion_pairing_supported:
             return
-        if not await self._offer_control_pairing(session, "companion_offer"):
+        if not await self._offer_optional_pairing(session, "companion_offer"):
             return
         errors: dict[str, str] | None = None
         while True:
@@ -859,19 +858,19 @@ class AirPlayControlPlayer(AirPlayPlayer):
         self, session: SetupSession, collected: dict[str, ConfigValueType]
     ) -> None:
         """
-        Offer optional MRP (playback monitoring) pairing, when supported and unpaired.
+        Offer optional MRP (playback monitoring) pairing, when supported.
 
         :param session: The setup flow session used to interact with the user.
         :param collected: The values collected so far; updated in place.
         """
-        if self._mrp_credentials or not self.mrp_pairing_supported:
+        if not self.mrp_pairing_supported:
             return
         endpoint = self._mrp_endpoint
         if endpoint is None:
             return
         discovery_info, protocol = endpoint
         cred_key = self._mrp_credentials_key
-        if not await self._offer_control_pairing(session, "mrp_offer"):
+        if not await self._offer_optional_pairing(session, "mrp_offer"):
             return
         errors: dict[str, str] | None = None
         while True:
@@ -899,26 +898,6 @@ class AirPlayControlPlayer(AirPlayPlayer):
                 await pairing.close()
             collected[cred_key] = credentials
             return
-
-    async def _offer_control_pairing(self, session: SetupSession, step_id: str) -> bool:
-        """
-        Ask whether to set up this optional control pairing now.
-
-        :param session: The setup flow session used to interact with the user.
-        :param step_id: The (i18n) step id describing the offered pairing.
-        """
-        values = await session.form(
-            [
-                ConfigEntry(
-                    key=CONF_PAIR_NOW,
-                    type=ConfigEntryType.BOOLEAN,
-                    default_value=False,
-                    category="protocol_generic",
-                )
-            ],
-            step_id=step_id,
-        )
-        return bool(values[CONF_PAIR_NOW])
 
     async def _begin_pyatv_pairing(
         self, discovery_info: AsyncServiceInfo | None, protocol: Protocol

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -42,6 +42,7 @@ from .constants import (
     CONF_ENTRY_SYNC_ADJUST_AIRPLAY,
     CONF_FORCE_RAOP,
     CONF_IGNORE_VOLUME,
+    CONF_PAIR_NOW,
     CONF_PAIRING_PASSWORD,
     CONF_PAIRING_PIN,
     CONF_PASSWORD,
@@ -167,9 +168,8 @@ class AirPlayPlayer(Player):
             self._requires_password_pairing() and self.protocol == StreamingProtocol.AIRPLAY2
         ):
             # Credentials for either protocol keep the player usable: the binary
-            # picks the best route for the credentials it has. The pairing section
-            # in the player config still offers pairing for the active protocol
-            # (e.g. to upgrade a legacy RAOP pairing to AirPlay 2).
+            # picks the best route for the credentials it has. Re-running the setup
+            # flow from the player settings offers replacing a stored pairing.
             if not (
                 self.get_setup_value(CONF_AIRPLAY_CREDENTIALS)
                 or self.get_setup_value(CONF_RAOP_CREDENTIALS)
@@ -817,26 +817,36 @@ class AirPlayPlayer(Player):
         self, session: SetupSession, collected: dict[str, ConfigValueType]
     ) -> None:
         """
-        Pair the streaming protocol (RAOP or AirPlay 2), unless already paired.
+        Pair the streaming protocol (RAOP or AirPlay 2).
 
-        Credentials for either protocol keep the player usable, so this no-ops when
-        any are already stored (e.g. when the flow is re-launched from the player
-        settings). The obtained credentials are added to ``collected`` under the
-        protocol-specific key.
+        When the device requires pairing this runs it, re-offering it as a skippable
+        step when credentials are already stored (so a re-launched flow can replace a
+        stale pairing). When the device requires no pairing, any leftover credentials
+        are cleared: they would keep forcing the pair-verify route, which some
+        receivers (e.g. HomePods after their password was removed) accept while
+        refusing to actually output audio. The obtained credentials are added to
+        ``collected`` under the protocol-specific key.
 
         :param session: The setup flow session used to interact with the user.
         :param collected: The values collected so far; updated in place.
         """
-        if self.get_setup_value(CONF_AIRPLAY_CREDENTIALS) or self.get_setup_value(
-            CONF_RAOP_CREDENTIALS
-        ):
-            return
         pin_pairing = self._requires_pin_pairing()
         # a password only replaces PIN pairing on the native AirPlay 2 flow
         password_pairing = (
             self._requires_password_pairing() and self.protocol == StreamingProtocol.AIRPLAY2
         )
         if not (pin_pairing or password_pairing):
+            for cred_key in (CONF_AIRPLAY_CREDENTIALS, CONF_RAOP_CREDENTIALS):
+                if self.get_setup_value(cred_key) is not None:
+                    collected[cred_key] = None
+            return
+        already_paired = bool(
+            self.get_setup_value(CONF_AIRPLAY_CREDENTIALS)
+            or self.get_setup_value(CONF_RAOP_CREDENTIALS)
+        )
+        if already_paired and not await self._offer_optional_pairing(
+            session, "streaming_repair_offer"
+        ):
             return
 
         protocol = self.protocol
@@ -878,6 +888,26 @@ class AirPlayPlayer(Player):
                 await pairing.close()
             collected[cred_key] = credentials
             return
+
+    async def _offer_optional_pairing(self, session: SetupSession, step_id: str) -> bool:
+        """
+        Ask whether to run the offered (optional) pairing now.
+
+        :param session: The setup flow session used to interact with the user.
+        :param step_id: The (i18n) step id describing the offered pairing.
+        """
+        values = await session.form(
+            [
+                ConfigEntry(
+                    key=CONF_PAIR_NOW,
+                    type=ConfigEntryType.BOOLEAN,
+                    default_value=False,
+                    category="protocol_generic",
+                )
+            ],
+            step_id=step_id,
+        )
+        return bool(values[CONF_PAIR_NOW])
 
     async def _prepare_streaming_pairing(
         self, protocol: StreamingProtocol, *, pin_pairing: bool

--- a/music_assistant/providers/airplay/strings.json
+++ b/music_assistant/providers/airplay/strings.json
@@ -45,6 +45,10 @@
       "title": "Enter the device password",
       "description": "This device is protected with a password. Enter it below to connect."
     },
+    "streaming_repair_offer": {
+      "title": "Pair again (optional)",
+      "description": "This device is already paired for streaming. Optionally pair again to replace the stored pairing, for example after the device was reset or its password was changed. You can skip this to keep the current pairing."
+    },
     "companion_offer": {
       "title": "Set up remote control (optional)",
       "description": "Optionally pair Companion controls to monitor power, wake the device before playback, and control native playback and volume. You can skip this and set it up later from the player settings."

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -841,6 +841,8 @@
   "provider.airplay.setup_flow.pair_password.title": "Enter the device password",
   "provider.airplay.setup_flow.pair_pin.description": "A PIN code is shown on the screen of your device. Enter it below to complete pairing.",
   "provider.airplay.setup_flow.pair_pin.title": "Pair with your device",
+  "provider.airplay.setup_flow.streaming_repair_offer.description": "This device is already paired for streaming. Optionally pair again to replace the stored pairing, for example after the device was reset or its password was changed. You can skip this to keep the current pairing.",
+  "provider.airplay.setup_flow.streaming_repair_offer.title": "Pair again (optional)",
   "provider.airplay_receiver.config_entries.airplay_name.description": "How should this AirPlay receiver be named in the AirPlay device list?",
   "provider.airplay_receiver.config_entries.airplay_name.label": "AirPlay Device Name",
   "provider.airplay_receiver.config_entries.mass_player_id.description": "The Music Assistant player connected to this AirPlay receiver plugin. When you stream audio via AirPlay to this virtual speaker, the audio will play on the selected player. Set to 'Auto' to automatically select a currently playing player, or the first available player if none is playing.",

--- a/tests/providers/airplay/test_setup_flow.py
+++ b/tests/providers/airplay/test_setup_flow.py
@@ -146,8 +146,9 @@ def _streaming_player(
     player_id: str = "test_player",
     raop: bool = False,
     setup_data: dict[str, Any] | None = None,
+    flags: str = "0x8",
 ) -> AirPlayPlayer:
-    """Create a base AirPlay player that requires PIN pairing (RAOP or AirPlay 2)."""
+    """Create a base AirPlay player; the default flags (0x8) require PIN pairing."""
     provider = MagicMock()
     provider.dacp_id = "0123456789ABCDEF"
     _stub_setup_data(provider, player_id, setup_data or {})
@@ -157,7 +158,7 @@ def _streaming_player(
     else:
         raop_info = None
         airplay_info = _service_info(
-            AIRPLAY_DISCOVERY_TYPE, {"features": AP2_FEATURES, "flags": "0x8"}
+            AIRPLAY_DISCOVERY_TYPE, {"features": AP2_FEATURES, "flags": flags}
         )
     return AirPlayPlayer(
         provider=provider,
@@ -301,16 +302,70 @@ async def test_streaming_pin_pairing_retries_on_wrong_pin() -> None:
     assert pin_form_errors[1].get("base")
 
 
-async def test_streaming_already_paired_finishes_without_pairing() -> None:
-    """Re-running the flow when streaming is already paired skips pairing and finishes."""
+async def test_streaming_repair_offer_declined_keeps_stored_pairing() -> None:
+    """Re-running the flow when already paired offers re-pairing; declining changes nothing."""
     finished_values: dict[str, Any] = {}
 
     async def finish(_session: SetupSession, values: dict[str, Any]) -> dict[str, str]:
         finished_values.update({"values": values})
         return {"player_id": "test_player"}
 
+    session, mass = _make_session(finish)
+    player = _streaming_player(setup_data={CONF_AIRPLAY_CREDENTIALS: FAKE_AP2_CREDS})
+
+    with patch(_PAIRING_TARGET) as pairing_cls:
+        task = asyncio.create_task(player.run_setup_flow(session))
+        await _pump(session, task, lambda _step: {CONF_PAIR_NOW: False})
+
+    pairing_cls.assert_not_called()
+    assert finished_values["values"] == {}
+    forms = [step for step in _published_steps(mass) if step.type == FlowStepType.FORM]
+    assert [step.step_id for step in forms] == ["streaming_repair_offer"]
+
+
+async def test_streaming_repair_offer_accepted_replaces_credentials() -> None:
+    """Accepting the re-pair offer runs a fresh pairing and stores the new credentials."""
+    new_creds = "cd" * 96
+    collected: dict[str, Any] = {}
+
+    async def finish(_session: SetupSession, values: dict[str, Any]) -> dict[str, str]:
+        collected.update(values)
+        return {"player_id": "test_player"}
+
     session, _mass = _make_session(finish)
     player = _streaming_player(setup_data={CONF_AIRPLAY_CREDENTIALS: FAKE_AP2_CREDS})
+    pairing = AsyncMock()
+    pairing.finish_pairing = AsyncMock(return_value=new_creds)
+    responses: dict[str, dict[str, Any]] = {
+        "streaming_repair_offer": {CONF_PAIR_NOW: True},
+        "pair_pin": {CONF_PAIRING_PIN: "1234"},
+    }
+
+    with patch(_PAIRING_TARGET, return_value=pairing):
+        task = asyncio.create_task(player.run_setup_flow(session))
+        await _pump(session, task, lambda step: responses[step.step_id])
+
+    assert collected == {CONF_AIRPLAY_CREDENTIALS: new_creds}
+    pairing.finish_pairing.assert_awaited_once_with(pin="1234")
+
+
+async def test_stale_credentials_cleared_when_pairing_not_required() -> None:
+    """
+    A device that (no longer) requires pairing gets its leftover credentials cleared.
+
+    Covers the HomePod trap: credentials stored while a password was set keep forcing
+    the pair-verify route after the password is removed again, which the device may
+    accept without actually outputting audio. Re-running the flow must reset this.
+    """
+    collected: dict[str, Any] = {}
+
+    async def finish(_session: SetupSession, values: dict[str, Any]) -> dict[str, str]:
+        collected.update(values)
+        return {"player_id": "test_player"}
+
+    session, mass = _make_session(finish)
+    # flags without the PIN/legacy/password bits: no pairing required
+    player = _streaming_player(setup_data={CONF_AIRPLAY_CREDENTIALS: FAKE_AP2_CREDS}, flags="0x4")
 
     with patch(_PAIRING_TARGET) as pairing_cls:
         task = asyncio.create_task(player.run_setup_flow(session))
@@ -318,7 +373,9 @@ async def test_streaming_already_paired_finishes_without_pairing() -> None:
         await task
 
     pairing_cls.assert_not_called()
-    assert finished_values["values"] == {}
+    assert collected == {CONF_AIRPLAY_CREDENTIALS: None}
+    # nothing to ask: the flow finishes without publishing any form
+    assert not [step for step in _published_steps(mass) if step.type == FlowStepType.FORM]
 
 
 async def test_abort_mid_pairing_closes_session() -> None:
@@ -414,18 +471,28 @@ async def test_two_code_sequence_streaming_then_companion() -> None:
     assert "pair_companion" in step_ids
 
 
-async def test_companion_offer_can_be_skipped() -> None:
-    """Declining the optional Companion offer collects nothing and never pairs."""
+async def test_all_pairings_reoffered_and_skippable_when_already_paired() -> None:
+    """
+    A fully paired device re-offers every pairing on a re-run; declining all is a no-op.
+
+    Previously stored credentials silently skipped their steps, leaving no way to
+    redo a stale pairing from the player settings.
+    """
     collected: dict[str, Any] = {}
 
     async def finish(_session: SetupSession, values: dict[str, Any]) -> dict[str, str]:
         collected.update(values)
         return {"player_id": "apctl"}
 
-    session, _mass = _make_session(finish, player_id="apctl")
-    # streaming already paired, so the flow goes straight to the optional offers
-    player = _control_player(setup_data={CONF_AIRPLAY_CREDENTIALS: FAKE_AP2_CREDS})
+    session, mass = _make_session(finish, player_id="apctl")
+    player = _control_player(
+        setup_data={
+            CONF_AIRPLAY_CREDENTIALS: FAKE_AP2_CREDS,
+            CONF_COMPANION_CREDENTIALS: "companion-creds",
+        }
+    )
     responses: dict[str, dict[str, Any]] = {
+        "streaming_repair_offer": {CONF_PAIR_NOW: False},
         "companion_offer": {CONF_PAIR_NOW: False},
         "mrp_offer": {CONF_PAIR_NOW: False},
     }
@@ -440,3 +507,5 @@ async def test_companion_offer_can_be_skipped() -> None:
     assert collected == {}
     pairing_cls.assert_not_called()
     pyatv_pair.assert_not_called()
+    step_ids = [step.step_id for step in _published_steps(mass) if step.type == FlowStepType.FORM]
+    assert step_ids == ["streaming_repair_offer", "companion_offer", "mrp_offer"]


### PR DESCRIPTION
Re-running an AirPlay player's setup flow (right-click → Reconfigure player) skipped every pairing step once credentials were stored, so there was no way to redo or remove a stale pairing.

Now:
- Each pairing (streaming, Companion, playback monitoring) is re-offered as a skippable step when it is already in place, so it can be redone/replaced.
- When the device does not require pairing (anymore), leftover streaming credentials are cleared so playback returns to the normal credential-less flow.

The second point matters for the silent-playback reports in music-assistant/support#5312: credentials stored while a HomePod had "Require Password" enabled are kept forever after the password is removed, and keep forcing the HAP pair-verify route. The HomePod accepts that session (RTSP/PTP all healthy, MA shows Playing) but never actually outputs audio. Reconfiguring the player now resets this state.