### PR TITLE
Add CI check rejecting conventional-commit PR title prefixes

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,46 @@
+---
+name: PR Title
+
+# Release notes are generated verbatim from PR titles
+# (.github/release-notes-config.yml), so a title has to read as a
+# user-facing description of the change: "Fix Sonos hanging after
+# reconnect", not "fix: sonos reconnect".
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - ready_for_review
+    branches:
+      - dev
+
+permissions: {}
+
+jobs:
+  check_title:
+    name: Verify
+    runs-on: ubuntu-latest
+    # GitHub-typed bots (Dependabot, musicassistant-bot[bot], etc.)
+    # generate their own titles, so failing here would only block
+    # their auto-merge.
+    if: github.event.pull_request.user.type != 'Bot'
+    steps:
+      - name: 📝 Reject conventional-commit title prefixes
+        env:
+          # Passed via env, never inlined into the script: the title
+          # is untrusted input.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          types='build|chore|ci|deps|docs|feat|feature|fix|perf|refactor|revert|style|tests?'
+          prefix=$(printf '%s' "$PR_TITLE" |
+            grep -oiE "^[[:space:]]*($types)(\([^)]*\))?!?[[:space:]]*:" || true)
+
+          if [ -n "$prefix" ]; then
+            echo "::error title=PR title uses a conventional-commit prefix::Drop the '$(printf '%s' "$prefix" | tr -d '[:space:]')' prefix. Release notes are generated straight from PR titles, so write the title as the user-facing change instead, for example 'Fix Sonos hanging after reconnect'."
+            exit 1
+          fi
+
+          echo "Title OK: $PR_TITLE"


### PR DESCRIPTION
# What does this implement/fix?

Release notes are generated verbatim from PR titles, so a conventional-commit style
title (`fix: sonos reconnect`) ends up in the notes as-is and has to be rewritten by
hand. This adds a CI check that rejects those prefixes so the title is written as a
user-facing change description up front: `Fix Sonos hanging after reconnect`.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- New `.github/workflows/pr-title.yml`, running on PR open/edit/reopen/ready-for-review
  against `dev`.
- Fails when the title starts with `build|chore|ci|deps|docs|feat|feature|fix|perf|refactor|revert|style|test(s)`,
  optionally scoped and/or `!`-marked, followed by a colon. The error names the prefix and
  shows the wanted form.
- Only that prefix is checked — no length, casing or wording rules — so titles like
  `Apple Music: signing in a second account no longer breaks the first` still pass.
- Bot PRs are skipped, matching `pr-labels.yaml`; their titles are generated and a
  failure would only block auto-merge.
- Read-only (`permissions: {}`), and the title is passed via env rather than inlined into
  the script.

Needs to be added as a required status check in branch protection to actually block a
merge.

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
