### PR TITLE
AirPlay playback no longer starts muted after the speaker was in standby

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -2423,10 +2423,23 @@ class Player(ABC):
             return None
         # handle protocol player as volume control
         if control := self.mass.players.get_player(volume_control):
-            if control.volume_level is not None:
-                return self.mass.players.scale_volume_from_device(
-                    self.player_id, control.volume_level
+            control_volume = control.volume_level
+            if (
+                control_volume == 0
+                and control.player_id != self.active_output_protocol
+                and any(
+                    linked.output_protocol_id == control.player_id
+                    for linked in self.linked_output_protocols
                 )
+            ):
+                # A linked protocol interface that is not actively rendering audio
+                # may report volume 0 while the device is in standby (e.g. the cast
+                # side of some devices), which doesn't reflect the real device volume.
+                # Treat it as unknown so we fall back to other sources instead of
+                # propagating a spurious hard mute.
+                control_volume = None
+            if control_volume is not None:
+                return self.mass.players.scale_volume_from_device(self.player_id, control_volume)
         # handle player control for volume if set
         if player_control := self.mass.players.get_player_control(volume_control):
             if player_control.volume_level is not None:

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -662,6 +662,13 @@ class AirPlayPlayer(Player):
                 # Native parent volume is on the receiver/amplifier scale.
                 # Keep the AirPlay child volume learned from DACP feedback instead.
                 return
+            if parent_player.state.volume_level == 0:
+                # A parent volume of 0 usually means the (idle) sibling interface
+                # feeding the parent doesn't know the real device volume, e.g. the
+                # cast side of the same device reports 0 while in standby. Adopting
+                # it would start the stream hard muted, so keep our own last known
+                # volume instead.
+                return
             if self._attr_volume_level == parent_player.state.volume_level:
                 return
             self._attr_volume_level = parent_player.state.volume_level

--- a/tests/models/test_player_volume.py
+++ b/tests/models/test_player_volume.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from music_assistant_models.enums import PlayerFeature
+from music_assistant_models.player import OutputProtocol
 
 from music_assistant.constants import CONF_MUTE_CONTROL, CONF_VOLUME_CONTROL
 from tests.common import MockPlayer, MockProvider
@@ -95,6 +96,85 @@ class TestFinalVolumeLevel:
 
         player.update_state(signal_event=False)
         assert player.state.volume_level == 42
+
+    def test_ignores_zero_from_idle_linked_protocol(self, mock_mass: MagicMock) -> None:
+        """Volume 0 from a linked protocol that is not the active output is not authoritative."""
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=lambda _pid, key, *_a: "cast_child" if key == CONF_VOLUME_CONTROL else None
+        )
+        provider = MockProvider("test", mass=mock_mass)
+        player = MockPlayer(provider, "main_player", "Main")
+        player._attr_volume_level = 55
+        player.set_linked_output_protocols(
+            [
+                OutputProtocol(
+                    output_protocol_id="cast_child",
+                    name="Chromecast",
+                    protocol_domain="chromecast",
+                )
+            ]
+        )
+
+        control = MagicMock()
+        control.player_id = "cast_child"
+        control.volume_level = 0
+        mock_mass.players.get_player = MagicMock(return_value=control)
+        mock_mass.players.get_player_control = MagicMock(return_value=None)
+        # With default min=0, max=100, scaling is identity
+        mock_mass.players.scale_volume_from_device = MagicMock(side_effect=lambda _pid, vol: vol)
+
+        player.update_state(signal_event=False)
+        assert player.state.volume_level == 55
+
+    def test_uses_zero_from_active_linked_protocol(self, mock_mass: MagicMock) -> None:
+        """Volume 0 from the linked protocol that is actively rendering is trusted."""
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=lambda _pid, key, *_a: "cast_child" if key == CONF_VOLUME_CONTROL else None
+        )
+        provider = MockProvider("test", mass=mock_mass)
+        player = MockPlayer(provider, "main_player", "Main")
+        player._attr_volume_level = 55
+        player.set_linked_output_protocols(
+            [
+                OutputProtocol(
+                    output_protocol_id="cast_child",
+                    name="Chromecast",
+                    protocol_domain="chromecast",
+                )
+            ]
+        )
+
+        control = MagicMock()
+        control.player_id = "cast_child"
+        control.volume_level = 0
+        mock_mass.players.get_player = MagicMock(return_value=control)
+        mock_mass.players.get_player_control = MagicMock(return_value=None)
+        # With default min=0, max=100, scaling is identity
+        mock_mass.players.scale_volume_from_device = MagicMock(side_effect=lambda _pid, vol: vol)
+
+        player.set_active_output_protocol("cast_child")
+        player.update_state(signal_event=False)
+        assert player.state.volume_level == 0
+
+    def test_uses_zero_from_external_control_player(self, mock_mass: MagicMock) -> None:
+        """Volume 0 from an external (non-linked) control player is trusted as genuine."""
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=lambda _pid, key, *_a: "amplifier" if key == CONF_VOLUME_CONTROL else None
+        )
+        provider = MockProvider("test", mass=mock_mass)
+        player = MockPlayer(provider, "main_player", "Main")
+        player._attr_volume_level = 55
+
+        control = MagicMock()
+        control.player_id = "amplifier"
+        control.volume_level = 0
+        mock_mass.players.get_player = MagicMock(return_value=control)
+        mock_mass.players.get_player_control = MagicMock(return_value=None)
+        # With default min=0, max=100, scaling is identity
+        mock_mass.players.scale_volume_from_device = MagicMock(side_effect=lambda _pid, vol: vol)
+
+        player.update_state(signal_event=False)
+        assert player.state.volume_level == 0
 
 
 class TestFinalVolumeMutedState:

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -729,6 +729,31 @@ def test_sync_volume_level_uses_parent_volume_without_native_parent(
     mock_update.assert_called_once()
 
 
+def test_sync_volume_level_ignores_parent_volume_zero(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """
+    Keep the last known volume when the parent reports volume 0.
+
+    An idle sibling interface (e.g. the cast side of the same device in standby)
+    may feed the parent a volume of 0 that doesn't reflect the real device volume;
+    adopting it would start the stream hard muted.
+    """
+    parent = MagicMock()
+    parent.state.volume_level = 0
+    parent.volume_control = None
+    airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
+    airplay_player.set_protocol_parent_id("parent")
+    airplay_player._attr_volume_level = 48
+
+    with patch.object(AirPlayPlayer, "update_state") as mock_update:
+        airplay_player.sync_volume_level()
+
+    assert airplay_player._attr_volume_level == 48
+    airplay_player.mass.config.set_raw_player_config_value.assert_not_called()  # type: ignore[attr-defined]
+    mock_update.assert_not_called()
+
+
 # --- Pause / stop dispatch tests ---
 
 


### PR DESCRIPTION
# What does this implement/fix?

Some speakers offer more than one streaming protocol (for example AirPlay and Chromecast on the same device). A few of these devices report a volume of 0 on their idle Chromecast interface while in standby. Music Assistant adopted that bogus 0 as the speaker's volume, so the next AirPlay stream connected and streamed just fine — but fully muted. To the user the speaker simply looked like it refused to start playing.

- A volume of 0 reported by a protocol interface of the same device that is not actively playing is no longer trusted; the last known volume is used instead.
- The AirPlay stream no longer adopts (and stores) a volume of 0 from the combined player when a stream starts.
- A volume of 0 from the interface that is actually playing, or from a separately configured volume control player (like an amplifier), is still respected.
- Added tests covering the new behavior.

**Related issue (if applicable):**

- n/a (reported via user log)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
