### PR TITLE
Autoplay continues your podcast or audiobook instead of switching to music

### DIFF
--- a/music_assistant/controllers/player_queues/README.md
+++ b/music_assistant/controllers/player_queues/README.md
@@ -185,14 +185,19 @@ Two distinct refill paths share the same "running low" trigger:
   recently-heard artists back, then best-effort spaces the assembled batch so adjacent tracks avoid
   sharing an artist (seam-aware against the current tail). A "radio" is just a dynamic playlist from
   the `radio_playlist` provider.
-- **Autoplay** refills using the per-queue configured mode, owned by `autoplay.py`: similar tracks
-  (seeded from the enqueued items), an infinite library mix (genre-biased, least-played), a chosen
-  playlist, or an automatic mode that tries similar first and falls back to the library mix. The
-  mode is read from the per-queue config; the playlist for playlist-mode is a per-queue config value.
+- **Autoplay** is the single "keep going" switch; what it appends is dispatched on the media type of
+  the queue's last item, since that is the item the appended ones follow. Music continues with the
+  per-queue configured mode, owned by `autoplay.py`: similar tracks (seeded from the enqueued items),
+  an infinite library mix (genre-biased, least-played), a chosen playlist, or an automatic mode that
+  tries similar first and falls back to the library mix. The mode is read from the per-queue config;
+  the playlist for playlist-mode is a per-queue config value. A podcast episode or audiobook instead
+  continues with its own successor — the next episode of the podcast, the next book in the collection
+  — resolved by `media_resolver.py`, and simply ends the queue when there is none. Live sources
+  (radio, audio source) have no natural end, so Autoplay does not apply to them at all.
 
 Data flow: dynamic `sources` → managed pool (per-source fetch + weighted, recency-gated allocation)
-→ appended `QueueItem`s; autoplay flag → `Autoplay` (mode-based selection) → appended
-`QueueItem`s.
+→ appended `QueueItem`s; autoplay flag → media-type dispatch → `Autoplay` (mode-based selection) or
+the next episode/book → appended `QueueItem`s.
 
 ## Track Resolution
 
@@ -238,7 +243,8 @@ player_queues/
 ├── managed_pool.py # ManagedPool: bounded dynamic-source pool, topped up + recency-gated, with
 │                   #   finite sources materialized to play through once
 ├── media_resolver.py # MediaResolver: resolves source media items (artist/album/genre/playlist/
-│                   #   audiobook/podcast/browse folder) into the concrete tracks to enqueue
+│                   #   audiobook/podcast/browse folder) into the concrete tracks to enqueue, plus
+│                   #   the successor (next episode/book) of an item that finished playing
 ├── queue_loader.py # QueueLoaderMixin: applies the enqueue option, loads single items, resume-from-
 │                   #   playlog, next-index, and the dynamic/autoplay queue refills
 ├── playback_tracker.py # PlaybackTrackerMixin: reconciles queue state from player updates, end-of-

--- a/music_assistant/controllers/player_queues/autoplay.py
+++ b/music_assistant/controllers/player_queues/autoplay.py
@@ -40,10 +40,14 @@ GENRE_SEED_ITEM_COUNT = 3
 GENRE_SEED_MEDIA_TYPES = (MediaType.TRACK, MediaType.ALBUM, MediaType.ARTIST)
 # media types that end on their own but have a natural successor of their own: Autoplay
 # continues these with the next episode/book instead of appending music
-SERIES_MEDIA_TYPES = (MediaType.AUDIOBOOK, MediaType.PODCAST_EPISODE)
+AUTOPLAY_SERIES_MEDIA_TYPES = (MediaType.AUDIOBOOK, MediaType.PODCAST_EPISODE)
 # media types Autoplay does not apply to: a live source has no natural end (stopping it means
 # the source stopped, not that the queue ran out) and a sound effect is a one-off
-EXCLUDED_MEDIA_TYPES = (MediaType.RADIO, MediaType.AUDIO_SOURCE, MediaType.SOUND_EFFECT)
+AUTOPLAY_EXCLUDED_MEDIA_TYPES = (
+    MediaType.RADIO,
+    MediaType.AUDIO_SOURCE,
+    MediaType.SOUND_EFFECT,
+)
 
 
 class AutoplayMode(StrEnum):

--- a/music_assistant/controllers/player_queues/autoplay.py
+++ b/music_assistant/controllers/player_queues/autoplay.py
@@ -1,10 +1,12 @@
 """
 Autoplay helper for the Player Queues controller.
 
-Autoplay keeps a queue playing once it runs out by appending a fresh batch of tracks.
-This helper resolves the configured Autoplay mode for a queue and produces the next
-batch of tracks for the library- and playlist-based modes. The similar-tracks (radio)
-modes reuse the controller's existing dynamic-radio machinery.
+Autoplay is the single "keep going" switch of a queue; what it appends depends on the media
+type of the item that is ending. Music continues with a fresh batch of tracks, a podcast
+episode or audiobook with its own successor, and a live source is left alone. This helper
+resolves the configured Autoplay mode for a queue and produces the next batch of tracks for
+the library- and playlist-based modes. The similar-tracks (radio) modes reuse the controller's
+existing dynamic-radio machinery.
 """
 
 from __future__ import annotations
@@ -36,6 +38,12 @@ AUTOPLAY_BATCH_SIZE = 25
 GENRE_SEED_ITEM_COUNT = 3
 # media types that carry a useful genre signal for the library mix
 GENRE_SEED_MEDIA_TYPES = (MediaType.TRACK, MediaType.ALBUM, MediaType.ARTIST)
+# media types that end on their own but have a natural successor of their own: Autoplay
+# continues these with the next episode/book instead of appending music
+SERIES_MEDIA_TYPES = (MediaType.AUDIOBOOK, MediaType.PODCAST_EPISODE)
+# media types Autoplay does not apply to: a live source has no natural end (stopping it means
+# the source stopped, not that the queue ran out) and a sound effect is a one-off
+EXCLUDED_MEDIA_TYPES = (MediaType.RADIO, MediaType.AUDIO_SOURCE, MediaType.SOUND_EFFECT)
 
 
 class AutoplayMode(StrEnum):

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -298,7 +298,6 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         # (an active dynamic source manages its own refills, so leave it be)
         if (
             queue.autoplay_enabled
-            and queue_data.enqueued_media_items
             and not queue.is_dynamic
             and queue.current_index is not None
             and (queue.items - queue.current_index) < 5

--- a/music_assistant/controllers/player_queues/media_resolver.py
+++ b/music_assistant/controllers/player_queues/media_resolver.py
@@ -40,7 +40,10 @@ from music_assistant.controllers.player_queues.constants import (
     ENQUEUE_SELECT_ARTIST_DEFAULT_VALUE,
 )
 from music_assistant.controllers.player_queues.helpers import sort_tracks
-from music_assistant.helpers.collections import get_collection_item_media_type_from_item_id
+from music_assistant.helpers.collections import (
+    get_collection_item_id,
+    get_collection_item_media_type_from_item_id,
+)
 
 if TYPE_CHECKING:
     from music_assistant.controllers.player_queues.controller import PlayerQueuesController
@@ -420,6 +423,76 @@ class MediaResolver:
         # return the (remaining) episode(s) to play
         return UniqueList(all_episodes[episode_index:])
 
+    async def get_next_podcast_episode(
+        self, episode: PodcastEpisode, userid: str | None = None
+    ) -> PodcastEpisode | None:
+        """
+        Return the episode to play after the given one, or None if there is none left.
+
+        Episodes are walked in the same order a full podcast enqueue produces, skipping the
+        ones that were already fully played.
+
+        :param episode: The episode that is being continued.
+        :param userid: User whose resume position should be applied.
+        """
+        podcast = episode.podcast
+        all_episodes = [
+            x async for x in self.mass.music.podcasts.episodes(podcast.item_id, podcast.provider)
+        ]
+        all_episodes.sort(key=lambda x: x.position)
+        current_index = next(
+            (idx for idx, x in enumerate(all_episodes) if x.uri == episode.uri), None
+        )
+        if current_index is None:
+            # the episode is no longer part of the feed, so we have nothing to continue from
+            return None
+        for candidate in all_episodes[current_index + 1 :]:
+            if candidate.fully_played:
+                continue
+            # ensure we have accurate resume info
+            fully_played, resume_position_ms = await self.mass.music.get_resume_position(
+                candidate, userid=userid
+            )
+            if fully_played:
+                continue
+            candidate.resume_position_ms = resume_position_ms
+            return candidate
+        return None
+
+    async def get_next_audiobook(
+        self, audiobook: Audiobook, userid: str | None = None
+    ) -> Audiobook | None:
+        """
+        Return the next book in the collection(s) the given book belongs to, if there is one.
+
+        Returns None for a standalone book and for a book whose collection has no not-fully-played
+        book left after it.
+
+        :param audiobook: The audiobook that is being continued.
+        :param userid: User whose resume position should be applied.
+        """
+        # collections are built from the library metadata, so a book that is not in the
+        # library has no series to continue with
+        library_item = (
+            audiobook
+            if audiobook.provider == "library"
+            else await self.mass.music.audiobooks.get_library_item_by_prov_id(
+                audiobook.item_id, audiobook.provider
+            )
+        )
+        if library_item is None:
+            return None
+        for collection in library_item.metadata.collections or []:
+            try:
+                media_collection = await self.mass.music.audiobooks.get_collection(
+                    get_collection_item_id(collection.title, MediaType.AUDIOBOOK)
+                )
+            except MediaNotFoundError:
+                continue
+            if next_book := await self._next_unplayed_book(media_collection, library_item, userid):
+                return next_book
+        return None
+
     async def _set_episode_resume_point(
         self, episode: PodcastEpisode, userid: str | None, start_from_beginning: bool
     ) -> None:
@@ -438,6 +511,29 @@ class MediaResolver:
         )
         episode.fully_played = fully_played
         episode.resume_position_ms = 0 if fully_played else resume_position_ms
+
+    async def _next_unplayed_book(
+        self,
+        collection: MediaCollection[Audiobook],
+        current: Audiobook,
+        userid: str | None,
+    ) -> Audiobook | None:
+        """Return the first not fully played book after `current` in the given collection."""
+        books = [x for x in collection.items if isinstance(x, Audiobook)]
+        current_index = next(
+            (idx for idx, x in enumerate(books) if x.item_id == current.item_id), None
+        )
+        if current_index is None:
+            return None
+        for candidate in books[current_index + 1 :]:
+            fully_played, resume_position_ms = await self.mass.music.get_resume_position(
+                candidate, userid=userid
+            )
+            if fully_played:
+                continue
+            candidate.resume_position_ms = resume_position_ms
+            return candidate
+        return None
 
     async def _resolve_library_artist(self, artist: Artist) -> Artist | None:
         """

--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -280,8 +280,9 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
                 # a dynamic queue tops up its bounded managed pool from its (dynamic + finite) sources
                 task_id = f"fill_dynamic_tracks_{queue_id}"
                 self.mass.call_later(5, self._fill_dynamic_tracks, queue_id, task_id=task_id)
-            elif queue.autoplay_enabled and queue_data.enqueued_media_items and running_low:
-                # autoplay refills using the per-queue configured Autoplay mode
+            elif queue.autoplay_enabled and running_low:
+                # autoplay appends whatever continues the queue's last item (more music, the
+                # next podcast episode/audiobook, or nothing at all)
                 task_id = f"fill_autoplay_tracks_{queue_id}"
                 self.mass.call_later(5, self._fill_autoplay_tracks, queue_id, task_id=task_id)
 

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -27,11 +27,13 @@ from music_assistant_models.errors import (
 )
 from music_assistant_models.media_items import (
     Album,
+    Audiobook,
     BrowseFolder,
     ItemMapping,
     MediaItemType,
     PlayableMediaItemType,
     Playlist,
+    PodcastEpisode,
     Track,
     UniqueList,
     media_from_dict,
@@ -39,6 +41,8 @@ from music_assistant_models.media_items import (
 
 from music_assistant.constants import ATTR_ANNOUNCEMENT_IN_PROGRESS
 from music_assistant.controllers.player_queues.autoplay import (
+    EXCLUDED_MEDIA_TYPES,
+    SERIES_MEDIA_TYPES,
     AutoplayMode,
 )
 from music_assistant.controllers.player_queues.base import _PlayerQueuesBase
@@ -423,23 +427,91 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         )
 
     async def _fill_autoplay_tracks(self, queue_id: str) -> None:
-        """Fill a Queue with additional tracks based on the configured Autoplay mode."""
+        """
+        Append more items to a queue that is running low, based on what is ending.
+
+        Autoplay is a single "keep going" switch; what it appends is decided by the media type
+        of the queue's last item, since that is the item the appended items follow.
+        """
         queue = self.get(queue_id)
         if queue is None or not queue.autoplay_enabled:
             return
         queue_data = self._queue_data[queue_id]
-        mode = self._autoplay.resolve_mode(queue_id)
-        self.logger.debug(
-            "Filling autoplay tracks (mode: %s) for queue %s", mode.value, queue.display_name
-        )
-        # Restore the queue owner's user context so provider filters and library access
-        # are respected during this background refill, mirroring _fill_dynamic_tracks.
+        if not queue_data.items:
+            return
+        last_item = queue_data.items[-1]
+        if last_item.media_type in EXCLUDED_MEDIA_TYPES:
+            return
+        # Restore the queue owner's user context so provider filters, library access and
+        # resume positions are respected during this background refill, mirroring
+        # _fill_dynamic_tracks.
         playback_user = (
             await self.mass.webserver.auth.get_user(queue_data.userid)
             if queue_data.userid
             else None
         )
         set_current_user(playback_user)
+        if last_item.media_type in SERIES_MEDIA_TYPES:
+            await self._fill_autoplay_next_in_series(queue_id, last_item)
+            return
+        await self._fill_autoplay_music_tracks(queue_id)
+
+    async def _fill_autoplay_next_in_series(self, queue_id: str, last_item: QueueItem) -> None:
+        """
+        Append the episode/book that follows the queue's last item, if there is one.
+
+        Nothing is appended for the last episode of a podcast or a book without a next one in
+        its collection, so the queue simply ends there.
+
+        :param queue_id: The queue to append to.
+        :param last_item: The queue's last item, an audiobook or podcast episode.
+        """
+        queue_data = self._queue_data[queue_id]
+        media_item = last_item.media_item
+        next_item: PodcastEpisode | Audiobook | None
+        try:
+            if isinstance(media_item, PodcastEpisode):
+                next_item = await self._media_resolver.get_next_podcast_episode(
+                    media_item, userid=queue_data.userid
+                )
+            elif isinstance(media_item, Audiobook):
+                next_item = await self._media_resolver.get_next_audiobook(
+                    media_item, userid=queue_data.userid
+                )
+            else:
+                return
+        except MusicAssistantError as err:
+            self.logger.warning(
+                "Autoplay failed to fetch the item following %s: %s", last_item.name, err
+            )
+            return
+        if next_item is None or not next_item.available:
+            self.logger.debug("Autoplay found nothing to play after %s", last_item.name)
+            return
+        if any(
+            item.media_item and item.media_item.uri == next_item.uri for item in queue_data.items
+        ):
+            # already queued (e.g. the user added it themselves), so there is nothing to do
+            return
+        await self.load(
+            queue_id,
+            [build_queue_item(queue_id, next_item)],
+            insert_at_index=len(queue_data.items) + 1,
+        )
+
+    async def _fill_autoplay_music_tracks(self, queue_id: str) -> None:
+        """Fill a Queue with additional tracks based on the configured Autoplay mode."""
+        queue = self.get(queue_id)
+        if queue is None:
+            return
+        queue_data = self._queue_data[queue_id]
+        if not queue_data.enqueued_media_items:
+            # the music refill needs what the user enqueued as its seed
+            return
+        mode = self._autoplay.resolve_mode(queue_id)
+        self.logger.debug(
+            "Filling autoplay tracks (mode: %s) for queue %s", mode.value, queue.display_name
+        )
         existing_tracks = {
             item.media_item
             for item in self._queue_data[queue_id].items
@@ -589,8 +661,10 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                             media_item.provider,
                         )
 
-                # Save requested media item to play on the queue so we can use it as a source
-                # for Autoplay. Use FIFO list to keep track of the last 10 played items
+                # Save requested media item to play on the queue so we can use it as a seed
+                # for Autoplay's music refill (the podcast/audiobook continuations resolve
+                # their successor from the queue's last item instead).
+                # Use FIFO list to keep track of the last 10 played items
                 # Skip ItemMapping and BrowseFolder - only queue full MediaItemType objects
                 if not isinstance(
                     media_item, (ItemMapping, BrowseFolder)

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -41,8 +41,8 @@ from music_assistant_models.media_items import (
 
 from music_assistant.constants import ATTR_ANNOUNCEMENT_IN_PROGRESS
 from music_assistant.controllers.player_queues.autoplay import (
-    EXCLUDED_MEDIA_TYPES,
-    SERIES_MEDIA_TYPES,
+    AUTOPLAY_EXCLUDED_MEDIA_TYPES,
+    AUTOPLAY_SERIES_MEDIA_TYPES,
     AutoplayMode,
 )
 from music_assistant.controllers.player_queues.base import _PlayerQueuesBase
@@ -440,7 +440,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         if not queue_data.items:
             return
         last_item = queue_data.items[-1]
-        if last_item.media_type in EXCLUDED_MEDIA_TYPES:
+        if last_item.media_type in AUTOPLAY_EXCLUDED_MEDIA_TYPES:
             return
         # Restore the queue owner's user context so provider filters, library access and
         # resume positions are respected during this background refill, mirroring
@@ -451,7 +451,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             else None
         )
         set_current_user(playback_user)
-        if last_item.media_type in SERIES_MEDIA_TYPES:
+        if last_item.media_type in AUTOPLAY_SERIES_MEDIA_TYPES:
             await self._fill_autoplay_next_in_series(queue_id, last_item)
             return
         await self._fill_autoplay_music_tracks(queue_id)

--- a/tests/controllers/player_queues/test_autoplay_dispatch.py
+++ b/tests/controllers/player_queues/test_autoplay_dispatch.py
@@ -1,0 +1,441 @@
+"""
+Tests for what Autoplay appends per media type.
+
+Autoplay is a single "keep going" switch: music continues with more music, a podcast episode
+or audiobook with its own successor, and a live source (radio/audio source) is left alone -
+including when the user stops it manually.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import MediaType, PlaybackState
+from music_assistant_models.media_items import (
+    Audiobook,
+    MediaCollection,
+    Podcast,
+    PodcastEpisode,
+    Radio,
+    Track,
+    UniqueList,
+)
+from music_assistant_models.media_items.metadata import MediaItemCollection, MediaItemMetadata
+from music_assistant_models.media_items.provider_mapping import ProviderMapping
+
+from music_assistant.controllers.player_queues.media_resolver import MediaResolver
+from music_assistant.controllers.player_queues.playback_tracker import PlaybackTrackerMixin
+from music_assistant.controllers.player_queues.queue_loader import QueueLoaderMixin
+from music_assistant.helpers.collections import get_collection_item_id
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from music_assistant_models.media_items import PlayableMediaItemType
+    from music_assistant_models.player_queue import PlayerQueue
+
+    from music_assistant.controllers.player_queues.helpers import CompareState
+
+
+def _mappings(item_id: str, provider: str, available: bool = True) -> set[ProviderMapping]:
+    """Build a single provider mapping for the given item."""
+    return {
+        ProviderMapping(
+            item_id=item_id,
+            provider_domain=provider,
+            provider_instance=provider,
+            available=available,
+        )
+    }
+
+
+def _podcast(item_id: str = "show1", provider: str = "test_prov") -> Podcast:
+    """Build a minimal Podcast."""
+    return Podcast(
+        item_id=item_id,
+        provider=provider,
+        name="Show",
+        provider_mappings=_mappings(item_id, provider),
+    )
+
+
+def _episode(
+    item_id: str,
+    position: int,
+    podcast: Podcast,
+    *,
+    fully_played: bool | None = None,
+    provider: str = "test_prov",
+) -> PodcastEpisode:
+    """Build a minimal PodcastEpisode of the given podcast."""
+    return PodcastEpisode(
+        item_id=item_id,
+        provider=provider,
+        name=f"Episode {position}",
+        provider_mappings=_mappings(item_id, provider),
+        position=position,
+        podcast=podcast,
+        fully_played=fully_played,
+    )
+
+
+def _audiobook(
+    item_id: str, *, provider: str = "library", collections: list[str] | None = None
+) -> Audiobook:
+    """Build a minimal Audiobook, optionally part of the given collection(s)."""
+    return Audiobook(
+        item_id=item_id,
+        provider=provider,
+        name=f"Book {item_id}",
+        provider_mappings=_mappings(item_id, provider),
+        metadata=MediaItemMetadata(
+            collections=UniqueList([MediaItemCollection(title=x) for x in collections or []])
+            if collections
+            else None
+        ),
+    )
+
+
+def _collection(name: str, *books: Audiobook) -> MediaCollection[Audiobook]:
+    """Build a library audiobook collection holding the given books, in order."""
+    return MediaCollection(
+        item_id=get_collection_item_id(name, MediaType.AUDIOBOOK),
+        name=name,
+        provider="library",
+        provider_mappings=set(),
+        items=UniqueList(list(books)),
+    )
+
+
+async def _aiter(episodes: list[PodcastEpisode]) -> AsyncGenerator[PodcastEpisode]:
+    """Yield the given episodes as the podcasts controller does."""
+    for episode in episodes:
+        yield episode
+
+
+def _resolver() -> tuple[MediaResolver, MagicMock]:
+    """Build a MediaResolver and return it with its mocked owning controller."""
+    queues = MagicMock()
+    return MediaResolver(queues), queues
+
+
+# --- next podcast episode ---
+
+
+async def test_next_podcast_episode_follows_the_played_one() -> None:
+    """The episode after the given one is returned, with its resume position applied."""
+    resolver, queues = _resolver()
+    podcast = _podcast()
+    played = _episode("ep1", 1, podcast)
+    queues.mass.music.podcasts.episodes = MagicMock(
+        return_value=_aiter(
+            [_episode("ep1", 1, podcast), _episode("ep2", 2, podcast), _episode("ep3", 3, podcast)]
+        )
+    )
+    queues.mass.music.get_resume_position = AsyncMock(return_value=(False, 42_000))
+
+    result = await resolver.get_next_podcast_episode(played)
+
+    assert result is not None
+    assert result.item_id == "ep2"
+    assert result.resume_position_ms == 42_000
+
+
+async def test_next_podcast_episode_skips_fully_played() -> None:
+    """An episode the user already finished is passed over."""
+    resolver, queues = _resolver()
+    podcast = _podcast()
+    queues.mass.music.podcasts.episodes = MagicMock(
+        return_value=_aiter(
+            [
+                _episode("ep1", 1, podcast),
+                _episode("ep2", 2, podcast, fully_played=True),
+                _episode("ep3", 3, podcast),
+            ]
+        )
+    )
+    queues.mass.music.get_resume_position = AsyncMock(return_value=(False, 0))
+
+    result = await resolver.get_next_podcast_episode(_episode("ep1", 1, podcast))
+
+    assert result is not None
+    assert result.item_id == "ep3"
+
+
+async def test_next_podcast_episode_at_end_of_feed() -> None:
+    """The last episode of a podcast has no successor, so playback stops there."""
+    resolver, queues = _resolver()
+    podcast = _podcast()
+    queues.mass.music.podcasts.episodes = MagicMock(
+        return_value=_aiter([_episode("ep1", 1, podcast), _episode("ep2", 2, podcast)])
+    )
+
+    assert await resolver.get_next_podcast_episode(_episode("ep2", 2, podcast)) is None
+
+
+# --- next audiobook ---
+
+
+async def test_next_audiobook_follows_the_collection_order() -> None:
+    """The next book of the series is returned, with its resume position applied."""
+    resolver, queues = _resolver()
+    book1 = _audiobook("1", collections=["Series"])
+    book2 = _audiobook("2", collections=["Series"])
+    queues.mass.music.audiobooks.get_collection = AsyncMock(
+        return_value=_collection("Series", book1, book2)
+    )
+    queues.mass.music.get_resume_position = AsyncMock(return_value=(False, 120_000))
+
+    result = await resolver.get_next_audiobook(book1)
+
+    assert result is not None
+    assert result.item_id == "2"
+    assert result.resume_position_ms == 120_000
+    assert queues.mass.music.audiobooks.get_collection.await_args.args == (
+        get_collection_item_id("Series", MediaType.AUDIOBOOK),
+    )
+
+
+async def test_next_audiobook_skips_fully_played_books() -> None:
+    """A book of the series that was already finished is passed over."""
+    resolver, queues = _resolver()
+    books = [_audiobook(str(i), collections=["Series"]) for i in (1, 2, 3)]
+    queues.mass.music.audiobooks.get_collection = AsyncMock(
+        return_value=_collection("Series", *books)
+    )
+    queues.mass.music.get_resume_position = AsyncMock(side_effect=[(True, 0), (False, 0)])
+
+    result = await resolver.get_next_audiobook(books[0])
+
+    assert result is not None
+    assert result.item_id == "3"
+
+
+async def test_next_audiobook_at_end_of_collection() -> None:
+    """The last book of a series has no successor, so playback stops there."""
+    resolver, queues = _resolver()
+    book1 = _audiobook("1", collections=["Series"])
+    book2 = _audiobook("2", collections=["Series"])
+    queues.mass.music.audiobooks.get_collection = AsyncMock(
+        return_value=_collection("Series", book1, book2)
+    )
+
+    assert await resolver.get_next_audiobook(book2) is None
+
+
+async def test_standalone_audiobook_has_no_successor() -> None:
+    """A book that is not part of a collection ends the queue."""
+    resolver, queues = _resolver()
+
+    assert await resolver.get_next_audiobook(_audiobook("1")) is None
+    queues.mass.music.audiobooks.get_collection.assert_not_called()
+
+
+async def test_audiobook_outside_the_library_has_no_successor() -> None:
+    """Collections are built from library metadata, so a provider-only book stops the queue."""
+    resolver, queues = _resolver()
+    queues.mass.music.audiobooks.get_library_item_by_prov_id = AsyncMock(return_value=None)
+
+    assert await resolver.get_next_audiobook(_audiobook("1", provider="test_prov")) is None
+
+
+# --- dispatch on the queue's last item ---
+
+
+def _queue_item(media_item: PlayableMediaItemType) -> Any:
+    """Build a queue item stand-in for the given media item."""
+    return SimpleNamespace(
+        media_item=media_item, media_type=media_item.media_type, name=media_item.name
+    )
+
+
+def _loader(*items: Any, seeds: list[Any] | None = None) -> Any:
+    """Build a queue loader stand-in holding a queue with the given items (autoplay on)."""
+    loader = MagicMock()
+    loader.get = MagicMock(
+        return_value=SimpleNamespace(queue_id="q1", display_name="Queue", autoplay_enabled=True)
+    )
+    loader._queue_data = {
+        "q1": SimpleNamespace(items=list(items), enqueued_media_items=seeds or [], userid=None)
+    }
+    loader._fill_autoplay_music_tracks = AsyncMock()
+    loader._fill_autoplay_next_in_series = AsyncMock()
+    loader.load = AsyncMock()
+    return loader
+
+
+def _track(item_id: str = "t1") -> Track:
+    """Build a minimal Track."""
+    return Track(
+        item_id=item_id,
+        provider="library",
+        name=f"Track {item_id}",
+        provider_mappings=_mappings(item_id, "library"),
+    )
+
+
+async def test_queue_ending_on_music_appends_music() -> None:
+    """A queue that ends on a track keeps using the configured (music) Autoplay mode."""
+    loader = _loader(_queue_item(_track()), seeds=[_track()])
+
+    await QueueLoaderMixin._fill_autoplay_tracks(loader, "q1")
+
+    loader._fill_autoplay_music_tracks.assert_awaited_once_with("q1")
+    loader._fill_autoplay_next_in_series.assert_not_awaited()
+
+
+async def test_queue_ending_on_audiobook_never_appends_music() -> None:
+    """Music enqueued earlier must not leak into a queue that now ends on an audiobook."""
+    book = _queue_item(_audiobook("1"))
+    loader = _loader(_queue_item(_track()), book, seeds=[_track()])
+
+    await QueueLoaderMixin._fill_autoplay_tracks(loader, "q1")
+
+    loader._fill_autoplay_music_tracks.assert_not_awaited()
+    loader._fill_autoplay_next_in_series.assert_awaited_once_with("q1", book)
+
+
+async def test_queue_ending_on_podcast_episode_continues_the_podcast() -> None:
+    """A queue that ends on a podcast episode continues with the next episode."""
+    episode = _queue_item(_episode("ep1", 1, _podcast()))
+    loader = _loader(episode, seeds=[_track()])
+
+    await QueueLoaderMixin._fill_autoplay_tracks(loader, "q1")
+
+    loader._fill_autoplay_music_tracks.assert_not_awaited()
+    loader._fill_autoplay_next_in_series.assert_awaited_once_with("q1", episode)
+
+
+async def test_queue_ending_on_live_source_appends_nothing() -> None:
+    """Radio and audio sources have no natural end, so Autoplay does not apply."""
+    for media_item in (
+        Radio(
+            item_id="r1",
+            provider="test_prov",
+            name="Radio",
+            provider_mappings=_mappings("r1", "test_prov"),
+        ),
+        SimpleNamespace(media_type=MediaType.AUDIO_SOURCE, name="Line in"),
+    ):
+        loader = _loader(_queue_item(cast("PlayableMediaItemType", media_item)), seeds=[_track()])
+
+        await QueueLoaderMixin._fill_autoplay_tracks(loader, "q1")
+
+        loader._fill_autoplay_music_tracks.assert_not_awaited()
+        loader._fill_autoplay_next_in_series.assert_not_awaited()
+
+
+async def test_autoplay_disabled_appends_nothing() -> None:
+    """With Autoplay off nothing is appended, whatever the queue ends on."""
+    loader = _loader(_queue_item(_track()), seeds=[_track()])
+    loader.get.return_value.autoplay_enabled = False
+
+    await QueueLoaderMixin._fill_autoplay_tracks(loader, "q1")
+
+    loader._fill_autoplay_music_tracks.assert_not_awaited()
+    loader._fill_autoplay_next_in_series.assert_not_awaited()
+
+
+async def test_music_refill_without_seeds_appends_nothing() -> None:
+    """The music refill needs an enqueued item as its seed."""
+    loader = _loader(_queue_item(_track()))
+
+    await QueueLoaderMixin._fill_autoplay_music_tracks(loader, "q1")
+
+    loader.load.assert_not_awaited()
+
+
+# --- appending the resolved successor ---
+
+
+async def test_next_in_series_appends_the_successor() -> None:
+    """The resolved next episode is appended behind the queue's last item."""
+    podcast = _podcast()
+    last_item = _queue_item(_episode("ep1", 1, podcast))
+    loader = _loader(last_item)
+    loader._media_resolver.get_next_podcast_episode = AsyncMock(
+        return_value=_episode("ep2", 2, podcast)
+    )
+
+    await QueueLoaderMixin._fill_autoplay_next_in_series(loader, "q1", last_item)
+
+    loader.load.assert_awaited_once()
+    queue_items = loader.load.await_args.args[1]
+    assert [x.media_item.item_id for x in queue_items] == ["ep2"]
+
+
+async def test_next_in_series_without_successor_appends_nothing() -> None:
+    """Nothing is appended when the podcast/series has nothing left to play."""
+    last_item = _queue_item(_episode("ep1", 1, _podcast()))
+    loader = _loader(last_item)
+    loader._media_resolver.get_next_podcast_episode = AsyncMock(return_value=None)
+
+    await QueueLoaderMixin._fill_autoplay_next_in_series(loader, "q1", last_item)
+
+    loader.load.assert_not_awaited()
+
+
+async def test_next_in_series_skips_an_already_queued_item() -> None:
+    """A successor the user already queued themselves is not added twice."""
+    podcast = _podcast()
+    next_episode = _episode("ep2", 2, podcast)
+    last_item = _queue_item(_episode("ep1", 1, podcast))
+    loader = _loader(_queue_item(next_episode), last_item)
+    loader._media_resolver.get_next_podcast_episode = AsyncMock(return_value=next_episode)
+
+    await QueueLoaderMixin._fill_autoplay_next_in_series(loader, "q1", last_item)
+
+    loader.load.assert_not_awaited()
+
+
+# --- live sources survive a manual stop ---
+
+
+def _stop_states(prev_item: Any) -> tuple[CompareState, CompareState]:
+    """Build the state pair for a queue that went from playing the given item to idle."""
+    prev_state = {
+        "state": PlaybackState.PLAYING,
+        "current_item_id": "i1",
+        "current_item": prev_item,
+        "last_playing_elapsed_time": 3600,
+    }
+    return cast("CompareState", prev_state), cast("CompareState", {"state": PlaybackState.IDLE})
+
+
+def _tracker() -> Any:
+    """Build a playback tracker stand-in for a single non-flow queue."""
+    tracker = MagicMock()
+    tracker._queue_data = {"q1": SimpleNamespace(flow_mode_stream_log=[])}
+    return tracker
+
+
+def _stopped_queue() -> PlayerQueue:
+    """Build a queue stand-in that has no next item left to play."""
+    return cast("PlayerQueue", SimpleNamespace(queue_id="q1", next_item=None, flow_mode=False))
+
+
+def test_live_source_queue_survives_a_manual_stop() -> None:
+    """Stopping a radio means the source stopped, not that the queue ran out: keep the items."""
+    for media_type in (MediaType.RADIO, MediaType.AUDIO_SOURCE):
+        tracker = _tracker()
+        prev_state, new_state = _stop_states(
+            SimpleNamespace(media_type=media_type, streamdetails=None, duration=None)
+        )
+
+        PlaybackTrackerMixin._handle_end_of_queue(tracker, _stopped_queue(), prev_state, new_state)
+
+        tracker.mass.create_task.assert_not_called()
+
+
+def test_finished_track_queue_is_cleared_on_stop() -> None:
+    """A queue that ran out of music is still cleared (or resumed) as before."""
+    tracker = _tracker()
+    prev_state, new_state = _stop_states(
+        SimpleNamespace(media_type=MediaType.TRACK, streamdetails=None, duration=3600)
+    )
+
+    PlaybackTrackerMixin._handle_end_of_queue(tracker, _stopped_queue(), prev_state, new_state)
+
+    tracker.mass.create_task.assert_called_once()


### PR DESCRIPTION
# What does this implement/fix?

Autoplay is the "keep going" switch of a queue, but it only ever knew how to add music. Playing a
podcast episode or an audiobook with Autoplay on did nothing at the end, and a queue that ended on
an audiobook could even start playing pop tracks, because Autoplay looked at the music you enqueued
earlier instead of at what was actually playing.

Autoplay now looks at what is ending and continues that:

- Music: a fresh batch of tracks, exactly as before.
- Podcast: the next episode, or the queue simply ends when there is none.
- Audiobook: the next book in the series, or the queue simply ends for a standalone book.
- Radio and other live sources: nothing is added, they have no end. Stopping one keeps it in the
  queue so you can start it again.
- Autoplay off: nothing is added, for anything.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
