### PR TITLE
AirPlay wrong-PIN error message can now be translated

### DIFF
--- a/music_assistant/providers/airplay/strings.json
+++ b/music_assistant/providers/airplay/strings.json
@@ -70,12 +70,10 @@
     }
   },
   "errors": {
-    "invalid_pin": "Enter the numeric PIN shown on the screen of your device."
+    "invalid_pin": "Enter the numeric PIN shown on the screen of your device.",
+    "show_dashboard_failed": "Failed to show the dashboard on {0}."
   },
   "manifest": {
     "description": "Stream to AirPlay-enabled devices on your local network."
-  },
-  "errors": {
-    "show_dashboard_failed": "Failed to show the dashboard on {0}."
   }
 }

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -826,6 +826,7 @@
   "provider.airplay.config_entries.password.label": "Device password",
   "provider.airplay.config_entries.sync_adjust.description": "Shifts when audio is heard on this device relative to the other players in a synced group. \nNegative values make this device play earlier; positive values make it play later. \nUse a negative value when this device is connected to a TV, AV receiver or amplifier that adds a processing delay, which makes it play slightly behind the rest of the group. \nExample: if this device lags the group by about 100 ms, set it to -100 to pull it back into sync.",
   "provider.airplay.config_entries.sync_adjust.label": "Audio synchronization delay correction",
+  "provider.airplay.errors.invalid_pin": "Enter the numeric PIN shown on the screen of your device.",
   "provider.airplay.errors.show_dashboard_failed": "Failed to show the dashboard on {0}.",
   "provider.airplay.manifest.description": "Stream to AirPlay-enabled devices on your local network.",
   "provider.airplay.setup_flow.abort.pairing_failed": "Could not start pairing with the device. Make sure the device is reachable on the network and try again.",


### PR DESCRIPTION
# What does this implement/fix?

When a wrong PIN is entered while pairing an AirPlay device, the error message was always shown in English, even when another interface language is configured. The AirPlay provider's translation source file accidentally contained two "errors" sections; the second one silently replaced the first, so the wrong-PIN message never ended up in the translations.

- Merged the two "errors" sections in the AirPlay strings.json into one.
- Regenerated the translations source file so the wrong-PIN message is included and can be translated.
- Checked all other providers for the same duplicate-key mistake — none affected.

**Related issue (if applicable):**

- n/a (found during code review)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
