### PR TITLE
Autoplay is on by default for new players

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1139,7 +1139,9 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                     active=False,
                     display_name=player.state.name,
                     available=player.state.available,
-                    autoplay_enabled=False,
+                    # Autoplay starts out on for a brand new queue; the player's own Autoplay
+                    # switch owns it from here on (and is restored above for a queue we know)
+                    autoplay_enabled=True,
                     items=0,
                 )
             )

--- a/tests/controllers/player_queues/test_new_queue_defaults.py
+++ b/tests/controllers/player_queues/test_new_queue_defaults.py
@@ -1,0 +1,64 @@
+"""
+Tests for the settings a queue starts out with when its player is first registered.
+
+Autoplay is on out of the box, but only for a queue that is genuinely new: a queue restored from
+cache keeps the switch the user left it on.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.player_queue import PlayerQueue
+
+from music_assistant.controllers.player_queues.controller import PlayerQueuesController
+from music_assistant.controllers.player_queues.state import PlayerQueueData
+
+
+def _controller(cached_state: dict[str, Any] | None = None) -> Any:
+    """
+    Build a queue-controller stand-in for ``on_player_register``.
+
+    :param cached_state: A previously persisted queue state to restore, or None for a new queue.
+    """
+    queues = MagicMock()
+    queues._queue_data = {}
+    queues.mass.cache.get = AsyncMock(side_effect=[cached_state, []])
+    return queues
+
+
+def _player(player_id: str = "p1") -> Any:
+    """Build a player stand-in with the state fields the queue snapshot is built from."""
+    return SimpleNamespace(
+        player_id=player_id, state=SimpleNamespace(name="Player A", available=True)
+    )
+
+
+async def test_new_queue_starts_with_autoplay_on() -> None:
+    """A queue created for a newly registered player starts out with Autoplay on."""
+    queues = _controller()
+
+    await PlayerQueuesController.on_player_register(queues, _player())
+
+    assert queues._queue_data["p1"].queue.autoplay_enabled is True
+
+
+async def test_restored_queue_keeps_its_own_autoplay_setting() -> None:
+    """An existing queue is restored as-is: switching Autoplay off has to stick across a restart."""
+    stored = PlayerQueueData(
+        queue=PlayerQueue(
+            queue_id="p1",
+            active=False,
+            display_name="Player A",
+            available=True,
+            autoplay_enabled=False,
+            items=0,
+        )
+    )
+    queues = _controller(stored.to_cache())
+
+    await PlayerQueuesController.on_player_register(queues, _player())
+
+    assert queues._queue_data["p1"].queue.autoplay_enabled is False


### PR DESCRIPTION
# What does this implement/fix?

Autoplay keeps a queue going when it runs out, but it was off by default, so most people never found
it. Now that Autoplay continues a podcast or audiobook instead of switching to music, it makes sense
as a default.

- A newly added player starts out with Autoplay on.
- Players you already have keep the setting they have, so nothing changes for them.
- The Autoplay button in the player controls is still how you turn it off per player.

**Related issue (if applicable):**

- builds on #5141

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
