### PR TITLE
Catch duplicate keys in translation source files

### DIFF
--- a/scripts/build_translations.py
+++ b/scripts/build_translations.py
@@ -13,6 +13,9 @@ validated to exist and the referencing key is omitted from the generated source,
 translates the shared string once while the server resolves the owner's key at runtime via its
 owner -> common fallback.
 
+A duplicated key inside an authoring file would silently lose strings (JSON parsers keep only
+the last value), so the build fails loudly on duplicate keys at any nesting depth.
+
 Standalone (no ``music_assistant`` imports) so it runs under any music-assistant-models version
 and without the full server import chain.
 
@@ -23,6 +26,7 @@ Usage:
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import sys
@@ -51,10 +55,22 @@ REFERENCE_PATTERN = re.compile(r"^\[%key:(.+)%\]$")
 def build_translations_source() -> dict[str, str]:
     """Assemble the flat English source from all authoring strings.json files."""
     raw: dict[str, str] = {}
+    duplicates: list[str] = []
     for prefix, path in _collect_source_files():
         with open(path, "rb") as file:
-            data = orjson.loads(file.read())
-        _flatten_into(data, prefix, raw)
+            content = file.read()
+        # orjson below silently keeps the last value when an object repeats a key, which
+        # would drop strings from the generated source; detect duplicates loudly instead.
+        rel_path = os.path.relpath(path, _REPO_ROOT)
+        try:
+            duplicates.extend(
+                f"{rel_path}: {key_path}" for key_path in _find_duplicate_keys(content)
+            )
+        except json.JSONDecodeError as err:
+            raise ValueError(f"{rel_path}: {err}") from err
+        _flatten_into(orjson.loads(content), prefix, raw)
+    if duplicates:
+        raise ValueError("Duplicate strings.json key(s):\n  " + "\n  ".join(sorted(duplicates)))
     return _resolve_references(raw)
 
 
@@ -89,6 +105,35 @@ def _iter_subdirs(path: str) -> list[str]:
         for entry in os.listdir(path)  # noqa: PTH208
         if not entry.startswith(".") and os.path.isdir(os.path.join(path, entry))
     ]
+
+
+class _RawJsonObject(list[tuple[str, Any]]):
+    """A JSON object kept as its raw key/value pairs, so duplicate keys stay observable."""
+
+
+def _find_duplicate_keys(content: bytes) -> list[str]:
+    """
+    Return the dotted key path of every duplicated object key in a JSON document.
+
+    :param content: The raw JSON document to inspect.
+    """
+    duplicates: list[str] = []
+
+    def _walk(node: Any, path: str) -> None:
+        if isinstance(node, _RawJsonObject):
+            seen: set[str] = set()
+            for key, value in node:
+                key_path = f"{path}.{key}" if path else key
+                if key in seen:
+                    duplicates.append(key_path)
+                seen.add(key)
+                _walk(value, key_path)
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                _walk(value, f"{path}[{index}]")
+
+    _walk(json.loads(content, object_pairs_hook=_RawJsonObject), "")
+    return duplicates
 
 
 def _flatten_into(data: dict[str, Any], prefix: str, out: dict[str, str]) -> None:

--- a/scripts/build_translations.py
+++ b/scripts/build_translations.py
@@ -66,9 +66,10 @@ def build_translations_source() -> dict[str, str]:
             duplicates.extend(
                 f"{rel_path}: {key_path}" for key_path in _find_duplicate_keys(content)
             )
-        except json.JSONDecodeError as err:
+            data = orjson.loads(content)
+        except (json.JSONDecodeError, UnicodeDecodeError) as err:
             raise ValueError(f"{rel_path}: {err}") from err
-        _flatten_into(orjson.loads(content), prefix, raw)
+        _flatten_into(data, prefix, raw)
     if duplicates:
         raise ValueError("Duplicate strings.json key(s):\n  " + "\n  ".join(sorted(duplicates)))
     return _resolve_references(raw)

--- a/tests/controllers/translations/test_translations.py
+++ b/tests/controllers/translations/test_translations.py
@@ -142,6 +142,21 @@ def test_build_translations_duplicate_key_fails_loudly(
         build_translations_source()
 
 
+def test_build_translations_malformed_file_names_the_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An authoring file that fails to parse is reported with its file path."""
+    strings_file = tmp_path / "strings.json"
+    strings_file.write_bytes(b'{"errors": ')
+    monkeypatch.setattr(
+        build_translations_module,
+        "_collect_source_files",
+        lambda: [("provider.foo.", str(strings_file))],
+    )
+    with pytest.raises(ValueError, match=r"strings\.json: "):
+        build_translations_source()
+
+
 def test_candidate_keys_common_rewrite() -> None:
     """An owner-namespaced key falls back to the shared common namespace."""
     assert _candidate_keys("provider.ytmusic.config_entries.username.label") == [

--- a/tests/controllers/translations/test_translations.py
+++ b/tests/controllers/translations/test_translations.py
@@ -29,7 +29,9 @@ from music_assistant.controllers.translations import (
     _format,
     _locale_candidates,
 )
+from scripts import build_translations as build_translations_module
 from scripts.build_translations import (
+    _find_duplicate_keys,
     _flatten_into,
     _resolve_references,
     build_translations_source,
@@ -37,6 +39,7 @@ from scripts.build_translations import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import Path
 
 
 def _make_controller() -> TranslationController:
@@ -107,6 +110,36 @@ def test_resolve_references_missing_target_raises() -> None:
         _resolve_references(
             {"provider.deezer.media.x.name": "[%key:common::media::does::not::exist%]"}
         )
+
+
+def test_find_duplicate_keys() -> None:
+    """Duplicated object keys are reported with their full key path, at any nesting depth."""
+    assert _find_duplicate_keys(b'{"a": "1", "b": {"c": "2"}}') == []
+    # two blocks with the same name at the top level (parsers keep only the last one)
+    assert _find_duplicate_keys(b'{"errors": {"a": "1"}, "other": {}, "errors": {"b": "2"}}') == [
+        "errors"
+    ]
+    assert _find_duplicate_keys(b'{"errors": {"pin": "a", "pin": "b"}}') == ["errors.pin"]
+    assert _find_duplicate_keys(b'{"a": [{"k": "1", "k": "2"}, {"k": "3"}]}') == ["a[0].k"]
+    assert _find_duplicate_keys(b'{"a": "1", "a": "2", "b": {"x": "1", "x": "2"}}') == [
+        "a",
+        "b.x",
+    ]
+
+
+def test_build_translations_duplicate_key_fails_loudly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A duplicated key in an authoring file fails the build, naming the file and key path."""
+    strings_file = tmp_path / "strings.json"
+    strings_file.write_bytes(b'{"errors": {"pin": "a"}, "errors": {"pin": "b"}}')
+    monkeypatch.setattr(
+        build_translations_module,
+        "_collect_source_files",
+        lambda: [("provider.foo.", str(strings_file))],
+    )
+    with pytest.raises(ValueError, match=r"Duplicate strings\.json key\(s\):[\s\S]*: errors"):
+        build_translations_source()
 
 
 def test_candidate_keys_common_rewrite() -> None:


### PR DESCRIPTION
# What does this implement/fix?

JSON parsers keep only the last value when a file contains the same key twice. A duplicated block in a `strings.json` authoring file therefore silently removed translations from the generated `en.json` — this actually happened in the AirPlay provider, where a doubled `"errors"` block dropped an error message without any warning.

The translations build (and its pre-commit/CI check) now fails on duplicate keys instead:

- every `strings.json` is validated for duplicate keys, at any nesting depth
- the error names the file and the exact key path of each duplicate
- a malformed `strings.json` now also reports which file is broken
- tests added for the new validation

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
