### PR TITLE
Fix failing protocol play/pause tests on dev

### DIFF
--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1008,7 +1008,10 @@ class TestProtocolOutputPlayPause:
         controller._players = {"player_1": player, "proto_1": protocol_player}
         mock_mass.players = controller
         mock_mass.player_queues = MagicMock()
-        mock_mass.player_queues.get = MagicMock(return_value=None)
+        # a non-empty queue, so the MA queue source advertises play/pause support
+        queue = MagicMock()
+        queue.items = [MagicMock()]
+        mock_mass.player_queues.get = MagicMock(return_value=queue)
         player.set_linked_output_protocols(
             [
                 OutputProtocol(


### PR DESCRIPTION
# What does this implement/fix?

Two recent PRs crossed each other: #5083 added play/pause tests that mock a player without any queue, while #5124 (merged in between) made the Music Assistant queue source only advertise play/pause when the queue actually has items. Combined, the two new tests now fail on `dev` before they ever reach the behaviour they were written to check.

- the test helper now mocks a queue with items, so the MA queue source supports play/pause again and the tests exercise the intended protocol-without-pause scenario
- test setup only, no production code changes

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
