### PR TITLE
Detect password-protected AirPlay devices more reliably

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -142,3 +142,7 @@ BASE_PLAYER_FEATURES: Final[set[PlayerFeature]] = {
 PIN_REQUIRED = 0x8
 PASSWORD_BIT = 0x80
 LEGACY_PAIRING_BIT = 0x200
+# Observed on tvOS when an AirPlay password is set. Apple TVs keep PASSWORD_BIT
+# raised at all times (it marks their onscreen-code capability, not a password),
+# so this is the only flags-based password signal they give.
+ATV_PASSWORD_BIT = 0x1000

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -36,6 +36,7 @@ from .constants import (
     AIRPLAY_PCM_FORMAT,
     AIRPLAY_RAOP_SETUP_LEAD_MS,
     AIRPLAY_REJOIN_ATTEMPT_DELAYS,
+    ATV_PASSWORD_BIT,
     BASE_PLAYER_FEATURES,
     CONF_AIRPLAY_CREDENTIALS,
     CONF_ENCRYPTION,
@@ -190,10 +191,17 @@ class AirPlayPlayer(Player):
     @property
     def password_required(self) -> bool:
         """Return if the device announces that it is password protected."""
-        # Two independent announcements: AirPlay 2 devices set the password bit in
-        # their sf/flags, while a legacy RAOP receiver only publishes the classic
-        # pw boolean in its TXT record.
-        if self._requires_password_pairing():
+        # Three announcement forms, verified against live devices: receivers
+        # publish the classic pw boolean and/or the password bit in sf/flags,
+        # except Apple TVs - they keep the password bit raised at all times, so
+        # for them only the tvOS-specific flags bit counts. Enforcement can also
+        # exist WITHOUT any announcement (stale TXT after the password was
+        # enabled); that case is caught at connect time via password_invalid.
+        flags = self._get_flags()
+        if flags & ATV_PASSWORD_BIT:
+            return True
+        is_apple_tv = (self.device_info.model or "").startswith("AppleTV")
+        if flags & PASSWORD_BIT and not is_apple_tv:
             return True
         if raop_info := self.raop_discovery_info:
             return (raop_info.decoded_properties.get("pw") or "").lower() == "true"

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -1135,8 +1135,11 @@ class AirPlayStream:
             self._connect_error.http_status,
             self._connect_error.detail,
         )
-        if self._connect_error.code == CONNECT_ERROR_AUTH_FAILED:
-            # The stored password is wrong: persist that so the player keeps
-            # offering its setup action (across restarts) until a working one
-            # is entered, instead of only failing at the next play attempt.
+        if self._connect_error.code in (CONNECT_ERROR_AUTH_FAILED, CONNECT_ERROR_AUTH_REQUIRED):
+            # The stored password is wrong, or the device demanded one we could
+            # not supply (devices can enforce a password without announcing it -
+            # e.g. an Apple TV with stale TXT records after the password was
+            # enabled). Persist that so the player keeps offering its setup
+            # action (across restarts) until a working password is entered,
+            # instead of only failing at the next play attempt.
             self.player.set_password_invalid(True)

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -1316,6 +1316,26 @@ def test_announced_password_without_one_stored_needs_setup(
     assert airplay_player.setup_reason == "password_required"
 
 
+def test_apple_tv_password_bit_alone_does_not_need_setup(airplay_player: AirPlayPlayer) -> None:
+    """Apple TVs raise the generic password bit at all times; it means nothing there."""
+    # a paired Apple TV without a password set must not be sent back into setup
+    _set_password_discovery(airplay_player, flags="0x4c4", paired=True)
+    airplay_player.device_info.model = "AppleTV14,1"
+
+    assert airplay_player.password_required is False
+    assert airplay_player.needs_setup is False
+
+
+def test_apple_tv_with_a_password_set_needs_setup(airplay_player: AirPlayPlayer) -> None:
+    """The tvOS-specific flags bit is the Apple TV's only password announcement."""
+    _set_password_discovery(airplay_player, flags="0x14c4")
+    airplay_player.device_info.model = "AppleTV11,1"
+
+    assert airplay_player.password_required is True
+    assert airplay_player.needs_setup is True
+    assert airplay_player.setup_reason == "password_required"
+
+
 @pytest.mark.parametrize(
     ("flags", "pw", "paired"),
     [

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -1713,12 +1713,27 @@ async def test_auth_failed_marks_the_stored_password_invalid() -> None:
 
 
 @pytest.mark.asyncio
-async def test_other_connect_failures_leave_the_password_marker_alone() -> None:
-    """Only an authentication failure says anything about the stored password."""
+async def test_auth_required_also_marks_the_password_as_needed() -> None:
+    """
+    A device that demanded a password we could not supply flips into setup.
+
+    Devices can enforce a password without announcing it (stale TXT records), so
+    the runtime signal must set the marker too - it is the only reliable one.
+    """
     player = _make_player()
     stream = AirPlayStream(player)
 
     stream._handle_status_line('[STATUS] error code=auth_required http=401 detail="no password"')
+
+    player.set_password_invalid.assert_called_once_with(True)
+
+
+@pytest.mark.asyncio
+async def test_plain_connect_failures_leave_the_password_marker_alone() -> None:
+    """A non-authentication failure says nothing about the stored password."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+
     stream._handle_status_line('[STATUS] error code=connect_failed http=0 detail="no route"')
 
     player.set_password_invalid.assert_not_called()


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5134, based on live testing against real password-protected devices (Apple TVs, Sonos speakers with a HomeKit-set password). Two findings needed handling:

- Apple TVs always advertise the generic password flags bit, even with no password set - keying "setup required" on that bit would have nagged every Apple TV owner for a password. Apple TVs now only count via the tvOS-specific flags bit that appears when a password is actually set.
- Devices can enforce a password without announcing one at all (stale TXT records after the password was enabled). The binary's "password required" failure report now also persists the marker that sends the player into setup, so such devices still get the guided password entry instead of a dead-end error.

Live verification: password streaming (the transient pairing with the device password) was confirmed working end to end against tvOS and Sonos Era 100; wrong and missing passwords produce the intended setup-required flow.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5312

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
