### PR TITLE
Use one source of truth for AirPlay password announcements

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -166,11 +166,12 @@ class AirPlayPlayer(Player):
     @property
     def needs_setup(self) -> bool:
         """Return if the player needs setup."""
+        # A stored password satisfies password protection on its own (the binary
+        # authenticates with it directly; stored credentials are only its
+        # fallback), so the password side is fully covered by the check above.
         if self.needs_password_setup:
             return True
-        if self._requires_pin_pairing() or (
-            self._requires_password_pairing() and self.protocol == StreamingProtocol.AIRPLAY2
-        ):
+        if self._requires_pin_pairing():
             # Credentials for either protocol keep the player usable: the binary
             # picks the best route for the credentials it has. Re-running the setup
             # flow from the player settings offers replacing a stored pairing.
@@ -820,14 +821,6 @@ class AirPlayPlayer(Player):
         """
         return bool(self._get_flags() & (LEGACY_PAIRING_BIT | PIN_REQUIRED))
 
-    def _requires_password_pairing(self) -> bool:
-        """
-        Check if this device requires password authentication.
-
-        Password can be used for pairing instead of interactive PIN entry.
-        """
-        return bool(self._get_flags() & PASSWORD_BIT)
-
     def _get_credentials_key(self, protocol: StreamingProtocol) -> str:
         """Get the config key for credentials for given protocol."""
         if protocol == StreamingProtocol.RAOP:
@@ -920,9 +913,7 @@ class AirPlayPlayer(Player):
         """
         pin_pairing = self._requires_pin_pairing()
         # a password only replaces PIN pairing on the native AirPlay 2 flow
-        password_pairing = (
-            self._requires_password_pairing() and self.protocol == StreamingProtocol.AIRPLAY2
-        )
+        password_pairing = self.password_required and self.protocol == StreamingProtocol.AIRPLAY2
         if not (pin_pairing or password_pairing):
             for cred_key in (CONF_AIRPLAY_CREDENTIALS, CONF_RAOP_CREDENTIALS):
                 if self.get_setup_value(cred_key) is not None:

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -151,6 +151,7 @@ def test_requires_pin_pairing(
         ({b"flags": b"0x4"}, None, False),
         ({b"sf": b"0x80"}, None, True),
         ({b"flags": b"0x90"}, None, True),
+        ({b"flags": b"0x1000"}, None, True),
         (None, {b"flags": "0x80"}, True),
         (None, {b"sf": b"0x81"}, True),
         (None, {b"flags": b"0x4"}, False),
@@ -159,22 +160,24 @@ def test_requires_pin_pairing(
         ({}, {}, False),
     ],
 )
-def test_requires_password_pairing(
+def test_password_required(
     airplay_player: AirPlayPlayer,
     aiplay_properties: dict[bytes, bytes] | None,
     raop_properties: dict[bytes, bytes] | None,
     expected: bool,
 ) -> None:
-    """Test the _requires_pairing method of AirPlayPlayer."""
+    """Test the flags-based password announcements (non-Apple-TV model)."""
     if aiplay_properties is not None:
         aiplay_discovery_info = MagicMock()
         aiplay_discovery_info.properties = aiplay_properties
+        aiplay_discovery_info.decoded_properties = {}
         airplay_player.airplay_discovery_info = aiplay_discovery_info
     if raop_properties is not None:
         raop_discovery_info = MagicMock()
         raop_discovery_info.properties = raop_properties
+        raop_discovery_info.decoded_properties = {}
         airplay_player.raop_discovery_info = raop_discovery_info
-    assert airplay_player._requires_password_pairing() == expected
+    assert airplay_player.password_required == expected
 
 
 def test_build_streaming_pairing_uses_discovered_ipv4_address() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5147, addressing the Copilot review comment that landed there after merge: the pairing flow and the setup gate still read the raw password flags bit directly, which disagrees with the refined Apple-TV-aware detection - an unpaired Apple TV could still be pushed into setup through the pairing path.

- All password decisions now go through the single refined check (the raw-bit helper is removed)
- A stored password now satisfies password protection on its own, matching how the binary actually authenticates (verified live: a password-protected speaker streams fine with just the password, no pairing credentials) - so such devices no longer demand pairing

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5312

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
