### PR TITLE
Clean MusicBrainz identifiers from OpenSubsonic and Plex servers

### DIFF
--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -45,12 +45,15 @@ def clean_tuple(values: Iterable[str]) -> tuple[str, ...]:
     return tuple(x.strip() for x in values if x not in (None, "", " "))
 
 
-def clean_mbid(value: str | None, source: str | None = None) -> str | None:
+def clean_mbid(
+    value: str | None, source: str | None = None, logger: logging.Logger | None = None
+) -> str | None:
     """
     Return a MusicBrainz identifier in canonical (lowercase UUID) form, or None if invalid.
 
-    :param value: The raw MusicBrainz identifier value from the file tags.
-    :param source: Origin of the value (e.g. filename), included in the log when invalid.
+    :param value: The raw MusicBrainz identifier value, from file tags or a provider payload.
+    :param source: Origin of the value (e.g. file path or provider item), logged when invalid.
+    :param logger: Logger to emit the warning to, defaults to the tags logger.
     """
     if not value:
         return None
@@ -59,9 +62,11 @@ def clean_mbid(value: str | None, source: str | None = None) -> str | None:
         return str(UUID(value.strip("\x00 \t\r\n")))
     except ValueError, TypeError, AttributeError:
         if source:
-            LOGGER.warning("Ignoring invalid MusicBrainz identifier %r in %s", value, source)
+            (logger or LOGGER).warning(
+                "Ignoring invalid MusicBrainz identifier %r in %s", value, source
+            )
         else:
-            LOGGER.warning("Ignoring invalid MusicBrainz identifier %r", value)
+            (logger or LOGGER).warning("Ignoring invalid MusicBrainz identifier %r", value)
         return None
 
 

--- a/music_assistant/providers/opensubsonic/parsers.py
+++ b/music_assistant/providers/opensubsonic/parsers.py
@@ -153,7 +153,7 @@ def parse_track(  # noqa: PLR0915
         track_number=sonic_song.track or 0,
     )
 
-    if mbid := clean_mbid(sonic_song.music_brainz_id, sonic_song.path or f"track {name}"):
+    if mbid := clean_mbid(sonic_song.music_brainz_id, sonic_song.path or f"track {name}", logger):
         track.mbid = mbid
 
     if sonic_song.sort_name:
@@ -226,7 +226,10 @@ def parse_track(  # noqa: PLR0915
 
 
 def parse_artist(
-    instance_id: str, sonic_artist: SonicArtist, sonic_info: SonicArtistInfo | None = None
+    instance_id: str,
+    sonic_artist: SonicArtist,
+    sonic_info: SonicArtistInfo | None = None,
+    logger: logging.Logger | None = None,
 ) -> Artist:
     """Parse artist and artistInfo into a Music Assistant Artist."""
     metadata: MediaItemMetadata = MediaItemMetadata()
@@ -280,7 +283,7 @@ def parse_artist(
         sort_name=sonic_artist.sort_name,
     )
 
-    if mbid := clean_mbid(sonic_artist.music_brainz_id, f"artist {sonic_artist.name}"):
+    if mbid := clean_mbid(sonic_artist.music_brainz_id, f"artist {sonic_artist.name}", logger):
         artist.mbid = mbid
 
     return artist
@@ -358,7 +361,7 @@ def parse_album(
     if sonic_album.sort_name:
         album.sort_name = sonic_album.sort_name
 
-    if mbid := clean_mbid(sonic_album.music_brainz_id, f"album {sonic_album.name}"):
+    if mbid := clean_mbid(sonic_album.music_brainz_id, f"album {sonic_album.name}", logger):
         album.mbid = mbid
 
     if sonic_album.artist_id:

--- a/music_assistant/providers/opensubsonic/parsers.py
+++ b/music_assistant/providers/opensubsonic/parsers.py
@@ -23,6 +23,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.constants import UNKNOWN_ARTIST
+from music_assistant.helpers.tags import clean_mbid
 from music_assistant.helpers.util import parse_title_and_version
 
 if TYPE_CHECKING:
@@ -152,8 +153,8 @@ def parse_track(  # noqa: PLR0915
         track_number=sonic_song.track or 0,
     )
 
-    if sonic_song.music_brainz_id:
-        track.mbid = sonic_song.music_brainz_id
+    if mbid := clean_mbid(sonic_song.music_brainz_id, sonic_song.path or f"track {name}"):
+        track.mbid = mbid
 
     if sonic_song.sort_name:
         track.sort_name = sonic_song.sort_name
@@ -279,8 +280,8 @@ def parse_artist(
         sort_name=sonic_artist.sort_name,
     )
 
-    if sonic_artist.music_brainz_id:
-        artist.mbid = sonic_artist.music_brainz_id
+    if mbid := clean_mbid(sonic_artist.music_brainz_id, f"artist {sonic_artist.name}"):
+        artist.mbid = mbid
 
     return artist
 
@@ -357,8 +358,8 @@ def parse_album(
     if sonic_album.sort_name:
         album.sort_name = sonic_album.sort_name
 
-    if sonic_album.music_brainz_id:
-        album.mbid = sonic_album.music_brainz_id
+    if mbid := clean_mbid(sonic_album.music_brainz_id, f"album {sonic_album.name}"):
+        album.mbid = mbid
 
     if sonic_album.artist_id:
         album.artists.append(

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -364,7 +364,9 @@ class OpenSonicProvider(MusicProvider):
         )
 
         if answer.artist:
-            ar = [parse_artist(self.instance_id, entry) for entry in answer.artist]
+            ar = [
+                parse_artist(self.instance_id, entry, logger=self.logger) for entry in answer.artist
+            ]
         else:
             ar = []
 
@@ -418,7 +420,7 @@ class OpenSonicProvider(MusicProvider):
                 continue
 
             for artist in index.artist:
-                yield parse_artist(self.instance_id, artist)
+                yield parse_artist(self.instance_id, artist, logger=self.logger)
 
     async def get_library_albums(self) -> AsyncGenerator[Album]:
         """
@@ -560,7 +562,7 @@ class OpenSonicProvider(MusicProvider):
         except (ParameterError, DataNotFoundError) as e:
             msg = f"Artist {prov_artist_id} not found"
             raise MediaNotFoundError(msg) from e
-        return parse_artist(self.instance_id, sonic_artist, sonic_info)
+        return parse_artist(self.instance_id, sonic_artist, sonic_info, logger=self.logger)
 
     @use_cache(3600 * 3)  # cache for 3 hours
     async def get_track(self, prov_track_id: str) -> Track:
@@ -955,7 +957,7 @@ class OpenSonicProvider(MusicProvider):
                 faves.items.append(parse_album(self.logger, self.instance_id, sonic_album))
         if starred.artist:
             for sonic_artist in starred.artist[: self._reco_limit]:
-                faves.items.append(parse_artist(self.instance_id, sonic_artist))
+                faves.items.append(parse_artist(self.instance_id, sonic_artist, logger=self.logger))
         if starred.song:
             for sonic_song in starred.song[: self._reco_limit]:
                 self._set_loudness(sonic_song)

--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import random
 import warnings
@@ -65,7 +64,7 @@ from plexapi.server import PlexServer
 
 from music_assistant.constants import DB_TABLE_PROVIDER_MAPPINGS, UNKNOWN_ARTIST
 from music_assistant.controllers.cache import use_cache
-from music_assistant.helpers.tags import async_parse_tags
+from music_assistant.helpers.tags import async_parse_tags, clean_mbid
 from music_assistant.helpers.util import parse_title_and_version
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.models.recommendation_payload import RecommendationPayloadMixin
@@ -1239,9 +1238,8 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             album.metadata.release_date = plex_album.originallyAvailableAt
         if (explicit := get_explicit(plex_album)) is not None:
             album.metadata.explicit = explicit
-        if mbid := get_musicbrainz_id(plex_album):
-            with contextlib.suppress(InvalidDataError):
-                album.mbid = mbid
+        if mbid := clean_mbid(get_musicbrainz_id(plex_album), f"album {plex_album.title}"):
+            album.mbid = mbid
 
         album.artists.append(
             self._get_item_mapping(
@@ -1282,9 +1280,8 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             artist.metadata.style = next(
                 (style.tag for style in plex_artist.styles if style.tag), None
             )
-        if mbid := get_musicbrainz_id(plex_artist):
-            with contextlib.suppress(InvalidDataError):
-                artist.mbid = mbid
+        if mbid := clean_mbid(get_musicbrainz_id(plex_artist), f"artist {plex_artist.title}"):
+            artist.mbid = mbid
         return artist
 
     async def _parse_playlist(self, plex_playlist: PlexPlaylist) -> Playlist:
@@ -1479,9 +1476,8 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             track.metadata.mood = next((mood.tag for mood in plex_track.moods if mood.tag), None)
         if (explicit := get_explicit(plex_track)) is not None:
             track.metadata.explicit = explicit
-        if mbid := get_musicbrainz_id(plex_track):
-            with contextlib.suppress(InvalidDataError):
-                track.mbid = mbid
+        if mbid := clean_mbid(get_musicbrainz_id(plex_track), f"track {plex_track.title}"):
+            track.mbid = mbid
         if plex_track.parentKey:
             track.album = self._get_item_mapping(
                 MediaType.ALBUM, plex_track.parentKey, plex_track.parentTitle

--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -1238,7 +1238,9 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             album.metadata.release_date = plex_album.originallyAvailableAt
         if (explicit := get_explicit(plex_album)) is not None:
             album.metadata.explicit = explicit
-        if mbid := clean_mbid(get_musicbrainz_id(plex_album), f"album {plex_album.title}"):
+        if mbid := clean_mbid(
+            get_musicbrainz_id(plex_album), f"album {plex_album.title}", self.logger
+        ):
             album.mbid = mbid
 
         album.artists.append(
@@ -1280,7 +1282,9 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             artist.metadata.style = next(
                 (style.tag for style in plex_artist.styles if style.tag), None
             )
-        if mbid := clean_mbid(get_musicbrainz_id(plex_artist), f"artist {plex_artist.title}"):
+        if mbid := clean_mbid(
+            get_musicbrainz_id(plex_artist), f"artist {plex_artist.title}", self.logger
+        ):
             artist.mbid = mbid
         return artist
 
@@ -1476,7 +1480,9 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             track.metadata.mood = next((mood.tag for mood in plex_track.moods if mood.tag), None)
         if (explicit := get_explicit(plex_track)) is not None:
             track.metadata.explicit = explicit
-        if mbid := clean_mbid(get_musicbrainz_id(plex_track), f"track {plex_track.title}"):
+        if mbid := clean_mbid(
+            get_musicbrainz_id(plex_track), f"track {plex_track.title}", self.logger
+        ):
             track.mbid = mbid
         if plex_track.parentKey:
             track.album = self._get_item_mapping(


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Apply the `clean_mbid()` helper to identifiers received from media servers, matching the behavior of the filesystem provider.

OpenSubsonic: an invalid identifier served by the server (e.g. one uppercase character) aborted the entire library sync with 'Invalid MusicBrainz identifier'. Fixable identifiers are now repaired and kept, invalid ones are skipped with a warning that includes the file path (tracks) or item name.

Plex: invalid identifiers were suppressed silently. They are now repaired when possible and logged with the item name otherwise.

**Related issue (if applicable):**

- related issue https://github.com/orgs/music-assistant/discussions/1682#discussioncomment-17823152

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
