### PR TITLE
Reduce WebRTC and WiiM log noise when debug logging is enabled

### DIFF
--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -159,7 +159,7 @@ class WebRTCGateway:
             rtc_log_level = LogLevel.VERBOSE
         elif self.logger.isEnabledFor(logging.DEBUG):
             rtc_log_level = LogLevel.WARNING
-            self.logger.addFilter(_drop_benign_native_noise)
+            self.logger.addFilter(_BENIGN_NATIVE_NOISE_FILTER)
         else:
             rtc_log_level = LogLevel.ERROR
         install_python_logger(self.logger, level=rtc_log_level)
@@ -173,7 +173,7 @@ class WebRTCGateway:
     async def stop(self) -> None:
         """Stop the WebRTC Gateway."""
         self.logger.info("Stopping WebRTC Gateway")
-        self.logger.removeFilter(_drop_benign_native_noise)
+        self.logger.removeFilter(_BENIGN_NATIVE_NOISE_FILTER)
         self._running = False
 
         # Close all sessions
@@ -834,10 +834,16 @@ class WebRTCGateway:
             pass  # Not valid JSON, ignore
 
 
-def _drop_benign_native_noise(record: logging.LogRecord) -> bool:
-    """Return whether this native libdatachannel log record is worth keeping."""
-    # Cloudflare omits the ERROR-CODE attribute, so libjuice warns on a benign refusal
-    return "TURN CreatePermission error response, code=0" not in record.getMessage()
+class _BenignNativeNoiseFilter(logging.Filter):
+    """Drops known-benign native libdatachannel log lines."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Return whether this log record is worth keeping."""
+        # Cloudflare omits the ERROR-CODE attribute, so libjuice warns on a benign refusal
+        return "TURN CreatePermission error response, code=0" not in record.getMessage()
+
+
+_BENIGN_NATIVE_NOISE_FILTER = _BenignNativeNoiseFilter()
 
 
 def _is_usable_ice_url(url: str) -> bool:

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -154,12 +154,12 @@ class WebRTCGateway:
         if self._running:
             self.logger.warning("WebRTC Gateway already running, skipping start")
             return
-        # Failing candidates, paths and permissions is how ICE converges, so below DEBUG
-        # we only take errors from libdatachannel's native logging.
+        # Failing candidates and permissions is how ICE converges: full chatter only at VERBOSE
         if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
             rtc_log_level = LogLevel.VERBOSE
         elif self.logger.isEnabledFor(logging.DEBUG):
-            rtc_log_level = LogLevel.DEBUG
+            rtc_log_level = LogLevel.WARNING
+            self.logger.addFilter(_drop_benign_native_noise)
         else:
             rtc_log_level = LogLevel.ERROR
         install_python_logger(self.logger, level=rtc_log_level)
@@ -173,6 +173,7 @@ class WebRTCGateway:
     async def stop(self) -> None:
         """Stop the WebRTC Gateway."""
         self.logger.info("Stopping WebRTC Gateway")
+        self.logger.removeFilter(_drop_benign_native_noise)
         self._running = False
 
         # Close all sessions
@@ -831,6 +832,12 @@ class WebRTCGateway:
                     self._set_sendspin_player_callback(session.session_id, client_id)
         except json.JSONDecodeError, TypeError:
             pass  # Not valid JSON, ignore
+
+
+def _drop_benign_native_noise(record: logging.LogRecord) -> bool:
+    """Return whether this native libdatachannel log record is worth keeping."""
+    # Cloudflare omits the ERROR-CODE attribute, so libjuice warns on a benign refusal
+    return "TURN CreatePermission error response, code=0" not in record.getMessage()
 
 
 def _is_usable_ice_url(url: str) -> bool:

--- a/music_assistant/providers/wiim/provider.py
+++ b/music_assistant/providers/wiim/provider.py
@@ -40,10 +40,11 @@ class WiimProvider(PlayerProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
+        # the sdk logs routine keep-alive chatter at INFO
         if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
             logging.getLogger("wiim").setLevel(logging.DEBUG)
         else:
-            logging.getLogger("wiim").setLevel(self.logger.level + 10)
+            logging.getLogger("wiim").setLevel(max(self.logger.level + 10, logging.WARNING))
 
         self.wiim_controller = WiimController(self.mass.http_session_no_ssl)
 

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -308,7 +308,7 @@ async def test_webrtc_gateway_start_stop(cert_pems: tuple[str, str]) -> None:
     ("logger_level", "expected_rtc_level"),
     [
         (VERBOSE_LOG_LEVEL, LogLevel.VERBOSE),
-        (logging.DEBUG, LogLevel.DEBUG),
+        (logging.DEBUG, LogLevel.WARNING),
         (logging.INFO, LogLevel.ERROR),
         (logging.WARNING, LogLevel.ERROR),
     ],
@@ -337,6 +337,44 @@ async def test_webrtc_gateway_native_log_level(
         await gateway.stop()
 
     install_logger.assert_called_once_with(gateway.logger, level=expected_rtc_level)
+    assert not gateway.logger.filters
+
+
+async def test_webrtc_gateway_drops_benign_turn_warning_at_debug(
+    cert_pems: tuple[str, str],
+) -> None:
+    """Test the benign Cloudflare CreatePermission warning is dropped at DEBUG level."""
+    cert_pem, key_pem = cert_pems
+    gateway = WebRTCGateway(
+        http_session=Mock(),
+        remote_id="TEST-REMOTE-ID",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+    )
+    gateway.logger = logging.getLogger("test_webrtc_benign_turn_warning")
+    gateway.logger.setLevel(logging.DEBUG)
+    records: list[logging.LogRecord] = []
+    handler = logging.Handler()
+    handler.emit = records.append  # type: ignore[method-assign]
+    gateway.logger.addHandler(handler)
+
+    with (
+        patch.object(gateway, "_run", new_callable=AsyncMock),
+        patch("music_assistant.controllers.webserver.remote_access.gateway.install_python_logger"),
+    ):
+        await gateway.start()
+        gateway.logger.warning(
+            "rtc::impl::IceTransport::LogCallback@390: "
+            "juice: Got TURN CreatePermission error response, code=0"
+        )
+        gateway.logger.warning("juice: Lost connectivity")
+        await gateway.stop()
+
+    gateway.logger.removeHandler(handler)
+    messages = [record.getMessage() for record in records if "juice" in record.getMessage()]
+    assert messages == ["juice: Lost connectivity"]
+    # stop() must remove the filter again
+    assert not gateway.logger.filters
 
 
 async def test_webrtc_gateway_handle_registration_message(cert_pems: tuple[str, str]) -> None:

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -341,7 +341,7 @@ async def test_webrtc_gateway_native_log_level(
 
 
 async def test_webrtc_gateway_drops_benign_turn_warning_at_debug(
-    cert_pems: tuple[str, str],
+    cert_pems: tuple[str, str], caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test the benign Cloudflare CreatePermission warning is dropped at DEBUG level."""
     cert_pem, key_pem = cert_pems
@@ -353,25 +353,21 @@ async def test_webrtc_gateway_drops_benign_turn_warning_at_debug(
     )
     gateway.logger = logging.getLogger("test_webrtc_benign_turn_warning")
     gateway.logger.setLevel(logging.DEBUG)
-    records: list[logging.LogRecord] = []
-    handler = logging.Handler()
-    handler.emit = records.append  # type: ignore[method-assign]
-    gateway.logger.addHandler(handler)
 
     with (
         patch.object(gateway, "_run", new_callable=AsyncMock),
         patch("music_assistant.controllers.webserver.remote_access.gateway.install_python_logger"),
     ):
         await gateway.start()
-        gateway.logger.warning(
-            "rtc::impl::IceTransport::LogCallback@390: "
-            "juice: Got TURN CreatePermission error response, code=0"
-        )
-        gateway.logger.warning("juice: Lost connectivity")
+        with caplog.at_level(logging.DEBUG, logger="test_webrtc_benign_turn_warning"):
+            gateway.logger.warning(
+                "rtc::impl::IceTransport::LogCallback@390: "
+                "juice: Got TURN CreatePermission error response, code=0"
+            )
+            gateway.logger.warning("juice: Lost connectivity")
         await gateway.stop()
 
-    gateway.logger.removeHandler(handler)
-    messages = [record.getMessage() for record in records if "juice" in record.getMessage()]
+    messages = [record.getMessage() for record in caplog.records if "juice" in record.getMessage()]
     assert messages == ["juice: Lost connectivity"]
     # stop() must remove the filter again
     assert not gateway.logger.filters


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5125: with the global log level at debug, the `remote_access` logger still forwarded libdatachannel's full native firehose (ICE/DTLS/SCTP state chatter at INFO plus the benign Cloudflare TURN `CreatePermission code=0` warnings), and the WiiM sdk logged routine keep-alive chatter at INFO — together flooding debug logs (~350 lines per 20 minutes).

- Reserve the full native WebRTC log output for VERBOSE; at DEBUG only forward native warnings (real connectivity signals such as `Lost connectivity`)
- Drop the known-benign Cloudflare `TURN CreatePermission error response, code=0` line at DEBUG (Cloudflare omits the ERROR-CODE attribute; relaying is proven to work fine)
- Cap the WiiM sdk logger at WARNING below VERBOSE, so its INFO keep-alive chatter (subscription renewals, multiroom polls) stays out of debug logs

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
