### PR TITLE
End dashboard sessions with a warning when the receiver dies unexpectedly

### DIFF
--- a/music_assistant/controllers/dashboard/controller.py
+++ b/music_assistant/controllers/dashboard/controller.py
@@ -290,6 +290,19 @@ class DashboardController(CoreController):
         if sessions_changed:
             self._signal_sessions_updated()
 
+    def end_session(self, dashboard_id: str, reason: str) -> None:
+        """
+        End the active session for an endpoint that stopped showing its dashboard.
+
+        :param dashboard_id: Id of a registered dashboard endpoint.
+        :param reason: Human-readable cause, logged as a warning.
+        """
+        session = self._sessions.pop(dashboard_id, None)
+        if session is None:
+            return
+        self.logger.warning("Dashboard session on %s ended: %s", session.name, reason)
+        self._signal_sessions_updated()
+
     async def resolve_dashboard_url(
         self, dashboard: DashboardType, player_id: str | None, *, prefer_local: bool = False
     ) -> str:

--- a/music_assistant/controllers/dashboard/controller.py
+++ b/music_assistant/controllers/dashboard/controller.py
@@ -287,6 +287,19 @@ class DashboardController(CoreController):
         if sessions_changed:
             self._signal_sessions_updated()
 
+    def end_session(self, dashboard_id: str, reason: str) -> None:
+        """
+        End the active session for an endpoint that stopped showing its dashboard.
+
+        :param dashboard_id: Id of a registered dashboard endpoint.
+        :param reason: Human-readable cause, logged as a warning.
+        """
+        session = self._sessions.pop(dashboard_id, None)
+        if session is None:
+            return
+        self.logger.warning("Dashboard session on %s ended: %s", session.name, reason)
+        self._signal_sessions_updated()
+
     async def resolve_dashboard_url(
         self, dashboard: DashboardType, player_id: str | None, *, prefer_local: bool = False
     ) -> str:

--- a/music_assistant/providers/chromecast/dashboard.py
+++ b/music_assistant/providers/chromecast/dashboard.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
 import pychromecast
@@ -11,22 +12,39 @@ from music_assistant_models.dashboard import DashboardDevice
 from music_assistant_models.enums import DashboardType
 from music_assistant_models.errors import PlayerUnavailableError
 from pychromecast.const import CAST_TYPE_CHROMECAST
+from pychromecast.socket_client import CONNECTION_STATUS_CONNECTED, CONNECTION_STATUS_LOST
 
+from .constants import MASS_APP_ID
 from .helpers import send_hide_dashboard, send_show_dashboard
 from .player import ChromecastPlayer
 
 if TYPE_CHECKING:
+    import asyncio
     from collections.abc import Callable
 
+    from pychromecast.controllers.receiver import CastStatus
+    from pychromecast.controllers.receiver import CastStatusListener as ReceiverStatusListener
     from pychromecast.models import CastInfo
+    from pychromecast.socket_client import ConnectionStatus, ConnectionStatusListener
 
     from .provider import ChromecastProvider
 
 # Seconds to wait for an on-demand dashboard cast connection before giving up.
 DASHBOARD_CONNECT_TIMEOUT = 10.0
 
+# Seconds a lost connection is allowed to recover before we consider the dashboard gone.
+DASHBOARD_CONNECTION_LOSS_GRACE = 60.0
+
 # Dashboard types the chromecast receiver app has routes for.
 SUPPORTED_DASHBOARD_TYPES = {DashboardType.PARTY, DashboardType.NOW_PLAYING}
+
+
+@dataclass
+class _ActiveDashboardCast:
+    """Tracks a dashboard currently showing on a Cast device, to detect it dying externally."""
+
+    cast_session_id: str | None
+    loss_timer: asyncio.TimerHandle | None = None
 
 
 class ChromecastDashboards:
@@ -44,6 +62,9 @@ class ChromecastDashboards:
         self._unregister_callbacks: dict[str, Callable[[], None]] = {}
         # Cast connections opened on-demand for dashboard casting (not registered players)
         self._dashboard_connections: dict[str, pychromecast.Chromecast] = {}
+        self._active_casts: dict[str, _ActiveDashboardCast] = {}
+        # device_id -> id(chromecast) already carrying our status/connection listener
+        self._listened_ccs: dict[str, int] = {}
         self._unloaded = False
 
     def register(self, uuid: UUID, cast_info: CastInfo) -> None:
@@ -72,6 +93,9 @@ class ChromecastDashboards:
         if chromecast := self._dashboard_connections.pop(device_id, None):
             # non-blocking: close the socket, the daemon thread exits on its own
             chromecast.disconnect(0)
+        self._cancel_loss_timer(device_id)
+        self._active_casts.pop(device_id, None)
+        self._listened_ccs.pop(device_id, None)
 
     async def unload(self) -> None:
         """Unregister all dashboard endpoints and disconnect cached on-demand connections."""
@@ -79,6 +103,11 @@ class ChromecastDashboards:
         for unregister_callback in list(self._unregister_callbacks.values()):
             unregister_callback()
         self._unregister_callbacks.clear()
+
+        for device_id in list(self._active_casts):
+            self._cancel_loss_timer(device_id)
+        self._active_casts.clear()
+        self._listened_ccs.clear()
 
         dashboard_connections = list(self._dashboard_connections.values())
         self._dashboard_connections.clear()
@@ -127,12 +156,24 @@ class ChromecastDashboards:
                 translation_args=[chromecast.name],
             ) from err
 
+        self._cancel_loss_timer(device_id)
+        session_id = chromecast.status.session_id if chromecast.status else None
+        self._active_casts[device_id] = _ActiveDashboardCast(cast_session_id=session_id)
+        if self._listened_ccs.get(device_id) != id(chromecast):
+            listener = _DashboardCastListener(self, device_id)
+            chromecast.register_status_listener(cast("ReceiverStatusListener", listener))
+            chromecast.register_connection_listener(cast("ConnectionStatusListener", listener))
+            self._listened_ccs[device_id] = id(chromecast)
+
     async def _on_hide(self, device_id: str) -> None:
         """
         Hide a Music Assistant dashboard from a Cast display device.
 
         :param device_id: Cast device uuid (as string) to hide the dashboard from.
         """
+        self._cancel_loss_timer(device_id)
+        self._active_casts.pop(device_id, None)
+
         chromecast = self._get_existing_chromecast(device_id)
         if chromecast is None:
             # nothing connected to this device: it can't be showing a dashboard
@@ -193,3 +234,74 @@ class ChromecastDashboards:
             del self._dashboard_connections[device_id]
 
         return None
+
+    def _handle_cast_status(self, device_id: str, status: CastStatus) -> None:
+        """Detect the dashboard receiver app being replaced or restarted, on the event loop."""
+        entry = self._active_casts.get(device_id)
+        if entry is None:
+            return
+        if status.app_id != MASS_APP_ID or status.session_id != entry.cast_session_id:
+            reason = f"the receiver app was closed (active app: {status.display_name or status.app_id or 'none'})"
+            self._session_lost(device_id, reason)
+
+    def _handle_connection_status(self, device_id: str, status: ConnectionStatus) -> None:
+        """Arm/disarm the connection-loss grace timer, on the event loop."""
+        entry = self._active_casts.get(device_id)
+        if entry is None:
+            return
+        if status.status == CONNECTION_STATUS_LOST:
+            if entry.loss_timer is None:
+                entry.loss_timer = self.mass.loop.call_later(
+                    DASHBOARD_CONNECTION_LOSS_GRACE,
+                    self._session_lost,
+                    device_id,
+                    "connection to the device was lost",
+                )
+        elif status.status == CONNECTION_STATUS_CONNECTED:
+            # the receiver status that follows reconnection re-verifies the app itself
+            self._cancel_loss_timer(device_id)
+
+    def _session_lost(self, device_id: str, reason: str) -> None:
+        """Report a dashboard session as lost and drop the on-demand connection, if any."""
+        entry = self._active_casts.pop(device_id, None)
+        if entry is None:
+            return
+        if entry.loss_timer is not None:
+            entry.loss_timer.cancel()
+        self.mass.dashboard.end_session(f"chromecast_{device_id}", reason)
+
+        if chromecast := self._dashboard_connections.pop(device_id, None):
+            # non-blocking: close the socket, the daemon thread exits on its own
+            chromecast.disconnect(0)
+
+    def _cancel_loss_timer(self, device_id: str) -> None:
+        """Cancel the pending connection-loss timer for device_id, if any."""
+        entry = self._active_casts.get(device_id)
+        if entry is not None and entry.loss_timer is not None:
+            entry.loss_timer.cancel()
+            entry.loss_timer = None
+
+
+class _DashboardCastListener:
+    """Watches a Cast device to detect its dashboard receiver dying externally."""
+
+    def __init__(self, dashboards: ChromecastDashboards, device_id: str) -> None:
+        """Bind this listener to the dashboards owner and the Cast device it watches."""
+        self.dashboards = dashboards
+        self.device_id = device_id
+
+    def new_cast_status(self, status: CastStatus) -> None:
+        """Handle updated CastStatus (called from the pychromecast socket thread)."""
+        if self.dashboards.mass.closing:
+            return
+        self.dashboards.mass.loop.call_soon_threadsafe(
+            self.dashboards._handle_cast_status, self.device_id, status
+        )
+
+    def new_connection_status(self, status: ConnectionStatus) -> None:
+        """Handle updated ConnectionStatus (called from the pychromecast socket thread)."""
+        if self.dashboards.mass.closing:
+            return
+        self.dashboards.mass.loop.call_soon_threadsafe(
+            self.dashboards._handle_connection_status, self.device_id, status
+        )

--- a/music_assistant/providers/chromecast/dashboard.py
+++ b/music_assistant/providers/chromecast/dashboard.py
@@ -44,6 +44,7 @@ class _ActiveDashboardCast:
     """Tracks a dashboard currently showing on a Cast device, to detect it dying externally."""
 
     cast_session_id: str | None
+    listener: _DashboardCastListener
     loss_timer: asyncio.TimerHandle | None = None
 
 
@@ -63,8 +64,6 @@ class ChromecastDashboards:
         # Cast connections opened on-demand for dashboard casting (not registered players)
         self._dashboard_connections: dict[str, pychromecast.Chromecast] = {}
         self._active_casts: dict[str, _ActiveDashboardCast] = {}
-        # device_id -> id(chromecast) already carrying our status/connection listener
-        self._listened_ccs: dict[str, int] = {}
         self._unloaded = False
 
     def register(self, uuid: UUID, cast_info: CastInfo) -> None:
@@ -93,9 +92,7 @@ class ChromecastDashboards:
         if chromecast := self._dashboard_connections.pop(device_id, None):
             # non-blocking: close the socket, the daemon thread exits on its own
             chromecast.disconnect(0)
-        self._cancel_loss_timer(device_id)
-        self._active_casts.pop(device_id, None)
-        self._listened_ccs.pop(device_id, None)
+        self._drop_active_cast(device_id)
 
     async def unload(self) -> None:
         """Unregister all dashboard endpoints and disconnect cached on-demand connections."""
@@ -105,9 +102,7 @@ class ChromecastDashboards:
         self._unregister_callbacks.clear()
 
         for device_id in list(self._active_casts):
-            self._cancel_loss_timer(device_id)
-        self._active_casts.clear()
-        self._listened_ccs.clear()
+            self._drop_active_cast(device_id)
 
         dashboard_connections = list(self._dashboard_connections.values())
         self._dashboard_connections.clear()
@@ -156,14 +151,14 @@ class ChromecastDashboards:
                 translation_args=[chromecast.name],
             ) from err
 
-        self._cancel_loss_timer(device_id)
+        self._drop_active_cast(device_id)
         session_id = chromecast.status.session_id if chromecast.status else None
-        self._active_casts[device_id] = _ActiveDashboardCast(cast_session_id=session_id)
-        if self._listened_ccs.get(device_id) != id(chromecast):
-            listener = _DashboardCastListener(self, device_id)
-            chromecast.register_status_listener(cast("ReceiverStatusListener", listener))
-            chromecast.register_connection_listener(cast("ConnectionStatusListener", listener))
-            self._listened_ccs[device_id] = id(chromecast)
+        listener = _DashboardCastListener(self, device_id)
+        self._active_casts[device_id] = _ActiveDashboardCast(
+            cast_session_id=session_id, listener=listener
+        )
+        chromecast.register_status_listener(cast("ReceiverStatusListener", listener))
+        chromecast.register_connection_listener(cast("ConnectionStatusListener", listener))
 
     async def _on_hide(self, device_id: str) -> None:
         """
@@ -171,8 +166,7 @@ class ChromecastDashboards:
 
         :param device_id: Cast device uuid (as string) to hide the dashboard from.
         """
-        self._cancel_loss_timer(device_id)
-        self._active_casts.pop(device_id, None)
+        self._drop_active_cast(device_id)
 
         chromecast = self._get_existing_chromecast(device_id)
         if chromecast is None:
@@ -263,11 +257,9 @@ class ChromecastDashboards:
 
     def _session_lost(self, device_id: str, reason: str) -> None:
         """Report a dashboard session as lost and drop the on-demand connection, if any."""
-        entry = self._active_casts.pop(device_id, None)
-        if entry is None:
+        if device_id not in self._active_casts:
             return
-        if entry.loss_timer is not None:
-            entry.loss_timer.cancel()
+        self._drop_active_cast(device_id)
         self.mass.dashboard.end_session(f"chromecast_{device_id}", reason)
 
         if chromecast := self._dashboard_connections.pop(device_id, None):
@@ -281,18 +273,38 @@ class ChromecastDashboards:
             entry.loss_timer.cancel()
             entry.loss_timer = None
 
+    def _drop_active_cast(self, device_id: str) -> None:
+        """Stop tracking device_id: cancel its loss timer and invalidate its listener."""
+        entry = self._active_casts.pop(device_id, None)
+        if entry is None:
+            return
+        if entry.loss_timer is not None:
+            entry.loss_timer.cancel()
+        entry.listener.invalidate()
+
 
 class _DashboardCastListener:
-    """Watches a Cast device to detect its dashboard receiver dying externally."""
+    """
+    Watches a Cast device to detect its dashboard receiver dying externally.
+
+    pychromecast has no API to unregister a listener from a Chromecast object,
+    so a superseded listener is invalidated instead: it stays registered but
+    its callbacks become no-ops.
+    """
 
     def __init__(self, dashboards: ChromecastDashboards, device_id: str) -> None:
         """Bind this listener to the dashboards owner and the Cast device it watches."""
         self.dashboards = dashboards
         self.device_id = device_id
+        self._valid = True
+
+    def invalidate(self) -> None:
+        """Stop forwarding callbacks from this listener."""
+        self._valid = False
 
     def new_cast_status(self, status: CastStatus) -> None:
         """Handle updated CastStatus (called from the pychromecast socket thread)."""
-        if self.dashboards.mass.closing:
+        if not self._valid or self.dashboards.mass.closing:
             return
         self.dashboards.mass.loop.call_soon_threadsafe(
             self.dashboards._handle_cast_status, self.device_id, status
@@ -300,7 +312,7 @@ class _DashboardCastListener:
 
     def new_connection_status(self, status: ConnectionStatus) -> None:
         """Handle updated ConnectionStatus (called from the pychromecast socket thread)."""
-        if self.dashboards.mass.closing:
+        if not self._valid or self.dashboards.mass.closing:
             return
         self.dashboards.mass.loop.call_soon_threadsafe(
             self.dashboards._handle_connection_status, self.device_id, status

--- a/tests/controllers/dashboard/test_controller.py
+++ b/tests/controllers/dashboard/test_controller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
@@ -690,6 +691,38 @@ async def test_hide_dashboard_unknown_id_is_graceful_noop() -> None:
     controller.mass.signal_event.assert_called_once_with(  # type: ignore[attr-defined]
         EventType.DASHBOARD_SESSIONS_UPDATED, data=[]
     )
+
+
+async def test_end_session_removes_session_and_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Ending an active session drops it, signals sessions updated, and logs a warning."""
+    controller = _make_controller()
+    controller.logger = logging.getLogger("test.dashboard")
+    device = DashboardDevice(dashboard_id="dash1", name="Living Room")
+    controller._dashboards["dash1"] = _RegisteredDashboard(device=device)
+    controller._sessions["dash1"] = DashboardSession(
+        dashboard_id="dash1", name="Living Room", dashboard=DashboardType.PARTY
+    )
+
+    with caplog.at_level(logging.WARNING, logger="test.dashboard"):
+        controller.end_session("dash1", "the receiver app was closed")
+
+    assert "dash1" not in controller._sessions
+    controller.mass.signal_event.assert_called_once_with(  # type: ignore[attr-defined]
+        EventType.DASHBOARD_SESSIONS_UPDATED, data=[]
+    )
+    assert "Living Room" in caplog.text
+    assert "the receiver app was closed" in caplog.text
+
+
+async def test_end_session_unknown_id_is_noop() -> None:
+    """Ending a session for an id without an active session is a silent no-op."""
+    controller = _make_controller()
+
+    controller.end_session("unknown", "some reason")
+
+    controller.mass.signal_event.assert_not_called()  # type: ignore[attr-defined]
 
 
 async def test_get_dashboard_sessions_returns_stored_sessions() -> None:

--- a/tests/controllers/dashboard/test_controller.py
+++ b/tests/controllers/dashboard/test_controller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, urlparse
@@ -680,6 +681,38 @@ async def test_hide_dashboard_unknown_id_is_graceful_noop() -> None:
     controller.mass.signal_event.assert_called_once_with(  # type: ignore[attr-defined]
         EventType.DASHBOARD_SESSIONS_UPDATED, data=[]
     )
+
+
+async def test_end_session_removes_session_and_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Ending an active session drops it, signals sessions updated, and logs a warning."""
+    controller = _make_controller()
+    controller.logger = logging.getLogger("test.dashboard")
+    device = DashboardDevice(dashboard_id="dash1", name="Living Room")
+    controller._dashboards["dash1"] = _RegisteredDashboard(device=device)
+    controller._sessions["dash1"] = DashboardSession(
+        dashboard_id="dash1", name="Living Room", dashboard=DashboardType.PARTY
+    )
+
+    with caplog.at_level(logging.WARNING, logger="test.dashboard"):
+        controller.end_session("dash1", "the receiver app was closed")
+
+    assert "dash1" not in controller._sessions
+    controller.mass.signal_event.assert_called_once_with(  # type: ignore[attr-defined]
+        EventType.DASHBOARD_SESSIONS_UPDATED, data=[]
+    )
+    assert "Living Room" in caplog.text
+    assert "the receiver app was closed" in caplog.text
+
+
+async def test_end_session_unknown_id_is_noop() -> None:
+    """Ending a session for an id without an active session is a silent no-op."""
+    controller = _make_controller()
+
+    controller.end_session("unknown", "some reason")
+
+    controller.mass.signal_event.assert_not_called()  # type: ignore[attr-defined]
 
 
 async def test_get_dashboard_sessions_returns_stored_sessions() -> None:

--- a/tests/providers/chromecast/test_dashboard_liveness.py
+++ b/tests/providers/chromecast/test_dashboard_liveness.py
@@ -42,7 +42,9 @@ def _chromecast(app_id: str = MASS_APP_ID, session_id: str = "session-1") -> Mag
 
 async def _show(dashboards: ChromecastDashboards, device_id: str, chromecast: MagicMock) -> None:
     """Drive a successful _on_show for device_id against an already-connected chromecast."""
-    dashboards.mass.dashboard.resolve_dashboard_url = AsyncMock(return_value="https://x")
+    dashboards.mass.dashboard.resolve_dashboard_url = AsyncMock(  # type: ignore[method-assign]
+        return_value="https://x"
+    )
     dashboards._dashboard_connections[device_id] = chromecast
     with patch("music_assistant.providers.chromecast.dashboard.send_show_dashboard"):
         await dashboards._on_show(device_id, DashboardType.PARTY, None)
@@ -93,8 +95,8 @@ def test_handle_cast_status_without_active_cast_is_noop() -> None:
     dashboards.mass.dashboard.end_session.assert_not_called()  # type: ignore[attr-defined]
 
 
-async def test_on_show_reuses_listener_for_same_chromecast_object() -> None:
-    """Re-showing on the same connection does not stack duplicate listeners."""
+async def test_reshow_invalidates_previous_listener() -> None:
+    """A re-show registers a fresh listener and stale callbacks from the old one are ignored."""
     dashboards = _make_dashboards()
     device_id = str(uuid4())
     chromecast = _chromecast()
@@ -102,8 +104,16 @@ async def test_on_show_reuses_listener_for_same_chromecast_object() -> None:
     await _show(dashboards, device_id, chromecast)
     await _show(dashboards, device_id, chromecast)
 
-    chromecast.register_status_listener.assert_called_once()
-    chromecast.register_connection_listener.assert_called_once()
+    first_listener = chromecast.register_status_listener.call_args_list[0][0][0]
+    second_listener = chromecast.register_status_listener.call_args_list[1][0][0]
+
+    other_status = MagicMock(app_id="OTHERAPP", session_id="x", display_name="YouTube")
+    first_listener.new_cast_status(other_status)
+    dashboards.mass.dashboard.end_session.assert_not_called()  # type: ignore[attr-defined]
+    assert device_id in dashboards._active_casts
+
+    second_listener.new_cast_status(other_status)
+    dashboards.mass.dashboard.end_session.assert_called_once()  # type: ignore[attr-defined]
 
 
 ### Connection status: loss grace timer
@@ -115,7 +125,9 @@ def test_connection_lost_arms_timer_and_reconnect_cancels_it() -> None:
     device_id = str(uuid4())
     timer_handle = MagicMock()
     dashboards.mass.loop.call_later.return_value = timer_handle  # type: ignore[attr-defined]
-    dashboards._active_casts[device_id] = _ActiveDashboardCast(cast_session_id="session-1")
+    dashboards._active_casts[device_id] = _ActiveDashboardCast(
+        cast_session_id="session-1", listener=MagicMock()
+    )
 
     dashboards._handle_connection_status(device_id, MagicMock(status=CONNECTION_STATUS_LOST))
 
@@ -137,7 +149,9 @@ def test_connection_lost_does_not_stack_a_second_timer() -> None:
     """A second LOST status while a timer is already pending does not arm another one."""
     dashboards = _make_dashboards()
     device_id = str(uuid4())
-    dashboards._active_casts[device_id] = _ActiveDashboardCast(cast_session_id="session-1")
+    dashboards._active_casts[device_id] = _ActiveDashboardCast(
+        cast_session_id="session-1", listener=MagicMock()
+    )
 
     dashboards._handle_connection_status(device_id, MagicMock(status=CONNECTION_STATUS_LOST))
     dashboards._handle_connection_status(device_id, MagicMock(status=CONNECTION_STATUS_LOST))
@@ -149,7 +163,9 @@ def test_connection_loss_timer_callback_ends_session() -> None:
     """The grace timer firing reports the session lost with the connection-loss reason."""
     dashboards = _make_dashboards()
     device_id = str(uuid4())
-    dashboards._active_casts[device_id] = _ActiveDashboardCast(cast_session_id="session-1")
+    dashboards._active_casts[device_id] = _ActiveDashboardCast(
+        cast_session_id="session-1", listener=MagicMock()
+    )
 
     dashboards._session_lost(device_id, "connection to the device was lost")
 
@@ -177,7 +193,7 @@ async def test_hide_cancels_loss_timer_without_ending_session() -> None:
     device_id = str(uuid4())
     timer_handle = MagicMock()
     dashboards._active_casts[device_id] = _ActiveDashboardCast(
-        cast_session_id="session-1", loss_timer=timer_handle
+        cast_session_id="session-1", listener=MagicMock(), loss_timer=timer_handle
     )
     dashboards.provider.browser = MagicMock(devices={})
 
@@ -187,3 +203,17 @@ async def test_hide_cancels_loss_timer_without_ending_session() -> None:
     timer_handle.cancel.assert_called_once()
     assert device_id not in dashboards._active_casts
     dashboards.mass.dashboard.end_session.assert_not_called()  # type: ignore[attr-defined]
+
+
+async def test_stale_connection_status_after_session_lost_is_ignored() -> None:
+    """A connection callback from an already-invalidated listener does not re-arm the timer."""
+    dashboards = _make_dashboards()
+    device_id = str(uuid4())
+    chromecast = _chromecast()
+    await _show(dashboards, device_id, chromecast)
+    listener = chromecast.register_status_listener.call_args[0][0]
+
+    dashboards._session_lost(device_id, "connection to the device was lost")
+    listener.new_connection_status(MagicMock(status=CONNECTION_STATUS_LOST))
+
+    dashboards.mass.loop.call_later.assert_not_called()  # type: ignore[attr-defined]

--- a/tests/providers/chromecast/test_dashboard_liveness.py
+++ b/tests/providers/chromecast/test_dashboard_liveness.py
@@ -1,0 +1,189 @@
+"""Tests for Chromecast dashboard session-liveness detection."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from music_assistant_models.enums import DashboardType
+from pychromecast.socket_client import CONNECTION_STATUS_CONNECTED, CONNECTION_STATUS_LOST
+
+from music_assistant.providers.chromecast.constants import MASS_APP_ID
+from music_assistant.providers.chromecast.dashboard import (
+    DASHBOARD_CONNECTION_LOSS_GRACE,
+    ChromecastDashboards,
+    _ActiveDashboardCast,
+)
+
+
+def _make_dashboards() -> ChromecastDashboards:
+    """Build a ChromecastDashboards instance with a fully mocked owning provider."""
+    provider = MagicMock()
+    provider.translation_owner = "provider.chromecast"
+    provider.domain = "chromecast"
+    provider.mass.closing = False
+    # run_in_executor just calls the function inline, synchronously
+    provider.mass.loop.run_in_executor = AsyncMock(
+        side_effect=lambda _executor, func, *args: func(*args)
+    )
+    provider.mass.loop.call_soon_threadsafe = MagicMock(side_effect=lambda func, *args: func(*args))
+    provider.mass.loop.call_later = MagicMock()
+    provider.mass.players.get_player.return_value = None
+    return ChromecastDashboards(provider)
+
+
+def _chromecast(app_id: str = MASS_APP_ID, session_id: str = "session-1") -> MagicMock:
+    """Build a connected Chromecast mock, already showing the MA receiver app."""
+    chromecast = MagicMock()
+    chromecast.socket_client.is_connected = True
+    chromecast.status = MagicMock(app_id=app_id, session_id=session_id)
+    return chromecast
+
+
+async def _show(dashboards: ChromecastDashboards, device_id: str, chromecast: MagicMock) -> None:
+    """Drive a successful _on_show for device_id against an already-connected chromecast."""
+    dashboards.mass.dashboard.resolve_dashboard_url = AsyncMock(return_value="https://x")
+    dashboards._dashboard_connections[device_id] = chromecast
+    with patch("music_assistant.providers.chromecast.dashboard.send_show_dashboard"):
+        await dashboards._on_show(device_id, DashboardType.PARTY, None)
+
+
+### Cast status: receiver app identity changes
+
+
+async def test_cast_status_different_app_ends_active_session() -> None:
+    """A cast status reporting a different app than ours ends the dashboard session."""
+    dashboards = _make_dashboards()
+    device_id = str(uuid4())
+    chromecast = _chromecast()
+    await _show(dashboards, device_id, chromecast)
+    listener = chromecast.register_status_listener.call_args[0][0]
+
+    other_status = MagicMock(app_id="OTHERAPP", session_id="other-session", display_name="YouTube")
+    listener.new_cast_status(other_status)
+
+    dashboards.mass.dashboard.end_session.assert_called_once_with(  # type: ignore[attr-defined]
+        f"chromecast_{device_id}", "the receiver app was closed (active app: YouTube)"
+    )
+    assert device_id not in dashboards._active_casts
+
+
+async def test_cast_status_same_app_and_session_keeps_active_session() -> None:
+    """MA audio playing in the same receiver app session leaves the dashboard session intact."""
+    dashboards = _make_dashboards()
+    device_id = str(uuid4())
+    chromecast = _chromecast(session_id="session-1")
+    await _show(dashboards, device_id, chromecast)
+    listener = chromecast.register_status_listener.call_args[0][0]
+
+    same_status = MagicMock(app_id=MASS_APP_ID, session_id="session-1")
+    listener.new_cast_status(same_status)
+
+    dashboards.mass.dashboard.end_session.assert_not_called()  # type: ignore[attr-defined]
+    assert device_id in dashboards._active_casts
+
+
+def test_handle_cast_status_without_active_cast_is_noop() -> None:
+    """A cast status for a device with no tracked active dashboard cast is ignored."""
+    dashboards = _make_dashboards()
+    status = MagicMock(app_id="OTHERAPP", session_id="other-session")
+
+    dashboards._handle_cast_status(str(uuid4()), status)
+
+    dashboards.mass.dashboard.end_session.assert_not_called()  # type: ignore[attr-defined]
+
+
+async def test_on_show_reuses_listener_for_same_chromecast_object() -> None:
+    """Re-showing on the same connection does not stack duplicate listeners."""
+    dashboards = _make_dashboards()
+    device_id = str(uuid4())
+    chromecast = _chromecast()
+
+    await _show(dashboards, device_id, chromecast)
+    await _show(dashboards, device_id, chromecast)
+
+    chromecast.register_status_listener.assert_called_once()
+    chromecast.register_connection_listener.assert_called_once()
+
+
+### Connection status: loss grace timer
+
+
+def test_connection_lost_arms_timer_and_reconnect_cancels_it() -> None:
+    """A lost connection arms the grace timer; reconnecting before it fires cancels it."""
+    dashboards = _make_dashboards()
+    device_id = str(uuid4())
+    timer_handle = MagicMock()
+    dashboards.mass.loop.call_later.return_value = timer_handle  # type: ignore[attr-defined]
+    dashboards._active_casts[device_id] = _ActiveDashboardCast(cast_session_id="session-1")
+
+    dashboards._handle_connection_status(device_id, MagicMock(status=CONNECTION_STATUS_LOST))
+
+    dashboards.mass.loop.call_later.assert_called_once_with(  # type: ignore[attr-defined]
+        DASHBOARD_CONNECTION_LOSS_GRACE,
+        dashboards._session_lost,
+        device_id,
+        "connection to the device was lost",
+    )
+    assert dashboards._active_casts[device_id].loss_timer is timer_handle
+
+    dashboards._handle_connection_status(device_id, MagicMock(status=CONNECTION_STATUS_CONNECTED))
+
+    timer_handle.cancel.assert_called_once()
+    assert dashboards._active_casts[device_id].loss_timer is None
+
+
+def test_connection_lost_does_not_stack_a_second_timer() -> None:
+    """A second LOST status while a timer is already pending does not arm another one."""
+    dashboards = _make_dashboards()
+    device_id = str(uuid4())
+    dashboards._active_casts[device_id] = _ActiveDashboardCast(cast_session_id="session-1")
+
+    dashboards._handle_connection_status(device_id, MagicMock(status=CONNECTION_STATUS_LOST))
+    dashboards._handle_connection_status(device_id, MagicMock(status=CONNECTION_STATUS_LOST))
+
+    dashboards.mass.loop.call_later.assert_called_once()  # type: ignore[attr-defined]
+
+
+def test_connection_loss_timer_callback_ends_session() -> None:
+    """The grace timer firing reports the session lost with the connection-loss reason."""
+    dashboards = _make_dashboards()
+    device_id = str(uuid4())
+    dashboards._active_casts[device_id] = _ActiveDashboardCast(cast_session_id="session-1")
+
+    dashboards._session_lost(device_id, "connection to the device was lost")
+
+    dashboards.mass.dashboard.end_session.assert_called_once_with(  # type: ignore[attr-defined]
+        f"chromecast_{device_id}", "connection to the device was lost"
+    )
+    assert device_id not in dashboards._active_casts
+
+
+def test_handle_connection_status_without_active_cast_is_noop() -> None:
+    """A connection status for a device with no tracked active dashboard cast is ignored."""
+    dashboards = _make_dashboards()
+
+    dashboards._handle_connection_status(str(uuid4()), MagicMock(status=CONNECTION_STATUS_LOST))
+
+    dashboards.mass.loop.call_later.assert_not_called()  # type: ignore[attr-defined]
+
+
+### Hide: no false-positive liveness report
+
+
+async def test_hide_cancels_loss_timer_without_ending_session() -> None:
+    """Hiding cancels a pending loss timer and drops the entry, without reporting it lost."""
+    dashboards = _make_dashboards()
+    device_id = str(uuid4())
+    timer_handle = MagicMock()
+    dashboards._active_casts[device_id] = _ActiveDashboardCast(
+        cast_session_id="session-1", loss_timer=timer_handle
+    )
+    dashboards.provider.browser = MagicMock(devices={})
+
+    with patch("music_assistant.providers.chromecast.dashboard.send_hide_dashboard"):
+        await dashboards._on_hide(device_id)
+
+    timer_handle.cancel.assert_called_once()
+    assert device_id not in dashboards._active_casts
+    dashboards.mass.dashboard.end_session.assert_not_called()  # type: ignore[attr-defined]


### PR DESCRIPTION
# What does this implement/fix?

A dashboard cast session only ended via an explicit `dashboard/hide`. When the receiver app on the device died for any other reason (network hiccup leading to an app quit, user exits the app on the device, another app cast over it, an automation stopping the player), the session lingered forever: nothing was logged and the frontend kept showing the endpoint as "casting".

- Add `DashboardController.end_session(dashboard_id, reason)`: drops the session, logs a warning (`Dashboard session on <name> ended: <reason>`) and signals `DASHBOARD_SESSIONS_UPDATED`, so the frontend's casting indicator clears itself
- The chromecast provider now watches devices it casts to: a cast status where the receiver app is gone, replaced or restarted ends the session immediately; a lost device connection ends it after a 60s grace period
- Same-app audio playback keeps the session alive (cast session id unchanged), and a connection blip that recovers re-verifies the app instead of ending the session
- Add tests for the controller method and the provider liveness detection

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
