### PR TITLE
Fix startup provider failures and show which provider needs attention

### DIFF
--- a/music_assistant/controllers/config/flows.py
+++ b/music_assistant/controllers/config/flows.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
 import logging
 import time
 from dataclasses import dataclass
@@ -24,7 +23,7 @@ from music_assistant_models.setup_flow import SetupFlowStep
 from music_assistant.constants import CONF_PLAYERS, CONF_PROVIDERS
 from music_assistant.controllers.config.helpers import _AUTH_ERROR_CODES
 from music_assistant.helpers.api import api_command
-from music_assistant.helpers.util import load_provider_module
+from music_assistant.helpers.util import import_module_in_thread, load_provider_module
 from music_assistant.models.player import Player
 from music_assistant.models.setup_flow import (
     AbortFlow,
@@ -596,7 +595,7 @@ class SetupFlowMixin:
         await load_provider_module(manifest.domain, manifest.requirements)
         module_path = f"music_assistant.providers.{manifest.domain}.setup_flow"
         try:
-            return await asyncio.to_thread(importlib.import_module, module_path)
+            return await import_module_in_thread(module_path)
         except ModuleNotFoundError as err:
             if err.name == module_path:
                 # the provider ships no setup_flow module: it needs no setup input

--- a/music_assistant/controllers/config/helpers.py
+++ b/music_assistant/controllers/config/helpers.py
@@ -51,13 +51,16 @@ def _provider_status(conf: ProviderConfig, is_loaded: bool) -> ProviderStatus:
     """Derive the (lifecycle) status of a provider from its config and load state."""
     if not conf.enabled:
         return ProviderStatus.DISABLED
-    if is_loaded:
-        # runtime (un)availability of a loaded provider is conveyed via ProviderInstance.available
-        return ProviderStatus.LOADED
+    # a recorded error wins over being loaded: a provider that hit a problem the user has to
+    # act on (e.g. one unloading itself after an auth failure) must not read as healthy, or
+    # the UI has no way to point at it - the status is what flags it in the providers list
     if conf.last_error is not None:
         if conf.last_error.error_code in _AUTH_ERROR_CODES:
             return ProviderStatus.AUTH_REQUIRED
         if conf.last_error.error_code == UnsupportedSystemError.error_code:
             return ProviderStatus.INCOMPATIBLE
         return ProviderStatus.ERROR
+    if is_loaded:
+        # runtime (un)availability of a loaded provider is conveyed via ProviderInstance.available
+        return ProviderStatus.LOADED
     return ProviderStatus.LOADING

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -20,12 +20,13 @@ import urllib.error
 import urllib.request
 import weakref
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Coroutine
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from ipaddress import IPv4Address, IPv6Address, ip_address
 from pathlib import Path
-from types import TracebackType
+from types import ModuleType, TracebackType
 from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, Protocol, Self, TypeVar, cast
 from urllib.parse import urlparse
 
@@ -1308,17 +1309,36 @@ async def is_hass_supervisor() -> bool:
     return await asyncio.to_thread(_check)
 
 
+# CPython holds a lock per module while importing it, so two threads importing modules with
+# overlapping dependency graphs (e.g. two providers that both pull in `requests`) can end up
+# waiting on each other's module locks. The import machinery then bails out at one of them with
+# a _DeadlockError ("deadlock detected by _ModuleLock(...)") instead of hanging, which surfaces
+# as a provider that failed to load and stays broken until it is reloaded by hand.
+# A single-worker executor keeps imports serialized without parking a thread from the default
+# pool while waiting; only the import itself is serialized, providers still load concurrently.
+_IMPORT_EXECUTOR = ThreadPoolExecutor(max_workers=1, thread_name_prefix="module_import")
+
 # requirements verified this session, so repeated (config) loads skip the version check
 _checked_requirements: set[str] = set()
+
+
+async def import_module_in_thread(name: str, package: str | None = None) -> ModuleType:
+    """
+    Import a module in a thread, serialized against all other imports done this way.
+
+    :param name: Name of the module to import, may be relative to the given package.
+    :param package: Package to resolve the name against, required for a relative name.
+    """
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_IMPORT_EXECUTOR, importlib.import_module, name, package)
 
 
 async def load_provider_module(domain: str, requirements: list[str]) -> ProviderModuleType:
     """Return module for given provider domain and make sure the requirements are met."""
 
-    def _get_provider_module(domain: str) -> ProviderModuleType:
-        return cast(
-            "ProviderModuleType", importlib.import_module(f".{domain}", "music_assistant.providers")
-        )
+    async def _get_provider_module() -> ProviderModuleType:
+        module = await import_module_in_thread(f".{domain}", "music_assistant.providers")
+        return cast("ProviderModuleType", module)
 
     # ensure module requirements are met
     for requirement in requirements:
@@ -1341,14 +1361,14 @@ async def load_provider_module(domain: str, requirements: list[str]) -> Provider
 
     # try to load the module
     try:
-        return await asyncio.to_thread(_get_provider_module, domain)
+        return await _get_provider_module()
     except ImportError:
         # (re)install ALL requirements
         for requirement in requirements:
             await install_package(requirement)
     # try loading the provider again to be safe
     # this will fail if something else is wrong (as it should)
-    return await asyncio.to_thread(_get_provider_module, domain)
+    return await _get_provider_module()
 
 
 async def has_tmpfs_mount() -> bool:

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -1330,7 +1330,16 @@ async def import_module_in_thread(name: str, package: str | None = None) -> Modu
     :param package: Package to resolve the name against, required for a relative name.
     """
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_IMPORT_EXECUTOR, importlib.import_module, name, package)
+    try:
+        return await loop.run_in_executor(_IMPORT_EXECUTOR, importlib.import_module, name, package)
+    except RuntimeError as err:
+        # threads we do not control (a library importing lazily in its own thread) can still
+        # cross a module lock with ours; the import machinery reports that as a deadlock at
+        # whoever detects it. The other import has finished by now, so a single retry sticks.
+        if "deadlock detected" not in str(err):
+            raise
+        LOGGER.warning("Retrying import of %s after a module lock collision: %s", name, err)
+        return await loop.run_in_executor(_IMPORT_EXECUTOR, importlib.import_module, name, package)
 
 
 async def load_provider_module(domain: str, requirements: list[str]) -> ProviderModuleType:

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -147,6 +147,16 @@ def _provider_error_from_exc(exc: BaseException) -> ProviderError:
     return ProviderError(error_code=999, message=message)
 
 
+def _provider_error_traceback(exc: BaseException) -> BaseException | None:
+    """Return the exception to log a traceback for, or None when its message says enough."""
+    # a handled condition (auth required, unsupported system, ...) explains itself, but anything
+    # unexpected - or a setup failure wrapping an underlying error - can only be diagnosed from a
+    # traceback, and by the time it is reported the user rarely still has verbose logging on
+    if not isinstance(exc, MusicAssistantError) or exc.__cause__ is not None:
+        return exc
+    return exc if LOGGER.isEnabledFor(VERBOSE_LOG_LEVEL) else None
+
+
 @asynccontextmanager
 async def _provider_load_step(
     domain: str, action: str, timeout: int | None = None
@@ -869,7 +879,7 @@ class MusicAssistant:
                     "Error loading provider(instance) %s: %s",
                     dep_prov_conf.name or dep_prov_conf.instance_id,
                     str(exc) or exc.__class__.__name__,
-                    exc_info=exc if LOGGER.isEnabledFor(VERBOSE_LOG_LEVEL) else None,
+                    exc_info=_provider_error_traceback(exc),
                 )
 
     async def load_provider(
@@ -942,8 +952,7 @@ class MusicAssistant:
                 prov_conf.name or prov_conf.instance_id,
                 str(exc) or exc.__class__.__name__,
                 " (will be retried later)" if will_retry else "",
-                # log full stack trace if verbose logging is enabled
-                exc_info=exc if LOGGER.isEnabledFor(VERBOSE_LOG_LEVEL) else None,
+                exc_info=_provider_error_traceback(exc),
             )
             return
 

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -103,7 +103,10 @@ LOGGER = logging.getLogger(MASS_LOGGER_NAME)
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 PROVIDERS_PATH = os.path.join(BASE_DIR, "providers")
-PROVIDER_SETUP_TIMEOUT = 30
+# These bounds guard against a wedged provider, they are not a performance budget: several
+# providers load at once on a busy event loop, so a step can take much longer in wall clock
+# time than it takes on its own. Keep them generous enough that a slow host never trips them.
+PROVIDER_SETUP_TIMEOUT = 120
 # Generous enough for the slowest hosts to load their ML models, but bounded so a wedged
 # provider fails to load instead of holding up startup forever.
 PROVIDER_ASYNC_INIT_TIMEOUT = 300
@@ -145,19 +148,40 @@ def _provider_error_from_exc(exc: BaseException) -> ProviderError:
 
 
 @asynccontextmanager
-async def _provider_load_step(domain: str, action: str, timeout: int) -> AsyncIterator[None]:
+async def _provider_load_step(
+    domain: str, action: str, timeout: int | None = None
+) -> AsyncIterator[None]:
     """
-    Bound a provider load step, surfacing a timeout as a regular setup failure.
+    Name a provider load step, so any failure in it surfaces as a usable setup failure.
 
     :param domain: Domain of the provider being loaded, used in the error message.
     :param action: Verb describing the step, used in the error message.
-    :param timeout: Seconds to allow the step before it is treated as failed.
+    :param timeout: Seconds to allow the step before it is treated as failed, if bounded.
     """
+    timeout_cm: asyncio.Timeout | None = None
     try:
-        async with asyncio.timeout(timeout):
+        if timeout is None:
             yield
+        else:
+            async with asyncio.timeout(timeout) as timeout_cm:
+                yield
     except TimeoutError as err:
-        msg = f"Provider {domain} did not {action} within {timeout} seconds"
+        if timeout_cm is not None and timeout_cm.expired():
+            msg = f"Provider {domain} did not {action} within {timeout} seconds"
+        else:
+            # a timeout from the provider's own code (an http call, say) carries no message
+            # of its own: name the step it happened in instead of blaming our own bound
+            msg = f"Provider {domain} timed out while trying to {action}"
+        raise SetupFailedError(msg) from err
+    except MusicAssistantError:
+        # already carries a message (and a translation key) meant for the user
+        raise
+    except Exception as err:
+        if str(err):
+            raise
+        # an exception without a message (a bare TimeoutError from an http call, say) would
+        # otherwise reach the user as nothing but its class name, with no hint of what failed
+        msg = f"Provider {domain} failed to {action}: {type(err).__name__}"
         raise SetupFailedError(msg) from err
 
 
@@ -831,8 +855,22 @@ class MusicAssistant:
             manifest = self.get_provider_manifest(dep_prov_conf.domain)
             if not manifest.depends_on:
                 continue
-            if manifest.depends_on == prov_conf.domain:
+            if manifest.depends_on != prov_conf.domain:
+                continue
+            try:
                 await self._load_provider(dep_prov_conf)
+            except Exception as exc:
+                # record the failure against the provider that hit it: attributing it to the
+                # provider we just loaded (which is fine) flags the wrong one in the UI
+                self.config.update_provider_last_error(
+                    dep_prov_conf.instance_id, _provider_error_from_exc(exc)
+                )
+                LOGGER.warning(
+                    "Error loading provider(instance) %s: %s",
+                    dep_prov_conf.name or dep_prov_conf.instance_id,
+                    str(exc) or exc.__class__.__name__,
+                    exc_info=exc if LOGGER.isEnabledFor(VERBOSE_LOG_LEVEL) else None,
+                )
 
     async def load_provider(
         self,
@@ -1197,7 +1235,9 @@ class MusicAssistant:
         self.config.seed_stored_config_values(conf)
 
         # try to setup the module
-        prov_mod = await load_provider_module(domain, prov_manifest.requirements)
+        # (unbounded: this may still have to install the provider's requirements)
+        async with _provider_load_step(domain, "import its module"):
+            prov_mod = await load_provider_module(domain, prov_manifest.requirements)
         async with _provider_load_step(domain, "load", PROVIDER_SETUP_TIMEOUT):
             provider = await prov_mod.setup(self, prov_manifest, conf)
 
@@ -1205,7 +1245,8 @@ class MusicAssistant:
         # (get_config_entries is an instance method). Rehydrate the config values from
         # storage against those entries and validate the complete config, before async
         # init so get_config_value reads there see the stored values.
-        await self.config.rehydrate_provider_config(provider)
+        async with _provider_load_step(domain, "resolve its configuration", PROVIDER_SETUP_TIMEOUT):
+            await self.config.rehydrate_provider_config(provider)
         try:
             provider.config.validate()
         except (KeyError, ValueError, AttributeError, TypeError) as err:
@@ -1218,17 +1259,41 @@ class MusicAssistant:
         async with _provider_load_step(domain, "initialize", PROVIDER_ASYNC_INIT_TIMEOUT):
             await provider.handle_async_init()
 
-        # if we reach this point, the provider loaded successfully
+        await self._register_loaded_provider(provider, conf)
+
+    async def _register_loaded_provider(
+        self, provider: ProviderInstanceType, conf: ProviderConfig
+    ) -> None:
+        """Register a provider that finished its setup and run its post-load steps."""
+        # the instance is now live: register it so the post-load steps below can resolve it
         self._providers[provider.instance_id] = provider
+        provider.available = True
+
+        # adapt logging name if needed
+        provider._set_log_level_from_config(provider.config)
+
+        try:
+            async with _provider_load_step(
+                provider.domain, "finish loading", PROVIDER_SETUP_TIMEOUT
+            ):
+                await self._update_available_providers_cache()
+                if isinstance(provider, MusicProvider):
+                    await self.music.on_provider_loaded(provider)
+                if isinstance(provider, PlayerProvider):
+                    await self.players.on_provider_loaded(provider)
+        except Exception:
+            # a provider that did not finish loading must not stay registered: it would
+            # report status LOADED while an error is recorded against it, which leaves the
+            # user with a warning they can only find by opening the provider's own settings
+            await self.unload_provider(provider.instance_id)
+            raise
+
+        # if we reach this point, the provider loaded successfully
         LOGGER.info(
             "Loaded %s provider %s",
             provider.type.value,
             provider.name,
         )
-        provider.available = True
-
-        # adapt logging name if needed
-        provider._set_log_level_from_config(provider.config)
 
         # execute post load actions
         async def _on_provider_loaded() -> None:
@@ -1245,11 +1310,6 @@ class MusicAssistant:
         # clear any previous error in config and signal update
         self.config.set(f"{CONF_PROVIDERS}/{conf.instance_id}/last_error", None)
         self.signal_event(EventType.PROVIDERS_UPDATED, data=self.get_providers())
-        await self._update_available_providers_cache()
-        if isinstance(provider, MusicProvider):
-            await self.music.on_provider_loaded(provider)
-        if isinstance(provider, PlayerProvider):
-            await self.players.on_provider_loaded(provider)
 
     async def __load_provider_manifests(self) -> None:
         """Preload all available provider manifest files."""

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -1285,7 +1285,16 @@ class MusicAssistant:
             # a provider that did not finish loading must not stay registered: it would
             # report status LOADED while an error is recorded against it, which leaves the
             # user with a warning they can only find by opening the provider's own settings
-            await self.unload_provider(provider.instance_id)
+            try:
+                await self.unload_provider(provider.instance_id)
+            except Exception as unload_err:
+                # the load failure is the one worth reporting, so keep it as the raised error
+                LOGGER.warning(
+                    "Error unloading provider %s: %s",
+                    provider.name,
+                    unload_err,
+                    exc_info=unload_err,
+                )
             raise
 
         # if we reach this point, the provider loaded successfully

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -58,7 +58,12 @@ from music_assistant.constants import (
     VERBOSE_LOG_LEVEL,
 )
 from music_assistant.controllers.cache import use_cache
-from music_assistant.helpers.util import infer_album_type, install_package, parse_title_and_version
+from music_assistant.helpers.util import (
+    import_module_in_thread,
+    infer_album_type,
+    install_package,
+    parse_title_and_version,
+)
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.models.recommendation_payload import RecommendationPayloadMixin
 
@@ -1224,6 +1229,6 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
             await install_package(package_name)
         # verify if the yt_dlp package is usable
         try:
-            await asyncio.to_thread(importlib.import_module, "yt_dlp")
+            await import_module_in_thread("yt_dlp")
         except ImportError:
             raise SetupFailedError("Package yt_dlp failed to install")

--- a/tests/controllers/config/test_provider_config_load.py
+++ b/tests/controllers/config/test_provider_config_load.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from music_assistant_models.config_entries import ConfigEntry, ProviderConfig, ProviderError
 from music_assistant_models.enums import ConfigEntryType, ProviderStatus, ProviderType
-from music_assistant_models.errors import LoginFailed
+from music_assistant_models.errors import LoginFailed, SetupFailedError
 
 from music_assistant.constants import CONF_PROVIDERS
 from music_assistant.controllers.config.helpers import _provider_status
@@ -72,6 +72,26 @@ async def test_failed_reload_records_auth_error(mass_minimal: MusicAssistant) ->
     prov_conf = _prov_conf(instance)
     prov_conf.last_error = ProviderError.from_dict(stored)
     assert _provider_status(prov_conf, is_loaded=False) == ProviderStatus.AUTH_REQUIRED
+
+
+async def test_failed_post_load_step_unloads_the_provider(mass_minimal: MusicAssistant) -> None:
+    """A provider that fails to finish loading is unloaded, so it can never read as loaded."""
+    instance = "spotify--test"
+    provider = MagicMock()
+    provider.instance_id = instance
+    provider.domain = "spotify"
+    with (
+        patch.object(
+            mass_minimal,
+            "_update_available_providers_cache",
+            AsyncMock(side_effect=TimeoutError),
+        ),
+        patch.object(mass_minimal, "unload_provider", AsyncMock()) as mock_unload,
+        pytest.raises(SetupFailedError, match="timed out while trying to finish loading"),
+    ):
+        await mass_minimal._register_loaded_provider(provider, _prov_conf(instance))
+
+    mock_unload.assert_awaited_once_with(instance)
 
 
 async def test_save_preserves_unknown_stored_values(mass_minimal: MusicAssistant) -> None:

--- a/tests/controllers/config/test_provider_status.py
+++ b/tests/controllers/config/test_provider_status.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+
+import pytest
 from music_assistant_models.config_entries import ProviderConfig, ProviderError
 from music_assistant_models.enums import ProviderStatus, ProviderType
 from music_assistant_models.errors import (
@@ -12,7 +15,7 @@ from music_assistant_models.errors import (
 )
 
 from music_assistant.controllers.config.helpers import _provider_status
-from music_assistant.mass import _provider_error_from_exc
+from music_assistant.mass import _provider_error_from_exc, _provider_load_step
 
 
 def _conf(*, enabled: bool = True, last_error: ProviderError | None = None) -> ProviderConfig:
@@ -45,6 +48,14 @@ def test_provider_status_derivation() -> None:
     )
 
 
+def test_recorded_error_is_reported_for_a_loaded_provider() -> None:
+    """A loaded provider carrying an error still reports it, so the UI can flag it."""
+    err = ProviderError(error_code=SetupFailedError.error_code, message="boom")
+    assert _provider_status(_conf(last_error=err), is_loaded=True) == ProviderStatus.ERROR
+    auth = ProviderError(error_code=AuthenticationRequired.error_code, message="auth")
+    assert _provider_status(_conf(last_error=auth), is_loaded=True) == ProviderStatus.AUTH_REQUIRED
+
+
 def test_provider_error_from_exc() -> None:
     """A MusicAssistantError keeps its code/translation_key; other exceptions get code 999."""
     err = _provider_error_from_exc(LoginFailed("bad creds"))
@@ -55,3 +66,34 @@ def test_provider_error_from_exc() -> None:
     assert generic.error_code == 999
     assert generic.message == "oops"
     assert generic.translation_key is None
+
+
+async def test_load_step_names_the_step_that_timed_out() -> None:
+    """A step that overruns its bound fails with a message naming step and bound."""
+    with pytest.raises(SetupFailedError, match="did not initialize within 0 seconds"):
+        async with _provider_load_step("demo", "initialize", 0):
+            await asyncio.sleep(5)
+
+
+async def test_load_step_separates_an_inner_timeout_from_its_own_bound() -> None:
+    """A bare TimeoutError from the provider's own code is not blamed on the bound."""
+    with pytest.raises(SetupFailedError, match="timed out while trying to load"):
+        async with _provider_load_step("demo", "load", 30):
+            raise TimeoutError
+
+
+async def test_load_step_names_the_step_for_a_message_less_error() -> None:
+    """An exception without a message is not surfaced as just its class name."""
+    with pytest.raises(SetupFailedError, match="failed to load: KeyError"):
+        async with _provider_load_step("demo", "load", 30):
+            raise KeyError
+
+
+async def test_load_step_leaves_informative_errors_alone() -> None:
+    """Errors that carry a message of their own are passed through untouched."""
+    with pytest.raises(LoginFailed, match="bad creds"):
+        async with _provider_load_step("demo", "load", 30):
+            raise LoginFailed("bad creds")
+    with pytest.raises(ValueError, match="oops"):
+        async with _provider_load_step("demo", "load", 30):
+            raise ValueError("oops")

--- a/tests/controllers/config/test_provider_status.py
+++ b/tests/controllers/config/test_provider_status.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import patch
 
 import pytest
 from music_assistant_models.config_entries import ProviderConfig, ProviderError
@@ -15,7 +16,11 @@ from music_assistant_models.errors import (
 )
 
 from music_assistant.controllers.config.helpers import _provider_status
-from music_assistant.mass import _provider_error_from_exc, _provider_load_step
+from music_assistant.mass import (
+    _provider_error_from_exc,
+    _provider_error_traceback,
+    _provider_load_step,
+)
 
 
 def _conf(*, enabled: bool = True, last_error: ProviderError | None = None) -> ProviderConfig:
@@ -66,6 +71,17 @@ def test_provider_error_from_exc() -> None:
     assert generic.error_code == 999
     assert generic.message == "oops"
     assert generic.translation_key is None
+
+
+def test_traceback_logged_for_unexpected_errors_only() -> None:
+    """Without verbose logging, only unexpected errors are worth a traceback."""
+    with patch("music_assistant.mass.LOGGER.isEnabledFor", return_value=False):
+        assert _provider_error_traceback(LoginFailed("bad creds")) is None
+        unexpected = ValueError("oops")
+        assert _provider_error_traceback(unexpected) is unexpected
+        wrapped = SetupFailedError("timed out while trying to load")
+        wrapped.__cause__ = TimeoutError()
+        assert _provider_error_traceback(wrapped) is wrapped
 
 
 async def test_load_step_names_the_step_that_timed_out() -> None:

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -151,6 +151,36 @@ class TestImportModuleInThread:
 
         assert max_in_flight == 1
 
+    @pytest.mark.asyncio
+    async def test_module_lock_collision_is_retried_once(self) -> None:
+        """A deadlock reported by the import machinery is retried, not passed on."""
+        module = MagicMock()
+        attempts = 0
+
+        def _import(*_args: object) -> MagicMock:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("deadlock detected by _ModuleLock('requests.structures')")
+            return module
+
+        with patch("music_assistant.helpers.util.importlib.import_module", _import):
+            assert await import_module_in_thread("some_module") is module
+        assert attempts == 2
+
+    @pytest.mark.asyncio
+    async def test_other_runtime_errors_are_not_retried(self) -> None:
+        """An unrelated RuntimeError from the module body is passed on as-is."""
+        with (
+            patch(
+                "music_assistant.helpers.util.importlib.import_module",
+                side_effect=RuntimeError("boom"),
+            ) as import_mock,
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            await import_module_in_thread("some_module")
+        assert import_mock.call_count == 1
+
 
 class TestLoadProviderModule:
     """load_provider_module verifies pinned requirements before importing the provider."""

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -11,6 +11,7 @@ import pytest
 from music_assistant.helpers import util
 from music_assistant.helpers.util import (
     get_source_ip_for_target,
+    import_module_in_thread,
     is_port_in_use,
     load_provider_module,
     sanitize_http_header_value,
@@ -121,6 +122,34 @@ class TestIsPortInUse:
             await is_port_in_use(38800, host=host)
         socket_mock.assert_called_once_with(family, socket.SOCK_STREAM)
         socket_mock.return_value.__enter__.return_value.bind.assert_called_once_with((host, 38800))
+
+
+class TestImportModuleInThread:
+    """import_module_in_thread imports off the event loop, one import at a time."""
+
+    @pytest.mark.asyncio
+    async def test_module_is_returned(self) -> None:
+        """A relative module name is resolved against the given package."""
+        assert await import_module_in_thread(".util", "music_assistant.helpers") is util
+
+    @pytest.mark.asyncio
+    async def test_concurrent_imports_are_serialized(self) -> None:
+        """Concurrent calls never have two imports in flight (which can deadlock)."""
+        in_flight = 0
+        max_in_flight = 0
+
+        def _slow_import(*_args: object) -> MagicMock:
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            time.sleep(0.05)
+            in_flight -= 1
+            return MagicMock()
+
+        with patch("music_assistant.helpers.util.importlib.import_module", _slow_import):
+            await asyncio.gather(*(import_module_in_thread(f"module_{idx}") for idx in range(5)))
+
+        assert max_in_flight == 1
 
 
 class TestLoadProviderModule:


### PR DESCRIPTION
# What does this implement/fix?

On the recent nightlies a provider could fail to load at startup for no clear reason, and the home
page warned that a provider needs attention while the providers list showed nothing wrong - the
only way to find the culprit was opening every provider's settings page in turn.

- Provider modules were imported from up to 8 threads at once. Python locks imports per module, so
  two providers pulling in the same library could end up waiting on each other, and one of them
  failed to load. Imports now run one at a time; providers still load in parallel and startup is
  no slower.
- A provider that hit a problem in the last step of its load stayed marked as loaded, so the
  providers list had nothing to flag. It is unloaded again now, and the error always shows up in
  the list.
- A provider that failed to load was reported on the provider it depends on, pointing at the wrong
  one. The error is recorded on the provider that actually hit it.
- Failures that carry no message of their own no longer show up as just "TimeoutError": every load
  step is named, so the error says what the provider was busy with, and unexpected failures write
  a full traceback to the log.
- Providers now get 120 seconds instead of 30 to load, since several load at the same time, and a
  provider that hits a temporary problem is retried automatically instead of staying broken until
  you press Reload.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
