### PR TITLE
Check out the base branch, and never post a bare mention

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -43,12 +43,6 @@ jobs:
       - name: ⤵️ Check out the base branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # The branch, not base.sha. base.sha is the base tip as of the last time the pull
-          # request was synchronised, which for an open pull request can be weeks old — so the
-          # checks that ran were whichever version existed when the contributor last rebased,
-          # and a check added since then is simply absent. Checking out the branch keeps the
-          # same guarantee (only ever the base, never the contributor's code) while making the
-          # current rules apply to every pull request.
           ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -43,7 +43,13 @@ jobs:
       - name: ⤵️ Check out the base branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          # The branch, not base.sha. base.sha is the base tip as of the last time the pull
+          # request was synchronised, which for an open pull request can be weeks old — so the
+          # checks that ran were whichever version existed when the contributor last rebased,
+          # and a check added since then is simply absent. Checking out the branch keeps the
+          # same guarantee (only ever the base, never the contributor's code) while making the
+          # current rules apply to every pull request.
+          ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 
       - name: 📝 Check the title and description
@@ -107,7 +113,19 @@ jobs:
             const sticky = comments.find(c =>
               c.body?.includes(marker) && c.user?.login === process.env.EXPECTED_APP_BOT_LOGIN);
 
-            const report = fs.readFileSync('report.md', 'utf8').trim();
+            const report = fs.existsSync('report.md')
+              ? fs.readFileSync('report.md', 'utf8').trim()
+              : '';
+
+            // A failure with nothing to report means the check step itself broke rather than
+            // finding problems with the pull request. "@author" and no message tells the author
+            // nothing and reads as a stray ping, so say nothing here and let the job failure
+            // carry it to whoever maintains the workflow.
+            if (failed && !report) {
+              core.setFailed('The check step produced no report; not commenting.');
+              return;
+            }
+
             const body = failed
               ? `${marker}\n@${author} ${report}`
               : `${marker}\n✅ The title and description are good to go. Thanks!`;


### PR DESCRIPTION
Two problems, both visible on #5158, where the bot commented "@Odn0" and nothing else.

The workflow checked out github.event.pull_request.base.sha. That is the base tip as of the last time a pull request was synchronised, not the current base: for the 54 open pull requests whose base predates this check being added earlier today, scripts/check_pr_metadata.py simply does not exist in the tree that gets checked out. The step then fails with "No module named scripts.check_pr_metadata" rather than with findings.

More generally it meant every pull request was validated by whichever version of the checker existed when its author last rebased, so a rule added or corrected here would not reach an open pull request until that branch was updated. Checking out base.ref keeps the guarantee the original comment describes — only ever the base branch, never the contributor's code — while making the current rules apply everywhere.

The second problem is what the comment step does with that failure. report.md is empty when the check crashes rather than finding problems, and the body is built as `@author ${report}`, so the author gets mentioned with no message and no way to know what is wanted. Treat an empty report as a broken check: say nothing on the pull request and fail the job so it surfaces to whoever maintains this workflow instead. Also tolerate report.md being absent rather than throwing.

# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
