### PR TITLE
Add Dutch to Alexa language commands

### DIFF
--- a/music_assistant/providers/alexa/__init__.py
+++ b/music_assistant/providers/alexa/__init__.py
@@ -55,7 +55,7 @@ ALEXA_LANGUAGE_COMMANDS = {
     "play_audio_fr-FR": "music assistant",
     "play_audio_it-IT": "chiedi a music assistant di riprodurre audio",
     "play_audio_pt-BR": "peça ao music assistant para reproduzir áudio",
-    "play_audio_nl-NL": "vraag music assistant om audio af te spelen",
+    "play_audio_nl-NL": "speel audio af op music assistant",
     "play_audio_default": "ask music assistant to play audio",
 }
 

--- a/music_assistant/providers/alexa/__init__.py
+++ b/music_assistant/providers/alexa/__init__.py
@@ -55,6 +55,7 @@ ALEXA_LANGUAGE_COMMANDS = {
     "play_audio_fr-FR": "music assistant",
     "play_audio_it-IT": "chiedi a music assistant di riprodurre audio",
     "play_audio_pt-BR": "peça ao music assistant para reproduzir áudio",
+    "play_audio_nl-NL": "vraag music assistant om audio af te spelen",
     "play_audio_default": "ask music assistant to play audio",
 }
 
@@ -405,6 +406,7 @@ class AlexaProvider(PlayerProvider):
                     ConfigValueOption("fr-CA"),
                     ConfigValueOption("it-IT"),
                     ConfigValueOption("pt-BR"),
+                    ConfigValueOption("nl-NL"),
                 ],
                 default_value="en-US",  # choose a sensible default
             ),

--- a/music_assistant/providers/alexa/strings.json
+++ b/music_assistant/providers/alexa/strings.json
@@ -33,6 +33,7 @@
         "fr-CA": "French (Canada)",
         "it-IT": "Italian (Italy)",
         "pt-BR": "Portuguese (Brazil)"
+        "nl-NL": "Portuguese (Brazil)"
       }
     }
   },

--- a/music_assistant/providers/alexa/strings.json
+++ b/music_assistant/providers/alexa/strings.json
@@ -33,7 +33,7 @@
         "fr-CA": "French (Canada)",
         "it-IT": "Italian (Italy)",
         "pt-BR": "Portuguese (Brazil)"
-        "nl-NL": "Portuguese (Brazil)"
+        "nl-NL": "Dutch (Netherlands)"
       }
     }
   },

--- a/music_assistant/providers/alexa/strings.json
+++ b/music_assistant/providers/alexa/strings.json
@@ -32,7 +32,7 @@
         "fr-FR": "French (France)",
         "fr-CA": "French (Canada)",
         "it-IT": "Italian (Italy)",
-        "pt-BR": "Portuguese (Brazil)"
+        "pt-BR": "Portuguese (Brazil)",
         "nl-NL": "Dutch (Netherlands)"
       }
     }

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -860,6 +860,7 @@
   "provider.alexa.config_entries.alexa_language.options.fr-CA": "French (Canada)",
   "provider.alexa.config_entries.alexa_language.options.fr-FR": "French (France)",
   "provider.alexa.config_entries.alexa_language.options.it-IT": "Italian (Italy)",
+  "provider.alexa.config_entries.alexa_language.options.nl-NL": "Dutch (Netherlands)",
   "provider.alexa.config_entries.alexa_language.options.pt-BR": "Portuguese (Brazil)",
   "provider.alexa.config_entries.api_password.label": "API Basic Auth Password",
   "provider.alexa.config_entries.api_url.label": "API Url",


### PR DESCRIPTION
# What does this implement/fix?

Adds Dutch (nl-NL) as a selectable language for the Alexa player provider.

- Adds `play_audio_nl-NL` to `ALEXA_LANGUAGE_COMMANDS` so Music Assistant
  speaks the correct Dutch trigger phrase to invoke the skill on nl-NL Echo
  devices.
- Adds `nl-NL` to the language `ConfigEntry` options in `get_config_entries()`.
- Adds the Dutch label to `strings.json` (and the regenerated translation source).

Follows the same pattern as the earlier Spanish/Italian language addition.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's AI Policy for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.