### PR TITLE
Fix AirPlay noise bursts and group sync issues on Apple devices

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -75,6 +75,17 @@ AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 2000
 # shared instant out to every member.
 AIRPLAY_START_LEAD_MS: Final[int] = 250
 AIRPLAY_GROUP_START_LEAD_MS: Final[int] = 500
+# Cold GROUP starts anchor further out: a receiver on a brand-new session
+# still acquires its PTP slave lock (~1.7-2.3 s measured on Sonos) and cannot
+# render at an anchor inside that window - it starts late and the group opens
+# audibly out of sync. Warm re-anchors reuse a locked clock and keep the
+# short leads above; solo cold starts have no sync partner to miss.
+AIRPLAY_COLD_GROUP_START_LEAD_MS: Final[int] = 2500
+# Margin added on top of a member's reported warm lead (the splice-timeline
+# queue depth on Apple receivers) when anchoring a warm re-start: covers the
+# command round-trips between the flush acks and the shared START so every
+# member's skip target lands beyond its queued audio.
+AIRPLAY_SPLICE_LEAD_MARGIN_MS: Final[int] = 150
 
 # Delay (seconds) before automatically re-joining a group member whose
 # cliairplay process died unexpectedly mid-session (e.g. the device rode out a
@@ -146,3 +157,8 @@ LEGACY_PAIRING_BIT = 0x200
 # raised at all times (it marks their onscreen-code capability, not a password),
 # so this is the only flags-based password signal they give.
 ATV_PASSWORD_BIT = 0x1000
+
+# Provider setting: opt-in for the shared PTP daemon's per-packet timing trace
+# (Announce/Sync/Follow_Up) when verbose logging is active. Off by default —
+# the trace floods the log and only matters for clock-sync debugging.
+CONF_VERBOSE_PTP_LOGGING: Final[str] = "verbose_ptp_logging"

--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -678,7 +678,26 @@ class AirPlayControlPlayer(AirPlayPlayer):
     @property
     def _stream_active(self) -> bool:
         """Return whether Music Assistant is actively streaming to this device."""
-        return bool((stream := getattr(self, "stream", None)) and stream.running)
+        active = bool((stream := getattr(self, "stream", None)) and stream.running)
+        if active:
+            self._stream_last_active = time.monotonic()
+        return active
+
+    @property
+    def _external_state_blocked(self) -> bool:
+        """
+        Return whether externally observed playback state must be ignored.
+
+        While Music Assistant streams to this device, the stream is the SOLE
+        authority on player state. The check extends a grace period past a
+        stream's end because a warm-to-cold fallback briefly tears the stream
+        down mid-playback: a Companion/MRP update slipping through that window
+        applies the device's view of our own dying session as an "external
+        source", freezing the UI on a stale snapshot.
+        """
+        if self._stream_active:
+            return True
+        return time.monotonic() - getattr(self, "_stream_last_active", 0.0) < 15.0
 
     @property
     def _mrp_endpoint(self) -> tuple[AsyncServiceInfo, Protocol] | None:
@@ -1052,7 +1071,7 @@ class AirPlayControlPlayer(AirPlayPlayer):
 
     def _handle_playing_update(self, playing: Playing) -> None:
         """Apply external playback state received over the MRP tunnel."""
-        if self._stream_active:
+        if self._external_state_blocked:
             return
         app = self._mrp_device.metadata.app if self._mrp_device else None
         playback_state = {
@@ -1111,6 +1130,11 @@ class AirPlayControlPlayer(AirPlayPlayer):
 
     def _ensure_source(self, source_id: str, source_name: str) -> None:
         """Add a passive source reported by MRP playback monitoring."""
+        # Track external ids so the stream can reclaim the device state from a
+        # leaked external snapshot (see AirPlayPlayer.set_state_from_stream).
+        if not hasattr(self, "_external_source_ids"):
+            self._external_source_ids: set[str] = set()
+        self._external_source_ids.add(source_id)
         can_play_pause = bool(
             self._device_for_feature(FeatureName.Play)
             or self._device_for_feature(FeatureName.Pause)

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -684,9 +684,7 @@ class AirPlayPlayer(Player):
         # view while we stream. While MA streams, the stream is the sole
         # authority on this player's state.
         active_source = getattr(self, "_attr_active_source", None)
-        if active_source is not None and active_source in getattr(
-            self, "_external_source_ids", ()
-        ):
+        if active_source is not None and active_source in getattr(self, "_external_source_ids", ()):
             media = getattr(self, "_attr_current_media", None)
             if media is not None and media.source_id == active_source:
                 self._attr_current_media = None

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -678,6 +678,19 @@ class AirPlayPlayer(Player):
         # Ignore state updates from old/stale streams
         if stream is not None and stream != self.stream:
             return
+        # The stream reclaims the device: an external (Companion-observed)
+        # source snapshot can leak in during a brief stream-restart window and
+        # would otherwise stick, freezing the UI on a stale "external source"
+        # view while we stream. While MA streams, the stream is the sole
+        # authority on this player's state.
+        active_source = getattr(self, "_attr_active_source", None)
+        if active_source is not None and active_source in getattr(
+            self, "_external_source_ids", ()
+        ):
+            media = getattr(self, "_attr_current_media", None)
+            if media is not None and media.source_id == active_source:
+                self._attr_current_media = None
+            self._attr_active_source = None
         if state is not None:
             self._attr_playback_state = state
         if elapsed_time is not None:

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -12,7 +12,8 @@ from contextlib import suppress
 from ipaddress import IPv4Address, IPv6Address, ip_address
 from typing import TYPE_CHECKING, Final, cast
 
-from music_assistant_models.enums import PlaybackState
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType, PlaybackState
 from music_assistant_models.errors import MediaNotFoundError
 from zeroconf import NonUniqueNameException, ServiceStateChange
 from zeroconf.asyncio import AsyncServiceInfo
@@ -39,6 +40,7 @@ from .constants import (
     COMPANION_DISCOVERY_TYPE,
     CONF_IGNORE_VOLUME,
     CONF_STORED_VOLUME,
+    CONF_VERBOSE_PTP_LOGGING,
     DACP_DISCOVERY_TYPE,
     EXTERNAL_ARTWORK_PATH_PREFIX,
     FALLBACK_VOLUME,
@@ -60,7 +62,7 @@ from .player import AirPlayPlayer, GenericAirPlayPlayer
 from .sendspin_bridge import SendspinBridgeManager
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
+    from music_assistant_models.config_entries import ProviderConfig
 
 # Marker the `cliairplay --ptp-daemon` process prints once it has bound the
 # privileged PTP ports (UDP 319/320) and opened its control channel. Until this
@@ -177,7 +179,15 @@ class AirPlayProvider(PlayerProvider):
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
-        return ()
+        return (
+            ConfigEntry(
+                key=CONF_VERBOSE_PTP_LOGGING,
+                type=ConfigEntryType.BOOLEAN,
+                default_value=False,
+                required=False,
+                advanced=True,
+            ),
+        )
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
@@ -762,10 +772,13 @@ class AirPlayProvider(PlayerProvider):
         bind_ip = str(self.mass.streams.bind_ip)
         if bind_ip not in ("0.0.0.0", "::", ""):
             args += ["--if", bind_ip]
-        # The daemon runs quiet by default; only a verbose session turns on its
-        # per-packet PTP tracing (Announce/Sync/Delay_Req), so a normal debug
-        # session does not flood the log with timing chatter.
-        if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+        # The daemon runs quiet by default: its per-packet PTP tracing
+        # (Announce/Sync/Delay_Req, ~10 lines/s) needs BOTH verbose logging and
+        # the dedicated opt-in, so ordinary verbose sessions are not flooded
+        # with timing chatter that only matters for clock-sync debugging.
+        if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL) and self.config.get_value(
+            CONF_VERBOSE_PTP_LOGGING
+        ):
             args += ["--debug", "10"]
         daemon = AsyncProcess(args, stdout=True, stderr=True, name="cliairplay-ptp-daemon")
         # (Re)gate readiness for this daemon instance: not ready until a reader

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -112,6 +112,16 @@ class AirPlayStream:
         self._connect_error: ConnectError | None = None
         # Set when the binary acknowledges an in-place FLUSH ([STATUS] flushed).
         self._flushed = asyncio.Event()
+        # Set when the binary acks a START ([STATUS] started); carries the
+        # (requested, actual) unix-ms pair. The binary corrects an infeasible
+        # instant FORWARD and always reports the truth, so a mismatch here is
+        # the self-verification signal for the start contract.
+        self._started = asyncio.Event()
+        self._start_ack: tuple[int, int] | None = None
+        # Receiver storm guard state: last-honored monotonic time per remote
+        # transport command, plus a counter of suppressed repeats.
+        self._remote_command_last: dict[str, float] = {}
+        self._remote_commands_suppressed: int = 0
         # Set when the binary reports the first audio bytes of the current
         # start cycle arriving on its stdin ([STATUS] audio). Together with
         # `connected` this makes readiness fully event-driven, so START can
@@ -134,6 +144,15 @@ class AirPlayStream:
         self.latency_lead_ms: int = 0
         self.device_min_frames: int = 0
         self.device_max_frames: int = 0
+        # Minimum lead (ms) a warm commanded START needs for exact placement.
+        # Nonzero on the Apple splice timeline, where the receiver's queued
+        # audio plays out before the new content can begin; a warm group
+        # anchor must sit beyond the largest member value. 0 = no constraint.
+        self.warm_lead_ms: int = 0
+        # Audible instant (unix ms) of the delivery head frozen by the latest
+        # warm flush, from the flushed ack (0 = none/no constraint). The warm
+        # START anchor must land beyond it for the splice skip to engage.
+        self.flushed_head_unix_ms: int = 0
         # Route the binary resolved for this stream (empty until reported),
         # e.g. "AirPlay 2 (native, PTP)" or "RAOP"
         self.active_route: str = ""
@@ -345,7 +364,7 @@ class AirPlayStream:
             return False
         return True
 
-    async def start(self, start_unix_ms: int = 0, position_ms: int = 0) -> None:
+    async def start(self, start_unix_ms: int = 0, position_ms: int = 0) -> int | None:
         """
         Anchor playback so the first pending stdin sample is audible at an instant.
 
@@ -357,6 +376,11 @@ class AirPlayStream:
             clamps to its minimum lead).
         :param position_ms: Media position mapped to that first sample, used as
             the base for elapsed reporting.
+        :return: The true scheduled audible instant (unix ms) from the binary's
+            started ack — the commanded instant when it was feasible, the
+            corrected-forward one otherwise; None when no ack arrived (older
+            binary), in which case the commanded instant was applied under the
+            legacy clamp semantics.
         :raises PlayerCommandFailed: If the START command cannot be delivered.
         """
         if not self.running or not self.connected:
@@ -371,6 +395,8 @@ class AirPlayStream:
         # the binary's first status arrives, interpolation would otherwise keep
         # extending the previous anchor's clock, briefly mapping a bogus position.
         self.player.set_state_from_stream(elapsed_time=self._start_position, stream=self)
+        self._started.clear()
+        self._start_ack = None
         async with self._metadata_lock:
             if not await self._write_cli_command(f"START_UNIX_MS={start_unix_ms}\nACTION=START"):
                 # Surfacing the dropped delivery lets the session fall back to a
@@ -388,6 +414,15 @@ class AirPlayStream:
             task_id=f"airplay_metadata_after_start_{self._stream_id}",
             abort_existing=True,
         )
+        # The binary always acks with the TRUE scheduled instant (correcting an
+        # infeasible one forward), so the caller can verify the contract and
+        # re-align a group. No ack within the timeout means an older binary:
+        # fall back to trusting the commanded instant (legacy clamp semantics).
+        try:
+            await asyncio.wait_for(self._started.wait(), 2.0)
+        except TimeoutError:
+            return None
+        return self._start_ack[1] if self._start_ack else None
 
     def reset_reanchor_shift(self) -> None:
         """Clear the accumulated re-anchor shift and its status-line supersession flag."""
@@ -696,6 +731,34 @@ class AirPlayStream:
                 "Ignoring unknown cliairplay remote command: %s", command_value
             )
             return
+        # Receiver storm guard: MediaRemote re-sends an unfulfilled transport
+        # command at ~10 Hz (measured on tvOS: a next-track storm at end of
+        # item drowned the whole server in seeks until playback collapsed).
+        # No human intends repeats that fast, so only one command per window
+        # is honored; the suppressed repeats are counted and reported loudly
+        # as the support signal.
+        window = (
+            2.0
+            if command in (AirPlayRemoteCommand.NEXT, AirPlayRemoteCommand.PREVIOUS)
+            else 0.5
+        )
+        now = time.monotonic()
+        last = self._remote_command_last.get(command_value, 0.0)
+        if now - last < window:
+            self._remote_commands_suppressed += 1
+            suppressed = self._remote_commands_suppressed
+            if suppressed in (1, 10) or suppressed % 100 == 0:
+                self.player.logger.warning(
+                    "Storm guard: suppressed %d repeated remote '%s' "
+                    "command(s) from %s within %.1fs",
+                    suppressed,
+                    command_value,
+                    self.player.display_name,
+                    window,
+                )
+            return
+        self._remote_command_last[command_value] = now
+        self._remote_commands_suppressed = 0
         prov = cast("AirPlayProvider", self.prov)
         prov.handle_remote_command(self.player, command)
 
@@ -757,6 +820,7 @@ class AirPlayStream:
             self.latency_lead_ms = int(fields.get("lead_ms", 0))
             self.device_min_frames = int(fields.get("device_min_frames", 0))
             self.device_max_frames = int(fields.get("device_max_frames", 0))
+            self.warm_lead_ms = int(fields.get("warm_lead_ms", 0))
         except ValueError:
             return
         self.player.logger.debug(
@@ -880,7 +944,43 @@ class AirPlayStream:
                 self._update_elapsed(millis / 1000)
         elif "[STATUS] paused" in line:
             player.set_state_from_stream(state=PlaybackState.PAUSED, stream=self)
+        elif "[STATUS] started " in line:
+            try:
+                fields = dict(part.split("=", 1) for part in line.split() if "=" in part)
+                requested = int(fields.get("requested_unix_ms", 0))
+                actual = int(fields.get("at_unix_ms", 0))
+            except ValueError, IndexError:
+                pass
+            else:
+                self._start_ack = (requested, actual)
+                if requested and actual and abs(actual - requested) > 2:
+                    # Loud on purpose: the commanded instant was infeasible and
+                    # the binary corrected it forward. The session re-aligns
+                    # the group from these acks; repeated corrections are the
+                    # support signal that leads/readiness need attention.
+                    player.logger.warning(
+                        "AirPlay start corrected by %+d ms on %s "
+                        "(requested %d, scheduled %d)",
+                        actual - requested,
+                        player.display_name,
+                        requested,
+                        actual,
+                    )
+                self._started.set()
         elif "[STATUS] flushed" in line:
+            # A splice-timeline member reports the audible instant of its
+            # frozen delivery head; the warm START must anchor beyond it (a
+            # commanded instant at or behind the head splices at the head,
+            # silently breaking the shared instant).
+            if "head_unix_ms=" in line:
+                try:
+                    self.flushed_head_unix_ms = int(
+                        line.split("head_unix_ms=")[1].split(maxsplit=1)[0]
+                    )
+                except ValueError, IndexError:
+                    self.flushed_head_unix_ms = 0
+            else:
+                self.flushed_head_unix_ms = 0
             self._flushed.set()
         elif "[STATUS] audio " in line:
             self._audio_present.set()

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -738,9 +738,7 @@ class AirPlayStream:
         # is honored; the suppressed repeats are counted and reported loudly
         # as the support signal.
         window = (
-            2.0
-            if command in (AirPlayRemoteCommand.NEXT, AirPlayRemoteCommand.PREVIOUS)
-            else 0.5
+            2.0 if command in (AirPlayRemoteCommand.NEXT, AirPlayRemoteCommand.PREVIOUS) else 0.5
         )
         now = time.monotonic()
         last = self._remote_command_last.get(command_value, 0.0)
@@ -959,8 +957,7 @@ class AirPlayStream:
                     # the group from these acks; repeated corrections are the
                     # support signal that leads/readiness need attention.
                     player.logger.warning(
-                        "AirPlay start corrected by %+d ms on %s "
-                        "(requested %d, scheduled %d)",
+                        "AirPlay start corrected by %+d ms on %s (requested %d, scheduled %d)",
                         actual - requested,
                         player.display_name,
                         requested,

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -524,9 +524,7 @@ class AirPlayStreamSession:
                         airplay_player.player_id,
                         (actual - adjust_ms) - start_unix_ms,
                     )
-                    start_at, fed_pos_due, prime, skip_bytes = map_to(
-                        (actual - adjust_ms) / 1000
-                    )
+                    start_at, fed_pos_due, prime, skip_bytes = map_to((actual - adjust_ms) / 1000)
                     self._client_skip_bytes[airplay_player.player_id] = skip_bytes
                 if prime:
                     await self._write_chunk_to_player(airplay_player, prime)
@@ -814,15 +812,11 @@ class AirPlayStreamSession:
                 continue
             sync_adjust = player.config.get_value(CONF_SYNC_ADJUST, 0)
             adjust_ms = sync_adjust if isinstance(sync_adjust, int) else 0
-            member_requirement = max(
-                member_requirement, stream.warm_lead_ms - min(0, adjust_ms)
-            )
+            member_requirement = max(member_requirement, stream.warm_lead_ms - min(0, adjust_ms))
         if member_requirement > 0:
             anchor = max(
                 anchor,
-                int(time.time() * 1000)
-                + member_requirement
-                + AIRPLAY_SPLICE_LEAD_MARGIN_MS,
+                int(time.time() * 1000) + member_requirement + AIRPLAY_SPLICE_LEAD_MARGIN_MS,
             )
         for player in self.sync_clients:
             stream = player.stream

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncGenerator
 from contextlib import suppress
 from typing import TYPE_CHECKING
 
-from music_assistant_models.enums import PlaybackState
+from music_assistant_models.enums import ContentType, PlaybackState
 from music_assistant_models.errors import MusicAssistantError, PlayerCommandFailed
 
 from music_assistant.constants import CONF_SYNC_ADJUST
@@ -16,8 +16,10 @@ from music_assistant.controllers.streams.audio_processing import get_media_sessi
 from music_assistant.helpers.ffmpeg import FFMpeg
 
 from .constants import (
+    AIRPLAY_COLD_GROUP_START_LEAD_MS,
     AIRPLAY_GROUP_START_LEAD_MS,
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
+    AIRPLAY_SPLICE_LEAD_MARGIN_MS,
     AIRPLAY_START_LEAD_MS,
     StreamingProtocol,
 )
@@ -78,10 +80,30 @@ class AirPlayStreamSession:
         # (the binary's ring cap of latency+2s plus the ~2s receiver buffer)
         # with enough slack left to prime the joiner.
         self._pcm_buffer = bytearray()
-        self._pcm_buffer_max = pcm_format.pcm_sample_size * 10  # 10 seconds
+        # Raw byte sizes of the PCM actually on the wire. At 24-bit the binary
+        # is fed s32le carriers (bit_depth stays 24 for the ALAC encode), so
+        # sizes MUST come from the content type: bit_depth-derived sizes are
+        # 6 bytes/frame while the wire frames are 8 — slicing or timing the
+        # feed on those boundaries cuts mid-sample (loud noise on a late
+        # joiner's prime) and inflates the position clock by 4/3.
+        bytes_per_sample = {
+            ContentType.PCM_S16LE: 2,
+            ContentType.PCM_S24LE: 3,
+            ContentType.PCM_S32LE: 4,
+            ContentType.PCM_F32LE: 4,
+        }.get(pcm_format.content_type, pcm_format.bit_depth // 8)
+        self._pcm_frame_size = bytes_per_sample * pcm_format.channels
+        self._pcm_byte_rate = self._pcm_frame_size * pcm_format.sample_rate
+        self._pcm_buffer_max = self._pcm_byte_rate * 10  # 10 seconds
         # Bytes still to skip off the head of the live feed for a late joiner
         # whose anchor lands ahead of the current write head, keyed by player id.
         self._client_skip_bytes: dict[str, int] = {}
+        # Cumulative bytes fed to the members (absolute stream coordinate of
+        # the write head). Source chunking makes no frame-alignment promise,
+        # so any slice or skip of the live feed must be aligned against THIS
+        # counter — aligning lengths in isolation can still land mid-sample,
+        # which a joiner renders as pure static.
+        self._pcm_total_fed: int = 0
 
     @property
     def effective_start_time(self) -> float:
@@ -207,6 +229,7 @@ class AirPlayStreamSession:
             # The stream position counter and the late-join prime buffer both
             # describe the OLD timeline; restart them before the new source pumps.
             self.seconds_streamed = 0
+            self._pcm_total_fed = 0
             self._pcm_buffer.clear()
             # The shared START below re-establishes start_time, so the per-client
             # late-join skip counters and every member's accumulated starvation
@@ -218,7 +241,7 @@ class AirPlayStreamSession:
             # the live connection and clock survive the flush, so a short
             # re-anchor lead replaces the full setup lead.
             await self._wait_members_audio_present()
-            await self._start_members(position_ms, self._anchor_start_unix_ms())
+            await self._start_members(position_ms, self._anchor_start_unix_ms(warm=True))
         except asyncio.CancelledError:
             raise
         except Exception as err:
@@ -268,6 +291,7 @@ class AirPlayStreamSession:
             player.set_state_from_stream(state=PlaybackState.PAUSED, stream=stream)
         # a parked session has no live timeline; the resume re-anchors it
         self.seconds_streamed = 0
+        self._pcm_total_fed = 0
         self._pcm_buffer.clear()
         self._client_skip_bytes.clear()
         self._reset_member_shifts()
@@ -376,65 +400,95 @@ class AirPlayStreamSession:
                 await self.stop_client(airplay_player, reason="session ended during late join")
                 return
             now = time.time()
-            pcm_sample_size = self.pcm_format.pcm_sample_size
-            frame_size = (self.pcm_format.bit_depth // 8) * self.pcm_format.channels
-            # Snapshot the ring buffer and map its span onto stream positions:
-            # it covers [seconds_streamed - buffer_seconds, seconds_streamed].
-            buffered_pcm = bytes(self._pcm_buffer)
-            buffer_seconds = len(buffered_pcm) / pcm_sample_size
-            ring_floor = self.seconds_streamed - buffer_seconds
+            pcm_sample_size = self._pcm_byte_rate
+            frame_size = self._pcm_frame_size
+            effective_start_time = self.effective_start_time
+
+            def map_to(anchor_at: float) -> tuple[float, float, bytes, int]:
+                """
+                Map an anchor instant onto the live feed.
+
+                Snapshots the ring and derives which stream position the group
+                plays at ``anchor_at``, returning the (possibly ring-capped)
+                anchor, the due feed position, the prime slice and the live
+                skip. Called again with the binary's TRUE scheduled instant
+                when it corrected the anchor forward, so the fed content
+                always matches where the joiner actually starts.
+                """
+                # Snapshot the ring and map its span onto stream positions:
+                # it covers [seconds_streamed - buffer_seconds, seconds_streamed].
+                buffered_pcm = bytes(self._pcm_buffer)
+                buffer_seconds = len(buffered_pcm) / pcm_sample_size
+                ring_floor = self.seconds_streamed - buffer_seconds
+                due = anchor_at - effective_start_time
+                skip = 0
+                prime_slice = b""
+                if due <= self.seconds_streamed:
+                    # The due position is at or behind the write head: prime
+                    # the joiner from the ring so the live feed then continues
+                    # seamlessly.
+                    if due < ring_floor:
+                        # The due position predates the ring (an unusually
+                        # large lead). Cap the prime at the whole buffer and
+                        # grow the headroom so the anchor still maps to the
+                        # prime's first sample exactly.
+                        self.prov.logger.debug(
+                            "Late joiner %s: due position %.2fs predates the "
+                            "%.2fs ring; capping prime at the whole buffer",
+                            airplay_player.player_id,
+                            due,
+                            buffer_seconds,
+                        )
+                        due = ring_floor
+                        anchor_at = effective_start_time + due
+                    keep_bytes = int((self.seconds_streamed - due) * pcm_sample_size)
+                    # Frame-align the prime START in ABSOLUTE stream
+                    # coordinates. The prime must end exactly at the write head
+                    # (the live feed continues byte-contiguously from there),
+                    # so only the start may move: shift it forward to the next
+                    # frame boundary (dropping under one frame, ~23 us).
+                    start_abs = self._pcm_total_fed - keep_bytes
+                    realign = (frame_size - start_abs % frame_size) % frame_size
+                    keep_bytes -= realign
+                    if realign:
+                        self.prov.logger.debug(
+                            "Late joiner %s: prime start realigned +%d bytes "
+                            "(write head sits mid-frame)",
+                            airplay_player.player_id,
+                            realign,
+                        )
+                    if keep_bytes > 0:
+                        prime_slice = buffered_pcm[len(buffered_pcm) - keep_bytes :]
+                else:
+                    # The due position is ahead of the write head: skip that
+                    # many bytes off the head of the live feed so the joiner's
+                    # first delivered byte is the sample due at the anchor.
+                    skip = int((due - self.seconds_streamed) * pcm_sample_size)
+                    # The first delivered live byte must land on a frame
+                    # boundary in ABSOLUTE stream coordinates (round the skip
+                    # up, under one frame).
+                    first_abs = self._pcm_total_fed + skip
+                    skip += (frame_size - first_abs % frame_size) % frame_size
+                return anchor_at, due, prime_slice, skip
 
             # cliairplay makes the first post-START stdin byte audible exactly at
-            # the anchor and then freezes it (no catch-up), so pick the anchor
-            # first — far enough ahead that the device can connect and prime —
-            # then derive which stream position the group plays at that instant.
-            # min_headroom is the most conservative of the session lead, the
-            # joiner's own lead and the late-join floor.
+            # the anchor, so pick the anchor first — far enough ahead that the
+            # device can connect and prime — then derive the stream position due
+            # at that instant. min_headroom is the most conservative of the
+            # session lead, the joiner's own lead and the late-join floor; the
+            # binary corrects an infeasible anchor forward and the mapping is
+            # then redone from its verified instant.
             min_headroom = max(
                 self.wait_start,
                 airplay_player.wait_start / 1000,
                 AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000,
             )
-            start_at = now + min_headroom
-            effective_start_time = self.effective_start_time
-            fed_pos_due = start_at - effective_start_time
-
-            skip_bytes = 0
-            prime = b""
-            if fed_pos_due <= self.seconds_streamed:
-                # The due position is at or behind the write head: prime the
-                # joiner from the ring so the live feed then continues seamlessly.
-                if fed_pos_due < ring_floor:
-                    # The due position predates the ring (an unusually large
-                    # lead). Cap the prime at the whole buffer and grow the
-                    # headroom so the anchor still maps to the prime's first
-                    # sample exactly.
-                    self.prov.logger.debug(
-                        "Late joiner %s: due position %.2fs predates the %.2fs ring; "
-                        "capping prime at the whole buffer",
-                        airplay_player.player_id,
-                        fed_pos_due,
-                        buffer_seconds,
-                    )
-                    fed_pos_due = ring_floor
-                    start_at = effective_start_time + fed_pos_due
-                keep_bytes = int((self.seconds_streamed - fed_pos_due) * pcm_sample_size)
-                keep_bytes -= keep_bytes % frame_size
-                if keep_bytes:
-                    prime = buffered_pcm[len(buffered_pcm) - keep_bytes :]
-            else:
-                # The due position is ahead of the write head: skip that many
-                # bytes off the head of the live feed so the joiner's first
-                # delivered byte is the sample due at the anchor.
-                skip_bytes = int((fed_pos_due - self.seconds_streamed) * pcm_sample_size)
-                skip_bytes -= skip_bytes % frame_size
-
+            start_at, fed_pos_due, prime, skip_bytes = map_to(now + min_headroom)
             self._client_skip_bytes[airplay_player.player_id] = skip_bytes
 
             start_unix_ms = int(start_at * 1000)
             sync_adjust = airplay_player.config.get_value(CONF_SYNC_ADJUST, 0)
-            if isinstance(sync_adjust, int):
-                start_unix_ms += sync_adjust
+            adjust_ms = sync_adjust if isinstance(sync_adjust, int) else 0
             position_ms = int(((self.media.elapsed_time or 0) + fed_pos_due) * 1000)
 
             self.prov.logger.debug(
@@ -459,7 +513,21 @@ class AirPlayStreamSession:
                 # group's feed. Anchored, the binary drains the prime as it
                 # streams in. The START does not re-anchor the session
                 # timeline (the group keeps playing).
-                await stream.start(start_unix_ms, position_ms)
+                actual = await stream.start(start_unix_ms + adjust_ms, position_ms)
+                if actual is not None and abs((actual - adjust_ms) - start_unix_ms) > 2:
+                    # The binary corrected the anchor forward (verified truth):
+                    # redo the mapping from the actual instant so the fed
+                    # content matches where the joiner really starts.
+                    self.prov.logger.warning(
+                        "Late joiner %s: anchor corrected %+d ms by the binary; "
+                        "remapping the prime",
+                        airplay_player.player_id,
+                        (actual - adjust_ms) - start_unix_ms,
+                    )
+                    start_at, fed_pos_due, prime, skip_bytes = map_to(
+                        (actual - adjust_ms) / 1000
+                    )
+                    self._client_skip_bytes[airplay_player.player_id] = skip_bytes
                 if prime:
                     await self._write_chunk_to_player(airplay_player, prime)
             except asyncio.CancelledError:
@@ -622,7 +690,8 @@ class AirPlayStreamSession:
 
             # Update seconds_streamed and ring buffer under the lock so
             # add_client always reads consistent values.
-            self.seconds_streamed += len(chunk) / self.pcm_format.pcm_sample_size
+            self.seconds_streamed += len(chunk) / self._pcm_byte_rate
+            self._pcm_total_fed += len(chunk)
             self._pcm_buffer.extend(chunk)
             overflow = len(self._pcm_buffer) - self._pcm_buffer_max
             if overflow > 0:
@@ -711,12 +780,63 @@ class AirPlayStreamSession:
         await airplay_player.stream.connect(use_shared_ptp)
         await self._start_player_ffmpeg(airplay_player, self.media)
 
-    def _anchor_start_unix_ms(self) -> int:
-        """Return the shared audible-start instant for a readiness-confirmed start."""
-        lead_ms = (
-            AIRPLAY_START_LEAD_MS if len(self.sync_clients) == 1 else AIRPLAY_GROUP_START_LEAD_MS
-        )
-        return int(time.time() * 1000) + lead_ms
+    def _anchor_start_unix_ms(self, *, warm: bool = False) -> int:
+        """
+        Return the shared audible-start instant for a readiness-confirmed start.
+
+        :param warm: True for a warm re-start over live connections (seek/next/
+            resume-from-park). Members on the Apple splice timeline report a
+            minimum warm lead — their queued audio plays out before the new
+            content can begin — and the shared anchor must sit beyond the
+            largest member value so every member splices at the same instant.
+        """
+        if len(self.sync_clients) == 1:
+            lead_ms = AIRPLAY_START_LEAD_MS
+        elif warm:
+            lead_ms = AIRPLAY_GROUP_START_LEAD_MS
+        else:
+            # Cold group start: cover the members' receiver-side clock
+            # acquisition (see AIRPLAY_COLD_GROUP_START_LEAD_MS).
+            lead_ms = AIRPLAY_COLD_GROUP_START_LEAD_MS
+        anchor = int(time.time() * 1000) + lead_ms
+        if not warm:
+            return anchor
+        # Splice-timeline members honor the commanded instant only when that
+        # instant (plus their sync_adjust) lands beyond their queued audio.
+        # A NEGATIVE sync_adjust moves a member's commanded instant earlier,
+        # eating into the lead, so it must be added to that member's
+        # requirement — otherwise the first round can never succeed for that
+        # member and every group start pays a corrective round.
+        member_requirement = 0
+        for player in self.sync_clients:
+            stream = player.stream
+            if stream is None or stream.warm_lead_ms <= 0:
+                continue
+            sync_adjust = player.config.get_value(CONF_SYNC_ADJUST, 0)
+            adjust_ms = sync_adjust if isinstance(sync_adjust, int) else 0
+            member_requirement = max(
+                member_requirement, stream.warm_lead_ms - min(0, adjust_ms)
+            )
+        if member_requirement > 0:
+            anchor = max(
+                anchor,
+                int(time.time() * 1000)
+                + member_requirement
+                + AIRPLAY_SPLICE_LEAD_MARGIN_MS,
+            )
+        for player in self.sync_clients:
+            stream = player.stream
+            if stream is None or stream.flushed_head_unix_ms <= 0:
+                continue
+            sync_adjust = player.config.get_value(CONF_SYNC_ADJUST, 0)
+            adjust_ms = sync_adjust if isinstance(sync_adjust, int) else 0
+            # The member's commanded instant is anchor + adjust; it must clear
+            # the member's frozen head with margin for the command round-trip.
+            anchor = max(
+                anchor,
+                stream.flushed_head_unix_ms - adjust_ms + AIRPLAY_SPLICE_LEAD_MARGIN_MS,
+            )
+        return anchor
 
     async def _wait_members_audio_present(self) -> None:
         """Wait until every member's binary reports the new audio flowing."""
@@ -736,23 +856,63 @@ class AirPlayStreamSession:
         """
         Anchor every member's playback at one shared audible instant.
 
+        The binaries verify the instant: each ack carries the TRUE scheduled
+        instant (an infeasible one is corrected forward, never silently
+        misplaced). When any member was corrected, every member is re-STARTed
+        at the largest reported instant so the group converges on one shared
+        instant; the recorded session anchor is always the verified truth.
+
         :param position_ms: Media position mapped to the first sample of the anchor.
         :param start_unix_ms: Shared audible-start instant in unix epoch ms.
         :param reanchor_session: Whether this start becomes the session timeline anchor.
         """
-        async with asyncio.TaskGroup() as task_group:
-            for player in self.sync_clients:
-                stream = player.stream
-                if stream is None:
-                    continue
-                member_start = start_unix_ms
-                sync_adjust = player.config.get_value(CONF_SYNC_ADJUST, 0)
-                if isinstance(sync_adjust, int):
-                    member_start += sync_adjust
-                task_group.create_task(stream.start(member_start, position_ms))
+        target_ms = start_unix_ms
+        for _ in range(4):
+            member_tasks: list[tuple[int, asyncio.Task[int | None]]] = []
+            async with asyncio.TaskGroup() as task_group:
+                for player in self.sync_clients:
+                    stream = player.stream
+                    if stream is None:
+                        continue
+                    sync_adjust = player.config.get_value(CONF_SYNC_ADJUST, 0)
+                    adjust_ms = sync_adjust if isinstance(sync_adjust, int) else 0
+                    member_tasks.append(
+                        (
+                            adjust_ms,
+                            task_group.create_task(
+                                stream.start(target_ms + adjust_ms, position_ms)
+                            ),
+                        )
+                    )
+            corrected_ms = target_ms
+            for adjust_ms, task in member_tasks:
+                actual = task.result()
+                if actual is None:
+                    continue  # older binary without a started ack
+                corrected_ms = max(corrected_ms, actual - adjust_ms)
+            if corrected_ms <= target_ms + 2:
+                break
+            self.prov.logger.warning(
+                "AirPlay group start corrected: a member could not honor %d, "
+                "re-anchoring all members at %d (+%d ms)",
+                target_ms,
+                corrected_ms,
+                corrected_ms - target_ms,
+            )
+            # The corrected instant already carries the binary's own
+            # command-latency slack; the extra margin covers fanning the
+            # retry out to every member so the next round lands.
+            target_ms = corrected_ms + AIRPLAY_SPLICE_LEAD_MARGIN_MS
+        else:
+            self.prov.logger.error(
+                "AirPlay group start did not converge after 4 rounds "
+                "(last instant %d) - members may be audibly out of sync; "
+                "please report this with a debug log",
+                target_ms,
+            )
         if reanchor_session:
-            self.start_unix_ms = start_unix_ms
-            self.start_time = start_unix_ms / 1000
+            self.start_unix_ms = target_ms
+            self.start_time = target_ms / 1000
 
     async def _flush_member(self, player: AirPlayPlayer) -> bool:
         """Flush one member's live stream in place and report the binary's ack."""

--- a/music_assistant/providers/airplay/strings.json
+++ b/music_assistant/providers/airplay/strings.json
@@ -34,6 +34,10 @@
     },
     "pair_now": {
       "label": "Set up now"
+    },
+    "verbose_ptp_logging": {
+      "label": "Verbose PTP daemon logging",
+      "description": "Log the shared PTP clock daemon's per-packet timing trace (Announce/Sync/Follow_Up) when verbose logging is active. Only useful when diagnosing multi-room clock sync issues; it floods the log at ~10 lines per second."
     }
   },
   "setup_flow": {

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -827,6 +827,8 @@
   "provider.airplay.config_entries.password.label": "Device password",
   "provider.airplay.config_entries.sync_adjust.description": "Shifts when audio is heard on this device relative to the other players in a synced group. \nNegative values make this device play earlier; positive values make it play later. \nUse a negative value when this device is connected to a TV, AV receiver or amplifier that adds a processing delay, which makes it play slightly behind the rest of the group. \nExample: if this device lags the group by about 100 ms, set it to -100 to pull it back into sync.",
   "provider.airplay.config_entries.sync_adjust.label": "Audio synchronization delay correction",
+  "provider.airplay.config_entries.verbose_ptp_logging.description": "Log the shared PTP clock daemon's per-packet timing trace (Announce/Sync/Follow_Up) when verbose logging is active. Only useful when diagnosing multi-room clock sync issues; it floods the log at ~10 lines per second.",
+  "provider.airplay.config_entries.verbose_ptp_logging.label": "Verbose PTP daemon logging",
   "provider.airplay.errors.authentication_failed": "The device rejected the saved password. Run the setup for this player to enter it again.",
   "provider.airplay.errors.invalid_pin": "Enter the numeric PIN shown on the screen of your device.",
   "provider.airplay.errors.show_dashboard_failed": "Failed to show the dashboard on {0}.",

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -11,6 +11,7 @@ from music_assistant_models.enums import PlaybackState
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.providers.airplay.constants import (
+    AIRPLAY_COLD_GROUP_START_LEAD_MS,
     AirPlayRemoteCommand,
     StreamingProtocol,
 )
@@ -176,7 +177,7 @@ async def test_ptp_daemon_spawn_advertises_dacp_identity() -> None:
         ),
         patch("music_assistant.providers.airplay.provider.AsyncProcess") as process_cls,
     ):
-        process_cls.return_value.start = AsyncMock()
+        process_cls.return_value.start = AsyncMock(return_value=None)
         await prov._start_ptp_daemon()
 
     assert process_cls.call_args.args[0] == [
@@ -209,19 +210,21 @@ async def test_ptp_daemon_spawn_quiet_at_debug_level() -> None:
         ),
         patch("music_assistant.providers.airplay.provider.AsyncProcess") as process_cls,
     ):
-        process_cls.return_value.start = AsyncMock()
+        process_cls.return_value.start = AsyncMock(return_value=None)
         await prov._start_ptp_daemon()
 
     assert "--debug" not in process_cls.call_args.args[0]
 
 
 async def test_ptp_daemon_spawn_traces_at_verbose_level() -> None:
-    """A verbose session turns on the daemon's per-packet timing trace."""
+    """The daemon's per-packet trace needs verbose logging AND the opt-in toggle."""
     prov = _ptp_provider()
     prov.dacp_id = "AABBCCDD11223344"
     prov.mass = MagicMock()
     prov.mass.streams.bind_ip = "0.0.0.0"
     prov.logger.setLevel(VERBOSE_LOG_LEVEL)
+    prov.config = MagicMock()
+    prov.config.get_value = MagicMock(return_value=True)
 
     def _consume_task(coro: object) -> MagicMock:
         if asyncio.iscoroutine(coro):
@@ -237,10 +240,24 @@ async def test_ptp_daemon_spawn_traces_at_verbose_level() -> None:
         ),
         patch("music_assistant.providers.airplay.provider.AsyncProcess") as process_cls,
     ):
-        process_cls.return_value.start = AsyncMock()
+        process_cls.return_value.start = AsyncMock(return_value=None)
         await prov._start_ptp_daemon()
 
     assert process_cls.call_args.args[0][-2:] == ["--debug", "10"]
+
+    # Without the opt-in the daemon stays quiet even on a verbose session
+    # (its ~10 lines/s timing trace would otherwise flood every verbose log).
+    prov.config.get_value = MagicMock(return_value=False)
+    with (
+        patch(
+            "music_assistant.providers.airplay.provider.get_cli_binary",
+            AsyncMock(return_value="/bin/cliairplay"),
+        ),
+        patch("music_assistant.providers.airplay.provider.AsyncProcess") as process_cls,
+    ):
+        process_cls.return_value.start = AsyncMock(return_value=None)
+        await prov._start_ptp_daemon()
+    assert "--debug" not in process_cls.call_args.args[0]
 
 
 def test_pyatv_logging_quiet_at_debug_level() -> None:
@@ -494,7 +511,11 @@ async def test_raop_session_resolves_ptp_for_first_ap2_late_joiner() -> None:
         player.stream = MagicMock(running=True, connected=True)
         player.stream.wait_for_connection = AsyncMock()
         player.stream.flush = AsyncMock(return_value=True)
-        player.stream.start = AsyncMock()
+        # Verified-start API defaults: no started ack, no warm-lead constraint
+        # (an older binary), so the test asserts the commanded values directly.
+        player.stream.start = AsyncMock(return_value=None)
+        player.stream.warm_lead_ms = 0
+        player.stream.flushed_head_unix_ms = 0
 
     with patch.object(
         session, "_start_client", new_callable=AsyncMock, side_effect=_start_client
@@ -518,7 +539,7 @@ async def test_session_start_applies_uniform_ptp_decision_to_all_members() -> No
         player.stream = MagicMock()
         player.stream.wait_for_connection = AsyncMock()
         player.stream.wait_audio_present = AsyncMock(return_value=True)
-        player.stream.start = AsyncMock()
+        player.stream.start = AsyncMock(return_value=None)
     session = _make_ptp_session(prov, players)
 
     with (
@@ -542,7 +563,7 @@ async def test_session_start_calculates_anchor_after_ptp_resolution() -> None:
         player.stream = MagicMock()
         player.stream.wait_for_connection = AsyncMock()
         player.stream.wait_audio_present = AsyncMock(return_value=True)
-        player.stream.start = AsyncMock()
+        player.stream.start = AsyncMock(return_value=None)
         player.config.get_value = MagicMock(return_value=0)
     session = _make_ptp_session(prov, players)
     now = 100.0
@@ -563,12 +584,14 @@ async def test_session_start_calculates_anchor_after_ptp_resolution() -> None:
     ):
         await session.start(MagicMock())
 
-    # anchor = now (103_000 ms) + the group start lead (500 ms); readiness is
-    # event-confirmed, so no setup-time guess is added on top.
-    assert session.start_unix_ms == 103_500
+    # anchor = now (103_000 ms) + the COLD group start lead: a cold group
+    # start covers the members' receiver-side clock acquisition, unlike the
+    # short event-confirmed warm leads.
+    expected = 103_000 + AIRPLAY_COLD_GROUP_START_LEAD_MS
+    assert session.start_unix_ms == expected
     for player in players:
         player.stream.start.assert_awaited_once()
-        assert player.stream.start.await_args.args[0] == 103_500
+        assert player.stream.start.await_args.args[0] == expected
 
 
 # --- Session decision reaches the CLI args (overrides bare liveness) ------------

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -414,7 +414,7 @@ async def test_cold_start_connects_then_anchors_first_start() -> None:
     stream = MagicMock()
     stream.connect = AsyncMock()
     stream.wait_for_connection = AsyncMock()
-    stream.start = AsyncMock()
+    stream.start = AsyncMock(return_value=None)
 
     with (
         patch(
@@ -447,7 +447,7 @@ async def test_cold_start_superseded_before_start_stops_transport() -> None:
     stream.connect = AsyncMock()
     stream.stop = AsyncMock()
     stream.wait_for_connection = AsyncMock()
-    stream.start = AsyncMock()
+    stream.start = AsyncMock(return_value=None)
 
     with (
         patch(
@@ -560,7 +560,7 @@ async def test_warm_stream_flushes_and_reanchors_on_kept_instance() -> None:
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     kept_stream = MagicMock()
     kept_stream.flush = AsyncMock(return_value=True)
-    kept_stream.start = AsyncMock()
+    kept_stream.start = AsyncMock(return_value=None)
     bridge._airplay_stream = kept_stream
     bridge._airplay_stream_start_task = asyncio.current_task()
 
@@ -579,7 +579,7 @@ async def test_warm_stream_flush_timeout_falls_back_to_cold() -> None:
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     kept_stream = MagicMock()
     kept_stream.flush = AsyncMock(return_value=False)
-    kept_stream.start = AsyncMock()
+    kept_stream.start = AsyncMock(return_value=None)
     bridge._airplay_stream = kept_stream
     bridge._airplay_stream_start_task = asyncio.current_task()
 
@@ -595,7 +595,7 @@ async def test_warm_stream_superseded_before_start_does_not_anchor() -> None:
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     kept_stream = MagicMock()
     kept_stream.flush = AsyncMock(return_value=True)
-    kept_stream.start = AsyncMock()
+    kept_stream.start = AsyncMock(return_value=None)
     bridge._airplay_stream = kept_stream
     # Simulate a newer stream start having already replaced the tracked task.
     bridge._airplay_stream_start_task = MagicMock()
@@ -619,7 +619,7 @@ async def test_warm_stream_cancellation_propagates() -> None:
         return True
 
     kept_stream.flush = AsyncMock(side_effect=flush)
-    kept_stream.start = AsyncMock()
+    kept_stream.start = AsyncMock(return_value=None)
     bridge._airplay_stream = kept_stream
 
     warm_task = asyncio.create_task(bridge._start_warm_stream(kept_stream, 1_784_000_000_000))

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -561,7 +561,7 @@ async def test_connect_queues_text_metadata_before_connection() -> None:
     metadata = MagicMock(corrected_elapsed_time=12.5)
     player.current_media = metadata
     process = MagicMock(closed=False)
-    process.start = AsyncMock()
+    process.start = AsyncMock(return_value=None)
     operation_order: list[str] = []
 
     async def create_pipe() -> None:
@@ -604,7 +604,7 @@ async def test_connect_failure_cleans_up_process_and_pipe() -> None:
     metadata = MagicMock(corrected_elapsed_time=0)
     player.current_media = metadata
     process = MagicMock(closed=False)
-    process.start = AsyncMock()
+    process.start = AsyncMock(return_value=None)
     process.kill = AsyncMock()
 
     def consume_task(awaitable: Any) -> MagicMock:
@@ -1001,7 +1001,7 @@ async def test_connect_resets_accumulated_shift() -> None:
     stream._reanchor_status_seen = True
     player.current_media = MagicMock(corrected_elapsed_time=0)
     process = MagicMock(closed=False)
-    process.start = AsyncMock()
+    process.start = AsyncMock(return_value=None)
 
     def consume_task(awaitable: Any) -> MagicMock:
         awaitable.close()

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -977,7 +977,7 @@ async def test_cleanup_after_removal_skips_idle_when_player_has_new_session_stre
     session = _make_session(now - 10, 12.5)
     player = _make_late_joiner()
     other_session = object()
-    player.set_state_from_stream = _stream_defaults(MagicMock())
+    player.set_state_from_stream = MagicMock()
     player.stream = _stream_defaults(MagicMock())
     player.stream.session = other_session
     session.sync_clients.clear()

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -9,10 +9,26 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from music_assistant_models.errors import PlayerCommandFailed
 
-from music_assistant.providers.airplay.constants import StreamingProtocol
+from music_assistant.providers.airplay.constants import (
+    AIRPLAY_COLD_GROUP_START_LEAD_MS,
+    StreamingProtocol,
+)
 from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
 
 PCM_SAMPLE_SIZE = 176400  # 44.1kHz / 16-bit / 2ch
+
+
+def _stream_defaults(stream: MagicMock) -> MagicMock:
+    """
+    Apply the verified-start API defaults to a mocked stream.
+
+    No started ack and no warm-lead constraint, matching an older binary, so
+    the tests assert the commanded values directly.
+    """
+    stream.start = AsyncMock(return_value=None)
+    stream.warm_lead_ms = 0
+    stream.flushed_head_unix_ms = 0
+    return stream
 
 
 def _make_session(
@@ -36,7 +52,7 @@ def _make_session(
     leader = MagicMock()
     leader.player_id = "leader"
     leader.protocol = StreamingProtocol.RAOP
-    leader.stream = MagicMock()
+    leader.stream = _stream_defaults(MagicMock())
     leader.stream.running = True
     leader.stream.connected = True
     leader.stream.wait_audio_present = AsyncMock(return_value=True)
@@ -68,13 +84,12 @@ def _setup_stream(player: MagicMock) -> Any:
     """Return a side_effect callable that sets up the stream mock on the player."""
 
     def _side_effect(*_args: Any, **_kwargs: Any) -> None:
-        player.stream = MagicMock()
+        player.stream = _stream_defaults(MagicMock())
         player.stream.running = True
         player.stream.connected = True
         player.stream.wait_for_connection = AsyncMock()
         player.stream.wait_audio_present = AsyncMock(return_value=True)
         player.stream.flush = AsyncMock(return_value=True)
-        player.stream.start = AsyncMock()
         player.stream.cumulative_shift_seconds = 0.0
 
     return _side_effect
@@ -156,7 +171,7 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
     operations: list[str] = []
 
     async def start_client(player: MagicMock, _use_shared_ptp: bool) -> None:
-        stream = MagicMock(running=True)
+        stream = _stream_defaults(MagicMock(running=True))
 
         async def wait_for_connection() -> None:
             operations.append(f"connected:{player.player_id}")
@@ -183,7 +198,7 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
     assert last_connected < first_start
     # start = now (100_000 ms) + the group start lead (500 ms), one shared instant
     starts = {int(op.rsplit(":", 1)[1]) for op in operations if op.startswith("started:")}
-    assert starts == {100_500}
+    assert starts == {100_000 + AIRPLAY_COLD_GROUP_START_LEAD_MS}
 
 
 @pytest.mark.asyncio
@@ -201,11 +216,11 @@ async def test_initial_single_player_starts_after_connect(
     player.protocol = protocol
     player.wait_start = 2500
     player.config.get_value = MagicMock(return_value=0)
-    stream = MagicMock(running=True)
+    stream = _stream_defaults(MagicMock(running=True))
     stream.wait_for_connection = AsyncMock()
     stream.wait_audio_present = AsyncMock(return_value=True)
     stream.flush = AsyncMock(return_value=True)
-    stream.start = AsyncMock()
+    stream.start = AsyncMock(return_value=None)
 
     async def start_client(_player: MagicMock, _use_shared_ptp: bool) -> None:
         player.stream = stream
@@ -234,12 +249,12 @@ async def test_initial_connection_failure_never_starts_partial_group() -> None:
     session.sync_clients.append(second_player)
 
     async def start_client(player: MagicMock, _use_shared_ptp: bool) -> None:
-        stream = MagicMock(running=True)
+        stream = _stream_defaults(MagicMock(running=True))
         if player is second_player:
             stream.wait_for_connection = AsyncMock(side_effect=TimeoutError("connect timeout"))
         else:
             stream.wait_for_connection = AsyncMock()
-        stream.start = AsyncMock()
+        stream.start = AsyncMock(return_value=None)
         player.stream = stream
 
     with (
@@ -265,14 +280,14 @@ async def test_initial_connection_cancellation_never_starts_group() -> None:
     player.protocol = StreamingProtocol.RAOP
     player.wait_start = 2500
     connection_waiting = asyncio.Event()
-    stream = MagicMock(running=True)
+    stream = _stream_defaults(MagicMock(running=True))
 
     async def wait_for_connection() -> None:
         connection_waiting.set()
         await asyncio.Event().wait()
 
     stream.wait_for_connection = AsyncMock(side_effect=wait_for_connection)
-    stream.start = AsyncMock()
+    stream.start = AsyncMock(return_value=None)
 
     async def start_client(_player: MagicMock, _use_shared_ptp: bool) -> None:
         player.stream = stream
@@ -309,7 +324,7 @@ def test_warm_replace_supports_every_streaming_protocol(
         player = MagicMock()
         player.player_id = f"player-{index}"
         player.protocol = protocol
-        player.stream = MagicMock(running=True, connected=True)
+        player.stream = _stream_defaults(MagicMock(running=True, connected=True))
         players.append(player)
     session.sync_clients = players
 
@@ -337,7 +352,7 @@ async def test_standby_supports_every_connected_streaming_protocol(
         player = MagicMock()
         player.player_id = f"player-{index}"
         player.protocol = protocol
-        player.stream = MagicMock(running=True, connected=True)
+        player.stream = _stream_defaults(MagicMock(running=True, connected=True))
         player.stream.send_cli_command = AsyncMock(return_value=True)
         players.append(player)
     session.sync_clients = players
@@ -369,11 +384,11 @@ async def test_standby_resumes_warm_on_existing_streams(
         player.player_id = f"player-{index}"
         player.protocol = protocol
         player.config.get_value = MagicMock(return_value=0)
-        player.stream = MagicMock(running=True, connected=True)
+        player.stream = _stream_defaults(MagicMock(running=True, connected=True))
         player.stream.send_cli_command = AsyncMock(return_value=True)
         player.stream.wait_audio_present = AsyncMock(return_value=True)
         player.stream.flush = AsyncMock(return_value=True)
-        player.stream.start = AsyncMock()
+        player.stream.start = AsyncMock(return_value=None)
         players.append(player)
         original_streams[player.player_id] = player.stream
     session.sync_clients = players
@@ -409,7 +424,7 @@ async def test_warm_replace_flushes_all_before_starting_any() -> None:
     for player_id in ("first", "delayed"):
         player = MagicMock(player_id=player_id, protocol=StreamingProtocol.AIRPLAY2)
         player.config.get_value = MagicMock(return_value=0)
-        stream = MagicMock(running=True, connected=True)
+        stream = _stream_defaults(MagicMock(running=True, connected=True))
 
         async def flush(*, current_id: str = player_id) -> bool:
             if current_id == "delayed":
@@ -419,7 +434,7 @@ async def test_warm_replace_flushes_all_before_starting_any() -> None:
 
         stream.flush = AsyncMock(side_effect=flush)
         stream.wait_audio_present = AsyncMock(return_value=True)
-        stream.start = AsyncMock()
+        stream.start = AsyncMock(return_value=None)
         player.stream = stream
         players.append(player)
     session.sync_clients = players
@@ -459,7 +474,7 @@ async def test_warm_replace_stops_old_audio_and_ffmpeg_before_flush() -> None:
         return True
 
     stream.flush = AsyncMock(side_effect=flush)
-    stream.start = AsyncMock()
+    stream.start = AsyncMock(return_value=None)
     old_ffmpeg = MagicMock(closed=False)
 
     async def kill_ffmpeg() -> None:
@@ -499,9 +514,9 @@ async def test_warm_replace_flush_failure_falls_back_to_cold() -> None:
     for player_id, acked in (("ok", True), ("failed", False)):
         player = MagicMock(player_id=player_id, protocol=StreamingProtocol.RAOP)
         player.config.get_value = MagicMock(return_value=0)
-        stream = MagicMock(running=True, connected=True)
+        stream = _stream_defaults(MagicMock(running=True, connected=True))
         stream.flush = AsyncMock(return_value=acked)
-        stream.start = AsyncMock()
+        stream.start = AsyncMock(return_value=None)
         player.stream = stream
         players.append(player)
     session.sync_clients = players
@@ -547,14 +562,14 @@ async def test_start_player_ffmpeg_wires_persistent_cli_stdin() -> None:
     old_ffmpeg.close = AsyncMock()
     session._player_ffmpeg[player.player_id] = old_ffmpeg
 
-    stream = MagicMock()
+    stream = _stream_defaults(MagicMock())
     stream.pcm_format = session.pcm_format
     cli_proc = MagicMock()
     cli_proc.proc.stdin.transport.get_extra_info.return_value.fileno.return_value = 77
     stream._cli_proc = cli_proc
     player.stream = stream
     new_ffmpeg = MagicMock()
-    new_ffmpeg.start = AsyncMock()
+    new_ffmpeg.start = AsyncMock(return_value=None)
 
     with (
         patch(
@@ -585,7 +600,7 @@ async def test_standby_requires_every_member_running_and_connected(stream_state:
     """Standby is unavailable when any member lacks a reusable connected session."""
     session = _make_session(0, 0)
     ready_player = MagicMock(player_id="ready", protocol=StreamingProtocol.AIRPLAY2)
-    ready_player.stream = MagicMock(running=True, connected=True)
+    ready_player.stream = _stream_defaults(MagicMock(running=True, connected=True))
     ready_player.stream.send_cli_command = AsyncMock()
     unavailable_player = MagicMock(player_id="unavailable", protocol=StreamingProtocol.RAOP)
     unavailable_player.stream = None
@@ -614,13 +629,13 @@ async def test_standby_returns_false_when_command_is_not_delivered() -> None:
     logger = MagicMock()
     session.prov.logger = logger
     delivered_player = MagicMock(player_id="delivered", protocol=StreamingProtocol.AIRPLAY2)
-    delivered_player.stream = MagicMock(running=True, connected=True)
+    delivered_player.stream = _stream_defaults(MagicMock(running=True, connected=True))
     delivered_player.stream.send_cli_command = AsyncMock(return_value=True)
     dropped_player = MagicMock(player_id="dropped", protocol=StreamingProtocol.RAOP)
-    dropped_player.stream = MagicMock(running=True, connected=True)
+    dropped_player.stream = _stream_defaults(MagicMock(running=True, connected=True))
     dropped_player.stream.send_cli_command = AsyncMock(return_value=False)
     pending_player = MagicMock(player_id="pending", protocol=StreamingProtocol.AIRPLAY2)
-    pending_player.stream = MagicMock(running=True, connected=True)
+    pending_player.stream = _stream_defaults(MagicMock(running=True, connected=True))
     pending_player.stream.send_cli_command = AsyncMock(return_value=True)
     session.sync_clients = [delivered_player, dropped_player, pending_player]
 
@@ -641,7 +656,7 @@ async def test_standby_returns_false_when_command_raises() -> None:
     logger = MagicMock()
     session.prov.logger = logger
     player = MagicMock(player_id="failed", protocol=StreamingProtocol.AIRPLAY2)
-    player.stream = MagicMock(running=True, connected=True)
+    player.stream = _stream_defaults(MagicMock(running=True, connected=True))
     player.stream.send_cli_command = AsyncMock(side_effect=OSError("command pipe failed"))
     session.sync_clients = [player]
 
@@ -749,7 +764,7 @@ async def test_late_join_no_running_session() -> None:
     session = _make_session(now - 10, 12.5)
     # Make the leader's stream not running
     leader = session.sync_clients[0]
-    leader.stream = MagicMock()
+    leader.stream = _stream_defaults(MagicMock())
     leader.stream.running = False
     player = _make_late_joiner()
 
@@ -918,7 +933,7 @@ async def test_stop_client_clears_skip_and_shift_state() -> None:
     """Tearing a client down drops its skip counter and resets its playout shift."""
     session = _make_session(0, 0)
     player = _make_late_joiner()
-    player.stream = MagicMock()
+    player.stream = _stream_defaults(MagicMock())
     player.stream.session = session
     player.stream.stop = AsyncMock()
     session._client_skip_bytes[player.player_id] = 12_345
@@ -941,7 +956,7 @@ async def test_replace_clears_skip_and_shift_state() -> None:
     stream.connected = True
     stream.flush = AsyncMock(return_value=True)
     stream.wait_audio_present = AsyncMock(return_value=True)
-    stream.start = AsyncMock()
+    stream.start = AsyncMock(return_value=None)
     session._client_skip_bytes[player.player_id] = 999
 
     with (
@@ -962,8 +977,8 @@ async def test_cleanup_after_removal_skips_idle_when_player_has_new_session_stre
     session = _make_session(now - 10, 12.5)
     player = _make_late_joiner()
     other_session = object()
-    player.set_state_from_stream = MagicMock()
-    player.stream = MagicMock()
+    player.set_state_from_stream = _stream_defaults(MagicMock())
+    player.stream = _stream_defaults(MagicMock())
     player.stream.session = other_session
     session.sync_clients.clear()
 


### PR DESCRIPTION
# What does this implement/fix?

Apple receivers (Apple TV, HomePod) produced a short static noise burst on every seek, track change, pause and stop, and sync groups could drift or glitch around those moments. Together with the paired cliairplay update (music-assistant/airplay-cli#25), playback to Apple devices is now one continuous, never-interrupted stream, and every commanded start is verified: the binary acknowledges the exact instant playback really begins, so the server can keep all group members locked to one shared instant and log any deviation.

- Warm starts (seek/next/resume) are anchored beyond every member's queued audio; the binary's acknowledgements are verified and a group is automatically re-aligned when a member reports a corrected start
- Cold group starts anchor past the receivers' clock acquisition, so grouped players begin in sync
- Late-join fixes: buffer math follows the actual wire format and slices are frame-aligned, fixing loud static and position drift when joining a hi-res session
- Externally observed (Companion/MRP) playback state is ignored while our own stream is active, ending frozen seek bars and "external source" takeovers during stream restarts
- Repeated remote commands from a receiver are rate-limited (guards against MediaRemote retry storms that could flood the server)
- New advanced "Verbose PTP daemon logging" toggle keeps the PTP daemon's per-packet trace out of ordinary verbose logs

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5386

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.