### PR TITLE
Pick a new go-librespot API port when the configured one is unavailable

### DIFF
--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -35,7 +35,11 @@ from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
 
 from music_assistant.constants import CONF_ENTRY_WARN_PREVIEW
 from music_assistant.helpers.process import AsyncProcess
-from music_assistant.helpers.util import interface_name_for_ip, select_free_port
+from music_assistant.helpers.util import (
+    interface_name_for_ip,
+    is_port_in_use,
+    select_free_port,
+)
 from music_assistant.models.plugin import PluginProvider
 
 from .client import GoLibrespotClient
@@ -668,9 +672,20 @@ class SpotifyConnectProvider(PluginProvider):
     async def _daemon_runner(self) -> None:
         """Run and supervise the go-librespot daemon, restarting it if it exits."""
         assert self._binary
+        assert self._client
         # Loop forever; unload() cancels this task and the explicit stop-check below
         # handles a graceful exit without a restart.
         while True:
+            # If the API port was taken while the daemon was down, move to a
+            # fresh port instead of crash-looping on a bind error.
+            if await is_port_in_use(self._api_port, host="127.0.0.1"):
+                self._api_port = await select_free_port(
+                    API_PORT_RANGE_START, API_PORT_RANGE_END, host="127.0.0.1"
+                )
+                self._client.base_url = f"http://127.0.0.1:{self._api_port}"
+                self.logger.warning(
+                    "API port in use by another process; switching to port %s", self._api_port
+                )
             self._write_config()
             proc: AsyncProcess | None = None
             try:

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -1,5 +1,6 @@
 """Tests for the Spotify Connect provider."""
 
+from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from music_assistant.providers.spotify_connect import (
@@ -7,6 +8,7 @@ from music_assistant.providers.spotify_connect import (
     API_PORT_RANGE_START,
     SpotifyConnectProvider,
 )
+from music_assistant.providers.spotify_connect.client import GoLibrespotClient
 
 
 async def test_async_init_probes_api_port_on_ipv4_loopback() -> None:
@@ -31,3 +33,46 @@ async def test_async_init_probes_api_port_on_ipv4_loopback() -> None:
     select_port.assert_awaited_once_with(API_PORT_RANGE_START, API_PORT_RANGE_END, host="127.0.0.1")
     assert provider._client is not None
     assert provider._client.base_url == "http://127.0.0.1:38801"
+
+
+async def test_daemon_runner_reselects_api_port_when_taken() -> None:
+    """An API port taken while the daemon was down is replaced before (re)starting."""
+    provider = object.__new__(SpotifyConnectProvider)
+    provider.mass = MagicMock()
+    provider.logger = MagicMock()
+    provider.config = MagicMock()
+    provider.config.name = "Spotify Test"
+    provider._binary = "/usr/bin/go-librespot"
+    provider._api_port = 38800
+    provider._client = GoLibrespotClient(provider.mass, "http://127.0.0.1:38800", provider.logger)
+    # exit the supervisor loop after a single iteration
+    provider._stop_called = True
+    provider._restart_error_count = 0
+
+    async def _no_stderr() -> AsyncGenerator[str]:
+        return
+        yield
+
+    proc = MagicMock()
+    proc.start = AsyncMock()
+    proc.close = AsyncMock()
+    proc.iter_stderr = _no_stderr
+
+    with (
+        patch(
+            "music_assistant.providers.spotify_connect.is_port_in_use",
+            new=AsyncMock(return_value=True),
+        ) as port_probe,
+        patch(
+            "music_assistant.providers.spotify_connect.select_free_port",
+            new=AsyncMock(return_value=38801),
+        ),
+        patch("music_assistant.providers.spotify_connect.AsyncProcess", return_value=proc),
+        patch.object(SpotifyConnectProvider, "_write_config") as write_config,
+    ):
+        await provider._daemon_runner()
+
+    port_probe.assert_awaited_once_with(38800, host="127.0.0.1")
+    assert provider._api_port == 38801
+    assert provider._client.base_url == "http://127.0.0.1:38801"
+    write_config.assert_called_once()


### PR DESCRIPTION
# What does this implement/fix?

The problem in the issue report may already be fixed on dev. The reporter is on version 2.9.10, but current dev has been changed to hand out each port only once.

While looking into the report, one remaining gap was found, each instance keeps the port it was given at startup and never picks another one. If that port is no longer free when the background process needs to start again (for example, because something else on the system took it in the meantime), the process fails to start, retries on the same port five times, and the plugin then shuts itself down with an error. That matches what the log in the issue shows.

This PR fixes that. Before starting the background process, the provider now checks whether its port is still free. If it isn't, the provider picks a new one and carries on. A conflict over a port now fixes itself on the next start attempt instead of taking the provider down. A test for this behaviour is included.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5952

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.