### PR TITLE
Apply AI Radio station edits to subsequent batches of a running session

### DIFF
--- a/music_assistant/providers/ai_radio/runtime.py
+++ b/music_assistant/providers/ai_radio/runtime.py
@@ -92,6 +92,7 @@ class AIRadioRuntimeMixin:
         config: ProviderConfig
         logger: logging.Logger
         _sessions: dict[str, SessionState]
+        _stations: dict[str, dict[str, Any]]
 
     def _set_session_progress(
         self,
@@ -343,6 +344,14 @@ class AIRadioRuntimeMixin:
         )
 
         while cursor < len(tracks):
+            # pick up station edits saved while this run is active, so prompts,
+            # character limits and section flow apply from the next batch onwards
+            if self._refresh_station_content(station, session.station_id):
+                self.logger.debug(
+                    "Station config refreshed for running session %s (station=%s)",
+                    session.session_id,
+                    session.station_id,
+                )
             batch_tracks = tracks[cursor : cursor + batch_size]
             is_first = cursor == 0
             is_last = (cursor + len(batch_tracks)) >= len(tracks)
@@ -1686,3 +1695,25 @@ class AIRadioRuntimeMixin:
                 "(for example Home Assistant with a TTS entity)."
             )
         return plugins[0]
+
+    def _refresh_station_content(self, station: dict[str, Any], station_id: str) -> bool:
+        """
+        Refresh the AI-content keys of a running session's station snapshot.
+
+        Returns True when the snapshot was updated with changed station settings.
+
+        :param station: The session's station snapshot to update in place.
+        :param station_id: The id of the station to read from the live store.
+        """
+        live_station = self._stations.get(station_id)
+        if live_station is None:
+            return False
+        changed = False
+        # only the AI-content keys are refreshed: run-time overrides (source playlist,
+        # player, playtime cap, batch size) are baked into the snapshot at start and
+        # must survive a refresh
+        for key in ("sections", "section_ids", "section_order", "merge_section_id", "general"):
+            if station.get(key) != live_station.get(key):
+                station[key] = deepcopy(live_station[key])
+                changed = True
+        return changed

--- a/tests/providers/ai_radio/test_runtime.py
+++ b/tests/providers/ai_radio/test_runtime.py
@@ -48,6 +48,7 @@ class DummyRuntime(AIRadioRuntimeMixin):
         """Initialize minimal state for runtime tests."""
         self.logger = logging.getLogger("tests.ai_radio.runtime")
         self._sessions: dict[str, SessionState] = {}
+        self._stations: dict[str, dict[str, Any]] = {}
         self.config = cast("Any", StubConfig())
 
     async def _run_playlist_mode(
@@ -738,6 +739,7 @@ async def test_run_dynamic_mode_has_watchdog_for_stalled_playback(
         def __init__(self) -> None:
             self.logger = logging.getLogger("tests.ai_radio.runtime.p7")
             self._sessions: dict[str, SessionState] = {}
+            self._stations: dict[str, dict[str, Any]] = {}
 
         async def _fetch_source_tracks(
             self, station: dict[str, Any]
@@ -864,6 +866,7 @@ async def test_run_dynamic_mode_clamps_prefetch_to_batch_size(
         def __init__(self) -> None:
             self.logger = logging.getLogger("tests.ai_radio.runtime.clamp_probe")
             self._sessions: dict[str, SessionState] = {}
+            self._stations: dict[str, dict[str, Any]] = {}
 
         async def _fetch_source_tracks(
             self, station: dict[str, Any]
@@ -920,6 +923,7 @@ def _make_watchdog_runtime_classes() -> tuple[type, type]:
         def __init__(self) -> None:
             self.logger = logging.getLogger("tests.ai_radio.runtime.watchdog")
             self._sessions: dict[str, SessionState] = {}
+            self._stations: dict[str, dict[str, Any]] = {}
 
         async def _fetch_source_tracks(
             self, station: dict[str, Any]
@@ -1535,6 +1539,7 @@ async def test_run_session_reports_a_queue_stop_as_stopped() -> None:
         def __init__(self) -> None:
             self.logger = logging.getLogger("tests.ai_radio.runtime.queue_stopped")
             self._sessions: dict[str, SessionState] = {}
+            self._stations: dict[str, dict[str, Any]] = {}
 
         async def _run_dynamic_mode(
             self, session: SessionState, station: dict[str, Any]
@@ -1549,3 +1554,77 @@ async def test_run_session_reports_a_queue_stop_as_stopped() -> None:
 
     assert session.status == "stopped"
     assert session.ended_at is not None
+
+
+# -- live station content refresh for running sessions --
+
+
+def _make_station_snapshot() -> dict[str, Any]:
+    """Return a station dict as captured by start_run for a dynamic session."""
+    return {
+        "id": "station_a",
+        "name": "Station A",
+        "source_playlist_id": "orig_playlist",
+        "default_player_id": "orig_player",
+        "max_duration_minutes": 0.0,
+        "dynamic_batch_size": 3,
+        "merge_section_id": "merge_1",
+        "general": {"instructions": "old instructions"},
+        "section_ids": ["sec_1"],
+        "sections": [{"id": "sec_1", "constraints": {"max_chars": 650}}],
+        "section_order": [{"when": "between_songs", "flow": [{"MUST": "sec_1"}]}],
+    }
+
+
+def test_refresh_station_content_applies_edits_and_keeps_overrides() -> None:
+    """Content keys refresh from the live store while run-time overrides survive."""
+    runtime = DummyRuntime()
+    snapshot = _make_station_snapshot()
+    # simulate start_run overrides baked into the snapshot
+    snapshot["source_playlist_id"] = "override_playlist"
+    snapshot["dynamic_batch_size"] = 5
+    live = _make_station_snapshot()
+    live["sections"] = [{"id": "sec_1", "constraints": {"max_chars": 200}}]
+    live["general"] = {"instructions": "new instructions"}
+    runtime._stations = {"station_a": live}
+
+    assert runtime._refresh_station_content(snapshot, "station_a")
+
+    assert snapshot["sections"][0]["constraints"]["max_chars"] == 200
+    assert snapshot["general"]["instructions"] == "new instructions"
+    assert snapshot["source_playlist_id"] == "override_playlist"
+    assert snapshot["dynamic_batch_size"] == 5
+
+
+def test_refresh_station_content_unchanged_returns_false() -> None:
+    """An unchanged live store leaves the snapshot as-is and reports no change."""
+    runtime = DummyRuntime()
+    snapshot = _make_station_snapshot()
+    runtime._stations = {"station_a": _make_station_snapshot()}
+
+    assert not runtime._refresh_station_content(snapshot, "station_a")
+    assert snapshot == _make_station_snapshot()
+
+
+def test_refresh_station_content_deleted_station_keeps_snapshot() -> None:
+    """A station deleted mid-run leaves the running snapshot untouched."""
+    runtime = DummyRuntime()
+    snapshot = _make_station_snapshot()
+    runtime._stations = {}
+
+    assert not runtime._refresh_station_content(snapshot, "station_a")
+    assert snapshot == _make_station_snapshot()
+
+
+def test_refresh_station_content_copies_deeply() -> None:
+    """Refreshed values are deep copies, so the live store cannot be mutated."""
+    runtime = DummyRuntime()
+    snapshot = _make_station_snapshot()
+    live = _make_station_snapshot()
+    live["sections"] = [{"id": "sec_1", "constraints": {"max_chars": 200}}]
+    runtime._stations = {"station_a": live}
+
+    runtime._refresh_station_content(snapshot, "station_a")
+    snapshot["sections"][0]["constraints"]["max_chars"] = 999
+
+    assert live["sections"][0]["constraints"]["max_chars"] == 200


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

AI Radio captured a snapshot of the station config at run start, so edits made in the Customize UI (segment prompts, character limits, section flow, host instructions) had no effect until the show was stopped and restarted.

The batch loop now refreshes the AI-content keys of the session's station snapshot from the live store before planning each batch, so edits apply from the next generated batch. Run-time overrides baked in by start_run (source playlist, player, playtime cap, batch size) are deliberately left untouched, as is playlist mode, which generates everything in a single pass.

Note that batches are generated ahead of playback, so an edit becomes audible a few songs after saving, not instantly.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
