### PR TITLE
Stop log flooding and retry storms when artwork fails to download

### DIFF
--- a/music_assistant/helpers/colors.py
+++ b/music_assistant/helpers/colors.py
@@ -18,6 +18,7 @@ import asyncio
 from typing import TYPE_CHECKING
 
 from modern_colorthief import get_palette as _mmcq_palette
+from music_assistant_models.errors import MusicAssistantError
 from music_assistant_models.media_items import MediaItemPalette
 
 from music_assistant.helpers.images import (
@@ -218,7 +219,13 @@ def extract_palette(image_bytes: bytes) -> MediaItemPalette:
 async def _extract_and_cache(
     mass: MusicAssistant, path_or_url: str, provider: str, key: str
 ) -> MediaItemPalette:
-    img_data = await get_image_data(mass, path_or_url, provider)
+    try:
+        img_data = await get_image_data(mass, path_or_url, provider)
+    except FileNotFoundError, MusicAssistantError:
+        # the image is unavailable (e.g. a stale artwork URL that 404s); the
+        # empty palette is not cached below, so extraction is retried once the
+        # image becomes available again
+        return MediaItemPalette()
     palette = await asyncio.to_thread(extract_palette, img_data)
     # Only persist a palette that actually yielded colors; an empty result is
     # usually a transient decode/download failure that should be retried rather

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import hashlib
 import itertools
+import logging
 import os
 import random
 import re
@@ -40,6 +41,8 @@ if TYPE_CHECKING:
 
     from music_assistant.mass import MusicAssistant
 
+
+LOGGER = logging.getLogger(__name__)
 
 # Thumbnail cache: on-disk (persistent) + small in-memory FIFO (hot path)
 _THUMB_CACHE_DIR = "thumbnails"
@@ -187,6 +190,35 @@ class _SourceMemoryCache:
 
 _source_memory_cache = _SourceMemoryCache()
 
+# Negative cache for sources that recently failed to fetch. Without it, a
+# persistently failing origin (e.g. an artwork URL that keeps returning 404)
+# is re-fetched — with a fresh error logged each time — for every thumbnail,
+# palette or metadata request that references it, and each consumer waits for
+# the full network round-trip just to fail again.
+_FAILED_SOURCE_TTL = 300
+_FAILED_SOURCE_MAX_ENTRIES = 256
+_failed_sources: OrderedDict[str, tuple[float, str]] = OrderedDict()
+
+
+def _get_failed_source(cache_key: str) -> str | None:
+    """Return the failure message for a recently failed source, or None."""
+    entry = _failed_sources.get(cache_key)
+    if entry is None:
+        return None
+    expires_at, message = entry
+    if time.monotonic() >= expires_at:
+        _failed_sources.pop(cache_key, None)
+        return None
+    return message
+
+
+def _store_failed_source(cache_key: str, message: str) -> None:
+    """Remember a failed source fetch so it is not retried for a short while."""
+    _failed_sources[cache_key] = (time.monotonic() + _FAILED_SOURCE_TTL, message)
+    _failed_sources.move_to_end(cache_key)
+    while len(_failed_sources) > _FAILED_SOURCE_MAX_ENTRIES:
+        _failed_sources.popitem(last=False)
+
 
 def _has_alpha(img: ImageClass) -> bool:
     """Return True if the image actually uses transparency."""
@@ -279,6 +311,9 @@ async def get_image_data(
     cache_key = create_thumb_hash(provider, path_or_url)
     if (cached := _source_memory_cache.get(cache_key)) is not None:
         return cached
+    # fail fast on sources that just failed instead of hammering the origin
+    if (failure := _get_failed_source(cache_key)) is not None:
+        raise FileNotFoundError(failure)
     # fetch de-duplicated across concurrent requests for the same source
     task: asyncio.Task[bytes] = mass.create_task(
         _fetch_and_cache_source_image,
@@ -367,7 +402,16 @@ async def _fetch_and_cache_source_image(
         _source_memory_cache.put(cache_key, disk_data)
         return disk_data
 
-    img_data, disk_cacheable = await _fetch_source_image(mass, path_or_url, provider, depth)
+    try:
+        img_data, disk_cacheable = await _fetch_source_image(mass, path_or_url, provider, depth)
+    except FileNotFoundError as err:
+        # remember the failure briefly and log it once, concisely: every
+        # thumbnail/palette/metadata request for this source would otherwise
+        # retry the origin and log the same error over and over
+        _store_failed_source(cache_key, str(err))
+        LOGGER.warning("%s (not retrying for %s seconds)", err, _FAILED_SOURCE_TTL)
+        raise
+    _failed_sources.pop(cache_key, None)
     _source_memory_cache.put(cache_key, img_data)
     if disk_cacheable:
         # persist to disk cache (best-effort, don't fail on I/O errors)
@@ -710,6 +754,7 @@ async def invalidate_cached_image(mass: MusicAssistant, provider: str, path_or_u
     for key in [key for key in _thumb_memory_cache if key.startswith(prefix)]:
         _thumb_memory_cache.pop(key, None)
     _source_memory_cache.pop(thumb_hash)
+    _failed_sources.pop(thumb_hash, None)
 
     thumb_dir = os.path.realpath(os.path.join(mass.cache_path, _THUMB_CACHE_DIR))
 

--- a/tests/helpers/test_colors.py
+++ b/tests/helpers/test_colors.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import io
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
+from aiohttp.client_exceptions import ClientError
 from PIL import Image, ImageDraw
 
+from music_assistant.helpers import images
 from music_assistant.helpers.colors import (
     _adjust_until_contrast,
     _contrast_ratio,
@@ -14,7 +18,14 @@ from music_assistant.helpers.colors import (
     _pick_on_color,
     _relative_luminance,
     extract_palette,
+    get_palette,
 )
+from music_assistant.helpers.images import invalidate_cached_image
+
+if TYPE_CHECKING:
+    import pytest
+
+    from music_assistant.mass import MusicAssistant
 
 _MIN_CONTRAST = 4.5
 
@@ -127,3 +138,38 @@ def test_extract_palette_end_to_end() -> None:
     assert palette.primary is not None
     if palette.background_dark is not None:
         assert _contrast_ratio(palette.background_dark, (255, 255, 255)) >= _MIN_CONTRAST
+
+
+async def test_get_palette_tolerates_unavailable_image(
+    mass_minimal: MusicAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unfetchable image yields an empty palette; extraction retries once it is back."""
+    mass_minimal.webserver = MagicMock(base_url="http://127.0.0.1:8095")
+    mass_minimal.streams = MagicMock(base_url="http://127.0.0.1:8097")
+    # mass_minimal constructs the cache controller without initializing it
+    cache_config = await mass_minimal.config.get_core_config(mass_minimal.cache.domain)
+    await mass_minimal.cache.setup(cache_config)
+    remote_url = "http://sonos.example.com:1400/getaa?u=gone.flac"
+
+    async def failing_remote_fetch(_mass: MusicAssistant, _url: str) -> bytes:
+        raise ClientError("404, message='Not Found'")
+
+    monkeypatch.setattr(images, "_fetch_remote_image", failing_remote_fetch)
+    try:
+        palette = await get_palette(mass_minimal, remote_url, "builtin")
+        assert palette is not None
+        assert palette.primary is None  # empty palette, but no exception raised
+
+        # nothing was cached for the failure, so once the artwork is reachable
+        # again the real palette is extracted
+        async def ok_remote_fetch(_mass: MusicAssistant, _url: str) -> bytes:
+            return _make_image_bytes([(200, 30, 30), (30, 30, 200)])
+
+        monkeypatch.setattr(images, "_fetch_remote_image", ok_remote_fetch)
+        await invalidate_cached_image(mass_minimal, "builtin", remote_url)
+        palette = await get_palette(mass_minimal, remote_url, "builtin")
+        assert palette is not None
+        assert palette.primary is not None
+    finally:
+        # drop the module-global image cache entries this test created
+        await invalidate_cached_image(mass_minimal, "builtin", remote_url)

--- a/tests/helpers/test_images.py
+++ b/tests/helpers/test_images.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import subprocess
 import time
@@ -13,6 +14,9 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiohttp import ClientSession, web
+from aiohttp.client_exceptions import ClientError
+from aiohttp.test_utils import TestServer
 from music_assistant_models.enums import ImageType, ProviderIconVariant
 from music_assistant_models.media_items import MediaItemImage
 from PIL import Image
@@ -42,9 +46,11 @@ def _reset_image_caches() -> Iterator[None]:
     """Isolate the module-level image caches between tests."""
     images._thumb_memory_cache.clear()
     images._source_memory_cache.clear()
+    images._failed_sources.clear()
     yield
     images._thumb_memory_cache.clear()
     images._source_memory_cache.clear()
+    images._failed_sources.clear()
 
 
 @pytest.fixture
@@ -276,6 +282,106 @@ async def test_remote_disk_entry_expires_after_ttl(
     os.utime(src_file, (expired, expired))
     await get_image_data(mass_minimal, remote_url, "builtin")
     assert len(fetch_calls) == 2
+
+
+async def test_failing_source_fails_fast_with_single_warning(
+    mass_minimal: MusicAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    fetch_calls: list[tuple[str, str]],
+) -> None:
+    """A persistently failing source is fetched once, then fails fast without new logs."""
+    mass_minimal.webserver = MagicMock(base_url="http://127.0.0.1:8095")
+    mass_minimal.streams = MagicMock(base_url="http://127.0.0.1:8097")
+    remote_url = "http://sonos.example.com:1400/getaa?u=missing.flac"
+
+    async def failing_remote_fetch(_mass: MusicAssistant, url: str) -> bytes:
+        raise ClientError(f"404, message='Not Found', url='{url}'")
+
+    monkeypatch.setattr(images, "_fetch_remote_image", failing_remote_fetch)
+    caplog.set_level(logging.WARNING, logger="music_assistant.helpers.images")
+
+    with pytest.raises(FileNotFoundError, match="404"):
+        await get_image_data(mass_minimal, remote_url, "builtin")
+    # follow-up requests (next metadata push, a thumbnail, a palette) fail
+    # fast without a new origin fetch and without logging again
+    with pytest.raises(FileNotFoundError, match="404"):
+        await get_image_data(mass_minimal, remote_url, "builtin")
+    with pytest.raises(FileNotFoundError, match="404"):
+        await get_image_thumb(mass_minimal, remote_url, 256, "builtin")
+
+    assert len(fetch_calls) == 1
+    warnings = [rec for rec in caplog.records if rec.name == "music_assistant.helpers.images"]
+    assert len(warnings) == 1
+    assert "not retrying" in warnings[0].getMessage()
+
+
+async def test_failed_source_retried_after_ttl_or_invalidation(
+    mass_minimal: MusicAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    fetch_calls: list[tuple[str, str]],
+) -> None:
+    """A failed source is retried after the negative-cache TTL or invalidation."""
+    mass_minimal.webserver = MagicMock(base_url="http://127.0.0.1:8095")
+    mass_minimal.streams = MagicMock(base_url="http://127.0.0.1:8097")
+    remote_url = "http://cdn.example.com/broken.jpg"
+    cache_key = create_thumb_hash("builtin", remote_url)
+
+    async def failing_remote_fetch(_mass: MusicAssistant, _url: str) -> bytes:
+        raise ClientError("503, message='Service Unavailable'")
+
+    monkeypatch.setattr(images, "_fetch_remote_image", failing_remote_fetch)
+    with pytest.raises(FileNotFoundError):
+        await get_image_data(mass_minimal, remote_url, "builtin")
+    assert len(fetch_calls) == 1
+
+    # once the TTL has passed, the origin is tried again
+    _expires_at, message = images._failed_sources[cache_key]
+    images._failed_sources[cache_key] = (time.monotonic() - 1, message)
+    with pytest.raises(FileNotFoundError):
+        await get_image_data(mass_minimal, remote_url, "builtin")
+    assert len(fetch_calls) == 2
+
+    # invalidation drops the entry immediately; a recovered origin then serves
+    await invalidate_cached_image(mass_minimal, "builtin", remote_url)
+    assert cache_key not in images._failed_sources
+
+    async def ok_remote_fetch(_mass: MusicAssistant, _url: str) -> bytes:
+        return b"remote-image-bytes"
+
+    monkeypatch.setattr(images, "_fetch_remote_image", ok_remote_fetch)
+    assert await get_image_data(mass_minimal, remote_url, "builtin") == b"remote-image-bytes"
+    assert len(fetch_calls) == 3
+
+
+async def test_remote_http_404_yields_file_not_found(mass_minimal: MusicAssistant) -> None:
+    """A real HTTP 404 response converts into FileNotFoundError with one origin hit."""
+    hits = 0
+
+    async def handler(_request: web.Request) -> web.Response:
+        nonlocal hits
+        hits += 1
+        return web.Response(status=404)
+
+    app = web.Application()
+    app.router.add_get("/getaa", handler)
+    server = TestServer(app)
+    await server.start_server()
+    session = ClientSession()
+    try:
+        mass_minimal.webserver = MagicMock(base_url="http://127.0.0.1:8095")
+        mass_minimal.streams = MagicMock(base_url="http://127.0.0.1:8097")
+        mass_minimal._http_session_no_ssl = session
+        url = str(server.make_url("/getaa")) + "?u=track.flac"
+        with pytest.raises(FileNotFoundError, match="404"):
+            await get_image_data(mass_minimal, url, "builtin")
+        # the negative cache prevents a second hit on the origin
+        with pytest.raises(FileNotFoundError, match="404"):
+            await get_image_data(mass_minimal, url, "builtin")
+        assert hits == 1
+    finally:
+        await session.close()
+        await server.close()
 
 
 async def test_own_imageproxy_url_cached_under_resolved_key_only(


### PR DESCRIPTION
# What does this implement/fix?

When an artwork URL keeps failing (e.g. a Sonos `getaa` URL returning 404 for the current track), every now-playing push, thumbnail and palette request re-fetched the same dead URL, logging the same lengthy error over and over and making every consumer wait for the full network round-trip just to fail again — delaying metadata delivery to players.

- Source images that fail to fetch are now remembered for 5 minutes: the first failure logs a single concise warning and follow-up requests fail fast without touching the origin (cleared early on cache invalidation)
- Color palette extraction now tolerates an unavailable image and returns an empty palette instead of raising, so player metadata updates are never disrupted by missing artwork

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
