### PR TITLE
Fix noisy 'Task exception was never retrieved' errors in the log

### DIFF
--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -723,12 +723,11 @@ class MusicAssistant:
 
         def task_done_callback(_task: asyncio.Task[Any]) -> None:
             self._tracked_tasks.pop(task_id, None)
-            # log unhandled exceptions
-            if (
-                LOGGER.isEnabledFor(logging.DEBUG)
-                and not _task.cancelled()
-                and (err := _task.exception())
-            ):
+            if _task.cancelled():
+                return
+            # always retrieve the exception, otherwise asyncio logs a noisy
+            # "Task exception was never retrieved" error at garbage collection time
+            if err := _task.exception():
                 task_name = _task.get_name() if hasattr(_task, "get_name") else str(_task)
                 LOGGER.warning(
                     "Exception in task %s - target: %s: %s",

--- a/tests/core/test_server_base.py
+++ b/tests/core/test_server_base.py
@@ -1,13 +1,16 @@
 """Tests for the core Music Assistant server object."""
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import EventType
 
+from music_assistant.constants import MASS_LOGGER_NAME
 from music_assistant.mass import MusicAssistant
 
 if TYPE_CHECKING:
+    import pytest
     from music_assistant_models.event import MassEvent
 
 
@@ -61,3 +64,23 @@ async def test_events(mass: MusicAssistant) -> None:
         mass.signal_event(EventType.UNKNOWN)
         await asyncio.sleep(0)
         assert flag is False
+
+
+async def test_create_task_failure_logged(
+    mass_minimal: MusicAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a failed task without awaiter is logged, also without debug logging."""
+
+    async def _boom() -> None:
+        raise ValueError("boom")
+
+    with caplog.at_level(logging.INFO, logger=MASS_LOGGER_NAME):
+        mass_minimal.create_task(_boom)
+        # allow the task's done callback to run
+        await asyncio.sleep(0)
+
+    assert any(
+        "boom" in record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+    )


### PR DESCRIPTION
# What does this implement/fix?

When a background task failed and nothing was awaiting its result (fire-and-forget tasks, or shared tasks whose awaiters were all cancelled — e.g. artwork/palette tasks during rapid track skips), the failure only got logged when debug logging was enabled. At normal log levels the exception was never retrieved, so asyncio dumped an unpredictable "Task exception was never retrieved" error with a full traceback at garbage-collection time.

- The task done callback now always retrieves the exception and logs a single warning at the moment of failure, at any log level
- The full traceback is only attached when debug logging is enabled, keeping normal logs concise
- Added a small regression test for the failure log

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
