### PR TITLE
Sync uploaded albums, artists and tracks from YouTube Music

### DIFF
--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -54,14 +54,23 @@ async def get_album(
     """Async wrapper around the ytmusicapi get_album function."""
 
     def _get_album() -> dict[str, Any]:
+        private = False
         if prov_album_id.startswith("FEmusic_library_privately_owned_release"):
+            private = True
             ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
             album = ytm.get_library_upload_album(browseId=prov_album_id)
+
+            for album_track in album.get("tracks", []):
+                # note: side-effect of the album/playlist videoId xreference below is
+                # to default these values if not present, so I'm reproducing that here
+                # given we don't need to (and can't) do the query that wraps it
+                album_track["isAvailable"] = album_track.get("isAvailable", True)
+                album_track["likeStatus"] = album_track.get("likeStatus", "INDIFFERENT")
+
         else:
             ytm = ytmusicapi.YTMusic(language=language)
             album = ytm.get_album(browseId=prov_album_id)
-
-        if "audioPlaylistId" in album:
+        if "audioPlaylistId" in album and not private:
             # Track id's from album tracks do not match with actual album tracks. E.g. a track
             # points to the videoId of the original version, while we want the album version
             try:

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -59,14 +59,6 @@ async def get_album(
             private = True
             ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
             album = ytm.get_library_upload_album(browseId=prov_album_id)
-
-            for album_track in album.get("tracks", []):
-                # note: side-effect of the album/playlist videoId xreference below is
-                # to default these values if not present, so I'm reproducing that here
-                # given we don't need to (and can't) do the query that wraps it
-                album_track["isAvailable"] = album_track.get("isAvailable", True)
-                album_track["likeStatus"] = album_track.get("likeStatus", "INDIFFERENT")
-
         else:
             ytm = ytmusicapi.YTMusic(language=language)
             album = ytm.get_album(browseId=prov_album_id)
@@ -86,8 +78,6 @@ async def get_album(
             for album_track in album.get("tracks", []):
                 if playlist_track := playlist_tracks_by_title.get(album_track.get("title")):
                     album_track["videoId"] = playlist_track["videoId"]
-                    album_track["isAvailable"] = playlist_track.get("isAvailable", True)
-                    album_track["likeStatus"] = playlist_track.get("likeStatus", "INDIFFERENT")
         return album
 
     return await _run_ytmusic(_get_album)

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -172,17 +172,26 @@ async def get_library_artists(
 
     def _get_library_artists() -> list[dict[str, Any]]:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
-        artists = (
+
+        artists = []
+        # Avoid duplicate ids from overlapping sources
+        seen_ids = set()
+
+        for artist in (
             ytm.get_library_subscriptions(limit=9999)
             + ytm.get_library_artists(limit=9999)
             + ytm.get_library_upload_artists(limit=9999)
-        )
-        # Sync properties with uniformal artist object
-        for artist in artists:
-            artist["id"] = artist["browseId"]
+        ):
+            # Sync properties with uniformal artist object
+            artist["id"] = artist["browseId"].removeprefix("MPLA")
             artist["name"] = artist["artist"]
             del artist["browseId"]
             del artist["artist"]
+
+            if artist["id"] not in seen_ids:
+                artists.append(artist)
+                seen_ids.add(artist["id"])
+
         return artists
 
     return await _run_ytmusic(_get_library_artists)

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -182,7 +182,11 @@ async def get_library_artists(
 
     def _get_library_artists() -> list[dict[str, Any]]:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
-        artists = ytm.get_library_subscriptions(limit=9999)
+        artists = (
+            ytm.get_library_subscriptions(limit=9999)
+            + ytm.get_library_artists(limit=9999)
+            + ytm.get_library_upload_artists(limit=9999)
+        )
         # Sync properties with uniformal artist object
         for artist in artists:
             artist["id"] = artist["browseId"]
@@ -201,7 +205,7 @@ async def get_library_albums(
 
     def _get_library_albums() -> list[dict[str, Any]]:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
-        return ytm.get_library_albums(limit=9999)
+        return ytm.get_library_albums(limit=9999) + ytm.get_library_upload_albums(limit=9999)
 
     return await _run_ytmusic(_get_library_albums)
 
@@ -231,7 +235,7 @@ async def get_library_tracks(
 
     def _get_library_tracks() -> list[dict[str, Any]]:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
-        return ytm.get_library_songs(limit=9999)
+        return ytm.get_library_songs(limit=9999) + ytm.get_library_upload_songs(limit=9999)
 
     return await _run_ytmusic(_get_library_tracks)
 


### PR DESCRIPTION
# What does this implement/fix?

This adds further to the changes from #3156 . [As discussed](https://github.com/music-assistant/server/pull/3156#issuecomment-4301799341) the resolved albums could miss a reverse link in the database.

These changes simply enumerate the upload versions of the album track and artist APIs, which seems to resolve the links in the database.

As a result 
* I can browse uploaded albums and songs
* The song<-->album links are solid ([issue from #3156](https://github.com/music-assistant/server/pull/3156#issuecomment-4301799341))
* "Favourited" upload music now turns up in the favourited auto playlist

The only non-trivial change surrounds that bit of patching in `_get_album()` - I've added code to explicitly avoid the exception path and reproduce the side-effects of that path assuming it had succeeded.  I have no indication the default handling there is needed, from my account data, but I thought it prudent to include them, since someone had already felt the need to patch them in the other path.

**Related issue (if applicable):**


## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
      Note `pre-commit` fails to run under `pyenv` which i use for isolation and python-version management.  The scripts break out of my venv and then complains the system python is wrong. 
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
