### PR TITLE
Stop re-sending unchanged album art around AirPlay track changes

### DIFF
--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -127,8 +127,14 @@ class AirPlayStream:
         # `connected` this makes readiness fully event-driven, so START can
         # use a short re-anchor lead instead of a guessed setup time.
         self._audio_present = asyncio.Event()
-        self._metadata_checksum = ""
         self._metadata_text_checksum = ""
+        # Artwork identity (the source image url) whose rendered bytes were
+        # last delivered to the binary. Settles on the first successful
+        # delivery, independent of the metadata generation: media updates
+        # around a track transition keep bumping the generation, and a settle
+        # tied to it would re-render and re-send the same art on every update
+        # until the churn stops.
+        self._metadata_artwork_checksum = ""
         self._pending_metadata_checksum = ""
         self._metadata_generation = 0
         self._metadata_lock = asyncio.Lock()
@@ -239,8 +245,8 @@ class AirPlayStream:
         await self.send_cli_command(f"VOLUME={volume}")
         self.mass.call_later(2, self.send_cli_command(f"VOLUME={volume}"))
         async with self._metadata_lock:
-            self._metadata_checksum = ""
             self._metadata_text_checksum = ""
+            self._metadata_artwork_checksum = ""
             self._pending_metadata_checksum = ""
             self._metadata_generation += 1
         # Push track metadata before START. Some receivers (notably Sonos) hold
@@ -451,6 +457,7 @@ class AirPlayStream:
         """
         metadata_checksum: str | None = None
         text_checksum: str | None = None
+        artwork_checksum = ""
         duration = 0
         title = ""
         artist = ""
@@ -467,6 +474,7 @@ class AirPlayStream:
             # full metadata each time — which makes an Apple TV re-render its
             # Now Playing popup.
             text_checksum = f"{item_id}|{title}|{artist}|{album}"
+            artwork_checksum = metadata.image_url or ""
             metadata_checksum = f"{text_checksum}|{metadata.image_url}"
 
         artwork_url: str | None = None
@@ -479,16 +487,13 @@ class AirPlayStream:
                     self._pending_metadata_checksum = metadata_checksum
                     self._metadata_generation += 1
                 metadata_generation = self._metadata_generation
+            needs_artwork = artwork_checksum != self._metadata_artwork_checksum
             if (
                 metadata
                 and metadata_checksum is not None
                 and text_checksum is not None
-                and (
-                    metadata_checksum != self._metadata_checksum
-                    or text_checksum != self._metadata_text_checksum
-                )
+                and (needs_artwork or text_checksum != self._metadata_text_checksum)
             ):
-                needs_artwork = metadata_checksum != self._metadata_checksum
                 if text_checksum != self._metadata_text_checksum:
                     # ITEMID gives the binary a stable per-track identity, so
                     # a later tag refinement for the same queue item (library
@@ -514,7 +519,7 @@ class AirPlayStream:
                     self._artwork_render_generations.add(metadata_generation)
                     artwork_url = metadata.image_url
                 elif not metadata.image_url or not needs_artwork:
-                    self._metadata_checksum = metadata_checksum
+                    self._metadata_artwork_checksum = artwork_checksum
             if progress is not None and (
                 self._last_progress_sent is None or abs(progress - self._last_progress_sent) >= 2
             ):
@@ -524,8 +529,8 @@ class AirPlayStream:
                 if await self.send_cli_command(f"{duration_cmd}PROGRESS={progress}"):
                     self._last_progress_sent = progress
 
-        if artwork_url is not None and metadata_checksum is not None:
-            await self._render_and_send_artwork(artwork_url, metadata_checksum, metadata_generation)
+        if artwork_url is not None:
+            await self._render_and_send_artwork(artwork_url, metadata_generation)
 
     def _full_media_duration(self, metadata: PlayerMedia) -> int:
         """
@@ -553,14 +558,12 @@ class AirPlayStream:
                     return min(int(full_duration), 3600)
         return min(metadata.duration or 0, 3600)
 
-    async def _render_and_send_artwork(
-        self, artwork_url: str, metadata_checksum: str, metadata_generation: int
-    ) -> None:
+    async def _render_and_send_artwork(self, artwork_url: str, metadata_generation: int) -> None:
         """
         Render and apply artwork for the current metadata generation.
 
-        :param artwork_url: Source URL for the artwork.
-        :param metadata_checksum: Identity of the metadata receiving the artwork.
+        :param artwork_url: Source URL for the artwork; settles as the
+            delivered artwork identity once the binary accepts the command.
         :param metadata_generation: Generation that must still be current before apply.
         """
         try:
@@ -576,15 +579,9 @@ class AirPlayStream:
                 and not self._stopped
                 and not self._stopping
                 and metadata_generation == self._metadata_generation
+                and await self.send_cli_command(f"ARTWORK={artwork}")
             ):
-                artwork_delivered = await self.send_cli_command(f"ARTWORK={artwork}")
-                if (
-                    artwork_delivered
-                    and not self._stopped
-                    and not self._stopping
-                    and metadata_generation == self._metadata_generation
-                ):
-                    self._metadata_checksum = metadata_checksum
+                self._metadata_artwork_checksum = artwork_url
 
     async def _build_cli_args(  # noqa: PLR0915
         self,

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -733,7 +733,7 @@ async def test_start_transition_artwork_settled_or_retried(complete_before_start
         assert commands[-2:] == [start_command, "ARTWORK=/cache/posttransition.jpg"]
         assert "ARTWORK=/cache/pretransition.jpg" not in commands
     assert stream._metadata_generation == 2
-    assert stream._metadata_checksum == "item-new|New track|Artist|Album|new-image"
+    assert stream._metadata_artwork_checksum == "new-image"
 
 
 @pytest.mark.asyncio
@@ -1362,9 +1362,7 @@ async def test_process_eof_during_render_does_not_send_artwork() -> None:
         ),
         patch.object(stream, "send_cli_command", new_callable=AsyncMock) as send_command,
     ):
-        render_task = asyncio.create_task(
-            stream._render_and_send_artwork("image", "metadata-checksum", 1)
-        )
+        render_task = asyncio.create_task(stream._render_and_send_artwork("image", 1))
         await render_started.wait()
         stream._stopped = True
         release_render.set()
@@ -1452,7 +1450,6 @@ async def test_metadata_revert_resends_text_after_superseded_artwork() -> None:
         image_url="second-image",
     )
     first_checksum = "First track|Artist|Album|180|None"
-    stream._metadata_checksum = first_checksum
     stream._metadata_text_checksum = first_checksum
     stream._pending_metadata_checksum = first_checksum
     artwork_started = asyncio.Event()
@@ -1498,7 +1495,7 @@ async def test_repeated_metadata_retries_superseded_artwork() -> None:
     stream._cli_proc = process
     initial_text_checksum = "item-initial|Initial|Artist|Album"
     initial_checksum = f"{initial_text_checksum}|initial-image"
-    stream._metadata_checksum = initial_checksum
+    stream._metadata_artwork_checksum = "initial-image"
     stream._metadata_text_checksum = initial_text_checksum
     stream._pending_metadata_checksum = initial_checksum
     metadata_b = MagicMock(
@@ -1561,7 +1558,7 @@ async def test_repeated_metadata_retries_superseded_artwork() -> None:
     assert "ARTWORK=b-stale.jpg\n" not in commands
     assert "ARTWORK=c.jpg\n" not in commands
     assert commands[-1] == "ARTWORK=b-final.jpg\n"
-    assert stream._metadata_checksum == "item-b|Track B|Artist|Album|b-image"
+    assert stream._metadata_artwork_checksum == "b-image"
 
 
 @pytest.mark.asyncio
@@ -1600,7 +1597,6 @@ async def test_failed_artwork_delivery_is_retried() -> None:
         album="Album",
         image_url="image",
     )
-    metadata_checksum = "item-1|Track|Artist|Album|image"
     artwork_path = "/cache/thumbnails/artwork.jpg"
 
     with (
@@ -1618,14 +1614,61 @@ async def test_failed_artwork_delivery_is_retried() -> None:
         ) as send_command,
     ):
         await stream.send_metadata(None, metadata)
-        assert stream._metadata_checksum == ""
+        assert stream._metadata_artwork_checksum == ""
         await stream.send_metadata(None, metadata)
 
     assert prepare_artwork.await_count == 2
     assert [args.args[0] for args in send_command.await_args_list].count(
         f"ARTWORK={artwork_path}"
     ) == 2
-    assert stream._metadata_checksum == metadata_checksum
+    assert stream._metadata_artwork_checksum == "image"
+
+
+@pytest.mark.asyncio
+async def test_text_refinement_keeps_delivered_artwork_settled() -> None:
+    """A text-only metadata update after delivery does not re-render unchanged art."""
+    stream = AirPlayStream(_make_player())
+    metadata = MagicMock(
+        duration=180,
+        title="Track",
+        artist="Artist",
+        album="Album",
+        image_url="image",
+    )
+    refined = MagicMock(
+        queue_item_id=metadata.queue_item_id,
+        duration=180,
+        title="Track (Remastered)",
+        artist="Artist",
+        album="Album",
+        image_url="image",
+    )
+    artwork_path = "/cache/thumbnails/artwork.jpg"
+
+    with (
+        patch.object(
+            stream,
+            "_prepare_artwork",
+            new_callable=AsyncMock,
+            return_value=artwork_path,
+        ) as prepare_artwork,
+        patch.object(
+            stream,
+            "send_cli_command",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as send_command,
+    ):
+        await stream.send_metadata(None, metadata)
+        assert stream._metadata_artwork_checksum == "image"
+        # the refinement bumps the metadata generation (pending identity
+        # changed), which before the identity settle re-armed the artwork
+        await stream.send_metadata(None, refined)
+
+    prepare_artwork.assert_awaited_once()
+    commands = [args.args[0] for args in send_command.await_args_list]
+    assert commands.count(f"ARTWORK={artwork_path}") == 1
+    assert "TITLE=Track (Remastered)" in commands[-1]
 
 
 # --- Structured connect failures reported by the binary ---


### PR DESCRIPTION
# What does this implement/fix?

Around a track change, every metadata update (a seek anchor, library tags settling after playback starts) invalidated the album-art delivery bookkeeping, so the server re-rendered and re-sent the identical artwork roughly once per second until the metadata stopped changing. The receiver already ignores the duplicate art, so nothing was visibly wrong — but every cycle cost a thumbnail render and a command write, and it filled the debug log with repeated artwork pushes.

- The delivered artwork is now remembered on its own and settles after the first successful delivery
- Metadata text refinements no longer re-render or re-send unchanged artwork
- Genuinely changed artwork still cancels a superseded in-flight delivery, so stale art can never land
- Added a regression test for the refinement-after-delivery case

Stacked on the gapless seeks branch (#5181).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
