### PR TITLE
Add external_until for poll-completed external steps

### DIFF
--- a/music_assistant/models/setup_flow.py
+++ b/music_assistant/models/setup_flow.py
@@ -229,6 +229,31 @@ class SetupSession:
         finally:
             self._callback_future = None
 
+    async def external_until(
+        self,
+        awaitable: Awaitable[_T],
+        url: str,
+        step_id: str = "auth",
+        expires_in: float | None = None,
+    ) -> _T:
+        """
+        Show an external "Open URL" step that completes when ``awaitable`` resolves.
+
+        Unlike :meth:`external`, which waits for a browser callback, this drives
+        completion from the given awaitable (e.g. a device-code poll) for flows that
+        have no callback to return to. The step renders identically - an Open button for
+        ``url`` plus a waiting spinner - and is dismissed when the awaitable resolves.
+
+        :param awaitable: The work/wait whose completion advances the flow.
+        :param url: The URL the user must open.
+        :param step_id: Stable slug identifying this step (also the i18n key segment).
+        :param expires_in: Optional deadline in seconds; when it passes,
+            StepExpiredError is raised here (and the client countdown runs out).
+        """
+        step = self._build_step(FlowStepType.EXTERNAL, step_id, url=url, expires_in=expires_in)
+        self._publish_step(step)
+        return await self._await_with_deadline(awaitable, expires_in)
+
     def progress(
         self,
         step_id: str,

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -1685,3 +1685,64 @@ async def test_netease_qr_flow_expiry_then_confirm(
     assert flow_mass.config.decrypt_string(setup_data[CONF_COOKIE]) == "cookie-xyz"
     assert flow_mass.config.decrypt_string(setup_data[CONF_UID]) == "42"
     assert flow_mass.config.decrypt_string(setup_data[CONF_API_BASE_URL]) == "http://127.0.0.1:3000"
+
+
+async def test_external_until_completes_on_awaitable(flow_mass: MusicAssistant) -> None:
+    """external_until shows an external step and completes on the awaitable (no callback)."""
+    release = asyncio.Event()
+
+    async def _work() -> dict[str, str]:
+        await release.wait()
+        return {"token": "abc"}
+
+    async def run_setup(session: SetupSession) -> None:
+        result = await session.external_until(
+            _work(),
+            url="https://example.com/device",
+            step_id="device",
+            expires_in=300,
+        )
+        await session.finish({"token": result["token"]})
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        assert step.type == FlowStepType.EXTERNAL
+        assert step.step_id == "device"
+        assert step.url == "https://example.com/device"
+        session = flow_mass.config._setup_flows[step.flow_id].session
+        # completion is driven by the awaitable resolving, not a browser callback
+        release.set()
+        await _wait_for(lambda: session.finished)
+    setup_data = flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}")["setup_data"]
+    assert flow_mass.config.decrypt_string(setup_data["token"]) == "abc"
+
+
+async def test_external_until_raises_on_deadline(flow_mass: MusicAssistant) -> None:
+    """external_until raises StepExpiredError when the awaitable outlives expires_in."""
+    expired = asyncio.Event()
+
+    async def _never() -> None:
+        await asyncio.Event().wait()
+
+    async def run_setup(session: SetupSession) -> None:
+        try:
+            await session.external_until(
+                _never(),
+                url="https://example.com/device",
+                step_id="device",
+                expires_in=0.1,
+            )
+        except StepExpiredError:
+            expired.set()
+            raise
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        assert step.type == FlowStepType.EXTERNAL
+        await _wait_for(lambda: expired.is_set())


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Add SetupSession.external_until(): show an external "Open URL" step (the same Open button + waiting spinner as external()) but complete it from a given awaitable instead of a browser callback. This lets poll-based device-code auth flows present the polished external-step UX without a callback to return to, leaving progress()/progress_until() untouched.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
