### PR TITLE
Fix late-joining AirPlay players starting out of sync

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -63,9 +63,15 @@ DACP_DISCOVERY_TYPE: Final[str] = "_dacp._tcp.local."
 # RAOP because its pre-fill is paced.
 AIRPLAY_RAOP_SETUP_LEAD_MS: Final[int] = 1500
 AIRPLAY_AP2_SETUP_LEAD_MS: Final[int] = 2500
-# Late joiners keep a more conservative headroom: besides connecting, their
-# pipeline must also be primed from the session's history buffer.
-AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 2000
+# Late joiners keep a much more conservative headroom: besides connecting and
+# priming from the session's history buffer, the receiver must re-acquire the
+# shared PTP clock before it can render its anchor. Its Delay_Req exchange
+# only resumes ~0.7-1.5 s after the join's START is acked (measured on a
+# Sonos Era 100 pair, 2026-07-31) and the servo needs a further ~1.7-2.3 s to
+# lock — and a missed anchor is permanent on the splice timeline (the frozen
+# line is never re-announced), heard as a constant echo on the joined member.
+# The anchor therefore sits beyond exchange-resume plus lock plus margin.
+AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 4000
 # Anchor lead for a readiness-confirmed START (cold and warm alike): the
 # session only anchors after the binary confirmed the connection ([STATUS]
 # connected) and the new audio flowing ([STATUS] audio), so the lead no longer

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -11,6 +11,7 @@ from music_assistant_models.errors import PlayerCommandFailed
 
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_COLD_GROUP_START_LEAD_MS,
+    AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
     StreamingProtocol,
 )
 from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
@@ -669,7 +670,7 @@ async def test_standby_returns_false_when_command_raises() -> None:
 async def test_late_join_empty_buffer() -> None:
     """Test that with an empty buffer, start_at = start_time + seconds_streamed."""
     now = time.time()
-    start_time = now - 10
+    start_time = now - 8
     seconds_streamed = 12.5
     session = _make_session(start_time, seconds_streamed)
     player = _make_late_joiner(wait_start_ms=2000)
@@ -799,19 +800,21 @@ async def test_late_join_primes_from_ring_tail_at_headroom() -> None:
         mock_start.side_effect = _setup_stream(player)
         await session.add_client(player)
 
-    # start_at is now + min_headroom (session.wait_start = 2.0); fed_pos_due = 2.5s
+    # start_at is now + min_headroom (the late-join floor); fed_pos_due = 4.5s
     assert mock_start.called, "_start_client was never called"
-    assert _captured_start_at(player) - now == pytest.approx(2.0, abs=0.01), (
+    expected_headroom = AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000
+    assert _captured_start_at(player) - now == pytest.approx(expected_headroom, abs=0.01), (
         f"start_at should be at now + min_headroom, "
         f"got offset {_captured_start_at(player) - now:.4f}s"
     )
 
-    # The last 2.5s of the ring is primed (positions 2.5s..5.0s), nothing skipped.
+    # The last 0.5s of the ring is primed (positions 4.5s..5.0s), nothing skipped.
     assert session._client_skip_bytes[player.player_id] == 0
     assert written_chunks, "No data was written to the player"
     remaining_seconds = len(written_chunks[0]) / PCM_SAMPLE_SIZE
-    assert remaining_seconds == pytest.approx(2.5, abs=0.01), (
-        f"expected 2.5s primed, got {remaining_seconds:.4f}s"
+    expected_primed = seconds_streamed - (expected_headroom + (now - start_time))
+    assert remaining_seconds == pytest.approx(expected_primed, abs=0.01), (
+        f"expected {expected_primed:.2f}s primed, got {remaining_seconds:.4f}s"
     )
 
 
@@ -821,7 +824,8 @@ async def test_late_join_skips_live_feed_when_anchor_ahead_of_write_head() -> No
     # Freeze time so both the test and the code under test agree on `now`.
     now = 1_000_000.0
     # Diagnosed clamp case: now - start_time = 8.84s, seconds_streamed = 10.0s,
-    # min_headroom = 2.5s and no group shift -> fed_pos_due = 11.34s > 10.0s.
+    # min_headroom = 4.0s (the floor) and no group shift ->
+    # fed_pos_due = 12.84s > 10.0s.
     start_time = now - 8.84
     seconds_streamed = 10.0
     session = _make_session(start_time, seconds_streamed)
@@ -843,10 +847,10 @@ async def test_late_join_skips_live_feed_when_anchor_ahead_of_write_head() -> No
         await session.add_client(player)
 
     # anchor is now + min_headroom and nothing is primed (position past the head)
-    assert _captured_start_at(player) - now == pytest.approx(2.5, abs=0.01)
+    assert _captured_start_at(player) - now == pytest.approx(4.0, abs=0.01)
     assert written_chunks == []
     skip_seconds = session._client_skip_bytes[player.player_id] / PCM_SAMPLE_SIZE
-    assert skip_seconds == pytest.approx(1.34, abs=0.01)
+    assert skip_seconds == pytest.approx(2.84, abs=0.01)
 
 
 @pytest.mark.asyncio
@@ -855,7 +859,7 @@ async def test_late_join_primes_from_ring_under_group_shift() -> None:
     # Freeze time so both the test and the code under test agree on `now`.
     now = 1_000_000.0
     # Same base as the clamp case, but the reference member accumulated a
-    # +1.539s starvation shift (67870 frames @44100) so the group's effective
+    # +3.039s starvation shift (134020 frames @44100) so the group's effective
     # anchor is later: fed_pos_due = 9.80s, back inside the ring. The joiner is
     # primed with ~0.2s from the ring tail and skips nothing.
     start_time = now - 8.84
@@ -864,7 +868,7 @@ async def test_late_join_primes_from_ring_under_group_shift() -> None:
     session.wait_start = 2.5
     session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 10)
     reference: Any = session.sync_clients[0]
-    reference.stream.cumulative_shift_seconds = 67870 / 44100
+    reference.stream.cumulative_shift_seconds = 134020 / 44100
     player = _make_late_joiner(wait_start_ms=2000)
 
     written_chunks: list[bytes] = []
@@ -880,7 +884,7 @@ async def test_late_join_primes_from_ring_under_group_shift() -> None:
         mock_start.side_effect = _setup_stream(player)
         await session.add_client(player)
 
-    assert _captured_start_at(player) - now == pytest.approx(2.5, abs=0.01)
+    assert _captured_start_at(player) - now == pytest.approx(4.0, abs=0.01)
     assert session._client_skip_bytes[player.player_id] == 0
     assert written_chunks, "expected a prime write from the ring tail"
     primed_seconds = len(written_chunks[0]) / PCM_SAMPLE_SIZE


### PR DESCRIPTION
# What does this implement/fix?

Re-adding an AirPlay player to a group that is already playing could leave it audibly out of sync — a constant echo that lasted until playback was restarted. A rejoining speaker first needs a moment to re-sync its clock with the group before it can start exactly on the commanded moment, and the join gave it slightly less time than slow devices need (worst right after a server restart). Because a running stream's timeline is fixed once started, a late start could never correct itself afterwards.

- Give late-joining players a longer start anchor so their clock sync completes in time, even on the slowest devices
- Late-join test expectations recomputed for the new headroom

**Related issue (if applicable):**

- none

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.