### PR TITLE
Fix providers wrongly showing a setup error when they loaded fine

### DIFF
--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -857,8 +857,23 @@ class MusicAssistant:
             )
             raise
 
-        # (re)load any dependants
-        prov_configs = await self.config.get_provider_configs(include_values=True)
+        # (re)load any dependents. The provider itself is loaded at this point, so a problem
+        # in this scan belongs to a dependent (or to nothing at all) and must never be
+        # recorded against - and thus flag - the provider we just loaded successfully.
+        try:
+            # resolving option values here would call get_config_entries() on every loaded
+            # provider (some of which do network i/o), for values _load_provider does not
+            # read: it seeds the stored raw values itself and rehydrates once the instance
+            # exists. Only the manifest-related fields below are needed to spot a dependent.
+            prov_configs = await self.config.get_provider_configs()
+        except Exception as exc:
+            LOGGER.warning(
+                "Error looking up dependents of provider(instance) %s: %s",
+                prov_conf.name or prov_conf.instance_id,
+                str(exc) or exc.__class__.__name__,
+                exc_info=_provider_error_traceback(exc),
+            )
+            return
         for dep_prov_conf in prov_configs:
             if not dep_prov_conf.enabled:
                 continue
@@ -1122,7 +1137,8 @@ class MusicAssistant:
             await self.config.create_builtin_provider_config(prov_manifest.domain)
 
         # load all configured (and enabled) builtin providers
-        prov_configs = await self.config.get_provider_configs(include_values=True)
+        # (only manifest-related fields are read here, so the option values are not resolved)
+        prov_configs = await self.config.get_provider_configs()
         builtin_configs: list[ProviderConfig] = [
             prov_conf
             for prov_conf in prov_configs
@@ -1181,7 +1197,8 @@ class MusicAssistant:
             self.config.set(CONF_DEFAULT_PROVIDERS_SETUP, default_providers_setup)
             self.config.save(True)
         # load all configured (and enabled) regular (non-builtin) providers
-        prov_configs = await self.config.get_provider_configs(include_values=True)
+        # (only manifest-related fields are read here, so the option values are not resolved)
+        prov_configs = await self.config.get_provider_configs()
         other_configs: list[ProviderConfig] = [
             prov_conf
             for prov_conf in prov_configs

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -240,10 +240,19 @@ class HomeAssistantProvider(PluginProvider):
 
         # append player controls entries (if we have an active instance)
         if self.available:
-            return (
-                *base_entries,
-                *(await _get_config_entries(self)),
-            )
+            try:
+                return (
+                    *base_entries,
+                    *(await _get_config_entries(self)),
+                )
+            except TimeoutError:
+                # listing the selectable entities needs a live sweep of Home Assistant, so a
+                # slow or busy instance must not fail config resolution for the whole server.
+                # The entries below carry no options but do keep any stored selection.
+                self.logger.warning(
+                    "Timeout fetching entities from Home Assistant, "
+                    "player control options are unavailable until the next refresh"
+                )
 
         return (
             *base_entries,

--- a/tests/controllers/config/test_provider_config_load.py
+++ b/tests/controllers/config/test_provider_config_load.py
@@ -9,6 +9,9 @@ Covers three fixes for the Spotify auth failures caused by refresh-token rotatio
   (e.g. auth_required) instead of appearing stuck loading (a spinning hourglass).
 - A raw provider value stored with ``immediate=True`` is flushed straight away instead of
   on the debounced timer, so a rotated (and thus revoked) token is not lost on a crash.
+
+Also covers the post-load dependent scan, which must neither resolve the option values of
+every provider nor record its own failures against the provider that just loaded fine.
 """
 
 from __future__ import annotations
@@ -124,6 +127,47 @@ async def test_save_preserves_unknown_stored_values(mass_minimal: MusicAssistant
     assert stored["values"]["legacy_token"] == "keep-me"
     # setup_data travels along untouched
     assert stored["setup_data"] == {"token": "abc"}
+
+
+async def test_dependent_scan_does_not_resolve_option_values(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """The post-load dependent scan reads the configs without resolving their option values."""
+    instance = "spotify--test"
+    with (
+        patch.object(mass_minimal, "_load_provider", AsyncMock()),
+        patch.object(
+            mass_minimal.config, "get_provider_configs", AsyncMock(return_value=[])
+        ) as mock_get,
+    ):
+        await mass_minimal.load_provider_config(_prov_conf(instance))
+
+    # resolving values calls get_config_entries() on every loaded provider, which for some
+    # (e.g. Home Assistant) means live network i/o - once per provider load
+    assert mock_get.await_args is not None
+    assert mock_get.await_args.kwargs.get("include_values") is not True
+    assert True not in mock_get.await_args.args
+
+
+async def test_dependent_scan_failure_is_not_blamed_on_loaded_provider(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A provider that loaded fine keeps a clean status when the dependent scan fails."""
+    config = mass_minimal.config
+    instance = "spotify--test"
+    config.set(
+        f"{CONF_PROVIDERS}/{instance}",
+        {"domain": "spotify", "type": "music", "instance_id": instance, "enabled": True},
+    )
+    with (
+        patch.object(mass_minimal, "_load_provider", AsyncMock()),
+        patch.object(config, "get_provider_configs", AsyncMock(side_effect=TimeoutError)),
+    ):
+        # the scan failure is swallowed: the provider itself loaded successfully
+        await mass_minimal.load_provider_config(_prov_conf(instance))
+
+    assert config.get(f"{CONF_PROVIDERS}/{instance}/last_error") is None
+    assert _provider_status(_prov_conf(instance), is_loaded=True) == ProviderStatus.LOADED
 
 
 async def test_immediate_flush_for_rotated_token(mass_minimal: MusicAssistant) -> None:

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -17,6 +17,7 @@ from music_assistant.constants import CONF_LOG_LEVEL
 from music_assistant.providers.hass import (
     CONF_AI_TASK_ENTITY,
     CONF_AUTH_TOKEN,
+    CONF_POWER_CONTROLS,
     CONF_TTS_ENTITY,
     CONF_URL,
     CONF_VERIFY_SSL,
@@ -438,3 +439,27 @@ async def test_tts_not_advertised_without_entity(config_values: dict[str, str]) 
         _,
     ):
         assert ProviderFeature.TTS not in provider.supported_features
+
+
+async def test_config_entries_survive_a_state_fetch_timeout() -> None:
+    """A Home Assistant too slow to list its entities yields entries without options."""
+    async with _start_provider([_state("switch.example", "Example")]) as (provider, _):
+        # the entity sweep only runs for a provider the load machinery marked available
+        provider.available = True
+        with patch.object(provider, "get_states", AsyncMock(side_effect=TimeoutError)):
+            entries = await provider.get_config_entries()
+
+    keys = {entry.key for entry in entries}
+    assert CONF_POWER_CONTROLS in keys
+    assert CONF_TTS_ENTITY in keys
+    assert all(not entry.options for entry in entries)
+
+
+async def test_config_entries_list_entities_as_options() -> None:
+    """A responsive Home Assistant offers its entities as player control options."""
+    async with _start_provider([_state("switch.example", "Example")]) as (provider, _):
+        provider.available = True
+        entries = await provider.get_config_entries()
+
+    power_controls = next(entry for entry in entries if entry.key == CONF_POWER_CONTROLS)
+    assert [option.value for option in power_controls.options] == ["switch.example"]


### PR DESCRIPTION
# What does this implement/fix?

On a server with many providers, most of them could show a `TimeoutError` in the settings
right after startup while they were in fact loaded and working fine.

The error came from a step that runs *after* a provider has loaded: the scan for providers
depending on it resolved the option values of every configured provider, which makes each
loaded provider recompute its options. For Home Assistant that means a live sweep of all
entities, so with providers loading concurrently that sweep ran dozens of times at once and
eventually hit its 30 second timeout. The failure was then recorded against whichever
provider had just finished loading, and a recorded error outranks "loaded" in the UI, so it
stuck around until that provider was reloaded by hand.

- The dependent scan no longer resolves option values, which it never used: the load path
  seeds the stored values itself and rehydrates them once the provider instance exists. Same
  for the two startup paths that pick which providers to load.
- A failure while looking up dependents is logged instead of being recorded against the
  provider that just loaded successfully.
- A timeout while listing Home Assistant entities no longer fails config resolution for the
  whole server. The player control options stay empty until the next refresh, and any stored
  selection is kept.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
