### PR TITLE
Fix rejoining AirPlay players that start out of sync when their clock is slow to lock

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -72,6 +72,11 @@ AIRPLAY_AP2_SETUP_LEAD_MS: Final[int] = 2500
 # line is never re-announced), heard as a constant echo on the joined member.
 # The anchor therefore sits beyond exchange-resume plus lock plus margin.
 AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 4000
+# Floor (ms) for a post-commit anchor correction to be worth an automatic
+# re-join: below this the audible offset a grouped member carries is small
+# enough that the re-join itself (a fresh connect, prime and START) costs more
+# than the drift it would fix.
+AIRPLAY_ANCHOR_RESYNC_MIN_MS: Final[int] = 150
 # Anchor lead for a readiness-confirmed START (cold and warm alike): the
 # session only anchors after the binary confirmed the connection ([STATUS]
 # connected) and the new audio flowing ([STATUS] audio), so the lead no longer

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -43,6 +43,8 @@ from music_assistant.providers.airplay.helpers import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from music_assistant_models.media_items import AudioFormat
     from music_assistant_models.player import PlayerMedia
 
@@ -118,6 +120,12 @@ class AirPlayStream:
         # the self-verification signal for the start contract.
         self._started = asyncio.Event()
         self._start_ack: tuple[int, int] | None = None
+        # Invoked (if set) when a [STATUS] anchor_corrected line arrives, i.e. the
+        # binary verified a commit against a receiver clock exchange that only
+        # resumed after the START ack and found the audible instant later than
+        # what that ack reported. Lets the owning session re-join a grouped
+        # member whose commit landed before the receiver was truly ready.
+        self.on_anchor_corrected: Callable[[int, int, int], None] | None = None
         # Receiver storm guard state: last-honored monotonic time per remote
         # transport command, plus a counter of suppressed repeats.
         self._remote_command_last: dict[str, float] = {}
@@ -370,7 +378,9 @@ class AirPlayStream:
             return False
         return True
 
-    async def start(self, start_unix_ms: int = 0, position_ms: int = 0) -> int | None:
+    async def start(
+        self, start_unix_ms: int = 0, position_ms: int = 0, *, join: bool = False
+    ) -> int | None:
         """
         Anchor playback so the first pending stdin sample is audible at an instant.
 
@@ -382,6 +392,10 @@ class AirPlayStream:
             clamps to its minimum lead).
         :param position_ms: Media position mapped to that first sample, used as
             the base for elapsed reporting.
+        :param join: This start must land on an already-live group timeline (a
+            late joiner): the binary then enforces receiver clock readiness and
+            corrects the anchor forward post-commit if needed ([STATUS]
+            anchor_corrected). Group/solo origin starts leave it False.
         :return: The true scheduled audible instant (unix ms) from the binary's
             started ack — the commanded instant when it was feasible, the
             corrected-forward one otherwise; None when no ack arrived (older
@@ -403,8 +417,11 @@ class AirPlayStream:
         self.player.set_state_from_stream(elapsed_time=self._start_position, stream=self)
         self._started.clear()
         self._start_ack = None
+        start_cmd = f"START_UNIX_MS={start_unix_ms}\nACTION=START"
+        if join:
+            start_cmd = f"START_UNIX_MS={start_unix_ms}\nSTART_JOIN=1\nACTION=START"
         async with self._metadata_lock:
-            if not await self._write_cli_command(f"START_UNIX_MS={start_unix_ms}\nACTION=START"):
+            if not await self._write_cli_command(start_cmd):
                 # Surfacing the dropped delivery lets the session fall back to a
                 # cold restart instead of waiting on an anchor that never happens.
                 raise PlayerCommandFailed(
@@ -977,7 +994,7 @@ class AirPlayStream:
             return active_group_id
         return None
 
-    def _handle_status_line(self, line: str) -> bool:
+    def _handle_status_line(self, line: str) -> bool:  # noqa: PLR0915
         """Dispatch one cliairplay status line; True ends the stderr loop."""
         player = self.player
         if "[STATUS] connected" in line:
@@ -1018,6 +1035,10 @@ class AirPlayStream:
                         actual,
                     )
             self._started.set()
+        elif "[STATUS] anchor_corrected " in line:
+            self._parse_anchor_corrected(line)
+        elif "[STATUS] clock_verified" in line:
+            self._parse_clock_verified(line)
         elif "[STATUS] flushed" in line:
             # A splice-timeline member reports the audible instant of its
             # frozen delivery head; the warm START must anchor beyond it (a
@@ -1307,3 +1328,49 @@ class AirPlayStream:
             # action (across restarts) until a working password is entered,
             # instead of only failing at the next play attempt.
             self.player.set_password_invalid(True)
+
+    def _parse_anchor_corrected(self, line: str) -> None:
+        """
+        Parse a post-commit [STATUS] anchor_corrected line and notify any observer.
+
+        The binary emits this at most once per START, when a receiver clock
+        exchange that only resumed after the START ack finally verifies the
+        commit and finds the audible instant later than what that ack reported.
+
+        :param line: The status line, e.g. ``[STATUS] anchor_corrected
+            requested_unix_ms=1750000000000 from_unix_ms=1750000000400
+            at_unix_ms=1750000000900``.
+        """
+        try:
+            fields = dict(part.split("=", 1) for part in line.split() if "=" in part)
+            requested_unix_ms = int(fields.get("requested_unix_ms", 0))
+            from_unix_ms = int(fields.get("from_unix_ms", 0))
+            at_unix_ms = int(fields.get("at_unix_ms", 0))
+        except ValueError, IndexError:
+            # Malformed line: drop it rather than react to bogus numbers.
+            return
+        # Loud on purpose: the receiver's clock exchange only resumed after the
+        # START ack, so the earlier-reported instant was not actually verified;
+        # the session decides whether the resulting offset is worth a re-join.
+        self.player.logger.warning(
+            "AirPlay anchor for %s corrected %+d ms after commit (requested %d, from %d, at %d)",
+            self.player.display_name,
+            at_unix_ms - from_unix_ms,
+            requested_unix_ms,
+            from_unix_ms,
+            at_unix_ms,
+        )
+        if self.on_anchor_corrected is not None:
+            self.on_anchor_corrected(requested_unix_ms, from_unix_ms, at_unix_ms)
+
+    def _parse_clock_verified(self, line: str) -> None:
+        """Debug-log a [STATUS] clock_verified line; no correction means no server action."""
+        try:
+            margin_ms = int(line.split("margin_ms=")[1])
+        except ValueError, IndexError:
+            return
+        self.player.logger.debug(
+            "cliairplay clock verified for %s (margin %d ms)",
+            self.player.display_name,
+            margin_ms,
+        )

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import time
 from collections.abc import AsyncGenerator
 from contextlib import suppress
@@ -16,6 +17,7 @@ from music_assistant.controllers.streams.audio_processing import get_media_sessi
 from music_assistant.helpers.ffmpeg import FFMpeg
 
 from .constants import (
+    AIRPLAY_ANCHOR_RESYNC_MIN_MS,
     AIRPLAY_COLD_GROUP_START_LEAD_MS,
     AIRPLAY_GROUP_START_LEAD_MS,
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
@@ -513,7 +515,7 @@ class AirPlayStreamSession:
                 # group's feed. Anchored, the binary drains the prime as it
                 # streams in. The START does not re-anchor the session
                 # timeline (the group keeps playing).
-                actual = await stream.start(start_unix_ms + adjust_ms, position_ms)
+                actual = await stream.start(start_unix_ms + adjust_ms, position_ms, join=True)
                 if actual is not None and abs((actual - adjust_ms) - start_unix_ms) > 2:
                     # The binary corrected the anchor forward (verified truth):
                     # redo the mapping from the actual instant so the fed
@@ -775,6 +777,9 @@ class AirPlayStreamSession:
         stream_pcm_format = airplay_player.get_stream_pcm_format(self.pcm_format)
         airplay_player.stream = AirPlayStream(airplay_player, pcm_format=stream_pcm_format)
         airplay_player.stream.session = self
+        airplay_player.stream.on_anchor_corrected = functools.partial(
+            self._handle_member_anchor_corrected, airplay_player
+        )
         await airplay_player.stream.connect(use_shared_ptp)
         await self._start_player_ffmpeg(airplay_player, self.media)
 
@@ -961,6 +966,71 @@ class AirPlayStreamSession:
         )
         await ffmpeg.start()
         self._player_ffmpeg[player.player_id] = ffmpeg
+
+    def _handle_member_anchor_corrected(
+        self, player: AirPlayPlayer, requested_unix_ms: int, from_unix_ms: int, at_unix_ms: int
+    ) -> None:
+        """
+        React to a member's stream verifying its commit against a live clock exchange.
+
+        Called synchronously from the stream's stderr-reader task context, so this
+        only ever logs or schedules a background task, never awaits anything itself.
+        A solo player's elapsed reporting already tracks the verified instant (the
+        binary reports it from real content), so only a grouped member whose offset
+        clears the resync floor is worth the cost of a re-join.
+
+        :param player: The member whose stream reported the correction.
+        :param requested_unix_ms: The instant originally commanded on the START (0
+            if the server let the binary pick).
+        :param from_unix_ms: The previously scheduled audible instant.
+        :param at_unix_ms: The new, verified audible instant.
+        """
+        delta_ms = at_unix_ms - from_unix_ms
+        solo = self.sync_clients == [player]
+        if solo or delta_ms <= AIRPLAY_ANCHOR_RESYNC_MIN_MS:
+            log = self.prov.logger.info if solo else self.prov.logger.warning
+            log(
+                "AirPlay anchor for %s verified %+d ms late (requested %d, from %d, at %d)",
+                player.display_name,
+                delta_ms,
+                requested_unix_ms,
+                from_unix_ms,
+                at_unix_ms,
+            )
+            return
+        self.prov.logger.warning(
+            "AirPlay anchor for %s verified %+d ms late (requested %d, from %d, at %d); "
+            "re-joining so its next commit lands after the verified clock exchange",
+            player.display_name,
+            delta_ms,
+            requested_unix_ms,
+            from_unix_ms,
+            at_unix_ms,
+        )
+        self.mass.create_task(
+            self._resync_member_anchor, player, task_id=f"airplay_resync_{player.player_id}"
+        )
+
+    async def _resync_member_anchor(self, player: AirPlayPlayer) -> None:
+        """
+        Re-join a member whose post-commit anchor correction crossed the resync floor.
+
+        Stops and re-adds the player through the regular late-join path so its
+        next commit lands after the receiver's clock exchange is verified live,
+        instead of racing it the way the original commit did.
+
+        :param player: The member to re-join.
+        """
+        # Scheduled work: re-check the session and this player's membership,
+        # since both may have changed by the time this task actually runs.
+        async with self._lock:
+            if not self.sync_clients or player not in self.sync_clients:
+                return
+            first_client = self.sync_clients[0]
+            if not first_client.stream or not first_client.stream.running:
+                return
+        await self.stop_client(player, reason="anchor corrected after commit")
+        await self.add_client(player)
 
 
 def _first_music_assistant_error(err: BaseException) -> MusicAssistantError | None:

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -655,6 +655,22 @@ async def test_start_sends_command_and_stamps_position() -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_join_marks_the_command() -> None:
+    """A late-join START carries START_JOIN=1 so the binary enforces clock readiness."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+
+    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command:
+        await stream.start(START_UNIX_MS, 0, join=True)
+
+    write_command.assert_awaited_once_with(
+        f"START_UNIX_MS={START_UNIX_MS}\nSTART_JOIN=1\nACTION=START"
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "complete_before_start",
     [True, False],
@@ -1702,6 +1718,75 @@ async def test_started_ack_status_line_parsing() -> None:
     stream._handle_status_line("[STATUS] started requested_unix_ms=garbage at_unix_ms=1")
     assert stream._started.is_set()
     assert stream._start_ack is None
+
+
+# --- Post-commit anchor verification ---
+
+
+def test_anchor_corrected_status_line_invokes_callback() -> None:
+    """A post-commit anchor correction is parsed and handed to the wired callback."""
+    stream = AirPlayStream(_make_player())
+    received: list[tuple[int, int, int]] = []
+    stream.on_anchor_corrected = lambda requested, from_ms, at_ms: received.append(
+        (requested, from_ms, at_ms)
+    )
+
+    ended = stream._handle_status_line(
+        "[STATUS] anchor_corrected requested_unix_ms=1750000000000 "
+        "from_unix_ms=1750000000400 at_unix_ms=1750000000900"
+    )
+
+    assert ended is False
+    assert received == [(1750000000000, 1750000000400, 1750000000900)]
+
+
+def test_anchor_corrected_status_line_logs_a_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """The correction is logged loudly, including the display name and the delta."""
+    stream = AirPlayStream(_make_player())
+
+    with caplog.at_level(logging.WARNING):
+        stream._handle_status_line(
+            "[STATUS] anchor_corrected requested_unix_ms=0 "
+            "from_unix_ms=1750000000400 at_unix_ms=1750000000900"
+        )
+
+    assert "Player A" in caplog.text
+    assert "+500 ms" in caplog.text
+
+
+def test_anchor_corrected_status_line_tolerates_missing_callback() -> None:
+    """A correction with nothing wired to on_anchor_corrected is parsed without raising."""
+    stream = AirPlayStream(_make_player())
+    assert stream.on_anchor_corrected is None
+
+    ended = stream._handle_status_line(
+        "[STATUS] anchor_corrected requested_unix_ms=0 "
+        "from_unix_ms=1750000000400 at_unix_ms=1750000000900"
+    )
+
+    assert ended is False
+
+
+def test_anchor_corrected_status_line_tolerates_malformed_line() -> None:
+    """A malformed anchor_corrected line is dropped instead of raising or notifying."""
+    stream = AirPlayStream(_make_player())
+    stream.on_anchor_corrected = MagicMock()
+
+    ended = stream._handle_status_line("[STATUS] anchor_corrected requested_unix_ms=garbage")
+
+    assert ended is False
+    stream.on_anchor_corrected.assert_not_called()
+
+
+def test_clock_verified_status_line_is_debug_logged(caplog: pytest.LogCaptureFixture) -> None:
+    """A clock_verified line needs no server action beyond a debug note of the margin."""
+    stream = AirPlayStream(_make_player())
+
+    with caplog.at_level(logging.DEBUG):
+        ended = stream._handle_status_line("[STATUS] clock_verified margin_ms=42")
+
+    assert ended is False
+    assert "42" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -993,3 +993,73 @@ async def test_cleanup_after_removal_skips_idle_when_player_has_new_session_stre
         await session._cleanup_after_removal(player)
 
     player.set_state_from_stream.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_start_client_wires_anchor_corrected_callback() -> None:
+    """Every member the session starts gets its stream's anchor-correction callback wired."""
+    session = _make_session(time.time(), 0)
+    player = _make_late_joiner()
+    stream_instance = _stream_defaults(MagicMock())
+    stream_instance.connect = AsyncMock()
+
+    with (
+        patch.object(session, "_handle_member_anchor_corrected") as handler,
+        patch(
+            "music_assistant.providers.airplay.stream_session.AirPlayStream",
+            return_value=stream_instance,
+        ),
+        patch.object(session, "_start_player_ffmpeg", new_callable=AsyncMock),
+    ):
+        await session._start_client(player, use_shared_ptp=False)
+        assert player.stream.on_anchor_corrected is not None
+        player.stream.on_anchor_corrected(100, 200, 260)
+
+    handler.assert_called_once_with(player, 100, 200, 260)
+
+
+def test_anchor_corrected_solo_member_only_logs() -> None:
+    """A solo member's late verification is informational; elapsed reporting stays truthful."""
+    session = _make_session(time.time(), 0)
+    logger = MagicMock()
+    session.prov.logger = logger
+    player: Any = session.sync_clients[0]
+
+    session._handle_member_anchor_corrected(player, 0, 1_750_000_000_000, 1_750_000_000_400)
+
+    logger.info.assert_called_once()
+    logger.warning.assert_not_called()
+    session.mass.create_task.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_anchor_corrected_grouped_small_delta_only_warns() -> None:
+    """A grouped member's correction under the resync floor is logged but not re-joined."""
+    session = _make_session(time.time(), 0)
+    logger = MagicMock()
+    session.prov.logger = logger
+    player: Any = session.sync_clients[0]
+    session.sync_clients.append(MagicMock())
+
+    session._handle_member_anchor_corrected(player, 0, 1_750_000_000_000, 1_750_000_000_100)
+
+    logger.warning.assert_called_once()
+    session.mass.create_task.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_anchor_corrected_grouped_large_delta_schedules_resync() -> None:
+    """A grouped member's correction past the resync floor schedules a coalesced re-join."""
+    session = _make_session(time.time(), 0)
+    logger = MagicMock()
+    session.prov.logger = logger
+    player: Any = session.sync_clients[0]
+    session.sync_clients.append(MagicMock())
+
+    session._handle_member_anchor_corrected(player, 0, 1_750_000_000_000, 1_750_000_000_400)
+
+    logger.warning.assert_called_once()
+    session.mass.create_task.assert_called_once()  # type: ignore[attr-defined]
+    call_args = session.mass.create_task.call_args  # type: ignore[attr-defined]
+    _target, *args = call_args.args
+    kwargs = call_args.kwargs
+    assert args == [player]
+    assert kwargs["task_id"] == f"airplay_resync_{player.player_id}"


### PR DESCRIPTION
# What does this implement/fix?

A speaker that rejoins a playing AirPlay group only resumes measuring the sender's clock after its start is already committed; if its clock locks too late for the start instant, the member plays behind the group permanently. The fixed 4-second join headroom usually covers this but is unverified. With airplay-cli#36 the binary now observes each receiver's clock exchange and verifies join anchors against it; this PR is the server half:

- late-join STARTs are marked (`START_JOIN=1`) so the binary enforces receiver clock readiness on exactly those starts (group/solo origins stay observation-only),
- `[STATUS] clock_verified` is debug-logged (readiness margin telemetry for tuning the fixed leads down later),
- `[STATUS] anchor_corrected` warns loudly and, when a grouped member's corrected offset crosses the resync floor (150 ms), schedules a drop-and-re-add through the regular late-join path — the re-join commits against the receiver's now-live clock exchange and lands verified.

Requires a cliairplay release with music-assistant/airplay-cli#36; older binaries never emit the lines and ignore the join mark, so both halves degrade gracefully in either direction.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.