### PR TITLE
Show the full track length after seeking

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1573,12 +1573,14 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         :param queue_item: The queue item to create media from.
         """
         queue_data = self._queue_data[queue_item.queue_id]
+        stream_duration: int | None = None
         if queue_item.streamdetails:
             # prefer netto duration
-            # when seeking, the player only receives the remaining duration
             duration = queue_item.streamdetails.duration or queue_item.duration
             if duration and queue_item.streamdetails.seek_position:
-                duration = int(duration - queue_item.streamdetails.seek_position)
+                # the audio handed to the player starts at the seek position,
+                # so it is shorter than the media item itself
+                stream_duration = int(duration - queue_item.streamdetails.seek_position)
         else:
             duration = queue_item.duration
         if queue_data.session_id is None:
@@ -1589,6 +1591,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             title=queue_item.name,
             image_url=MASS_LOGO_ONLINE,
             duration=duration,
+            stream_duration=stream_duration,
             source_id=queue_item.queue_id,
             queue_item_id=queue_item.queue_item_id,
             custom_data={

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1578,9 +1578,11 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             # prefer netto duration
             duration = queue_item.streamdetails.duration or queue_item.duration
             if duration and queue_item.streamdetails.seek_position:
-                # the audio handed to the player starts at the seek position,
-                # so it is shorter than the media item itself
-                stream_duration = int(duration - queue_item.streamdetails.seek_position)
+                # the audio handed to the player starts at the seek position, so it is
+                # shorter than the media item itself. seeking to (or past) the end
+                # leaves no stream to describe, so the full length is kept instead.
+                remaining = int(duration - queue_item.streamdetails.seek_position)
+                stream_duration = remaining if remaining > 0 else None
         else:
             duration = queue_item.duration
         if queue_data.session_id is None:

--- a/music_assistant/helpers/upnp.py
+++ b/music_assistant/helpers/upnp.py
@@ -204,9 +204,12 @@ def create_didl_metadata(media: PlayerMedia, url: str | None = None) -> str:
     # - Streaming transfer mode (bit 24)
     # - Background transfer mode supported (bit 22)
     # - DLNA v1.5 (bit 20)
-    duration_str = str(int(media.duration or 0) // 3600).zfill(2) + ":"
-    duration_str += str((int(media.duration or 0) % 3600) // 60).zfill(2) + ":"
-    duration_str += str(int(media.duration or 0) % 60).zfill(2)
+    # the res duration describes the audio we hand over, which is shorter than
+    # the media item when playback starts at a seek position
+    stream_duration = int(media.stream_duration or media.duration or 0)
+    duration_str = str(stream_duration // 3600).zfill(2) + ":"
+    duration_str += str((stream_duration % 3600) // 60).zfill(2) + ":"
+    duration_str += str(stream_duration % 60).zfill(2)
 
     return (
         '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/">'

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -664,7 +664,7 @@ class ChromecastPlayer(Player):
             "contentType": f"audio/{file_ext}",
             "streamType": stream_type,
             "metadata": metadata,
-            "duration": media.duration,
+            "duration": media.stream_duration or media.duration,
         }
 
     def _flow_stream_underrun(self) -> bool:

--- a/music_assistant/providers/hass_players/player.py
+++ b/music_assistant/providers/hass_players/player.py
@@ -265,7 +265,7 @@ class HomeAssistantPlayer(Player):
                 "albumName": media.album,
                 "images": [{"url": media.image_url}] if media.image_url else None,
                 "imageUrl": media.image_url,
-                "duration": media.duration,
+                "duration": media.stream_duration or media.duration,
             },
         }
         if self.extra_data.get("hass_domain") == "esphome":

--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -1428,7 +1428,8 @@ small {{ color: #666; display: block; margin-top: 4px; }}
             return web.Response(status=504, text="Playback setup timeout")
 
         # Resolve duration from media or queue item for Content-Length header
-        duration = media.duration or 0
+        # (the length of the audio we serve, not of the media item)
+        duration = media.stream_duration or media.duration or 0
         if not duration and media.source_id and media.queue_item_id:
             queue_item = self.provider.mass.player_queues.get_item(
                 media.source_id, media.queue_item_id
@@ -2022,8 +2023,9 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         if not media:
             return web.Response(status=404, text="No active stream")
 
-        duration = media.duration or 0
-        if media.source_id and media.queue_item_id:
+        # the Content-Length describes the audio we serve, not the media item
+        duration = media.stream_duration or media.duration or 0
+        if not duration and media.source_id and media.queue_item_id:
             queue_item = self.provider.mass.player_queues.get_item(
                 media.source_id, media.queue_item_id
             )

--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -46,6 +46,7 @@ from .player import MSXPlayer
 
 if TYPE_CHECKING:
     from multidict import MultiMapping
+    from music_assistant_models.player import PlayerMedia
 
     from .provider import MSXBridgeProvider
 
@@ -1427,8 +1428,25 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         if not media:
             return web.Response(status=504, text="Playback setup timeout")
 
-        # Resolve duration from media or queue item for Content-Length header
-        # (the length of the audio we serve, not of the media item)
+        return await self._serve_audio_stream(
+            request,
+            player,
+            media,
+            duration=self._resolve_served_duration(media),
+        )
+
+    # --- Audio Streaming Infrastructure ---
+
+    def _resolve_served_duration(self, media: PlayerMedia) -> int:
+        """
+        Return the length in seconds of the audio served for the given media, or 0 if unknown.
+
+        This is what the Content-Length header is derived from, so it describes
+        the audio we actually serve rather than the media item: starting
+        playback at a seek position yields a shorter stream.
+
+        :param media: The media being served.
+        """
         duration = media.stream_duration or media.duration or 0
         if not duration and media.source_id and media.queue_item_id:
             queue_item = self.provider.mass.player_queues.get_item(
@@ -1439,15 +1457,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
                     duration = getattr(queue_item.media_item, "duration", None) or duration
                 if not duration and queue_item.duration:
                     duration = queue_item.duration
-
-        return await self._serve_audio_stream(
-            request,
-            player,
-            media,
-            duration=duration,
-        )
-
-    # --- Audio Streaming Infrastructure ---
+        return int(duration)
 
     @staticmethod
     def _build_audio_params(
@@ -2023,23 +2033,11 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         if not media:
             return web.Response(status=404, text="No active stream")
 
-        # the Content-Length describes the audio we serve, not the media item
-        duration = media.stream_duration or media.duration or 0
-        if not duration and media.source_id and media.queue_item_id:
-            queue_item = self.provider.mass.player_queues.get_item(
-                media.source_id, media.queue_item_id
-            )
-            if queue_item:
-                if queue_item.media_item:
-                    duration = getattr(queue_item.media_item, "duration", None) or duration
-                if not duration and queue_item.duration:
-                    duration = queue_item.duration
-
         return await self._serve_audio_stream(
             request,
             player,
             media,
-            duration=duration,
+            duration=self._resolve_served_duration(media),
         )
 
     # --- Library API Routes ---

--- a/music_assistant/providers/msx_bridge/player.py
+++ b/music_assistant/providers/msx_bridge/player.py
@@ -216,10 +216,9 @@ class MSXPlayer(Player):
         if self._attr_playback_state != PlaybackState.PLAYING:
             return
         normalized = max(0.0, float(position))
-        current_media = self._attr_current_media
-        duration = getattr(current_media, "duration", None) if current_media is not None else None
-        if isinstance(duration, (int, float)) and duration > 0:
-            normalized = min(normalized, float(duration))
+        duration = self._served_duration()
+        if duration is not None:
+            normalized = min(normalized, duration)
         self._attr_elapsed_time = normalized
         # elapsed_time_last_updated is compared against time.time() by MA core
         # (corrected_elapsed_time) — must stay wall-clock. The WS staleness
@@ -256,12 +255,9 @@ class MSXPlayer(Player):
             now = time.time()
             delta = now - self._attr_elapsed_time_last_updated
             new_elapsed = max(0.0, float(self._attr_elapsed_time) + float(delta))
-            current_media = self._attr_current_media
-            duration = (
-                getattr(current_media, "duration", None) if current_media is not None else None
-            )
-            if isinstance(duration, (int, float)) and duration > 0:
-                new_elapsed = min(new_elapsed, float(duration))
+            duration = self._served_duration()
+            if duration is not None:
+                new_elapsed = min(new_elapsed, duration)
             self._attr_elapsed_time = new_elapsed
             self._attr_elapsed_time_last_updated = now
             self.update_state()
@@ -353,6 +349,20 @@ class MSXPlayer(Player):
         provider.notify_play_playlist(self.player_id, start_index, queue_id=source_id)
         self._playing_from_queue = True
 
+    def _served_duration(self) -> float | None:
+        """
+        Return the length in seconds of the audio served to the TV, if known.
+
+        The TV reports its position within that audio, which is shorter than the
+        media item itself when playback starts at a seek position.
+        """
+        if (media := self._attr_current_media) is None:
+            return None
+        duration = media.stream_duration or media.duration
+        if not isinstance(duration, (int, float)) or duration <= 0:
+            return None
+        return float(duration)
+
     def _resolve_media_metadata(
         self, media: PlayerMedia
     ) -> tuple[str | None, str | None, str | None, int | None]:
@@ -360,7 +370,7 @@ class MSXPlayer(Player):
         title = media.title
         artist = media.artist
         image_url = media.image_url
-        duration = media.duration
+        duration = media.stream_duration or media.duration
         if media.source_id and media.queue_item_id:
             queue_item = self.mass.player_queues.get_item(media.source_id, media.queue_item_id)
             if queue_item:

--- a/music_assistant/providers/roku_media_assistant/player.py
+++ b/music_assistant/providers/roku_media_assistant/player.py
@@ -191,7 +191,7 @@ class MediaAssistantPlayer(Player):
                 ),
                 "albumArt": ("" if self.flow_mode else media.image_url or ""),
                 "songFormat": "flac",
-                "duration": media.duration or "",
+                "duration": media.stream_duration or media.duration or "",
                 "isLive": (
                     "true"
                     if media.media_type == MediaType.RADIO
@@ -243,7 +243,7 @@ class MediaAssistantPlayer(Player):
                         "artistName": media.artist,
                         "albumArt": media.image_url,
                         "songFormat": "flac",
-                        "duration": media.duration,
+                        "duration": media.stream_duration or media.duration,
                         "enqueue": "true",
                     },
                 )

--- a/music_assistant/providers/samsung_wam/features/playback/handler.py
+++ b/music_assistant/providers/samsung_wam/features/playback/handler.py
@@ -84,11 +84,12 @@ class PlaybackHandler(WamPlayerFeatureBase):
 
         stream_url = await self.mass.streams.resolve_stream_url(self.player.player_id, media)
 
+        duration = media.stream_duration or media.duration
         item = UrlMediaItem(
             url=stream_url,
             title=media.title,
             description=media.artist,
-            duration=str(int(media.duration)) if media.duration else "0",
+            duration=str(int(duration)) if duration else "0",
             thumbnail=media.image_url,
         )
 

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -340,6 +340,9 @@ class SonosPlayerProvider(PlayerProvider):
 
     def _parse_sonos_queue_item(self, media: PlayerMedia) -> dict[str, Any]:
         """Parse MusicAssistant PlayerMedia to a Sonos Media (queue) object."""
+        # the speaker tracks its position within the audio we serve, which is
+        # shorter than the media item when playback starts at a seek position
+        duration = media.stream_duration or media.duration
         return {
             "id": media.queue_item_id or media.uri,
             "track": {
@@ -349,7 +352,7 @@ class SonosPlayerProvider(PlayerProvider):
                 "service": {"name": "Music Assistant", "id": "mass"},
                 "name": media.title,
                 "imageUrl": media.image_url,
-                "durationMillis": int(media.duration * 1000) if media.duration else 0,
+                "durationMillis": int(duration * 1000) if duration else 0,
                 "artist": {
                     "name": media.artist,
                 }

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -482,7 +482,7 @@ class SqueezelitePlayer(Player):
             "album": media.album,
             "artist": media.artist,
             "image_url": media.image_url,
-            "duration": media.duration,
+            "duration": media.stream_duration or media.duration,
             "source_id": media.source_id,
             "queue_item_id": media.queue_item_id,
         }

--- a/tests/controllers/player_queues/test_player_media_duration.py
+++ b/tests/controllers/player_queues/test_player_media_duration.py
@@ -1,0 +1,70 @@
+"""Tests that PlayerMedia separates the media length from the served stream length."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.queue_item import QueueItem
+from music_assistant_models.streamdetails import StreamDetails
+
+from music_assistant.controllers.player_queues import PlayerQueuesController
+from music_assistant.controllers.player_queues.state import PlayerQueueData
+
+QUEUE_ID = "q1"
+FULL_DURATION = 300
+
+
+def _controller_with_item(
+    seek_position: int = 0, streamdetails_duration: int | None = FULL_DURATION
+) -> tuple[PlayerQueuesController, QueueItem]:
+    """Build a bare controller holding a single track, optionally seeked into."""
+    ctrl = PlayerQueuesController.__new__(PlayerQueuesController)
+    queue_item = QueueItem(
+        queue_id=QUEUE_ID,
+        queue_item_id="item1",
+        name="Track 1",
+        duration=FULL_DURATION,
+    )
+    queue_item.streamdetails = StreamDetails(
+        provider="test",
+        item_id="item1",
+        audio_format=AudioFormat(),
+        duration=streamdetails_duration,
+        seek_position=seek_position,
+    )
+    queue_data = PlayerQueueData(queue=MagicMock())
+    queue_data.session_id = "session1"
+    ctrl._queue_data = {QUEUE_ID: queue_data}
+    ctrl.mass = MagicMock()
+    return ctrl, queue_item
+
+
+async def test_unseeked_item_has_no_separate_stream_duration() -> None:
+    """Without a seek the stream matches the media item, so stream_duration stays unset."""
+    ctrl, queue_item = _controller_with_item()
+
+    media = await ctrl.player_media_from_queue_item(queue_item)
+
+    assert media.duration == FULL_DURATION
+    assert media.stream_duration is None
+
+
+async def test_seeked_item_keeps_full_duration_and_reports_stream_duration() -> None:
+    """A seek shortens only the stream; duration stays the full media length."""
+    ctrl, queue_item = _controller_with_item(seek_position=120)
+
+    media = await ctrl.player_media_from_queue_item(queue_item)
+
+    assert media.duration == FULL_DURATION
+    assert media.stream_duration == FULL_DURATION - 120
+
+
+async def test_item_without_streamdetails_duration_falls_back_to_item_duration() -> None:
+    """The queue item's own duration is used when streamdetails carry none."""
+    ctrl, queue_item = _controller_with_item(seek_position=60, streamdetails_duration=None)
+
+    media = await ctrl.player_media_from_queue_item(queue_item)
+
+    assert media.duration == FULL_DURATION
+    assert media.stream_duration == FULL_DURATION - 60

--- a/tests/controllers/player_queues/test_player_media_duration.py
+++ b/tests/controllers/player_queues/test_player_media_duration.py
@@ -60,6 +60,25 @@ async def test_seeked_item_keeps_full_duration_and_reports_stream_duration() -> 
     assert media.stream_duration == FULL_DURATION - 120
 
 
+async def test_seek_to_the_end_leaves_no_stream_duration() -> None:
+    """A seek that leaves no audio to play keeps the full media length."""
+    ctrl, queue_item = _controller_with_item(seek_position=FULL_DURATION)
+
+    media = await ctrl.player_media_from_queue_item(queue_item)
+
+    assert media.duration == FULL_DURATION
+    assert media.stream_duration is None
+
+
+async def test_seek_past_the_streamed_length_never_goes_negative() -> None:
+    """Seeking beyond what the stream itself holds never yields a negative length."""
+    ctrl, queue_item = _controller_with_item(seek_position=295, streamdetails_duration=290)
+
+    media = await ctrl.player_media_from_queue_item(queue_item)
+
+    assert media.stream_duration is None
+
+
 async def test_item_without_streamdetails_duration_falls_back_to_item_duration() -> None:
     """The queue item's own duration is used when streamdetails carry none."""
     ctrl, queue_item = _controller_with_item(seek_position=60, streamdetails_duration=None)

--- a/tests/providers/msx_bridge/test_http_server.py
+++ b/tests/providers/msx_bridge/test_http_server.py
@@ -809,6 +809,39 @@ async def test_msx_audio_arms_wait_before_enqueue(
         await client.close()
 
 
+# --- Served audio length (Content-Length) ---
+
+
+def test_served_duration_uses_media_duration(provider: MSXBridgeProvider) -> None:
+    """Without a seek the served audio is the whole media item."""
+    server = MSXHTTPServer(provider, 0)
+    media = PlayerMedia(uri="library://track/1", duration=180)
+
+    assert server._resolve_served_duration(media) == 180
+
+
+def test_served_duration_prefers_stream_duration(provider: MSXBridgeProvider) -> None:
+    """Starting mid-track serves less audio than the media item is long."""
+    server = MSXHTTPServer(provider, 0)
+    media = PlayerMedia(uri="library://track/1", duration=180, stream_duration=60)
+
+    assert server._resolve_served_duration(media) == 60
+
+
+def test_served_duration_falls_back_to_queue_item(
+    provider: MSXBridgeProvider, mass_mock: Mock
+) -> None:
+    """A media item of unknown length is resolved through its queue item."""
+    server = MSXHTTPServer(provider, 0)
+    queue_item = MagicMock()
+    queue_item.media_item = None
+    queue_item.duration = 240
+    mass_mock.player_queues.get_item.return_value = queue_item
+    media = PlayerMedia(uri="library://track/1", source_id="q1", queue_item_id="item1")
+
+    assert server._resolve_served_duration(media) == 240
+
+
 # --- MSX playlist endpoints ---
 
 


### PR DESCRIPTION
# What does this implement/fix?

When you seek within a track, Music Assistant restarts the audio stream at the new position. The track length handed to the player was then overwritten with the *remaining* time, so the player believed the track had become shorter.

For players that report an absolute position (AirPlay) that total is simply wrong, and devices that redraw their now-playing screen whenever the length changes — an Apple TV, for example — flickered on every seek.

`PlayerMedia.duration` is now always the full length of the track. A new `stream_duration` carries the length of the audio actually served, and is only set when playback starts at a seek position.

**Related issue (if applicable):**

- companion models PR: music-assistant/models#342 (requires `music-assistant-models` 1.1.177, already pinned on `dev`)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changed

- The queue now reports the full track length, plus the served stream length separately
- Players whose stream restarts at zero read the stream length: Cast, DLNA, Sonos, Sonos S1, Squeezelite, WiiM, MusicCast, Roku, Samsung WAM, Home Assistant players and MSX
- AirPlay and Sendspin, which report an absolute position, now get the real track length
- MSX `Content-Length` matches the audio actually served, also when starting mid-track

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
