### PR TITLE
Keep Apple TV protocol chatter out of AirPlay debug logs

### DIFF
--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import socket
 import time
 from contextlib import suppress
@@ -77,6 +78,9 @@ PTP_DAEMON_READY_TIMEOUT: Final[float] = 3.0
 # Grace period after broadcasting a goodbye for a stale DACP registration before
 # re-registering the (name-stable) service, letting the cache flush the old record.
 DACP_RECLAIM_DELAY: Final[float] = 1.0
+# Opt-in for pyatv's own debug logging. Set to any non-empty value to trace the
+# pyatv protocol traffic itself.
+ENV_PYATV_DEBUG: Final[str] = "MASS_PYATV_DEBUG"
 
 
 class AirPlayProvider(PlayerProvider):
@@ -361,14 +365,16 @@ class AirPlayProvider(PlayerProvider):
         return await player.async_get_external_artwork(artwork_id)
 
     def _set_pyatv_log_level(self) -> None:
-        """Keep pyatv's (very chatty) logging quiet unless verbose logging is enabled."""
-        # pyatv is extremely chatty at debug level (it logs every protocol
-        # message and heartbeat of each control connection), so only pass
-        # through its debug logging when verbose logging is enabled
-        if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+        """Keep pyatv's (very chatty) logging quiet unless it is explicitly asked for."""
+        # pyatv logs every protocol message, HTTP exchange and encrypted payload of
+        # each control connection at debug level, which buries our own logging and
+        # rotates the log file within minutes. Its debug output is therefore held
+        # back even on verbose sessions, which are meant to surface our own deep
+        # diagnostics (the cliairplay [STATUS] and PTP traces) rather than pyatv's.
+        if os.environ.get(ENV_PYATV_DEBUG):
             logging.getLogger("pyatv").setLevel(logging.DEBUG)
         else:
-            logging.getLogger("pyatv").setLevel(self.logger.level + 10)
+            logging.getLogger("pyatv").setLevel(max(self.logger.level + 10, logging.INFO))
 
     async def _setup_player(
         self, player_id: str, display_name: str, discovery_info: AsyncServiceInfo

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import time
 from contextlib import AbstractContextManager
-from typing import cast
+from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from music_assistant_models.enums import PlaybackState
@@ -16,7 +16,7 @@ from music_assistant.providers.airplay.constants import (
     StreamingProtocol,
 )
 from music_assistant.providers.airplay.player import AirPlayPlayer
-from music_assistant.providers.airplay.provider import AirPlayProvider
+from music_assistant.providers.airplay.provider import ENV_PYATV_DEBUG, AirPlayProvider
 from music_assistant.providers.airplay.sendspin_bridge import (
     SendspinAirPlayBridge,
     SendspinBridgeManager,
@@ -24,6 +24,9 @@ from music_assistant.providers.airplay.sendspin_bridge import (
 from music_assistant.providers.airplay.stream import AirPlayStream
 from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
 from music_assistant.providers.airplay_receiver import airplay_receiver_port
+
+if TYPE_CHECKING:
+    import pytest
 
 INSTANCE_ID = "airplay"
 START_UNIX_MS = 1_750_000_000_000
@@ -271,10 +274,22 @@ def test_pyatv_logging_quiet_at_debug_level() -> None:
     assert logging.getLogger("pyatv").level == logging.INFO
 
 
-def test_pyatv_logging_traces_at_verbose_level() -> None:
-    """A verbose session passes pyatv's debug logging through."""
+def test_pyatv_logging_quiet_at_verbose_level() -> None:
+    """A verbose session keeps pyatv's protocol chatter out of the log too."""
     prov = _ptp_provider()
     prov.logger.setLevel(VERBOSE_LOG_LEVEL)
+
+    prov._set_pyatv_log_level()
+
+    # verbose is there to surface our own diagnostics, not pyatv's protocol dumps
+    assert logging.getLogger("pyatv").level == logging.INFO
+
+
+def test_pyatv_logging_traces_with_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The dedicated opt-in releases pyatv's own debug logging."""
+    prov = _ptp_provider()
+    prov.logger.setLevel(VERBOSE_LOG_LEVEL)
+    monkeypatch.setenv(ENV_PYATV_DEBUG, "1")
 
     prov._set_pyatv_log_level()
 


### PR DESCRIPTION
# What does this implement/fix?

Running the server at debug log level with an Apple TV configured filled `musicassistant.log` with the Apple TV control library's own protocol traffic: connection heartbeats every couple of seconds, HTTP request/response dumps and encrypted payload hex. On a live session that accounted for ~90% of the log file, rotating the 10 MB log within minutes and burying Music Assistant's own AirPlay lines.

That chatter was tied to the AirPlay provider's verbose level. Verbose is there to surface our own deep diagnostics (the `[STATUS]` and PTP clock traces), so it no longer drags the library's protocol logging along with it. Those dumps are still reachable on their own for the rare case where the protocol traffic itself is what needs debugging.

- The `pyatv` logger tree now stays at INFO on both debug and verbose sessions.
- Its debug output moves behind a `MASS_PYATV_DEBUG` environment variable.
- Music Assistant's own AirPlay debug and verbose logging is unchanged.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
