### PR TITLE
Fix providers that depend on another provider failing to start

### DIFF
--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -882,7 +882,15 @@ class MusicAssistant:
             if manifest.depends_on != prov_conf.domain:
                 continue
             try:
-                await self._load_provider(dep_prov_conf)
+                # the scan above skipped the config values, but the load path does need them:
+                # a provider reads config (e.g. its log level) while it is being constructed.
+                # Resolve them here, for this single dependent instead of for every provider.
+                dep_conf = await self.config.get_provider_config(dep_prov_conf.instance_id)
+            except KeyError:
+                # config was removed while we were scanning
+                continue
+            try:
+                await self._load_provider(dep_conf)
             except Exception as exc:
                 # record the failure against the provider that hit it: attributing it to the
                 # provider we just loaded (which is fine) flags the wrong one in the UI

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -363,7 +363,9 @@ class Provider:
             # async_init completed
             logging_name = self.name
         self.logger = mass_logger.getChild(logging_name)
-        log_level = str(config.get_value(CONF_LOG_LEVEL))
+        # fall back to the entry's own default: a config that reaches us without its
+        # entries resolved must not take the whole provider down over a log level
+        log_level = str(config.get_value(CONF_LOG_LEVEL) or "GLOBAL")
         if log_level == "GLOBAL":
             self.logger.setLevel(mass_logger.level)
         else:

--- a/tests/controllers/config/test_provider_config_load.py
+++ b/tests/controllers/config/test_provider_config_load.py
@@ -23,8 +23,9 @@ import pytest
 from music_assistant_models.config_entries import ConfigEntry, ProviderConfig, ProviderError
 from music_assistant_models.enums import ConfigEntryType, ProviderStatus, ProviderType
 from music_assistant_models.errors import LoginFailed, SetupFailedError
+from music_assistant_models.provider import ProviderManifest
 
-from music_assistant.constants import CONF_PROVIDERS
+from music_assistant.constants import CONF_LOG_LEVEL, CONF_PROVIDERS
 from music_assistant.controllers.config.helpers import _provider_status
 from music_assistant.mass import MusicAssistant
 
@@ -147,6 +148,39 @@ async def test_dependent_scan_does_not_resolve_option_values(
     assert mock_get.await_args is not None
     assert mock_get.await_args.kwargs.get("include_values") is not True
     assert True not in mock_get.await_args.args
+
+
+async def test_dependent_is_loaded_with_resolved_config_values(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A dependent is handed a config with its values resolved, not the bare scan result."""
+    config = mass_minimal.config
+    instance = "dependent--test"
+    raw = {"domain": "dependent", "type": "player", "instance_id": instance, "enabled": True}
+    config.set(f"{CONF_PROVIDERS}/{instance}", raw)
+    mass_minimal._provider_manifests["dependent"] = ProviderManifest(
+        type=ProviderType.PLAYER,
+        domain="dependent",
+        name="Dependent",
+        description="",
+        codeowners=[],
+        depends_on="spotify",
+    )
+    # what the (deliberately cheap) dependent scan yields: no entries, so no values
+    scanned = cast("ProviderConfig", ProviderConfig.parse([], raw))
+    assert scanned.get_value(CONF_LOG_LEVEL) is None
+
+    with (
+        patch.object(mass_minimal, "_load_provider", AsyncMock()) as mock_load,
+        patch.object(config, "get_provider_configs", AsyncMock(return_value=[scanned])),
+    ):
+        await mass_minimal.load_provider_config(_prov_conf("spotify--test"))
+
+    loaded = mock_load.await_args_list[-1].args[0]
+    assert loaded.instance_id == instance
+    # a provider reads its log level while being constructed, so an unresolved config
+    # (value None) makes logger.setLevel() raise and the dependent never loads at all
+    assert loaded.get_value(CONF_LOG_LEVEL) == "GLOBAL"
 
 
 async def test_dependent_scan_failure_is_not_blamed_on_loaded_provider(


### PR DESCRIPTION
# What does this implement/fix?

Providers that rely on another provider (such as Home Assistant Players, Local Audio Out and Hue Lights Sync) could fail to start with a confusing `Unknown level: 'None'` setup error, leaving them unavailable until the next restart.

They are started right after the provider they depend on, and on that path they were handed a configuration that had not been filled in yet, so reading their log level setting failed and took the whole provider down with it.

- Fill in the configuration before starting a provider that depends on another one
- Fall back to the default log level when the setting is missing, so it can never block a provider from starting

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
