### PR TITLE
Start AirPlay late joins as soon as the speaker is ready

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -63,19 +63,12 @@ DACP_DISCOVERY_TYPE: Final[str] = "_dacp._tcp.local."
 # RAOP because its pre-fill is paced.
 AIRPLAY_RAOP_SETUP_LEAD_MS: Final[int] = 1500
 AIRPLAY_AP2_SETUP_LEAD_MS: Final[int] = 2500
-# Late joiners anchor a deliberately low headroom ahead — a first guess, not
-# a worst-case bound. A join START makes the binary verify receiver clock
-# readiness from its PTP probe streak and correct an early anchor forward to
-# exact readiness, advancing the joiner's queued content by the same amount
-# ([STATUS] anchor_corrected): the cut frames are audio the group already
-# played, so the correction is inaudible and the join lands as soon as the
-# receiver can render (~2.7-3.8 s after the START ack on a cold clock,
-# measured on Sonos Era 100 and Apple TV 4K). The floor only keeps the
-# correction window open: it must clear the binary's verification arm window
-# (AP2_CLOCK_VERIFY_MIN_WINDOW_MS = 600 ms pacing depth + 500 ms poll round
-# and slack, cliairplay src/ap2_client.c) plus one further 250 ms poll round
-# and the START command latency; a member's sync_adjust shifts its commanded
-# anchor within the same budget.
+# Late joiners anchor a low first guess, not a worst-case bound: a join START
+# makes the binary verify receiver clock readiness and correct the anchor
+# forward to it, advancing the queued content by the same (inaudible) amount.
+# The floor only keeps that correction window open: it must clear the binary's
+# verification arm window (AP2_CLOCK_VERIFY_MIN_WINDOW_MS, 1100 ms) plus a
+# poll round and the START command latency.
 AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 1500
 # Anchor lead for a readiness-confirmed START (cold and warm alike): the
 # session only anchors after the binary confirmed the connection ([STATUS]

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -63,15 +63,20 @@ DACP_DISCOVERY_TYPE: Final[str] = "_dacp._tcp.local."
 # RAOP because its pre-fill is paced.
 AIRPLAY_RAOP_SETUP_LEAD_MS: Final[int] = 1500
 AIRPLAY_AP2_SETUP_LEAD_MS: Final[int] = 2500
-# Late joiners keep a much more conservative headroom: besides connecting and
-# priming from the session's history buffer, the receiver must re-acquire the
-# shared PTP clock before it can render its anchor. Its Delay_Req exchange
-# only resumes ~0.7-1.5 s after the join's START is acked (measured on a
-# Sonos Era 100 pair, 2026-07-31) and the servo needs a further ~1.7-2.3 s to
-# lock — and a missed anchor is permanent on the splice timeline (the frozen
-# line is never re-announced), heard as a constant echo on the joined member.
-# The anchor therefore sits beyond exchange-resume plus lock plus margin.
-AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 4000
+# Late joiners anchor a deliberately low headroom ahead — a first guess, not
+# a worst-case bound. A join START makes the binary verify receiver clock
+# readiness from its PTP probe streak and correct an early anchor forward to
+# exact readiness, advancing the joiner's queued content by the same amount
+# ([STATUS] anchor_corrected): the cut frames are audio the group already
+# played, so the correction is inaudible and the join lands as soon as the
+# receiver can render (~2.7-3.8 s after the START ack on a cold clock,
+# measured on Sonos Era 100 and Apple TV 4K). The floor only keeps the
+# correction window open: it must clear the binary's verification arm window
+# (AP2_CLOCK_VERIFY_MIN_WINDOW_MS = 600 ms pacing depth + 500 ms poll round
+# and slack, cliairplay src/ap2_client.c) plus one further 250 ms poll round
+# and the START command latency; a member's sync_adjust shifts its commanded
+# anchor within the same budget.
+AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 1500
 # Anchor lead for a readiness-confirmed START (cold and warm alike): the
 # session only anchors after the binary confirmed the connection ([STATUS]
 # connected) and the new audio flowing ([STATUS] audio), so the lead no longer

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -118,6 +118,10 @@ class AirPlayStream:
         # the self-verification signal for the start contract.
         self._started = asyncio.Event()
         self._start_ack: tuple[int, int] | None = None
+        # Whether the last commanded START was a late-join start: routes the
+        # correction log levels (a corrected join is the routine landing path,
+        # a corrected origin start is a loud signal).
+        self._start_was_join = False
         # Receiver storm guard state: last-honored monotonic time per remote
         # transport command, plus a counter of suppressed repeats.
         self._remote_command_last: dict[str, float] = {}
@@ -409,6 +413,7 @@ class AirPlayStream:
         self.player.set_state_from_stream(elapsed_time=self._start_position, stream=self)
         self._started.clear()
         self._start_ack = None
+        self._start_was_join = join
         start_cmd = f"START_UNIX_MS={start_unix_ms}\nACTION=START"
         if join:
             start_cmd = f"START_UNIX_MS={start_unix_ms}\nSTART_JOIN=1\nACTION=START"
@@ -1015,11 +1020,14 @@ class AirPlayStream:
             else:
                 self._start_ack = (requested, actual)
                 if requested and actual and abs(actual - requested) > 2:
-                    # Loud on purpose: the commanded instant was infeasible and
-                    # the binary corrected it forward. The session re-aligns
-                    # the group from these acks; repeated corrections are the
-                    # support signal that leads/readiness need attention.
-                    player.logger.warning(
+                    # The session re-aligns the group from these acks. A
+                    # corrected join is the routine landing path (the low join
+                    # headroom defers to the binary's readiness correction);
+                    # for origin starts and group convergence rounds a
+                    # correction stays loud — there repeated corrections are
+                    # the support signal that leads/readiness need attention.
+                    player.logger.log(
+                        logging.INFO if self._start_was_join else logging.WARNING,
                         "AirPlay start corrected by %+d ms on %s (requested %d, scheduled %d)",
                         actual - requested,
                         player.display_name,
@@ -1347,10 +1355,11 @@ class AirPlayStream:
         # The binary's elapsed counts only the retained content, so the
         # position base moves by the cut to keep reported progress exact.
         self._start_position += content_cut_ms / 1000
-        # Loud on purpose: the join raced the receiver's clock exchange and the
-        # commanded lead was too tight — recurring corrections mean the join
-        # headroom needs attention.
-        self.player.logger.warning(
+        # Routine for a join start: the low join headroom defers to this
+        # correction, which lands the anchor at exact receiver readiness. A
+        # post-commit correction on any other START stays loud.
+        self.player.logger.log(
+            logging.INFO if self._start_was_join else logging.WARNING,
             "AirPlay anchor for %s corrected %+d ms after commit "
             "(requested %d, at %d, content advanced %d ms to stay in sync)",
             self.player.display_name,

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -517,8 +517,9 @@ class AirPlayStreamSession:
                 if actual is not None and abs((actual - adjust_ms) - start_unix_ms) > 2:
                     # The binary corrected the anchor forward (verified truth):
                     # redo the mapping from the actual instant so the fed
-                    # content matches where the joiner really starts.
-                    self.prov.logger.warning(
+                    # content matches where the joiner really starts. Routine
+                    # at the low join headroom, so informational only.
+                    self.prov.logger.info(
                         "Late joiner %s: anchor corrected %+d ms by the binary; "
                         "remapping the prime",
                         airplay_player.player_id,

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -785,7 +785,9 @@ async def test_late_join_primes_from_ring_tail_at_headroom() -> None:
     session = _make_session(start_time, seconds_streamed)
     # Fill ring buffer with 5 seconds of non-silent PCM.
     session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 5)
-    player = _make_late_joiner(wait_start_ms=2000)
+    # Leads below the late-join floor, so the floor is what anchors the join.
+    session.wait_start = 1.0
+    player = _make_late_joiner(wait_start_ms=1000)
 
     written_chunks: list[bytes] = []
 
@@ -800,7 +802,7 @@ async def test_late_join_primes_from_ring_tail_at_headroom() -> None:
         mock_start.side_effect = _setup_stream(player)
         await session.add_client(player)
 
-    # start_at is now + min_headroom (the late-join floor); fed_pos_due = 4.5s
+    # start_at is now + min_headroom (the late-join floor); fed_pos_due = 2.0s
     assert mock_start.called, "_start_client was never called"
     expected_headroom = AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000
     assert _captured_start_at(player) - now == pytest.approx(expected_headroom, abs=0.01), (
@@ -808,7 +810,7 @@ async def test_late_join_primes_from_ring_tail_at_headroom() -> None:
         f"got offset {_captured_start_at(player) - now:.4f}s"
     )
 
-    # The last 0.5s of the ring is primed (positions 4.5s..5.0s), nothing skipped.
+    # The last 3.0s of the ring is primed (positions 2.0s..5.0s), nothing skipped.
     assert session._client_skip_bytes[player.player_id] == 0
     assert written_chunks, "No data was written to the player"
     remaining_seconds = len(written_chunks[0]) / PCM_SAMPLE_SIZE
@@ -824,8 +826,8 @@ async def test_late_join_skips_live_feed_when_anchor_ahead_of_write_head() -> No
     # Freeze time so both the test and the code under test agree on `now`.
     now = 1_000_000.0
     # Diagnosed clamp case: now - start_time = 8.84s, seconds_streamed = 10.0s,
-    # min_headroom = 4.0s (the floor) and no group shift ->
-    # fed_pos_due = 12.84s > 10.0s.
+    # min_headroom = 2.5s (the session lead, above the late-join floor) and no
+    # group shift -> fed_pos_due = 11.34s > 10.0s.
     start_time = now - 8.84
     seconds_streamed = 10.0
     session = _make_session(start_time, seconds_streamed)
@@ -847,10 +849,10 @@ async def test_late_join_skips_live_feed_when_anchor_ahead_of_write_head() -> No
         await session.add_client(player)
 
     # anchor is now + min_headroom and nothing is primed (position past the head)
-    assert _captured_start_at(player) - now == pytest.approx(4.0, abs=0.01)
+    assert _captured_start_at(player) - now == pytest.approx(2.5, abs=0.01)
     assert written_chunks == []
     skip_seconds = session._client_skip_bytes[player.player_id] / PCM_SAMPLE_SIZE
-    assert skip_seconds == pytest.approx(2.84, abs=0.01)
+    assert skip_seconds == pytest.approx(1.34, abs=0.01)
 
 
 @pytest.mark.asyncio
@@ -860,8 +862,8 @@ async def test_late_join_primes_from_ring_under_group_shift() -> None:
     now = 1_000_000.0
     # Same base as the clamp case, but the reference member accumulated a
     # +3.039s starvation shift (134020 frames @44100) so the group's effective
-    # anchor is later: fed_pos_due = 9.80s, back inside the ring. The joiner is
-    # primed with ~0.2s from the ring tail and skips nothing.
+    # anchor is later: fed_pos_due = 8.30s, back inside the ring. The joiner is
+    # primed with ~1.7s from the ring tail and skips nothing.
     start_time = now - 8.84
     seconds_streamed = 10.0
     session = _make_session(start_time, seconds_streamed)
@@ -884,11 +886,11 @@ async def test_late_join_primes_from_ring_under_group_shift() -> None:
         mock_start.side_effect = _setup_stream(player)
         await session.add_client(player)
 
-    assert _captured_start_at(player) - now == pytest.approx(4.0, abs=0.01)
+    assert _captured_start_at(player) - now == pytest.approx(2.5, abs=0.01)
     assert session._client_skip_bytes[player.player_id] == 0
     assert written_chunks, "expected a prime write from the ring tail"
     primed_seconds = len(written_chunks[0]) / PCM_SAMPLE_SIZE
-    assert primed_seconds == pytest.approx(0.199, abs=0.01)
+    assert primed_seconds == pytest.approx(1.699, abs=0.01)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Adding a player to already-playing AirPlay music waited a fixed 4 seconds before the newcomer made sound — a worst-case guess for how long its clock needs to lock. Since airplay-cli v0.4.4 the binary verifies the speaker's actual readiness on every join and moves the start forward when the guess was too tight, advancing the queued audio by the same amount so the join stays in sync. That makes the worst-case guess unnecessary.

- Lower the late-join start headroom from 4 s to 1.5 s: the readiness correction lands every join at the exact moment the speaker can start — typically up to a second sooner, and quick re-adds no longer wait out the full guess.
- Log routine join corrections at info level; corrections on origin starts and group convergence rounds remain warnings.
- Update the late-join tests to the new floor and keep the floor itself covered.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.