### PR TITLE
Stop one component's log level from flooding the log with unrelated messages

### DIFF
--- a/music_assistant/__main__.py
+++ b/music_assistant/__main__.py
@@ -85,7 +85,10 @@ def setup_logger(data_path: str, level: str = "DEBUG") -> logging.Logger:
     # define log formatter
     log_fmt = "%(asctime)s.%(msecs)03d %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
 
-    # base logging config for the root logger
+    # base logging config for the root logger.
+    # The root level doubles as the gate for third-party libraries that never get an
+    # explicit level of their own, so it is kept separate from the Music Assistant log
+    # level below: a verbose MA (or provider) level stays scoped to MA's own loggers.
     logging.basicConfig(level=logging.INFO)
 
     colorfmt = f"%(log_color)s{log_fmt}%(reset)s"

--- a/music_assistant/models/core_controller.py
+++ b/music_assistant/models/core_controller.py
@@ -178,6 +178,3 @@ class CoreController:
             self.logger.setLevel(mass_logger.level)
         else:
             self.logger.setLevel(log_level)
-        if logging.getLogger().level > self.logger.level:
-            # if the root logger's level is higher, we need to adjust that too
-            logging.getLogger().setLevel(self.logger.level)

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -368,7 +368,4 @@ class Provider:
             self.logger.setLevel(mass_logger.level)
         else:
             self.logger.setLevel(log_level)
-        if logging.getLogger().level > self.logger.level:
-            # if the root logger's level is higher, we need to adjust that too
-            logging.getLogger().setLevel(self.logger.level)
         self.logger.debug("Log level configured to %s", log_level)

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from collections.abc import Callable
 from contextlib import suppress
@@ -55,8 +56,10 @@ from music_assistant_models.errors import AlreadyRegisteredError, SetupFailedErr
 from music_assistant.constants import (
     CONF_ENABLED,
     CONF_ENTRY_MANUAL_DISCOVERY_IPS,
+    CONF_LOG_LEVEL,
     CONF_PLAYERS,
     CONF_PROVIDERS,
+    VERBOSE_LOG_LEVEL,
 )
 from music_assistant.helpers.util import format_ip_for_url
 from music_assistant.mass import MusicAssistant
@@ -293,6 +296,7 @@ class SendspinProvider(PlayerProvider):
 
     async def handle_async_init(self) -> None:
         """Load the persistent server identity and pairing store, then create the server."""
+        self._set_aiosendspin_log_level()
         storage_dir = Path(self.mass.storage_path) / "sendspin"
         identity_path = storage_dir / IDENTITY_FILENAME
         try:
@@ -346,6 +350,14 @@ class SendspinProvider(PlayerProvider):
         # seed the hass availability snapshot so the first (un)load is seen as a change
         hass = self.mass.get_provider("hass")
         self._hass_available = hass is not None and hass.available
+
+    async def update_config(self, config: ProviderConfig, changed_keys: set[str]) -> None:
+        """Handle logic when the config is updated."""
+        await super().update_config(config, changed_keys)
+        # a log level(-only) change does not reload the provider,
+        # so realign aiosendspin's logger here
+        if f"values/{CONF_LOG_LEVEL}" in changed_keys:
+            self._set_aiosendspin_log_level()
 
     def event_cb(self, server: SendspinServer, event: SendspinEvent) -> None:
         """Event callback registered to the sendspin server."""
@@ -847,6 +859,15 @@ class SendspinProvider(PlayerProvider):
             ),
             return_exceptions=True,
         )
+
+    def _set_aiosendspin_log_level(self) -> None:
+        """Keep aiosendspin's (very chatty) logging quiet unless verbose logging is enabled."""
+        # aiosendspin logs every protocol message of every client session at debug
+        # level, so only pass that through when verbose logging is enabled
+        if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+            logging.getLogger("aiosendspin").setLevel(logging.DEBUG)
+        else:
+            logging.getLogger("aiosendspin").setLevel(self.logger.level + 10)
 
     def _begin_client_event(self, client_id: str) -> int:
         """Increment version and in-flight task count for a client event."""

--- a/tests/models/test_provider.py
+++ b/tests/models/test_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import fields
 from typing import cast
 from unittest.mock import MagicMock
@@ -10,10 +11,11 @@ from music_assistant_models.enums import EventType, ProviderType
 from music_assistant_models.errors import LoginFailed
 from music_assistant_models.provider import ProviderInstance
 
+from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.models.provider import Provider
 
 
-def _make_base_provider() -> Provider:
+def _make_base_provider(log_level: str = "GLOBAL") -> Provider:
     """Construct a minimal base Provider with stubbed mass/manifest/config."""
     mass = MagicMock()
     manifest = MagicMock()
@@ -22,7 +24,7 @@ def _make_base_provider() -> Provider:
     config = MagicMock()
     config.name = "Test Provider"
     config.instance_id = "test_instance"
-    config.get_value = MagicMock(return_value="GLOBAL")
+    config.get_value = MagicMock(return_value=log_level)
     return Provider(mass, manifest, config, supported_features=set())
 
 
@@ -91,3 +93,33 @@ def test_unload_with_error_forwards_exception() -> None:
     mass.call_later.assert_called_once_with(
         1, mass.unload_provider_with_error, "test_instance", err
     )
+
+
+def test_verbose_log_level_stays_scoped_to_the_provider() -> None:
+    """A provider on VERBOSE logs its own records without un-gating unrelated loggers."""
+    logging.addLevelName(VERBOSE_LOG_LEVEL, "VERBOSE")
+    root_logger = logging.getLogger()
+    # a library that never gets an explicit level, so it follows the root logger
+    third_party_logger = logging.getLogger("test_unconfigured_library")
+    emitted: list[str] = []
+
+    class _CaptureHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            emitted.append(record.name)
+
+    handler = _CaptureHandler()
+    previous_root_level = root_logger.level
+    root_logger.setLevel(logging.INFO)
+    try:
+        provider = _make_base_provider("VERBOSE")
+        assert provider.logger.level == VERBOSE_LOG_LEVEL
+        assert root_logger.level == logging.INFO
+        assert not third_party_logger.isEnabledFor(logging.DEBUG)
+
+        # the provider's own records must still reach the root handlers
+        root_logger.addHandler(handler)
+        provider.logger.log(VERBOSE_LOG_LEVEL, "verbose record")
+        assert emitted == [provider.logger.name]
+    finally:
+        root_logger.removeHandler(handler)
+        root_logger.setLevel(previous_root_level)


### PR DESCRIPTION
# What does this implement/fix?

Setting a log level on a single provider or core controller — or simply starting the server with `--log-level debug` — also lowered the log level of the whole process. Every library that has no log level of its own then started writing debug messages, so the log filled up with output nobody asked for and the interesting lines got buried.

A component's log level now only affects that component. Libraries stay quiet unless the provider that owns them asks for their debug output, which is how most providers already worked.

- A provider or core controller log level no longer changes the log level of unrelated components
- The Sendspin provider now controls its library's logging the same way the other providers do, so setting Sendspin to verbose still gives the full detail
- Added a test that guards the scoping

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
