### PR TITLE
Do not update the playback position when we are not playing in MusicCast

### DIFF
--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -280,8 +280,8 @@ class MusicCastPlayer(Player):
                 self._attr_playback_state = PlaybackState.PAUSED
             case MusicCastPlayerState.PLAYING:
                 self._attr_playback_state = PlaybackState.PLAYING
-                self._attr_elapsed_time = self.zone_device.media_position
                 if self.zone_device.media_position_updated_at is not None:
+                    self._attr_elapsed_time = self.zone_device.media_position
                     self._attr_elapsed_time_last_updated = (
                         self.zone_device.media_position_updated_at.timestamp()
                     )

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -281,15 +281,12 @@ class MusicCastPlayer(Player):
             case MusicCastPlayerState.PLAYING:
                 self._attr_playback_state = PlaybackState.PLAYING
                 self._attr_elapsed_time = self.zone_device.media_position
+                if self.zone_device.media_position_updated_at is not None:
+                    self._attr_elapsed_time_last_updated = (
+                        self.zone_device.media_position_updated_at.timestamp()
+                    )
             case MusicCastPlayerState.IDLE | MusicCastPlayerState.OFF:
                 self._attr_playback_state = PlaybackState.IDLE
-
-        if self.zone_device.media_position_updated_at is not None:
-            self._attr_elapsed_time_last_updated = (
-                self.zone_device.media_position_updated_at.timestamp()
-            )
-        else:
-            self._attr_elapsed_time_last_updated = None
 
         # UPDATE UPNP HELPER
         now = time.time()

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -274,14 +274,16 @@ class MusicCastPlayer(Player):
 
         # STATE
 
+        self._attr_elapsed_time = None
         match self.zone_device.state:
             case MusicCastPlayerState.PAUSED:
                 self._attr_playback_state = PlaybackState.PAUSED
             case MusicCastPlayerState.PLAYING:
                 self._attr_playback_state = PlaybackState.PLAYING
+                self._attr_elapsed_time = self.zone_device.media_position
             case MusicCastPlayerState.IDLE | MusicCastPlayerState.OFF:
                 self._attr_playback_state = PlaybackState.IDLE
-        self._attr_elapsed_time = self.zone_device.media_position
+
         if self.zone_device.media_position_updated_at is not None:
             self._attr_elapsed_time_last_updated = (
                 self.zone_device.media_position_updated_at.timestamp()


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Sometimes the playback position reported by the MC device appears to be flaky if we are not playing. Let's only update the position if we are actually playing.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
