### PR TITLE
Remove the extra delay when starting a single AirPlay speaker

### DIFF
--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -233,7 +233,7 @@ The `AirPlayStreamSession` class in [stream_session.py](stream_session.py) manag
    - Wires each member's ffmpeg into its persistent CLI stdin and starts feeding audio
    - Waits until every member's binary confirms the feed flowing (`[STATUS] audio`),
      then sends one shared audible start instant with a short anchor lead
-     (250 ms solo / 500 ms group); readiness is fully event-driven, so no
+     (400 ms solo / 500 ms group); readiness is fully event-driven, so no
      setup time is guessed and the binary bursts the receiver pre-fill after START
 
 2. **Client Setup** (per player, `_start_client()` method)
@@ -426,7 +426,7 @@ protocol path (RAOP, AirPlay 2 RAOP-compat and native).
 1. Start every CLI and wait until every group member reports connected
 2. Wire each member's ffmpeg into its persistent stdin, begin feeding PCM and
    wait until every member confirms the feed flowing (`[STATUS] audio`)
-3. Send one shared `START` (now + 250 ms solo / 500 ms group) to every member;
+3. Send one shared `START` (now + 400 ms solo / 500 ms group) to every member;
    readiness is event-confirmed so the anchor covers only the receiver re-anchor,
    and the binary bursts the receiver pre-fill from START
 4. **Warm seek / next-track / grouped resume** reuse the live connections: MA

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -70,17 +70,17 @@ AIRPLAY_AP2_SETUP_LEAD_MS: Final[int] = 2500
 # verification arm window (AP2_CLOCK_VERIFY_MIN_WINDOW_MS, 1100 ms) plus a
 # poll round and the START command latency.
 AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 1500
-# Anchor lead for a readiness-confirmed START (cold and warm alike): the
-# session only anchors after the binary confirmed the connection ([STATUS]
-# connected) and the new audio flowing ([STATUS] audio), so the lead no longer
-# guesses at setup or transcoder spin-up time. It covers the receiver
+# Anchor leads for a readiness-confirmed START (cold and warm alike), solo and
+# group: the session only anchors after the binary confirmed the connection
+# ([STATUS] connected) and the new audio flowing ([STATUS] audio), so a lead no
+# longer guesses at setup or transcoder spin-up time. Both cover the receiver
 # re-anchor (accepted down to ~150 ms in the flush-ladder measurements) plus
-# the command's trip down the pipe, and for groups fanning the shared instant
-# out to every member. The pipe margin is what keeps the lead workable: the
-# binary rejects any instant inside its own 250 ms floor measured from when IT
-# reads the command, and corrects a miss to that floor plus another full lead,
-# so a lead sitting exactly on the floor misses by the delivery time every
-# time and turns a start into a group-wide re-anchor ladder.
+# the command's trip down the pipe; the group one also covers fanning the
+# shared instant out to every member. The pipe margin is what keeps them
+# workable: the binary rejects any instant inside its own 250 ms floor,
+# measured from when IT reads the command, and corrects a miss to that floor
+# plus another full lead — so a lead sitting exactly on the floor misses by the
+# delivery time every time and turns a start into a group-wide re-anchor ladder.
 AIRPLAY_START_LEAD_MS: Final[int] = 400
 AIRPLAY_GROUP_START_LEAD_MS: Final[int] = 500
 # Cold GROUP starts anchor further out: a receiver on a brand-new session

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -73,11 +73,15 @@ AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 1500
 # Anchor lead for a readiness-confirmed START (cold and warm alike): the
 # session only anchors after the binary confirmed the connection ([STATUS]
 # connected) and the new audio flowing ([STATUS] audio), so the lead no longer
-# guesses at setup or transcoder spin-up time. It covers just the receiver
-# re-anchor (accepted down to ~150 ms in the flush-ladder measurements; the
-# binary clamps below its own 250 ms floor) plus, for groups, fanning the
-# shared instant out to every member.
-AIRPLAY_START_LEAD_MS: Final[int] = 250
+# guesses at setup or transcoder spin-up time. It covers the receiver
+# re-anchor (accepted down to ~150 ms in the flush-ladder measurements) plus
+# the command's trip down the pipe, and for groups fanning the shared instant
+# out to every member. The pipe margin is what keeps the lead workable: the
+# binary rejects any instant inside its own 250 ms floor measured from when IT
+# reads the command, and corrects a miss to that floor plus another full lead,
+# so a lead sitting exactly on the floor misses by the delivery time every
+# time and turns a start into a group-wide re-anchor ladder.
+AIRPLAY_START_LEAD_MS: Final[int] = 400
 AIRPLAY_GROUP_START_LEAD_MS: Final[int] = 500
 # Cold GROUP starts anchor further out: a receiver on a brand-new session
 # still acquires its PTP slave lock (~1.7-2.3 s measured on Sonos) and cannot

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -11,7 +11,9 @@ from music_assistant_models.errors import PlayerCommandFailed
 
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_COLD_GROUP_START_LEAD_MS,
+    AIRPLAY_GROUP_START_LEAD_MS,
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
+    AIRPLAY_START_LEAD_MS,
     StreamingProtocol,
 )
 from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
@@ -234,8 +236,8 @@ async def test_initial_single_player_starts_after_connect(
     ):
         await session.start(MagicMock())
 
-    # start = now (200_000 ms) + the solo start lead (250 ms), position 0
-    stream.start.assert_awaited_once_with(200_250, 0)
+    # start = now (200_000 ms) + the solo start lead, position 0
+    stream.start.assert_awaited_once_with(200_000 + AIRPLAY_START_LEAD_MS, 0)
 
 
 @pytest.mark.asyncio
@@ -405,7 +407,9 @@ async def test_standby_resumes_warm_on_existing_streams(
         assert await session.replace(MagicMock(), media)
 
     # start = now (100_000 ms) + solo/group start lead, position 10s
-    expected_start = 100_000 + (250 if len(protocols) == 1 else 500)
+    expected_start = 100_000 + (
+        AIRPLAY_START_LEAD_MS if len(protocols) == 1 else AIRPLAY_GROUP_START_LEAD_MS
+    )
     for player in players:
         stream = original_streams[player.player_id]
         assert player.stream is stream


### PR DESCRIPTION
# What does this implement/fix?

Starting playback on a single AirPlay speaker was always delayed by roughly
0.85 second, and logged two warnings that looked like a real fault.

The lead we schedule the start with sat exactly on the binary's own 250 ms
minimum. Because the binary measures that minimum from the moment it reads the
command, our instant always arrived a couple of milliseconds too late to be
accepted. Every miss is corrected forward by another full lead, and the retry
then lands behind the meanwhile-armed audio timeline, so a start needed three
rounds to settle.

Adding the command's trip down the pipe to the lead makes the first round land.

- Raise the single-speaker start lead so it clears the binary's minimum plus
  the command delivery time
- Bind the start-lead assertions in the tests to the constants instead of
  repeating their values

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
