### PR TITLE
Keep the account login dialog in step with the browser

### DIFF
--- a/music_assistant/controllers/config/flows.py
+++ b/music_assistant/controllers/config/flows.py
@@ -357,6 +357,7 @@ class SetupFlowMixin:
             session=session, target_key=target_key, required_scope=required_scope
         )
         self._setup_flows[flow_id] = flow
+        LOGGER.debug("Starting setup flow %s for %s", flow_id, target_key)
         flow.task = self.mass.create_task(self._run_flow(flow, flow_coro))
         self._schedule_flow_sweep()
         if session.current_step is None:
@@ -394,6 +395,7 @@ class SetupFlowMixin:
                 )
                 session.publish_abort("internal_error")
         finally:
+            LOGGER.debug("Setup flow %s ended", session.flow_id)
             session.close()
             self._pop_flow(flow)
 

--- a/music_assistant/helpers/oauth.py
+++ b/music_assistant/helpers/oauth.py
@@ -10,6 +10,11 @@ from music_assistant.models.setup_flow import SetupFlowError
 # smuggle along in the OAuth `state` parameter.
 HOSTED_CALLBACK_URL = "https://music-assistant.io/callback"
 
+# Deadline for the browser part of an OAuth flow. Bounded so the client shows a
+# countdown and a consent that never comes back (window closed, callback blocked)
+# ends the flow instead of leaving the user with a spinner.
+OAUTH_STEP_TIMEOUT = 10 * 60
+
 
 def hosted_bounce_redirect(callback_url: str) -> tuple[str, str]:
     """

--- a/music_assistant/helpers/oauth.py
+++ b/music_assistant/helpers/oauth.py
@@ -35,7 +35,7 @@ def authorization_code_from_params(params: dict[str, str]) -> str:
     :param params: The merged callback query/body params returned by session.external().
     """
     code = params.get("code")
-    # the hosted relay page forwards a literal "null" code when consent was denied
+    # an older (cached) hosted relay page forwards a literal "null" code on denied consent
     if not code or code == "null":
         error = params.get("error") or "no authorization code returned"
         raise SetupFlowError(f"Authorization failed: {error}")

--- a/music_assistant/models/setup_flow.py
+++ b/music_assistant/models/setup_flow.py
@@ -214,6 +214,8 @@ class SetupSession:
 
         The flow resumes when the external party (or a bounce page) hits this flow's
         ``callback_url``; GET query and POST body parameters are merged and returned.
+        As soon as the callback lands a generic progress step replaces the external one,
+        so the client stops asking the user for something they already did.
 
         :param url: The URL the user must open.
         :param step_id: Stable slug identifying this step (also the i18n key segment).
@@ -225,9 +227,11 @@ class SetupSession:
         self._callback_future = asyncio.get_running_loop().create_future()
         self._publish_step(step)
         try:
-            return await self._await_with_deadline(self._callback_future, expires_in)
+            params = await self._await_with_deadline(self._callback_future, expires_in)
         finally:
             self._callback_future = None
+        self.progress("working")
+        return params
 
     async def external_until(
         self,
@@ -431,6 +435,12 @@ class SetupSession:
             except Exception as err:
                 LOGGER.error("Failed to parse setup flow callback body: %s", err)
         if self._callback_future is not None and not self._callback_future.done():
+            # the values carry the authorization code/token, so only log the keys
+            LOGGER.debug(
+                "Setup flow %s resumed by callback with params: %s",
+                self.flow_id,
+                ", ".join(sorted(params)),
+            )
             # only a callback that resolves a pending external step counts as
             # activity: the route is unauthenticated, so bare requests must not
             # be able to keep the flow alive past the idle TTL
@@ -548,6 +558,7 @@ class SetupSession:
 
     def _publish_step(self, step: SetupFlowStep) -> None:
         """Store the step as current, mark activity and push it to subscribers."""
+        LOGGER.debug("Setup flow %s published %s step: %s", self.flow_id, step.type, step.step_id)
         self.current_step = step
         self.last_activity = time.monotonic()
         self._step_changed.set()

--- a/music_assistant/providers/filesystem_google_drive/auth.py
+++ b/music_assistant/providers/filesystem_google_drive/auth.py
@@ -16,7 +16,11 @@ from aiohttp import ClientError
 from google_drive_api.auth import AbstractAuth
 from music_assistant_models.errors import LoginFailed, ProviderUnavailableError
 
-from music_assistant.helpers.oauth import authorization_code_from_params, hosted_bounce_redirect
+from music_assistant.helpers.oauth import (
+    OAUTH_STEP_TIMEOUT,
+    authorization_code_from_params,
+    hosted_bounce_redirect,
+)
 from music_assistant.models.setup_flow import SetupFlowError
 
 from .constants import OAUTH_AUTHORIZE_URL, OAUTH_SCOPE, OAUTH_TOKEN_URL
@@ -48,7 +52,9 @@ async def authorize(session: SetupSession, client_id: str, client_secret: str) -
         "prompt": "consent",
     }
     result = await session.external(
-        f"{OAUTH_AUTHORIZE_URL}?{urlencode(params)}", step_id="authenticate"
+        f"{OAUTH_AUTHORIZE_URL}?{urlencode(params)}",
+        step_id="authenticate",
+        expires_in=OAUTH_STEP_TIMEOUT,
     )
     code = authorization_code_from_params(result)
     data = {

--- a/music_assistant/providers/filesystem_onedrive/auth.py
+++ b/music_assistant/providers/filesystem_onedrive/auth.py
@@ -17,7 +17,11 @@ from aiohttp import ClientError
 from music_assistant_models.errors import LoginFailed, ProviderUnavailableError
 
 from music_assistant.constants import CONF_PROVIDERS
-from music_assistant.helpers.oauth import authorization_code_from_params, hosted_bounce_redirect
+from music_assistant.helpers.oauth import (
+    OAUTH_STEP_TIMEOUT,
+    authorization_code_from_params,
+    hosted_bounce_redirect,
+)
 from music_assistant.models.setup_flow import SetupFlowError
 from music_assistant.providers.filesystem_cloud.base import CONF_REFRESH_TOKEN
 
@@ -47,7 +51,9 @@ async def authorize(session: SetupSession, client_id: str, client_secret: str) -
         "state": state,
     }
     result = await session.external(
-        f"{OAUTH_AUTHORIZE_URL}?{urlencode(params)}", step_id="authenticate"
+        f"{OAUTH_AUTHORIZE_URL}?{urlencode(params)}",
+        step_id="authenticate",
+        expires_in=OAUTH_STEP_TIMEOUT,
     )
     code = authorization_code_from_params(result)
     data = {

--- a/music_assistant/providers/spotify/setup_flow.py
+++ b/music_assistant/providers/spotify/setup_flow.py
@@ -13,6 +13,7 @@ from music_assistant_models.enums import ConfigEntryType
 from music_assistant.helpers.app_vars import app_var
 from music_assistant.helpers.oauth import (
     HOSTED_CALLBACK_URL,
+    OAUTH_STEP_TIMEOUT,
     authorization_code_from_params,
     hosted_bounce_redirect,
 )
@@ -105,7 +106,7 @@ async def _pkce_authenticate(session: SetupSession, client_id: str, step_id: str
         "state": state,
     }
     callback_params = await session.external(
-        f"{AUTHORIZE_URL}?{urlencode(params)}", step_id=step_id
+        f"{AUTHORIZE_URL}?{urlencode(params)}", step_id=step_id, expires_in=OAUTH_STEP_TIMEOUT
     )
     code = authorization_code_from_params(callback_params)
     token_params = {

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -479,6 +479,29 @@ async def test_external_step_replaced_by_progress_on_callback(flow_mass: MusicAs
         await _wait_for(lambda: session.finished)
 
 
+async def test_external_expiry_aborts_flow(
+    flow_mass: MusicAssistant, flow_events: list[MassEvent]
+) -> None:
+    """An external step whose callback never arrives times out and releases its route."""
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.external("https://example.com/authorize", expires_in=0.05)
+        await session.finish({})
+
+    with _use_flow(flow_mass, run_setup):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        assert step.expires_at is not None
+        abort_step = await _wait_for(
+            lambda: next(iter(_abort_events(flow_events)), None), timeout=2
+        )
+    assert abort_step.reason == "timed_out"
+    assert step.flow_id not in flow_mass.config._setup_flows
+    # the expired step is not followed by a progress step: nothing was completed
+    assert not [event.data for event in flow_events if event.data.type == FlowStepType.PROGRESS]
+    registered_routes = cast("Any", flow_mass.webserver).routes
+    assert f"/setup_flow/callback/{step.flow_id}" not in registered_routes
+
+
 async def test_external_callback_json_body_coerced(flow_mass: MusicAssistant) -> None:
     """A JSON callback body with non-string values is coerced to the str params contract."""
     received: dict[str, str] = {}

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -448,6 +448,37 @@ async def test_external_step_callback_roundtrip(flow_mass: MusicAssistant) -> No
     await _wait_for(lambda: callback_path not in registered_routes)
 
 
+async def test_external_step_replaced_by_progress_on_callback(flow_mass: MusicAssistant) -> None:
+    """The external step gives way to a progress step while the callback is processed."""
+    release = asyncio.Event()
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.external("https://example.com/authorize")
+        await release.wait()
+        await session.finish({})
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        session = flow_mass.config._setup_flows[step.flow_id].session
+        callback_path = f"/setup_flow/callback/{step.flow_id}"
+        handler = cast("Any", flow_mass.webserver).routes[callback_path]
+        await handler(make_mocked_request("GET", f"{callback_path}?code=abc"))
+        progress_step = await _wait_for(
+            lambda: (
+                session.current_step
+                if session.current_step is not None
+                and session.current_step.type == FlowStepType.PROGRESS
+                else None
+            )
+        )
+        assert progress_step.step_id == "working"
+        release.set()
+        await _wait_for(lambda: session.finished)
+
+
 async def test_external_callback_json_body_coerced(flow_mass: MusicAssistant) -> None:
     """A JSON callback body with non-string values is coerced to the str params contract."""
     received: dict[str, str] = {}


### PR DESCRIPTION
# What does this implement/fix?

When you connect a Spotify (or Google Drive / OneDrive) account, the dialog keeps showing
"Waiting for you to complete this step…" after you already signed in and authorized in the
browser. The dialog only moves on once the server is done saving and reloading the provider,
so it looks stuck — most visibly on the optional "own Spotify developer key" step.

On top of that, an authorization that never comes back (browser window closed, redirect
blocked) left the dialog spinning indefinitely with no countdown and no way out.

- The external (browser) step is now replaced by a progress step the moment the
  authorization comes back, so the dialog no longer asks for something you already did.
- The Spotify, Google Drive and OneDrive browser step now has a 10 minute deadline, so the
  dialog shows a countdown and ends the setup instead of spinning forever.
- Setup flow steps and callbacks are logged at debug level, which was missing entirely and
  made reports like this impossible to diagnose from a log.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
