### PR TITLE
Fix speakers joining a playing group out of sync

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -63,13 +63,29 @@ DACP_DISCOVERY_TYPE: Final[str] = "_dacp._tcp.local."
 # RAOP because its pre-fill is paced.
 AIRPLAY_RAOP_SETUP_LEAD_MS: Final[int] = 1500
 AIRPLAY_AP2_SETUP_LEAD_MS: Final[int] = 2500
-# Late joiners anchor a low first guess, not a worst-case bound: a join START
-# makes the binary verify receiver clock readiness and report the instant it can
-# truly honor, onto which the server then maps the joiner's content. The floor
-# only keeps that verification window open: it must clear the binary's
-# verification arm window (AP2_CLOCK_VERIFY_MIN_WINDOW_MS, 1100 ms) plus a
-# poll round and the START command latency.
-AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 1500
+# Lower bound for a late joiner's anchor, and the whole anchor whenever the
+# binary reports no readiness projection ([STATUS] clock_ready). It has to keep
+# the binary's own clock verification viable without any device evidence: that
+# verification gives up 850 ms before the anchor, and a cold receiver was
+# measured taking 1078 ms after connect to send its first clock probe, so an
+# anchor below 1078 + 850 = ~1.93 s can close the window before a single probe
+# arrives - the joiner then seats on a cold clock and lands audibly behind.
+# 2500 ms clears that by ~570 ms, the margin the field-proven value carried.
+AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 2500
+# How long a join waits for the binary's first receiver-clock projection
+# ([STATUS] clock_ready with state=probing|ready). The binary emits its first
+# line right after [STATUS] connected and refreshes it about every 250 ms, and
+# the projection exists from the receiver's first probe (~1078 ms after connect
+# on a cold device), so this only has to cover a slower device before giving up
+# and anchoring on the floor above.
+AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS: Final[int] = 2500
+# Lead added on top of a reported readiness instant when anchoring a join. The
+# binary refuses to place an anchor inside its own 250 ms floor, measured from
+# when IT reads the START command rather than when the server sends it (the same
+# trap as AIRPLAY_START_LEAD_MS, see PR #5208), so the lead carries that floor
+# plus 250 ms for the command reaching the binary and for the convergence error
+# of a projection made from the receiver's very first probe.
+AIRPLAY_JOIN_CLOCK_READY_LEAD_MS: Final[int] = 500
 # How long a join START waits for the binary's [STATUS] started ack. That ack is
 # held back until the clock verification above resolves, so the window must
 # cover the verification arm window plus a poll round on top of the commanded

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -64,12 +64,20 @@ DACP_DISCOVERY_TYPE: Final[str] = "_dacp._tcp.local."
 AIRPLAY_RAOP_SETUP_LEAD_MS: Final[int] = 1500
 AIRPLAY_AP2_SETUP_LEAD_MS: Final[int] = 2500
 # Late joiners anchor a low first guess, not a worst-case bound: a join START
-# makes the binary verify receiver clock readiness and correct the anchor
-# forward to it, advancing the queued content by the same (inaudible) amount.
-# The floor only keeps that correction window open: it must clear the binary's
+# makes the binary verify receiver clock readiness and report the instant it can
+# truly honor, onto which the server then maps the joiner's content. The floor
+# only keeps that verification window open: it must clear the binary's
 # verification arm window (AP2_CLOCK_VERIFY_MIN_WINDOW_MS, 1100 ms) plus a
 # poll round and the START command latency.
 AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 1500
+# How long a join START waits for the binary's [STATUS] started ack. That ack is
+# held back until the clock verification above resolves, so the window must
+# cover the verification arm window plus a poll round on top of the commanded
+# anchor (which bounds the verification), where a plain START acks within the
+# command round-trip. On timeout the server falls back to trusting the commanded
+# instant, so a window shorter than the binary's verification silently maps the
+# joiner's content onto an instant the binary never used.
+AIRPLAY_JOIN_START_ACK_TIMEOUT_MS: Final[int] = 5000
 # Anchor lead for a readiness-confirmed START (cold and warm alike): the
 # session only anchors after the binary confirmed the connection ([STATUS]
 # connected) and the new audio flowing ([STATUS] audio), so the lead no longer

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -132,6 +132,12 @@ class AirPlayStream:
         # `connected` this makes readiness fully event-driven, so START can
         # use a short re-anchor lead instead of a guessed setup time.
         self._audio_present = asyncio.Event()
+        # Set once the binary settled the receiver's clock readiness ([STATUS]
+        # clock_ready): either it projected when the clock becomes usable, or it
+        # reported that there is nothing to wait for. The projected instant
+        # (unix ms) stays 0 in the latter case.
+        self._clock_ready = asyncio.Event()
+        self._clock_ready_at_unix_ms: int = 0
         self._metadata_text_checksum = ""
         # Artwork identity (the source image url) whose rendered bytes were
         # last delivered to the binary. Settles on the first successful
@@ -374,6 +380,26 @@ class AirPlayStream:
         except TimeoutError:
             return False
         return True
+
+    async def wait_clock_ready(self, timeout: float = 2.5) -> int | None:
+        """
+        Wait for the binary to project when the receiver's clock becomes usable.
+
+        A receiver starts probing its clock as soon as it is connected, so the
+        projection is available well before any anchor is announced and resolves
+        from the receiver's first probe rather than from its full servo lock.
+
+        :param timeout: Seconds to wait for the projection.
+        :return: The projected instant (unix ms) at which the receiver's clock
+            is usable — possibly already in the past when it is locked — or None
+            when there is nothing to wait for (NTP timing, a receiver that never
+            probed within the timeout, or a binary that does not report it).
+        """
+        try:
+            await asyncio.wait_for(self._clock_ready.wait(), timeout)
+        except TimeoutError:
+            return None
+        return self._clock_ready_at_unix_ms or None
 
     async def start(
         self, start_unix_ms: int = 0, position_ms: int = 0, *, join: bool = False
@@ -1057,6 +1083,8 @@ class AirPlayStream:
             self._started.set()
         elif "[STATUS] anchor_corrected " in line:
             self._parse_anchor_corrected(line)
+        elif "[STATUS] clock_ready " in line:
+            self._parse_clock_ready(line)
         elif "[STATUS] clock_verified" in line:
             self._parse_clock_verified(line)
         elif "[STATUS] flushed" in line:
@@ -1387,6 +1415,39 @@ class AirPlayStream:
             requested_unix_ms,
             at_unix_ms,
             content_cut_ms,
+        )
+
+    def _parse_clock_ready(self, line: str) -> None:
+        """
+        Parse a [STATUS] clock_ready line into the receiver's readiness projection.
+
+        :param line: The status line, e.g. ``[STATUS] clock_ready mode=ptp
+            state=probing streak_ms=0 exchanges=1 ready_in_ms=2300
+            ready_at_unix_ms=1750000002300``.
+        """
+        try:
+            fields = dict(part.split("=", 1) for part in line.split() if "=" in part)
+            mode = fields.get("mode", "")
+            state = fields.get("state", "")
+            ready_at_unix_ms = int(fields.get("ready_at_unix_ms", 0))
+        except ValueError, IndexError:
+            # Malformed line: drop it rather than react to bogus numbers.
+            return
+        if state == "cold" and mode != "ntp":
+            # No probe seen yet, so the line carries no projection; the binary
+            # keeps reporting until one exists.
+            return
+        # NTP timing has no receiver clock to wait for, and a state without a
+        # projection resolves the wait with nothing so a caller falls back
+        # instead of blocking on evidence that will not arrive.
+        self._clock_ready_at_unix_ms = 0 if mode == "ntp" else ready_at_unix_ms
+        self._clock_ready.set()
+        self.player.logger.debug(
+            "cliairplay reports the clock for %s as %s (mode=%s, usable at %d)",
+            self.player.display_name,
+            state,
+            mode,
+            self._clock_ready_at_unix_ms,
         )
 
     def _parse_clock_verified(self, line: str) -> None:

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -27,6 +27,7 @@ from music_assistant.helpers.named_pipe import AsyncNamedPipeWriter
 from music_assistant.helpers.process import AsyncProcess
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_ARTWORK_SIZE,
+    AIRPLAY_JOIN_START_ACK_TIMEOUT_MS,
     AIRPLAY_PCM_FORMAT,
     CONF_AIRPLAY_CREDENTIALS,
     CONF_ENCRYPTION,
@@ -390,8 +391,9 @@ class AirPlayStream:
             the base for elapsed reporting.
         :param join: This start must land on an already-live group timeline (a
             late joiner): the binary then enforces receiver clock readiness and
-            corrects the anchor forward post-commit if needed ([STATUS]
-            anchor_corrected). Group/solo origin starts leave it False.
+            holds its ack until that resolves, so the returned instant is the one
+            the caller must map the joiner's content onto. Group/solo origin
+            starts leave it False.
         :return: The true scheduled audible instant (unix ms) from the binary's
             started ack — the commanded instant when it was feasible, the
             corrected-forward one otherwise; None when no ack arrived (older
@@ -443,13 +445,31 @@ class AirPlayStream:
         )
         # The binary always acks with the TRUE scheduled instant (correcting an
         # infeasible one forward), so the caller can verify the contract and
-        # re-align a group. No ack within the timeout means an older binary:
-        # fall back to trusting the commanded instant (legacy clamp semantics).
+        # re-align a group. A join's ack is held back until the receiver clock
+        # verification resolves and therefore gets a much wider window than a
+        # plain start, which acks within the command round-trip. No ack within
+        # the timeout means an older binary: fall back to trusting the commanded
+        # instant (legacy clamp semantics).
+        ack_timeout = AIRPLAY_JOIN_START_ACK_TIMEOUT_MS / 1000 if join else 2.0
         try:
-            await asyncio.wait_for(self._started.wait(), 2.0)
+            await asyncio.wait_for(self._started.wait(), ack_timeout)
         except TimeoutError:
             return None
         return self._start_ack[1] if self._start_ack else None
+
+    def rebase_position(self, position_ms: int) -> None:
+        """
+        Re-map reported progress onto a start instant that moved after the command.
+
+        A join's START is acked with the instant the receiver can actually seat,
+        which may be later than the commanded one. The caller maps its content
+        onto that instant and reports the position that lands there.
+
+        :param position_ms: Media position of the first sample the binary
+            renders at the acked instant.
+        """
+        self._start_position = position_ms / 1000
+        self.player.set_state_from_stream(elapsed_time=self._start_position, stream=self)
 
     def reset_reanchor_shift(self) -> None:
         """Clear the accumulated re-anchor shift and its status-line supersession flag."""

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -18,6 +18,8 @@ from music_assistant.helpers.ffmpeg import FFMpeg
 from .constants import (
     AIRPLAY_COLD_GROUP_START_LEAD_MS,
     AIRPLAY_GROUP_START_LEAD_MS,
+    AIRPLAY_JOIN_CLOCK_READY_LEAD_MS,
+    AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS,
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
     AIRPLAY_SPLICE_LEAD_MARGIN_MS,
     AIRPLAY_START_LEAD_MS,
@@ -351,8 +353,9 @@ class AirPlayStreamSession:
 
         The joiner cannot honour an anchor in the past — cliairplay makes the
         first post-START stdin byte audible exactly at the instant it acks and
-        then freezes the anchor, with no catch-up. So an anchor a fixed headroom
-        into the future is commanded, the binary acks the instant it can truly
+        then freezes the anchor, with no catch-up. So the anchor is commanded
+        just past the instant the receiver reports its clock becomes usable (and
+        never inside the join floor), the binary acks the instant it can truly
         honour, and the stream position due at that instant is derived from the
         group's effective (shift-adjusted) timeline. Depending on where that
         position falls relative to the ring buffer the joiner is either primed
@@ -361,10 +364,11 @@ class AirPlayStreamSession:
         head), so its first audible sample lands exactly where the group is
         playing.
 
-        Timing-source readiness and the START ack are awaited without the session
-        lock so the rest of the group keeps being fed meanwhile; all buffer and
-        anchor math stays under the lock so ``seconds_streamed``, the ring buffer
-        and the per-client skip counter stay consistent with the live feed.
+        Timing-source readiness, the receiver's clock projection and the START
+        ack are all awaited without the session lock so the rest of the group
+        keeps being fed meanwhile; all buffer and anchor math stays under the
+        lock so ``seconds_streamed``, the ring buffer and the per-client skip
+        counter stay consistent with the live feed.
         """
         await self._resolve_late_joiner_ptp(airplay_player)
         async with self._lock:
@@ -375,6 +379,14 @@ class AirPlayStreamSession:
             stream = airplay_player.stream
             assert stream
             await stream.wait_for_connection()
+            # A receiver starts probing its clock at connect, so how long it
+            # still needs is measurable before any anchor is announced. Waiting
+            # for that projection here — outside the session lock, so the rest
+            # of the group keeps being fed — lets the join anchor on the
+            # device's own readiness instead of a fixed guess.
+            ready_at_unix_ms = await stream.wait_clock_ready(
+                timeout=AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS / 1000
+            )
         except asyncio.CancelledError:
             await self.stop_client(airplay_player, reason="late joiner start cancelled")
             raise
@@ -456,17 +468,30 @@ class AirPlayStreamSession:
             return anchor_at, due, prime_slice, skip
 
         now = time.time()
+        self.prov.logger.debug(
+            "Late joiner %s: receiver clock readiness %s",
+            airplay_player.player_id,
+            f"projected {ready_at_unix_ms / 1000 - now:.2f}s out"
+            if ready_at_unix_ms
+            else "not reported; anchoring on the join floor",
+        )
         async with self._lock:
             if not self._session_is_live():
                 await self.stop_client(airplay_player, reason="session ended during late join")
                 return
             # cliairplay makes the first post-START stdin byte audible exactly at
             # the instant it acks, so the anchor is commanded first and the
-            # content mapped onto the ack afterwards. min_headroom is the
-            # late-join floor: low enough that the joiner starts promptly, high
-            # enough for the binary to verify the receiver clock before it.
+            # content mapped onto the ack afterwards. It sits just past the
+            # instant the receiver's clock becomes usable; the floor is only a
+            # lower bound, and carries the whole anchor when no projection came.
             min_headroom = AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000
-            requested_at, fed_pos_due = map_to(now + min_headroom)[:2]
+            anchor_at = now + min_headroom
+            if ready_at_unix_ms:
+                anchor_at = max(
+                    anchor_at,
+                    (ready_at_unix_ms + AIRPLAY_JOIN_CLOCK_READY_LEAD_MS) / 1000,
+                )
+            requested_at, fed_pos_due = map_to(anchor_at)[:2]
             start_unix_ms = int(requested_at * 1000)
             sync_adjust = airplay_player.config.get_value(CONF_SYNC_ADJUST, 0)
             adjust_ms = sync_adjust if isinstance(sync_adjust, int) else 0

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -65,7 +65,6 @@ class AirPlayStreamSession:
         self._ptp_lock = asyncio.Lock()
         self.start_unix_ms: int = 0
         self.start_time: float = 0.0
-        self.wait_start: float = 0.0
         self.seconds_streamed: float = 0
         # Timing source for the whole session, decided once in start() and applied
         # identically to every native AirPlay 2 member (and any late joiner) so a
@@ -142,7 +141,6 @@ class AirPlayStreamSession:
             # a bounded daemon-readiness wait cannot consume the setup lead.
             self.use_shared_ptp = await self._resolve_shared_ptp(ap2_members)
             self._shared_ptp_resolved = True
-        self.wait_start = max(p.wait_start for p in self.sync_clients) / 1000
         position_ms = int((self.media.elapsed_time or 0) * 1000)
         try:
             async with asyncio.TaskGroup() as task_group:
@@ -352,27 +350,25 @@ class AirPlayStreamSession:
         Add a sync client to the session as a late joiner.
 
         The joiner cannot honour an anchor in the past — cliairplay makes the
-        first post-START stdin byte audible exactly at the commanded instant and
-        then freezes the anchor, with no catch-up. So the anchor is chosen a
-        fixed headroom into the future and the stream position due at that
-        instant is derived from the group's effective (shift-adjusted) timeline.
-        Depending on where that position falls relative to the ring buffer the
-        joiner is either primed from the ring tail (position at or behind the
-        write head) or has the leading bytes of the live feed skipped (position
-        ahead of the write head), so its first audible sample lands exactly where
-        the group is playing.
+        first post-START stdin byte audible exactly at the instant it acks and
+        then freezes the anchor, with no catch-up. So an anchor a fixed headroom
+        into the future is commanded, the binary acks the instant it can truly
+        honour, and the stream position due at that instant is derived from the
+        group's effective (shift-adjusted) timeline. Depending on where that
+        position falls relative to the ring buffer the joiner is either primed
+        from the ring tail (position at or behind the write head) or has the
+        leading bytes of the live feed skipped (position ahead of the write
+        head), so its first audible sample lands exactly where the group is
+        playing.
 
-        Timing-source readiness is resolved before the session lock; all buffer
-        and anchor math stays under the lock so ``seconds_streamed``, the ring
-        buffer and the per-client skip counter stay consistent with the live
-        feed.
+        Timing-source readiness and the START ack are awaited without the session
+        lock so the rest of the group keeps being fed meanwhile; all buffer and
+        anchor math stays under the lock so ``seconds_streamed``, the ring buffer
+        and the per-client skip counter stay consistent with the live feed.
         """
         await self._resolve_late_joiner_ptp(airplay_player)
         async with self._lock:
-            if not self.sync_clients:
-                return
-            first_client = self.sync_clients[0]
-            if not first_client.stream or not first_client.stream.running:
+            if not self._session_is_live():
                 return
         try:
             await self._start_client(airplay_player, self.use_shared_ptp)
@@ -391,171 +387,199 @@ class AirPlayStreamSession:
             await self.stop_client(airplay_player, reason="late joiner connection failed")
             return
 
-        async with self._lock:
-            if not self.sync_clients:
-                await self.stop_client(airplay_player, reason="session ended during late join")
-                return
-            first_client = self.sync_clients[0]
-            if not first_client.stream or not first_client.stream.running:
-                await self.stop_client(airplay_player, reason="session ended during late join")
-                return
-            now = time.time()
-            pcm_sample_size = self._pcm_byte_rate
-            frame_size = self._pcm_frame_size
+        pcm_sample_size = self._pcm_byte_rate
+        frame_size = self._pcm_frame_size
+
+        def map_to(anchor_at: float) -> tuple[float, float, bytes, int]:
+            """
+            Map an anchor instant onto the live feed (call under the lock).
+
+            Snapshots the ring and derives which stream position the group
+            plays at ``anchor_at``, returning the (possibly ring-capped)
+            anchor, the due feed position, the prime slice and the live skip.
+            """
+            # Snapshot the ring and map its span onto stream positions:
+            # it covers [seconds_streamed - buffer_seconds, seconds_streamed].
             effective_start_time = self.effective_start_time
+            buffered_pcm = bytes(self._pcm_buffer)
+            buffer_seconds = len(buffered_pcm) / pcm_sample_size
+            ring_floor = self.seconds_streamed - buffer_seconds
+            due = anchor_at - effective_start_time
+            skip = 0
+            prime_slice = b""
+            if due <= self.seconds_streamed:
+                # The due position is at or behind the write head: prime
+                # the joiner from the ring so the live feed then continues
+                # seamlessly.
+                if due < ring_floor:
+                    # The due position predates the ring (an unusually
+                    # large lead). Cap the prime at the whole buffer and
+                    # grow the headroom so the anchor still maps to the
+                    # prime's first sample exactly.
+                    self.prov.logger.debug(
+                        "Late joiner %s: due position %.2fs predates the "
+                        "%.2fs ring; capping prime at the whole buffer",
+                        airplay_player.player_id,
+                        due,
+                        buffer_seconds,
+                    )
+                    due = ring_floor
+                    anchor_at = effective_start_time + due
+                keep_bytes = int((self.seconds_streamed - due) * pcm_sample_size)
+                # Frame-align the prime START in ABSOLUTE stream
+                # coordinates. The prime must end exactly at the write head
+                # (the live feed continues byte-contiguously from there),
+                # so only the start may move: shift it forward to the next
+                # frame boundary (dropping under one frame, ~23 us).
+                start_abs = self._pcm_total_fed - keep_bytes
+                realign = (frame_size - start_abs % frame_size) % frame_size
+                keep_bytes -= realign
+                if realign:
+                    self.prov.logger.debug(
+                        "Late joiner %s: prime start realigned +%d bytes "
+                        "(write head sits mid-frame)",
+                        airplay_player.player_id,
+                        realign,
+                    )
+                if keep_bytes > 0:
+                    prime_slice = buffered_pcm[len(buffered_pcm) - keep_bytes :]
+            else:
+                # The due position is ahead of the write head: skip that
+                # many bytes off the head of the live feed so the joiner's
+                # first delivered byte is the sample due at the anchor.
+                skip = int((due - self.seconds_streamed) * pcm_sample_size)
+                # The first delivered live byte must land on a frame
+                # boundary in ABSOLUTE stream coordinates (round the skip
+                # up, under one frame).
+                first_abs = self._pcm_total_fed + skip
+                skip += (frame_size - first_abs % frame_size) % frame_size
+            return anchor_at, due, prime_slice, skip
 
-            def map_to(anchor_at: float) -> tuple[float, float, bytes, int]:
-                """
-                Map an anchor instant onto the live feed.
-
-                Snapshots the ring and derives which stream position the group
-                plays at ``anchor_at``, returning the (possibly ring-capped)
-                anchor, the due feed position, the prime slice and the live
-                skip. Called again with the binary's TRUE scheduled instant
-                when it corrected the anchor forward, so the fed content
-                always matches where the joiner actually starts.
-                """
-                # Snapshot the ring and map its span onto stream positions:
-                # it covers [seconds_streamed - buffer_seconds, seconds_streamed].
-                buffered_pcm = bytes(self._pcm_buffer)
-                buffer_seconds = len(buffered_pcm) / pcm_sample_size
-                ring_floor = self.seconds_streamed - buffer_seconds
-                due = anchor_at - effective_start_time
-                skip = 0
-                prime_slice = b""
-                if due <= self.seconds_streamed:
-                    # The due position is at or behind the write head: prime
-                    # the joiner from the ring so the live feed then continues
-                    # seamlessly.
-                    if due < ring_floor:
-                        # The due position predates the ring (an unusually
-                        # large lead). Cap the prime at the whole buffer and
-                        # grow the headroom so the anchor still maps to the
-                        # prime's first sample exactly.
-                        self.prov.logger.debug(
-                            "Late joiner %s: due position %.2fs predates the "
-                            "%.2fs ring; capping prime at the whole buffer",
-                            airplay_player.player_id,
-                            due,
-                            buffer_seconds,
-                        )
-                        due = ring_floor
-                        anchor_at = effective_start_time + due
-                    keep_bytes = int((self.seconds_streamed - due) * pcm_sample_size)
-                    # Frame-align the prime START in ABSOLUTE stream
-                    # coordinates. The prime must end exactly at the write head
-                    # (the live feed continues byte-contiguously from there),
-                    # so only the start may move: shift it forward to the next
-                    # frame boundary (dropping under one frame, ~23 us).
-                    start_abs = self._pcm_total_fed - keep_bytes
-                    realign = (frame_size - start_abs % frame_size) % frame_size
-                    keep_bytes -= realign
-                    if realign:
-                        self.prov.logger.debug(
-                            "Late joiner %s: prime start realigned +%d bytes "
-                            "(write head sits mid-frame)",
-                            airplay_player.player_id,
-                            realign,
-                        )
-                    if keep_bytes > 0:
-                        prime_slice = buffered_pcm[len(buffered_pcm) - keep_bytes :]
-                else:
-                    # The due position is ahead of the write head: skip that
-                    # many bytes off the head of the live feed so the joiner's
-                    # first delivered byte is the sample due at the anchor.
-                    skip = int((due - self.seconds_streamed) * pcm_sample_size)
-                    # The first delivered live byte must land on a frame
-                    # boundary in ABSOLUTE stream coordinates (round the skip
-                    # up, under one frame).
-                    first_abs = self._pcm_total_fed + skip
-                    skip += (frame_size - first_abs % frame_size) % frame_size
-                return anchor_at, due, prime_slice, skip
-
+        now = time.time()
+        async with self._lock:
+            if not self._session_is_live():
+                await self.stop_client(airplay_player, reason="session ended during late join")
+                return
             # cliairplay makes the first post-START stdin byte audible exactly at
-            # the anchor, so pick the anchor first — far enough ahead that the
-            # device can connect and prime — then derive the stream position due
-            # at that instant. min_headroom is the most conservative of the
-            # session lead, the joiner's own lead and the late-join floor; the
-            # binary corrects an infeasible anchor forward and the mapping is
-            # then redone from its verified instant.
-            min_headroom = max(
-                self.wait_start,
-                airplay_player.wait_start / 1000,
-                AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000,
-            )
-            start_at, fed_pos_due, prime, skip_bytes = map_to(now + min_headroom)
-            self._client_skip_bytes[airplay_player.player_id] = skip_bytes
-
-            start_unix_ms = int(start_at * 1000)
+            # the instant it acks, so the anchor is commanded first and the
+            # content mapped onto the ack afterwards. min_headroom is the
+            # late-join floor: low enough that the joiner starts promptly, high
+            # enough for the binary to verify the receiver clock before it.
+            min_headroom = AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000
+            requested_at, fed_pos_due = map_to(now + min_headroom)[:2]
+            start_unix_ms = int(requested_at * 1000)
             sync_adjust = airplay_player.config.get_value(CONF_SYNC_ADJUST, 0)
             adjust_ms = sync_adjust if isinstance(sync_adjust, int) else 0
             position_ms = int(((self.media.elapsed_time or 0) + fed_pos_due) * 1000)
 
-            self.prov.logger.debug(
-                "Late joiner %s: priming %.2fs, skipping %.2fs, stream_pos=%.2fs, "
-                "fed_pos_due=%.2fs, start_at is %.2fs from now "
-                "(min_headroom=%.2fs, effective_shift=%.2fs)",
+        try:
+            # Anchor the joiner BEFORE feeding the prime: pre-START the binary
+            # only buffers stdin into its bounded ring and sends nothing, so a
+            # prime longer than that ring would wedge that write — and, through
+            # the session lock, stall the whole group's feed. Anchored, the
+            # binary drains the prime as it streams in. The START does not
+            # re-anchor the session timeline (the group keeps playing). Its ack
+            # is awaited WITHOUT the session lock: the binary holds that ack
+            # until the receiver's clock readiness resolves, which would
+            # otherwise starve every other member's feed for that whole wait.
+            actual = await stream.start(start_unix_ms + adjust_ms, position_ms, join=True)
+        except asyncio.CancelledError:
+            await self.stop_client(airplay_player, reason="late joiner start cancelled")
+            raise
+        except Exception as err:
+            self.prov.logger.warning(
+                "Late joiner %s: failed to start/prime pipeline: %r",
                 airplay_player.player_id,
-                len(prime) / pcm_sample_size,
-                skip_bytes / pcm_sample_size,
-                self.seconds_streamed,
-                fed_pos_due,
-                start_at - now,
-                min_headroom,
-                effective_start_time - self.start_time,
+                err,
             )
+            await self.stop_client(airplay_player, reason="late joiner start/prime failed")
+            return
 
-            try:
-                # Anchor the joiner BEFORE feeding the prime: pre-START the
-                # binary only buffers stdin into its bounded ring and sends
-                # nothing, so a prime longer than that ring would wedge the
-                # write here — and, through the session lock, stall the whole
-                # group's feed. Anchored, the binary drains the prime as it
-                # streams in. The START does not re-anchor the session
-                # timeline (the group keeps playing).
-                actual = await stream.start(start_unix_ms + adjust_ms, position_ms, join=True)
-                if actual is not None and abs((actual - adjust_ms) - start_unix_ms) > 2:
-                    # The binary corrected the anchor forward (verified truth):
-                    # redo the mapping from the actual instant so the fed
-                    # content matches where the joiner really starts. Routine
-                    # at the low join headroom, so informational only.
-                    self.prov.logger.info(
-                        "Late joiner %s: anchor corrected %+d ms by the binary; "
-                        "remapping the prime",
-                        airplay_player.player_id,
-                        (actual - adjust_ms) - start_unix_ms,
+        try:
+            async with self._lock:
+                if not self._session_is_live():
+                    await self.stop_client(airplay_player, reason="session ended during late join")
+                    return
+                if airplay_player.stream is not stream or not stream.running:
+                    await self.stop_client(
+                        airplay_player, reason="late joiner stopped during start"
                     )
-                    start_at, fed_pos_due, prime, skip_bytes = map_to((actual - adjust_ms) / 1000)
-                    self._client_skip_bytes[airplay_player.player_id] = skip_bytes
-                if prime:
-                    await self._write_chunk_to_player(airplay_player, prime)
-            except asyncio.CancelledError:
-                await self.stop_client(airplay_player, reason="late joiner start cancelled")
-                raise
-            except Exception as err:
-                self.prov.logger.warning(
-                    "Late joiner %s: failed to start/prime pipeline: %r",
-                    airplay_player.player_id,
-                    err,
-                )
-                await self.stop_client(airplay_player, reason="late joiner start/prime failed")
-                return
+                    return
+                # Map the content onto the instant the binary acked — its
+                # verified truth — falling back to the commanded instant when no
+                # ack arrived (older binary). The ring is re-snapshotted here, so
+                # the mapping covers whatever the group was fed while the ack was
+                # outstanding.
+                acked_at = (actual - adjust_ms) / 1000 if actual is not None else requested_at
+                start_at, fed_pos_due, prime, skip_bytes = map_to(acked_at)
+                self._client_skip_bytes[airplay_player.player_id] = skip_bytes
+                # An instant that moved carries the content mapped onto it
+                # further into the stream than the position sent with the
+                # command, so progress is reported against the sample that
+                # actually lands on the anchor.
+                acked_position_ms = int(((self.media.elapsed_time or 0) + fed_pos_due) * 1000)
+                if acked_position_ms != position_ms:
+                    stream.rebase_position(acked_position_ms)
 
-            if airplay_player not in self.sync_clients:
-                self.sync_clients.append(airplay_player)
-            if airplay_player.protocol == StreamingProtocol.AIRPLAY2 and not self.use_shared_ptp:
-                ap2_members = sum(
-                    1
-                    for player in self.sync_clients
-                    if player.protocol == StreamingProtocol.AIRPLAY2
+                self.prov.logger.debug(
+                    "Late joiner %s: priming %.2fs, skipping %.2fs, stream_pos=%.2fs, "
+                    "fed_pos_due=%.2fs, start_at is %.2fs from now, acked %+d ms off the "
+                    "commanded instant (min_headroom=%.2fs, effective_shift=%.2fs)",
+                    airplay_player.player_id,
+                    len(prime) / pcm_sample_size,
+                    skip_bytes / pcm_sample_size,
+                    self.seconds_streamed,
+                    fed_pos_due,
+                    start_at - time.time(),
+                    int(acked_at * 1000) - start_unix_ms,
+                    min_headroom,
+                    self.effective_start_time - self.start_time,
                 )
-                self._warn_degraded_shared_ptp(ap2_members)
+
+                if prime:
+                    try:
+                        await self._write_chunk_to_player(airplay_player, prime)
+                    except Exception as err:
+                        self.prov.logger.warning(
+                            "Late joiner %s: failed to start/prime pipeline: %r",
+                            airplay_player.player_id,
+                            err,
+                        )
+                        await self.stop_client(
+                            airplay_player, reason="late joiner start/prime failed"
+                        )
+                        return
+
+                if airplay_player not in self.sync_clients:
+                    self.sync_clients.append(airplay_player)
+                if (
+                    airplay_player.protocol == StreamingProtocol.AIRPLAY2
+                    and not self.use_shared_ptp
+                ):
+                    ap2_members = sum(
+                        1
+                        for player in self.sync_clients
+                        if player.protocol == StreamingProtocol.AIRPLAY2
+                    )
+                    self._warn_degraded_shared_ptp(ap2_members)
+        except asyncio.CancelledError:
+            # the joiner is anchored and audible from here on, so a cancellation
+            # before it is part of the session must still tear it down
+            await self.stop_client(airplay_player, reason="late joiner start cancelled")
+            raise
 
         self.prov.logger.debug(
             "Late joiner %s: started after %.2fs",
             airplay_player.player_id,
             time.time() - now,
         )
+
+    def _session_is_live(self) -> bool:
+        """Return whether the session still has a running reference member (call under the lock)."""
+        if not self.sync_clients:
+            return False
+        reference_stream = self.sync_clients[0].stream
+        return reference_stream is not None and reference_stream.running
 
     async def _resolve_shared_ptp(self, ap2_members: int | None = None) -> bool:
         """

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -513,7 +513,6 @@ async def test_raop_session_resolves_ptp_for_first_ap2_late_joiner() -> None:
     pcm_format.bit_depth = 16
     pcm_format.channels = 2
     session.start_time = time.time() - 5
-    session.wait_start = 1.5
     session.seconds_streamed = 5
 
     async def _wait_ptp_daemon_ready() -> bool:

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -526,8 +526,10 @@ async def test_raop_session_resolves_ptp_for_first_ap2_late_joiner() -> None:
         player.stream.wait_for_connection = AsyncMock()
         player.stream.flush = AsyncMock(return_value=True)
         # Verified-start API defaults: no started ack, no warm-lead constraint
-        # (an older binary), so the test asserts the commanded values directly.
+        # and no receiver clock projection (an older binary), so the test
+        # asserts the commanded values directly.
         player.stream.start = AsyncMock(return_value=None)
+        player.stream.wait_clock_ready = AsyncMock(return_value=None)
         player.stream.warm_lead_ms = 0
         player.stream.flushed_head_unix_ms = 0
 

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -898,6 +898,65 @@ def test_flushed_status_sets_flush_event() -> None:
     assert stream._flushed.is_set()
 
 
+@pytest.mark.asyncio
+async def test_clock_ready_projection_resolves_the_wait() -> None:
+    """A probing receiver reports when its clock becomes usable, from its first probe."""
+    stream = AirPlayStream(_make_player())
+
+    assert (
+        stream._handle_status_line(
+            "[STATUS] clock_ready mode=ptp state=probing streak_ms=0 exchanges=1 "
+            f"ready_in_ms=2300 ready_at_unix_ms={START_UNIX_MS}"
+        )
+        is False
+    )
+
+    assert await stream.wait_clock_ready(timeout=0.01) == START_UNIX_MS
+
+
+@pytest.mark.asyncio
+async def test_clock_ready_cold_line_keeps_waiting_for_a_projection() -> None:
+    """A receiver that has not probed yet carries no projection, so the wait goes on."""
+    stream = AirPlayStream(_make_player())
+
+    stream._handle_status_line(
+        "[STATUS] clock_ready mode=ptp state=cold streak_ms=0 exchanges=0 "
+        "ready_in_ms=0 ready_at_unix_ms=0"
+    )
+
+    assert await stream.wait_clock_ready(timeout=0.01) is None
+    assert not stream._clock_ready.is_set()
+
+    stream._handle_status_line(
+        "[STATUS] clock_ready mode=ptp state=ready streak_ms=2400 exchanges=9 "
+        f"ready_in_ms=0 ready_at_unix_ms={START_UNIX_MS}"
+    )
+
+    assert await stream.wait_clock_ready(timeout=0.01) == START_UNIX_MS
+
+
+@pytest.mark.asyncio
+async def test_clock_ready_ntp_resolves_without_a_projection() -> None:
+    """NTP timing has no receiver clock to wait for, so the wait ends with nothing."""
+    stream = AirPlayStream(_make_player())
+
+    stream._handle_status_line(
+        "[STATUS] clock_ready mode=ntp state=ready streak_ms=0 exchanges=0 "
+        f"ready_in_ms=0 ready_at_unix_ms={START_UNIX_MS}"
+    )
+
+    assert stream._clock_ready.is_set()
+    assert await stream.wait_clock_ready(timeout=0.01) is None
+
+
+@pytest.mark.asyncio
+async def test_wait_clock_ready_times_out_for_a_binary_that_never_reports() -> None:
+    """A binary that does not report readiness leaves the caller with no projection."""
+    stream = AirPlayStream(_make_player())
+
+    assert await stream.wait_clock_ready(timeout=0.01) is None
+
+
 def test_elapsed_includes_start_position() -> None:
     """Reported progress is the current anchor's media base plus the binary delta."""
     player = _make_player()

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -11,6 +11,8 @@ from music_assistant_models.errors import PlayerCommandFailed
 
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_COLD_GROUP_START_LEAD_MS,
+    AIRPLAY_JOIN_CLOCK_READY_LEAD_MS,
+    AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS,
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
     StreamingProtocol,
 )
@@ -23,10 +25,11 @@ def _stream_defaults(stream: MagicMock) -> MagicMock:
     """
     Apply the verified-start API defaults to a mocked stream.
 
-    No started ack and no warm-lead constraint, matching an older binary, so
-    the tests assert the commanded values directly.
+    No started ack, no warm-lead constraint and no receiver clock projection,
+    matching an older binary, so the tests assert the commanded values directly.
     """
     stream.start = AsyncMock(return_value=None)
+    stream.wait_clock_ready = AsyncMock(return_value=None)
     stream.warm_lead_ms = 0
     stream.flushed_head_unix_ms = 0
     return stream
@@ -822,8 +825,9 @@ async def test_late_join_skips_live_feed_when_anchor_ahead_of_write_head() -> No
     # Freeze time so both the test and the code under test agree on `now`.
     now = 1_000_000.0
     # Diagnosed clamp case: now - start_time = 8.84s, seconds_streamed = 10.0s,
-    # min_headroom = 1.5s (the late-join floor) and no group shift, so the
-    # anchor is due at 10.34s of feed, past the 10.0s write head.
+    # min_headroom = 2.5s (the late-join floor, no readiness projection) and no
+    # group shift, so the anchor is due at 11.34s of feed, past the 10.0s write
+    # head.
     start_time = now - 8.84
     seconds_streamed = 10.0
     session = _make_session(start_time, seconds_streamed)
@@ -848,7 +852,7 @@ async def test_late_join_skips_live_feed_when_anchor_ahead_of_write_head() -> No
     assert _captured_start_at(player) - now == pytest.approx(expected_headroom, abs=0.01)
     assert written_chunks == []
     skip_seconds = session._client_skip_bytes[player.player_id] / PCM_SAMPLE_SIZE
-    assert skip_seconds == pytest.approx(0.34, abs=0.01)
+    assert skip_seconds == pytest.approx(1.34, abs=0.01)
 
 
 @pytest.mark.asyncio
@@ -858,8 +862,8 @@ async def test_late_join_primes_from_ring_under_group_shift() -> None:
     now = 1_000_000.0
     # Same base as the clamp case, but the reference member accumulated a
     # +3.039s starvation shift (134020 frames @44100) so the group's effective
-    # anchor is later: fed_pos_due = 7.30s, back inside the ring. The joiner is
-    # primed with ~2.7s from the ring tail and skips nothing.
+    # anchor is later: fed_pos_due = 8.30s, back inside the ring. The joiner is
+    # primed with ~1.7s from the ring tail and skips nothing.
     start_time = now - 8.84
     seconds_streamed = 10.0
     session = _make_session(start_time, seconds_streamed)
@@ -886,7 +890,121 @@ async def test_late_join_primes_from_ring_under_group_shift() -> None:
     assert session._client_skip_bytes[player.player_id] == 0
     assert written_chunks, "expected a prime write from the ring tail"
     primed_seconds = len(written_chunks[0]) / PCM_SAMPLE_SIZE
-    assert primed_seconds == pytest.approx(2.699, abs=0.01)
+    assert primed_seconds == pytest.approx(1.699, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_late_join_anchors_on_the_reported_clock_readiness() -> None:
+    """A projected readiness instant anchors the join, just past the receiver's clock."""
+    # Freeze time so both the test and the code under test agree on `now`.
+    now = 1_000_000.0
+    session = _make_session(now - 5.0, 5.0)
+    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 5)
+    player = _make_late_joiner()
+    # A cold receiver: its clock is projected usable 3.0s out, well past the floor.
+    ready_at_unix_ms = int((now + 3.0) * 1000)
+
+    def setup_with_projection(*_args: Any, **_kwargs: Any) -> None:
+        _setup_stream(player)()
+        player.stream.wait_clock_ready = AsyncMock(return_value=ready_at_unix_ms)
+
+    with (
+        patch.object(session, "_start_client", side_effect=setup_with_projection),
+        patch.object(session, "_write_chunk_to_player", new_callable=AsyncMock),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
+    ):
+        await session.add_client(player)
+
+    expected_lead = AIRPLAY_JOIN_CLOCK_READY_LEAD_MS / 1000
+    assert _captured_start_at(player) - now == pytest.approx(3.0 + expected_lead, abs=0.01)
+    player.stream.wait_clock_ready.assert_awaited_once_with(
+        timeout=AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS / 1000
+    )
+
+
+@pytest.mark.asyncio
+async def test_late_join_floor_wins_over_a_clock_that_is_already_ready() -> None:
+    """A receiver whose clock is already locked still gets the join floor as its anchor."""
+    # Freeze time so both the test and the code under test agree on `now`.
+    now = 1_000_000.0
+    session = _make_session(now - 5.0, 5.0)
+    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 5)
+    player = _make_late_joiner()
+    # A warm receiver reports a readiness instant that has already passed.
+    ready_at_unix_ms = int((now - 1.0) * 1000)
+
+    def setup_with_projection(*_args: Any, **_kwargs: Any) -> None:
+        _setup_stream(player)()
+        player.stream.wait_clock_ready = AsyncMock(return_value=ready_at_unix_ms)
+
+    with (
+        patch.object(session, "_start_client", side_effect=setup_with_projection),
+        patch.object(session, "_write_chunk_to_player", new_callable=AsyncMock),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
+    ):
+        await session.add_client(player)
+
+    expected_headroom = AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000
+    assert _captured_start_at(player) - now == pytest.approx(expected_headroom, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_late_join_falls_back_to_the_floor_without_a_clock_projection() -> None:
+    """No projection (older binary, NTP timing or a silent receiver) anchors on the floor."""
+    # Freeze time so both the test and the code under test agree on `now`.
+    now = 1_000_000.0
+    session = _make_session(now - 5.0, 5.0)
+    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 5)
+    player = _make_late_joiner()
+
+    with (
+        patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start,
+        patch.object(session, "_write_chunk_to_player", new_callable=AsyncMock),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
+    ):
+        mock_start.side_effect = _setup_stream(player)
+        await session.add_client(player)
+
+    # every fallback shape surfaces as "no projection" to the session
+    player.stream.wait_clock_ready.assert_awaited_once_with(
+        timeout=AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS / 1000
+    )
+    expected_headroom = AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000
+    assert _captured_start_at(player) - now == pytest.approx(expected_headroom, abs=0.01)
+    assert player in session.sync_clients
+
+
+@pytest.mark.asyncio
+async def test_late_join_feed_keeps_flowing_while_waiting_for_clock_readiness() -> None:
+    """The group keeps being fed while a joiner's receiver clock projection is pending."""
+    session = _make_session(time.time() - 5, 5.0)
+    player = _make_late_joiner()
+    readiness_pending = asyncio.Event()
+    readiness_released = asyncio.Event()
+
+    def setup_pending_projection(*_args: Any, **_kwargs: Any) -> None:
+        _setup_stream(player)()
+
+        async def wait_clock_ready(*_args: Any, **_kwargs: Any) -> None:
+            readiness_pending.set()
+            await readiness_released.wait()
+
+        player.stream.wait_clock_ready = AsyncMock(side_effect=wait_clock_ready)
+
+    with (
+        patch.object(session, "_start_client", side_effect=setup_pending_projection),
+        patch.object(session, "_write_chunk_to_player", new_callable=AsyncMock),
+    ):
+        join = asyncio.create_task(session.add_client(player))
+        await asyncio.wait_for(readiness_pending.wait(), timeout=5)
+        assert await asyncio.wait_for(
+            session._write_chunk_to_all_players(b"\x02" * PCM_SAMPLE_SIZE), timeout=5
+        )
+        readiness_released.set()
+        await asyncio.wait_for(join, timeout=5)
+
+    assert session.seconds_streamed == pytest.approx(6.0)
+    assert player in session.sync_clients
 
 
 @pytest.mark.asyncio
@@ -932,11 +1050,11 @@ async def test_late_join_feed_keeps_flowing_while_start_ack_is_outstanding() -> 
     # that second of feed reached the leader and moved the write head to 6.0s
     assert ("leader", PCM_SAMPLE_SIZE) in writes
     assert session.seconds_streamed == pytest.approx(6.0)
-    # the anchor (now + the 1.5s floor) is due at 6.5s of feed, so the joiner
-    # skips only the 0.5s still to come, not the 1.5s due at the commanded
+    # the anchor (now + the 2.5s floor) is due at 7.5s of feed, so the joiner
+    # skips only the 1.5s still to come, not the 2.5s due at the commanded
     # mapping: the content is mapped against the head the feed actually reached
     skip_seconds = session._client_skip_bytes[player.player_id] / PCM_SAMPLE_SIZE
-    assert skip_seconds == pytest.approx(0.5, abs=0.01)
+    assert skip_seconds == pytest.approx(1.5, abs=0.01)
     assert player in session.sync_clients
 
 
@@ -1008,14 +1126,14 @@ async def test_late_join_maps_content_from_the_acked_instant() -> None:
 
     commanded_ms = int((now + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000) * 1000) + adjust_ms
     assert player.stream.start.await_args.args[0] == commanded_ms
-    # The ack lands 1.5s later than commanded, so the due position is 8.0s of
-    # feed instead of 6.5s: the joiner skips 3.0s of the live feed.
+    # The ack lands 1.5s later than commanded, so the due position is 9.0s of
+    # feed instead of 7.5s: the joiner skips 4.0s of the live feed.
     assert written_chunks == []
     skip_seconds = session._client_skip_bytes[player.player_id] / PCM_SAMPLE_SIZE
-    assert skip_seconds == pytest.approx(3.0, abs=0.01)
+    assert skip_seconds == pytest.approx(4.0, abs=0.01)
     # Progress is reported against the sample that lands on the acked instant,
     # not the one that would have landed on the commanded instant.
-    player.stream.rebase_position.assert_called_once_with(8000)
+    player.stream.rebase_position.assert_called_once_with(9000)
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -64,17 +64,15 @@ def _make_session(
     session.start_time = start_time
     session.seconds_streamed = seconds_streamed
     session.start_unix_ms = 1  # dummy
-    session.wait_start = 2.0
 
     return session
 
 
-def _make_late_joiner(wait_start_ms: int = 2000) -> MagicMock:
+def _make_late_joiner() -> MagicMock:
     """Create a mock AirPlay player for late-join testing."""
     player = MagicMock()
     player.player_id = "late_joiner"
     player.protocol = StreamingProtocol.RAOP
-    player.wait_start = wait_start_ms
     player.stream = None
     player.config = MagicMock()
     player.config.get_value = MagicMock(return_value=0)
@@ -673,7 +671,7 @@ async def test_late_join_empty_buffer() -> None:
     start_time = now - 8
     seconds_streamed = 12.5
     session = _make_session(start_time, seconds_streamed)
-    player = _make_late_joiner(wait_start_ms=2000)
+    player = _make_late_joiner()
 
     with patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start:
         mock_start.side_effect = _setup_stream(player)
@@ -696,7 +694,7 @@ async def test_late_join_caps_prime_at_whole_ring_when_position_predates_it() ->
     start_time = now + 5.0
     session = _make_session(start_time, seconds_streamed)
     session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * buffer_seconds)
-    player = _make_late_joiner(wait_start_ms=2000)
+    player = _make_late_joiner()
 
     written_chunks: list[bytes] = []
 
@@ -785,9 +783,7 @@ async def test_late_join_primes_from_ring_tail_at_headroom() -> None:
     session = _make_session(start_time, seconds_streamed)
     # Fill ring buffer with 5 seconds of non-silent PCM.
     session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 5)
-    # Leads below the late-join floor, so the floor is what anchors the join.
-    session.wait_start = 1.0
-    player = _make_late_joiner(wait_start_ms=1000)
+    player = _make_late_joiner()
 
     written_chunks: list[bytes] = []
 
@@ -826,14 +822,13 @@ async def test_late_join_skips_live_feed_when_anchor_ahead_of_write_head() -> No
     # Freeze time so both the test and the code under test agree on `now`.
     now = 1_000_000.0
     # Diagnosed clamp case: now - start_time = 8.84s, seconds_streamed = 10.0s,
-    # min_headroom = 2.5s (the session lead, above the late-join floor) and no
-    # group shift -> fed_pos_due = 11.34s > 10.0s.
+    # min_headroom = 1.5s (the late-join floor) and no group shift, so the
+    # anchor is due at 10.34s of feed, past the 10.0s write head.
     start_time = now - 8.84
     seconds_streamed = 10.0
     session = _make_session(start_time, seconds_streamed)
-    session.wait_start = 2.5
     session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 10)
-    player = _make_late_joiner(wait_start_ms=2000)
+    player = _make_late_joiner()
 
     written_chunks: list[bytes] = []
 
@@ -849,10 +844,11 @@ async def test_late_join_skips_live_feed_when_anchor_ahead_of_write_head() -> No
         await session.add_client(player)
 
     # anchor is now + min_headroom and nothing is primed (position past the head)
-    assert _captured_start_at(player) - now == pytest.approx(2.5, abs=0.01)
+    expected_headroom = AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000
+    assert _captured_start_at(player) - now == pytest.approx(expected_headroom, abs=0.01)
     assert written_chunks == []
     skip_seconds = session._client_skip_bytes[player.player_id] / PCM_SAMPLE_SIZE
-    assert skip_seconds == pytest.approx(1.34, abs=0.01)
+    assert skip_seconds == pytest.approx(0.34, abs=0.01)
 
 
 @pytest.mark.asyncio
@@ -862,16 +858,15 @@ async def test_late_join_primes_from_ring_under_group_shift() -> None:
     now = 1_000_000.0
     # Same base as the clamp case, but the reference member accumulated a
     # +3.039s starvation shift (134020 frames @44100) so the group's effective
-    # anchor is later: fed_pos_due = 8.30s, back inside the ring. The joiner is
-    # primed with ~1.7s from the ring tail and skips nothing.
+    # anchor is later: fed_pos_due = 7.30s, back inside the ring. The joiner is
+    # primed with ~2.7s from the ring tail and skips nothing.
     start_time = now - 8.84
     seconds_streamed = 10.0
     session = _make_session(start_time, seconds_streamed)
-    session.wait_start = 2.5
     session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 10)
     reference: Any = session.sync_clients[0]
     reference.stream.cumulative_shift_seconds = 134020 / 44100
-    player = _make_late_joiner(wait_start_ms=2000)
+    player = _make_late_joiner()
 
     written_chunks: list[bytes] = []
 
@@ -886,11 +881,141 @@ async def test_late_join_primes_from_ring_under_group_shift() -> None:
         mock_start.side_effect = _setup_stream(player)
         await session.add_client(player)
 
-    assert _captured_start_at(player) - now == pytest.approx(2.5, abs=0.01)
+    expected_headroom = AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000
+    assert _captured_start_at(player) - now == pytest.approx(expected_headroom, abs=0.01)
     assert session._client_skip_bytes[player.player_id] == 0
     assert written_chunks, "expected a prime write from the ring tail"
     primed_seconds = len(written_chunks[0]) / PCM_SAMPLE_SIZE
-    assert primed_seconds == pytest.approx(1.699, abs=0.01)
+    assert primed_seconds == pytest.approx(2.699, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_late_join_feed_keeps_flowing_while_start_ack_is_outstanding() -> None:
+    """The group keeps being fed while a join's START ack is outstanding."""
+    # Freeze time so both the test and the code under test agree on `now`.
+    now = 1_000_000.0
+    start_time = now - 5.0
+    session = _make_session(start_time, 5.0)
+    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 5)
+    player = _make_late_joiner()
+    ack_outstanding = asyncio.Event()
+    ack_released = asyncio.Event()
+
+    def setup_deferred_ack(*_args: Any, **_kwargs: Any) -> None:
+        _setup_stream(player)()
+
+        async def start(*_args: Any, **_kwargs: Any) -> None:
+            # the binary holds its ack until the receiver clock is verified
+            ack_outstanding.set()
+            await ack_released.wait()
+
+        player.stream.start = AsyncMock(side_effect=start)
+
+    writes: list[tuple[str, int]] = []
+
+    async def capture_write(target: Any, chunk: bytes) -> None:
+        writes.append((target.player_id, len(chunk)))
+
+    with (
+        patch.object(session, "_start_client", side_effect=setup_deferred_ack),
+        patch.object(session, "_write_chunk_to_player", side_effect=capture_write),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
+    ):
+        join = asyncio.create_task(session.add_client(player))
+        await asyncio.wait_for(ack_outstanding.wait(), timeout=5)
+        assert await asyncio.wait_for(
+            session._write_chunk_to_all_players(b"\x02" * PCM_SAMPLE_SIZE), timeout=5
+        )
+        ack_released.set()
+        await asyncio.wait_for(join, timeout=5)
+
+    # that second of feed reached the leader and moved the write head to 6.0s
+    assert ("leader", PCM_SAMPLE_SIZE) in writes
+    assert session.seconds_streamed == pytest.approx(6.0)
+    # the anchor (now + the 1.5s floor) is due at 6.5s of feed, so the joiner
+    # skips only the 0.5s still to come, not the 1.5s due at the commanded
+    # mapping: the content is mapped against the head the feed actually reached
+    skip_seconds = session._client_skip_bytes[player.player_id] / PCM_SAMPLE_SIZE
+    assert skip_seconds == pytest.approx(0.5, abs=0.01)
+    assert player in session.sync_clients
+
+
+@pytest.mark.asyncio
+async def test_late_join_cancelled_while_ack_outstanding_stops_the_client() -> None:
+    """A join cancelled while its START ack is outstanding never half-joins the session."""
+    session = _make_session(time.time() - 5, 5.0)
+    player = _make_late_joiner()
+    ack_outstanding = asyncio.Event()
+
+    def setup_pending_ack(*_args: Any, **_kwargs: Any) -> None:
+        _setup_stream(player)()
+
+        async def start(*_args: Any, **_kwargs: Any) -> None:
+            ack_outstanding.set()
+            await asyncio.Event().wait()
+
+        player.stream.start = AsyncMock(side_effect=start)
+
+    with (
+        patch.object(session, "_start_client", side_effect=setup_pending_ack),
+        patch.object(session, "stop_client", new_callable=AsyncMock) as stop_client,
+    ):
+        join = asyncio.create_task(session.add_client(player))
+        await asyncio.wait_for(ack_outstanding.wait(), timeout=5)
+        join.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await join
+
+    assert player not in session.sync_clients
+    stop_client.assert_awaited_once_with(player, reason="late joiner start cancelled")
+
+
+@pytest.mark.asyncio
+async def test_late_join_maps_content_from_the_acked_instant() -> None:
+    """A binary that acks later than commanded gets its content mapped to the acked instant."""
+    # Freeze time so both the test and the code under test agree on `now`.
+    now = 1_000_000.0
+    start_time = now - 5.0
+    session = _make_session(start_time, 5.0)
+    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 5)
+    player = _make_late_joiner()
+    # A sync_adjust rides on top of the commanded instant, so it has to be taken
+    # back out of the ack before the content is mapped onto it.
+    adjust_ms = 200
+    player.config.get_value = MagicMock(return_value=adjust_ms)
+    deferral_ms = 1500
+
+    def setup_deferred_ack(*_args: Any, **_kwargs: Any) -> None:
+        _setup_stream(player)()
+
+        async def start(start_unix_ms: int, _position_ms: int, *, join: bool = False) -> int:
+            assert join is True
+            return start_unix_ms + deferral_ms
+
+        player.stream.start = AsyncMock(side_effect=start)
+
+    written_chunks: list[bytes] = []
+
+    async def capture_write(_player: Any, chunk: bytes) -> None:
+        written_chunks.append(chunk)
+
+    with (
+        patch.object(session, "_start_client", side_effect=setup_deferred_ack),
+        patch.object(session, "_write_chunk_to_player", side_effect=capture_write),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
+    ):
+        await session.add_client(player)
+
+    commanded_ms = int((now + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000) * 1000) + adjust_ms
+    assert player.stream.start.await_args.args[0] == commanded_ms
+    # The ack lands 1.5s later than commanded, so the due position is 8.0s of
+    # feed instead of 6.5s: the joiner skips 3.0s of the live feed.
+    assert written_chunks == []
+    skip_seconds = session._client_skip_bytes[player.player_id] / PCM_SAMPLE_SIZE
+    assert skip_seconds == pytest.approx(3.0, abs=0.01)
+    # Progress is reported against the sample that lands on the acked instant,
+    # not the one that would have landed on the commanded instant.
+    player.stream.rebase_position.assert_called_once_with(8000)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

A speaker added to an already-playing group could end up audibly behind the
others for the rest of the session, with only stopping and rejoining it as a
reliable fix.

We anchored the join at a guessed instant built from the setup lead we
advertise to Sendspin. That value is 2.5 seconds for every AirPlay 2 speaker,
and it already covers work that has finished by then, so the anchor was always
further out than needed and the speaker's clock was never ready for it. The
binary then moved the anchor after the fact and tried to compensate by
discarding queued audio that, on a join, had usually not arrived yet.

The join now commands its own floor and maps its audio onto whatever instant
the speaker acknowledges — which the binary withholds until it has verified the
speaker's clock. That acknowledgement is awaited without the session lock, so
the rest of the group keeps playing while a member joins.

**Requires the matching airplay-cli change:** music-assistant/airplay-cli#38 (merged) and music-assistant/airplay-cli#39

- Anchor a join at the late-join floor instead of the Sendspin setup lead
- Map the joiner's audio onto the acknowledged instant, and report its progress
  against the sample that lands there
- Await the join's acknowledgement without holding the session lock, so no
  member's audio stalls behind it
- Give a join its own acknowledgement timeout, since it is answered late by
  design

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
