### PR TITLE
Remove unused authentication middleware

### DIFF
--- a/music_assistant/controllers/webserver/README.md
+++ b/music_assistant/controllers/webserver/README.md
@@ -121,8 +121,8 @@ Manages individual WebSocket connections:
 
 ### 5. Authentication Helpers
 
-**Middleware ([helpers/auth_middleware.py](helpers/auth_middleware.py)):**
-- Request authentication for HTTP endpoints
+**Helpers ([helpers/auth_middleware.py](helpers/auth_middleware.py)):**
+- Request authentication for HTTP endpoints, called per handler (there is no aiohttp middleware)
 - User context management (thread-local storage)
 - Ingress detection (Home Assistant add-on)
 - Token extraction from Authorization header
@@ -318,10 +318,11 @@ Enable or disable remote access:
 ### HTTP Request Flow
 
 ```
-HTTP Request → Webserver → Auth Middleware → Command Handler → Response
+HTTP Request → Webserver → Command Handler → Response
                                 |
-                                ├─ Ingress? → Auto-authenticate with HA headers
-                                └─ Regular? → Validate Bearer token
+                                └─ get_authenticated_user()
+                                   ├─ Ingress? → Auto-authenticate with HA headers
+                                   └─ Regular? → Validate Bearer token
 ```
 
 ### WebSocket Request Flow
@@ -468,7 +469,7 @@ webserver/
 ├── api_docs.py                         # API documentation generator
 ├── README.md                           # This file
 ├── helpers/
-│   ├── auth_middleware.py              # HTTP auth middleware
+│   ├── auth_middleware.py              # HTTP/WebSocket auth helpers
 │   └── auth_providers.py               # Authentication providers
 └── remote_access/
     ├── __init__.py                     # Remote access manager

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -319,7 +319,7 @@ class WebserverController(CoreController):
             # add assets subdir as static_content
             static_content=("/assets", os.path.join(frontend_dir, "assets"), "assets"),
             ingress_tcp_site_params=ingress_tcp_site_params,
-            # Add mass object to app for use in auth middleware
+            # Add mass object to app for use by the auth helpers
             app_state={"mass": self.mass},
             ssl_context=ssl_context,
         )

--- a/music_assistant/controllers/webserver/helpers/auth_middleware.py
+++ b/music_assistant/controllers/webserver/helpers/auth_middleware.py
@@ -1,4 +1,4 @@
-"""Authentication middleware and helpers for HTTP requests and WebSocket connections."""
+"""Authentication helpers for HTTP requests and WebSocket connections."""
 
 from __future__ import annotations
 
@@ -8,7 +8,6 @@ from contextvars import ContextVar
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Final, Self, cast
 
-from aiohttp import web
 from music_assistant_models.auth import AuthProviderType, Scope, User, UserRole
 from music_assistant_models.errors import InsufficientPermissions, InvalidDataError
 
@@ -19,6 +18,8 @@ from .auth_providers import get_ha_user_details, get_ha_user_role
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.auth")
 
 if TYPE_CHECKING:
+    from aiohttp import web
+
     from music_assistant import MusicAssistant
 
 # Context key for storing authenticated user in request
@@ -72,7 +73,7 @@ async def get_authenticated_user(request: web.Request) -> User | None:
 
     :param request: The aiohttp request.
     """
-    # Check if user is already in context (from middleware)
+    # Return the user resolved by an earlier call on this same request
     if USER_CONTEXT_KEY in request:
         return cast("User | None", request[USER_CONTEXT_KEY])
 
@@ -167,21 +168,6 @@ async def get_authenticated_user(request: web.Request) -> User | None:
         # Store in request context
         request[USER_CONTEXT_KEY] = user
 
-    return user
-
-
-async def require_authentication(request: web.Request) -> User:
-    """
-    Require authentication for a request, raise 401 if not authenticated.
-
-    :param request: The aiohttp request.
-    """
-    user = await get_authenticated_user(request)
-    if not user:
-        raise web.HTTPUnauthorized(
-            text="Authentication required",
-            headers={"WWW-Authenticate": 'Bearer realm="Music Assistant"'},
-        )
     return user
 
 
@@ -365,48 +351,6 @@ def is_request_from_ingress(request: web.Request) -> bool:
         pass
 
     return False
-
-
-@web.middleware
-async def auth_middleware(request: web.Request, handler: Any) -> web.StreamResponse:
-    """
-    Authenticate requests and store user in context.
-
-    :param request: The aiohttp request.
-    :param handler: The request handler.
-    """
-    # Skip authentication for ingress requests (HA handles auth)
-    if is_request_from_ingress(request):
-        return cast("web.StreamResponse", await handler(request))
-
-    # Unauthenticated routes (static files, info, login, setup, etc.)
-    unauthenticated_paths = [
-        "/info",
-        "/login",
-        "/setup",
-        "/auth/",
-        "/api-docs/",
-        "/assets/",
-        "/favicon.ico",
-        "/manifest.json",
-        "/index.html",
-        "/",
-    ]
-
-    # Check if path should bypass auth
-    for path_prefix in unauthenticated_paths:
-        if request.path.startswith(path_prefix):
-            return cast("web.StreamResponse", await handler(request))
-
-    # Try to authenticate
-    user = await get_authenticated_user(request)
-
-    # Store user in context (might be None for unauthenticated requests)
-    request[USER_CONTEXT_KEY] = user
-
-    # Let the handler decide if authentication is required
-    # The handler will call require_authentication() if needed
-    return cast("web.StreamResponse", await handler(request))
 
 
 class ImpersonatedUser:


### PR DESCRIPTION
# What does this implement/fix?

The webserver contained an authentication middleware that was never actually
hooked up to the web application, so it never ran. On top of that, its list of
paths to skip ended with `/`, which matches every request, so even if it had
been mounted it would have done nothing.

Authentication for HTTP requests is (and stays) handled per request handler,
which checks the user and the required permission scope before running a
command. This just removes the leftover code so the auth code is easier to
follow.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Removed the never-mounted `auth_middleware` from the webserver auth helpers.
- Removed `require_authentication`, which was only there for that middleware and had no callers.
- Updated the webserver README and a few comments that described the (now gone) middleware.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
