### PR TITLE
Fix Music Timeline bonus questions running out of answer options

### DIFF
--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -341,15 +341,25 @@ class MusicTimelineQuizType(QuizType):
             preferred,
             limit=BONUS_CANDIDATE_LIMIT,
         )
-        distractors = self._filter_bonus_candidates(
-            track,
-            bonus_type,
-            [
-                *preferred,
-                *(await self._source_pool_bonus_distractors(track, bonus_type)),
-            ],
-            limit=DEFAULT_BONUS_OPTION_COUNT - 1,
-        )
+        if self._has_enough_bonus_candidates(track, bonus_type, preferred):
+            distractors = self._filter_bonus_candidates(
+                track,
+                bonus_type,
+                preferred,
+                limit=DEFAULT_BONUS_OPTION_COUNT - 1,
+            )
+        else:
+            # the source pool holds every configured track, so it is only walked
+            # when the preferred candidates cannot fill every wrong option
+            distractors = self._filter_bonus_candidates(
+                track,
+                bonus_type,
+                [
+                    *preferred,
+                    *(await self._source_pool_bonus_distractors(track, bonus_type)),
+                ],
+                limit=DEFAULT_BONUS_OPTION_COUNT - 1,
+            )
         if self.config.use_ai_distractors:
             mixed = await self._get_ai_bonus_distractors(
                 track,

--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -211,7 +211,7 @@ class MusicTimelineQuizType(QuizType):
                 ]
 
     async def _get_eligible_tracks(self) -> list[Track]:
-        """Return unique source tracks with usable release metadata."""
+        """Return the unique source tracks that can be played and placed on the timeline."""
         if self._eligible_tracks is not None:
             return self._eligible_tracks
         source_tracks = list((await self._get_source_track_pool()).values())
@@ -346,7 +346,7 @@ class MusicTimelineQuizType(QuizType):
             bonus_type,
             [
                 *preferred,
-                *self._source_pool_bonus_distractors(track, bonus_type),
+                *(await self._source_pool_bonus_distractors(track, bonus_type)),
             ],
             limit=DEFAULT_BONUS_OPTION_COUNT - 1,
         )
@@ -421,13 +421,15 @@ class MusicTimelineQuizType(QuizType):
         primary_artist = self._primary_artist(track)
         if primary_artist is None:
             return []
-        assert self._eligible_tracks is not None
+        # a bonus distractor only needs a display label, so the complete source pool
+        # is used here instead of the (release-year bounded) playback set
+        source_tracks = (await self._get_source_track_pool()).values()
         candidates = self._filter_bonus_candidates(
             track,
             TimelineBonusType.TITLE,
             [
                 self._bonus_candidate(candidate, TimelineBonusType.TITLE)
-                for candidate in self._eligible_tracks
+                for candidate in source_tracks
                 if self._track_has_primary_artist(candidate, primary_artist)
             ],
             limit=BONUS_CANDIDATE_LIMIT,
@@ -689,21 +691,21 @@ class MusicTimelineQuizType(QuizType):
                 break
         return result
 
-    def _source_pool_bonus_distractors(
+    async def _source_pool_bonus_distractors(
         self,
         track: Track,
         bonus_type: TimelineBonusType,
     ) -> list[SuggestionCandidate]:
         """Return unrelated source-pool candidates as the final resilience fallback."""
-        assert self._eligible_tracks is not None
+        source_tracks = (await self._get_source_track_pool()).values()
         if bonus_type == TimelineBonusType.TITLE:
             return [
                 self._bonus_candidate(candidate, bonus_type)
-                for candidate in self._eligible_tracks
+                for candidate in source_tracks
                 if candidate.uri != track.uri
             ]
         candidates: list[SuggestionCandidate] = []
-        for candidate in self._eligible_tracks:
+        for candidate in source_tracks:
             if candidate.uri != track.uri:
                 candidates.extend(self._artist_candidates(candidate.artists))
         return candidates

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -912,13 +912,19 @@ async def test_title_bonus_uses_same_artist_source_tracks_outside_playback_set()
     )
     quiz._eligible_tracks = [current, unrelated]
 
-    options = await quiz._create_bonus_options(current, TimelineBonusType.TITLE)
+    with patch.object(
+        quiz,
+        "_source_pool_bonus_distractors",
+        wraps=quiz._source_pool_bonus_distractors,
+    ) as source_pool_fallback:
+        options = await quiz._create_bonus_options(current, TimelineBonusType.TITLE)
 
     assert {option.label for option in options if not option.is_correct} == {
         "D.A.N.C.E.",
         "Phantom",
         "Audio, Video, Disco",
     }
+    source_pool_fallback.assert_not_awaited()
     mass.music.artists.top_tracks.assert_not_awaited()
     mass.music.search.assert_not_awaited()
 

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -897,6 +897,91 @@ async def test_title_bonus_uses_unrelated_source_only_when_grounded_pool_is_spar
 
 
 @pytest.mark.asyncio
+async def test_title_bonus_uses_same_artist_source_tracks_outside_playback_set() -> None:
+    """Ground same-artist titles in the complete source pool without extra lookups."""
+    current = _track("current", "Genesis", "Justice", album_year=2007)
+    undated_same_artist = [
+        _track("one", "D.A.N.C.E.", "Justice"),
+        _track("two", "Phantom", "Justice"),
+        _track("three", "Audio, Video, Disco", "Justice"),
+    ]
+    unrelated = _track("unrelated", "Teardrop", "Massive Attack", album_year=1998)
+    quiz, mass = _quiz(
+        [current, *undated_same_artist, unrelated],
+        title_mode=TimelineBonusMode.MULTIPLE_CHOICE,
+    )
+    quiz._eligible_tracks = [current, unrelated]
+
+    options = await quiz._create_bonus_options(current, TimelineBonusType.TITLE)
+
+    assert {option.label for option in options if not option.is_correct} == {
+        "D.A.N.C.E.",
+        "Phantom",
+        "Audio, Video, Disco",
+    }
+    mass.music.artists.top_tracks.assert_not_awaited()
+    mass.music.search.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_bonus_fallback_uses_source_tracks_outside_playback_set() -> None:
+    """Fill the last-resort bonus options from source tracks the timeline cannot use."""
+    current = _track("current", "Genesis", "Justice", album_year=2007)
+    undated = [
+        _track("one", "Teardrop", "Massive Attack"),
+        _track("two", "Glory Box", "Portishead"),
+        _track("three", "Roads", "Tricky"),
+    ]
+    quiz, _ = _quiz(
+        [current, *undated],
+        artist_mode=TimelineBonusMode.MULTIPLE_CHOICE,
+        title_mode=TimelineBonusMode.MULTIPLE_CHOICE,
+    )
+    quiz._eligible_tracks = [current]
+
+    artist_options = await quiz._create_bonus_options(current, TimelineBonusType.ARTIST)
+    title_options = await quiz._create_bonus_options(current, TimelineBonusType.TITLE)
+
+    assert {option.label for option in artist_options if not option.is_correct} == {
+        "Massive Attack",
+        "Portishead",
+        "Tricky",
+    }
+    assert {option.label for option in title_options if not option.is_correct} == {
+        "Teardrop",
+        "Glory Box",
+        "Roads",
+    }
+
+
+@pytest.mark.asyncio
+async def test_rejected_track_is_excluded_from_bonus_options() -> None:
+    """Never reuse a rejected track as a bonus label while the pool can still fill options."""
+    current = _track("current", "Genesis", "Justice", album_year=2007)
+    failed = _track("failed", "Teardrop", "Massive Attack", album_year=1998)
+    remaining = [
+        _track("one", "Glory Box", "Portishead"),
+        _track("two", "Roads", "Tricky"),
+        _track("three", "Sexy Boy", "Air"),
+    ]
+    quiz, _ = _quiz(
+        [current, failed, *remaining],
+        title_mode=TimelineBonusMode.MULTIPLE_CHOICE,
+    )
+    quiz._eligible_tracks = [current, failed]
+    assert failed.uri is not None
+
+    quiz.reject_track(failed.uri)
+    options = await quiz._create_bonus_options(current, TimelineBonusType.TITLE)
+
+    assert {option.label for option in options if not option.is_correct} == {
+        "Glory Box",
+        "Roads",
+        "Sexy Boy",
+    }
+
+
+@pytest.mark.asyncio
 async def test_ai_artist_bonus_keeps_real_candidates_dominant() -> None:
     """Use two ranked similar artists and at most one synthetic artist."""
     current = _track("current", "Genesis", "Justice", album_year=2007)


### PR DESCRIPTION
# What does this implement/fix?

In the Music Timeline quiz, the wrong answers for the artist and title bonus questions were taken from the small set of songs the game keeps for playback. That set is intentionally limited to about ten songs because looking up a release year is expensive, and only songs we actually play need one.

A wrong answer only needs a name, so that limit was holding it back for nothing: the game looked up extra songs online every round, and after a few playback failures it could run out of options and abort the round.

- Bonus questions now take their wrong answers from all songs in the selected playlist/album/artist, which is already loaded
- Fewer online lookups while a round is being prepared
- The playback set stays as it was and is now only used for picking songs to play
- Added tests for the wider pool and for rejected songs

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
