### PR TITLE
Improve Music Timeline song variety and release years

### DIFF
--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Iterable
 from typing import TYPE_CHECKING, ClassVar, Final, cast
 
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import AlbumType, MediaType
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import (
     Album,
@@ -18,9 +18,14 @@ from music_assistant_models.media_items import (
     Track,
 )
 
-from music_assistant.constants import DYNAMIC_PLAYLIST_SAMPLE_SIZE
+from music_assistant.constants import (
+    DYNAMIC_PLAYLIST_SAMPLE_SIZE,
+    VARIOUS_ARTISTS_MBID,
+    VARIOUS_ARTISTS_NAME,
+)
 from music_assistant.controllers.music.constants import DYNAMIC_RADIO_DYNAMIC_TARGET
 from music_assistant.controllers.music.recency import RecencyWindows
+from music_assistant.helpers.compare import compare_strings
 from music_assistant.helpers.datetime import utc
 from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.uri import parse_uri
@@ -59,12 +64,38 @@ SUPPORTED_SOURCE_MEDIA_TYPES: Final = frozenset(
         MediaType.GENRE,
     }
 )
+UNTRUSTED_RELEASE_ALBUM_TYPES: Final = frozenset(
+    {
+        AlbumType.COMPILATION,
+        AlbumType.LIVE,
+        AlbumType.SOUNDTRACK,
+    }
+)
 
 
 def is_supported_source(media_type: MediaType, provider: str) -> bool:
     """Return whether a media item can supply Music Quiz tracks."""
     return media_type in SUPPORTED_SOURCE_MEDIA_TYPES and (
         media_type != MediaType.GENRE or provider == "library"
+    )
+
+
+def has_untrusted_release_year(album: Album | ItemMapping) -> bool:
+    """
+    Return whether an album's year is unusable as the release year of its tracks.
+
+    An ``ItemMapping`` carries no album type or artists and is always trusted.
+
+    :param album: Album attached to a selected track.
+    """
+    if not isinstance(album, Album):
+        return False
+    if album.album_type in UNTRUSTED_RELEASE_ALBUM_TYPES:
+        return True
+    return any(
+        artist.mbid == VARIOUS_ARTISTS_MBID
+        or compare_strings(artist.name, VARIOUS_ARTISTS_NAME, strict=False)
+        for artist in album.artists
     )
 
 
@@ -408,7 +439,11 @@ def get_track_release_year(track: Track) -> int | None:
     :param track: Track whose release year should be resolved.
     """
     album = track.album
-    album_year = album.year if isinstance(album, Album | ItemMapping) else None
+    album_year = (
+        album.year
+        if isinstance(album, Album | ItemMapping) and not has_untrusted_release_year(album)
+        else None
+    )
     track_year = (
         track.metadata.release_date.year if track.metadata.release_date is not None else None
     )

--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -230,7 +230,8 @@ class MusicTimelineQuizType(QuizType):
                 enriched = await self.mass.music.tracks.get(track.item_id, track.provider)
             except Exception as err:
                 LOGGER.debug("Could not enrich Music Quiz track %s: %s", track.uri, err)
-                return None
+                # a failed lookup is no reason to drop a track that already carries a year
+                return track if self._track_is_eligible(track) else None
             # the track controller can fail to resolve an album mapping, so accept the
             # best release year the enriched track offers rather than requiring an album
             return enriched if self._track_is_eligible(enriched) else None

--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
     from music_assistant.providers.music_quiz.models import MusicQuizConfig
 
 LOGGER = logging.getLogger(__name__)
+SYSTEM_RANDOM = secrets.SystemRandom()
 
 DEFAULT_BONUS_OPTION_COUNT = 4
 COMPLETED_REVEAL_AUTO_ADVANCE_SECONDS = 30.0
@@ -218,7 +219,7 @@ class MusicTimelineQuizType(QuizType):
         eligible_tracks: dict[str, Track] = {}
         unresolved_tracks: list[Track] = []
         for track in source_tracks:
-            if self._track_is_eligible(track):
+            if self._track_is_resolved(track):
                 assert track.uri is not None
                 eligible_tracks[track.uri] = track
             elif track.available and track.is_playable:
@@ -230,9 +231,14 @@ class MusicTimelineQuizType(QuizType):
             except Exception as err:
                 LOGGER.debug("Could not enrich Music Quiz track %s: %s", track.uri, err)
                 return None
+            # the track controller can fail to resolve an album mapping, so accept the
+            # best release year the enriched track offers rather than requiring an album
             return enriched if self._track_is_eligible(enriched) else None
 
         target_track_count = self.config.round_count + 1 + PLAYBACK_REPLACEMENT_RESERVE
+        # enrichment stops at the target count, so sample the whole source pool
+        # instead of always enriching the same leading tracks
+        SYSTEM_RANDOM.shuffle(unresolved_tracks)
         unresolved_offset = 0
         while len(eligible_tracks) < target_track_count and unresolved_offset < len(
             unresolved_tracks
@@ -842,6 +848,22 @@ class MusicTimelineQuizType(QuizType):
             label=label,
             title=label if bonus_type == TimelineBonusType.TITLE else None,
         )
+
+    @classmethod
+    def _track_is_resolved(cls, track: Track) -> bool:
+        """
+        Return whether a track is usable for Music Timeline without resolving its album.
+
+        :param track: Source track to classify.
+        """
+        if not cls._track_is_eligible(track):
+            return False
+        album = track.album
+        if not isinstance(album, ItemMapping) or album.year is None:
+            return True
+        # an album mapping carries no album type, so a year taken from it cannot be judged;
+        # a year the track carries itself differs from the mapping's and stands on its own
+        return cls._release_year(track) != album.year
 
     @classmethod
     def _track_is_eligible(cls, track: Track) -> bool:

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -4,22 +4,25 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import AlbumType, ExternalID, MediaType
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import (
     Album,
+    Artist,
     ItemMapping,
     ProviderMapping,
     Track,
 )
 from music_assistant_models.unique_list import UniqueList
 
+from music_assistant.constants import VARIOUS_ARTISTS_MBID, VARIOUS_ARTISTS_NAME
 from music_assistant.controllers.music.recency import RecencySnapshot
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.music_quiz.ai_distractors import AI_QUERY_TIMEOUT_SECONDS
@@ -44,6 +47,9 @@ from music_assistant.providers.music_quiz.suggestions import (
     answer_labels_are_too_close,
 )
 
+# album types whose year describes a reissue rather than an original release
+UNTRUSTED_ALBUM_TYPES = frozenset({AlbumType.COMPILATION, AlbumType.LIVE, AlbumType.SOUNDTRACK})
+
 
 def _track(
     item_id: str,
@@ -54,9 +60,21 @@ def _track(
     release_year: int | None = None,
     available: bool = True,
     is_playable: bool = True,
+    album_mapping: bool = False,
 ) -> Track:
-    """Return a track with configurable album and metadata years."""
+    """Return a track with a resolved or unresolved album and configurable years."""
     provider = "prov"
+    album: Album | ItemMapping = (
+        ItemMapping(
+            media_type=MediaType.ALBUM,
+            item_id=f"album-{item_id}",
+            provider=provider,
+            name=f"Album {item_id}",
+            year=album_year,
+        )
+        if album_mapping
+        else _full_album(f"album-{item_id}", f"Album {item_id}", year=album_year)
+    )
     track = Track(
         item_id=item_id,
         provider=provider,
@@ -73,13 +91,7 @@ def _track(
                 )
             ]
         ),
-        album=ItemMapping(
-            media_type=MediaType.ALBUM,
-            item_id=f"album-{item_id}",
-            provider=provider,
-            name=f"Album {item_id}",
-            year=album_year,
-        ),
+        album=album,
         provider_mappings={
             ProviderMapping(
                 item_id=item_id,
@@ -92,6 +104,50 @@ def _track(
     if release_year is not None:
         track.metadata.release_date = datetime(release_year, 1, 1, tzinfo=UTC)
     return track
+
+
+def _full_album(
+    item_id: str,
+    name: str,
+    *,
+    album_type: AlbumType = AlbumType.ALBUM,
+    artists: Sequence[Artist | ItemMapping] = (),
+    year: int | None = None,
+    provider: str = "prov",
+) -> Album:
+    """Return a full album with configurable compilation evidence."""
+    return Album(
+        item_id=item_id,
+        provider=provider,
+        name=name,
+        album_type=album_type,
+        artists=UniqueList(artists),
+        year=year,
+        provider_mappings={
+            ProviderMapping(
+                item_id=item_id,
+                provider_domain=provider,
+                provider_instance=provider,
+            )
+        },
+    )
+
+
+def _album_artist(
+    item_id: str,
+    name: str,
+    *,
+    mbid: str | None = None,
+    provider: str = "prov",
+) -> Artist:
+    """Return a full album artist with optional MusicBrainz identity."""
+    return Artist(
+        item_id=item_id,
+        provider=provider,
+        name=name,
+        external_ids={(ExternalID.MB_ARTIST, mbid)} if mbid else set(),
+        provider_mappings=set(),
+    )
 
 
 def _artist(item_id: str, name: str) -> ItemMapping:
@@ -336,12 +392,174 @@ async def test_track_enrichment_stops_after_game_requirement_and_reserve() -> No
     await quiz.initialize()
 
     assert mass.music.tracks.get.await_count == expected_enrichments
-    assert [await_call.args[0] for await_call in mass.music.tracks.get.await_args_list] == [
-        track.item_id for track in partial[:expected_enrichments]
-    ]
+    enriched_ids = [await_call.args[0] for await_call in mass.music.tracks.get.await_args_list]
+    assert len(set(enriched_ids)) == expected_enrichments
+    assert set(enriched_ids) <= {track.item_id for track in partial}
     assert quiz._eligible_tracks is not None
     assert len(quiz._eligible_tracks) == target_count
     assert quiz._eligible_tracks[: len(ready)] == ready
+
+
+@pytest.mark.asyncio
+async def test_bounded_enrichment_samples_across_the_whole_source_pool() -> None:
+    """Draw the bounded enrichment sample from anywhere in the source pool."""
+    partial = [
+        _track(f"partial-{index}", f"Partial {index}", f"Artist {index}") for index in range(20)
+    ]
+    enriched = {
+        track.item_id: _track(
+            track.item_id,
+            track.name,
+            track.artist_str,
+            album_year=2000 + index,
+        )
+        for index, track in enumerate(partial)
+    }
+    round_count = 3
+    target_count = round_count + 1 + PLAYBACK_REPLACEMENT_RESERVE
+    quiz, mass = _quiz(partial, round_count=round_count)
+    mass.music.tracks.get.side_effect = lambda item_id, _provider: enriched[item_id]
+
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types.music_timeline.SYSTEM_RANDOM.shuffle",
+        side_effect=list.reverse,
+    ) as shuffle:
+        await quiz.initialize()
+
+    shuffle.assert_called_once()
+    enriched_ids = [await_call.args[0] for await_call in mass.music.tracks.get.await_args_list]
+    assert enriched_ids == [track.item_id for track in reversed(partial[-target_count:])]
+    assert quiz._eligible_tracks is not None
+    assert len(quiz._eligible_tracks) == target_count
+
+
+def test_only_unresolved_album_mapping_years_require_enrichment() -> None:
+    """Require album resolution only for a year that can come from an album mapping."""
+    resolved = _track("resolved", "Resolved", "Artist", album_year=1998)
+    mapped = _track("mapped", "Mapped", "Artist", album_year=1998, album_mapping=True)
+    mapped_with_track_year = _track(
+        "own-year",
+        "Own Year",
+        "Artist",
+        album_year=1998,
+        release_year=1962,
+        album_mapping=True,
+    )
+    mapped_without_album_year = _track(
+        "undated-album",
+        "Undated Album",
+        "Artist",
+        release_year=1975,
+        album_mapping=True,
+    )
+    undated = _track("undated", "Undated", "Artist")
+
+    assert MusicTimelineQuizType._track_is_resolved(resolved) is True
+    assert MusicTimelineQuizType._track_is_resolved(mapped) is False
+    assert MusicTimelineQuizType._track_is_resolved(mapped_with_track_year) is True
+    assert MusicTimelineQuizType._track_is_resolved(mapped_without_album_year) is True
+    assert MusicTimelineQuizType._track_is_resolved(undated) is False
+
+
+@pytest.mark.asyncio
+async def test_album_mapping_years_are_enriched_before_they_are_trusted() -> None:
+    """Resolve an album mapping before accepting the release year it reports."""
+    mapped = _track("mapped", "Mapped Track", "Artist", album_year=1998, album_mapping=True)
+    enriched = _track("mapped", "Mapped Track", "Artist")
+    enriched.album = _full_album("album-mapped", "Real Album", year=1998)
+    resolved = _track("resolved", "Resolved Track", "Other Artist", album_year=2007)
+    quiz, mass = _quiz([mapped, resolved])
+    mass.music.tracks.get.return_value = enriched
+
+    await quiz.initialize()
+
+    enriched_ids = [await_call.args[0] for await_call in mass.music.tracks.get.await_args_list]
+    assert enriched_ids == [mapped.item_id]
+    assert quiz._eligible_tracks is not None
+    assert {track.item_id for track in quiz._eligible_tracks} == {"mapped", "resolved"}
+
+
+@pytest.mark.asyncio
+async def test_enrichment_excludes_tracks_revealed_as_compilations() -> None:
+    """Drop a track once enrichment reveals its album is a compilation."""
+    mapped = _track("mapped", "Mapped Track", "Artist", album_year=1998, album_mapping=True)
+    enriched = _track("mapped", "Mapped Track", "Artist")
+    enriched.album = _full_album(
+        "album-mapped",
+        "Party Hits",
+        album_type=AlbumType.COMPILATION,
+        year=1998,
+    )
+    resolved = [
+        _track(f"resolved-{index}", f"Resolved {index}", "Artist", album_year=1990 + index)
+        for index in range(2)
+    ]
+    quiz, mass = _quiz([mapped, *resolved])
+    mass.music.tracks.get.return_value = enriched
+
+    await quiz.initialize()
+
+    mass.music.tracks.get.assert_awaited_once_with(mapped.item_id, mapped.provider)
+    assert quiz._eligible_tracks is not None
+    assert {track.item_id for track in quiz._eligible_tracks} == {"resolved-0", "resolved-1"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("album_type", [AlbumType.ALBUM, AlbumType.SINGLE])
+async def test_enrichment_keeps_tracks_revealed_as_original_releases(
+    album_type: AlbumType,
+) -> None:
+    """Keep the resolved year of a track whose album dates an original release."""
+    mapped = _track("mapped", "Mapped Track", "Artist", album_year=1998, album_mapping=True)
+    enriched = _track("mapped", "Mapped Track", "Artist")
+    enriched.album = _full_album(
+        "album-mapped",
+        "Real Album",
+        album_type=album_type,
+        year=1971,
+    )
+    resolved = [
+        _track(f"resolved-{index}", f"Resolved {index}", "Artist", album_year=1990 + index)
+        for index in range(2)
+    ]
+    quiz, mass = _quiz([mapped, *resolved])
+    mass.music.tracks.get.return_value = enriched
+
+    await quiz.initialize()
+
+    assert quiz._eligible_tracks is not None
+    eligible_tracks = {track.item_id: track for track in quiz._eligible_tracks}
+    assert set(eligible_tracks) == {"mapped", "resolved-0", "resolved-1"}
+    assert MusicTimelineQuizType._release_year(eligible_tracks["mapped"]) == 1971
+
+
+@pytest.mark.asyncio
+async def test_album_mappings_stay_eligible_when_enrichment_cannot_resolve_them() -> None:
+    """Trust an album mapping year once its resolution has been attempted."""
+    mapped = [
+        _track(
+            f"mapped-{index}",
+            f"Mapped {index}",
+            f"Artist {index}",
+            album_year=1990 + index,
+            album_mapping=True,
+        )
+        for index in range(12)
+    ]
+    round_count = 3
+    target_count = round_count + 1 + PLAYBACK_REPLACEMENT_RESERVE
+    tracks_by_id = {track.item_id: track for track in mapped}
+    quiz, mass = _quiz(mapped, round_count=round_count)
+    mass.music.tracks.get.side_effect = lambda item_id, _provider: tracks_by_id[item_id]
+
+    await quiz.initialize()
+
+    assert mass.music.tracks.get.await_count == target_count
+    assert quiz._eligible_tracks is not None
+    assert len(quiz._eligible_tracks) == target_count
+    assert [MusicTimelineQuizType._release_year(track) for track in quiz._eligible_tracks] == [
+        1990 + int(track.item_id.removeprefix("mapped-")) for track in quiz._eligible_tracks
+    ]
 
 
 @pytest.mark.asyncio
@@ -479,6 +697,99 @@ def test_release_year_uses_earliest_valid_track_or_album_year() -> None:
     assert MusicTimelineQuizType._release_year(future_album) == 2004
     assert MusicTimelineQuizType._release_year(too_old_track) == 2006
     assert MusicTimelineQuizType._release_year(invalid) is None
+
+
+@pytest.mark.parametrize("album_type", list(AlbumType), ids=lambda value: value.value)
+def test_release_year_trusts_only_original_release_album_types(album_type: AlbumType) -> None:
+    """Accept album years only from album types that date an original release."""
+    track = _track("typed", "Typed Track", "Artist")
+    track.album = _full_album("album", "Typed Album", album_type=album_type, year=1998)
+    expected_year = None if album_type in UNTRUSTED_ALBUM_TYPES else 1998
+
+    assert MusicTimelineQuizType._release_year(track) == expected_year
+
+
+@pytest.mark.parametrize(
+    "album_artists",
+    [
+        [_album_artist("va-mbid", "Artistes divers", mbid=VARIOUS_ARTISTS_MBID)],
+        [_album_artist("va-name", VARIOUS_ARTISTS_NAME)],
+        [
+            _album_artist("primary", "Primary Artist"),
+            _album_artist("va-multiple", "VARIOUS-ARTISTS"),
+        ],
+    ],
+    ids=["canonical-mbid", "canonical-name", "multiple-artists"],
+)
+def test_release_year_rejects_various_artists_album_credits(
+    album_artists: list[Artist],
+) -> None:
+    """Reject the album year of a various-artists set typed as a regular album."""
+    track = _track("various", "Various Track", "Artist")
+    track.album = _full_album(
+        "album",
+        "Various Album",
+        album_type=AlbumType.ALBUM,
+        artists=album_artists,
+        year=1998,
+    )
+
+    assert MusicTimelineQuizType._release_year(track) is None
+
+
+def test_release_year_trusts_an_album_mapping_without_compilation_evidence() -> None:
+    """Accept the album year of a mapping that carries no album type or artists."""
+    track = _track("mapping", "Mapped Track", "Artist", album_year=1998)
+    track.album = ItemMapping(
+        media_type=MediaType.ALBUM,
+        item_id="album-mapping",
+        provider="prov",
+        name=VARIOUS_ARTISTS_NAME,
+        year=1998,
+    )
+
+    assert MusicTimelineQuizType._release_year(track) == 1998
+
+
+def test_release_year_of_a_compilation_falls_back_to_the_track_year() -> None:
+    """Read the track year when a compilation album supplies the only other year."""
+    track = _track("compilation", "Compilation Track", "Artist", release_year=1962)
+    track.album = _full_album(
+        "album",
+        "Greatest Hits",
+        album_type=AlbumType.COMPILATION,
+        year=1998,
+    )
+
+    assert MusicTimelineQuizType._release_year(track) == 1962
+
+
+@pytest.mark.asyncio
+async def test_compilation_tracks_are_excluded_from_the_eligible_pool() -> None:
+    """Build the timeline pool from original releases only."""
+    dated = [
+        _track(f"dated-{index}", f"Dated {index}", "Artist", album_year=1990 + index)
+        for index in range(2)
+    ]
+    compilations = [
+        _track(f"compilation-{index}", f"Compilation {index}", "Artist") for index in range(2)
+    ]
+    for index, track in enumerate(compilations):
+        track.album = _full_album(
+            f"album-{index}",
+            f"Party Hits {index}",
+            album_type=AlbumType.COMPILATION,
+            year=2005 + index,
+        )
+    tracks = [*dated, *compilations]
+    quiz, mass = _quiz(tracks, round_count=1)
+    tracks_by_id = {track.item_id: track for track in tracks}
+    mass.music.tracks.get.side_effect = lambda item_id, _provider: tracks_by_id[item_id]
+
+    await quiz.initialize()
+
+    assert quiz._eligible_tracks is not None
+    assert [track.uri for track in quiz._eligible_tracks] == [track.uri for track in dated]
 
 
 def test_reject_track_removes_it_from_music_timeline_caches() -> None:

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import AlbumType, ExternalID, MediaType
-from music_assistant_models.errors import InvalidDataError
+from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
 from music_assistant_models.media_items import (
     Album,
     Artist,
@@ -531,6 +531,30 @@ async def test_enrichment_keeps_tracks_revealed_as_original_releases(
     eligible_tracks = {track.item_id: track for track in quiz._eligible_tracks}
     assert set(eligible_tracks) == {"mapped", "resolved-0", "resolved-1"}
     assert MusicTimelineQuizType._release_year(eligible_tracks["mapped"]) == 1971
+
+
+@pytest.mark.asyncio
+async def test_album_mappings_stay_eligible_when_enrichment_fails() -> None:
+    """Trust an album mapping year when its resolution raises."""
+    mapped = [
+        _track(
+            f"mapped-{index}",
+            f"Mapped {index}",
+            f"Artist {index}",
+            album_year=1990 + index,
+            album_mapping=True,
+        )
+        for index in range(12)
+    ]
+    round_count = 3
+    target_count = round_count + 1 + PLAYBACK_REPLACEMENT_RESERVE
+    quiz, mass = _quiz(mapped, round_count=round_count)
+    mass.music.tracks.get.side_effect = MediaNotFoundError("provider unavailable")
+
+    await quiz.initialize()
+
+    assert quiz._eligible_tracks is not None
+    assert len(quiz._eligible_tracks) == target_count
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Music Timeline kept picking from the same handful of songs on a playlist, and sometimes showed the wrong release year.

The wrong years come from compilation albums. A greatest-hits or various-artists album is released years - sometimes decades - after the song itself, so its year is not the song's release year. Checked against a real library: songs that appear both on a compilation and on their original album had years that were on average 10 years apart, up to 36.

The repeated songs come from a limit on how many tracks are looked up to find their release year. That lookup always started at the top of the playlist, so every game ended up using the same first tracks.

## Changes

- Pick the tracks to look up at random from the whole playlist instead of always starting at the top
- Ignore the album year for compilations, live albums, soundtracks and various-artists albums
- Look up the album when a playlist only supplies minimal album details, so its type can be judged
- Music Trivia benefits too: live and soundtrack years are no longer used as release years there either

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
