### PR TITLE
Log the resolved interface and publish IP when starting cliairplay

### DIFF
--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -778,6 +778,9 @@ class AirPlayProvider(PlayerProvider):
         bind_ip = str(self.mass.streams.bind_ip)
         if bind_ip not in ("0.0.0.0", "::", ""):
             args += ["--if", bind_ip]
+            if_detail = bind_ip
+        else:
+            if_detail = f"<omitted: all interfaces ({bind_ip or 'unset'})>"
         # The daemon runs quiet by default: its per-packet PTP tracing
         # (Announce/Sync/Delay_Req, ~10 lines/s) needs BOTH verbose logging and
         # the dedicated opt-in, so ordinary verbose sessions are not flooded
@@ -786,6 +789,10 @@ class AirPlayProvider(PlayerProvider):
             CONF_VERBOSE_PTP_LOGGING
         ):
             args += ["--debug", "10"]
+        # The binding the daemon ends up with is the first thing needed when triaging
+        # timing issues from a user's log, and it is invisible otherwise: --if is left
+        # out entirely for a default bind ip.
+        self.logger.debug("Starting shared PTP clock daemon: if=%s", if_detail)
         daemon = AsyncProcess(args, stdout=True, stderr=True, name="cliairplay-ptp-daemon")
         # (Re)gate readiness for this daemon instance: not ready until a reader
         # sees the "daemon up" line (a restart clears any previous readiness).

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -761,27 +761,54 @@ class AirPlayStream:
         if_arg: str | None = None
         target_is_ipv6 = ":" in self.player.address
         if_ip = await resolve_if_ip(self.mass, str(self.player.device_info.ip_address))
-        if if_ip not in ("0.0.0.0", "::", ""):
+        if if_ip in ("0.0.0.0", "::", ""):
+            if_detail = f"<omitted: all interfaces ({if_ip or 'unset'})>"
+        else:
             try:
                 source_is_ipv6 = isinstance(ipaddress.ip_address(if_ip), ipaddress.IPv6Address)
+            except ValueError:
+                # A configured zeroconf interface is handed back verbatim, so this may be
+                # an interface name rather than an address. Its family cannot be matched
+                # against the device, so route selection is left to the binary.
+                if_detail = f"<omitted: {if_ip} is not an ip address>"
+            else:
                 if source_is_ipv6 == target_is_ipv6:
                     if_arg = if_ip
+                    if_detail = if_ip
                     args += ["--if", if_ip]
-            except ValueError:
-                pass
+                else:
+                    if_detail = f"<omitted: {if_ip} family differs from device>"
 
         # Address advertised inside the protocol (timing peers) for hosts where
         # the reachable address differs from the bind address (e.g. containers).
         publish_ip = str(self.mass.streams.publish_ip or "")
-        if publish_ip and publish_ip != if_arg:
+        if not publish_ip:
+            publish_detail = "<unset>"
+        elif publish_ip == if_arg:
+            publish_detail = f"<omitted: same as if ({publish_ip})>"
+        else:
             try:
                 publish_is_ipv6 = isinstance(
                     ipaddress.ip_address(publish_ip), ipaddress.IPv6Address
                 )
-                if publish_is_ipv6 == target_is_ipv6:
-                    args += ["--publish-ip", publish_ip]
             except ValueError:
-                pass
+                publish_detail = f"<omitted: {publish_ip} is not an ip address>"
+            else:
+                if publish_is_ipv6 == target_is_ipv6:
+                    publish_detail = publish_ip
+                    args += ["--publish-ip", publish_ip]
+                else:
+                    publish_detail = f"<omitted: {publish_ip} family differs from device>"
+
+        # The addressing the stream ends up with is the first thing needed when triaging
+        # a connection or timing issue from a user's log, and it is invisible otherwise:
+        # both flags are dropped silently when the resolved value is unusable here.
+        self.player.logger.debug(
+            "cliairplay network binding for player %s: if=%s publish_ip=%s",
+            self.player.player_id,
+            if_detail,
+            publish_detail,
+        )
 
         # Debug level
         if self.prov.logger.isEnabledFor(VERBOSE_LOG_LEVEL):


### PR DESCRIPTION
# What does this implement/fix?

The AirPlay provider spawns cliairplay in two places and never records the addressing it resolved for them, which is the biggest blind spot when triaging AirPlay issues from a user's log. Both `--if` and `--publish-ip` are dropped silently when the resolved value is unusable (a default bind address, an interface name rather than an IP, or an address family that doesn't match the device), so the log gives no hint that a binding was ever attempted.

Each spawn now logs one DEBUG line with the interface and publish IP actually passed, and names the reason when a flag was left out:

```
cliairplay network binding for player 0a1b2c3d: if=192.168.1.20 publish_ip=<unset>
cliairplay network binding for player 0a1b2c3d: if=<omitted: eth0 is not an ip address> publish_ip=10.0.0.5
Starting shared PTP clock daemon: if=<omitted: all interfaces (0.0.0.0)>
```

It pairs with the `[STATUS] clock_ready mode=<ptp|ntp>` line from #5210: that one reports the timing mode the binary ended up with, this one reports which interface it was asked to bind — together they separate a genuine bind failure from an interface that was never selected.

**Related issue (if applicable):**

- n/a

## Changes

- Log the resolved interface and publish IP for every per-stream cliairplay spawn, including why either flag was omitted.
- Log the resolved interface for the shared PTP clock daemon spawn.
- Capture the omission reason where `--if` / `--publish-ip` were previously discarded by a bare `except ValueError: pass`. The argv that gets built is unchanged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally. (argv construction is unchanged; verified against the test suite, not against a live receiver)
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes. No new tests — logging only, no behaviour to assert.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (n/a)
