### PR TITLE
Report AirPlay speakers that stay silent while shown as playing

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -77,7 +77,12 @@ AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 2500
 # line right after [STATUS] connected and refreshes it about every 250 ms, and
 # the projection exists from the receiver's first probe (~1078 ms after connect
 # on a cold device), so this only has to cover a slower device before giving up
-# and anchoring on the floor above.
+# and anchoring on the floor above. Independent of the binary's own stall
+# report (state=stalled), which is a slower, higher-confidence diagnosis of a
+# receiver that never answers at all: a join that times out here has simply run
+# out of planning time and falls back, while a stall says the speaker will not
+# play. Keep them apart - tightening the stall report to meet this deadline
+# would trade the margin that keeps it free of false alarms.
 AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS: Final[int] = 2500
 # Lead added on top of a reported readiness instant when anchoring a join. The
 # binary refuses to place an anchor inside its own 250 ms floor, measured from

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -183,6 +183,10 @@ class AirPlayStream:
         # binaries emit it alongside the legacy warn for the same event, so the
         # warn line is then ignored to avoid double counting.
         self._reanchor_status_seen: bool = False
+        # Set once a stalled receiver clock has been reported, so the warning
+        # stays a single support signal instead of repeating with every
+        # clock_ready update of this stream session.
+        self._clock_stall_warned: bool = False
 
     @property
     def running(self) -> bool:
@@ -1448,6 +1452,9 @@ class AirPlayStream:
         """
         Parse a [STATUS] clock_ready line into the receiver's readiness projection.
 
+        A ``stalled`` state means the receiver never answered our clock and will
+        render silence, which is warned about once per stream session.
+
         :param line: The status line, e.g. ``[STATUS] clock_ready mode=ptp
             state=probing streak_ms=0 exchanges=1 ready_in_ms=2300
             ready_at_unix_ms=1750000002300``.
@@ -1464,6 +1471,18 @@ class AirPlayStream:
             # No probe seen yet, so the line carries no projection; the binary
             # keeps reporting until one exists.
             return
+        if state == "stalled" and not self._clock_stall_warned:
+            # The receiver is not slaving to our clock at all, so it renders
+            # silence while everything else about the session looks healthy.
+            self._clock_stall_warned = True
+            self.player.logger.warning(
+                "%s has not answered the server's PTP clock (%s clock exchange(s), "
+                "probe streak %s ms), so it will not play any audio. Check that UDP "
+                "319/320 traffic can flow between the speaker and the server.",
+                self.player.display_name,
+                fields.get("exchanges", "?"),
+                fields.get("streak_ms", "?"),
+            )
         # NTP timing has no receiver clock to wait for, and a state without a
         # projection resolves the wait with nothing so a caller falls back
         # instead of blocking on evidence that will not arrive.

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -1471,7 +1471,8 @@ class AirPlayStream:
             # No probe seen yet, so the line carries no projection; the binary
             # keeps reporting until one exists.
             return
-        if state == "stalled" and not self._clock_stall_warned:
+        stalled = state == "stalled" and mode != "ntp"
+        if stalled and not self._clock_stall_warned:
             # The receiver is not slaving to our clock at all, so it renders
             # silence while everything else about the session looks healthy.
             self._clock_stall_warned = True
@@ -1485,8 +1486,9 @@ class AirPlayStream:
             )
         # NTP timing has no receiver clock to wait for, and a state without a
         # projection resolves the wait with nothing so a caller falls back
-        # instead of blocking on evidence that will not arrive.
-        self._clock_ready_at_unix_ms = 0 if mode == "ntp" else ready_at_unix_ms
+        # instead of blocking on evidence that will not arrive. A stalled clock
+        # is one of those states however the line is numbered.
+        self._clock_ready_at_unix_ms = 0 if mode == "ntp" or stalled else ready_at_unix_ms
         self._clock_ready.set()
         self.player.logger.debug(
             "cliairplay reports the clock for %s as %s (mode=%s, usable at %d)",

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -957,6 +957,47 @@ async def test_wait_clock_ready_times_out_for_a_binary_that_never_reports() -> N
     assert await stream.wait_clock_ready(timeout=0.01) is None
 
 
+@pytest.mark.asyncio
+async def test_clock_ready_stalled_state_warns_once(caplog: pytest.LogCaptureFixture) -> None:
+    """A receiver that never answers our clock is reported loudly once and carries no projection."""
+    stream = AirPlayStream(_make_player())
+
+    with caplog.at_level(logging.DEBUG):
+        ended = stream._handle_status_line(
+            "[STATUS] clock_ready mode=ptp state=stalled streak_ms=0 exchanges=0 "
+            "ready_in_ms=0 ready_at_unix_ms=0"
+        )
+        stream._handle_status_line(
+            "[STATUS] clock_ready mode=ptp state=stalled streak_ms=0 exchanges=0 "
+            "ready_in_ms=0 ready_at_unix_ms=0"
+        )
+
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert ended is False
+    assert len(warnings) == 1
+    assert "Player A" in warnings[0].getMessage()
+    assert "319/320" in warnings[0].getMessage()
+    assert stream._clock_ready.is_set()
+    assert await stream.wait_clock_ready(timeout=0.01) is None
+
+
+@pytest.mark.parametrize("state", ["cold", "probing", "ready"])
+def test_clock_ready_handshake_states_do_not_warn(
+    state: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Any state but a stall is a normal step of the clock handshake and stays quiet."""
+    stream = AirPlayStream(_make_player())
+
+    with caplog.at_level(logging.DEBUG):
+        ended = stream._handle_status_line(
+            f"[STATUS] clock_ready mode=ptp state={state} streak_ms=900 exchanges=4 "
+            f"ready_in_ms=940 ready_at_unix_ms={START_UNIX_MS}"
+        )
+
+    assert ended is False
+    assert [record for record in caplog.records if record.levelno >= logging.WARNING] == []
+
+
 def test_elapsed_includes_start_position() -> None:
     """Reported progress is the current anchor's media base plus the binary delta."""
     player = _make_player()

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -981,6 +981,20 @@ async def test_clock_ready_stalled_state_warns_once(caplog: pytest.LogCaptureFix
     assert await stream.wait_clock_ready(timeout=0.01) is None
 
 
+def test_clock_ready_stall_warning_is_ptp_only(caplog: pytest.LogCaptureFixture) -> None:
+    """An NTP-timed session has no clock of ours to answer, so it never reads as a stall."""
+    stream = AirPlayStream(_make_player())
+
+    with caplog.at_level(logging.DEBUG):
+        stream._handle_status_line(
+            "[STATUS] clock_ready mode=ntp state=stalled streak_ms=0 exchanges=0 "
+            f"ready_in_ms=0 ready_at_unix_ms={START_UNIX_MS}"
+        )
+
+    assert [record for record in caplog.records if record.levelno >= logging.WARNING] == []
+    assert stream._clock_ready_at_unix_ms == 0
+
+
 @pytest.mark.parametrize("state", ["cold", "probing", "ready"])
 def test_clock_ready_handshake_states_do_not_warn(
     state: str, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
# What does this implement/fix?

A speaker that never answers the server's clock cannot work out when to start, so it plays nothing. The session still establishes and audio keeps flowing, so Music Assistant showed it as playing indefinitely with nothing in the log to explain the silence.

The binary now reports that state, and it is surfaced as a warning naming the speaker, so the cause is visible instead of being invisible.

Needs the matching airplay-cli change: music-assistant/airplay-cli#41

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/5312

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.