### PR TITLE
Remove an unused, empty helper function

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -1043,10 +1043,6 @@ def interface_name_for_ip(ip: str) -> str | None:
     return None
 
 
-async def get_primary_ip_address() -> str | None:
-    """Return the primary IP address of the system."""
-
-
 async def is_port_in_use(port: int, host: str | None = None) -> bool:
     """
     Check if a port is in use.


### PR DESCRIPTION
# What does this implement/fix?

One of the helper functions in the codebase was left empty: it had no code in it at all, so it always returned nothing, and nothing anywhere called it. Cleaning it up so nobody picks it up by mistake later.

## Changes

- Removed the empty, unused `get_primary_ip_address()` helper from `helpers/util.py`

Two similarly named helpers are still in use and are untouched: `get_primary_ip_address_from_zeroconf()` in the same file, and the Sonos provider's own `get_primary_ip_address()`.

## Types of changes

- [x] Maintenance / chore — `maintenance`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
