### PR TITLE
Fix AirPlay 2 speakers playing silence on multi-homed hosts

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -64,6 +64,7 @@ from music_assistant.constants import (
     ICY_HEADERS,
     SILENCE_FILE,
     VERBOSE_LOG_LEVEL,
+    WILDCARD_BIND_IPS,
 )
 from music_assistant.controllers.players.helpers import AnnounceData
 from music_assistant.controllers.streams.announcements import (
@@ -101,6 +102,7 @@ from music_assistant.helpers.ffmpeg import LOGGER as FFMPEG_LOGGER
 from music_assistant.helpers.util import (
     format_ip_for_url,
     get_ip_addresses,
+    get_source_ip_for_target,
     sanitize_http_header_value,
 )
 from music_assistant.helpers.webserver import Webserver
@@ -174,6 +176,7 @@ class StreamsController(CoreController):
         self.manifest.icon = "cast-audio"
         self.announcement_renderer = AnnouncementRenderer()
         self._bind_ip: str = "0.0.0.0"
+        self._configured_publish_ip: str | None = None
         self.audio = StreamsAudio(mass)
         self.audio_processing = AudioProcessingManager(mass)
         self._audio_analysis = AudioAnalysisController(self)
@@ -199,6 +202,7 @@ class StreamsController(CoreController):
             "active_output_streams": self._active_output_streams,
             "active_announcements": self.announcement_renderer.active_announcements,
             "active_announcement_renders": self.announcement_renderer.active_renders,
+            "publish_ip_configured": self._configured_publish_ip is not None,
         }
 
     @property
@@ -210,6 +214,51 @@ class StreamsController(CoreController):
     def bind_ip(self) -> str:
         """Return the IP address this streamserver is bound to."""
         return self._bind_ip
+
+    async def get_source_ip(self, target_ip: str | None = None) -> str | None:
+        """
+        Return a local, bindable source IP on the player-facing network.
+
+        For callers that bind a socket or hand a local interface address to a helper
+        process, so their traffic leaves on the network the players live on. The result
+        is always an address of this host, never the advertised address, which may not
+        exist here at all.
+
+        Returns None when no single interface should be pinned, which the caller must
+        read as "bind all interfaces and let the routing table decide".
+
+        :param target_ip: IP address of the device the traffic is meant for. Omit it for
+            a shared consumer that serves every player at once; such a caller can only be
+            pinned by an explicitly configured bind IP.
+        """
+        if self._bind_ip and self._bind_ip not in WILDCARD_BIND_IPS:
+            if target_ip and not _same_ip_family(self._bind_ip, target_ip):
+                return None
+            return self._bind_ip
+        if not target_ip:
+            return None
+        return await get_source_ip_for_target(target_ip) or None
+
+    def get_publish_ip(self, target_ip: str) -> str | None:
+        """
+        Return the address to advertise to the device at ``target_ip``, if one is configured.
+
+        Only an explicitly configured publish IP is returned. An auto-detected one is a
+        guess at this host's primary interface, which on a multi-homed host is not
+        necessarily the network the players live on, so callers that can derive the
+        address from the connection itself must prefer that over the guess.
+
+        Returns None when no publish IP was configured, or when the configured one cannot
+        apply to this device.
+
+        :param target_ip: IP address of the device that would receive the address, used to
+            reject an address of the wrong IP family.
+        """
+        if not self._configured_publish_ip:
+            return None
+        if not _same_ip_family(self._configured_publish_ip, target_ip):
+            return None
+        return self._configured_publish_ip
 
     @property
     def smart_fades_available(self) -> bool:
@@ -367,11 +416,14 @@ class StreamsController(CoreController):
         await check_ffmpeg_version()
         # start the webserver
         self.publish_port = config.get_value(CONF_BIND_PORT, DEFAULT_PORT)
-        publish_ip = str(config.get_value(CONF_PUBLISH_IP) or CONF_VALUE_AUTO)
-        if publish_ip == CONF_VALUE_AUTO:
-            # resolve the "auto" default (or an unset value) to this server's primary IP
-            publish_ip = (await get_ip_addresses(include_ipv6=True))[0]
-        self.publish_ip = publish_ip
+        configured_publish_ip = str(config.get_value(CONF_PUBLISH_IP) or CONF_VALUE_AUTO)
+        self._configured_publish_ip = (
+            None if configured_publish_ip == CONF_VALUE_AUTO else configured_publish_ip
+        )
+        # resolve the "auto" default (or an unset value) to this server's primary IP
+        self.publish_ip = (
+            self._configured_publish_ip or (await get_ip_addresses(include_ipv6=True))[0]
+        )
         self._bind_ip = bind_ip = str(config.get_value(CONF_BIND_IP))
         # print a big fat message in the log where the streamserver is running
         # because this is a common source of issues for people with more complex setups
@@ -1568,3 +1620,8 @@ class StreamsController(CoreController):
             self.audio.smart_fades_mixer.logger.setLevel(self.logger.level)
         else:
             self.audio.smart_fades_mixer.logger.setLevel(log_level)
+
+
+def _same_ip_family(ip: str, other_ip: str) -> bool:
+    """Return whether two addresses belong to the same IP family."""
+    return (":" in ip) == (":" in other_ip)

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -1131,30 +1131,14 @@ async def get_ip_from_host(dns_name: str) -> str | None:
     return await asyncio.to_thread(_resolve)
 
 
-async def get_source_ip_for_target(
-    target_ip: str,
-    *,
-    bind_ip: str | None = None,
-    publish_ip: str | None = None,
-) -> str:
+async def get_source_ip_for_target(target_ip: str) -> str:
     """
-    Resolve a local, bindable source IP that routes to ``target_ip``.
+    Return the local interface address the routing table would egress to ``target_ip`` from.
 
-    For providers that must bind a socket to, or advertise a callback URL
-    reachable by, one specific device. ``publish_ip`` (the server's advertised
-    address) is not necessarily a locally bindable interface address — e.g. a
-    container behind a published IP, or a multi-homed host — so binding to it
-    directly can fail with ``EADDRNOTAVAIL``.
+    Empty when no route to the target can be determined.
 
-    Resolution order:
-      1. an explicitly configured, concrete (non-wildcard) ``bind_ip``;
-      2. a routing-table lookup to ``target_ip`` (the interface that would
-         actually egress to it);
-      3. ``publish_ip`` as a concrete fallback;
-      4. ``bind_ip`` (even if a wildcard) as a last resort.
+    :param target_ip: IP address of the device the traffic is meant for.
     """
-    if bind_ip and bind_ip not in ("0.0.0.0", "::"):
-        return bind_ip
 
     def _routing_lookup() -> str:
         try:
@@ -1176,9 +1160,7 @@ async def get_source_ip_for_target(
                 pass
         return ""
 
-    if routed := await asyncio.to_thread(_routing_lookup):
-        return routed
-    return str(publish_ip or "") or str(bind_ip or "")
+    return await asyncio.to_thread(_routing_lookup)
 
 
 async def get_ip_pton(ip_string: str) -> bytes:

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -199,3 +199,7 @@ ATV_PASSWORD_BIT = 0x1000
 # (Announce/Sync/Follow_Up) when verbose logging is active. Off by default —
 # the trace floods the log and only matters for clock-sync debugging.
 CONF_VERBOSE_PTP_LOGGING: Final[str] = "verbose_ptp_logging"
+
+# The cliairplay binary tags no log levels on its output, so a genuine problem is
+# recognised by keyword and promoted to a warning that stays visible at normal levels.
+CLI_PROBLEM_MARKERS: Final[tuple[str, ...]] = ("error", "cannot", "failed", "unable")

--- a/music_assistant/providers/airplay/helpers.py
+++ b/music_assistant/providers/airplay/helpers.py
@@ -13,9 +13,8 @@ from aiohttp import ClientError, ClientTimeout
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 
-from music_assistant.constants import CONF_ZEROCONF_INTERFACES
 from music_assistant.helpers.process import check_output
-from music_assistant.helpers.util import format_ip_for_url, get_source_ip_for_target
+from music_assistant.helpers.util import format_ip_for_url
 
 if TYPE_CHECKING:
     from zeroconf.asyncio import AsyncServiceInfo
@@ -34,30 +33,6 @@ _CLI_BINARY_CHECK_TIMEOUT = 15.0
 # Bound the /info capability probe: it runs in the discovery path, and a receiver
 # that is slow to answer must not hold up player registration.
 _INFO_PROBE_TIMEOUT = 5.0
-
-
-async def resolve_if_ip(mass: MusicAssistant, target_ip: str) -> str:
-    """
-    Resolve best local interface IP for cliairplay's --if argument.
-
-    :param mass: The MusicAssistant instance.
-    :param target_ip: The IP address of the target AirPlay device.
-    """
-    # 1. Prefer an explicitly configured zeroconf interface. The setting may be a
-    #    comma-separated list; pick the first non-empty, non-default/all entry.
-    zc_iface = str(mass.discovery.config.get_value(CONF_ZEROCONF_INTERFACES, "default"))
-    for candidate in zc_iface.split(","):
-        iface = candidate.strip()
-        if iface and iface not in ("default", "all"):
-            return iface
-    # 2. Otherwise resolve a bindable, device-reachable source IP: an explicit
-    #    stream bind_ip, else a routing-table lookup to this specific device,
-    #    else publish_ip. Shared with the other providers that need this.
-    return await get_source_ip_for_target(
-        target_ip,
-        bind_ip=str(mass.streams.bind_ip),
-        publish_ip=str(mass.streams.publish_ip or ""),
-    )
 
 
 def convert_airplay_volume(value: float) -> int:

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -38,6 +38,7 @@ from music_assistant.models.player_provider import PlayerProvider
 from .constants import (
     AIRPLAY_DISCOVERY_TYPE,
     AIRPLAY_VOLUME_MUTE,
+    CLI_PROBLEM_MARKERS,
     COMPANION_DISCOVERY_TYPE,
     CONF_IGNORE_VOLUME,
     CONF_STORED_VOLUME,
@@ -775,12 +776,9 @@ class AirPlayProvider(PlayerProvider):
         # (which derive their PTP clock id from --dacp), so receivers see one
         # consistent clock whether the daemon or an in-process engine serves it.
         args = [cli_binary, "--ptp-daemon", "--dacp", self.dacp_id]
-        bind_ip = str(self.mass.streams.bind_ip)
-        if bind_ip not in ("0.0.0.0", "::", ""):
-            args += ["--if", bind_ip]
-            if_detail = bind_ip
-        else:
-            if_detail = f"<omitted: all interfaces ({bind_ip or 'unset'})>"
+        if_arg = await self.mass.streams.get_source_ip()
+        if if_arg:
+            args += ["--if", if_arg]
         # The daemon runs quiet by default: its per-packet PTP tracing
         # (Announce/Sync/Delay_Req, ~10 lines/s) needs BOTH verbose logging and
         # the dedicated opt-in, so ordinary verbose sessions are not flooded
@@ -792,7 +790,7 @@ class AirPlayProvider(PlayerProvider):
         # The binding the daemon ends up with is the first thing needed when triaging
         # timing issues from a user's log, and it is invisible otherwise: --if is left
         # out entirely for a default bind ip.
-        self.logger.debug("Starting shared PTP clock daemon: if=%s", if_detail)
+        self.logger.debug("Starting shared PTP clock daemon: if=%s", if_arg or "<all interfaces>")
         daemon = AsyncProcess(args, stdout=True, stderr=True, name="cliairplay-ptp-daemon")
         # (Re)gate readiness for this daemon instance: not ready until a reader
         # sees the "daemon up" line (a restart clears any previous readiness).
@@ -826,10 +824,8 @@ class AirPlayProvider(PlayerProvider):
         """Log a PTP daemon output line and detect its readiness signal."""
         # Routine daemon output is verbose-only so it never floods a user's log
         # (the per-packet timing trace only runs at verbose in the first place).
-        # The daemon tags no log levels, so a genuine problem is recognised by
-        # keyword and promoted to a warning that stays visible at normal levels.
         lowered = line.lower()
-        if any(marker in lowered for marker in ("error", "cannot", "failed", "unable")):
+        if any(marker in lowered for marker in CLI_PROBLEM_MARKERS):
             self.logger.warning("PTP daemon: %s", line)
         else:
             self.logger.log(VERBOSE_LOG_LEVEL, "PTP daemon: %s", line)

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -9,7 +9,6 @@ status is reported on stderr in normalized [STATUS] format.
 from __future__ import annotations
 
 import asyncio
-import ipaddress
 import logging
 import re
 import time
@@ -29,6 +28,7 @@ from music_assistant.providers.airplay.constants import (
     AIRPLAY_ARTWORK_SIZE,
     AIRPLAY_JOIN_START_ACK_TIMEOUT_MS,
     AIRPLAY_PCM_FORMAT,
+    CLI_PROBLEM_MARKERS,
     CONF_AIRPLAY_CREDENTIALS,
     CONF_ENCRYPTION,
     CONF_PASSWORD,
@@ -39,7 +39,6 @@ from music_assistant.providers.airplay.constants import (
 from music_assistant.providers.airplay.helpers import (
     generate_active_remote_id,
     get_cli_binary,
-    resolve_if_ip,
     serialize_txt_records,
 )
 
@@ -762,56 +761,29 @@ class AirPlayStream:
                 args += ["--ptp-shared"]
 
         # Local interface binding
-        if_arg: str | None = None
-        target_is_ipv6 = ":" in self.player.address
-        if_ip = await resolve_if_ip(self.mass, str(self.player.device_info.ip_address))
-        if if_ip in ("0.0.0.0", "::", ""):
-            if_detail = f"<omitted: all interfaces ({if_ip or 'unset'})>"
-        else:
-            try:
-                source_is_ipv6 = isinstance(ipaddress.ip_address(if_ip), ipaddress.IPv6Address)
-            except ValueError:
-                # A configured zeroconf interface is handed back verbatim, so this may be
-                # an interface name rather than an address. Its family cannot be matched
-                # against the device, so route selection is left to the binary.
-                if_detail = f"<omitted: {if_ip} is not an ip address>"
-            else:
-                if source_is_ipv6 == target_is_ipv6:
-                    if_arg = if_ip
-                    if_detail = if_ip
-                    args += ["--if", if_ip]
-                else:
-                    if_detail = f"<omitted: {if_ip} family differs from device>"
+        target_ip = str(self.player.device_info.ip_address)
+        if_arg = await self.mass.streams.get_source_ip(target_ip)
+        if if_arg:
+            args += ["--if", if_arg]
 
-        # Address advertised inside the protocol (timing peers) for hosts where
-        # the reachable address differs from the bind address (e.g. containers).
-        publish_ip = str(self.mass.streams.publish_ip or "")
-        if not publish_ip:
-            publish_detail = "<unset>"
-        elif publish_ip == if_arg:
-            publish_detail = f"<omitted: same as if ({publish_ip})>"
-        else:
-            try:
-                publish_is_ipv6 = isinstance(
-                    ipaddress.ip_address(publish_ip), ipaddress.IPv6Address
-                )
-            except ValueError:
-                publish_detail = f"<omitted: {publish_ip} is not an ip address>"
-            else:
-                if publish_is_ipv6 == target_is_ipv6:
-                    publish_detail = publish_ip
-                    args += ["--publish-ip", publish_ip]
-                else:
-                    publish_detail = f"<omitted: {publish_ip} family differs from device>"
+        # Address advertised inside the protocol (timing peers) for hosts where the
+        # reachable address differs from the bind address (e.g. containers). The binary
+        # treats this as authoritative for the receiver's clock-source filter and it
+        # outranks its own connection-derived fallback, so only pass an address the user
+        # actually configured: an auto-detected one would silence a receiver whenever it
+        # names an interface the timing packets do not leave from.
+        publish_arg = self.mass.streams.get_publish_ip(target_ip)
+        if publish_arg and publish_arg != if_arg:
+            args += ["--publish-ip", publish_arg]
 
         # The addressing the stream ends up with is the first thing needed when triaging
         # a connection or timing issue from a user's log, and it is invisible otherwise:
-        # both flags are dropped silently when the resolved value is unusable here.
+        # both flags are dropped silently when no value applies here.
         self.player.logger.debug(
             "cliairplay network binding for player %s: if=%s publish_ip=%s",
             self.player.player_id,
-            if_detail,
-            publish_detail,
+            if_arg or "<all interfaces>",
+            publish_arg or "<not configured>",
         )
 
         # Debug level
@@ -994,7 +966,13 @@ class AirPlayStream:
             if self._handle_status_line(line):
                 expected_eof = True
                 break
-            logger.log(VERBOSE_LOG_LEVEL, line)
+            # Routine binary output is verbose-only so it never floods a user's log, but
+            # its own diagnostics (a failed socket bind, a missing receiver clock) are the
+            # first thing needed when triaging silent playback, so those stay visible.
+            if any(marker in line.lower() for marker in CLI_PROBLEM_MARKERS):
+                logger.warning("cliairplay for %s: %s", player.display_name, line)
+            else:
+                logger.log(VERBOSE_LOG_LEVEL, line)
             await asyncio.sleep(0)
 
         logger.debug("cliairplay stderr reader ended")

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -453,7 +453,9 @@ class AirPlayReceiverProvider(PluginProvider):
         config_content = config_content.replace("{METADATA_PIPE}", self.metadata_pipe.path)
         config_content = config_content.replace("{AUDIO_PIPE}", self.audio_pipe.path)
         config_content = config_content.replace("{PORT}", str(self.airplay_port))
-        config_content = config_content.replace("{INTERFACE_LINE}", self._get_mdns_interface_line())
+        config_content = config_content.replace(
+            "{INTERFACE_LINE}", await self._get_mdns_interface_line()
+        )
 
         # Set default volume based on default player's current volume if available
         # Convert player volume (0-100) to AirPlay volume (-30.0 to 0.0 dB)
@@ -473,7 +475,7 @@ class AirPlayReceiverProvider(PluginProvider):
 
         await asyncio.to_thread(_write_config)
 
-    def _get_mdns_interface_line(self) -> str:
+    async def _get_mdns_interface_line(self) -> str:
         """
         Build the shairport-sync ``general.interface`` directive, or an empty string.
 
@@ -482,8 +484,8 @@ class AirPlayReceiverProvider(PluginProvider):
         announced on the intended network instead of an unrelated one (e.g. a
         Docker bridge). Returns an empty string to advertise on all interfaces.
         """
-        bind_ip = self.mass.streams.bind_ip
-        if not bind_ip or bind_ip == "0.0.0.0":
+        bind_ip = await self.mass.streams.get_source_ip()
+        if not bind_ip:
             return ""
         iface_name = interface_name_for_ip(bind_ip)
         if not iface_name:

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -615,7 +615,7 @@ class SpotifyConnectProvider(PluginProvider):
         except Exception as err:
             self.logger.debug("Failed to persist player ID: %s", err)
 
-    def _write_config(self) -> None:
+    def _write_config(self, source_ip: str | None) -> None:
         """
         Write the go-librespot ``config.yml`` for this instance.
 
@@ -623,6 +623,9 @@ class SpotifyConnectProvider(PluginProvider):
         sidestep an extra dependency and any string-quoting pitfalls (the device
         name is user-provided). The config dir doubles as the credential/device
         cache so the Spotify Connect device stays paired across restarts.
+
+        :param source_ip: Local address of the player-facing interface, or None to
+            advertise the Spotify Connect device on all interfaces.
         """
         os.makedirs(self.cache_dir, exist_ok=True)
         initial_volume = 50
@@ -658,14 +661,13 @@ class SpotifyConnectProvider(PluginProvider):
         # Advertise the Spotify Connect device only on the interface the streams
         # server binds to, so it lands on the right network on multi-homed hosts.
         # go-librespot selects advertise interfaces by name, so map the IP to one.
-        bind_ip = self.mass.streams.bind_ip
-        if bind_ip and bind_ip != "0.0.0.0":
-            if iface_name := interface_name_for_ip(bind_ip):
+        if source_ip:
+            if iface_name := interface_name_for_ip(source_ip):
                 config["zeroconf_interfaces_to_advertise"] = [iface_name]
             else:
                 self.logger.debug(
                     "No interface found for stream bind IP %s; advertising on all interfaces",
-                    bind_ip,
+                    source_ip,
                 )
         config_file = os.path.join(self.cache_dir, "config.yml")
         with open(config_file, "w", encoding="utf-8") as fileobj:
@@ -688,7 +690,7 @@ class SpotifyConnectProvider(PluginProvider):
                 self.logger.warning(
                     "API port in use by another process; switching to port %s", self._api_port
                 )
-            self._write_config()
+            self._write_config(await self.mass.streams.get_source_ip())
             proc: AsyncProcess | None = None
             try:
                 # stdout carries the decoded PCM (audio_output_pipe=/dev/stdout) and

--- a/music_assistant/providers/wiim/provider.py
+++ b/music_assistant/providers/wiim/provider.py
@@ -15,7 +15,6 @@ from music_assistant.constants import CONF_ENTRY_MANUAL_DISCOVERY_IPS, VERBOSE_L
 from music_assistant.helpers.util import (
     get_port_from_zeroconf,
     get_primary_ip_address_from_zeroconf,
-    get_source_ip_for_target,
 )
 from music_assistant.models.player_provider import PlayerProvider
 
@@ -164,11 +163,8 @@ class WiimProvider(PlayerProvider):
                 upnp_location,
                 self.mass.http_session_no_ssl,
                 host=ip_address,
-                local_host=await get_source_ip_for_target(
-                    ip_address,
-                    bind_ip=str(self.mass.streams.bind_ip),
-                    publish_ip=str(self.mass.streams.publish_ip or ""),
-                ),
+                local_host=await self.mass.streams.get_source_ip(ip_address)
+                or str(self.mass.streams.publish_ip),
                 polling_interval=60,
             )
         except (WiimRequestException, WiimDeviceException) as err:

--- a/music_assistant/providers/wiim/provider.py
+++ b/music_assistant/providers/wiim/provider.py
@@ -163,8 +163,7 @@ class WiimProvider(PlayerProvider):
                 upnp_location,
                 self.mass.http_session_no_ssl,
                 host=ip_address,
-                local_host=await self.mass.streams.get_source_ip(ip_address)
-                or str(self.mass.streams.publish_ip),
+                local_host=await self.mass.streams.get_source_ip(ip_address),
                 polling_interval=60,
             )
         except (WiimRequestException, WiimDeviceException) as err:

--- a/tests/controllers/streams/test_controller.py
+++ b/tests/controllers/streams/test_controller.py
@@ -1,0 +1,107 @@
+"""Tests for the network addressing helpers on the streams controller."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from music_assistant.controllers.streams.controller import StreamsController
+
+DEVICE_IP = "192.168.1.50"
+DEVICE_IP_V6 = "fd00::50"
+
+
+def _streams_controller(
+    bind_ip: str = "0.0.0.0",
+    configured_publish_ip: str | None = None,
+) -> StreamsController:
+    """Build a streams controller with only its addressing state populated."""
+    mass = MagicMock()
+    mass.config.get_raw_core_config_value.return_value = "GLOBAL"
+    controller = StreamsController(mass)
+    controller._bind_ip = bind_ip
+    controller._configured_publish_ip = configured_publish_ip
+    return controller
+
+
+class TestGetSourceIp:
+    """get_source_ip returns a local, bindable address on the player-facing network."""
+
+    @pytest.mark.asyncio
+    async def test_concrete_bind_ip_wins_for_every_device(self) -> None:
+        """An operator pin narrows the whole server, so no routing lookup is needed."""
+        controller = _streams_controller(bind_ip="192.168.1.5")
+        with patch(
+            "music_assistant.controllers.streams.controller.get_source_ip_for_target",
+            new=AsyncMock(),
+        ) as routing_lookup:
+            assert await controller.get_source_ip(DEVICE_IP) == "192.168.1.5"
+        routing_lookup.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_concrete_bind_ip_rejected_for_other_ip_family(self) -> None:
+        """A bind IP of the wrong family cannot carry traffic to the device."""
+        controller = _streams_controller(bind_ip="192.168.1.5")
+        assert await controller.get_source_ip(DEVICE_IP_V6) is None
+
+    @pytest.mark.asyncio
+    async def test_wildcard_bind_ip_resolves_per_device_route(self) -> None:
+        """Without an operator pin, the interface that routes to the device is used."""
+        controller = _streams_controller(bind_ip="0.0.0.0")
+        with patch(
+            "music_assistant.controllers.streams.controller.get_source_ip_for_target",
+            new=AsyncMock(return_value="192.168.1.5"),
+        ) as routing_lookup:
+            assert await controller.get_source_ip(DEVICE_IP) == "192.168.1.5"
+        routing_lookup.assert_awaited_once_with(DEVICE_IP)
+
+    @pytest.mark.asyncio
+    async def test_unroutable_target_pins_nothing(self) -> None:
+        """An inconclusive routing lookup leaves the choice to the routing table."""
+        controller = _streams_controller(bind_ip="0.0.0.0")
+        with patch(
+            "music_assistant.controllers.streams.controller.get_source_ip_for_target",
+            new=AsyncMock(return_value=""),
+        ):
+            assert await controller.get_source_ip(DEVICE_IP) is None
+
+    @pytest.mark.asyncio
+    async def test_shared_consumer_without_target_pins_nothing(self) -> None:
+        """A caller serving every player cannot be narrowed without an operator pin."""
+        controller = _streams_controller(bind_ip="0.0.0.0")
+        assert await controller.get_source_ip() is None
+
+    @pytest.mark.asyncio
+    async def test_shared_consumer_honours_concrete_bind_ip(self) -> None:
+        """An operator pin still applies to a caller that serves every player."""
+        controller = _streams_controller(bind_ip="192.168.1.5")
+        assert await controller.get_source_ip() == "192.168.1.5"
+
+
+class TestGetPublishIp:
+    """get_publish_ip only hands out an address the user actually configured."""
+
+    def test_configured_publish_ip_is_returned(self) -> None:
+        """An explicit publish IP is a reachability statement and is honoured verbatim."""
+        controller = _streams_controller(configured_publish_ip="10.45.0.20")
+        assert controller.get_publish_ip(DEVICE_IP) == "10.45.0.20"
+
+    def test_auto_detected_publish_ip_is_not_returned(self) -> None:
+        """An auto-detected publish IP is only a guess and must never be advertised."""
+        controller = _streams_controller()
+        controller.publish_ip = "10.45.0.20"
+        assert controller.get_publish_ip(DEVICE_IP) is None
+
+    def test_configured_publish_ip_of_other_ip_family_is_rejected(self) -> None:
+        """An address the device cannot even parse is worse than none at all."""
+        controller = _streams_controller(configured_publish_ip="10.45.0.20")
+        assert controller.get_publish_ip(DEVICE_IP_V6) is None
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_report_whether_publish_ip_is_configured() -> None:
+    """Diagnostics distinguish a configured publish IP from an auto-detected one."""
+    assert (await _streams_controller().get_diagnostics())["publish_ip_configured"] is False
+    controller = _streams_controller(configured_publish_ip="10.45.0.20")
+    assert (await controller.get_diagnostics())["publish_ip_configured"] is True

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -20,46 +20,25 @@ from music_assistant.helpers.util import (
 
 
 class TestGetSourceIpForTarget:
-    """get_source_ip_for_target resolves a bindable, device-reachable source IP."""
+    """get_source_ip_for_target reports the interface the routing table egresses from."""
 
     @pytest.mark.asyncio
-    async def test_prefers_explicit_bind_ip(self) -> None:
-        """A concrete (non-wildcard) bind_ip is honoured as-is."""
-        result = await get_source_ip_for_target(
-            "10.10.20.31", bind_ip="10.0.0.5", publish_ip="10.45.0.20"
-        )
-        assert result == "10.0.0.5"
-
-    @pytest.mark.asyncio
-    async def test_uses_routing_lookup_when_bind_ip_wildcard(self) -> None:
-        """With a wildcard bind_ip, the per-device routing lookup result wins."""
+    async def test_returns_routing_lookup_result(self) -> None:
+        """The address the kernel picks for the target is handed back as-is."""
         with patch("music_assistant.helpers.util.socket.socket") as mock_socket:
             sock = mock_socket.return_value.__enter__.return_value
             sock.getsockname.return_value = ("10.10.20.106", 0)
-            result = await get_source_ip_for_target(
-                "10.10.20.31", bind_ip="0.0.0.0", publish_ip="10.45.0.20"
-            )
+            result = await get_source_ip_for_target("10.10.20.31")
         assert result == "10.10.20.106"
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_publish_ip_on_lookup_failure(self) -> None:
-        """If the routing lookup cannot resolve, fall back to publish_ip."""
+    async def test_returns_empty_string_when_unroutable(self) -> None:
+        """A target with no route resolves to nothing rather than a guess."""
         with patch("music_assistant.helpers.util.socket.socket") as mock_socket:
             sock = mock_socket.return_value.__enter__.return_value
             sock.connect.side_effect = OSError("no route to host")
-            result = await get_source_ip_for_target(
-                "10.10.20.31", bind_ip="0.0.0.0", publish_ip="10.45.0.20"
-            )
-        assert result == "10.45.0.20"
-
-    @pytest.mark.asyncio
-    async def test_falls_back_to_bind_ip_when_no_publish_ip(self) -> None:
-        """With no publish_ip and an inconclusive lookup, return the bind_ip as last resort."""
-        with patch("music_assistant.helpers.util.socket.socket") as mock_socket:
-            sock = mock_socket.return_value.__enter__.return_value
-            sock.connect.side_effect = OSError("no route to host")
-            result = await get_source_ip_for_target("10.10.20.31", bind_ip="0.0.0.0", publish_ip="")
-        assert result == "0.0.0.0"
+            result = await get_source_ip_for_target("10.10.20.31")
+        assert result == ""
 
 
 class TestSelectFreePort:

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -160,7 +160,7 @@ async def test_ptp_daemon_spawn_advertises_dacp_identity() -> None:
     prov = _ptp_provider()
     prov.dacp_id = "AABBCCDD11223344"
     prov.mass = MagicMock()
-    prov.mass.streams.bind_ip = "0.0.0.0"
+    prov.mass.streams.get_source_ip = AsyncMock(return_value=None)
     # The spawn mirrors the live logger level into --debug flags; pin the
     # level so suite ordering (other tests raising verbosity) cannot leak
     # extra args into this assertion.
@@ -191,12 +191,42 @@ async def test_ptp_daemon_spawn_advertises_dacp_identity() -> None:
     ]
 
 
+async def test_ptp_daemon_spawn_pins_operator_configured_interface() -> None:
+    """One daemon serves every player, so only an explicit operator pin narrows it."""
+    prov = _ptp_provider()
+    prov.dacp_id = "AABBCCDD11223344"
+    prov.mass = MagicMock()
+    prov.mass.streams.get_source_ip = AsyncMock(return_value="192.168.1.5")
+    prov.logger.setLevel(logging.INFO)
+
+    def _consume_task(coro: object) -> MagicMock:
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        return MagicMock()
+
+    prov.mass.create_task.side_effect = _consume_task
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.provider.get_cli_binary",
+            AsyncMock(return_value="/bin/cliairplay"),
+        ),
+        patch("music_assistant.providers.airplay.provider.AsyncProcess") as process_cls,
+    ):
+        process_cls.return_value.start = AsyncMock(return_value=None)
+        await prov._start_ptp_daemon()
+
+    args = process_cls.call_args.args[0]
+    assert args[args.index("--if") + 1] == "192.168.1.5"
+    prov.mass.streams.get_source_ip.assert_awaited_once_with()
+
+
 async def test_ptp_daemon_spawn_quiet_at_debug_level() -> None:
     """A normal debug session keeps the daemon quiet (no per-packet tracing)."""
     prov = _ptp_provider()
     prov.dacp_id = "AABBCCDD11223344"
     prov.mass = MagicMock()
-    prov.mass.streams.bind_ip = "0.0.0.0"
+    prov.mass.streams.get_source_ip = AsyncMock(return_value=None)
     prov.logger.setLevel(logging.DEBUG)
 
     def _consume_task(coro: object) -> MagicMock:
@@ -224,7 +254,7 @@ async def test_ptp_daemon_spawn_traces_at_verbose_level() -> None:
     prov = _ptp_provider()
     prov.dacp_id = "AABBCCDD11223344"
     prov.mass = MagicMock()
-    prov.mass.streams.bind_ip = "0.0.0.0"
+    prov.mass.streams.get_source_ip = AsyncMock(return_value=None)
     prov.logger.setLevel(VERBOSE_LOG_LEVEL)
     prov.config = MagicMock()
     prov.config.get_value = MagicMock(return_value=True)
@@ -635,6 +665,8 @@ def _stream_player(*, ptp_daemon_running: bool) -> MagicMock:
     prov.ptp_daemon_running = ptp_daemon_running
     prov.logger = logging.getLogger("test.airplay.prov")
     prov.mass.streams.publish_ip = "192.168.1.99"
+    prov.mass.streams.get_source_ip = AsyncMock(return_value="192.168.1.5")
+    prov.mass.streams.get_publish_ip = MagicMock(return_value=None)
     player.provider = prov
     return player
 
@@ -642,15 +674,9 @@ def _stream_player(*, ptp_daemon_running: bool) -> MagicMock:
 async def _build_args(player: MagicMock, use_shared_ptp: bool | None) -> list[str]:
     """Assemble CLI args for the player with the externals patched out."""
     stream = AirPlayStream(player)
-    with (
-        patch(
-            "music_assistant.providers.airplay.stream.get_cli_binary",
-            return_value="/fake/cliairplay",
-        ),
-        patch(
-            "music_assistant.providers.airplay.stream.resolve_if_ip",
-            return_value="192.168.1.5",
-        ),
+    with patch(
+        "music_assistant.providers.airplay.stream.get_cli_binary",
+        return_value="/fake/cliairplay",
     ):
         return await stream._build_cli_args(use_shared_ptp)
 

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -66,7 +66,11 @@ def _make_player() -> MagicMock:
     prov.dacp_id = "ABCDEF0123456789"
     prov.ptp_daemon_running = True
     prov.logger = logging.getLogger("test.airplay.prov")
+    # auto-detected publish ip: reachable address of this host, but not the interface
+    # the stream to this device leaves from - so it is never handed to the binary
     prov.mass.streams.publish_ip = "192.168.1.99"
+    prov.mass.streams.get_source_ip = AsyncMock(return_value="192.168.1.5")
+    prov.mass.streams.get_publish_ip = MagicMock(return_value=None)
     player.provider = prov
     return player
 
@@ -74,15 +78,9 @@ def _make_player() -> MagicMock:
 async def _build_args(player: MagicMock) -> list[str]:
     """Build the CLI args for the given player with the externals patched out."""
     stream = AirPlayStream(player)
-    with (
-        patch(
-            "music_assistant.providers.airplay.stream.get_cli_binary",
-            return_value="/fake/cliairplay",
-        ),
-        patch(
-            "music_assistant.providers.airplay.stream.resolve_if_ip",
-            return_value="192.168.1.5",
-        ),
+    with patch(
+        "music_assistant.providers.airplay.stream.get_cli_binary",
+        return_value="/fake/cliairplay",
     ):
         return await stream._build_cli_args()
 
@@ -123,13 +121,67 @@ async def test_cli_args_default_auto() -> None:
     assert "--latency" not in args
     # PTP daemon is running: stream attaches to the shared clock
     assert "--ptp-shared" in args
-    # networking
+    # networking: the interface the timing packets leave from is pinned
     assert _arg_value(args, "--if") == "192.168.1.5"
-    assert _arg_value(args, "--publish-ip") == "192.168.1.99"
+    assert "--publish-ip" not in args
     # the target is the only positional argument; PREPARE selects stdin
     assert args[-1] == "192.168.1.50"
     assert "-" not in args
     assert "--cmdpipe" in args
+
+
+@pytest.mark.asyncio
+async def test_cli_args_auto_publish_ip_is_never_advertised() -> None:
+    """
+    An auto-detected publish IP must not reach --publish-ip.
+
+    The binary treats it as authoritative for the PTP timing-peer list, while the
+    timing packets leave from the resolved --if interface. A peer list naming any
+    other address makes the receiver discard our clock and play silence.
+    """
+    player = _make_player()
+    player.provider.mass.streams.publish_ip = "10.45.0.20"
+
+    args = await _build_args(player)
+
+    assert _arg_value(args, "--if") == "192.168.1.5"
+    assert "--publish-ip" not in args
+    assert "10.45.0.20" not in args
+
+
+@pytest.mark.asyncio
+async def test_cli_args_configured_publish_ip_is_advertised() -> None:
+    """An explicitly configured publish IP is a reachability statement and is passed on."""
+    player = _make_player()
+    player.provider.mass.streams.get_publish_ip = MagicMock(return_value="10.45.0.20")
+
+    args = await _build_args(player)
+
+    assert _arg_value(args, "--publish-ip") == "10.45.0.20"
+    player.provider.mass.streams.get_publish_ip.assert_called_once_with("192.168.1.50")
+
+
+@pytest.mark.asyncio
+async def test_cli_args_publish_ip_omitted_when_it_matches_the_interface() -> None:
+    """A publish IP identical to the bound interface adds nothing to the peer list."""
+    player = _make_player()
+    player.provider.mass.streams.get_publish_ip = MagicMock(return_value="192.168.1.5")
+
+    args = await _build_args(player)
+
+    assert _arg_value(args, "--if") == "192.168.1.5"
+    assert "--publish-ip" not in args
+
+
+@pytest.mark.asyncio
+async def test_cli_args_no_interface_pin_leaves_routing_to_the_binary() -> None:
+    """With no interface to pin, --if is dropped so the routing table decides."""
+    player = _make_player()
+    player.provider.mass.streams.get_source_ip = AsyncMock(return_value=None)
+
+    args = await _build_args(player)
+
+    assert "--if" not in args
 
 
 @pytest.mark.asyncio
@@ -184,15 +236,9 @@ async def test_cli_args_hires_pcm_format() -> None:
     player = _make_player()
     hires_format = AudioFormat(content_type=ContentType.PCM_S32LE, sample_rate=48000, bit_depth=24)
     stream = AirPlayStream(player, pcm_format=hires_format)
-    with (
-        patch(
-            "music_assistant.providers.airplay.stream.get_cli_binary",
-            return_value="/fake/cliairplay",
-        ),
-        patch(
-            "music_assistant.providers.airplay.stream.resolve_if_ip",
-            return_value="192.168.1.5",
-        ),
+    with patch(
+        "music_assistant.providers.airplay.stream.get_cli_binary",
+        return_value="/fake/cliairplay",
     ):
         args = await stream._build_cli_args()
 

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -39,6 +39,7 @@ async def test_daemon_runner_reselects_api_port_when_taken() -> None:
     """An API port taken while the daemon was down is replaced before (re)starting."""
     provider = object.__new__(SpotifyConnectProvider)
     provider.mass = MagicMock()
+    provider.mass.streams.get_source_ip = AsyncMock(return_value="192.168.1.5")
     provider.logger = MagicMock()
     provider.config = MagicMock()
     provider.config.name = "Spotify Test"
@@ -75,4 +76,5 @@ async def test_daemon_runner_reselects_api_port_when_taken() -> None:
     port_probe.assert_awaited_once_with(38800, host="127.0.0.1")
     assert provider._api_port == 38801
     assert provider._client.base_url == "http://127.0.0.1:38801"
-    write_config.assert_called_once()
+    # the daemon config pins the advertisement to the player-facing interface
+    write_config.assert_called_once_with("192.168.1.5")


### PR DESCRIPTION
# What does this implement/fix?

An AirPlay 2 speaker could connect, receive audio and be shown as playing indefinitely while staying completely silent, on any host where the default route is not the interface that reaches the players — a VPN interface holding the default route is enough to trigger it.

`cliairplay` treats `--publish-ip` as authoritative for the AirPlay 2 timing-peer list (`timingPeerInfo`/SETPEERS), outranking both the bound interface and the RTSP socket's local address. Apple receivers only accept a clock source whose address is in that list, and our timing packets are sent unicast, so they leave from the interface that routes to the speaker. Advertising any other address makes the receiver discard our clock and render nothing, while the sender keeps counting frames and reporting progress.

Music Assistant passed `--publish-ip` whenever it merely differed from `--if`. The publish IP is auto-detected from the default route while `--if` is resolved per device, so on a multi-homed host those differ and we poisoned the peer list by default. Only an explicitly configured publish IP is a statement about reachability (NAT, containers); an auto-detected one is a guess, and it must never outrank an address derived from the connection itself.

Address resolution now lives on the streams controller, which owns the player-facing network. Player providers ask it rather than each deriving an answer from `bind_ip`/`publish_ip` on their own — the AirPlay provider previously resolved its interface through the *discovery* controller's zeroconf setting, which held an inverted view of the same question.

This pairs with #5217: that reports a speaker whose clock never answers, this removes the most common reason it doesn't.

**Related issue (if applicable):**

- n/a

## Changes

- `StreamsController.get_source_ip()` returns a locally bindable address on the player-facing network, or `None` for "bind everything". `get_publish_ip()` returns an address to advertise, and only ever one the user configured.
- The streams controller keeps the explicitly-configured publish IP distinct from an auto-detected one, which `setup()` previously flattened. Reported in diagnostics as `publish_ip_configured`.
- AirPlay passes `--publish-ip` only when it was configured; `--if` and the shared PTP daemon's binding come from the same controller call.
- `resolve_if_ip` is deleted from the AirPlay provider, along with the interface-name branch it needed for a zeroconf setting that cannot hold one.
- `get_source_ip_for_target()` is reduced to the routing lookup, its precedence rules having moved to the controller. That drops its fallback to `publish_ip`, which contradicted its own documented contract and could hand back an address this host cannot bind.
- WiiM, the AirPlay receiver and Spotify Connect use the shared call instead of open-coding a wildcard test.
- Error output from the `cliairplay` binary is logged as a warning naming the speaker, instead of being visible only at verbose level.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally. (verified against the test suite; the silent-playback path itself has not been reproduced against a live receiver)
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable. Includes a regression test asserting an auto-detected publish IP never reaches the argv, and new coverage for the controller's resolution.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (n/a)
