### PR TITLE
Fix AirPlay speakers playing behind when grouped with a Sendspin player

### DIFF
--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -435,9 +435,10 @@ protocol path (RAOP, AirPlay 2 RAOP-compat and native).
    then feeds a fresh ffmpeg into the same stdin, awaits `[STATUS] audio` and
    sends one shared `START`.
    Standby keeps each protocol connection alive for the same flush-refill resume
-5. Sendspin starts preserve its externally supplied audible instant, riding the
-   same persistent-stdin flush-refill (cold connect + `START`, warm `FLUSH` +
-   `START`) instead of a cold reconnect
+5. Sendspin starts ride the same persistent-stdin flush-refill (cold connect +
+   `START`, warm `FLUSH` + `START`) instead of a cold reconnect. They anchor as
+   a join, so the binary reports the instant it really scheduled and the bridge
+   maps the group's audio onto that instant rather than the one it asked for
 6. Per-player `sync_adjust` config allows fine-tuning (+/- milliseconds)
 
 ### Shared PTP Clock Daemon

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -57,12 +57,6 @@ MRP_DISCOVERY_TYPE: Final[str] = "_mediaremotetv._tcp.local."
 RAOP_DISCOVERY_TYPE: Final[str] = "_raop._tcp.local."
 DACP_DISCOVERY_TYPE: Final[str] = "_dacp._tcp.local."
 
-# Setup lead (ms) advertised to externally timed sources such as Sendspin.
-# It covers process spawn, connect/session setup and receiver pre-fill before
-# the commanded audible instant. Native AirPlay 2 needs a larger budget than
-# RAOP because its pre-fill is paced.
-AIRPLAY_RAOP_SETUP_LEAD_MS: Final[int] = 1500
-AIRPLAY_AP2_SETUP_LEAD_MS: Final[int] = 2500
 # Lower bound for a late joiner's anchor, and the whole anchor whenever the
 # binary reports no readiness projection ([STATUS] clock_ready). It has to keep
 # the binary's own clock verification viable without any device evidence: that

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -29,12 +29,10 @@ from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
 from music_assistant.models.setup_flow import AbortFlow
 
 from .constants import (
-    AIRPLAY_AP2_SETUP_LEAD_MS,
     AIRPLAY_DISCOVERY_TYPE,
     AIRPLAY_HIRES_AUDIO_FORMATS,
     AIRPLAY_HIRES_SAMPLE_RATES,
     AIRPLAY_PCM_FORMAT,
-    AIRPLAY_RAOP_SETUP_LEAD_MS,
     AIRPLAY_REJOIN_ATTEMPT_DELAYS,
     ATV_PASSWORD_BIT,
     BASE_PLAYER_FEATURES,
@@ -270,13 +268,6 @@ class AirPlayPlayer(Player):
         return {
             p.player_id for p in prov.get_players() if p.available and p.player_id != self.player_id
         }
-
-    @property
-    def wait_start(self) -> int:
-        """Get the setup lead required by an externally timed audio source."""
-        if self.protocol == StreamingProtocol.RAOP:
-            return AIRPLAY_RAOP_SETUP_LEAD_MS
-        return AIRPLAY_AP2_SETUP_LEAD_MS
 
     async def get_config_entries(self) -> list[ConfigEntry]:
         """Return all (provider/player specific) Config Entries for the given player (if any)."""

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -91,6 +91,13 @@ BRIDGE_COLD_CONNECT_BUDGET_MS: int = 2000
 BRIDGE_COLD_START_LEAD_MS: int = AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS + BRIDGE_COLD_CONNECT_BUDGET_MS
 BRIDGE_WARM_START_LEAD_MS: int = AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS
 
+# Buffer (ms) Sendspin keeps the bridge supplied with for the whole stream, and
+# the only floor a live source honours -- the start lead above is a hint Sendspin
+# may ignore to keep live latency down. It keeps the binary's ring fed rather
+# than tracking real time, without charging every other group member the full
+# start lead in added latency on a live source.
+BRIDGE_MIN_BUFFER_MS: int = 1000
+
 # Defensive cap (µs of audio) on the backlog held while the start anchor is being
 # settled. Sendspin bounds what it hands a joiner at 30 s of producer backlog, so
 # a hold growing past that means the anchor never resolved; the oldest chunks are
@@ -369,11 +376,11 @@ class SendspinAirPlayBridge:
 
     def _refresh_bridge_timing(self) -> None:
         """
-        Push the AirPlay startup lead to the bridge role.
+        Push the AirPlay startup lead and ongoing buffer to the bridge role.
 
         The lead is how far ahead of the audible instant Sendspin schedules the
         first chunk; a kept, already-connected CLI needs less of it than a cold
-        one. ``min_buffer_ms`` is 0 — the device carries its own jitter buffer.
+        one.
         """
         if self._bridge_role is None:
             return
@@ -384,7 +391,7 @@ class SendspinAirPlayBridge:
         )
         self._bridge_role.set_timing(
             required_lead_time_ms=lead_ms,
-            min_buffer_ms=0,
+            min_buffer_ms=BRIDGE_MIN_BUFFER_MS,
         )
 
     def _stream_is_warm_eligible(self) -> bool:

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections import deque
 from contextlib import suppress
 from typing import TYPE_CHECKING, cast
 
@@ -41,6 +42,12 @@ from music_assistant.providers.sendspin.bridge_role import (
 )
 from music_assistant.providers.sendspin.helpers import bridge_client_id_from_mac
 
+from .constants import (
+    AIRPLAY_JOIN_CLOCK_READY_LEAD_MS,
+    AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS,
+    AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
+    AIRPLAY_SPLICE_LEAD_MARGIN_MS,
+)
 from .helpers import player_id_to_mac_address
 from .stream import AirPlayStream
 
@@ -60,7 +67,8 @@ if TYPE_CHECKING:
 # seconds), and dumping that into the binary's stdin ahead of the start anchor
 # desyncs playback. Pace writes to keep the device buffered to at most this many
 # seconds of audio ahead of real time -- comfortably above the binary's own
-# prefill need (~wait_start + its ~2 s buffer) yet far below a whole-track backlog.
+# prefill need (the start lead plus its ~2 s buffer) yet far below a whole-track
+# backlog.
 MAX_DEVICE_BUFFER_SECONDS: float = 8.0
 
 # How long to keep a connected CLI alive after a sendspin stream ends, waiting
@@ -68,6 +76,30 @@ MAX_DEVICE_BUFFER_SECONDS: float = 8.0
 # this window. Comfortably longer than a sendspin stream restart, short enough
 # that a genuine stop stops the device promptly.
 BRIDGE_WARM_GRACE_SECONDS: float = 4.0
+
+# Budget (ms) for a cold transport: a process spawn plus connect/session setup
+# was measured at 1.66-1.83 s, and 2000 keeps a small margin over the slowest
+# measurement.
+BRIDGE_COLD_CONNECT_BUDGET_MS: int = 2000
+
+# Lead (ms) reported to Sendspin so it schedules the first chunk that far ahead
+# of the instant it wants audible. It has to cover getting the transport ready
+# plus the binary's own clock-verification floor, which the anchor can never
+# undercut -- a shorter lead makes the anchor land past the first chunks and
+# their audio is dropped. A cold start adds its connect budget on top; a kept,
+# already-connected CLI pays no connect, leaving only the floor.
+BRIDGE_COLD_START_LEAD_MS: int = AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS + BRIDGE_COLD_CONNECT_BUDGET_MS
+BRIDGE_WARM_START_LEAD_MS: int = AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS
+
+# Defensive cap (µs of audio) on the backlog held while the start anchor is being
+# settled. Sendspin bounds what it hands a joiner at 30 s of producer backlog, so
+# a hold growing past that means the anchor never resolved; the oldest chunks are
+# dropped instead of letting the backlog grow without bound.
+MAX_HELD_AUDIO_US: int = 45_000_000
+# Companion cap on the number of held chunks: the µs cap cannot bound a run of
+# zero-duration chunks. Sits generously above the count of 25 ms frames the
+# bridge role delivers across MAX_HELD_AUDIO_US.
+MAX_HELD_CHUNKS: int = 4_000
 
 
 def get_bridge_client_id(airplay_player: AirPlayPlayer) -> str | None:
@@ -112,6 +144,29 @@ def sendspin_audible_instant_to_unix_ms(
     """
     future_s = (audible_instant_us - sendspin_now_us) / 1_000_000
     return int((unix_now + future_s) * 1000)
+
+
+def unix_ms_to_sendspin_audible_instant(
+    unix_ms: int,
+    sendspin_now_us: int,
+    unix_now: float,
+) -> int:
+    """
+    Map a unix epoch millisecond onto an audible instant on the Sendspin clock.
+
+    The inverse of :func:`sendspin_audible_instant_to_unix_ms`, used to place the
+    instant the binary acked back on the shared Sendspin timeline so chunk
+    timestamps can be measured against it. It carries the same requirement:
+    ``sendspin_now_us`` and ``unix_now`` must be sampled back to back, because
+    only the offset from now transfers between the two clocks.
+
+    :param unix_ms: Unix epoch millisecond to map.
+    :param sendspin_now_us: ``sendspin_server.clock.now_us()`` captured now.
+    :param unix_now: ``time.time()`` captured at the same instant as sendspin_now_us.
+    :return: The Sendspin-clock instant (µs) that coincides with ``unix_ms``.
+    """
+    future_s = unix_ms / 1000 - unix_now
+    return sendspin_now_us + round(future_s * 1_000_000)
 
 
 def device_buffer_ahead_seconds(
@@ -187,6 +242,16 @@ class SendspinAirPlayBridge:
         self._airplay_stream_ready = asyncio.Event()
         # Whether the current stream has been anchored with its first START.
         self._started = False
+        # Whether _drop_until_us reflects the instant the binary acked. Until it
+        # does, arriving chunks are held instead of placed.
+        self._anchor_settled = False
+        # Chunks delivered while the anchor is still being negotiated. Held as
+        # chunks rather than queued bytes because _align_chunk places bytes
+        # relative to _drop_until_us, which the ack is about to move.
+        self._held_chunks: deque[AudioChunk] = deque()
+        # Running total of the held chunks' duration, kept alongside the deque so
+        # the cap does not re-sum the whole backlog on every chunk.
+        self._held_us: int = 0
         self._cleanup_task: asyncio.Task[None] | None = None
         # Timer id for the deferred teardown on stream end. A seek/next ends the
         # sendspin stream and immediately starts a new one; deferring the CLI
@@ -304,16 +369,21 @@ class SendspinAirPlayBridge:
 
     def _refresh_bridge_timing(self) -> None:
         """
-        Push the AirPlay startup latency to the bridge role.
+        Push the AirPlay startup lead to the bridge role.
 
-        ``wait_start`` is the lead time the device needs before audio begins, so
-        Sendspin schedules the first chunk that far ahead instead of dropping it.
-        ``min_buffer_ms`` is 0 — the device carries its own jitter buffer.
+        The lead is how far ahead of the audible instant Sendspin schedules the
+        first chunk; a kept, already-connected CLI needs less of it than a cold
+        one. ``min_buffer_ms`` is 0 — the device carries its own jitter buffer.
         """
         if self._bridge_role is None:
             return
+        lead_ms = (
+            BRIDGE_WARM_START_LEAD_MS
+            if self._stream_is_warm_eligible()
+            else BRIDGE_COLD_START_LEAD_MS
+        )
         self._bridge_role.set_timing(
-            required_lead_time_ms=int(self.airplay_player.wait_start),
+            required_lead_time_ms=lead_ms,
             min_buffer_ms=0,
         )
 
@@ -383,6 +453,9 @@ class SendspinAirPlayBridge:
         self._drop_until_us = 0
         self._start_unix_ms = 0
         self._started = keep_stream
+        self._anchor_settled = False
+        self._held_chunks.clear()
+        self._held_us = 0
 
     def _on_bridge_stream_start(self) -> None:
         """
@@ -419,6 +492,9 @@ class SendspinAirPlayBridge:
         self._drop_until_us = 0
         self._start_unix_ms = 0
         self._started = keep_stream
+        self._anchor_settled = False
+        self._held_chunks.clear()
+        self._held_us = 0
         # Drain stale audio data from the previous stream
         while not self._write_queue.empty():
             self._write_queue.get_nowait()
@@ -439,39 +515,16 @@ class SendspinAirPlayBridge:
             if cleanup and not cleanup.done():
                 await cleanup
 
-            # Derive the audible start instant from _drop_until_us (set on first
-            # chunk arrival) so the CLI has enough lead to connect and establish
-            # the session. _drop_until_us is on the Sendspin (monotonic) clock;
-            # map it to the unix epoch ms used by the START command.
-            sendspin_clock_now_us = self.sendspin_server.clock.now_us()
-            unix_clock_now = time.time()
-            start_unix_ms = sendspin_audible_instant_to_unix_ms(
-                self._drop_until_us, sendspin_clock_now_us, unix_clock_now
-            )
-            lead_us = self._drop_until_us - sendspin_clock_now_us
-            if lead_us <= 0:
-                # Session setup outran the lead budget (e.g. a slow teardown of a
-                # previous stream ahead of us). The anchor is already in the past,
-                # so the binary cannot honour it and playback starts late relative
-                # to the Sendspin timeline. Surface it instead of failing silently.
-                self.logger.warning(
-                    "AirPlay start anchor for %s is not in the future "
-                    "(setup exceeded the %dms lead) - playback may start late",
-                    self.airplay_player.display_name,
-                    int(self.airplay_player.wait_start),
-                )
-            sync_adjust = self.airplay_player.config.get_value(CONF_SYNC_ADJUST, 0)
-            if isinstance(sync_adjust, int) and sync_adjust != 0:
-                start_unix_ms += sync_adjust
-            # Publish the audible anchor so the writer can pace against it.
-            self._start_unix_ms = start_unix_ms
-
             # A kept, still-connected stream (see _stream_is_warm_eligible,
             # checked by the stream-start callbacks) absorbs the new media via a
             # flush-refill on the SAME cli stdin instead of a cold reconnect.
             kept_stream = self._airplay_stream
             if kept_stream is not None:
-                if await self._start_warm_stream(kept_stream, start_unix_ms):
+                if await self._start_warm_stream(kept_stream):
+                    return
+                if asyncio.current_task() is not self._airplay_stream_start_task:
+                    # Not a failure: a newer stream start owns the bridge and the
+                    # kept stream, so neither is this task's to tear down.
                     return
                 # Warm handover failed - tear down the kept stream and fall through
                 # to the cold path below, which spawns a fresh process.
@@ -483,32 +536,33 @@ class SendspinAirPlayBridge:
             # On a rapid skip, _on_bridge_stream_start snapshots self._airplay_stream
             # for cleanup. If we assigned it earlier, the new stream would be missed
             # and leaked. Only publish once connect() succeeds and this task is current.
-            new_stream = AirPlayStream(self.airplay_player)
-            if not await self._start_cold_stream(new_stream, start_unix_ms):
-                return
-            self.logger.info(
-                "Bridge protocol started for %s (start_unix_ms=%s, lookahead=%.0fms)",
-                self.airplay_player.display_name,
-                start_unix_ms,
-                lead_us / 1000,
-            )
+            await self._start_cold_stream(AirPlayStream(self.airplay_player))
         except Exception as err:
             self.logger.error(
                 "Failed to start AirPlay protocol for %s: %s",
                 self.airplay_player.display_name,
                 err,
             )
+            if asyncio.current_task() is not self._airplay_stream_start_task:
+                # A newer stream start owns the bridge: its backlog, writer gate
+                # and stream must survive this task's failure untouched.
+                self.logger.debug(
+                    "Superseded AirPlay start for %s failed, leaving the newer stream alone",
+                    self.airplay_player.display_name,
+                )
+                return
             # Stop accepting chunks, unblock the writer, and schedule full cleanup
             self._is_streaming = False
+            self._held_chunks.clear()
+            self._held_us = 0
             self._airplay_stream_ready.set()
             self._schedule_cleanup()
 
-    async def _start_cold_stream(self, stream: AirPlayStream, start_unix_ms: int) -> bool:
+    async def _start_cold_stream(self, stream: AirPlayStream) -> bool:
         """
         Connect a fresh bridge transport and anchor its first START.
 
         :param stream: New AirPlay stream to start.
-        :param start_unix_ms: Audible-start instant for the first sample.
         :return: True when the stream is anchored, False when superseded.
         """
         try:
@@ -519,18 +573,25 @@ class SendspinAirPlayBridge:
                 return False
             self._airplay_stream = stream
             self.airplay_player.stream = stream
-            # The binary buffers stdin into its ring from process start; unblock
-            # the writer so it feeds PCM, then anchor the start.
-            self._airplay_stream_ready.set()
-            await stream.start(start_unix_ms)
-            self._started = True
+            if await self._anchor_stream(stream, warm=False):
+                return True
+            # A superseded cold stream is this task's to tear down: it was
+            # connected here and no other start owns it (unlike the warm path,
+            # where the kept stream belongs to the newer start). Only unpublish
+            # what still points at it, so a newer owner's assignment survives.
+            with suppress(Exception):
+                await stream.stop(force=True)
+            if self._airplay_stream is stream:
+                self._airplay_stream = None
+            if self.airplay_player.stream is stream:
+                self.airplay_player.stream = None
+            return False
         except BaseException:
             with suppress(Exception):
                 await stream.stop(force=True)
             raise
-        return True
 
-    async def _start_warm_stream(self, stream: AirPlayStream, start_unix_ms: int) -> bool:
+    async def _start_warm_stream(self, stream: AirPlayStream) -> bool:
         """
         Flush a kept, still-connected stream and resume it on the new track.
 
@@ -540,7 +601,6 @@ class SendspinAirPlayBridge:
         failure returns False so the caller falls back to a cold restart.
 
         :param stream: The kept AirPlayStream to flush and resume.
-        :param start_unix_ms: The audible-start instant to re-anchor at.
         """
         try:
             if not await stream.flush():
@@ -548,17 +608,7 @@ class SendspinAirPlayBridge:
             if asyncio.current_task() is not self._airplay_stream_start_task:
                 # A newer stream start owns the bridge; leave the stream to it.
                 return False
-            # The binary drained its ring + stdin on flush and keeps reading
-            # stdin; unblock the writer to feed the new track into the SAME cli
-            # stdin, then re-anchor the resumed start.
-            self._airplay_stream_ready.set()
-            await stream.start(start_unix_ms)
-            self._started = True
-            self.logger.info(
-                "Bridge warm handover for %s (start_unix_ms=%d)",
-                self.airplay_player.display_name,
-                start_unix_ms,
-            )
+            return await self._anchor_stream(stream, warm=True)
         except asyncio.CancelledError:
             raise
         except Exception as err:
@@ -568,6 +618,120 @@ class SendspinAirPlayBridge:
                 err,
             )
             return False
+
+    async def _anchor_stream(self, stream: AirPlayStream, *, warm: bool) -> bool:
+        """
+        Anchor a connected stream on the Sendspin timeline and release the writer.
+
+        Commands the START, then maps the bridge's content onto the instant the
+        binary acked rather than the one that was asked for, so the device plays
+        the same audio at the same time as the rest of the Sendspin group. The
+        writer stays blocked until that mapping is in place.
+
+        :param stream: The connected AirPlay stream to anchor.
+        :param warm: True when re-anchoring a kept, still-connected stream, whose
+            queued audio the new anchor has to clear.
+        :return: True when the stream is anchored, False when superseded.
+        """
+        ready_at_unix_ms = await stream.wait_clock_ready(
+            timeout=AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS / 1000
+        )
+        sendspin_now_us = self.sendspin_server.clock.now_us()
+        unix_now = time.time()
+        now_ms = int(unix_now * 1000)
+        # The instant Sendspin wants the first chunk we hold to be audible; the
+        # anchor never precedes it, so nothing Sendspin scheduled is thrown away.
+        first_chunk_unix_ms = sendspin_audible_instant_to_unix_ms(
+            self._drop_until_us, sendspin_now_us, unix_now
+        )
+        anchor_ms = max(now_ms + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS, first_chunk_unix_ms)
+        if ready_at_unix_ms:
+            anchor_ms = max(anchor_ms, ready_at_unix_ms + AIRPLAY_JOIN_CLOCK_READY_LEAD_MS)
+        sync_adjust = self.airplay_player.config.get_value(CONF_SYNC_ADJUST, 0)
+        adjust_ms = sync_adjust if isinstance(sync_adjust, int) else 0
+        if warm:
+            # A splice-timeline receiver honours the commanded instant only when
+            # it lands beyond the audio still queued behind the flushed head. A
+            # NEGATIVE sync_adjust moves the commanded instant earlier, eating
+            # into the lead, so it has to be added back to the requirement.
+            if stream.warm_lead_ms > 0:
+                anchor_ms = max(
+                    anchor_ms,
+                    now_ms
+                    + stream.warm_lead_ms
+                    - min(0, adjust_ms)
+                    + AIRPLAY_SPLICE_LEAD_MARGIN_MS,
+                )
+            if stream.flushed_head_unix_ms > 0:
+                anchor_ms = max(
+                    anchor_ms,
+                    stream.flushed_head_unix_ms - adjust_ms + AIRPLAY_SPLICE_LEAD_MARGIN_MS,
+                )
+        commanded_ms = anchor_ms + adjust_ms
+
+        # Always a join: the Sendspin timeline is the group's, never the bridge's
+        # to set, so the binary must hold its ack until the receiver clock
+        # verification resolves and report the instant it really scheduled.
+        actual = await stream.start(commanded_ms, join=True)
+
+        # The ack can be held for seconds, so re-check ownership before touching
+        # any state a newer stream start may already own.
+        if (
+            asyncio.current_task() is not self._airplay_stream_start_task
+            or self._airplay_stream is not stream
+        ):
+            return False
+        if actual is None:
+            self.logger.warning(
+                "AirPlay start for %s was not acknowledged, trusting the commanded "
+                "instant %d - playback may start slightly late",
+                self.airplay_player.display_name,
+                commanded_ms,
+            )
+        acked_adjusted = actual if actual is not None else commanded_ms
+        # The command carries the device's sync_adjust; the group timeline does not.
+        acked_timeline_ms = acked_adjusted - adjust_ms
+        sendspin_now_us = self.sendspin_server.clock.now_us()
+        unix_now = time.time()
+        anchor_us = unix_ms_to_sendspin_audible_instant(
+            acked_timeline_ms, sendspin_now_us, unix_now
+        )
+        skipped_us = anchor_us - self._drop_until_us
+        self._start_unix_ms = acked_adjusted
+        self._drop_until_us = anchor_us
+        self._queued_frames = 0
+        self._anchor_settled = True
+        self._started = True
+        # Replay what arrived while the anchor was being settled before yielding
+        # to the loop, so the backlog stays ahead of whatever _on_audio_chunk
+        # delivers next.
+        held = list(self._held_chunks)
+        self._held_chunks.clear()
+        self._held_us = 0
+        for chunk in held:
+            if chunk.timestamp_us + chunk.duration_us <= self._drop_until_us:
+                continue
+            self._align_chunk(chunk)
+        self._airplay_stream_ready.set()
+
+        self.logger.info(
+            "Bridge protocol %s for %s (start_unix_ms=%d, acked %+d ms off the commanded "
+            "instant, skipping %.0fms of content)",
+            "resumed" if warm else "started",
+            self.airplay_player.display_name,
+            acked_adjusted,
+            acked_adjusted - commanded_ms,
+            skipped_us / 1000,
+        )
+        if skipped_us > 500_000:
+            self.logger.warning(
+                "AirPlay start for %s dropped %.0fms of audio: Sendspin scheduled the first "
+                "chunk %.0fms ahead but the device could not be audible before %.0fms",
+                self.airplay_player.display_name,
+                skipped_us / 1000,
+                first_chunk_unix_ms - now_ms,
+                acked_timeline_ms - now_ms,
+            )
         return True
 
     def _on_volume_change(self, volume: int) -> None:
@@ -668,20 +832,27 @@ class SendspinAirPlayBridge:
                 return
 
         if self._airplay_stream_start_task is None:
-            # Anchor byte 0 to the instant Sendspin scheduled for the first chunk it
-            # actually delivered -- i.e. trust the shared timeline instead of inventing
-            # our own "now + wait_start" start. Sendspin already schedules the first
-            # sample the AirPlay setup budget ahead because we report
-            # required_lead_time_ms = wait_start at registration:
+            # Provisionally anchor byte 0 to the instant Sendspin scheduled for the
+            # first chunk it actually delivered -- the shared timeline, rather than a
+            # start of our own invention. Sendspin schedules that first sample the
+            # bridge lead ahead because that is what _refresh_bridge_timing reports as
+            # required_lead_time_ms:
             #   * fresh track  -> the first chunk IS file position 0, so the intro is
-            #     kept (the old "now + wait_start" anchor discarded the opening seconds
-            #     whenever Sendspin had scheduled position 0 earlier than that instant);
+            #     kept;
             #   * late join     -> the first chunk is the catch-up target, i.e. the
             #     group's current playback position, so the joiner lands in sync.
+            # _anchor_stream re-bases this onto the instant the binary acks.
             self._drop_until_us = chunk.timestamp_us
             self._airplay_stream_start_task = self.mass.create_task(
                 self._start_protocol_from_chunk()
             )
+
+        if not self._anchor_settled:
+            # The binary has not acked its anchor yet, and that ack moves
+            # _drop_until_us. Hold the chunk instead of placing it against a
+            # reference that is about to change.
+            self._hold_chunk(chunk)
+            return
 
         # Drop chunks that end entirely before the target start time.
         chunk_end_us = chunk.timestamp_us + chunk.duration_us
@@ -689,6 +860,22 @@ class SendspinAirPlayBridge:
             return
 
         self._align_chunk(chunk)
+
+    def _hold_chunk(self, chunk: AudioChunk) -> None:
+        """
+        Keep a chunk until the start anchor settles, capping the backlog.
+
+        The backlog is bounded by both its duration and its chunk count; the
+        count is what bounds a run of zero-duration chunks.
+
+        :param chunk: The chunk to replay once the anchor is known.
+        """
+        self._held_chunks.append(chunk)
+        self._held_us += chunk.duration_us
+        while len(self._held_chunks) > 1 and (
+            self._held_us > MAX_HELD_AUDIO_US or len(self._held_chunks) > MAX_HELD_CHUNKS
+        ):
+            self._held_us -= self._held_chunks.popleft().duration_us
 
     def _align_chunk(self, chunk: AudioChunk) -> None:
         """
@@ -709,7 +896,10 @@ class SendspinAirPlayBridge:
         )
         drift_frames = target_frames - self._queued_frames
         drift_us = round(drift_frames * 1_000_000 / BRIDGE_SAMPLE_RATE)
-        if abs(drift_us) > 1_000:
+        # The first placement after an anchor sits at the gap between the anchor
+        # and the chunk by construction, which is not drift; only a cursor that
+        # already advanced can have drifted away from the timeline.
+        if self._queued_frames and abs(drift_us) > 1_000:
             self.logger.warning(
                 "Realigned %d µs of Sendspin timeline drift for %s",
                 drift_us,
@@ -799,6 +989,9 @@ class SendspinAirPlayBridge:
         self._queued_frames = 0
         self._airplay_stream_ready.clear()
         self._started = False
+        self._anchor_settled = False
+        self._held_chunks.clear()
+        self._held_us = 0
         if self._airplay_stream_start_task:
             self._airplay_stream_start_task.cancel()
             with suppress(asyncio.CancelledError, Exception):

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -721,9 +721,11 @@ class SendspinAirPlayBridge:
             self._align_chunk(chunk)
         self._airplay_stream_ready.set()
 
+        # The content shift is signed: a later anchor skips content, an earlier
+        # one (the binary is free to ack either way) pads silence up to it.
         self.logger.info(
             "Bridge protocol %s for %s (start_unix_ms=%d, acked %+d ms off the commanded "
-            "instant, skipping %.0fms of content)",
+            "instant, content shifted %+.0f ms)",
             "resumed" if warm else "started",
             self.airplay_player.display_name,
             acked_adjusted,

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -436,7 +436,6 @@ def _ap2_player() -> MagicMock:
     """Return a mock player that resolves to native AirPlay 2."""
     player = MagicMock()
     player.protocol = StreamingProtocol.AIRPLAY2
-    player.wait_start = 2500
     return player
 
 
@@ -444,7 +443,6 @@ def _raop_player() -> MagicMock:
     """Return a mock player that resolves to legacy RAOP."""
     player = MagicMock()
     player.protocol = StreamingProtocol.RAOP
-    player.wait_start = 1500
     return player
 
 

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -1,13 +1,18 @@
 """
 Unit tests for the Sendspin -> AirPlay bridge timing.
 
-Cover five things, with the Sendspin clock mocked via ``ManualClock`` so the
+Cover seven things, with the Sendspin clock mocked via ``ManualClock`` so the
 tests are deterministic and independent of the host wall-clock:
 
 * the clock-domain conversion turning a Sendspin audible instant (Sendspin's own
-  monotonic clock) into the unix epoch ms used by the START command;
+  monotonic clock) into the unix epoch ms used by the START command, and back;
+* the startup lead reported to Sendspin, which decides how far ahead of the
+  audible instant it schedules the first chunk;
 * the start anchor: byte 0 is anchored to the first chunk Sendspin delivers, so a
   fresh track keeps position 0 and a late joiner lands at the group's live position;
+* anchoring against the binary: the commanded instant honours the join headroom,
+  the receiver's clock-ready projection and the content Sendspin already
+  scheduled, and the content is then mapped onto the instant the binary acked;
 * the timeline alignment that keeps every chunk at the byte offset its timestamp
   claims, so a discontinuity in the Sendspin timeline does not shift the device
   off the group's clock for the rest of the stream;
@@ -16,7 +21,8 @@ tests are deterministic and independent of the host wall-clock:
 * the warm handover: a running, connected stream is kept (not torn down) across
   a new Sendspin stream and rides the persistent-stdin flush-refill (FLUSH +
   re-anchoring START) instead of a cold reconnect -- with flush-timeout and
-  superseded-task fallback.
+  superseded-task fallback, and the supersession handling that keeps a stale
+  start from tearing down the stream a newer one owns.
 """
 
 import asyncio
@@ -27,12 +33,22 @@ import pytest
 from aiosendspin.clock import ManualClock
 from aiosendspin.server.roles import AudioChunk
 
-from music_assistant.providers.airplay.constants import StreamingProtocol
+from music_assistant.providers.airplay.constants import (
+    AIRPLAY_JOIN_CLOCK_READY_LEAD_MS,
+    AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
+    AIRPLAY_SPLICE_LEAD_MARGIN_MS,
+    StreamingProtocol,
+)
 from music_assistant.providers.airplay.sendspin_bridge import (
+    BRIDGE_COLD_START_LEAD_MS,
+    BRIDGE_WARM_START_LEAD_MS,
     MAX_DEVICE_BUFFER_SECONDS,
+    MAX_HELD_AUDIO_US,
+    MAX_HELD_CHUNKS,
     SendspinAirPlayBridge,
     device_buffer_ahead_seconds,
     sendspin_audible_instant_to_unix_ms,
+    unix_ms_to_sendspin_audible_instant,
 )
 from music_assistant.providers.sendspin.bridge_role import (
     BRIDGE_BYTES_PER_SAMPLE,
@@ -41,19 +57,21 @@ from music_assistant.providers.sendspin.bridge_role import (
 )
 
 BRIDGE_BYTES_PER_SECOND = BRIDGE_SAMPLE_RATE * BRIDGE_CHANNELS * BRIDGE_BYTES_PER_SAMPLE
+BRIDGE_BYTES_PER_FRAME = BRIDGE_CHANNELS * BRIDGE_BYTES_PER_SAMPLE
 
 # A large, arbitrary Sendspin monotonic-clock epoch (microseconds). Real
 # monotonic clocks start from an unspecified point (e.g. host boot), so the
 # conversion must never depend on this value.
 SENDSPIN_EPOCH_US = 5_000_000_000_000  # ~57.8 days of monotonic uptime
 UNIX_NOW_S = 1_784_000_000.0  # fixed unix wall-clock reading for the tests
-AP2_LEAD_MS = 2500
-RAOP_LEAD_MS = 1500
+UNIX_NOW_MS = int(UNIX_NOW_S * 1000)
+COLD_LEAD_MS = BRIDGE_COLD_START_LEAD_MS
+WARM_LEAD_MS = BRIDGE_WARM_START_LEAD_MS
 
 
-def _audible_instant_us(clock: ManualClock, wait_start_ms: int) -> int:
-    """Return a sample Sendspin audible instant wait_start ahead of now (exercises the mapping)."""
-    return clock.now_us() + wait_start_ms * 1_000
+def _audible_instant_us(clock: ManualClock, lead_ms: int) -> int:
+    """Return a sample Sendspin audible instant that far ahead of now (exercises the mapping)."""
+    return clock.now_us() + lead_ms * 1_000
 
 
 def _unix_at(sendspin_us: int) -> float:
@@ -62,13 +80,13 @@ def _unix_at(sendspin_us: int) -> float:
 
 
 def test_maps_future_delta_to_unix_now_plus_lead() -> None:
-    """An instant wait_start ahead maps to unix_now + wait_start (in ms)."""
+    """An instant a lead ahead maps to unix_now + that lead (in ms)."""
     clock = ManualClock(now_us_value=SENDSPIN_EPOCH_US)
-    drop_until = _audible_instant_us(clock, AP2_LEAD_MS)
+    drop_until = _audible_instant_us(clock, COLD_LEAD_MS)
 
     start_unix_ms = sendspin_audible_instant_to_unix_ms(drop_until, clock.now_us(), UNIX_NOW_S)
 
-    assert start_unix_ms == int(UNIX_NOW_S * 1000) + AP2_LEAD_MS
+    assert start_unix_ms == int(UNIX_NOW_S * 1000) + COLD_LEAD_MS
 
 
 def test_standing_clock_offset_cancels_out() -> None:
@@ -84,10 +102,10 @@ def test_standing_clock_offset_cancels_out() -> None:
     clock_b = ManualClock(now_us_value=SENDSPIN_EPOCH_US + 987_654_321_000)
 
     result_a = sendspin_audible_instant_to_unix_ms(
-        _audible_instant_us(clock_a, AP2_LEAD_MS), clock_a.now_us(), UNIX_NOW_S
+        _audible_instant_us(clock_a, COLD_LEAD_MS), clock_a.now_us(), UNIX_NOW_S
     )
     result_b = sendspin_audible_instant_to_unix_ms(
-        _audible_instant_us(clock_b, AP2_LEAD_MS), clock_b.now_us(), UNIX_NOW_S
+        _audible_instant_us(clock_b, COLD_LEAD_MS), clock_b.now_us(), UNIX_NOW_S
     )
 
     assert result_a == result_b
@@ -100,11 +118,11 @@ def test_derived_start_equals_sendspin_audible_instant_in_unix() -> None:
     Models the two clocks as running at the same rate with a constant offset
     (unix = anchor + (sendspin_us - epoch)/1e6). The bridge only ever reads the
     two clocks together, so the result must land exactly on the unix time that
-    coincides with the Sendspin audible instant, for any offset and any wait_start.
+    coincides with the Sendspin audible instant, for any offset and any lead.
     """
-    for wait_start_ms in (RAOP_LEAD_MS, AP2_LEAD_MS):
+    for lead_ms in (WARM_LEAD_MS, COLD_LEAD_MS):
         clock = ManualClock(now_us_value=SENDSPIN_EPOCH_US)
-        drop_until = _audible_instant_us(clock, wait_start_ms)
+        drop_until = _audible_instant_us(clock, lead_ms)
         # Some real time passes between setting the anchor and starting the CLI.
         clock.advance_us(40_000)  # 40 ms of setup churn (cleanup, task hop)
         sendspin_now = clock.now_us()
@@ -124,7 +142,7 @@ def test_scheduling_gap_between_reads_shrinks_lead_not_target() -> None:
     (advanced) Sendspin clock and unix reading.
     """
     clock = ManualClock(now_us_value=SENDSPIN_EPOCH_US)
-    drop_until = _audible_instant_us(clock, AP2_LEAD_MS)
+    drop_until = _audible_instant_us(clock, COLD_LEAD_MS)
 
     immediate = sendspin_audible_instant_to_unix_ms(drop_until, clock.now_us(), UNIX_NOW_S)
 
@@ -135,16 +153,16 @@ def test_scheduling_gap_between_reads_shrinks_lead_not_target() -> None:
     assert immediate == delayed
     # And the remaining lead really did shrink by the gap.
     remaining_lead_ms = delayed - int((UNIX_NOW_S + gap_s) * 1000)
-    assert remaining_lead_ms == AP2_LEAD_MS - int(gap_s * 1000)
+    assert remaining_lead_ms == COLD_LEAD_MS - int(gap_s * 1000)
 
 
 def test_anchor_already_in_the_past_maps_to_a_past_unix_instant() -> None:
     """
     An audible instant behind 'now' yields a unix ms before the unix reading.
 
-    This is the setup-outran-the-lead edge case: the value is still a faithful
-    projection (negative lead), which the caller detects to warn about a late
-    start rather than silently mis-anchoring.
+    This is the setup-outran-the-lead edge case: the value stays a faithful
+    projection (negative lead) rather than being clamped here, so the anchor
+    math can see it and raise the start to the join floor itself.
     """
     clock = ManualClock(now_us_value=SENDSPIN_EPOCH_US)
     audible_in_the_past = clock.now_us() - 300_000  # 300 ms ago
@@ -162,8 +180,8 @@ def test_anchor_already_in_the_past_maps_to_a_past_unix_instant() -> None:
 
 def _make_bridge(
     clock_now_us: int,
-    wait_start_ms: int = AP2_LEAD_MS,
     protocol: StreamingProtocol = StreamingProtocol.AIRPLAY2,
+    sync_adjust: int = 0,
 ) -> SendspinAirPlayBridge:
     """Build a bridge with mocked provider/player/server and a ManualClock."""
     provider = MagicMock()
@@ -171,8 +189,10 @@ def _make_bridge(
     airplay_player = MagicMock()
     airplay_player.player_id = "apc43875e9e53a"
     airplay_player.display_name = "Test Player"
-    airplay_player.wait_start = wait_start_ms
     airplay_player.protocol = protocol
+    # A real int: the anchor math guards sync_adjust with isinstance(..., int), so
+    # a MagicMock would silently read as 0 and pass the test for the wrong reason.
+    airplay_player.config.get_value = MagicMock(return_value=sync_adjust)
     sendspin_server = MagicMock()
     sendspin_server.clock = ManualClock(now_us_value=clock_now_us)
     bridge = SendspinAirPlayBridge(provider, airplay_player, sendspin_server)
@@ -191,23 +211,25 @@ def _pcm_chunk(timestamp_us: int, duration_us: int = 100_000) -> AudioChunk:
 
 def test_fresh_start_anchors_to_first_chunk_and_keeps_intro() -> None:
     """
-    A fresh track's opening is kept: byte 0 anchors to the first chunk, not now+wait_start.
+    A fresh track's opening is kept: byte 0 anchors to the first chunk, not now+lead.
 
     Models the clip scenario where the first delivered chunk (file position 0)
-    is scheduled earlier than ``clock.now() + wait_start``. Anchoring to
-    ``now + wait_start`` (the old behaviour) would drop everything before it -- the
-    intro. The chunk timestamp must win, and its audio must be queued, not dropped.
+    is scheduled earlier than ``clock.now() + the bridge lead``. Anchoring to
+    ``now + lead`` would drop everything before it -- the intro. The chunk
+    timestamp must win, and its audio must reach the CLI, not be dropped.
     """
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    now_plus_wait_start = SENDSPIN_EPOCH_US + AP2_LEAD_MS * 1_000
+    now_plus_lead = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
     first_chunk_ts = SENDSPIN_EPOCH_US + 250_000  # position 0, only 250 ms ahead of now
-    assert first_chunk_ts < now_plus_wait_start
+    assert first_chunk_ts < now_plus_lead
 
     with patch.object(bridge, "_start_protocol_from_chunk", MagicMock()):
         bridge._on_audio_chunk(_pcm_chunk(first_chunk_ts))
 
     assert bridge._drop_until_us == first_chunk_ts
-    assert not bridge._write_queue.empty()  # opening audio queued, not discarded
+    # Held while the anchor is negotiated, then queued -- never discarded.
+    _settle_anchor(bridge)
+    assert not bridge._write_queue.empty()
 
 
 def test_late_join_anchors_to_catchup_target_live_position() -> None:
@@ -215,19 +237,19 @@ def test_late_join_anchors_to_catchup_target_live_position() -> None:
     A late joiner lands at the group's current position, not at track zero.
 
     After minutes of playback the first delivered chunk is the catch-up target
-    (playhead + wait_start), far from the track start. The anchor must follow that
+    (playhead + the bridge lead), far from the track start. The anchor must follow that
     chunk so the joiner maps onto the live timeline instead of restarting at 0.
     """
     playhead_us = SENDSPIN_EPOCH_US + 600_000_000  # 600 s into the session
     bridge = _make_bridge(clock_now_us=playhead_us)
-    catchup_target_ts = playhead_us + AP2_LEAD_MS * 1_000
+    catchup_target_ts = playhead_us + COLD_LEAD_MS * 1_000
 
     with patch.object(bridge, "_start_protocol_from_chunk", MagicMock()):
         bridge._on_audio_chunk(_pcm_chunk(catchup_target_ts))
 
     assert bridge._drop_until_us == catchup_target_ts
-    # The anchor tracks the advanced playhead, not a fresh now+wait_start-from-zero.
-    assert bridge._drop_until_us > SENDSPIN_EPOCH_US + AP2_LEAD_MS * 1_000
+    # The anchor tracks the advanced playhead, not a fresh now+lead-from-zero.
+    assert bridge._drop_until_us > SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
 
 
 # --- Timeline alignment: a discontinuity must not shift the device off the group clock ---
@@ -243,6 +265,16 @@ def _drain_queued_bytes(bridge: SendspinAirPlayBridge) -> int:
     return total
 
 
+def _settle_anchor(bridge: SendspinAirPlayBridge) -> None:
+    """Model the binary acking exactly the anchor asked for: replay what was held."""
+    bridge._anchor_settled = True
+    held = list(bridge._held_chunks)
+    bridge._held_chunks.clear()
+    bridge._held_us = 0
+    for chunk in held:
+        bridge._align_chunk(chunk)
+
+
 def _start_stream_at(bridge: SendspinAirPlayBridge, first_chunk_ts: int) -> None:
     """Feed the anchoring first chunk so the bridge is aligned and streaming."""
     with patch.object(bridge, "_start_protocol_from_chunk", MagicMock()):
@@ -250,6 +282,7 @@ def _start_stream_at(bridge: SendspinAirPlayBridge, first_chunk_ts: int) -> None
     # The mocked task reports done() truthy by default, which the chunk handler
     # reads as a failed protocol start; model a start still in flight instead.
     cast("MagicMock", bridge._airplay_stream_start_task).done.return_value = False
+    _settle_anchor(bridge)
 
 
 def _expected_frames(bridge: SendspinAirPlayBridge, timeline_end_us: int) -> int:
@@ -321,10 +354,12 @@ def test_stream_start_resets_the_write_cursor(server_side: bool) -> None:
 
     A cursor carried over from the previous stream would place the first chunk of
     the new one far behind the write position and get it trimmed away as already
-    written.
+    written, and a settled-anchor flag carried over would let the new stream's
+    chunks be placed against the previous stream's anchor.
     """
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     _start_stream_at(bridge, SENDSPIN_EPOCH_US + 250_000)
+    bridge._held_chunks.append(_pcm_chunk(SENDSPIN_EPOCH_US + 250_000))
     assert bridge._queued_frames > 0
 
     if server_side:
@@ -334,6 +369,8 @@ def test_stream_start_resets_the_write_cursor(server_side: bool) -> None:
 
     assert bridge._queued_frames == 0
     assert bridge._drop_until_us == 0
+    assert bridge._anchor_settled is False
+    assert not bridge._held_chunks
 
 
 def test_contiguous_chunks_are_written_untouched() -> None:
@@ -406,15 +443,38 @@ async def test_failed_cli_write_does_not_advance_pacing_cursor() -> None:
 # --- Commanded cold start and warm handover ------------------------------------
 
 
-async def test_cold_start_connects_then_anchors_first_start() -> None:
-    """A fresh bridge stream anchors its first START only after the CLI connects."""
-    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    bridge._drop_until_us = SENDSPIN_EPOCH_US + AP2_LEAD_MS * 1_000
-    bridge._airplay_stream_start_task = asyncio.current_task()
+def _make_anchor_stream(
+    *,
+    ready_at_unix_ms: int | None = None,
+    ack: int | None = None,
+    warm_lead_ms: int = 0,
+    flushed_head_unix_ms: int = 0,
+) -> MagicMock:
+    """
+    Build an AirPlayStream mock the anchor math can run against.
+
+    ``warm_lead_ms`` / ``flushed_head_unix_ms`` must be real ints: the anchor
+    compares them with ``> 0``, which a bare MagicMock cannot answer.
+    """
     stream = MagicMock()
     stream.connect = AsyncMock()
     stream.wait_for_connection = AsyncMock()
-    stream.start = AsyncMock(return_value=None)
+    stream.stop = AsyncMock()
+    stream.flush = AsyncMock(return_value=True)
+    stream.wait_clock_ready = AsyncMock(return_value=ready_at_unix_ms)
+    stream.start = AsyncMock(return_value=ack)
+    stream.warm_lead_ms = warm_lead_ms
+    stream.flushed_head_unix_ms = flushed_head_unix_ms
+    return stream
+
+
+async def test_cold_start_connects_then_anchors_first_start() -> None:
+    """A fresh bridge stream anchors its first START only after the CLI connects."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    commanded = UNIX_NOW_MS + COLD_LEAD_MS
+    stream = _make_anchor_stream(ack=commanded)
 
     with (
         patch(
@@ -430,7 +490,7 @@ async def test_cold_start_connects_then_anchors_first_start() -> None:
 
     stream.connect.assert_awaited_once_with()
     stream.wait_for_connection.assert_awaited_once_with()
-    stream.start.assert_awaited_once_with(int(UNIX_NOW_S * 1000) + AP2_LEAD_MS)
+    stream.start.assert_awaited_once_with(commanded, join=True)
     assert bridge._airplay_stream is stream
     assert bridge.airplay_player.stream is stream
     assert bridge._started is True
@@ -440,14 +500,10 @@ async def test_cold_start_connects_then_anchors_first_start() -> None:
 async def test_cold_start_superseded_before_start_stops_transport() -> None:
     """A cold bridge start that is superseded after connect stops its transport."""
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    bridge._drop_until_us = SENDSPIN_EPOCH_US + AP2_LEAD_MS * 1_000
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
     # a different task owns the bridge: this cold start is stale
     bridge._airplay_stream_start_task = MagicMock()
-    stream = MagicMock()
-    stream.connect = AsyncMock()
-    stream.stop = AsyncMock()
-    stream.wait_for_connection = AsyncMock()
-    stream.start = AsyncMock(return_value=None)
+    stream = _make_anchor_stream()
 
     with (
         patch(
@@ -463,6 +519,410 @@ async def test_cold_start_superseded_before_start_stops_transport() -> None:
 
     stream.start.assert_not_awaited()
     stream.stop.assert_awaited_once_with(force=True)
+
+
+async def test_cold_start_superseded_during_the_anchor_stops_its_transport() -> None:
+    """
+    A cold stream superseded while the binary holds its ack is torn down.
+
+    The anchor publishes the stream before commanding START, so a supersession
+    inside it would otherwise leave a live cliairplay attached to the receiver
+    with nobody owning it.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    stream = _make_anchor_stream()
+
+    async def start(start_unix_ms: int, **_kwargs: object) -> int:
+        # A newer stream start claimed the bridge while the binary held its ack.
+        bridge._airplay_stream_start_task = MagicMock()
+        return start_unix_ms
+
+    stream.start = AsyncMock(side_effect=start)
+
+    with patch(
+        "music_assistant.providers.airplay.sendspin_bridge.time.time",
+        return_value=UNIX_NOW_S,
+    ):
+        assert await bridge._start_cold_stream(stream) is False
+
+    stream.stop.assert_awaited_once_with(force=True)
+    assert bridge._airplay_stream is None
+    assert bridge.airplay_player.stream is None
+
+
+async def test_superseded_cold_stream_teardown_spares_the_newer_owner() -> None:
+    """A newer start's published stream survives the stale cold stream's teardown."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    stream = _make_anchor_stream()
+    newer_stream = _make_anchor_stream()
+
+    async def start(start_unix_ms: int, **_kwargs: object) -> int:
+        bridge._airplay_stream_start_task = MagicMock()
+        bridge._airplay_stream = newer_stream
+        bridge.airplay_player.stream = newer_stream
+        return start_unix_ms
+
+    stream.start = AsyncMock(side_effect=start)
+
+    with patch(
+        "music_assistant.providers.airplay.sendspin_bridge.time.time",
+        return_value=UNIX_NOW_S,
+    ):
+        assert await bridge._start_cold_stream(stream) is False
+
+    stream.stop.assert_awaited_once_with(force=True)
+    newer_stream.stop.assert_not_awaited()
+    assert bridge._airplay_stream is newer_stream
+    assert bridge.airplay_player.stream is newer_stream
+
+
+# --- Anchoring: command an instant the device can hit, then honour the ack ---
+
+
+def _prepare_anchor(
+    bridge: SendspinAirPlayBridge, stream: MagicMock, first_chunk_lead_ms: int
+) -> None:
+    """Wire a bridge so ``_anchor_stream`` can be awaited directly on ``stream``."""
+    bridge._drop_until_us = bridge.sendspin_server.clock.now_us() + first_chunk_lead_ms * 1_000
+    bridge._airplay_stream = stream
+    bridge._airplay_stream_start_task = asyncio.current_task()
+
+
+async def _anchor(bridge: SendspinAirPlayBridge, stream: MagicMock, *, warm: bool = False) -> bool:
+    """Run ``_anchor_stream`` with the unix clock pinned to UNIX_NOW_S."""
+    with patch(
+        "music_assistant.providers.airplay.sendspin_bridge.time.time",
+        return_value=UNIX_NOW_S,
+    ):
+        return await bridge._anchor_stream(stream, warm=warm)
+
+
+def _commanded_instant(stream: MagicMock) -> int:
+    """Return the instant the START command carried."""
+    return int(stream.start.await_args.args[0])
+
+
+async def test_anchor_floors_at_the_join_headroom() -> None:
+    """
+    A Sendspin lead shorter than the binary needs is raised to the join floor.
+
+    The binary verifies the receiver's clock before it will seat an anchor and
+    gives up on that verification shortly before the commanded instant, so an
+    anchor inside AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS leaves the device seating on
+    an unverified clock and landing audibly behind the group.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    stream = _make_anchor_stream()
+    _prepare_anchor(bridge, stream, first_chunk_lead_ms=250)
+
+    assert await _anchor(bridge, stream) is True
+
+    assert _commanded_instant(stream) == UNIX_NOW_MS + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS
+
+
+async def test_anchor_follows_the_clock_ready_projection() -> None:
+    """A receiver that projects a later readiness pushes the anchor out past it."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    ready_at = UNIX_NOW_MS + 3200
+    stream = _make_anchor_stream(ready_at_unix_ms=ready_at)
+    _prepare_anchor(bridge, stream, first_chunk_lead_ms=250)
+
+    assert await _anchor(bridge, stream) is True
+
+    assert _commanded_instant(stream) == ready_at + AIRPLAY_JOIN_CLOCK_READY_LEAD_MS
+
+
+async def test_anchor_never_precedes_content_already_scheduled() -> None:
+    """
+    A buffered source keeps its intro: the anchor lands on the first chunk we hold.
+
+    Sendspin can schedule the first sample much further out than the device
+    needs. Anchoring on the floor instead would place byte 0 in the middle of
+    the audio already delivered and throw away everything before it.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    first_chunk_us = SENDSPIN_EPOCH_US + 6_000_000
+    stream = _make_anchor_stream(ack=UNIX_NOW_MS + 6000)
+    _prepare_anchor(bridge, stream, first_chunk_lead_ms=6000)
+    bridge._held_chunks.append(_pcm_chunk(first_chunk_us))
+
+    assert await _anchor(bridge, stream) is True
+
+    assert _commanded_instant(stream) == UNIX_NOW_MS + 6000
+    # Nothing skipped, and the held opening reached the writer intact.
+    assert bridge._drop_until_us == first_chunk_us
+    assert _drain_queued_bytes(bridge) == 100_000 * BRIDGE_BYTES_PER_SECOND // 1_000_000
+
+
+async def test_writer_stays_blocked_until_the_start_is_acked() -> None:
+    """
+    The writer is released only once the content is mapped onto the acked instant.
+
+    Feeding the CLI before the ack would place bytes against an anchor the
+    binary has not confirmed and may still correct forward.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    stream = _make_anchor_stream()
+    _prepare_anchor(bridge, stream, first_chunk_lead_ms=250)
+    ack_gate = asyncio.Event()
+    start_called = asyncio.Event()
+
+    async def start(start_unix_ms: int, **_kwargs: object) -> int:
+        start_called.set()
+        await ack_gate.wait()
+        return start_unix_ms
+
+    stream.start = AsyncMock(side_effect=start)
+    anchor_task = asyncio.create_task(_anchor(bridge, stream))
+    bridge._airplay_stream_start_task = cast("asyncio.Task[None]", anchor_task)
+    await start_called.wait()
+
+    assert not bridge._airplay_stream_ready.is_set()
+    ack_gate.set()
+    assert await anchor_task is True
+    assert bridge._airplay_stream_ready.is_set()
+
+
+async def test_chunks_arriving_before_the_ack_are_held_and_replayed_in_order() -> None:
+    """Audio delivered while the anchor is outstanding is queued once, in order."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    stream = _make_anchor_stream()
+    _prepare_anchor(bridge, stream, first_chunk_lead_ms=2500)
+    first_chunk_us = SENDSPIN_EPOCH_US + 2_500_000
+    ack_gate = asyncio.Event()
+    start_called = asyncio.Event()
+
+    async def start(start_unix_ms: int, **_kwargs: object) -> int:
+        start_called.set()
+        await ack_gate.wait()
+        return start_unix_ms
+
+    stream.start = AsyncMock(side_effect=start)
+    anchor_task = asyncio.create_task(_anchor(bridge, stream))
+    bridge._airplay_stream_start_task = cast("asyncio.Task[None]", anchor_task)
+    await start_called.wait()
+
+    for index in range(4):
+        bridge._on_audio_chunk(_pcm_chunk(first_chunk_us + index * 100_000))
+    assert len(bridge._held_chunks) == 4
+    assert bridge._write_queue.empty()
+
+    ack_gate.set()
+    assert await anchor_task is True
+
+    # Four contiguous 100 ms chunks, replayed without padding or trimming.
+    assert bridge._queued_frames == _expected_frames(bridge, first_chunk_us + 400_000)
+    assert _drain_queued_bytes(bridge) == 4 * 100_000 * BRIDGE_BYTES_PER_SECOND // 1_000_000
+
+
+def test_held_backlog_is_capped_and_drops_the_oldest() -> None:
+    """An anchor that never settles cannot grow the hold without bound."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    chunk_us = 100_000
+    over_cap = MAX_HELD_AUDIO_US // chunk_us + 50
+
+    for index in range(over_cap):
+        bridge._hold_chunk(_pcm_chunk(SENDSPIN_EPOCH_US + index * chunk_us))
+
+    assert sum(chunk.duration_us for chunk in bridge._held_chunks) <= MAX_HELD_AUDIO_US
+    # The running total the cap is measured against tracks the deque exactly.
+    assert bridge._held_us == sum(chunk.duration_us for chunk in bridge._held_chunks)
+    # The oldest went, the newest stayed.
+    assert bridge._held_chunks[0].timestamp_us > SENDSPIN_EPOCH_US
+    assert bridge._held_chunks[-1].timestamp_us == SENDSPIN_EPOCH_US + (over_cap - 1) * chunk_us
+
+
+def test_held_backlog_is_capped_by_chunk_count() -> None:
+    """
+    A run of zero-duration chunks is bounded by the count cap.
+
+    Such chunks carry no duration at all, so the µs cap can never trip on them
+    however many arrive.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+
+    for index in range(MAX_HELD_CHUNKS + 50):
+        bridge._hold_chunk(_pcm_chunk(SENDSPIN_EPOCH_US + index, duration_us=0))
+
+    assert len(bridge._held_chunks) == MAX_HELD_CHUNKS
+    assert bridge._held_us == 0
+    assert bridge._held_chunks[-1].timestamp_us == SENDSPIN_EPOCH_US + MAX_HELD_CHUNKS + 49
+
+
+async def test_corrected_ack_rebases_the_content_onto_the_acked_instant() -> None:
+    """An instant the binary moved forward re-bases the anchor, cursor and pacing base."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    correction_ms = 3000
+    acked = UNIX_NOW_MS + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS + correction_ms
+    stream = _make_anchor_stream(ack=acked)
+    _prepare_anchor(bridge, stream, first_chunk_lead_ms=250)
+    bridge._queued_frames = 12_345
+
+    assert await _anchor(bridge, stream) is True
+
+    assert _commanded_instant(stream) == UNIX_NOW_MS + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS
+    assert bridge._drop_until_us == SENDSPIN_EPOCH_US + (acked - UNIX_NOW_MS) * 1_000
+    assert bridge._queued_frames == 0
+    assert bridge._start_unix_ms == acked
+
+
+async def test_content_before_the_acked_instant_is_dropped_and_trimmed() -> None:
+    """Held audio the acked anchor moved past is dropped, the straddling chunk trimmed."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    acked = UNIX_NOW_MS + 2600
+    stream = _make_anchor_stream(ack=acked)
+    _prepare_anchor(bridge, stream, first_chunk_lead_ms=250)
+    anchor_us = SENDSPIN_EPOCH_US + 2_600_000
+    for offset in (-200_000, -50_000, 50_000):
+        bridge._held_chunks.append(_pcm_chunk(anchor_us + offset))
+
+    assert await _anchor(bridge, stream) is True
+
+    # Fully-behind chunk gone, the straddling one keeps its 50 ms tail, and the
+    # last chunk continues contiguously: 150 ms of audio in total.
+    assert bridge._queued_frames == _expected_frames(bridge, anchor_us + 150_000)
+    assert _drain_queued_bytes(bridge) == bridge._queued_frames * BRIDGE_BYTES_PER_FRAME
+
+
+async def test_sync_adjust_shifts_the_command_but_not_the_content_mapping() -> None:
+    """The device's own offset rides on the command; the group timeline stays untouched."""
+    adjust_ms = 300
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US, sync_adjust=adjust_ms)
+    anchor_ms = UNIX_NOW_MS + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS
+    stream = _make_anchor_stream(ack=anchor_ms + adjust_ms)
+    _prepare_anchor(bridge, stream, first_chunk_lead_ms=250)
+
+    assert await _anchor(bridge, stream) is True
+
+    assert _commanded_instant(stream) == anchor_ms + adjust_ms
+    # Pacing tracks the real wall-clock instant of byte 0 (adjust included)...
+    assert bridge._start_unix_ms == anchor_ms + adjust_ms
+    # ...while the content is placed on the group timeline, without it.
+    assert bridge._drop_until_us == SENDSPIN_EPOCH_US + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS * 1_000
+
+
+async def test_ack_earlier_than_commanded_is_trusted_verbatim() -> None:
+    """
+    An acked instant before the commanded one is used as-is, never clamped up.
+
+    Clamping to the commanded instant would map the content onto a moment the
+    binary is not rendering at and put the device ahead of the rest of the group.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    acked = UNIX_NOW_MS + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS - 400
+    stream = _make_anchor_stream(ack=acked)
+    _prepare_anchor(bridge, stream, first_chunk_lead_ms=250)
+
+    assert await _anchor(bridge, stream) is True
+
+    assert _commanded_instant(stream) > acked
+    assert bridge._start_unix_ms == acked
+    assert bridge._drop_until_us == SENDSPIN_EPOCH_US + (acked - UNIX_NOW_MS) * 1_000
+
+
+def test_first_chunk_after_an_anchor_is_not_reported_as_drift() -> None:
+    """The gap between a fresh anchor and its first chunk is placement, not drift."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US
+    bridge._queued_frames = 0
+
+    bridge._align_chunk(_pcm_chunk(SENDSPIN_EPOCH_US + 900_000))
+
+    cast("MagicMock", bridge.logger).warning.assert_not_called()
+
+    # A cursor that already advanced can drift, and that is still reported.
+    bridge._align_chunk(_pcm_chunk(SENDSPIN_EPOCH_US + 2_000_000))
+
+    cast("MagicMock", bridge.logger).warning.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("warm_lead_ms", "flushed_head_offset_ms", "adjust_ms", "expected_anchor_offset_ms"),
+    [
+        (4000, 0, 0, 4000 + AIRPLAY_SPLICE_LEAD_MARGIN_MS),
+        (4000, 0, -600, 4600 + AIRPLAY_SPLICE_LEAD_MARGIN_MS),
+        (0, 5000, 0, 5000 + AIRPLAY_SPLICE_LEAD_MARGIN_MS),
+    ],
+)
+async def test_warm_anchor_clears_the_receivers_queued_audio(
+    warm_lead_ms: int,
+    flushed_head_offset_ms: int,
+    adjust_ms: int,
+    expected_anchor_offset_ms: int,
+) -> None:
+    """
+    A warm re-anchor lands beyond the audio the receiver still has queued.
+
+    A negative sync_adjust moves the commanded instant earlier and eats into that
+    lead, so it is added back to the requirement.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US, sync_adjust=adjust_ms)
+    stream = _make_anchor_stream(
+        warm_lead_ms=warm_lead_ms,
+        flushed_head_unix_ms=UNIX_NOW_MS + flushed_head_offset_ms if flushed_head_offset_ms else 0,
+    )
+    _prepare_anchor(bridge, stream, first_chunk_lead_ms=250)
+
+    assert await _anchor(bridge, stream, warm=True) is True
+
+    assert _commanded_instant(stream) == UNIX_NOW_MS + expected_anchor_offset_ms + adjust_ms
+
+
+async def test_missing_ack_falls_back_to_the_commanded_instant() -> None:
+    """An older binary that never acks must not wedge the writer."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    stream = _make_anchor_stream(ack=None)
+    _prepare_anchor(bridge, stream, first_chunk_lead_ms=250)
+
+    assert await _anchor(bridge, stream) is True
+
+    commanded = UNIX_NOW_MS + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS
+    assert bridge._start_unix_ms == commanded
+    assert bridge._drop_until_us == SENDSPIN_EPOCH_US + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS * 1_000
+    assert bridge._anchor_settled is True
+    assert bridge._airplay_stream_ready.is_set()
+
+
+async def test_superseded_during_the_ack_mutates_nothing() -> None:
+    """A newer stream start taking over while the ack is outstanding wins untouched."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    stream = _make_anchor_stream()
+    _prepare_anchor(bridge, stream, first_chunk_lead_ms=250)
+    original_drop_until = bridge._drop_until_us
+    bridge._held_chunks.append(_pcm_chunk(original_drop_until))
+
+    async def start(start_unix_ms: int, **_kwargs: object) -> int:
+        # A newer stream start claimed the bridge while the binary held its ack.
+        bridge._airplay_stream_start_task = MagicMock()
+        return start_unix_ms
+
+    stream.start = AsyncMock(side_effect=start)
+
+    assert await _anchor(bridge, stream) is False
+
+    assert bridge._drop_until_us == original_drop_until
+    assert bridge._start_unix_ms == 0
+    assert bridge._started is False
+    assert bridge._anchor_settled is False
+    assert len(bridge._held_chunks) == 1
+    assert not bridge._airplay_stream_ready.is_set()
+
+
+def test_unix_to_sendspin_instant_round_trips() -> None:
+    """The two clock-domain helpers are exact inverses of each other."""
+    clock = ManualClock(now_us_value=SENDSPIN_EPOCH_US)
+    for lead_ms in (-300, 0, WARM_LEAD_MS, COLD_LEAD_MS):
+        audible_us = _audible_instant_us(clock, lead_ms)
+        unix_ms = sendspin_audible_instant_to_unix_ms(audible_us, clock.now_us(), UNIX_NOW_S)
+
+        assert unix_ms == UNIX_NOW_MS + lead_ms
+        assert (
+            unix_ms_to_sendspin_audible_instant(unix_ms, clock.now_us(), UNIX_NOW_S) == audible_us
+        )
 
 
 # --- Warm handover: a kept stream survives a new stream start and rides flush-refill ---
@@ -495,7 +955,6 @@ def test_on_bridge_stream_start_keeps_raop_stream() -> None:
     """A started legacy RAOP stream is eligible for warm Sendspin flush-refill."""
     bridge = _make_bridge(
         clock_now_us=SENDSPIN_EPOCH_US,
-        wait_start_ms=RAOP_LEAD_MS,
         protocol=StreamingProtocol.RAOP,
     )
     old_stream = _make_kept_stream()
@@ -513,7 +972,6 @@ def test_sendspin_callbacks_keep_raop_stream_until_warm_handover() -> None:
     """Both Sendspin start callbacks preserve a reusable legacy RAOP session."""
     bridge = _make_bridge(
         clock_now_us=SENDSPIN_EPOCH_US,
-        wait_start_ms=RAOP_LEAD_MS,
         protocol=StreamingProtocol.RAOP,
     )
     kept_stream = _make_kept_stream()
@@ -558,18 +1016,22 @@ def test_on_stream_start_keeps_warm_eligible_stream() -> None:
 async def test_warm_stream_flushes_and_reanchors_on_kept_instance() -> None:
     """A warm handover flushes and re-anchors START on the same stream instance."""
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    kept_stream = MagicMock()
-    kept_stream.flush = AsyncMock(return_value=True)
-    kept_stream.start = AsyncMock(return_value=None)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + WARM_LEAD_MS * 1_000
+    commanded = UNIX_NOW_MS + WARM_LEAD_MS
+    kept_stream = _make_anchor_stream(ack=commanded)
     bridge._airplay_stream = kept_stream
     bridge._airplay_stream_start_task = asyncio.current_task()
 
-    committed = await bridge._start_warm_stream(kept_stream, 1_784_000_000_000)
+    with patch(
+        "music_assistant.providers.airplay.sendspin_bridge.time.time",
+        return_value=UNIX_NOW_S,
+    ):
+        committed = await bridge._start_warm_stream(kept_stream)
 
     assert committed is True
     assert bridge._airplay_stream is kept_stream  # no new instance was built
     kept_stream.flush.assert_awaited_once_with()
-    kept_stream.start.assert_awaited_once_with(1_784_000_000_000)
+    kept_stream.start.assert_awaited_once_with(commanded, join=True)
     assert bridge._started is True
     assert bridge._airplay_stream_ready.is_set()
 
@@ -577,13 +1039,12 @@ async def test_warm_stream_flushes_and_reanchors_on_kept_instance() -> None:
 async def test_warm_stream_flush_timeout_falls_back_to_cold() -> None:
     """A flush that is never acknowledged never re-anchors and falls back to cold."""
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    kept_stream = MagicMock()
+    kept_stream = _make_anchor_stream()
     kept_stream.flush = AsyncMock(return_value=False)
-    kept_stream.start = AsyncMock(return_value=None)
     bridge._airplay_stream = kept_stream
     bridge._airplay_stream_start_task = asyncio.current_task()
 
-    committed = await bridge._start_warm_stream(kept_stream, 1_784_000_000_000)
+    committed = await bridge._start_warm_stream(kept_stream)
 
     assert committed is False
     kept_stream.start.assert_not_awaited()
@@ -593,14 +1054,12 @@ async def test_warm_stream_flush_timeout_falls_back_to_cold() -> None:
 async def test_warm_stream_superseded_before_start_does_not_anchor() -> None:
     """If a newer stream start already owns the bridge, the stale flush never re-anchors."""
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    kept_stream = MagicMock()
-    kept_stream.flush = AsyncMock(return_value=True)
-    kept_stream.start = AsyncMock(return_value=None)
+    kept_stream = _make_anchor_stream()
     bridge._airplay_stream = kept_stream
     # Simulate a newer stream start having already replaced the tracked task.
     bridge._airplay_stream_start_task = MagicMock()
 
-    committed = await bridge._start_warm_stream(kept_stream, 1_784_000_000_000)
+    committed = await bridge._start_warm_stream(kept_stream)
 
     assert committed is False
     kept_stream.start.assert_not_awaited()
@@ -609,7 +1068,7 @@ async def test_warm_stream_superseded_before_start_does_not_anchor() -> None:
 async def test_warm_stream_cancellation_propagates() -> None:
     """Cancellation while flushing propagates without re-anchoring."""
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    kept_stream = MagicMock()
+    kept_stream = _make_anchor_stream()
     flush_waiting = asyncio.Event()
 
     async def flush(*_args: object, **_kwargs: object) -> bool:
@@ -619,13 +1078,165 @@ async def test_warm_stream_cancellation_propagates() -> None:
         return True
 
     kept_stream.flush = AsyncMock(side_effect=flush)
-    kept_stream.start = AsyncMock(return_value=None)
     bridge._airplay_stream = kept_stream
 
-    warm_task = asyncio.create_task(bridge._start_warm_stream(kept_stream, 1_784_000_000_000))
+    warm_task = asyncio.create_task(bridge._start_warm_stream(kept_stream))
     await flush_waiting.wait()
     warm_task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await warm_task
 
     kept_stream.start.assert_not_awaited()
+
+
+async def test_warm_handover_superseded_during_the_anchor_keeps_the_stream() -> None:
+    """
+    A superseded warm handover leaves the kept stream to the newer start.
+
+    The anchor reports the same False for "superseded" as for a genuine failure,
+    so without an ownership re-check the stale task would stop the very transport
+    the newer start decided to keep and put a second cliairplay on the receiver.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + WARM_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    kept_stream = _make_anchor_stream()
+    bridge._airplay_stream = kept_stream
+    bridge.airplay_player.stream = kept_stream
+    cold_stream = _make_anchor_stream()
+
+    async def start(start_unix_ms: int, **_kwargs: object) -> int:
+        # A newer stream start claimed the bridge while the binary held its ack.
+        bridge._airplay_stream_start_task = MagicMock()
+        return start_unix_ms
+
+    kept_stream.start = AsyncMock(side_effect=start)
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=cold_stream,
+        ),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.time",
+            return_value=UNIX_NOW_S,
+        ),
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    kept_stream.stop.assert_not_awaited()
+    cold_stream.connect.assert_not_awaited()
+    assert bridge._airplay_stream is kept_stream
+    assert bridge.airplay_player.stream is kept_stream
+
+
+async def test_superseded_start_failure_leaves_the_newer_stream_alone() -> None:
+    """
+    A stale start that fails must not take the newer stream's state with it.
+
+    The receiver is busy precisely because the newer start just claimed it, so a
+    superseded cold connect failing is the ordinary outcome. Running the recovery
+    would drop the newer stream's held backlog, release its writer before its own
+    anchor is settled and schedule its teardown.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    bridge._hold_chunk(_pcm_chunk(SENDSPIN_EPOCH_US))
+    newer_stream = _make_anchor_stream()
+    stale_stream = _make_anchor_stream()
+
+    async def connect() -> None:
+        # The newer start won the receiver, so this one cannot have it.
+        bridge._airplay_stream_start_task = MagicMock()
+        bridge._airplay_stream = newer_stream
+        bridge.airplay_player.stream = newer_stream
+        raise OSError("device busy")
+
+    stale_stream.connect = AsyncMock(side_effect=connect)
+
+    with patch(
+        "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+        return_value=stale_stream,
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    assert bridge._is_streaming is True
+    assert len(bridge._held_chunks) == 1
+    assert not bridge._airplay_stream_ready.is_set()
+    assert bridge._airplay_stream is newer_stream
+    newer_stream.stop.assert_not_awaited()
+    # No teardown was scheduled for the newer stream's resources.
+    cast("MagicMock", bridge.mass).create_task.assert_not_called()
+
+
+# --- Startup lead: how far ahead Sendspin schedules the first chunk ---
+
+
+def _make_timed_bridge() -> tuple[SendspinAirPlayBridge, MagicMock]:
+    """Return a bridge with a mocked bridge role attached, plus that role."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    role = MagicMock()
+    bridge._bridge_role = role
+    return bridge, role
+
+
+def test_bridge_timing_reports_the_cold_lead_without_a_warm_stream() -> None:
+    """Without a reusable stream the lead has to cover a full process spawn and connect."""
+    bridge, role = _make_timed_bridge()
+
+    bridge._refresh_bridge_timing()
+
+    role.set_timing.assert_called_once_with(
+        required_lead_time_ms=BRIDGE_COLD_START_LEAD_MS, min_buffer_ms=0
+    )
+
+
+def test_bridge_timing_reports_the_warm_lead_for_a_reusable_stream() -> None:
+    """A kept, connected, already-anchored stream pays no connect, so it needs less lead."""
+    bridge, role = _make_timed_bridge()
+    bridge._airplay_stream = _make_kept_stream()
+    bridge._started = True
+
+    bridge._refresh_bridge_timing()
+
+    role.set_timing.assert_called_once_with(
+        required_lead_time_ms=BRIDGE_WARM_START_LEAD_MS, min_buffer_ms=0
+    )
+
+
+def test_bridge_timing_is_a_noop_without_a_bridge_role() -> None:
+    """Timing can be refreshed before registration completes, with nothing to push it to."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    assert bridge._bridge_role is None
+
+    bridge._refresh_bridge_timing()
+
+
+def test_stream_start_reads_the_lead_before_rewinding_the_stream_state() -> None:
+    """
+    The warm/cold decision is taken while the previous stream's state is intact.
+
+    ``_on_stream_start`` rewinds the per-stream state; reading the timing after
+    that rewind would report the cold lead for every start, including the warm
+    handovers that need none of that budget.
+    """
+    bridge, role = _make_timed_bridge()
+    kept_stream = _make_kept_stream()
+    bridge._airplay_stream = kept_stream
+    bridge.airplay_player.stream = kept_stream
+    bridge._started = True
+    observed: list[tuple[bool, object]] = []
+    refresh = bridge._refresh_bridge_timing
+
+    def record() -> None:
+        observed.append((bridge._started, bridge._airplay_stream))
+        refresh()
+
+    with patch.object(bridge, "_refresh_bridge_timing", record):
+        bridge._on_stream_start(MagicMock())
+
+    assert observed == [(True, kept_stream)]
+    role.set_timing.assert_called_once_with(
+        required_lead_time_ms=BRIDGE_WARM_START_LEAD_MS, min_buffer_ms=0
+    )

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -41,6 +41,7 @@ from music_assistant.providers.airplay.constants import (
 )
 from music_assistant.providers.airplay.sendspin_bridge import (
     BRIDGE_COLD_START_LEAD_MS,
+    BRIDGE_MIN_BUFFER_MS,
     BRIDGE_WARM_START_LEAD_MS,
     MAX_DEVICE_BUFFER_SECONDS,
     MAX_HELD_AUDIO_US,
@@ -1188,7 +1189,7 @@ def test_bridge_timing_reports_the_cold_lead_without_a_warm_stream() -> None:
     bridge._refresh_bridge_timing()
 
     role.set_timing.assert_called_once_with(
-        required_lead_time_ms=BRIDGE_COLD_START_LEAD_MS, min_buffer_ms=0
+        required_lead_time_ms=BRIDGE_COLD_START_LEAD_MS, min_buffer_ms=BRIDGE_MIN_BUFFER_MS
     )
 
 
@@ -1201,7 +1202,7 @@ def test_bridge_timing_reports_the_warm_lead_for_a_reusable_stream() -> None:
     bridge._refresh_bridge_timing()
 
     role.set_timing.assert_called_once_with(
-        required_lead_time_ms=BRIDGE_WARM_START_LEAD_MS, min_buffer_ms=0
+        required_lead_time_ms=BRIDGE_WARM_START_LEAD_MS, min_buffer_ms=BRIDGE_MIN_BUFFER_MS
     )
 
 
@@ -1238,5 +1239,5 @@ def test_stream_start_reads_the_lead_before_rewinding_the_stream_state() -> None
 
     assert observed == [(True, kept_stream)]
     role.set_timing.assert_called_once_with(
-        required_lead_time_ms=BRIDGE_WARM_START_LEAD_MS, min_buffer_ms=0
+        required_lead_time_ms=BRIDGE_WARM_START_LEAD_MS, min_buffer_ms=BRIDGE_MIN_BUFFER_MS
     )

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -111,8 +111,7 @@ async def test_initial_client_failure_stops_started_clients() -> None:
     """A partial group startup failure cancels siblings before session teardown."""
     session = _make_session(time.time(), 0)
     first_player: Any = session.sync_clients[0]
-    first_player.wait_start = 0
-    second_player = MagicMock(wait_start=0)
+    second_player = MagicMock()
     session.sync_clients.append(second_player)
     first_started = asyncio.Event()
     first_cancelled = asyncio.Event()
@@ -165,9 +164,8 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
     first_player: Any = session.sync_clients[0]
     first_player.player_id = "first"
     first_player.protocol = first_protocol
-    first_player.wait_start = 2500
     first_player.config.get_value = MagicMock(return_value=0)
-    second_player = MagicMock(player_id="second", wait_start=2500)
+    second_player = MagicMock(player_id="second")
     second_player.protocol = second_protocol
     second_player.config.get_value = MagicMock(return_value=0)
     session.sync_clients.append(second_player)
@@ -218,7 +216,6 @@ async def test_initial_single_player_starts_after_connect(
     player: Any = session.sync_clients[0]
     player.player_id = "solo"
     player.protocol = protocol
-    player.wait_start = 2500
     player.config.get_value = MagicMock(return_value=0)
     stream = _stream_defaults(MagicMock(running=True))
     stream.wait_for_connection = AsyncMock()
@@ -247,8 +244,7 @@ async def test_initial_connection_failure_never_starts_partial_group() -> None:
     session = _make_session(0, 0)
     first_player: Any = session.sync_clients[0]
     first_player.protocol = StreamingProtocol.RAOP
-    first_player.wait_start = 2500
-    second_player = MagicMock(player_id="second", wait_start=2500)
+    second_player = MagicMock(player_id="second")
     second_player.protocol = StreamingProtocol.RAOP
     session.sync_clients.append(second_player)
 
@@ -282,7 +278,6 @@ async def test_initial_connection_cancellation_never_starts_group() -> None:
     player: Any = session.sync_clients[0]
     player.player_id = "solo"
     player.protocol = StreamingProtocol.RAOP
-    player.wait_start = 2500
     connection_waiting = asyncio.Event()
     stream = _stream_defaults(MagicMock(running=True))
 


### PR DESCRIPTION
# What does this implement/fix?

Grouping an AirPlay speaker with a Sendspin player (an ESPHome Voice PE, for
example) could leave the AirPlay speaker playing several seconds behind the
rest of the group for the whole session, with no way to recover other than
stopping and starting again.

When Sendspin drives an AirPlay speaker, the speaker is anchored at an exact
instant. If that instant turns out to be too soon, cliairplay picks the
earliest one it can honour and reports it back — but we kept using the instant
we originally asked for, so the speaker played late by exactly that difference
and nothing ever corrected it. Logs from an affected setup show corrections of
3.7 to 5.8 seconds being reported and ignored.

The start is now anchored the same way a late joiner already is: the speaker is
anchored before any audio is fed, and the audio is mapped onto the instant the
speaker acknowledged rather than the one it was asked for. Audio the speaker
can no longer reach is skipped so it lands with the group instead of behind it.

Separately, we asked Sendspin for the time we need using a field it treats as a
hint and may ignore on live sources such as radio, leaving the speaker supplied
with only whatever another group member happened to ask for. The buffer the
bridge needs is now declared as well.

**Related issue (if applicable):**

- n/a

- Anchor a bridged start as a join and map the audio onto the acknowledged
  instant instead of the requested one
- Hold arriving audio until the anchor is settled rather than placing it
  against a target that is about to move
- Clear the receiver's queued audio when re-anchoring a kept connection, so
  track changes land on the commanded instant too
- Own the startup lead in the bridge, split by cold and warm start, and drop
  the now-unused player setup lead
- Declare the buffer the bridge needs for the whole stream, so a live source
  keeps it supplied
- Warn when audio has to be skipped to stay in sync, naming how much lead was
  available and how much was needed

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.