### PR TITLE
Fix a group start recording an instant it never used

### DIFF
--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -483,6 +483,17 @@ class AirPlayStream:
         try:
             await asyncio.wait_for(self._started.wait(), ack_timeout)
         except TimeoutError:
+            # An older binary and a binary that failed the start look identical
+            # from here, and the caller treats both as "the commanded instant
+            # stands". Say so: on a current binary this line is the only sign
+            # that the content was mapped onto an instant nothing confirmed.
+            self.player.logger.warning(
+                "AirPlay player %s did not acknowledge its start within %.1fs; "
+                "assuming the commanded instant %d was applied",
+                self.player.display_name,
+                ack_timeout,
+                start_unix_ms,
+            )
             return None
         return self._start_ack[1] if self._start_ack else None
 

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -911,6 +911,7 @@ class AirPlayStreamSession:
         :param reanchor_session: Whether this start becomes the session timeline anchor.
         """
         target_ms = start_unix_ms
+        corrected_ms = start_unix_ms
         for _ in range(4):
             member_tasks: list[tuple[int, asyncio.Task[int | None]]] = []
             async with asyncio.TaskGroup() as task_group:
@@ -948,9 +949,14 @@ class AirPlayStreamSession:
             # retry out to every member so the next round lands.
             target_ms = corrected_ms + AIRPLAY_SPLICE_LEAD_MARGIN_MS
         else:
+            # No round landed, so the members sit on the instants they last
+            # reported, not on the retry that was about to be commanded. The
+            # anchor has to record where they actually are, or every later
+            # joiner maps against a timeline the group never played.
+            target_ms = corrected_ms
             self.prov.logger.error(
                 "AirPlay group start did not converge after 4 rounds "
-                "(last instant %d) - members may be audibly out of sync; "
+                "(members last reported %d) - they may be audibly out of sync; "
                 "please report this with a debug log",
                 target_ms,
             )

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -206,6 +206,31 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
 
 
 @pytest.mark.asyncio
+async def test_group_start_that_never_converges_anchors_where_members_landed() -> None:
+    """A group that keeps correcting is anchored at the members' own last instant."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.config.get_value = MagicMock(return_value=0)
+    stream = _stream_defaults(MagicMock(running=True))
+    commanded: list[int] = []
+
+    async def start(start_unix_ms: int, _position_ms: int) -> int:
+        # Correct every round, so the loop exhausts without ever converging.
+        commanded.append(start_unix_ms)
+        return start_unix_ms + 100
+
+    stream.start = AsyncMock(side_effect=start)
+    player.stream = stream
+
+    await session._start_members(0, 100_000)
+
+    # The retry after the final round is never commanded, so it must not become
+    # the session anchor: that would map every later joiner behind the group.
+    assert session.start_unix_ms == commanded[-1] + 100
+    assert session.start_unix_ms not in commanded
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "protocol",
     [StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2],


### PR DESCRIPTION
# What does this implement/fix?

Two separate problems on the group start path, both found while reviewing the
last few days of AirPlay timing work.

A group start where a speaker keeps asking for a later instant gives up after
four rounds. It then recorded the instant it was *about to try next*, not the
one the speakers had actually reported — leaving the session half a frame's
worth ahead of where the group really plays, and putting every speaker that
joined later slightly behind it. The support log named that same never-used
instant, which made the failure hard to read.

Separately, a start that was never acknowledged returned quietly. The caller
treats that as "the instant we asked for was applied", which is correct for an
older binary but indistinguishable from a speaker that failed to start — so
audio could be lined up against an instant nothing ever confirmed, with nothing
in the log to say so.

- Record the instant the members last reported when a group start does not
  converge, and name that instant in the error
- Warn when a speaker does not acknowledge its start, naming the instant that
  is being assumed instead
- Cover the non-converging group start, which had no test

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
