### PR TITLE
Keep speakers playing when a group switches output

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -2101,6 +2101,152 @@ class ProtocolLinkingMixin:
         )
         return True
 
+    def _translate_native_members_to_protocol(
+        self, parent_player: Player, protocol_domain: str, member_ids: list[str]
+    ) -> list[str]:
+        """
+        Translate natively grouped members onto the protocol domain the parent plays through.
+
+        Members that do not have that protocol cannot follow the parent at all and are
+        dropped with a warning instead.
+
+        :param parent_player: The parent player the members are grouped with.
+        :param protocol_domain: The protocol domain selected for the group.
+        :param member_ids: The member IDs that were selected for native grouping.
+        """
+        translated: list[str] = []
+        for member_id in member_ids:
+            member_player = self.get_player(member_id)
+            if not member_player:
+                continue
+            # a native group's members may be listed by their protocol player id
+            if member_player.protocol_parent_id:
+                member_player = self.get_player(member_player.protocol_parent_id) or member_player
+            member_protocol = member_player.get_output_protocol_by_domain(protocol_domain)
+            if not member_protocol or not member_protocol.available:
+                self.logger.warning(
+                    "Cannot group %s with %s: the group plays through the %s protocol, "
+                    "which %s does not support",
+                    member_player.state.name,
+                    parent_player.state.name,
+                    protocol_domain,
+                    member_player.state.name,
+                )
+                continue
+            # For native protocol players, use the member's player_id directly
+            translated.append(
+                member_player.player_id
+                if member_protocol.is_native
+                else member_protocol.output_protocol_id
+            )
+            self.logger.log(
+                VERBOSE_LOG_LEVEL,
+                "Moving %s from native grouping to the %s protocol",
+                member_player.state.name,
+                protocol_domain,
+            )
+        return translated
+
+    def _move_native_members_to_group_protocol(
+        self,
+        parent_player: Player,
+        parent_protocol_player: Player | None,
+        parent_protocol_domain: str | None,
+        protocol_members: list[str],
+        native_members: list[str],
+    ) -> None:
+        """
+        Move the members selected for native grouping onto the protocol the group ended up on.
+
+        Does nothing unless the group ends up on one of the parent's protocols while the
+        parent's native grouping needs the parent's own stream: only then do those members
+        have no session left to attach to.
+
+        :param parent_player: The parent player being joined.
+        :param parent_protocol_player: The protocol player selected for the group, if any.
+        :param parent_protocol_domain: The protocol domain selected for the group, if any.
+        :param protocol_members: The protocol member list the translated IDs are added to.
+        :param native_members: The native member IDs, emptied when they are moved over.
+        """
+        if not (
+            native_members
+            and parent_protocol_domain
+            and parent_protocol_player
+            and parent_protocol_player.player_id != parent_player.player_id
+            and parent_player.native_grouping_requires_own_stream
+        ):
+            return
+        protocol_members.extend(
+            self._translate_native_members_to_protocol(
+                parent_player, parent_protocol_domain, native_members
+            )
+        )
+        native_members.clear()
+
+    def _migrate_stranded_native_members(
+        self,
+        parent_player: Player,
+        parent_protocol_player: Player,
+        protocol_members: list[str],
+    ) -> list[str]:
+        """
+        Move the native members that a switch to the given protocol strands onto that protocol.
+
+        Returns the member IDs that are still attached to the parent's own stream, so the
+        caller can release them from it. Empty unless the parent renders that stream itself
+        while its native grouping attaches the members to exactly that stream: only then are
+        they left without anything to play.
+
+        :param parent_player: The parent player that is about to switch protocol.
+        :param parent_protocol_player: The protocol player the parent will render through.
+        :param protocol_members: The protocol member list the translated IDs are added to.
+        """
+        if parent_protocol_player.player_id == parent_player.player_id:
+            return []
+        if not parent_player.native_grouping_requires_own_stream:
+            return []
+        if parent_player.active_output_protocol not in (None, "native"):
+            return []
+        if parent_player.state.playback_state not in (PlaybackState.PLAYING, PlaybackState.PAUSED):
+            return []
+        stranded = [
+            member_id
+            for member_id in parent_player.group_members
+            if member_id != parent_player.player_id
+        ]
+        for protocol_id in self._translate_native_members_to_protocol(
+            parent_player, parent_protocol_player.provider.domain, stranded
+        ):
+            if protocol_id not in protocol_members:
+                protocol_members.append(protocol_id)
+        return stranded
+
+    async def _stop_native_session(
+        self,
+        parent_player: Player,
+        parent_protocol_player: Player,
+        stranded_native_members: list[str],
+    ) -> None:
+        """
+        Release the given members from the parent's own stream and stop it.
+
+        :param parent_player: The parent player whose native session is handed over.
+        :param parent_protocol_player: The protocol player taking the output over.
+        :param stranded_native_members: The members to release, already migrated.
+        """
+        self.logger.debug(
+            "Stopping the native session of %s before switching to %s, migrated members: %s",
+            parent_player.state.name,
+            parent_protocol_player.state.name,
+            stranded_native_members,
+        )
+        # The members already joined the protocol group, so the native session only has to
+        # release them and stop. Releasing them first also clears the native group, which
+        # keeps a later native playback command from resurrecting it. Both calls take the
+        # provider's own lock, so they must run one after the other.
+        await parent_player.set_members(player_ids_to_remove=stranded_native_members)
+        await parent_player.stop()
+
     def _translate_members_for_protocols(
         self,
         parent_player: Player,
@@ -2277,6 +2423,16 @@ class ProtocolLinkingMixin:
                 parent_player.state.name,
             )
 
+        # Post-pass: the protocol selected for the group is only known once every child has
+        # been processed, so the members picked for native grouping are corrected here.
+        self._move_native_members_to_group_protocol(
+            parent_player,
+            parent_protocol_player,
+            parent_protocol_domain,
+            protocol_members,
+            native_members,
+        )
+
         return protocol_members, native_members, parent_protocol_player, parent_protocol_domain
 
     async def _forward_protocol_set_members(
@@ -2319,6 +2475,17 @@ class ProtocolLinkingMixin:
             )
             return
 
+        # Members that ride the parent's own stream are stranded by the protocol switch below,
+        # so they join the protocol group in this very same call and their native session is
+        # torn down afterwards.
+        stranded_native_members = (
+            self._migrate_stranded_native_members(
+                parent_player, parent_protocol_player, filtered_protocol_add
+            )
+            if filtered_protocol_add
+            else []
+        )
+
         self.logger.debug(
             "Calling set_members on protocol player %s with add=%s, remove=%s",
             parent_protocol_player.state.name,
@@ -2349,6 +2516,12 @@ class ProtocolLinkingMixin:
         if filtered_protocol_add:
             previous_protocol = parent_player.active_output_protocol
             was_playing = parent_player.state.playback_state == PlaybackState.PLAYING
+            # A paused player still holds its output, so the handover has to run for it
+            # too - only the resume at the end is reserved for a player that was playing,
+            # so adding a member does not start playback on its own.
+            was_rendering = was_playing or parent_player.state.playback_state == (
+                PlaybackState.PAUSED
+            )
 
             # Determine if we're switching protocols (which requires restart)
             # Native protocol: parent_protocol_player is the same as parent_player
@@ -2363,25 +2536,29 @@ class ProtocolLinkingMixin:
 
             self.logger.debug(
                 "Protocol grouping: is_native=%s, already_native=%s, already_this=%s, "
-                "switching=%s, was_playing=%s",
+                "switching=%s, was_rendering=%s",
                 is_native_protocol,
                 already_using_native,
                 already_using_this_protocol,
                 switching_protocols,
-                was_playing,
+                was_rendering,
             )
 
             # Update active output protocol if not already using native
             if not (is_native_protocol and already_using_native):
                 parent_player.set_active_output_protocol(parent_protocol_player.player_id)
 
-            # Restart playback only if we're switching protocols
-            if was_playing and switching_protocols:
+            # Hand the output over only if we're switching protocols
+            if was_rendering and switching_protocols:
                 self.logger.info(
                     "Restarting playback on %s via %s protocol after switching protocols",
                     parent_player.state.name,
                     parent_protocol_player.provider.domain,
                 )
+                if stranded_native_members:
+                    await self._stop_native_session(
+                        parent_player, parent_protocol_player, stranded_native_members
+                    )
                 # Collect existing members from old protocol before stopping it,
                 # so we can re-add them to the new protocol after restart.
                 old_protocol_members: list[str] = []
@@ -2417,7 +2594,8 @@ class ProtocolLinkingMixin:
                 else:
                     old_parent_members = []
                 # Resume playback on the new protocol and re-add migrated members.
-                await self.mass.players.cmd_resume(parent_player.player_id)
+                if was_playing:
+                    await self.mass.players.cmd_resume(parent_player.player_id)
                 if old_parent_members:
                     self.logger.debug(
                         "Re-adding migrated members %s to %s on new protocol",

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -2551,16 +2551,17 @@ class ProtocolLinkingMixin:
             # Hand the output over only if we're switching protocols
             if was_rendering and switching_protocols:
                 self.logger.info(
-                    "Restarting playback on %s via %s protocol after switching protocols",
+                    "Handing the output of %s over to the %s protocol%s",
                     parent_player.state.name,
                     parent_protocol_player.provider.domain,
+                    " and resuming playback" if was_playing else "",
                 )
                 if stranded_native_members:
                     await self._stop_native_session(
                         parent_player, parent_protocol_player, stranded_native_members
                     )
                 # Collect existing members from old protocol before stopping it,
-                # so we can re-add them to the new protocol after restart.
+                # so we can re-add them to the new protocol afterwards.
                 old_protocol_members: list[str] = []
                 if (
                     previous_protocol

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -613,6 +613,18 @@ class Player(ABC):
         return self._attr_can_group_with
 
     @property
+    def native_grouping_requires_own_stream(self) -> bool:
+        """
+        Return whether native grouping only works while this player renders its own stream.
+
+        Device-side grouping keeps working whatever feeds the leader, so members can
+        stay natively grouped while the leader streams over another protocol.
+        Grouping that attaches members to the leader's own stream has nothing for
+        them to join once the leader moves to a protocol.
+        """
+        return False
+
+    @property
     def is_active_session(self) -> bool:
         """
         Return whether this group player is currently holding (capturing) its members.

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -269,6 +269,11 @@ class AirPlayPlayer(Player):
             p.player_id for p in prov.get_players() if p.available and p.player_id != self.player_id
         }
 
+    @property
+    def native_grouping_requires_own_stream(self) -> bool:
+        """Return True: members are attached to this player's own stream session."""
+        return True
+
     async def get_config_entries(self) -> list[ConfigEntry]:
         """Return all (provider/player specific) Config Entries for the given player (if any)."""
         # Pairing/credentials are no longer config entries: they are collected by the
@@ -589,6 +594,15 @@ class AirPlayPlayer(Player):
                     # (e.g. after a dynamic leader switch where the stream continues)
                     if child_player_to_add not in stream_session.sync_clients:
                         await stream_session.add_client(child_player_to_add)
+                elif self.active_output_protocol not in (None, "native"):
+                    # Members can only be attached to this player's own stream session, which
+                    # does not exist while it renders through one of its output protocols.
+                    self.logger.warning(
+                        "%s joined the group of %s while that player renders through another "
+                        "output protocol: there is no stream session to join, so it stays silent",
+                        child_player_to_add.display_name if child_player_to_add else player_id,
+                        self.display_name,
+                    )
 
             # Ensure group leader includes itself in group_members when it has members
             # This is required for the synced_to property to work correctly

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -77,6 +77,8 @@ class MockProvider:
         self.manifest.name = f"Mock {domain} Provider"
         self.mass = mass or MagicMock()
         self.logger = logging.getLogger(f"test.{domain}")
+        # the controller iterates these when a group related field changes
+        self.players: list[Player] = []
 
 
 class MockPlayer(Player):
@@ -146,6 +148,15 @@ class MockPlayer(Player):
 
         # Clear cache to reflect changes
         self._cache.clear()
+
+
+class SessionBoundMockPlayer(MockPlayer):
+    """Mock player whose native grouping attaches members to its own stream (e.g. AirPlay)."""
+
+    @property
+    def native_grouping_requires_own_stream(self) -> bool:
+        """Return True: native members ride this player's own stream session."""
+        return True
 
 
 @pytest.fixture
@@ -2110,6 +2121,174 @@ class TestJoinActiveNativeSession:
         assert protocol_domain == "airplay"
 
 
+class TestSessionBoundNativeGrouping:
+    """
+    Grouping a parent whose native grouping only works while it renders its own stream.
+
+    Such native members are attached to that very stream, so they cannot stay natively
+    grouped once the group is moved onto one of the parent's output protocols. Parents
+    with device-side native grouping are unaffected and keep their hybrid groups.
+    """
+
+    @staticmethod
+    def _link_bridge(player: MockPlayer, bridge_id: str) -> None:
+        """Link a bridge protocol player to a native player."""
+        player.set_linked_output_protocols(
+            [
+                OutputProtocol(
+                    output_protocol_id=bridge_id,
+                    name="Bridge",
+                    protocol_domain="sendspin",
+                    priority=40,
+                    available=True,
+                )
+            ]
+        )
+
+    def _build_topology(
+        self,
+        mock_mass: MagicMock,
+        parent_class: type[MockPlayer],
+        with_orphan: bool = False,
+    ) -> tuple[PlayerController, dict[str, MockPlayer]]:
+        """
+        Build a leader with a natively groupable member and a bridge-only member.
+
+        The leader and its member speak the same (speaker) provider, so they group natively.
+        Both also expose a bridge protocol player, which is the only way to reach the third
+        member: a native player of the bridge domain.
+
+        :param mock_mass: The mocked MusicAssistant instance.
+        :param parent_class: The player class to build the leader from.
+        :param with_orphan: Add a second natively groupable member without a bridge protocol.
+        """
+        controller = PlayerController(mock_mass)
+        speaker_provider = MockProvider("speaker", instance_id="speaker_instance", mass=mock_mass)
+        bridge_provider = MockProvider("sendspin", instance_id="sendspin_instance", mass=mock_mass)
+
+        leader = parent_class(speaker_provider, "speaker_leader", "Living Room")
+        leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+        leader._cache.clear()
+
+        member = MockPlayer(speaker_provider, "speaker_member", "Kitchen")
+        member._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+        member._cache.clear()
+
+        bridge_leader = MockPlayer(
+            bridge_provider,
+            "bridge_leader",
+            "Living Room (Bridge)",
+            player_type=PlayerType.PROTOCOL,
+        )
+        bridge_leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        bridge_leader._cache.clear()
+        bridge_leader.set_protocol_parent_id("speaker_leader")
+
+        bridge_member = MockPlayer(
+            bridge_provider,
+            "bridge_member",
+            "Kitchen (Bridge)",
+            player_type=PlayerType.PROTOCOL,
+        )
+        bridge_member._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        bridge_member._cache.clear()
+        bridge_member.set_protocol_parent_id("speaker_member")
+
+        # native player of the bridge domain: only reachable through the bridge protocol
+        bridge_only = MockPlayer(bridge_provider, "bridge_only", "Voice Assistant")
+        bridge_only._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+        bridge_only._cache.clear()
+
+        self._link_bridge(leader, "bridge_leader")
+        self._link_bridge(member, "bridge_member")
+
+        players: dict[str, MockPlayer] = {
+            "speaker_leader": leader,
+            "speaker_member": member,
+            "bridge_leader": bridge_leader,
+            "bridge_member": bridge_member,
+            "bridge_only": bridge_only,
+        }
+        if with_orphan:
+            orphan = MockPlayer(speaker_provider, "speaker_orphan", "Bedroom")
+            orphan._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+            orphan._cache.clear()
+            players["speaker_orphan"] = orphan
+
+        mock_mass.players = controller
+        controller._players = dict(players)
+        for player in players.values():
+            player.update_state(signal_event=False)
+        return controller, players
+
+    @pytest.mark.parametrize(
+        "member_order",
+        [
+            ["speaker_member", "bridge_only"],
+            ["bridge_only", "speaker_member"],
+        ],
+    )
+    def test_native_members_follow_the_group_protocol(
+        self, mock_mass: MagicMock, member_order: list[str]
+    ) -> None:
+        """A natively groupable member moves onto the protocol the group ends up on."""
+        controller, players = self._build_topology(mock_mass, SessionBoundMockPlayer)
+
+        protocol_members, native_members, _, protocol_domain = (
+            controller._translate_members_for_protocols(
+                parent_player=players["speaker_leader"],
+                player_ids=member_order,
+                parent_protocol_player=None,
+                parent_protocol_domain=None,
+            )
+        )
+
+        assert native_members == []
+        assert set(protocol_members) == {"bridge_only", "bridge_member"}
+        assert protocol_domain == "sendspin"
+
+    def test_member_without_the_group_protocol_is_refused(
+        self, mock_mass: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A native member that lacks the group's protocol is dropped, the others still move."""
+        controller, players = self._build_topology(
+            mock_mass, SessionBoundMockPlayer, with_orphan=True
+        )
+
+        with caplog.at_level(logging.WARNING):
+            protocol_members, native_members, _, _ = controller._translate_members_for_protocols(
+                parent_player=players["speaker_leader"],
+                player_ids=["speaker_member", "speaker_orphan", "bridge_only"],
+                parent_protocol_player=None,
+                parent_protocol_domain=None,
+            )
+
+        assert native_members == []
+        assert set(protocol_members) == {"bridge_only", "bridge_member"}
+        assert (
+            "Cannot group Bedroom with Living Room: the group plays through the sendspin "
+            "protocol, which Bedroom does not support" in caplog.text
+        )
+
+    def test_device_side_parent_keeps_its_hybrid_group(self, mock_mass: MagicMock) -> None:
+        """A parent with device-side native grouping keeps its members natively grouped."""
+        controller, players = self._build_topology(mock_mass, MockPlayer)
+
+        protocol_members, native_members, _, protocol_domain = (
+            controller._translate_members_for_protocols(
+                parent_player=players["speaker_leader"],
+                player_ids=["speaker_member", "bridge_only"],
+                parent_protocol_player=None,
+                parent_protocol_domain=None,
+            )
+        )
+
+        assert native_members == ["speaker_member"]
+        assert protocol_members == ["bridge_only"]
+        assert protocol_domain == "sendspin"
+
+
 class TestCanGroupWith:
     """Tests for can_group_with property with three scenarios."""
 
@@ -2594,6 +2773,70 @@ class TestNativePlayerProtocolGrouping:
 class TestProtocolSwitchingDuringPlayback:
     """Tests for dynamic protocol switching when group members change during playback."""
 
+    def _build_session_bound_group(
+        self, mock_mass: MagicMock, playback_state: PlaybackState
+    ) -> tuple[PlayerController, dict[str, MockPlayer]]:
+        """
+        Build a leader that renders its own stream, one native member and a bridge-only player.
+
+        :param mock_mass: The mocked MusicAssistant instance.
+        :param playback_state: The state the leader is in when the switch happens.
+        :return: The controller and its players by ID.
+        """
+        controller = PlayerController(mock_mass)
+        speaker_provider = MockProvider("speaker", instance_id="speaker_instance", mass=mock_mass)
+        bridge_provider = MockProvider("sendspin", instance_id="sendspin_instance", mass=mock_mass)
+
+        leader = SessionBoundMockPlayer(speaker_provider, "speaker_leader", "Living Room")
+        leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+        leader._attr_group_members = ["speaker_leader", "speaker_member"]
+        leader._attr_playback_state = playback_state
+        leader._cache.clear()
+
+        member = MockPlayer(speaker_provider, "speaker_member", "Kitchen")
+        member._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+        member._cache.clear()
+
+        bridge_only = MockPlayer(bridge_provider, "bridge_only", "Voice Assistant")
+        bridge_only._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+        bridge_only._cache.clear()
+
+        players: dict[str, MockPlayer] = {
+            "speaker_leader": leader,
+            "speaker_member": member,
+            "bridge_only": bridge_only,
+        }
+        for parent_id, bridge_id, bridge_name in (
+            ("speaker_leader", "bridge_leader", "Living Room (Bridge)"),
+            ("speaker_member", "bridge_member", "Kitchen (Bridge)"),
+        ):
+            bridge = MockPlayer(
+                bridge_provider, bridge_id, bridge_name, player_type=PlayerType.PROTOCOL
+            )
+            bridge._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+            bridge._cache.clear()
+            bridge.set_protocol_parent_id(parent_id)
+            players[bridge_id] = bridge
+            players[parent_id].set_linked_output_protocols(
+                [
+                    OutputProtocol(
+                        output_protocol_id=bridge_id,
+                        name="Bridge",
+                        protocol_domain="sendspin",
+                        priority=40,
+                        available=True,
+                    )
+                ]
+            )
+
+        mock_mass.players = controller
+        controller._players = dict(players)
+        for registered_player in players.values():
+            registered_player.update_state(signal_event=False)
+        leader.set_active_output_protocol("native")
+        return controller, players
+
     async def test_no_protocol_set_during_grouping_without_playback(
         self, mock_mass: MagicMock
     ) -> None:
@@ -2830,6 +3073,71 @@ class TestProtocolSwitchingDuringPlayback:
 
         # Playback should NOT have been restarted because we're going back to native
         assert not resume_called, "cmd_resume should not be called when switching to native"
+
+    @pytest.mark.parametrize("playback_state", [PlaybackState.PLAYING, PlaybackState.PAUSED])
+    async def test_native_session_is_stopped_and_members_migrate(
+        self, mock_mass: MagicMock, playback_state: PlaybackState
+    ) -> None:
+        """
+        A parent that renders its own stream hands its native members over to the new protocol.
+
+        The members join the protocol group in the same call as the new member, after which
+        the native session releases them and stops. Playback resumes only for a player that
+        was playing, so adding a member to a paused group does not start it.
+        """
+        controller, players = self._build_session_bound_group(mock_mass, playback_state)
+        leader = players["speaker_leader"]
+        bridge_leader = players["bridge_leader"]
+
+        # record the sequence of provider level calls the switch performs
+        calls: list[tuple[str, Any]] = []
+        leader_set_members = leader.set_members
+        bridge_set_members = bridge_leader.set_members
+
+        async def record_leader_set_members(
+            player_ids_to_add: list[str] | None = None,
+            player_ids_to_remove: list[str] | None = None,
+        ) -> None:
+            calls.append(("leader_set_members", player_ids_to_remove))
+            await leader_set_members(player_ids_to_add, player_ids_to_remove)
+
+        async def record_bridge_set_members(
+            player_ids_to_add: list[str] | None = None,
+            player_ids_to_remove: list[str] | None = None,
+        ) -> None:
+            calls.append(("bridge_set_members", player_ids_to_add))
+            await bridge_set_members(player_ids_to_add, player_ids_to_remove)
+
+        async def record_leader_stop() -> None:
+            calls.append(("leader_stop", None))
+
+        leader.set_members = record_leader_set_members  # type: ignore[method-assign]
+        leader.stop = record_leader_stop  # type: ignore[method-assign]
+        bridge_leader.set_members = record_bridge_set_members  # type: ignore[method-assign]
+        controller.cmd_resume = AsyncMock()  # type: ignore[method-assign]
+        controller._handle_set_members = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._forward_protocol_set_members(
+            parent_player=leader,
+            parent_protocol_player=bridge_leader,
+            protocol_members_to_add=["bridge_only"],
+            protocol_members_to_remove=[],
+        )
+
+        assert calls == [
+            # the native member joins the protocol group together with the new member
+            ("bridge_set_members", ["bridge_only", "bridge_member"]),
+            ("leader_set_members", ["speaker_member"]),
+            ("leader_stop", None),
+        ]
+        assert leader.active_output_protocol == "bridge_leader"
+        # Only a player that was playing resumes: adding a member to a paused group
+        # hands the output over without starting playback.
+        if playback_state == PlaybackState.PLAYING:
+            controller.cmd_resume.assert_awaited_once_with("speaker_leader")
+        else:
+            controller.cmd_resume.assert_not_awaited()
+        controller._handle_set_members.assert_not_awaited()
 
 
 class TestNativeProtocolPlayerGrouping:

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -1,6 +1,7 @@
 """Unit tests for AirPlay player."""
 
 import asyncio
+import logging
 import time
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
@@ -1250,6 +1251,44 @@ async def test_stop_cancels_pending_rejoin() -> None:
         assert player._rejoin_task is None
         await asyncio.sleep(0)
         assert rejoin_task.cancelled()
+
+
+# --- Group membership and the leader's stream session ---
+
+
+@pytest.mark.asyncio
+async def test_set_members_adds_the_child_to_the_running_session() -> None:
+    """A member joining a leader with a live session is added to that session."""
+    leader = _make_playing_leader()
+    child = _make_idle_player("child")
+    _attach_running_session(leader, [leader])
+    session = cast("MagicMock", leader.stream).session
+    session.add_client = AsyncMock()
+    _players_mock(leader).get_player.side_effect = lambda player_id: {"child": child}.get(player_id)
+
+    await leader.set_members(player_ids_to_add=["child"])
+
+    session.add_client.assert_awaited_once_with(child)
+    assert leader.group_members == ["leader", "child"]
+
+
+@pytest.mark.asyncio
+async def test_set_members_warns_when_the_leader_has_no_session(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A member joining a leader that renders through a protocol gets no audio, loudly."""
+    leader = _make_idle_player("leader")
+    leader.logger = logging.getLogger("test.airplay.player")
+    child = _make_idle_player("child")
+    _players_mock(leader).get_player.side_effect = lambda player_id: {"child": child}.get(player_id)
+    # the leader hands its audio to one of its output protocols, so it has no session
+    leader.set_active_output_protocol("bridge_leader")
+
+    with caplog.at_level(logging.WARNING):
+        await leader.set_members(player_ids_to_add=["child"])
+
+    assert leader.group_members == ["leader", "child"]
+    assert "no stream session to join" in caplog.text
 
 
 # --- Device password ---


### PR DESCRIPTION
# What does this implement/fix?

Adding a speaker that can only be reached over a different protocol — an ESPHome
Voice PE joining a group of HomePods, for example — left the speakers that were
already playing behind on an output their leader had just left.

For AirPlay that is fatal: its grouping attaches members to the leader's own
stream, so once the leader moves to another output there is nothing left for
them to play. They stayed listed as part of the group and went silent, with no
error anywhere. Meanwhile the leader's old stream was never stopped, so it kept
playing alongside the new one — in the reported case two connections to the same
HomePod and two to the same radio station, ending with the speaker dropping its
session, the group picking a new leader twice, and most speakers falling silent.

Grouping that works independently of what feeds the leader — a Sonos or WiiM
group, where the speakers follow whatever the leader plays — is unaffected and
keeps working exactly as before.

**Related issue (if applicable):**

- n/a

- Move speakers onto the group's new output when their grouping depends on the
  leader's own stream, and say so when one cannot be reached over that output
  instead of leaving it silently in the group
- Stop the leader's old stream once its speakers have moved across
- Hand the output over for a paused group too, without starting playback
- Leave grouping that works independently of the leader's own stream untouched

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.