### PR TITLE
Fix Flow Mode progress after abandoned stream probes

### DIFF
--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -323,13 +323,31 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
         played_time = 0.0
         queue_index: int | None = queue.current_index or 0
         track_time = 0.0
-        for play_log_entry in queue_data.flow_mode_stream_log:
+        flow_log = queue_data.flow_mode_stream_log
+        for log_index, play_log_entry in enumerate(flow_log):
             # seconds_streamed is bytes-derived stream-time, so the boundary check
             # doesn't need a speed factor. Only the still-streaming tail entry has
             # seconds_streamed=None; we'll break inside it before the sentinel matters.
             if play_log_entry.seconds_streamed is not None:
                 # NOTE: 'seconds_streamed' can be 0 if there was a stream error
                 entry_stream_duration = play_log_entry.seconds_streamed
+            elif log_index < len(flow_log) - 1:
+                # Some players open the same flow URL several times while probing the
+                # stream. A probe can leave an unfinished entry behind before the
+                # connection that actually plays the audio appends the next entry.
+                # Recover the completed stream duration from the shared QueueItem;
+                # treating this non-tail entry as the active sentinel would pin the
+                # queue to the previous track and let elapsed time overflow its duration.
+                stale_queue_index = self.index_by_id(queue.queue_id, play_log_entry.queue_item_id)
+                stale_queue_item = self.get_item(queue.queue_id, stale_queue_index)
+                if (
+                    stale_queue_item
+                    and stale_queue_item.streamdetails
+                    and stale_queue_item.streamdetails.seconds_streamed is not None
+                ):
+                    entry_stream_duration = stale_queue_item.streamdetails.seconds_streamed
+                else:
+                    entry_stream_duration = 0
             else:
                 entry_stream_duration = 3600 * 24 * 7
             if elapsed_time_queue_total > (entry_stream_duration + played_time):

--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -326,8 +326,9 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
         flow_log = queue_data.flow_mode_stream_log
         for log_index, play_log_entry in enumerate(flow_log):
             # seconds_streamed is bytes-derived stream-time, so the boundary check
-            # doesn't need a speed factor. Only the still-streaming tail entry has
-            # seconds_streamed=None; we'll break inside it before the sentinel matters.
+            # doesn't need a speed factor. Normally only the still-streaming tail entry
+            # has seconds_streamed=None (we'll break inside it before the sentinel
+            # matters); an abandoned probe entry is the exception, handled below.
             if play_log_entry.seconds_streamed is not None:
                 # NOTE: 'seconds_streamed' can be 0 if there was a stream error
                 entry_stream_duration = play_log_entry.seconds_streamed
@@ -338,8 +339,7 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
                 # Recover the completed stream duration from the shared QueueItem;
                 # treating this non-tail entry as the active sentinel would pin the
                 # queue to the previous track and let elapsed time overflow its duration.
-                stale_queue_index = self.index_by_id(queue.queue_id, play_log_entry.queue_item_id)
-                stale_queue_item = self.get_item(queue.queue_id, stale_queue_index)
+                stale_queue_item = self.get_item(queue.queue_id, play_log_entry.queue_item_id)
                 if (
                     stale_queue_item
                     and stale_queue_item.streamdetails

--- a/tests/controllers/player_queues/test_flow_progress.py
+++ b/tests/controllers/player_queues/test_flow_progress.py
@@ -1,0 +1,78 @@
+"""Tests for Flow Mode queue progress tracking."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+from music_assistant_models.enums import PlaybackState
+
+from music_assistant.controllers.player_queues.playback_tracker import PlaybackTrackerMixin
+
+QUEUE_ID = "queue-1"
+
+
+def _queue_item(item_id: str, seconds_streamed: float | None) -> SimpleNamespace:
+    """Create a minimal queue item with stream bookkeeping."""
+    return SimpleNamespace(
+        queue_item_id=item_id,
+        streamdetails=SimpleNamespace(
+            seconds_streamed=seconds_streamed,
+            seek_position=0,
+        ),
+        extra_attributes={},
+    )
+
+
+def _flow_progress(
+    elapsed: float,
+    log: list[SimpleNamespace],
+    items: list[SimpleNamespace],
+) -> tuple[int | None, float]:
+    """Calculate Flow Mode progress with a minimal playback tracker."""
+    queue = SimpleNamespace(queue_id=QUEUE_ID, current_index=0, elapsed_time=0)
+    tracker = MagicMock()
+    tracker._queue_data = {
+        QUEUE_ID: SimpleNamespace(flow_mode_stream_log=log),
+    }
+    tracker.index_by_id.side_effect = lambda _queue_id, item_id: next(
+        (index for index, item in enumerate(items) if item.queue_item_id == item_id),
+        None,
+    )
+    tracker.get_item.side_effect = lambda _queue_id, index: (
+        items[index] if isinstance(index, int) else None
+    )
+    player = SimpleNamespace(
+        state=SimpleNamespace(
+            corrected_elapsed_time=elapsed,
+            playback_state=PlaybackState.PLAYING,
+        )
+    )
+
+    return PlaybackTrackerMixin._get_flow_queue_stream_index(
+        cast("Any", tracker), cast("Any", queue), cast("Any", player)
+    )
+
+
+def test_flow_progress_recovers_unfinished_non_tail_probe_entry() -> None:
+    """An abandoned probe entry must not pin progress to the previous track."""
+    items = [_queue_item("track-1", 100.0), _queue_item("track-2", None)]
+    log = [
+        SimpleNamespace(queue_item_id="track-1", seconds_streamed=None),
+        SimpleNamespace(queue_item_id="track-2", seconds_streamed=None),
+    ]
+
+    index, elapsed = _flow_progress(125.0, log, items)
+
+    assert index == 1
+    assert elapsed == 25.0
+
+
+def test_flow_progress_keeps_unfinished_tail_as_active_entry() -> None:
+    """The unfinished tail entry remains the sentinel for the active track."""
+    items = [_queue_item("track-1", None)]
+    log = [SimpleNamespace(queue_item_id="track-1", seconds_streamed=None)]
+
+    index, elapsed = _flow_progress(25.0, log, items)
+
+    assert index == 0
+    assert elapsed == 25.0

--- a/tests/controllers/player_queues/test_flow_progress.py
+++ b/tests/controllers/player_queues/test_flow_progress.py
@@ -38,8 +38,10 @@ def _flow_progress(
         (index for index, item in enumerate(items) if item.queue_item_id == item_id),
         None,
     )
-    tracker.get_item.side_effect = lambda _queue_id, index: (
-        items[index] if isinstance(index, int) else None
+    tracker.get_item.side_effect = lambda _queue_id, id_or_index: (
+        items[id_or_index]
+        if isinstance(id_or_index, int)
+        else next((item for item in items if item.queue_item_id == id_or_index), None)
     )
     player = SimpleNamespace(
         state=SimpleNamespace(


### PR DESCRIPTION
# What does this implement/fix?

Some players open the same Flow Mode URL multiple times while probing the stream. A probe can leave an unfinished, non-tail play-log entry before the connection producing audible playback appends the next item.

Flow progress mapping currently treats every unfinished entry as the active seven-day sentinel. That pins the queue title/index to the abandoned entry and lets elapsed time exceed the track duration.

This change treats only the unfinished tail as active. For an unfinished non-tail entry, it recovers the bytes-derived streamed duration from the shared queue item before mapping cumulative player time. Regression tests cover both the abandoned non-tail entry and the normal active-tail behavior.

**Related issue (if applicable):**

- No public issue filed; reproduced against Kodi Flow Mode with duplicate HTTP consumers.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

## Local validation

- `pytest -q tests/controllers/player_queues --no-cov`: `219 passed`
- Ruff: passed
- mypy for the changed playback tracker and test: passed
- `pre-commit run --all-files`: passed
- `git diff --check`: passed
