### PR TITLE
Fix seek progress snapback before stream restart

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -862,9 +862,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             raise InvalidCommand("Can not seek outside of duration range.")
         if queue.current_index is None:
             raise InvalidCommand(f"Queue {queue_player.state.name} has no current index.")
-        # Publish the requested position before rebuilding the stream so clients do not
-        # snap back to the previous elapsed clock between their optimistic update and
-        # the first player update from the restarted stream.
+        # Publish the seek target before rebuilding the stream to prevent progress snapback.
         queue.elapsed_time = position
         queue.elapsed_time_last_updated = time.time()
         self.signal_update(queue_id)

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -862,6 +862,12 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             raise InvalidCommand("Can not seek outside of duration range.")
         if queue.current_index is None:
             raise InvalidCommand(f"Queue {queue_player.state.name} has no current index.")
+        # Publish the requested position before rebuilding the stream so clients do not
+        # snap back to the previous elapsed clock between their optimistic update and
+        # the first player update from the restarted stream.
+        queue.elapsed_time = position
+        queue.elapsed_time_last_updated = time.time()
+        self.signal_update(queue_id)
         await self.play_index(queue_id, queue.current_index, seek_position=position)
 
     @api_command("player_queues/resume", required_scope=Scope.QUEUES_CONTROL)

--- a/tests/controllers/player_queues/test_play_index_elapsed.py
+++ b/tests/controllers/player_queues/test_play_index_elapsed.py
@@ -77,6 +77,30 @@ async def test_play_index_sets_elapsed_to_seek_position() -> None:
     assert all(elapsed == 30 for item_id, elapsed in signals if item_id == "new"), signals
 
 
+async def test_seek_publishes_target_before_restarting_stream() -> None:
+    """A seek publishes its target before play_index starts rebuilding the stream."""
+    ctrl, queue, _signals = _controller_with_stale_queue()
+    events: list[tuple[str, float]] = []
+    before = time.time()
+
+    def _record_signal(_queue_id: str, items_changed: bool = False) -> None:  # noqa: ARG001
+        events.append(("signal", queue.elapsed_time))
+
+    async def _record_restart(*_args: object, **_kwargs: object) -> None:
+        events.append(("restart", queue.elapsed_time))
+
+    ctrl.signal_update = Mock(side_effect=_record_signal)  # type: ignore[method-assign]
+    play_index = AsyncMock(side_effect=_record_restart)
+    ctrl.play_index = play_index  # type: ignore[method-assign]
+
+    await ctrl.seek(QUEUE_ID, 30)
+
+    play_index.assert_awaited_once_with(QUEUE_ID, 0, seek_position=30)
+    assert events == [("signal", 30), ("restart", 30)]
+    assert queue.elapsed_time == 30
+    assert queue.elapsed_time_last_updated >= before
+
+
 async def test_play_index_retry_fallback_discards_failed_items_seek_position() -> None:
     """Falling back to another item after a load failure zeroes elapsed_time, not seek_position."""
     ctrl, queue, signals = _controller_with_stale_queue()


### PR DESCRIPTION
# What does this implement/fix?

Seeking a queue item rebuilds the stream through `play_index`. Clients optimistically move the progress slider to the requested position, but the queue continues exposing its previous elapsed clock until asynchronous item loading completes. A state refresh during that window makes the slider snap back before it moves to the requested position again.

Publish the validated seek target and a fresh elapsed timestamp before starting the stream rebuild. This keeps the server state aligned with the client's optimistic position while the new stream is being prepared. `play_index` still performs the authoritative reset added by #4898 once the item has loaded.

A regression test verifies that the target position is signaled before `play_index` begins and that the queue timestamp is refreshed.

**Related issue (if applicable):**

- Follow-up to https://github.com/music-assistant/server/pull/4898

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

## Local validation

- `pytest -q tests/controllers/player_queues --no-cov`: `218 passed`
- Ruff: passed
- mypy for the changed controller and test: passed
- `pre-commit run --all-files`: passed
- `git diff --check`: passed
- Controlled live seek before the change exposed the target after 98 ms; after the change it exposed the target after 41 ms and never republished the old position before playback resumed.
