### PR TITLE
Redact authorization headers from request logs

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -105,7 +105,7 @@ from music_assistant.helpers.util import (
     get_source_ip_for_target,
     sanitize_http_header_value,
 )
-from music_assistant.helpers.webserver import Webserver
+from music_assistant.helpers.webserver import Webserver, redact_sensitive_headers
 from music_assistant.models.core_controller import CoreController
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.models.plugin import PluginProvider
@@ -1606,7 +1606,7 @@ class StreamsController(CoreController):
                 request.method,
                 request.path,
                 request.remote,
-                request.headers,
+                redact_sensitive_headers(request.headers),
             )
         else:
             self.logger.debug(

--- a/music_assistant/helpers/webserver.py
+++ b/music_assistant/helpers/webserver.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Mapping
 from typing import TYPE_CHECKING, Any, Final
 
 from aiohttp import web
@@ -20,6 +20,23 @@ MAX_LINE_SIZE: Final = 24570
 DynamicRouteHandler = Callable[
     [web.Request], Coroutine[Any, Any, web.Response | web.StreamResponse]
 ]
+
+
+REDACTED_HEADER_VALUE: Final = "<redacted>"
+
+
+def redact_sensitive_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    """
+    Return request headers with credential-bearing values redacted.
+
+    :param headers: Headers to prepare for logging.
+    """
+    return {
+        key: REDACTED_HEADER_VALUE
+        if key.lower().startswith(("authorization", "proxy-authorization"))
+        else value
+        for key, value in headers.items()
+    }
 
 
 class Webserver:
@@ -205,6 +222,6 @@ class Webserver:
             request.method,
             request.path,
             request.remote,
-            request.headers,
+            redact_sensitive_headers(request.headers),
         )
         return web.Response(status=404)

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -1,5 +1,6 @@
 """Tests for utility/helper functions."""
 
+import logging
 import os
 import signal
 import subprocess
@@ -9,6 +10,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aiohttp.test_utils import make_mocked_request
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import (
     MusicAssistantError,
@@ -20,6 +22,47 @@ from zeroconf import InterfaceChoice, IPVersion
 
 from music_assistant.helpers import _ml_inference_probe, uri, util
 from music_assistant.helpers.aiohttp_client import encoded_request_url
+from music_assistant.helpers.webserver import Webserver, redact_sensitive_headers
+
+
+def test_redact_sensitive_headers() -> None:
+    """Credential-bearing request headers are redacted without hiding diagnostics."""
+    headers = {
+        "Accept": "application/json",
+        "Authorization": "Bearer secret-token",
+        "aUtHoRiZaTiOn-Extra": "secret-extra",
+        "PROXY-AUTHORIZATION": "Basic secret-proxy",
+    }
+
+    assert redact_sensitive_headers(headers) == {
+        "Accept": "application/json",
+        "Authorization": "<redacted>",
+        "aUtHoRiZaTiOn-Extra": "<redacted>",
+        "PROXY-AUTHORIZATION": "<redacted>",
+    }
+    assert "secret-token" not in str(redact_sensitive_headers(headers))
+    assert "secret-proxy" not in str(redact_sensitive_headers(headers))
+
+
+async def test_unhandled_request_log_redacts_sensitive_headers(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The catch-all request log never includes an Authorization value."""
+    logger = logging.getLogger("test_webserver")
+    webserver = Webserver(logger, enable_dynamic_routes=True)
+    request = make_mocked_request(
+        "GET",
+        "/unknown",
+        headers={"Authorization": "Bearer secret-token", "Accept": "application/json"},
+    )
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        response = await webserver._handle_catch_all(request)
+
+    assert response.status == 404
+    assert "secret-token" not in caplog.text
+    assert "<redacted>" in caplog.text
+    assert "application/json" in caplog.text
 
 
 def test_version_extract() -> None:


### PR DESCRIPTION
# What does this implement/fix?

On start-up, we can log unreacted authorization headers like:

```
2026-08-02 09:54:35.050 WARNING (MainThread) [music_assistant.webserver] Received unhandled GET request to /mcp/v1 from fe80::8ce:86dc:edc7:8e09
headers: <CIMultiDictProxy('Accept': 'text/event-stream, application/json', 'mcp-session-id': '75379a6e0f9a40508df674c5efb34efb', 'mcp-protocol-version': '2025-11-25', 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsI _truncated the rest_', 'Host': 'homeassistant.local:8095')>
```
during the window where we're accepting HTTP requests but before all of the handlers are registered.

This new helper redacts sensitive HTTP auth headers the two places we log request.headers and now it looks like:
```
2026-08-02 10:55:56.964 WARNING (MainThread) [music_assistant.webserver] Received unhandled GET request to /mcp/v1 from fe80::8ce:86dc:edc7:8e09
headers: {'Host': 'homeassistant.local:8095', 'User-Agent': 'curl/8.7.1', 'Accept': 'text/event-stream, application/json', 'mcp-session-id': 'repro-session', 'mcp-protocol-version': '2025-11-25', 'Authorization': '<redacted>'}
```

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
