### PR TITLE
Wait for every group member's clock before anchoring playback

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -77,14 +77,14 @@ AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 2500
 # out of planning time and falls back, while a stall says the speaker will not
 # play. Keep them apart - tightening the stall report to meet this deadline
 # would trade the margin that keeps it free of false alarms.
-AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS: Final[int] = 2500
+AIRPLAY_CLOCK_READY_TIMEOUT_MS: Final[int] = 2500
 # Lead added on top of a reported readiness instant when anchoring a join. The
 # binary refuses to place an anchor inside its own 250 ms floor, measured from
 # when IT reads the START command rather than when the server sends it (the same
 # trap as AIRPLAY_START_LEAD_MS, see PR #5208), so the lead carries that floor
 # plus 250 ms for the command reaching the binary and for the convergence error
 # of a projection made from the receiver's very first probe.
-AIRPLAY_JOIN_CLOCK_READY_LEAD_MS: Final[int] = 500
+AIRPLAY_CLOCK_READY_LEAD_MS: Final[int] = 500
 # How long a join START waits for the binary's [STATUS] started ack. That ack is
 # held back until the clock verification above resolves, so the window must
 # cover the verification arm window plus a poll round on top of the commanded

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -66,24 +66,25 @@ DACP_DISCOVERY_TYPE: Final[str] = "_dacp._tcp.local."
 # arrives - the joiner then seats on a cold clock and lands audibly behind.
 # 2500 ms clears that by ~570 ms, the margin the field-proven value carried.
 AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS: Final[int] = 2500
-# How long a join waits for the binary's first receiver-clock projection
-# ([STATUS] clock_ready with state=probing|ready). The binary emits its first
-# line right after [STATUS] connected and refreshes it about every 250 ms, and
-# the projection exists from the receiver's first probe (~1078 ms after connect
-# on a cold device), so this only has to cover a slower device before giving up
-# and anchoring on the floor above. Independent of the binary's own stall
-# report (state=stalled), which is a slower, higher-confidence diagnosis of a
-# receiver that never answers at all: a join that times out here has simply run
-# out of planning time and falls back, while a stall says the speaker will not
-# play. Keep them apart - tightening the stall report to meet this deadline
-# would trade the margin that keeps it free of false alarms.
+# How long a group start, a join or the Sendspin bridge waits for the binary's
+# first receiver-clock projection ([STATUS] clock_ready with state=probing|
+# ready). The binary emits its first line right after [STATUS] connected and
+# refreshes it about every 250 ms, and the projection exists from the receiver's
+# first probe (~1078 ms after connect on a cold device), so this only has to
+# cover a slower device before giving up and anchoring on the lead alone.
+# Independent of the binary's own stall report (state=stalled), which is a
+# slower, higher-confidence diagnosis of a receiver that never answers at all: a
+# wait that times out here has simply run out of planning time and falls back,
+# while a stall says the speaker will not play. Keep them apart - tightening the
+# stall report to meet this deadline would trade the margin that keeps it free
+# of false alarms.
 AIRPLAY_CLOCK_READY_TIMEOUT_MS: Final[int] = 2500
-# Lead added on top of a reported readiness instant when anchoring a join. The
-# binary refuses to place an anchor inside its own 250 ms floor, measured from
-# when IT reads the START command rather than when the server sends it (the same
-# trap as AIRPLAY_START_LEAD_MS, see PR #5208), so the lead carries that floor
-# plus 250 ms for the command reaching the binary and for the convergence error
-# of a projection made from the receiver's very first probe.
+# Lead added on top of a reported readiness instant, wherever one is waited for.
+# The binary refuses to place an anchor inside its own 250 ms floor, measured
+# from when IT reads the START command rather than when the server sends it (the
+# same trap as AIRPLAY_START_LEAD_MS), so the lead carries that floor plus 250 ms
+# for the command reaching the binary and for the convergence error of a
+# projection made from the receiver's very first probe.
 AIRPLAY_CLOCK_READY_LEAD_MS: Final[int] = 500
 # How long a join START waits for the binary's [STATUS] started ack. That ack is
 # held back until the clock verification above resolves, so the window must

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -43,8 +43,8 @@ from music_assistant.providers.sendspin.bridge_role import (
 from music_assistant.providers.sendspin.helpers import bridge_client_id_from_mac
 
 from .constants import (
-    AIRPLAY_JOIN_CLOCK_READY_LEAD_MS,
-    AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS,
+    AIRPLAY_CLOCK_READY_LEAD_MS,
+    AIRPLAY_CLOCK_READY_TIMEOUT_MS,
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
     AIRPLAY_SPLICE_LEAD_MARGIN_MS,
 )
@@ -641,7 +641,7 @@ class SendspinAirPlayBridge:
         :return: True when the stream is anchored, False when superseded.
         """
         ready_at_unix_ms = await stream.wait_clock_ready(
-            timeout=AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS / 1000
+            timeout=AIRPLAY_CLOCK_READY_TIMEOUT_MS / 1000
         )
         sendspin_now_us = self.sendspin_server.clock.now_us()
         unix_now = time.time()
@@ -653,7 +653,7 @@ class SendspinAirPlayBridge:
         )
         anchor_ms = max(now_ms + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS, first_chunk_unix_ms)
         if ready_at_unix_ms:
-            anchor_ms = max(anchor_ms, ready_at_unix_ms + AIRPLAY_JOIN_CLOCK_READY_LEAD_MS)
+            anchor_ms = max(anchor_ms, ready_at_unix_ms + AIRPLAY_CLOCK_READY_LEAD_MS)
         sync_adjust = self.airplay_player.config.get_value(CONF_SYNC_ADJUST, 0)
         adjust_ms = sync_adjust if isinstance(sync_adjust, int) else 0
         if warm:

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -16,10 +16,10 @@ from music_assistant.controllers.streams.audio_processing import get_media_sessi
 from music_assistant.helpers.ffmpeg import FFMpeg
 
 from .constants import (
+    AIRPLAY_CLOCK_READY_LEAD_MS,
+    AIRPLAY_CLOCK_READY_TIMEOUT_MS,
     AIRPLAY_COLD_GROUP_START_LEAD_MS,
     AIRPLAY_GROUP_START_LEAD_MS,
-    AIRPLAY_JOIN_CLOCK_READY_LEAD_MS,
-    AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS,
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
     AIRPLAY_SPLICE_LEAD_MARGIN_MS,
     AIRPLAY_START_LEAD_MS,
@@ -158,7 +158,16 @@ class AirPlayStreamSession:
             # binary bursts the receiver pre-fill after START.
             self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
             await self._wait_members_audio_present()
-            await self._start_members(position_ms, self._anchor_start_unix_ms())
+            # A receiver renders nothing at an anchor its clock cannot seat yet,
+            # and a freshly connected one needs about a second before it even
+            # starts probing — too late for the binary to raise its own commit
+            # floor, and an origin start is the one case it will not correct
+            # afterwards. So the anchor waits for the receivers to say when
+            # they can play.
+            ready_at_unix_ms = await self._wait_members_clock_ready()
+            await self._start_members(
+                position_ms, self._anchor_start_unix_ms(ready_at_unix_ms=ready_at_unix_ms)
+            )
         except asyncio.CancelledError:
             await self.stop()
             raise
@@ -385,7 +394,7 @@ class AirPlayStreamSession:
             # of the group keeps being fed — lets the join anchor on the
             # device's own readiness instead of a fixed guess.
             ready_at_unix_ms = await stream.wait_clock_ready(
-                timeout=AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS / 1000
+                timeout=AIRPLAY_CLOCK_READY_TIMEOUT_MS / 1000
             )
         except asyncio.CancelledError:
             await self.stop_client(airplay_player, reason="late joiner start cancelled")
@@ -489,7 +498,7 @@ class AirPlayStreamSession:
             if ready_at_unix_ms:
                 anchor_at = max(
                     anchor_at,
-                    (ready_at_unix_ms + AIRPLAY_JOIN_CLOCK_READY_LEAD_MS) / 1000,
+                    (ready_at_unix_ms + AIRPLAY_CLOCK_READY_LEAD_MS) / 1000,
                 )
             requested_at, fed_pos_due = map_to(anchor_at)[:2]
             start_unix_ms = int(requested_at * 1000)
@@ -828,7 +837,7 @@ class AirPlayStreamSession:
         await airplay_player.stream.connect(use_shared_ptp)
         await self._start_player_ffmpeg(airplay_player, self.media)
 
-    def _anchor_start_unix_ms(self, *, warm: bool = False) -> int:
+    def _anchor_start_unix_ms(self, *, warm: bool = False, ready_at_unix_ms: int = 0) -> int:
         """
         Return the shared audible-start instant for a readiness-confirmed start.
 
@@ -837,6 +846,10 @@ class AirPlayStreamSession:
             minimum warm lead — their queued audio plays out before the new
             content can begin — and the shared anchor must sit beyond the
             largest member value so every member splices at the same instant.
+        :param ready_at_unix_ms: Latest instant at which a member's receiver
+            clock becomes usable, as the binaries reported it. The anchor never
+            lands before it. 0 when no member reported a projection, leaving the
+            lead below as the whole anchor.
         """
         if len(self.sync_clients) == 1:
             lead_ms = AIRPLAY_START_LEAD_MS
@@ -847,6 +860,8 @@ class AirPlayStreamSession:
             # acquisition (see AIRPLAY_COLD_GROUP_START_LEAD_MS).
             lead_ms = AIRPLAY_COLD_GROUP_START_LEAD_MS
         anchor = int(time.time() * 1000) + lead_ms
+        if ready_at_unix_ms:
+            anchor = max(anchor, ready_at_unix_ms + AIRPLAY_CLOCK_READY_LEAD_MS)
         if not warm:
             return anchor
         # Splice-timeline members honor the commanded instant only when that
@@ -889,6 +904,31 @@ class AirPlayStreamSession:
         )
         if not all(results):
             raise PlayerCommandFailed("audio feed was not confirmed")
+
+    async def _wait_members_clock_ready(self) -> int:
+        """
+        Return the latest instant at which every member's receiver clock is usable.
+
+        :return: Unix epoch ms of the latest projection any member reported, or 0
+            when none did — a receiver on NTP timing, one that never answered, or
+            a binary too old to report. The caller then anchors on its lead alone.
+        """
+        results = await asyncio.gather(
+            *[
+                p.stream.wait_clock_ready(timeout=AIRPLAY_CLOCK_READY_TIMEOUT_MS / 1000)
+                for p in self.sync_clients
+                if p.stream
+            ]
+        )
+        ready_at_unix_ms = max((r for r in results if r), default=0)
+        if len(results) != len([r for r in results if r]):
+            self.prov.logger.debug(
+                "AirPlay start: %d of %d member(s) reported no receiver clock projection; "
+                "anchoring those on the start lead alone",
+                len(results) - len([r for r in results if r]),
+                len(results),
+            )
+        return ready_at_unix_ms
 
     async def _start_members(
         self,

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -158,12 +158,12 @@ class AirPlayStreamSession:
             # binary bursts the receiver pre-fill after START.
             self._audio_source_task = asyncio.create_task(self._audio_streamer(audio_source))
             await self._wait_members_audio_present()
-            # A receiver renders nothing at an anchor its clock cannot seat yet,
-            # and a freshly connected one needs about a second before it even
-            # starts probing — too late for the binary to raise its own commit
-            # floor, and an origin start is the one case it will not correct
-            # afterwards. So the anchor waits for the receivers to say when
-            # they can play.
+            # Members of a group have to agree on one instant, and a freshly
+            # connected receiver needs about a second before it even starts
+            # probing — too late for the binary to raise its own commit floor,
+            # and a first start is the one case it will not correct afterwards.
+            # So a group anchor waits for the receivers to say when they can
+            # play, rather than trusting the lead to have covered it.
             ready_at_unix_ms = await self._wait_members_clock_ready()
             await self._start_members(
                 position_ms, self._anchor_start_unix_ms(ready_at_unix_ms=ready_at_unix_ms)
@@ -910,9 +910,15 @@ class AirPlayStreamSession:
         Return the latest instant at which every member's receiver clock is usable.
 
         :return: Unix epoch ms of the latest projection any member reported, or 0
-            when none did — a receiver on NTP timing, one that never answered, or
-            a binary too old to report. The caller then anchors on its lead alone.
+            when there is nothing to wait for — a solo start, a receiver on NTP
+            timing, one that never answered, or a binary too old to report. The
+            caller then anchors on its lead alone.
         """
+        if len(self.sync_clients) == 1:
+            # A lone receiver seats a fresh session by itself within ~20 ms and
+            # has no partner to be late against, so waiting only delays it. The
+            # instant matters once members have to agree on one.
+            return 0
         results = await asyncio.gather(
             *[
                 p.stream.wait_clock_ready(timeout=AIRPLAY_CLOCK_READY_TIMEOUT_MS / 1000)

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -907,7 +907,10 @@ class AirPlayStreamSession:
 
     async def _wait_members_clock_ready(self) -> int:
         """
-        Return the latest instant at which every member's receiver clock is usable.
+        Return the latest receiver-clock readiness any member reported.
+
+        Members that report nothing are not represented in the result; the
+        caller anchors those on its lead alone.
 
         :return: Unix epoch ms of the latest projection any member reported, or 0
             when there is nothing to wait for — a solo start, a receiver on NTP

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -583,6 +583,7 @@ async def test_session_start_applies_uniform_ptp_decision_to_all_members() -> No
         player.stream = MagicMock()
         player.stream.wait_for_connection = AsyncMock()
         player.stream.wait_audio_present = AsyncMock(return_value=True)
+        player.stream.wait_clock_ready = AsyncMock(return_value=None)
         player.stream.start = AsyncMock(return_value=None)
     session = _make_ptp_session(prov, players)
 
@@ -607,6 +608,7 @@ async def test_session_start_calculates_anchor_after_ptp_resolution() -> None:
         player.stream = MagicMock()
         player.stream.wait_for_connection = AsyncMock()
         player.stream.wait_audio_present = AsyncMock(return_value=True)
+        player.stream.wait_clock_ready = AsyncMock(return_value=None)
         player.stream.start = AsyncMock(return_value=None)
         player.config.get_value = MagicMock(return_value=0)
     session = _make_ptp_session(prov, players)

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -34,7 +34,7 @@ from aiosendspin.clock import ManualClock
 from aiosendspin.server.roles import AudioChunk
 
 from music_assistant.providers.airplay.constants import (
-    AIRPLAY_JOIN_CLOCK_READY_LEAD_MS,
+    AIRPLAY_CLOCK_READY_LEAD_MS,
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
     AIRPLAY_SPLICE_LEAD_MARGIN_MS,
     StreamingProtocol,
@@ -634,7 +634,7 @@ async def test_anchor_follows_the_clock_ready_projection() -> None:
 
     assert await _anchor(bridge, stream) is True
 
-    assert _commanded_instant(stream) == ready_at + AIRPLAY_JOIN_CLOCK_READY_LEAD_MS
+    assert _commanded_instant(stream) == ready_at + AIRPLAY_CLOCK_READY_LEAD_MS
 
 
 async def test_anchor_never_precedes_content_already_scheduled() -> None:

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -204,22 +204,27 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
 
 
 @pytest.mark.asyncio
-async def test_initial_start_never_anchors_before_the_receiver_clock_is_usable() -> None:
-    """A cold receiver whose clock lands after the start lead pushes the anchor out."""
+async def test_group_start_never_anchors_before_every_receiver_clock_is_usable() -> None:
+    """A member whose clock lands past the group lead pushes the shared anchor out."""
     now = 100.0
     session = _make_session(0, 0)
-    player: Any = session.sync_clients[0]
-    player.protocol = StreamingProtocol.AIRPLAY2
-    player.config.get_value = MagicMock(return_value=0)
-    # Readiness lands past the solo start lead, as an Apple TV does on a fresh
-    # connect: anchoring on the lead alone would render silence.
-    ready_at = int(now * 1000) + AIRPLAY_START_LEAD_MS + 400
+    first: Any = session.sync_clients[0]
+    first.protocol = StreamingProtocol.AIRPLAY2
+    first.config.get_value = MagicMock(return_value=0)
+    second = MagicMock(player_id="second", protocol=StreamingProtocol.AIRPLAY2)
+    second.config.get_value = MagicMock(return_value=0)
+    session.sync_clients.append(second)
+    # The slower member's clock lands past the cold group lead, so anchoring on
+    # that lead alone would leave it seated at a different instant to the first.
+    ready_at = int(now * 1000) + AIRPLAY_COLD_GROUP_START_LEAD_MS + 400
 
-    async def start_client(_player: MagicMock, _use_shared_ptp: bool) -> None:
+    async def start_client(player: MagicMock, _use_shared_ptp: bool) -> None:
         stream = _stream_defaults(MagicMock(running=True))
         stream.wait_for_connection = AsyncMock()
         stream.wait_audio_present = AsyncMock(return_value=True)
-        stream.wait_clock_ready = AsyncMock(return_value=ready_at)
+        stream.wait_clock_ready = AsyncMock(
+            return_value=ready_at if player is second else int(now * 1000)
+        )
         player.stream = stream
 
     with (
@@ -230,7 +235,38 @@ async def test_initial_start_never_anchors_before_the_receiver_clock_is_usable()
     ):
         await session.start(MagicMock())
 
-    assert player.stream.start.await_args.args[0] == ready_at + AIRPLAY_CLOCK_READY_LEAD_MS
+    expected = ready_at + AIRPLAY_CLOCK_READY_LEAD_MS
+    for player in (first, second):
+        assert player.stream.start.await_args.args[0] == expected
+
+
+@pytest.mark.asyncio
+async def test_solo_start_does_not_wait_for_a_clock_projection() -> None:
+    """A lone receiver seats itself, so its start keeps the short lead."""
+    now = 100.0
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.protocol = StreamingProtocol.AIRPLAY2
+    player.config.get_value = MagicMock(return_value=0)
+
+    async def start_client(_player: MagicMock, _use_shared_ptp: bool) -> None:
+        stream = _stream_defaults(MagicMock(running=True))
+        stream.wait_for_connection = AsyncMock()
+        stream.wait_audio_present = AsyncMock(return_value=True)
+        # A projection far in the future must not delay a solo start.
+        stream.wait_clock_ready = AsyncMock(return_value=int(now * 1000) + 5_000)
+        player.stream = stream
+
+    with (
+        patch.object(session, "_start_client", side_effect=start_client),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch.object(session, "_resolve_shared_ptp", new_callable=AsyncMock, return_value=False),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
+    ):
+        await session.start(MagicMock())
+
+    assert player.stream.start.await_args.args[0] == int(now * 1000) + AIRPLAY_START_LEAD_MS
+    player.stream.wait_clock_ready.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -10,10 +10,10 @@ import pytest
 from music_assistant_models.errors import PlayerCommandFailed
 
 from music_assistant.providers.airplay.constants import (
+    AIRPLAY_CLOCK_READY_LEAD_MS,
+    AIRPLAY_CLOCK_READY_TIMEOUT_MS,
     AIRPLAY_COLD_GROUP_START_LEAD_MS,
     AIRPLAY_GROUP_START_LEAD_MS,
-    AIRPLAY_JOIN_CLOCK_READY_LEAD_MS,
-    AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS,
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
     AIRPLAY_START_LEAD_MS,
     StreamingProtocol,
@@ -201,6 +201,36 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
     # start = now (100_000 ms) + the group start lead (500 ms), one shared instant
     starts = {int(op.rsplit(":", 1)[1]) for op in operations if op.startswith("started:")}
     assert starts == {100_000 + AIRPLAY_COLD_GROUP_START_LEAD_MS}
+
+
+@pytest.mark.asyncio
+async def test_initial_start_never_anchors_before_the_receiver_clock_is_usable() -> None:
+    """A cold receiver whose clock lands after the start lead pushes the anchor out."""
+    now = 100.0
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.protocol = StreamingProtocol.AIRPLAY2
+    player.config.get_value = MagicMock(return_value=0)
+    # Readiness lands past the solo start lead, as an Apple TV does on a fresh
+    # connect: anchoring on the lead alone would render silence.
+    ready_at = int(now * 1000) + AIRPLAY_START_LEAD_MS + 400
+
+    async def start_client(_player: MagicMock, _use_shared_ptp: bool) -> None:
+        stream = _stream_defaults(MagicMock(running=True))
+        stream.wait_for_connection = AsyncMock()
+        stream.wait_audio_present = AsyncMock(return_value=True)
+        stream.wait_clock_ready = AsyncMock(return_value=ready_at)
+        player.stream = stream
+
+    with (
+        patch.object(session, "_start_client", side_effect=start_client),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch.object(session, "_resolve_shared_ptp", new_callable=AsyncMock, return_value=False),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
+    ):
+        await session.start(MagicMock())
+
+    assert player.stream.start.await_args.args[0] == ready_at + AIRPLAY_CLOCK_READY_LEAD_MS
 
 
 @pytest.mark.asyncio
@@ -939,10 +969,10 @@ async def test_late_join_anchors_on_the_reported_clock_readiness() -> None:
     ):
         await session.add_client(player)
 
-    expected_lead = AIRPLAY_JOIN_CLOCK_READY_LEAD_MS / 1000
+    expected_lead = AIRPLAY_CLOCK_READY_LEAD_MS / 1000
     assert _captured_start_at(player) - now == pytest.approx(3.0 + expected_lead, abs=0.01)
     player.stream.wait_clock_ready.assert_awaited_once_with(
-        timeout=AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS / 1000
+        timeout=AIRPLAY_CLOCK_READY_TIMEOUT_MS / 1000
     )
 
 
@@ -991,7 +1021,7 @@ async def test_late_join_falls_back_to_the_floor_without_a_clock_projection() ->
 
     # every fallback shape surfaces as "no projection" to the session
     player.stream.wait_clock_ready.assert_awaited_once_with(
-        timeout=AIRPLAY_JOIN_CLOCK_READY_TIMEOUT_MS / 1000
+        timeout=AIRPLAY_CLOCK_READY_TIMEOUT_MS / 1000
     )
     expected_headroom = AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000
     assert _captured_start_at(player) - now == pytest.approx(expected_headroom, abs=0.01)


### PR DESCRIPTION
# What does this implement/fix?

Speakers in a group have to begin at one shared instant, but a freshly
connected speaker needs about a second before it can answer our clock at all -
and until it has, nothing can tell whether the instant we picked is one it can
actually play at. A speaker joining an existing group already waited for that
answer; a group starting from cold did not, so its members could be placed at
an instant a slower one was not able to honour.

The binary cannot cover for it either: at that point the speaker has not
answered once, so there is nothing to hold the start back with, and a first
start is the one case it deliberately leaves alone rather than moving it.

A speaker playing on its own is left exactly as it was. It seats itself and has
no partner to be late against, so waiting on its clock would only have made it
slower to start.

- Wait for every member's reported clock readiness before anchoring a group
  start, the same way a join already does
- Drop `JOIN` from the two readiness constants, which now govern the join, the
  group start and the Sendspin bridge alike
- Cover both a member whose clock lands past the group lead, and a lone speaker
  that must not wait at all

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
