### PR TITLE
Reduce unexpected Snapcast debug logging

### DIFF
--- a/music_assistant/providers/snapcast/provider.py
+++ b/music_assistant/providers/snapcast/provider.py
@@ -20,7 +20,7 @@ from snapcast.control.server import CONTROL_PORT, Snapserver
 from zeroconf import NonUniqueNameException
 from zeroconf.asyncio import AsyncServiceInfo
 
-from music_assistant.constants import CONF_ENABLED
+from music_assistant.constants import CONF_ENABLED, CONF_LOG_LEVEL, VERBOSE_LOG_LEVEL
 from music_assistant.helpers.compare import create_safe_string
 from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.process import AsyncProcess, check_output
@@ -55,6 +55,7 @@ from music_assistant.providers.snapcast.player import SnapCastPlayer
 from music_assistant.providers.universal_group.constants import UGP_PREFIX
 
 if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ProviderConfig
     from music_assistant_models.player import PlayerMedia
 
     from .snap_cntrl_proto import SnapclientProto, SnapgroupProto, SnapserverProto
@@ -218,8 +219,7 @@ class SnapCastProvider(PlayerProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        # set snapcast logging
-        logging.getLogger("snapcast").setLevel(self.logger.level)
+        self._set_snapcast_log_level()
         self._use_builtin_server = not self.config.get_value(CONF_USE_EXTERNAL_SERVER)
         self._stop_called = False
         self._controlscript_available = False
@@ -279,6 +279,14 @@ class SnapCastProvider(PlayerProvider):
         except OSError as err:
             msg = "Unable to start the Snapserver connection ?"
             raise SetupFailedError(msg) from err
+
+    async def update_config(self, config: ProviderConfig, changed_keys: set[str]) -> None:
+        """Handle logic when the config is updated."""
+        await super().update_config(config, changed_keys)
+        # a log level(-only) change does not reload the provider,
+        # so realign snapcast's logger here
+        if f"values/{CONF_LOG_LEVEL}" in changed_keys:
+            self._set_snapcast_log_level()
 
     async def loaded_in_mass(self) -> None:
         """Call after the provider has been loaded."""
@@ -884,3 +892,12 @@ class SnapCastProvider(PlayerProvider):
             return ma_player
 
         return None
+
+    def _set_snapcast_log_level(self) -> None:
+        """Align snapcast's log level with the provider's log level."""
+        # snapcast is very chatty at debug level, so only pass through its
+        # debug logging when verbose logging is enabled
+        if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+            logging.getLogger("snapcast").setLevel(logging.DEBUG)
+        else:
+            logging.getLogger("snapcast").setLevel(self.logger.level + 10)

--- a/tests/providers/snapcast/test_provider.py
+++ b/tests/providers/snapcast/test_provider.py
@@ -1,0 +1,54 @@
+"""Tests for the Snapcast provider."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from music_assistant.constants import CONF_LOG_LEVEL, VERBOSE_LOG_LEVEL
+from music_assistant.models.player_provider import PlayerProvider
+from music_assistant.providers.snapcast.provider import SnapCastProvider
+
+
+def _provider_with_log_level(level: int) -> SnapCastProvider:
+    provider = SnapCastProvider.__new__(SnapCastProvider)
+    provider.logger = logging.getLogger("snapcast-provider-test")
+    provider.logger.setLevel(level)
+    return provider
+
+
+@pytest.mark.parametrize(
+    ("provider_level", "snapcast_level"),
+    [
+        (logging.INFO, logging.WARNING),
+        (logging.DEBUG, logging.INFO),
+        (VERBOSE_LOG_LEVEL, logging.DEBUG),
+    ],
+)
+def test_snapcast_library_log_level(provider_level: int, snapcast_level: int) -> None:
+    """Snapcast logging stays quieter than the provider unless verbose logging is enabled."""
+    provider = _provider_with_log_level(provider_level)
+
+    with patch("music_assistant.providers.snapcast.provider.logging.getLogger") as get_logger:
+        provider._set_snapcast_log_level()
+
+    get_logger.assert_called_once_with("snapcast")
+    get_logger.return_value.setLevel.assert_called_once_with(snapcast_level)
+
+
+async def test_log_level_config_update_realigns_snapcast_logger() -> None:
+    """A log-level-only config update immediately realigns Snapcast logging."""
+    provider = _provider_with_log_level(logging.INFO)
+    config = MagicMock()
+    changed_keys = {f"values/{CONF_LOG_LEVEL}"}
+
+    with (
+        patch.object(PlayerProvider, "update_config", new_callable=AsyncMock) as update_config,
+        patch.object(SnapCastProvider, "_set_snapcast_log_level") as set_log_level,
+    ):
+        await provider.update_config(config, changed_keys)
+
+    update_config.assert_awaited_once_with(config, changed_keys)
+    set_log_level.assert_called_once_with()


### PR DESCRIPTION
# What does this implement/fix?

Snapcast mirrored the provider log level directly, so normal debug runs included noisy library debug output.

- Keep the Snapcast library logger one level quieter than the provider.
- Enable library debug logging only when the provider uses verbose logging.
- Reapply the library level after log-only config changes.
- Cover the level mapping and runtime update behavior.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.