### PR TITLE
Enable Zeroconf discovery logging

### DIFF
--- a/music_assistant/controllers/discovery/controller.py
+++ b/music_assistant/controllers/discovery/controller.py
@@ -197,10 +197,11 @@ class DiscoveryController(CoreController):
 
     def _configure_library_loggers(self) -> None:
         """Align third-party discovery logging with the discovery controller log level."""
-        if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
-            logging.getLogger("async_upnp_client").setLevel(logging.DEBUG)
-        else:
-            logging.getLogger("async_upnp_client").setLevel(self.logger.level + 10)
+        library_log_level = (
+            logging.DEBUG if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL) else self.logger.level + 10
+        )
+        for logger_name in ("async_upnp_client", "zeroconf"):
+            logging.getLogger(logger_name).setLevel(library_log_level)
 
     def _create_aiozc(self, config: CoreConfig) -> AsyncZeroconf:
         """Create the shared AsyncZeroconf instance for the discovery controller."""

--- a/tests/controllers/discovery/test_discovery.py
+++ b/tests/controllers/discovery/test_discovery.py
@@ -1,11 +1,14 @@
 """Tests for the discovery core controller."""
 
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from zeroconf import IPVersion
 from zeroconf.asyncio import AsyncZeroconf
 
+from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.mass import MusicAssistant
 
 
@@ -21,6 +24,36 @@ class StubUpnpProvider:
         self.manifest = MagicMock(mdns_discovery=None, upnp_discovery=["roku:ecp"])
         self.on_mdns_service_state_change = AsyncMock()
         self.on_upnp_service_discovered = AsyncMock()
+
+
+@pytest.mark.parametrize(
+    ("controller_level", "library_level"),
+    [
+        (VERBOSE_LOG_LEVEL, logging.DEBUG),
+        (logging.DEBUG, logging.INFO),
+        (logging.INFO, logging.WARNING),
+    ],
+)
+def test_discovery_library_logger_levels(
+    mass_minimal: MusicAssistant, controller_level: int, library_level: int
+) -> None:
+    """Discovery library loggers should only expose debug output at VERBOSE."""
+    controller_logger = mass_minimal.discovery.logger
+    library_loggers = [
+        logging.getLogger("async_upnp_client"),
+        logging.getLogger("zeroconf"),
+    ]
+    previous_controller_level = controller_logger.level
+    previous_library_levels = [logger.level for logger in library_loggers]
+    try:
+        controller_logger.setLevel(controller_level)
+        mass_minimal.discovery._configure_library_loggers()
+
+        assert all(logger.level == library_level for logger in library_loggers)
+    finally:
+        controller_logger.setLevel(previous_controller_level)
+        for logger, previous_level in zip(library_loggers, previous_library_levels, strict=True):
+            logger.setLevel(previous_level)
 
 
 async def test_run_provider_discovery_dispatches_upnp_callbacks(mass: MusicAssistant) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Zeroconf debug logs became unreachable after third-party logging stopped inheriting the global root level.

- Align Zeroconf logging with the Discovery controller level.
- Enable Zeroconf debug output only when Discovery is set to VERBOSE.
- Cover the discovery library log-level mapping with tests.

The package-wide `zeroconf` logger is intentional: zeroconf 0.149.16 sends its protocol diagnostics through that logger, while `zeroconf.asyncio` has no log calls and would provide no useful mDNS signal.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.