### PR TITLE
Improve AirPlay late-join buffering

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -119,6 +119,37 @@ AIRPLAY_COLD_GROUP_START_LEAD_MS: Final[int] = 2500
 # member's skip target lands beyond its queued audio.
 AIRPLAY_SPLICE_LEAD_MARGIN_MS: Final[int] = 150
 
+# Floor for the late-join PCM ring, which has to hold every sample between the
+# audible position and the write head: a joiner's anchor maps onto content the
+# group was already fed but has not played yet. That distance - the write-head
+# lead - is the sum of every buffer between the session's byte counter and the
+# speaker, and it is far larger than the binary's own ring alone:
+#   ~5.7 s  the per-member ffmpeg and the pipes around it (measured 5.2 s
+#           steady / 5.7 s peak at 44.1 kHz/16-bit, which is the worst case in
+#           SECONDS - the same buffers hold ~4.3 s at the 32-bit hi-res carrier
+#           rate, and low-delay ffmpeg flags do not shrink them)
+#   ~4.0 s  the cliairplay ring: the binary's own lead (2000 ms default,
+#           clamped to the device-reported window) plus its 2 s of slack
+#   ~2.0 s  the receiver's own buffer
+# ~11.7 s in total, against 8.9-11.0 s measured across native AirPlay 2
+# sessions (Apple TV and Sonos, joining in both directions). This floor is that
+# sum rounded up, and it is only a floor: the lead is measured per session and
+# the ring grows to match, because a receiver that reports a wider lead window
+# or buffers more deeply moves the sum with nothing to announce it.
+AIRPLAY_LATE_JOIN_RING_MIN_SECONDS: Final[float] = 12.0
+# Grown on top of the largest lead a session has actually shown, so a lead that
+# drifts up between two joins cannot clip the oldest sample a joiner needs.
+AIRPLAY_LATE_JOIN_RING_MARGIN_SECONDS: Final[float] = 2.0
+# Hard bound on the ring, which is per session (one ring feeds every member) and
+# costs byte_rate x seconds. Bounded in BYTES rather than seconds on purpose:
+# the seconds the ring must hold are largest at the LOWEST byte rate (see the
+# measurements above), so a single byte bound buys ~35 s at 44.1 kHz/16-bit -
+# three times the measured lead, where the seconds are actually needed - and
+# still ~16 s at the 32-bit hi-res carrier, where the pipeline holds fewer
+# seconds anyway. 6 MiB per playing group is a few percent of the server's idle
+# footprint.
+AIRPLAY_LATE_JOIN_RING_MAX_BYTES: Final[int] = 6 * 1024 * 1024
+
 # Delay (seconds) before automatically re-joining a group member whose
 # cliairplay process died unexpectedly mid-session (e.g. the device rode out a
 # network blackout longer than the binary's own keepalive tolerance). A single

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -21,6 +21,9 @@ from .constants import (
     AIRPLAY_COLD_GROUP_START_LEAD_MS,
     AIRPLAY_GROUP_START_LEAD_MS,
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
+    AIRPLAY_LATE_JOIN_RING_MARGIN_SECONDS,
+    AIRPLAY_LATE_JOIN_RING_MAX_BYTES,
+    AIRPLAY_LATE_JOIN_RING_MIN_SECONDS,
     AIRPLAY_SPLICE_LEAD_MARGIN_MS,
     AIRPLAY_START_LEAD_MS,
     StreamingProtocol,
@@ -77,10 +80,16 @@ class AirPlayStreamSession:
         # Raw PCM ring buffer for late joiners. When a late joiner arrives we
         # send this buffer to prime its pipeline so it starts playing quickly
         # instead of waiting for the full pipeline to fill from scratch.
-        # Must cover how far the feed runs ahead of the audible position
-        # (the binary's ring cap of latency+2s plus the ~2s receiver buffer)
-        # with enough slack left to prime the joiner.
+        # It must cover the write-head lead - how far the feed runs ahead of the
+        # audible position - because that is exactly the span a joiner's anchor
+        # maps into. The lead is not a constant of the protocol: it is the sum
+        # of every buffer downstream of this counter (see
+        # AIRPLAY_LATE_JOIN_RING_MIN_SECONDS), so it is measured per session and
+        # the ring is grown to match.
         self._pcm_buffer = bytearray()
+        # Largest write-head lead this session has shown, and the ring size
+        # derived from it.
+        self._peak_lead_seconds: float = 0.0
         # Raw byte sizes of the PCM actually on the wire. At 24-bit the binary
         # is fed s32le carriers (bit_depth stays 24 for the ALAC encode), so
         # sizes MUST come from the content type: bit_depth-derived sizes are
@@ -95,7 +104,7 @@ class AirPlayStreamSession:
         }.get(pcm_format.content_type, pcm_format.bit_depth // 8)
         self._pcm_frame_size = bytes_per_sample * pcm_format.channels
         self._pcm_byte_rate = self._pcm_frame_size * pcm_format.sample_rate
-        self._pcm_buffer_max = self._pcm_byte_rate * 10  # 10 seconds
+        self._pcm_buffer_max = self._ring_bytes_for(0.0)
         # Bytes still to skip off the head of the live feed for a late joiner
         # whose anchor lands ahead of the current write head, keyed by player id.
         self._client_skip_bytes: dict[str, int] = {}
@@ -411,20 +420,26 @@ class AirPlayStreamSession:
         pcm_sample_size = self._pcm_byte_rate
         frame_size = self._pcm_frame_size
 
-        def map_to(anchor_at: float) -> tuple[float, float, bytes, int]:
+        def map_to(anchor_at: float, *, committed: bool) -> tuple[float, float, bytes, int]:
             """
             Map an anchor instant onto the live feed (call under the lock).
 
             Snapshots the ring and derives which stream position the group
-            plays at ``anchor_at``, returning the (possibly ring-capped)
-            anchor, the due feed position, the prime slice and the live skip.
+            plays at ``anchor_at``, returning the anchor, the due feed
+            position, the prime slice and the live skip.
+
+            :param anchor_at: Instant at which the joiner's first delivered
+                sample becomes audible.
+            :param committed: True once the binary has acked the instant, which
+                fixes it. A due position the ring can no longer reach is then
+                covered with silence rather than by moving the anchor, because
+                moving an instant the binary already owns would offset the
+                joiner from the group by exactly that much.
             """
-            # Snapshot the ring and map its span onto stream positions:
-            # it covers [seconds_streamed - buffer_seconds, seconds_streamed].
+            # Snapshot the ring, which ends at the write head: it covers the
+            # stream positions [seconds_streamed - len(ring)/rate, seconds_streamed].
             effective_start_time = self.effective_start_time
             buffered_pcm = bytes(self._pcm_buffer)
-            buffer_seconds = len(buffered_pcm) / pcm_sample_size
-            ring_floor = self.seconds_streamed - buffer_seconds
             due = anchor_at - effective_start_time
             skip = 0
             prime_slice = b""
@@ -432,20 +447,6 @@ class AirPlayStreamSession:
                 # The due position is at or behind the write head: prime
                 # the joiner from the ring so the live feed then continues
                 # seamlessly.
-                if due < ring_floor:
-                    # The due position predates the ring (an unusually
-                    # large lead). Cap the prime at the whole buffer and
-                    # grow the headroom so the anchor still maps to the
-                    # prime's first sample exactly.
-                    self.prov.logger.debug(
-                        "Late joiner %s: due position %.2fs predates the "
-                        "%.2fs ring; capping prime at the whole buffer",
-                        airplay_player.player_id,
-                        due,
-                        buffer_seconds,
-                    )
-                    due = ring_floor
-                    anchor_at = effective_start_time + due
                 keep_bytes = int((self.seconds_streamed - due) * pcm_sample_size)
                 # Frame-align the prime START in ABSOLUTE stream
                 # coordinates. The prime must end exactly at the write head
@@ -462,8 +463,54 @@ class AirPlayStreamSession:
                         airplay_player.player_id,
                         realign,
                     )
-                if keep_bytes > 0:
-                    prime_slice = buffered_pcm[len(buffered_pcm) - keep_bytes :]
+                # The ring's own head is frame-aligned only by accident - it is
+                # trimmed on byte overflow - so align it too before measuring
+                # how much of the requested prime it can really serve.
+                ring_head_abs = self._pcm_total_fed - len(buffered_pcm)
+                ring_realign = (frame_size - ring_head_abs % frame_size) % frame_size
+                servable = buffered_pcm[ring_realign:]
+                if keep_bytes > len(servable):
+                    # The due position predates the ring: the write head ran
+                    # further ahead of the audible position than the ring was
+                    # sized for. Those samples are gone, so the join either
+                    # starts a little later (anchor still free to move) or opens
+                    # with that much silence (anchor already acked) - both keep
+                    # the real content on the instant the group plays it, which
+                    # dropping the missing head would not.
+                    missing = keep_bytes - len(servable)
+                    lead = self.seconds_streamed - (time.time() - effective_start_time)
+                    if committed:
+                        # One ring's worth is already far past any real
+                        # shortfall, so it bounds what an implausible ack (one
+                        # mapping back near the session start) can allocate.
+                        pad = min(missing, self._pcm_buffer_max)
+                        prime_slice = bytes(pad) + servable
+                        self.prov.logger.warning(
+                            "Late joiner %s: the feed runs %.2fs ahead of the audible "
+                            "position, past the %.2fs of audio kept for a join; opening "
+                            "with %.2fs of silence so the content still lands in sync. "
+                            "The joiner is audible that much late; please report this "
+                            "with a debug log.",
+                            airplay_player.player_id,
+                            lead,
+                            len(servable) / pcm_sample_size,
+                            pad / pcm_sample_size,
+                        )
+                    else:
+                        due += missing / pcm_sample_size
+                        anchor_at = effective_start_time + due
+                        prime_slice = servable
+                        self.prov.logger.debug(
+                            "Late joiner %s: due position predates the %.2fs ring "
+                            "(feed runs %.2fs ahead); anchoring %.2fs later, on the "
+                            "ring's oldest sample",
+                            airplay_player.player_id,
+                            len(servable) / pcm_sample_size,
+                            lead,
+                            missing / pcm_sample_size,
+                        )
+                elif keep_bytes > 0:
+                    prime_slice = servable[len(servable) - keep_bytes :]
             else:
                 # The due position is ahead of the write head: skip that
                 # many bytes off the head of the live feed so the joiner's
@@ -500,7 +547,7 @@ class AirPlayStreamSession:
                     anchor_at,
                     (ready_at_unix_ms + AIRPLAY_CLOCK_READY_LEAD_MS) / 1000,
                 )
-            requested_at, fed_pos_due = map_to(anchor_at)[:2]
+            requested_at, fed_pos_due = map_to(anchor_at, committed=False)[:2]
             start_unix_ms = int(requested_at * 1000)
             sync_adjust = airplay_player.config.get_value(CONF_SYNC_ADJUST, 0)
             adjust_ms = sync_adjust if isinstance(sync_adjust, int) else 0
@@ -545,7 +592,7 @@ class AirPlayStreamSession:
                 # the mapping covers whatever the group was fed while the ack was
                 # outstanding.
                 acked_at = (actual - adjust_ms) / 1000 if actual is not None else requested_at
-                start_at, fed_pos_due, prime, skip_bytes = map_to(acked_at)
+                start_at, fed_pos_due, prime, skip_bytes = map_to(acked_at, committed=True)
                 self._client_skip_bytes[airplay_player.player_id] = skip_bytes
                 # An instant that moved carries the content mapped onto it
                 # further into the stream than the position sent with the
@@ -558,7 +605,8 @@ class AirPlayStreamSession:
                 self.prov.logger.debug(
                     "Late joiner %s: priming %.2fs, skipping %.2fs, stream_pos=%.2fs, "
                     "fed_pos_due=%.2fs, start_at is %.2fs from now, acked %+d ms off the "
-                    "commanded instant (min_headroom=%.2fs, effective_shift=%.2fs)",
+                    "commanded instant (min_headroom=%.2fs, effective_shift=%.2fs, "
+                    "write_head_lead=%.2fs, peak=%.2fs, ring=%.2fs)",
                     airplay_player.player_id,
                     len(prime) / pcm_sample_size,
                     skip_bytes / pcm_sample_size,
@@ -568,6 +616,9 @@ class AirPlayStreamSession:
                     int(acked_at * 1000) - start_unix_ms,
                     min_headroom,
                     self.effective_start_time - self.start_time,
+                    self.seconds_streamed - (time.time() - self.effective_start_time),
+                    self._peak_lead_seconds,
+                    self._pcm_buffer_max / pcm_sample_size,
                 )
 
                 if prime:
@@ -607,6 +658,46 @@ class AirPlayStreamSession:
             airplay_player.player_id,
             time.time() - now,
         )
+
+    def _ring_bytes_for(self, lead_seconds: float) -> int:
+        """
+        Return the late-join ring size that covers a given write-head lead.
+
+        :param lead_seconds: Lead the ring has to span, before margin.
+        """
+        seconds = max(
+            lead_seconds + AIRPLAY_LATE_JOIN_RING_MARGIN_SECONDS,
+            AIRPLAY_LATE_JOIN_RING_MIN_SECONDS,
+        )
+        size = min(int(seconds * self._pcm_byte_rate), AIRPLAY_LATE_JOIN_RING_MAX_BYTES)
+        # Keep it a whole number of frames so it can bound a silence pad without
+        # knocking the prime off its frame boundaries.
+        return size - size % self._pcm_frame_size
+
+    def _observe_write_head_lead(self) -> None:
+        """
+        Track how far the feed runs ahead of the audible position (call under the lock).
+
+        A joiner's anchor maps into exactly this span, so the ring is grown to
+        the largest lead the session has shown. It only ever grows: shrinking it
+        mid-session would discard history a joiner still needs, and the lead is
+        at its largest right after the anchor is placed - the whole downstream
+        pipeline is full by then - so the ring is sized long before any late
+        join can arrive.
+        """
+        if self.start_time <= 0:
+            return  # not anchored yet, so there is no audible position to measure against
+        now = time.time()
+        if now < self.effective_start_time:
+            # Still inside the start lead: everything fed is ahead of an anchor
+            # that has not arrived, which would read as a lead seconds larger
+            # than the pipeline really holds.
+            return
+        lead = self.seconds_streamed - (now - self.effective_start_time)
+        if lead <= self._peak_lead_seconds:
+            return
+        self._peak_lead_seconds = lead
+        self._pcm_buffer_max = self._ring_bytes_for(lead)
 
     def _session_is_live(self) -> bool:
         """Return whether the session still has a running reference member (call under the lock)."""
@@ -749,6 +840,7 @@ class AirPlayStreamSession:
             # add_client always reads consistent values.
             self.seconds_streamed += len(chunk) / self._pcm_byte_rate
             self._pcm_total_fed += len(chunk)
+            self._observe_write_head_lead()
             self._pcm_buffer.extend(chunk)
             overflow = len(self._pcm_buffer) - self._pcm_buffer_max
             if overflow > 0:

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -485,16 +485,23 @@ class AirPlayStreamSession:
                         # mapping back near the session start) can allocate.
                         pad = min(missing, self._pcm_buffer_max)
                         prime_slice = bytes(pad) + servable
+                        # A clamped pad cannot reach the due position, so the
+                        # joiner really does end up ahead of the group by the
+                        # remainder. Say which of the two happened.
+                        residual = (missing - pad) / pcm_sample_size
                         self.prov.logger.warning(
                             "Late joiner %s: the feed runs %.2fs ahead of the audible "
                             "position, past the %.2fs of audio kept for a join; opening "
-                            "with %.2fs of silence so the content still lands in sync. "
-                            "The joiner is audible that much late; please report this "
-                            "with a debug log.",
+                            "with %.2fs of silence to cover the missing head. %s Please "
+                            "report this with a debug log.",
                             airplay_player.player_id,
                             lead,
                             len(servable) / pcm_sample_size,
                             pad / pcm_sample_size,
+                            f"That still leaves it {residual:.2f}s ahead of the group."
+                            if residual
+                            else "The content itself still lands in sync; the joiner is "
+                            "only audible that much late.",
                         )
                     else:
                         due += missing / pcm_sample_size

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -1480,3 +1480,45 @@ def test_write_head_lead_is_not_measured_before_the_anchor_arrives() -> None:
     with patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now):
         unanchored._observe_write_head_lead()
     assert unanchored._peak_lead_seconds == 0.0
+
+
+@pytest.mark.asyncio
+async def test_late_join_silence_pad_is_bounded_and_reports_the_residual() -> None:
+    """An implausible ack is padded only up to the ring bound, and says so."""
+    now = 1_000_000.0
+    session = _make_session(now - 400.0, 420.0)
+    session._pcm_total_fed = int(420.0 * PCM_SAMPLE_SIZE)
+    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 2)
+    session._pcm_buffer_max = PCM_SAMPLE_SIZE * 2
+    session._peak_lead_seconds = 1e6
+    logger = MagicMock()
+    session.prov.logger = logger
+    player = _make_late_joiner()
+
+    written: list[tuple[str, bytes]] = []
+
+    async def capture_write(target: Any, chunk: bytes) -> None:
+        written.append((target.player_id, chunk))
+
+    def setup_with_stale_ack(*_args: Any, **_kwargs: Any) -> None:
+        _setup_stream(player)()
+        # The binary reports an instant far behind the commanded one, mapping
+        # the joiner back near the start of the session. 320s of head is owed.
+        player.stream.start = AsyncMock(return_value=int((now - 300.0) * 1000))
+
+    with (
+        patch.object(session, "_start_client", side_effect=setup_with_stale_ack),
+        patch.object(session, "_write_chunk_to_player", side_effect=capture_write),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
+    ):
+        await session.add_client(player)
+
+    prime = next(chunk for pid, chunk in written if pid == player.player_id)
+    # Bounded at one ring of silence plus the ring itself - never the 320s owed.
+    assert len(prime) / PCM_SAMPLE_SIZE == pytest.approx(4.0, abs=0.01)
+    assert (session._pcm_total_fed - len(prime)) % session._pcm_frame_size == 0
+    # The joiner cannot be placed exactly, so the log must not claim sync.
+    logger.warning.assert_called_once()
+    tail = logger.warning.call_args.args[-1]
+    assert "ahead of the group" in tail
+    assert "in sync" not in tail

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -15,6 +15,9 @@ from music_assistant.providers.airplay.constants import (
     AIRPLAY_COLD_GROUP_START_LEAD_MS,
     AIRPLAY_GROUP_START_LEAD_MS,
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
+    AIRPLAY_LATE_JOIN_RING_MARGIN_SECONDS,
+    AIRPLAY_LATE_JOIN_RING_MAX_BYTES,
+    AIRPLAY_LATE_JOIN_RING_MIN_SECONDS,
     AIRPLAY_START_LEAD_MS,
     StreamingProtocol,
 )
@@ -1328,3 +1331,152 @@ async def test_cleanup_after_removal_skips_idle_when_player_has_new_session_stre
         await session._cleanup_after_removal(player)
 
     player.set_state_from_stream.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_late_join_pads_with_silence_when_the_ring_ran_out_under_a_committed_anchor() -> None:
+    """A due position lost to the ring after the START is covered with silence, not a moved anchor."""
+    # Freeze time so both the test and the code under test agree on `now`.
+    now = 1_000_000.0
+    start_time = now - 100.0
+    session = _make_session(start_time, 110.0)
+    session._pcm_total_fed = int(110.0 * PCM_SAMPLE_SIZE)
+    # An 8s ring against a 10s write-head lead: wide enough when the anchor is
+    # planned, too narrow by the time the binary owns the instant.
+    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 8)
+    session._pcm_buffer_max = PCM_SAMPLE_SIZE * 8
+    # Freeze the adaptive sizing so this test covers the cap, not the growth.
+    session._peak_lead_seconds = 1e6
+    logger = MagicMock()
+    session.prov.logger = logger
+    player = _make_late_joiner()
+
+    written: list[tuple[str, bytes]] = []
+
+    async def capture_write(target: Any, chunk: bytes) -> None:
+        written.append((target.player_id, chunk))
+
+    def setup_with_feed(*_args: Any, **_kwargs: Any) -> None:
+        _setup_stream(player)()
+
+        async def start(_start_unix_ms: int, _position_ms: int, *, join: bool = False) -> None:
+            assert join is True
+            # The group keeps being fed while the START ack is outstanding: this
+            # is what pushes the joiner's due position off the back of the ring.
+            await session._write_chunk_to_all_players(b"\x02" * int(2.0 * PCM_SAMPLE_SIZE))
+
+        player.stream.start = AsyncMock(side_effect=start)
+
+    with (
+        patch.object(session, "_start_client", side_effect=setup_with_feed),
+        patch.object(session, "_write_chunk_to_player", side_effect=capture_write),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
+    ):
+        await session.add_client(player)
+
+    # The anchor is the one that was commanded: an acked instant is never moved.
+    headroom = AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS / 1000
+    assert _captured_start_at(player) == pytest.approx(now + headroom, abs=0.001)
+    prime = next(chunk for pid, chunk in written if pid == player.player_id)
+    # due is 102.5s of feed and the write head reached 112.0s, so 9.5s is owed
+    # while only 8s survives in the ring: the missing 1.5s opens as silence.
+    assert len(prime) / PCM_SAMPLE_SIZE == pytest.approx(9.5, abs=0.001)
+    pad = int(1.5 * PCM_SAMPLE_SIZE)
+    assert prime[:pad] == bytes(pad), "the missing head must be silence"
+    assert set(prime[pad:]) == {1, 2}, "the rest must be the buffered feed"
+    assert pad % session._pcm_frame_size == 0
+    assert session._client_skip_bytes[player.player_id] == 0
+    # Position still reports where the GROUP is at that instant, because the
+    # real content lands exactly where it would have without the shortfall.
+    player.stream.rebase_position.assert_not_called()
+    logger.warning.assert_called_once()
+    assert "silence" in logger.warning.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_late_join_ring_shortfall_keeps_a_misaligned_ring_head_frame_aligned() -> None:
+    """A silence pad over a mid-frame ring head still lands the feed on frame boundaries."""
+    now = 1_000_000.0
+    session = _make_session(now - 100.0, 110.0)
+    # Both the write head and the ring head sit mid-frame.
+    session._pcm_total_fed = int(110.0 * PCM_SAMPLE_SIZE) + 3
+    session._pcm_buffer = bytearray(b"\x01" * (PCM_SAMPLE_SIZE * 8 + 2))
+    session._pcm_buffer_max = len(session._pcm_buffer)
+    session._peak_lead_seconds = 1e6
+    player = _make_late_joiner()
+
+    written: list[tuple[str, bytes]] = []
+
+    async def capture_write(target: Any, chunk: bytes) -> None:
+        written.append((target.player_id, chunk))
+
+    def setup_with_feed(*_args: Any, **_kwargs: Any) -> None:
+        _setup_stream(player)()
+
+        async def start(_start_unix_ms: int, _position_ms: int, *, join: bool = False) -> None:
+            assert join is True
+            await session._write_chunk_to_all_players(b"\x02" * (int(2.0 * PCM_SAMPLE_SIZE) + 1))
+
+        player.stream.start = AsyncMock(side_effect=start)
+
+    with (
+        patch.object(session, "_start_client", side_effect=setup_with_feed),
+        patch.object(session, "_write_chunk_to_player", side_effect=capture_write),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
+    ):
+        await session.add_client(player)
+
+    prime = next(chunk for pid, chunk in written if pid == player.player_id)
+    frame_size = session._pcm_frame_size
+    # The prime ends exactly at the write head, so its start - and therefore the
+    # whole padded prime - has to sit on an absolute frame boundary.
+    assert (session._pcm_total_fed - len(prime)) % frame_size == 0
+    pad_len = len(prime) - len(prime.lstrip(b"\x00"))
+    assert pad_len % frame_size == 0
+
+
+def test_ring_grows_to_the_observed_write_head_lead() -> None:
+    """The ring tracks the largest lead a session shows, above a floor and under a byte cap."""
+    now = 1_000_000.0
+    session = _make_session(now - 100.0, 100.0)
+    assert session._pcm_buffer_max == int(AIRPLAY_LATE_JOIN_RING_MIN_SECONDS * PCM_SAMPLE_SIZE)
+
+    with patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now):
+        # A 4s lead stays under the floor, which keeps the ring where it was.
+        session.seconds_streamed = 104.0
+        session._observe_write_head_lead()
+        assert session._pcm_buffer_max == int(AIRPLAY_LATE_JOIN_RING_MIN_SECONDS * PCM_SAMPLE_SIZE)
+
+        # A 15s lead carries the ring past the floor, with the margin on top.
+        session.seconds_streamed = 115.0
+        session._observe_write_head_lead()
+        assert session._peak_lead_seconds == pytest.approx(15.0, abs=0.001)
+        expected = int((15.0 + AIRPLAY_LATE_JOIN_RING_MARGIN_SECONDS) * PCM_SAMPLE_SIZE)
+        assert session._pcm_buffer_max == expected
+
+        # A lead that falls back never shrinks the ring: the history a joiner
+        # still needs is already in it.
+        session.seconds_streamed = 108.0
+        session._observe_write_head_lead()
+        assert session._pcm_buffer_max == expected
+
+        # Growth is bounded in bytes, so a hi-res rate cannot multiply it out.
+        session.seconds_streamed = 100.0 + 3600.0
+        session._observe_write_head_lead()
+        assert session._pcm_buffer_max == AIRPLAY_LATE_JOIN_RING_MAX_BYTES
+
+
+def test_write_head_lead_is_not_measured_before_the_anchor_arrives() -> None:
+    """Audio fed inside the start lead is not counted as pipeline depth."""
+    now = 1_000_000.0
+    # Anchored 2.5s into the future: nothing is audible yet.
+    session = _make_session(now + 2.5, 8.0)
+    with patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now):
+        session._observe_write_head_lead()
+    assert session._peak_lead_seconds == 0.0
+    assert session._pcm_buffer_max == int(AIRPLAY_LATE_JOIN_RING_MIN_SECONDS * PCM_SAMPLE_SIZE)
+
+    unanchored = _make_session(0.0, 8.0)
+    with patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now):
+        unanchored._observe_write_head_lead()
+    assert unanchored._peak_lead_seconds == 0.0


### PR DESCRIPTION
# What does this implement/fix?

When a speaker joins an AirPlay group that is already playing, Music Assistant primes it from a buffer of recently sent audio so it can start quickly. That buffer was a fixed 10 seconds, which is slightly too small: the audio pipeline actually runs 9-11 seconds ahead of what you hear, most of it inside ffmpeg rather than the AirPlay side. When the buffer came up short, the joining speaker could start marginally out of step with the rest of the group.

## Changes

- Measure how far ahead the pipeline actually runs and size the buffer to match, instead of assuming. Bounded to 6 MiB per playing group.
- Never move a start instant the player has already committed to. If the buffer still falls short, the join opens with a moment of silence so the audio itself still lands in sync.
- Report that case as a warning with the relevant numbers, and include the measured values in the late-join debug line, so it is visible in a support log instead of silent.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
