### PR TITLE
Fix one bad join code locking out all other guests

### DIFF
--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -30,6 +30,7 @@ from music_assistant_models.errors import (
 from music_assistant.constants import DB_TABLE_PLAYLOG, HOMEASSISTANT_SYSTEM_USER, MASS_LOGGER_NAME
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     ROLE_SCOPES,
+    get_current_client_id,
     get_current_token,
     get_current_user,
     has_scope,
@@ -75,8 +76,17 @@ HA_TOKEN_NAME = "Home Assistant Integration"
 JOIN_CODE_LENGTH = 12
 JOIN_CODE_CHARSET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"  # No I/O/0/1 for readability
 JOIN_CODE_DEFAULT_EXPIRY_HOURS = 8
-# No source IP available here, so throttle failed exchanges globally under one key.
-JOIN_CODE_RATE_LIMIT_KEY = "join_code_exchange"
+# Failed exchanges are throttled per calling websocket connection, so one guest fumbling a
+# stale QR code cannot lock out every other guest at a party. Callers that reach the API
+# without a connection identity (the JSON RPC endpoint, in-process callers) share one bucket.
+JOIN_CODE_ANONYMOUS_RATE_LIMIT_KEY = "no-connection"
+# Second, server-wide bucket that backstops the per-connection buckets, since a client can
+# start a new connection (and thus a new bucket) at will. The join code itself is what makes
+# guessing infeasible (12 chars over a 32 symbol alphabet is ~2^60, valid for hours), so this
+# ceiling is deliberately far above any plausible party-scale burst of legitimate failures.
+JOIN_CODE_GLOBAL_RATE_LIMIT_KEY = "all-connections"
+JOIN_CODE_GLOBAL_FAILURE_CEILING = 1000
+JOIN_CODE_GLOBAL_COOLDOWN_SECONDS = 60
 
 
 class AuthenticationManager:
@@ -95,7 +105,13 @@ class AuthenticationManager:
         self.logger = LOGGER
         self._has_users: bool = False
         self.jwt_helper: JWTHelper = None  # type: ignore[assignment]
-        self._join_code_rate_limiter = LoginRateLimiter()
+        self._join_code_rate_limiter = LoginRateLimiter(subject="client")
+        self._join_code_global_rate_limiter = LoginRateLimiter(
+            delay_tiers=((JOIN_CODE_GLOBAL_FAILURE_CEILING, JOIN_CODE_GLOBAL_COOLDOWN_SECONDS),),
+            warn_threshold=JOIN_CODE_GLOBAL_FAILURE_CEILING,
+            alert_threshold=JOIN_CODE_GLOBAL_FAILURE_CEILING * 2,
+            subject="join_codes",
+        )
         # Stops concurrent exchanges from passing the rate limit check before failures land
         self._join_code_exchange_lock = asyncio.Lock()
 
@@ -1483,31 +1499,28 @@ class AuthenticationManager:
         :param code: The short join code.
         :return: Authentication result with access token if successful.
         """
+        client_id = get_current_client_id()
+        rate_limit_key = client_id or JOIN_CODE_ANONYMOUS_RATE_LIMIT_KEY
         async with self._join_code_exchange_lock:
-            allowed, remaining_delay = await self._join_code_rate_limiter.check_rate_limit(
-                JOIN_CODE_RATE_LIMIT_KEY
-            )
-            if not allowed:
-                self.logger.warning(
-                    "Join code exchange rate limit exceeded. %d seconds remaining.", remaining_delay
-                )
-                return {
-                    "success": False,
-                    "error": (
-                        f"Too many failed attempts. Please try again in {remaining_delay} seconds."
-                    ),
-                }
+            if throttled := await self._check_join_code_rate_limit(rate_limit_key, code):
+                return throttled
 
             token = await self._exchange_join_code(code)
 
             if not token:
-                await self._join_code_rate_limiter.record_failed_attempt(JOIN_CODE_RATE_LIMIT_KEY)
+                await self._join_code_rate_limiter.record_failed_attempt(rate_limit_key)
+                await self._join_code_global_rate_limiter.record_failed_attempt(
+                    JOIN_CODE_GLOBAL_RATE_LIMIT_KEY
+                )
                 return {
                     "success": False,
                     "error": "Invalid or expired join code",
                 }
 
-        # No clear_attempts on success: any valid-code holder could reset the global counter
+            # Only a per-connection bucket is cleared on success, so presenting a valid code
+            # lifts the throttle for that connection alone and never for anyone else.
+            if client_id:
+                await self._join_code_rate_limiter.clear_attempts(rate_limit_key)
 
         # Decode token to get user info
         try:
@@ -1890,6 +1903,43 @@ class AuthenticationManager:
         else:
             self.logger.info("Password changed for user %s", target_user.username)
 
+    async def _check_join_code_rate_limit(self, key: str, code: str) -> dict[str, Any] | None:
+        """
+        Check the join code exchange throttles that apply to the calling client.
+
+        :param key: Rate limit key identifying the calling client.
+        :param code: The join code the client wants to exchange, used for diagnostics only.
+        :return: The error result to return to the caller, or None if the attempt may proceed.
+        """
+        limiters = (
+            ("client", self._join_code_rate_limiter, key),
+            ("server", self._join_code_global_rate_limiter, JOIN_CODE_GLOBAL_RATE_LIMIT_KEY),
+        )
+        for scope, limiter, limiter_key in limiters:
+            allowed, remaining_delay = await limiter.check_rate_limit(limiter_key)
+            if allowed:
+                continue
+            self.logger.warning(
+                "Join code exchange throttled by the %s limit "
+                "(client=%s, code=%s, client_failures=%d, server_failures=%d). "
+                "%d seconds remaining.",
+                scope,
+                key,
+                _mask_join_code(code),
+                self._join_code_rate_limiter.get_attempt_count(key),
+                self._join_code_global_rate_limiter.get_attempt_count(
+                    JOIN_CODE_GLOBAL_RATE_LIMIT_KEY
+                ),
+                remaining_delay,
+            )
+            return {
+                "success": False,
+                "error": (
+                    f"Too many failed attempts. Please try again in {remaining_delay} seconds."
+                ),
+            }
+        return None
+
     async def _exchange_join_code(self, code: str) -> str | None:
         """
         Exchange a join code for a JWT access token.
@@ -1917,7 +1967,11 @@ class AuthenticationManager:
         await self.database.commit()
 
         if not row:
-            self.logger.warning("Join code exchange rejected (code=%s)", code.upper())
+            self.logger.warning(
+                "Join code exchange rejected (client=%s, code=%s)",
+                get_current_client_id() or JOIN_CODE_ANONYMOUS_RATE_LIMIT_KEY,
+                _mask_join_code(code),
+            )
             return None
 
         user = await self.get_user(row["user_id"])
@@ -2014,3 +2068,14 @@ class AuthenticationManager:
             days=TOKEN_ABSOLUTE_MAX_EXPIRATION - HA_TOKEN_ROTATION_MARGIN
         )
         return now < rotate_after
+
+
+def _mask_join_code(code: str) -> str:
+    """
+    Mask a join code so support logs can correlate attempts without exposing a usable code.
+
+    :param code: The join code as supplied by the client.
+    :return: The code with everything past its prefix replaced by asterisks.
+    """
+    normalized = code.upper()
+    return normalized[:4] + "*" * max(len(normalized) - 4, 0)

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -31,6 +31,7 @@ from music_assistant.constants import DB_TABLE_PLAYLOG, HOMEASSISTANT_SYSTEM_USE
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     ROLE_SCOPES,
     get_current_client_id,
+    get_current_peer_address,
     get_current_token,
     get_current_user,
     has_scope,
@@ -1499,10 +1500,9 @@ class AuthenticationManager:
         :param code: The short join code.
         :return: Authentication result with access token if successful.
         """
-        client_id = get_current_client_id()
-        rate_limit_key = client_id or JOIN_CODE_ANONYMOUS_RATE_LIMIT_KEY
+        rate_limit_key, key_is_exclusive = _join_code_rate_limit_key()
         async with self._join_code_exchange_lock:
-            if throttled := await self._check_join_code_rate_limit(rate_limit_key, code):
+            if throttled := await self._check_join_code_rate_limit(rate_limit_key):
                 return throttled
 
             token = await self._exchange_join_code(code)
@@ -1517,9 +1517,9 @@ class AuthenticationManager:
                     "error": "Invalid or expired join code",
                 }
 
-            # Only a per-connection bucket is cleared on success, so presenting a valid code
-            # lifts the throttle for that connection alone and never for anyone else.
-            if client_id:
+            # A bucket is only cleared when it belongs to one caller alone, so presenting a
+            # valid code never lifts the throttle for anyone else.
+            if key_is_exclusive:
                 await self._join_code_rate_limiter.clear_attempts(rate_limit_key)
 
         # Decode token to get user info
@@ -1903,12 +1903,11 @@ class AuthenticationManager:
         else:
             self.logger.info("Password changed for user %s", target_user.username)
 
-    async def _check_join_code_rate_limit(self, key: str, code: str) -> dict[str, Any] | None:
+    async def _check_join_code_rate_limit(self, key: str) -> dict[str, Any] | None:
         """
         Check the join code exchange throttles that apply to the calling client.
 
         :param key: Rate limit key identifying the calling client.
-        :param code: The join code the client wants to exchange, used for diagnostics only.
         :return: The error result to return to the caller, or None if the attempt may proceed.
         """
         limiters = (
@@ -1919,13 +1918,15 @@ class AuthenticationManager:
             allowed, remaining_delay = await limiter.check_rate_limit(limiter_key)
             if allowed:
                 continue
+            # The attempted code is deliberately absent here: it has not been checked yet,
+            # so it may well be a valid one. Each failure that filled the bucket already
+            # logged its own (rejected, and therefore unusable) code.
             self.logger.warning(
                 "Join code exchange throttled by the %s limit "
-                "(client=%s, code=%s, client_failures=%d, server_failures=%d). "
+                "(client=%s, client_failures=%d, server_failures=%d). "
                 "%d seconds remaining.",
                 scope,
                 key,
-                _mask_join_code(code),
                 self._join_code_rate_limiter.get_attempt_count(key),
                 self._join_code_global_rate_limiter.get_attempt_count(
                     JOIN_CODE_GLOBAL_RATE_LIMIT_KEY
@@ -2068,6 +2069,20 @@ class AuthenticationManager:
             days=TOKEN_ABSOLUTE_MAX_EXPIRATION - HA_TOKEN_ROTATION_MARGIN
         )
         return now < rotate_after
+
+
+def _join_code_rate_limit_key() -> tuple[str, bool]:
+    """
+    Work out which bucket the calling client's failed join code exchanges belong to.
+
+    :return: The rate limit key, and whether that key identifies a single caller
+        exclusively (a shared key must never be cleared on a successful exchange).
+    """
+    if client_id := get_current_client_id():
+        return client_id, True
+    if peer_address := get_current_peer_address():
+        return f"peer:{peer_address}", False
+    return JOIN_CODE_ANONYMOUS_RATE_LIMIT_KEY, False
 
 
 def _mask_join_code(code: str) -> str:

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -63,6 +63,7 @@ from .helpers.auth_middleware import (
     has_scope,
     is_request_from_ingress,
     resolve_command_impersonation,
+    set_current_peer_address,
     set_current_token,
     set_current_user,
     set_impersonated_user,
@@ -545,6 +546,9 @@ class WebserverController(CoreController):
 
     async def _handle_jsonrpc_api_command(self, request: web.Request) -> web.Response:
         """Handle incoming JSON RPC API command."""
+        # These requests carry no connection identity, so the peer address is all an
+        # unauthenticated handler has to tell one caller apart from another.
+        set_current_peer_address(request.remote)
         # Fail early if we don't have any users yet
         if not self.auth.has_users:
             return web.Response(status=503, text="Setup required")

--- a/music_assistant/controllers/webserver/helpers/auth_middleware.py
+++ b/music_assistant/controllers/webserver/helpers/auth_middleware.py
@@ -65,6 +65,10 @@ impersonated_user: ContextVar[User | None] = ContextVar("impersonated_user", def
 sendspin_player_id: ContextVar[str | None] = ContextVar("sendspin_player_id", default=None)
 # ContextVar for tracking the websocket client id associated with the current connection
 current_client_id: ContextVar[str | None] = ContextVar("current_client_id", default=None)
+# ContextVar for tracking the network address a stateless API request came from.
+# A reverse proxy or Home Assistant Ingress presents its own address for every client
+# behind it, so this identifies a caller far less precisely than a client id does.
+current_peer_address: ContextVar[str | None] = ContextVar("current_peer_address", default=None)
 
 
 async def get_authenticated_user(request: web.Request) -> User | None:
@@ -319,6 +323,24 @@ def set_current_client_id(client_id: str | None) -> None:
     :param client_id: The client id to set.
     """
     current_client_id.set(client_id)
+
+
+def get_current_peer_address() -> str | None:
+    """
+    Get the network address the current stateless API request came from.
+
+    :return: The peer address, or None if the caller is not a stateless API request.
+    """
+    return current_peer_address.get()
+
+
+def set_current_peer_address(peer_address: str | None) -> None:
+    """
+    Set the network address for the current stateless API request.
+
+    :param peer_address: The peer address to set.
+    """
+    current_peer_address.set(peer_address)
 
 
 def is_request_from_ingress(request: web.Request) -> bool:

--- a/music_assistant/controllers/webserver/helpers/auth_providers.py
+++ b/music_assistant/controllers/webserver/helpers/auth_providers.py
@@ -33,6 +33,8 @@ LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.auth")
 # Progressive (failed attempts, delay in seconds) tiers applied to a single rate limit key
 DEFAULT_DELAY_TIERS: Final[tuple[tuple[int, int], ...]] = ((3, 30), (6, 60), (10, 120), (15, 300))
 DEFAULT_TRACKING_WINDOW: Final = timedelta(minutes=30)
+# Tracked keys before expired ones are swept from the rate limiter's bookkeeping
+PRUNE_THRESHOLD: Final = 128
 
 
 def normalize_username(username: str) -> str:
@@ -236,6 +238,13 @@ class LoginRateLimiter:
                     self._subject,
                     key,
                 )
+
+            # A key is only cleaned up when it is used again, and most keys (a one-off
+            # connection, a made-up username) never come back, so sweep the whole map once
+            # it grows past what any legitimate burst of callers produces.
+            if len(self._failed_attempts) > PRUNE_THRESHOLD:
+                for tracked_key in list(self._failed_attempts):
+                    self._cleanup_old_attempts(tracked_key)
 
     async def clear_attempts(self, key: str) -> None:
         """

--- a/music_assistant/controllers/webserver/helpers/auth_providers.py
+++ b/music_assistant/controllers/webserver/helpers/auth_providers.py
@@ -7,9 +7,10 @@ import hashlib
 import logging
 import secrets
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Final, TypedDict, cast
 from urllib.parse import urlparse
 
 from hass_client import HomeAssistantClient
@@ -28,6 +29,10 @@ if TYPE_CHECKING:
 
 
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.auth")
+
+# Progressive (failed attempts, delay in seconds) tiers applied to a single rate limit key
+DEFAULT_DELAY_TIERS: Final[tuple[tuple[int, int], ...]] = ((3, 30), (6, 60), (10, 120), (15, 300))
+DEFAULT_TRACKING_WINDOW: Final = timedelta(minutes=30)
 
 
 def normalize_username(username: str) -> str:
@@ -118,62 +123,74 @@ async def get_ha_user_role(
 class LoginRateLimiter:
     """Rate limiter for login attempts to prevent brute force attacks."""
 
-    def __init__(self) -> None:
-        """Initialize the rate limiter."""
-        # Track failed attempts per username: {username: [timestamp1, timestamp2, ...]}
+    def __init__(
+        self,
+        delay_tiers: Sequence[tuple[int, int]] = DEFAULT_DELAY_TIERS,
+        tracking_window: timedelta = DEFAULT_TRACKING_WINDOW,
+        warn_threshold: int = 10,
+        alert_threshold: int = 20,
+        subject: str = "username",
+    ) -> None:
+        """
+        Initialize the rate limiter.
+
+        :param delay_tiers: (failed attempts, delay in seconds) pairs in ascending order of
+            attempts. The highest tier whose attempt count is reached sets the delay.
+        :param tracking_window: How long a failed attempt keeps counting towards the tiers.
+        :param warn_threshold: Failed attempts for one key before suspicious activity is logged.
+        :param alert_threshold: Failed attempts for one key before a stronger warning is logged.
+        :param subject: What the keys of this limiter identify, used in log messages.
+        """
+        # Track failed attempts per key: {key: [timestamp1, timestamp2, ...]}
         self._failed_attempts: dict[str, list[datetime]] = {}
-        # Time window for tracking attempts (30 minutes)
-        self._tracking_window = timedelta(minutes=30)
+        self._delay_tiers = tuple(delay_tiers)
+        self._tracking_window = tracking_window
+        self._warn_threshold = warn_threshold
+        self._alert_threshold = alert_threshold
+        self._subject = subject
         # Lock for thread-safe access to _failed_attempts
         self._lock = asyncio.Lock()
 
-    def get_delay(self, username: str) -> int:
+    def get_attempt_count(self, key: str) -> int:
         """
-        Get the delay in seconds before next login attempt is allowed.
+        Get the number of failed attempts for a key inside the tracking window.
 
-        Progressive delays based on failed attempts:
-        - 1-2 attempts: no delay
-        - 3-5 attempts: 30 seconds
-        - 6-9 attempts: 60 seconds
-        - 10-14 attempts: 120 seconds
-        - 15+ attempts: 300 seconds (5 minutes)
+        :param key: The key to count failed attempts for.
+        :return: Number of failed attempts still being tracked.
+        """
+        self._cleanup_old_attempts(key)
+        return len(self._failed_attempts.get(key, ()))
 
-        :param username: The username attempting to log in.
+    def get_delay(self, key: str) -> int:
+        """
+        Get the delay in seconds before the next attempt for a key is allowed.
+
+        :param key: The key attempting to authenticate.
         :return: Delay in seconds (0 if no delay needed).
         """
-        self._cleanup_old_attempts(username)
+        attempt_count = self.get_attempt_count(key)
+        delay = 0
+        for tier_attempts, tier_delay in self._delay_tiers:
+            if attempt_count >= tier_attempts:
+                delay = tier_delay
+        return delay
 
-        if username not in self._failed_attempts:
-            return 0
-
-        attempt_count = len(self._failed_attempts[username])
-
-        if attempt_count < 3:
-            return 0
-        if attempt_count < 6:
-            return 30
-        if attempt_count < 10:
-            return 60
-        if attempt_count < 15:
-            return 120
-        return 300  # 5 minutes max delay
-
-    async def check_rate_limit(self, username: str) -> tuple[bool, int]:
+    async def check_rate_limit(self, key: str) -> tuple[bool, int]:
         """
-        Check if login attempt is allowed and apply delay if needed.
+        Check if an attempt is allowed and apply delay if needed.
 
-        :param username: The username attempting to log in.
+        :param key: The key attempting to authenticate.
         :return: Tuple of (allowed, delay_seconds). If not allowed, includes remaining delay.
         """
         async with self._lock:
-            self._cleanup_old_attempts(username)
+            self._cleanup_old_attempts(key)
 
-            if username not in self._failed_attempts or not self._failed_attempts[username]:
+            if key not in self._failed_attempts or not self._failed_attempts[key]:
                 return True, 0
 
             # Get the most recent failed attempt
-            last_attempt = self._failed_attempts[username][-1]
-            required_delay = self.get_delay(username)
+            last_attempt = self._failed_attempts[key][-1]
+            required_delay = self.get_delay(key)
 
             if required_delay == 0:
                 return True, 0
@@ -188,60 +205,65 @@ class LoginRateLimiter:
 
             return True, 0
 
-    async def record_failed_attempt(self, username: str) -> None:
+    async def record_failed_attempt(self, key: str) -> None:
         """
-        Record a failed login attempt.
+        Record a failed attempt.
 
-        :param username: The username that failed to log in.
+        :param key: The key that failed to authenticate.
         """
         async with self._lock:
-            self._cleanup_old_attempts(username)
+            self._cleanup_old_attempts(key)
 
-            if username not in self._failed_attempts:
-                self._failed_attempts[username] = []
+            if key not in self._failed_attempts:
+                self._failed_attempts[key] = []
 
-            self._failed_attempts[username].append(utc())
+            self._failed_attempts[key].append(utc())
 
             # Log warning for suspicious activity
-            attempt_count = len(self._failed_attempts[username])
-            if attempt_count == 10:
+            attempt_count = len(self._failed_attempts[key])
+            if attempt_count == self._warn_threshold:
                 LOGGER.warning(
-                    "Suspicious login activity: 10 failed attempts for username '%s'", username
+                    "Suspicious activity: %d failed attempts (%s=%s)",
+                    attempt_count,
+                    self._subject,
+                    key,
                 )
-            elif attempt_count == 20:
+            elif attempt_count == self._alert_threshold:
                 LOGGER.warning(
-                    "High suspicious login activity: 20 failed attempts for username '%s'. "
-                    "Consider manually disabling this account.",
-                    username,
+                    "High suspicious activity: %d failed attempts (%s=%s). "
+                    "Manual intervention may be needed.",
+                    attempt_count,
+                    self._subject,
+                    key,
                 )
 
-    async def clear_attempts(self, username: str) -> None:
+    async def clear_attempts(self, key: str) -> None:
         """
-        Clear failed attempts for a username (called after successful login).
+        Clear failed attempts for a key (called after a successful attempt).
 
-        :param username: The username to clear.
+        :param key: The key to clear.
         """
         async with self._lock:
-            if username in self._failed_attempts:
-                del self._failed_attempts[username]
+            if key in self._failed_attempts:
+                del self._failed_attempts[key]
 
-    def _cleanup_old_attempts(self, username: str) -> None:
+    def _cleanup_old_attempts(self, key: str) -> None:
         """
         Remove failed attempts outside the tracking window.
 
-        :param username: The username to clean up.
+        :param key: The key to clean up.
         """
-        if username not in self._failed_attempts:
+        if key not in self._failed_attempts:
             return
 
         cutoff_time = utc() - self._tracking_window
-        self._failed_attempts[username] = [
-            timestamp for timestamp in self._failed_attempts[username] if timestamp > cutoff_time
+        self._failed_attempts[key] = [
+            timestamp for timestamp in self._failed_attempts[key] if timestamp > cutoff_time
         ]
 
-        # Remove username if no attempts left
-        if not self._failed_attempts[username]:
-            del self._failed_attempts[username]
+        # Remove key if no attempts left
+        if not self._failed_attempts[key]:
+            del self._failed_attempts[key]
 
 
 class LoginProviderConfig(TypedDict, total=False):

--- a/music_assistant/controllers/webserver/helpers/auth_providers.py
+++ b/music_assistant/controllers/webserver/helpers/auth_providers.py
@@ -160,8 +160,8 @@ class LoginRateLimiter:
         :param key: The key to count failed attempts for.
         :return: Number of failed attempts still being tracked.
         """
-        self._cleanup_old_attempts(key)
-        return len(self._failed_attempts.get(key, ()))
+        cutoff_time = utc() - self._tracking_window
+        return sum(1 for timestamp in self._failed_attempts.get(key, ()) if timestamp > cutoff_time)
 
     def get_delay(self, key: str) -> int:
         """

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -213,6 +213,10 @@ class WebsocketClientHandler:
             self._logger.warning("Invalid command: %s", msg.command)
             return
 
+        # The client id identifies the connection, not the user, and unauthenticated handlers
+        # need it too (the join code exchange throttles per connection), so always set it.
+        set_current_client_id(self.client_id)
+
         # Check authentication if required
         if handler.authenticated or handler.required_scope:
             # For Ingress, user should already be set from _handle_ingress_auth
@@ -228,11 +232,10 @@ class WebsocketClientHandler:
                 )
                 return
 
-            # Set user, token, sendspin player and client id in context for API methods
+            # Set user, token and sendspin player in context for API methods
             set_current_user(self._authenticated_user)
             set_current_token(self._current_token)
             set_sendspin_player_id(self._sendspin_player_id)
-            set_current_client_id(self.client_id)
 
             # Check scope if required
             if handler.required_scope and not has_scope(

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -213,9 +213,14 @@ class WebsocketClientHandler:
             self._logger.warning("Invalid command: %s", msg.command)
             return
 
-        # The client id identifies the connection, not the user, and unauthenticated handlers
-        # need it too (the join code exchange throttles per connection), so always set it.
+        # Put this connection's identity in context for the API methods. ContextVars live
+        # for as long as the connection does, so every command sets all of them: an
+        # unauthenticated handler must see this connection's own (possibly absent) user
+        # rather than whatever the command before it left behind.
         set_current_client_id(self.client_id)
+        set_current_user(self._authenticated_user)
+        set_current_token(self._current_token)
+        set_sendspin_player_id(self._sendspin_player_id)
 
         # Check authentication if required
         if handler.authenticated or handler.required_scope:
@@ -231,11 +236,6 @@ class WebsocketClientHandler:
                     )
                 )
                 return
-
-            # Set user, token and sendspin player in context for API methods
-            set_current_user(self._authenticated_user)
-            set_current_token(self._current_token)
-            set_sendspin_player_id(self._sendspin_player_id)
 
             # Check scope if required
             if handler.required_scope and not has_scope(

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -40,6 +40,7 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
     set_impersonated_user,
 )
 from music_assistant.controllers.webserver.helpers.auth_providers import (
+    PRUNE_THRESHOLD,
     BuiltinLoginProvider,
     LoginRateLimiter,
 )
@@ -2082,6 +2083,29 @@ async def test_login_rate_limiter_drops_attempts_outside_window() -> None:
 
     await limiter.record_failed_attempt("key")
     assert limiter.get_attempt_count("key") == 0
+
+
+async def test_login_rate_limiter_prunes_expired_keys() -> None:
+    """
+    Verify expired keys do not pile up when they are never used again.
+
+    Keys are one-off by nature (a connection that gives up, a made-up username), so
+    without the sweep the bookkeeping would grow for as long as the server runs.
+    """
+    limiter = LoginRateLimiter(tracking_window=timedelta(seconds=0))
+
+    for index in range(PRUNE_THRESHOLD + 1):
+        await limiter.record_failed_attempt(f"key{index}")
+
+    # Every attempt is already outside this limiter's window, so the sweep drops them all.
+    assert len(limiter._failed_attempts) == 0
+
+    live = LoginRateLimiter()
+    for index in range(PRUNE_THRESHOLD + 1):
+        await live.record_failed_attempt(f"key{index}")
+
+    # Attempts inside the tracking window are never swept away.
+    assert len(live._failed_attempts) == PRUNE_THRESHOLD + 1
 
 
 async def test_resolve_command_impersonation(auth_manager: AuthenticationManager) -> None:

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -17,6 +17,8 @@ from music_assistant_models.errors import InsufficientPermissions, InvalidDataEr
 from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER
 from music_assistant.controllers.config import ConfigController
 from music_assistant.controllers.webserver.auth import (
+    JOIN_CODE_GLOBAL_FAILURE_CEILING,
+    JOIN_CODE_GLOBAL_RATE_LIMIT_KEY,
     JOIN_CODE_LENGTH,
     TOKEN_ABSOLUTE_MAX_EXPIRATION,
     TOKEN_ACTIVITY_PERSIST_INTERVAL,
@@ -24,6 +26,7 @@ from music_assistant.controllers.webserver.auth import (
     TOKEN_LONG_LIVED_EXPIRATION,
     TOKEN_SHORT_LIVED_EXPIRATION,
     AuthenticationManager,
+    _mask_join_code,
 )
 from music_assistant.controllers.webserver.controller import WebserverController
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
@@ -31,11 +34,15 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_current_user,
     has_scope,
     resolve_command_impersonation,
+    set_current_client_id,
     set_current_token,
     set_current_user,
     set_impersonated_user,
 )
-from music_assistant.controllers.webserver.helpers.auth_providers import BuiltinLoginProvider
+from music_assistant.controllers.webserver.helpers.auth_providers import (
+    BuiltinLoginProvider,
+    LoginRateLimiter,
+)
 from music_assistant.helpers.datetime import utc
 from music_assistant.mass import MusicAssistant
 
@@ -1877,10 +1884,10 @@ async def test_exchange_join_code_success_does_not_reset_rate_limit(
     auth_manager: AuthenticationManager,
 ) -> None:
     """
-    Verify a successful exchange does not clear the failed-attempt counter.
+    Verify a successful exchange does not clear the shared failed-attempt counter.
 
-    The rate limit key is global, so clearing on success would let an attacker
-    holding any valid code reset the counter at will and bypass throttling.
+    Callers without a connection identity share one bucket, so clearing it on success
+    would let an attacker holding any valid code reset the counter for everyone.
 
     :param auth_manager: AuthenticationManager instance.
     """
@@ -1899,6 +1906,182 @@ async def test_exchange_join_code_success_does_not_reset_rate_limit(
     result = await auth_manager.exchange_join_code(code)
     assert result["success"] is False
     assert "too many" in result["error"].lower()
+
+
+async def test_exchange_join_code_rate_limit_is_per_connection(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """
+    Verify one throttled client does not lock out the other clients.
+
+    At a party every guest exchanges a join code over their own connection, so a guest
+    re-scanning an expired QR code must only ever throttle their own connection.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    user = await auth_manager.create_user(username="partyguest", role=UserRole.GUEST)
+    code, _ = await auth_manager.generate_join_code(user=user, expires_in_hours=24, max_uses=0)
+
+    # One guest burns through the progressive delay threshold with a stale code.
+    set_current_client_id("connection-a")
+    for _ in range(3):
+        assert (await auth_manager.exchange_join_code("EXPIRED12345"))["success"] is False
+    result = await auth_manager.exchange_join_code("EXPIRED12345")
+    assert "too many" in result["error"].lower()
+
+    # A second guest is unaffected, both for a bad code and for a valid one.
+    set_current_client_id("connection-b")
+    result = await auth_manager.exchange_join_code("EXPIRED12345")
+    assert "invalid" in result["error"].lower()
+    assert (await auth_manager.exchange_join_code(code))["success"] is True
+
+    set_current_client_id(None)
+
+
+async def test_exchange_join_code_success_clears_connection_rate_limit(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """
+    Verify a successful exchange clears the counter of that connection only.
+
+    A per-connection counter can only be cleared by the connection that filled it, so a
+    valid code holder cannot lift the throttle for anyone else.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    user = await auth_manager.create_user(username="clearingguest", role=UserRole.GUEST)
+    code, _ = await auth_manager.generate_join_code(user=user, expires_in_hours=24, max_uses=0)
+
+    set_current_client_id("connection-c")
+    for _ in range(2):
+        assert (await auth_manager.exchange_join_code("MISTYPED1234"))["success"] is False
+
+    assert (await auth_manager.exchange_join_code(code))["success"] is True
+
+    # Without the reset, the fourth failure overall would trip the threshold.
+    for _ in range(2):
+        result = await auth_manager.exchange_join_code("MISTYPED1234")
+        assert "invalid" in result["error"].lower()
+
+    # The shared bucket of connection-less callers is untouched by all of this.
+    set_current_client_id(None)
+    result = await auth_manager.exchange_join_code("MISTYPED1234")
+    assert "invalid" in result["error"].lower()
+
+
+async def test_exchange_join_code_global_ceiling_throttles_every_client(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """
+    Verify the server-wide ceiling still backstops the per-connection counters.
+
+    A client can open a fresh connection (and thus a fresh counter) at will, so the
+    ceiling is what bounds sustained abuse.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    user = await auth_manager.create_user(username="ceilingguest", role=UserRole.GUEST)
+    code, _ = await auth_manager.generate_join_code(user=user, expires_in_hours=24, max_uses=0)
+
+    for _ in range(JOIN_CODE_GLOBAL_FAILURE_CEILING):
+        await auth_manager._join_code_global_rate_limiter.record_failed_attempt(
+            JOIN_CODE_GLOBAL_RATE_LIMIT_KEY
+        )
+
+    # An untouched connection is throttled, even when it presents a valid code.
+    set_current_client_id("connection-never-seen-before")
+    result = await auth_manager.exchange_join_code(code)
+    assert result["success"] is False
+    assert "too many" in result["error"].lower()
+
+    set_current_client_id(None)
+
+
+async def test_join_code_global_ceiling_exceeds_party_scale() -> None:
+    """
+    Verify the server-wide ceiling leaves room for a large party's legitimate failures.
+
+    An expired QR poster makes every guest present fail a few times in a row; that burst
+    must not be able to reach the ceiling.
+    """
+    plausible_guests = 100
+    retries_per_guest = 5
+    assert 2 * plausible_guests * retries_per_guest <= JOIN_CODE_GLOBAL_FAILURE_CEILING
+
+
+def test_mask_join_code() -> None:
+    """Verify the log mask keeps a correlatable prefix but no usable code."""
+    assert _mask_join_code("abcdefghjklm") == "ABCD********"
+    assert _mask_join_code("abc") == "ABC"
+
+
+async def test_exchange_join_code_logs_identify_the_caller(
+    auth_manager: AuthenticationManager,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Verify a support log can tell a rejected code apart from a throttled client.
+
+    :param auth_manager: AuthenticationManager instance.
+    :param caplog: Log capture fixture.
+    """
+    set_current_client_id("connection-d")
+    for _ in range(3):
+        await auth_manager.exchange_join_code("MISTYPED1234")
+    rejections = [record.getMessage() for record in caplog.records if "rejected" in record.message]
+    assert len(rejections) == 3
+    assert "client=connection-d" in rejections[0]
+    # the attempted code is only ever logged masked
+    assert "code=MIST********" in rejections[0]
+    assert "MISTYPED1234" not in rejections[0]
+
+    caplog.clear()
+    await auth_manager.exchange_join_code("MISTYPED1234")
+    throttles = [record.getMessage() for record in caplog.records if "throttled" in record.message]
+    assert len(throttles) == 1
+    assert "throttled by the client limit" in throttles[0]
+    assert "client=connection-d" in throttles[0]
+    assert "client_failures=3" in throttles[0]
+    assert "server_failures=3" in throttles[0]
+
+    set_current_client_id(None)
+
+
+async def test_login_rate_limiter_default_tiers() -> None:
+    """Verify the default progressive delays escalate with the failed attempt count."""
+    limiter = LoginRateLimiter()
+
+    assert limiter.get_attempt_count("bob") == 0
+    for expected_count, expected_delay in ((2, 0), (3, 30), (6, 60), (10, 120), (15, 300)):
+        while limiter.get_attempt_count("bob") < expected_count:
+            await limiter.record_failed_attempt("bob")
+        assert limiter.get_delay("bob") == expected_delay
+
+    await limiter.clear_attempts("bob")
+    assert limiter.get_attempt_count("bob") == 0
+    assert limiter.get_delay("bob") == 0
+
+
+async def test_login_rate_limiter_custom_tiers() -> None:
+    """Verify a limiter can be configured with its own threshold and delay."""
+    limiter = LoginRateLimiter(delay_tiers=((3, 60),))
+
+    for _ in range(2):
+        await limiter.record_failed_attempt("key")
+    assert await limiter.check_rate_limit("key") == (True, 0)
+
+    await limiter.record_failed_attempt("key")
+    allowed, remaining_delay = await limiter.check_rate_limit("key")
+    assert allowed is False
+    assert 0 < remaining_delay <= 60
+
+
+async def test_login_rate_limiter_drops_attempts_outside_window() -> None:
+    """Verify attempts older than the tracking window stop counting."""
+    limiter = LoginRateLimiter(tracking_window=timedelta(seconds=0))
+
+    await limiter.record_failed_attempt("key")
+    assert limiter.get_attempt_count("key") == 0
 
 
 async def test_resolve_command_impersonation(auth_manager: AuthenticationManager) -> None:

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -35,6 +35,7 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
     has_scope,
     resolve_command_impersonation,
     set_current_client_id,
+    set_current_peer_address,
     set_current_token,
     set_current_user,
     set_impersonated_user,
@@ -1936,8 +1937,6 @@ async def test_exchange_join_code_rate_limit_is_per_connection(
     assert "invalid" in result["error"].lower()
     assert (await auth_manager.exchange_join_code(code))["success"] is True
 
-    set_current_client_id(None)
-
 
 async def test_exchange_join_code_success_clears_connection_rate_limit(
     auth_manager: AuthenticationManager,
@@ -1995,19 +1994,37 @@ async def test_exchange_join_code_global_ceiling_throttles_every_client(
     assert result["success"] is False
     assert "too many" in result["error"].lower()
 
-    set_current_client_id(None)
 
-
-async def test_join_code_global_ceiling_exceeds_party_scale() -> None:
+async def test_exchange_join_code_rate_limit_falls_back_to_peer_address(
+    auth_manager: AuthenticationManager,
+) -> None:
     """
-    Verify the server-wide ceiling leaves room for a large party's legitimate failures.
+    Verify stateless API callers are told apart by the address they connect from.
 
-    An expired QR poster makes every guest present fail a few times in a row; that burst
-    must not be able to reach the ceiling.
+    The login page exchanges join codes over the JSON RPC endpoint, which carries no
+    connection identity, so without this every such caller would share one bucket.
+
+    :param auth_manager: AuthenticationManager instance.
     """
-    plausible_guests = 100
-    retries_per_guest = 5
-    assert 2 * plausible_guests * retries_per_guest <= JOIN_CODE_GLOBAL_FAILURE_CEILING
+    user = await auth_manager.create_user(username="httpguest", role=UserRole.GUEST)
+    code, _ = await auth_manager.generate_join_code(user=user, expires_in_hours=24, max_uses=0)
+
+    set_current_peer_address("192.0.2.10")
+    for _ in range(3):
+        assert (await auth_manager.exchange_join_code("EXPIRED12345"))["success"] is False
+    assert "too many" in (await auth_manager.exchange_join_code("EXPIRED12345"))["error"].lower()
+
+    # A caller from another address is unaffected.
+    set_current_peer_address("192.0.2.11")
+    assert (await auth_manager.exchange_join_code(code))["success"] is True
+
+    # An address can be shared by everyone behind a proxy, so success must not clear it.
+    set_current_peer_address("192.0.2.10")
+    assert "too many" in (await auth_manager.exchange_join_code(code))["error"].lower()
+
+    # A websocket client id always wins over the peer address.
+    set_current_client_id("connection-e")
+    assert (await auth_manager.exchange_join_code(code))["success"] is True
 
 
 def test_mask_join_code() -> None:
@@ -2044,8 +2061,6 @@ async def test_exchange_join_code_logs_identify_the_caller(
     assert "client=connection-d" in throttles[0]
     assert "client_failures=3" in throttles[0]
     assert "server_failures=3" in throttles[0]
-
-    set_current_client_id(None)
 
 
 async def test_login_rate_limiter_default_tiers() -> None:

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -12,7 +12,11 @@ from music_assistant_models.errors import InsufficientPermissions
 
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_current_client_id,
+    get_current_token,
+    get_current_user,
     set_current_client_id,
+    set_current_token,
+    set_current_user,
 )
 from music_assistant.controllers.webserver.websocket_client import WebsocketClientHandler
 from music_assistant.helpers.api import APICommandHandler
@@ -141,3 +145,17 @@ async def test_command_sets_client_id_in_context(authenticated: bool) -> None:
 
     assert _sent_error_code(client) is None
     assert get_current_client_id() == "test_client"
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_command_does_not_inherit_a_user() -> None:
+    """An unauthenticated command must not see the user of a command that ran before it."""
+    set_current_user(User(user_id="user_1", username="tester", role=UserRole.ADMIN))
+    set_current_token("stale_token")
+    client = _create_client(None, _command_handler(authenticated=False))
+
+    await client._handle_command(CommandMessage(message_id="1", command="test/protected"))
+
+    assert _sent_error_code(client) is None
+    assert get_current_user() is None
+    assert get_current_token() is None

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -10,6 +10,10 @@ from music_assistant_models.api import CommandMessage, ErrorResultMessage
 from music_assistant_models.auth import Scope, User, UserRole
 from music_assistant_models.errors import InsufficientPermissions
 
+from music_assistant.controllers.webserver.helpers.auth_middleware import (
+    get_current_client_id,
+    set_current_client_id,
+)
 from music_assistant.controllers.webserver.websocket_client import WebsocketClientHandler
 from music_assistant.helpers.api import APICommandHandler
 
@@ -116,3 +120,24 @@ async def test_scoped_command_rejects_unauthenticated_socket() -> None:
 
     assert _sent_error_code(client) is not None
     client.mass.create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("authenticated", [True, False])
+async def test_command_sets_client_id_in_context(authenticated: bool) -> None:
+    """
+    Every dispatched command exposes the connection's client id, authenticated or not.
+
+    Unauthenticated handlers such as the join code exchange throttle per connection and
+    would otherwise see the id of whatever ran on this connection before them.
+
+    :param authenticated: Whether the dispatched command requires authentication.
+    """
+    set_current_client_id("stale_client")
+    role = UserRole.GUEST if authenticated else None
+    client = _create_client(role, _command_handler(authenticated=authenticated))
+
+    await client._handle_command(CommandMessage(message_id="1", command="test/protected"))
+
+    assert _sent_error_code(client) is None
+    assert get_current_client_id() == "test_client"


### PR DESCRIPTION
# What does this implement/fix?

Guests join a party by scanning a QR code. Failed attempts were counted in one
shared counter, so a few failures from a single guest — usually someone scanning
a poster with an expired code — blocked everyone else from joining for up to
five minutes, and joining successfully never reset it.

Failed attempts are now counted per device, so one guest struggling with an old
code no longer affects anyone else.

**Related issue (if applicable):**

- n/a (reported during testing: one phone could not join while others could)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Count failed join attempts per device instead of server-wide
- Keep a much higher server-wide limit as a backstop against abuse
- Reset a device's counter once it joins successfully
- Log which device was throttled, so support logs show who filled the counter
- Clean up rate limiter bookkeeping that previously kept growing

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
