### PR TITLE
Log which AirPlay speaker failed to start

### DIFF
--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -182,9 +182,10 @@ class AirPlayStreamSession:
             await self.stop()
             raise
         except Exception as err:
-            # playback failed to start, cleanup. Which member failed is logged
-            # where it failed; this is the one line saying the whole session went
-            # with it, for the failures no single member owns.
+            # playback failed to start, cleanup. This runs for every failure. A
+            # per-member one has already been named where it happened, so here
+            # the line says the whole session went down with it; for a failure
+            # no single member owns, it is the only line there is.
             self.prov.logger.warning(
                 "AirPlay start failed for a session of %d member(s): %s",
                 len(self.sync_clients),

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Coroutine
 from contextlib import suppress
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import ContentType, PlaybackState
 from music_assistant_models.errors import MusicAssistantError, PlayerCommandFailed
@@ -147,9 +147,19 @@ class AirPlayStreamSession:
         try:
             async with asyncio.TaskGroup() as task_group:
                 for player in self.sync_clients:
-                    task_group.create_task(self._start_client(player, self.use_shared_ptp))
+                    task_group.create_task(
+                        self._member_start_step(
+                            player, "spawn its cli", self._start_client(player, self.use_shared_ptp)
+                        )
+                    )
             await asyncio.gather(
-                *[p.stream.wait_for_connection() for p in self.sync_clients if p.stream]
+                *[
+                    self._member_start_step(
+                        player, "connect to its device", player.stream.wait_for_connection()
+                    )
+                    for player in self.sync_clients
+                    if player.stream
+                ]
             )
             # The binary buffers stdin into its ring from process start; feed
             # audio first and wait for every member to confirm it flowing, then
@@ -172,7 +182,14 @@ class AirPlayStreamSession:
             await self.stop()
             raise
         except Exception as err:
-            # playback failed to start, cleanup
+            # playback failed to start, cleanup. Which member failed is logged
+            # where it failed; this is the one line saying the whole session went
+            # with it, for the failures no single member owns.
+            self.prov.logger.warning(
+                "AirPlay start failed for a session of %d member(s): %s",
+                len(self.sync_clients),
+                err,
+            )
             await self.stop()
             # A member can fail for a specific, user-actionable reason (a device
             # that needs its password configured, for example). That error must
@@ -817,6 +834,34 @@ class AirPlayStreamSession:
             if airplay_player.stream:
                 await airplay_player.stream.write_audio_eof()
 
+    async def _member_start_step(
+        self, airplay_player: AirPlayPlayer, step: str, awaitable: Coroutine[Any, Any, None]
+    ) -> None:
+        """
+        Run one per-member step of a group start, naming the member if it fails.
+
+        A group start fans its members out over a task group and a gather, both
+        of which collapse into a single exception at the caller - so with five
+        speakers connecting, nothing in the log says which one failed. That,
+        with whatever reason its binary reported, is the whole diagnostic.
+
+        :param airplay_player: The member the step belongs to.
+        :param step: What the member was doing, for the failure message.
+        :param awaitable: The step to run.
+        """
+        try:
+            await awaitable
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            self.prov.logger.warning(
+                "AirPlay group start: %s failed to %s: %s",
+                airplay_player.display_name,
+                step,
+                err,
+            )
+            raise
+
     async def _start_client(self, airplay_player: AirPlayPlayer, use_shared_ptp: bool) -> None:
         """
         Connect a CLI process and start its ffmpeg for a single client.
@@ -899,11 +944,18 @@ class AirPlayStreamSession:
 
     async def _wait_members_audio_present(self) -> None:
         """Wait until every member's binary reports the new audio flowing."""
-        results = await asyncio.gather(
-            *[p.stream.wait_audio_present() for p in self.sync_clients if p.stream]
-        )
-        if not all(results):
-            raise PlayerCommandFailed("audio feed was not confirmed")
+        members = [(p, p.stream) for p in self.sync_clients if p.stream]
+        results = await asyncio.gather(*[stream.wait_audio_present() for _, stream in members])
+        if all(results):
+            return
+        # Name the members that never reported audio: they are what has to be
+        # looked at, and the group start below is abandoned for all of them.
+        silent = [
+            player.display_name
+            for (player, _), present in zip(members, results, strict=True)
+            if not present
+        ]
+        raise PlayerCommandFailed(f"audio feed was not confirmed by {', '.join(silent)}")
 
     async def _wait_members_clock_ready(self) -> int:
         """

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -1,6 +1,7 @@
 """Unit tests for AirPlay stream session late-join logic."""
 
 import asyncio
+import logging
 import time
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -360,6 +361,63 @@ async def test_initial_connection_failure_never_starts_partial_group() -> None:
         stream: Any = player.stream
         stream.start.assert_not_awaited()
     stop_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_connection_failure_names_the_member_that_failed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The log has to say WHICH speaker failed, and what its binary reported."""
+    session = _make_session(0, 0)
+    prov_logger = logging.getLogger("test.airplay.session")
+    session.prov.logger = prov_logger
+    first_player: Any = session.sync_clients[0]
+    first_player.display_name = "Player A"
+    first_player.protocol = StreamingProtocol.RAOP
+    second_player = MagicMock(player_id="second", display_name="Player B")
+    second_player.protocol = StreamingProtocol.RAOP
+    session.sync_clients.append(second_player)
+
+    async def start_client(player: MagicMock, _use_shared_ptp: bool) -> None:
+        stream = _stream_defaults(MagicMock(running=True))
+        if player is second_player:
+            stream.wait_for_connection = AsyncMock(
+                side_effect=TimeoutError("cliairplay did not connect to Player B: no route")
+            )
+        else:
+            stream.wait_for_connection = AsyncMock()
+        player.stream = stream
+
+    with (
+        caplog.at_level(logging.WARNING),
+        patch.object(session, "_start_client", side_effect=start_client),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch.object(session, "stop", new_callable=AsyncMock),
+        pytest.raises(PlayerCommandFailed),
+    ):
+        await session.start(MagicMock())
+
+    assert "Player B failed to connect to its device" in caplog.text
+    assert "no route" in caplog.text
+    assert "Player A failed" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_unconfirmed_audio_feed_names_the_silent_members() -> None:
+    """A member whose binary never reported audio flowing is named in the failure."""
+    session = _make_session(0, 0)
+    first_player: Any = session.sync_clients[0]
+    first_player.display_name = "Player A"
+    first_player.protocol = StreamingProtocol.RAOP
+    first_player.stream.wait_audio_present = AsyncMock(return_value=True)
+    second_player = MagicMock(player_id="second", display_name="Player B")
+    second_player.protocol = StreamingProtocol.RAOP
+    second_player.stream = _stream_defaults(MagicMock(running=True))
+    second_player.stream.wait_audio_present = AsyncMock(return_value=False)
+    session.sync_clients.append(second_player)
+
+    with pytest.raises(PlayerCommandFailed, match="not confirmed by Player B"):
+        await session._wait_members_audio_present()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

A failed group start only logged "Playback failed to start". With five speakers in the group there was no way to tell which one failed, or why.

The log now names the speaker and what its helper reported. Same for a speaker that never confirmed audio.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
