### PR TITLE
Correct outdated comments about Sendspin stream buffering

### DIFF
--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -48,10 +48,10 @@ _DEFAULT_SENDSPIN_PCM_FORMAT = SendspinAudioFormat(
     channels=2,
     sample_type="float",
 )
-# Media types whose upstream feeds at realtime rate, so the Sendspin queue
-# cannot grow after playback begins. Buffered types (tracks, podcasts, etc.)
-# race ahead and fill the queue naturally, so the min_buffer startup wait is
-# pure latency.
+# Media types whose upstream feeds at realtime rate, so the Sendspin queue cannot
+# grow after playback begins, so their send-ahead stays at the min_buffer_ms floor.
+# Buffered types (tracks, podcasts, etc.) race ahead and fill the queue naturally, so
+# their send-ahead may extend to a larger required_lead_time_ms without lasting cost.
 _LIVE_MEDIA_TYPES: frozenset[MediaType] = frozenset(
     {
         MediaType.RADIO,


### PR DESCRIPTION
# What does this implement/fix?

The comments around the Sendspin live/buffered distinction described behaviour that no longer matches the code. Both live and buffered sources wait for `min_buffer_ms` before playback starts; buffered sources only extend that wait when the player asks for a longer lead time. The old comment claimed buffered sources skipped the wait entirely, which sent a recent latency investigation down the wrong path.

Comments only, no behaviour change.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
