### PR TITLE
Skip an AirPlay speaker that would only play silence

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -31,6 +31,26 @@ class AirPlayRemoteCommand(StrEnum):
     PREVIOUS = "previous"
 
 
+class ClockReadiness(StrEnum):
+    """
+    How a receiver's clock readiness resolved for an anchor decision.
+
+    Only PROJECTED carries an instant; the rest all mean "anchor on the lead
+    alone", but for very different reasons - one is a device that will not play
+    at all, and treating them alike hides it.
+    """
+
+    # The binary projected when the receiver's clock becomes usable.
+    PROJECTED = "projected"
+    # NTP timing: there is no receiver clock to wait for.
+    NOT_APPLICABLE = "not_applicable"
+    # The receiver never answered our PTP clock and will render silence.
+    STALLED = "stalled"
+    # Nothing arrived within the wait: a slow device (retryable) or a binary
+    # too old to report readiness at all.
+    UNREPORTED = "unreported"
+
+
 CONF_VOLUME_START: Final[str] = "volume_start"
 CONF_PASSWORD: Final[str] = "password"
 # Storage-only marker (no config entry) set when the device rejected the stored

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -47,6 +47,7 @@ from .constants import (
     AIRPLAY_CLOCK_READY_TIMEOUT_MS,
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
     AIRPLAY_SPLICE_LEAD_MARGIN_MS,
+    ClockReadiness,
 )
 from .helpers import player_id_to_mac_address
 from .stream import AirPlayStream
@@ -640,9 +641,18 @@ class SendspinAirPlayBridge:
             queued audio the new anchor has to clear.
         :return: True when the stream is anchored, False when superseded.
         """
-        ready_at_unix_ms = await stream.wait_clock_ready(
+        readiness, ready_at_unix_ms = await stream.wait_clock_ready(
             timeout=AIRPLAY_CLOCK_READY_TIMEOUT_MS / 1000
         )
+        if readiness is ClockReadiness.STALLED:
+            # A bridged device that never answered our clock renders silence,
+            # and unlike a group member it is the whole playback: say so where
+            # the anchor is decided rather than letting it look anchored.
+            self.logger.warning(
+                "%s never answered the server's PTP clock, so this stream will be silent "
+                "until it does; anchoring anyway",
+                self.airplay_player.display_name,
+            )
         sendspin_now_us = self.sendspin_server.clock.now_us()
         unix_now = time.time()
         now_ms = int(unix_now * 1000)

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -35,6 +35,7 @@ from music_assistant.providers.airplay.constants import (
     CONF_PASSWORD,
     CONF_RAOP_CREDENTIALS,
     AirPlayRemoteCommand,
+    ClockReadiness,
     StreamingProtocol,
 )
 from music_assistant.providers.airplay.helpers import (
@@ -145,9 +146,11 @@ class AirPlayStream:
         # Set once the binary settled the receiver's clock readiness ([STATUS]
         # clock_ready): either it projected when the clock becomes usable, or it
         # reported that there is nothing to wait for. The projected instant
-        # (unix ms) stays 0 in the latter case.
+        # (unix ms) stays 0 in the latter case, and the readiness below says
+        # which of the reasons it was.
         self._clock_ready = asyncio.Event()
         self._clock_ready_at_unix_ms: int = 0
+        self._clock_readiness: ClockReadiness = ClockReadiness.UNREPORTED
         self._metadata_text_checksum = ""
         # Artwork identity (the source image url) whose rendered bytes were
         # last delivered to the binary. Settles on the first successful
@@ -407,7 +410,7 @@ class AirPlayStream:
             return False
         return True
 
-    async def wait_clock_ready(self, timeout: float = 2.5) -> int | None:
+    async def wait_clock_ready(self, timeout: float = 2.5) -> tuple[ClockReadiness, int]:
         """
         Wait for the binary to project when the receiver's clock becomes usable.
 
@@ -416,16 +419,19 @@ class AirPlayStream:
         from the receiver's first probe rather than from its full servo lock.
 
         :param timeout: Seconds to wait for the projection.
-        :return: The projected instant (unix ms) at which the receiver's clock
-            is usable — possibly already in the past when it is locked — or None
-            when there is nothing to wait for (NTP timing, a receiver that never
-            probed within the timeout, or a binary that does not report it).
+        :return: How the readiness resolved, and the projected instant (unix ms)
+            at which the receiver's clock is usable — possibly already in the
+            past when it is locked. Only :attr:`ClockReadiness.PROJECTED` carries
+            an instant; every other outcome pairs with 0 and leaves the caller
+            anchoring on its lead alone, but for reasons that differ enough to
+            act on: a stalled receiver will render silence, NTP timing has no
+            clock to wait for, and an unreported one is worth retrying.
         """
         try:
             await asyncio.wait_for(self._clock_ready.wait(), timeout)
         except TimeoutError:
-            return None
-        return self._clock_ready_at_unix_ms or None
+            return (ClockReadiness.UNREPORTED, 0)
+        return (self._clock_readiness, self._clock_ready_at_unix_ms)
 
     async def start(
         self, start_unix_ms: int = 0, position_ms: int = 0, *, join: bool = False
@@ -1598,14 +1604,25 @@ class AirPlayStream:
         # NTP timing has no receiver clock to wait for, and a state without a
         # projection resolves the wait with nothing so a caller falls back
         # instead of blocking on evidence that will not arrive. A stalled clock
-        # is one of those states however the line is numbered.
-        self._clock_ready_at_unix_ms = 0 if mode == "ntp" or stalled else ready_at_unix_ms
+        # is one of those states however the line is numbered — but the caller
+        # has to be able to tell the three apart, so each carries its own
+        # readiness rather than a bare missing instant.
+        if mode == "ntp":
+            self._clock_readiness = ClockReadiness.NOT_APPLICABLE
+        elif stalled:
+            self._clock_readiness = ClockReadiness.STALLED
+        else:
+            self._clock_readiness = ClockReadiness.PROJECTED
+        self._clock_ready_at_unix_ms = (
+            ready_at_unix_ms if self._clock_readiness is ClockReadiness.PROJECTED else 0
+        )
         self._clock_ready.set()
         self.player.logger.debug(
-            "cliairplay reports the clock for %s as %s (mode=%s, usable at %d)",
+            "cliairplay reports the clock for %s as %s (mode=%s, readiness=%s, usable at %d)",
             self.player.display_name,
             state,
             mode,
+            self._clock_readiness,
             self._clock_ready_at_unix_ms,
         )
 

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -26,6 +26,7 @@ from .constants import (
     AIRPLAY_LATE_JOIN_RING_MIN_SECONDS,
     AIRPLAY_SPLICE_LEAD_MARGIN_MS,
     AIRPLAY_START_LEAD_MS,
+    ClockReadiness,
     StreamingProtocol,
 )
 from .helpers import get_final_output_format
@@ -38,6 +39,18 @@ if TYPE_CHECKING:
 
     from .player import AirPlayPlayer
     from .provider import AirPlayProvider
+
+# What each readiness outcome means for the join anchor. They all end up
+# anchoring on the join floor, so only the reason distinguishes a device that
+# needs longer from one that will not play at all.
+_CLOCK_READINESS_NOTES: dict[ClockReadiness, str] = {
+    ClockReadiness.PROJECTED: "usable in {out:.2f}s; anchoring just past that",
+    ClockReadiness.NOT_APPLICABLE: "runs on NTP timing, so there is none to wait for; "
+    "anchoring on the join floor",
+    ClockReadiness.STALLED: "never answered ours; anchoring on the join floor",
+    ClockReadiness.UNREPORTED: "was not reported within {timeout:.1f}s (a slow device, or a "
+    "binary too old to report it); anchoring on the join floor",
+}
 
 
 class AirPlayStreamSession:
@@ -420,7 +433,7 @@ class AirPlayStreamSession:
             # for that projection here — outside the session lock, so the rest
             # of the group keeps being fed — lets the join anchor on the
             # device's own readiness instead of a fixed guess.
-            ready_at_unix_ms = await stream.wait_clock_ready(
+            readiness, ready_at_unix_ms = await stream.wait_clock_ready(
                 timeout=AIRPLAY_CLOCK_READY_TIMEOUT_MS / 1000
             )
         except asyncio.CancelledError:
@@ -433,6 +446,20 @@ class AirPlayStreamSession:
                 err,
             )
             await self.stop_client(airplay_player, reason="late joiner connection failed")
+            return
+
+        if readiness is ClockReadiness.STALLED:
+            # The receiver never answered our clock, so it would render silence
+            # for as long as it stayed in the group while every other signal
+            # said it was playing. Better to leave it out: the group keeps
+            # playing and the player stays idle, which is the visible truth.
+            # The binary's own report names the device and the ports to check.
+            self.prov.logger.warning(
+                "Late joiner %s: not adding it to the group - its receiver never answered "
+                "the server's PTP clock, so it would render silence",
+                airplay_player.player_id,
+            )
+            await self.stop_client(airplay_player, reason="receiver clock stalled")
             return
 
         pcm_sample_size = self._pcm_byte_rate
@@ -550,11 +577,12 @@ class AirPlayStreamSession:
 
         now = time.time()
         self.prov.logger.debug(
-            "Late joiner %s: receiver clock readiness %s",
+            "Late joiner %s: receiver clock %s",
             airplay_player.player_id,
-            f"projected {ready_at_unix_ms / 1000 - now:.2f}s out"
-            if ready_at_unix_ms
-            else "not reported; anchoring on the join floor",
+            _CLOCK_READINESS_NOTES.get(readiness, "").format(
+                out=ready_at_unix_ms / 1000 - now,
+                timeout=AIRPLAY_CLOCK_READY_TIMEOUT_MS / 1000,
+            ),
         )
         async with self._lock:
             if not self._session_is_live():
@@ -1081,13 +1109,23 @@ class AirPlayStreamSession:
                 if p.stream
             ]
         )
-        ready_at_unix_ms = max((r for r in results if r), default=0)
-        if len(results) != len([r for r in results if r]):
+        ready_at_unix_ms = max(
+            (at for readiness, at in results if readiness is ClockReadiness.PROJECTED), default=0
+        )
+        # A group start does not drop a member that stalled - the rest of the
+        # group would still be started, and the member is already warned about
+        # by name, with the ports to check, where the binary reported it. Say
+        # which outcomes were seen so the anchor decision is readable.
+        unprojected = [
+            readiness for readiness, _ in results if readiness is not ClockReadiness.PROJECTED
+        ]
+        if unprojected:
             self.prov.logger.debug(
-                "AirPlay start: %d of %d member(s) reported no receiver clock projection; "
+                "AirPlay start: %d of %d member(s) reported no receiver clock projection (%s); "
                 "anchoring those on the start lead alone",
-                len(results) - len([r for r in results if r]),
+                len(unprojected),
                 len(results),
+                ", ".join(sorted({readiness.value for readiness in unprojected})),
             )
         return ready_at_unix_ms
 

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -13,6 +13,7 @@ from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_COLD_GROUP_START_LEAD_MS,
     AirPlayRemoteCommand,
+    ClockReadiness,
     StreamingProtocol,
 )
 from music_assistant.providers.airplay.player import AirPlayPlayer
@@ -557,7 +558,7 @@ async def test_raop_session_resolves_ptp_for_first_ap2_late_joiner() -> None:
         # and no receiver clock projection (an older binary), so the test
         # asserts the commanded values directly.
         player.stream.start = AsyncMock(return_value=None)
-        player.stream.wait_clock_ready = AsyncMock(return_value=None)
+        player.stream.wait_clock_ready = AsyncMock(return_value=(ClockReadiness.UNREPORTED, 0))
         player.stream.warm_lead_ms = 0
         player.stream.flushed_head_unix_ms = 0
 
@@ -583,7 +584,7 @@ async def test_session_start_applies_uniform_ptp_decision_to_all_members() -> No
         player.stream = MagicMock()
         player.stream.wait_for_connection = AsyncMock()
         player.stream.wait_audio_present = AsyncMock(return_value=True)
-        player.stream.wait_clock_ready = AsyncMock(return_value=None)
+        player.stream.wait_clock_ready = AsyncMock(return_value=(ClockReadiness.UNREPORTED, 0))
         player.stream.start = AsyncMock(return_value=None)
     session = _make_ptp_session(prov, players)
 
@@ -608,7 +609,7 @@ async def test_session_start_calculates_anchor_after_ptp_resolution() -> None:
         player.stream = MagicMock()
         player.stream.wait_for_connection = AsyncMock()
         player.stream.wait_audio_present = AsyncMock(return_value=True)
-        player.stream.wait_clock_ready = AsyncMock(return_value=None)
+        player.stream.wait_clock_ready = AsyncMock(return_value=(ClockReadiness.UNREPORTED, 0))
         player.stream.start = AsyncMock(return_value=None)
         player.config.get_value = MagicMock(return_value=0)
     session = _make_ptp_session(prov, players)

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -37,6 +37,7 @@ from music_assistant.providers.airplay.constants import (
     AIRPLAY_CLOCK_READY_LEAD_MS,
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
     AIRPLAY_SPLICE_LEAD_MARGIN_MS,
+    ClockReadiness,
     StreamingProtocol,
 )
 from music_assistant.providers.airplay.sendspin_bridge import (
@@ -462,7 +463,7 @@ def _make_anchor_stream(
     stream.wait_for_connection = AsyncMock()
     stream.stop = AsyncMock()
     stream.flush = AsyncMock(return_value=True)
-    stream.wait_clock_ready = AsyncMock(return_value=ready_at_unix_ms)
+    stream.wait_clock_ready = AsyncMock(return_value=(ClockReadiness.PROJECTED, ready_at_unix_ms))
     stream.start = AsyncMock(return_value=ack)
     stream.warm_lead_ms = warm_lead_ms
     stream.flushed_head_unix_ms = flushed_head_unix_ms

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -22,6 +22,7 @@ from music_assistant.providers.airplay.constants import (
     CONF_ENCRYPTION,
     CONF_PASSWORD,
     AirPlayRemoteCommand,
+    ClockReadiness,
     StreamingProtocol,
 )
 from music_assistant.providers.airplay.stream import AirPlayStream, CliError
@@ -1012,7 +1013,10 @@ async def test_clock_ready_projection_resolves_the_wait() -> None:
         is False
     )
 
-    assert await stream.wait_clock_ready(timeout=0.01) == START_UNIX_MS
+    assert await stream.wait_clock_ready(timeout=0.01) == (
+        ClockReadiness.PROJECTED,
+        START_UNIX_MS,
+    )
 
 
 @pytest.mark.asyncio
@@ -1025,7 +1029,7 @@ async def test_clock_ready_cold_line_keeps_waiting_for_a_projection() -> None:
         "ready_in_ms=0 ready_at_unix_ms=0"
     )
 
-    assert await stream.wait_clock_ready(timeout=0.01) is None
+    assert await stream.wait_clock_ready(timeout=0.01) == (ClockReadiness.UNREPORTED, 0)
     assert not stream._clock_ready.is_set()
 
     stream._handle_status_line(
@@ -1033,7 +1037,10 @@ async def test_clock_ready_cold_line_keeps_waiting_for_a_projection() -> None:
         f"ready_in_ms=0 ready_at_unix_ms={START_UNIX_MS}"
     )
 
-    assert await stream.wait_clock_ready(timeout=0.01) == START_UNIX_MS
+    assert await stream.wait_clock_ready(timeout=0.01) == (
+        ClockReadiness.PROJECTED,
+        START_UNIX_MS,
+    )
 
 
 @pytest.mark.asyncio
@@ -1047,15 +1054,15 @@ async def test_clock_ready_ntp_resolves_without_a_projection() -> None:
     )
 
     assert stream._clock_ready.is_set()
-    assert await stream.wait_clock_ready(timeout=0.01) is None
+    assert await stream.wait_clock_ready(timeout=0.01) == (ClockReadiness.NOT_APPLICABLE, 0)
 
 
 @pytest.mark.asyncio
 async def test_wait_clock_ready_times_out_for_a_binary_that_never_reports() -> None:
-    """A binary that does not report readiness leaves the caller with no projection."""
+    """A binary that does not report readiness is told apart from one that answered."""
     stream = AirPlayStream(_make_player())
 
-    assert await stream.wait_clock_ready(timeout=0.01) is None
+    assert await stream.wait_clock_ready(timeout=0.01) == (ClockReadiness.UNREPORTED, 0)
 
 
 @pytest.mark.asyncio
@@ -1079,7 +1086,7 @@ async def test_clock_ready_stalled_state_warns_once(caplog: pytest.LogCaptureFix
     assert "Player A" in warnings[0].getMessage()
     assert "319/320" in warnings[0].getMessage()
     assert stream._clock_ready.is_set()
-    assert await stream.wait_clock_ready(timeout=0.01) is None
+    assert await stream.wait_clock_ready(timeout=0.01) == (ClockReadiness.STALLED, 0)
 
 
 def test_clock_ready_stall_warning_is_ptp_only(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -20,6 +20,7 @@ from music_assistant.providers.airplay.constants import (
     AIRPLAY_LATE_JOIN_RING_MAX_BYTES,
     AIRPLAY_LATE_JOIN_RING_MIN_SECONDS,
     AIRPLAY_START_LEAD_MS,
+    ClockReadiness,
     StreamingProtocol,
 )
 from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
@@ -35,7 +36,7 @@ def _stream_defaults(stream: MagicMock) -> MagicMock:
     matching an older binary, so the tests assert the commanded values directly.
     """
     stream.start = AsyncMock(return_value=None)
-    stream.wait_clock_ready = AsyncMock(return_value=None)
+    stream.wait_clock_ready = AsyncMock(return_value=(ClockReadiness.UNREPORTED, 0))
     stream.warm_lead_ms = 0
     stream.flushed_head_unix_ms = 0
     return stream
@@ -227,7 +228,10 @@ async def test_group_start_never_anchors_before_every_receiver_clock_is_usable()
         stream.wait_for_connection = AsyncMock()
         stream.wait_audio_present = AsyncMock(return_value=True)
         stream.wait_clock_ready = AsyncMock(
-            return_value=ready_at if player is second else int(now * 1000)
+            return_value=(
+                ClockReadiness.PROJECTED,
+                ready_at if player is second else int(now * 1000),
+            )
         )
         player.stream = stream
 
@@ -258,7 +262,9 @@ async def test_solo_start_does_not_wait_for_a_clock_projection() -> None:
         stream.wait_for_connection = AsyncMock()
         stream.wait_audio_present = AsyncMock(return_value=True)
         # A projection far in the future must not delay a solo start.
-        stream.wait_clock_ready = AsyncMock(return_value=int(now * 1000) + 5_000)
+        stream.wait_clock_ready = AsyncMock(
+            return_value=(ClockReadiness.PROJECTED, int(now * 1000) + 5_000)
+        )
         player.stream = stream
 
     with (
@@ -1057,7 +1063,9 @@ async def test_late_join_anchors_on_the_reported_clock_readiness() -> None:
 
     def setup_with_projection(*_args: Any, **_kwargs: Any) -> None:
         _setup_stream(player)()
-        player.stream.wait_clock_ready = AsyncMock(return_value=ready_at_unix_ms)
+        player.stream.wait_clock_ready = AsyncMock(
+            return_value=(ClockReadiness.PROJECTED, ready_at_unix_ms)
+        )
 
     with (
         patch.object(session, "_start_client", side_effect=setup_with_projection),
@@ -1086,7 +1094,9 @@ async def test_late_join_floor_wins_over_a_clock_that_is_already_ready() -> None
 
     def setup_with_projection(*_args: Any, **_kwargs: Any) -> None:
         _setup_stream(player)()
-        player.stream.wait_clock_ready = AsyncMock(return_value=ready_at_unix_ms)
+        player.stream.wait_clock_ready = AsyncMock(
+            return_value=(ClockReadiness.PROJECTED, ready_at_unix_ms)
+        )
 
     with (
         patch.object(session, "_start_client", side_effect=setup_with_projection),
@@ -1126,6 +1136,58 @@ async def test_late_join_falls_back_to_the_floor_without_a_clock_projection() ->
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "readiness",
+    [ClockReadiness.UNREPORTED, ClockReadiness.NOT_APPLICABLE],
+    ids=["unreported", "ntp"],
+)
+async def test_late_join_without_a_projection_still_joins(readiness: ClockReadiness) -> None:
+    """A device with no clock to wait for is a fallback, not a reason to refuse it."""
+    now = 1_000_000.0
+    session = _make_session(now - 5.0, 5.0)
+    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 5)
+    player = _make_late_joiner()
+
+    def setup_without_projection(*_args: Any, **_kwargs: Any) -> None:
+        _setup_stream(player)()
+        player.stream.wait_clock_ready = AsyncMock(return_value=(readiness, 0))
+
+    with (
+        patch.object(session, "_start_client", side_effect=setup_without_projection),
+        patch.object(session, "_write_chunk_to_player", new_callable=AsyncMock),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
+    ):
+        await session.add_client(player)
+
+    assert player in session.sync_clients
+
+
+@pytest.mark.asyncio
+async def test_late_joiner_with_a_stalled_clock_is_not_added() -> None:
+    """A receiver that never answered our clock renders silence, so keep it out of the group."""
+    now = 1_000_000.0
+    session = _make_session(now - 5.0, 5.0)
+    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 5)
+    player = _make_late_joiner()
+
+    def setup_stalled(*_args: Any, **_kwargs: Any) -> None:
+        _setup_stream(player)()
+        player.stream.wait_clock_ready = AsyncMock(return_value=(ClockReadiness.STALLED, 0))
+
+    with (
+        patch.object(session, "_start_client", side_effect=setup_stalled),
+        patch.object(session, "_write_chunk_to_player", new_callable=AsyncMock),
+        patch.object(session, "stop_client", new_callable=AsyncMock) as stop_client,
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
+    ):
+        await session.add_client(player)
+
+    player.stream.start.assert_not_awaited()
+    assert player not in session.sync_clients
+    stop_client.assert_awaited_once_with(player, reason="receiver clock stalled")
+
+
+@pytest.mark.asyncio
 async def test_late_join_feed_keeps_flowing_while_waiting_for_clock_readiness() -> None:
     """The group keeps being fed while a joiner's receiver clock projection is pending."""
     session = _make_session(time.time() - 5, 5.0)
@@ -1136,9 +1198,10 @@ async def test_late_join_feed_keeps_flowing_while_waiting_for_clock_readiness() 
     def setup_pending_projection(*_args: Any, **_kwargs: Any) -> None:
         _setup_stream(player)()
 
-        async def wait_clock_ready(*_args: Any, **_kwargs: Any) -> None:
+        async def wait_clock_ready(*_args: Any, **_kwargs: Any) -> tuple[ClockReadiness, int]:
             readiness_pending.set()
             await readiness_released.wait()
+            return (ClockReadiness.UNREPORTED, 0)
 
         player.stream.wait_clock_ready = AsyncMock(side_effect=wait_clock_ready)
 


### PR DESCRIPTION
# What does this implement/fix?

Some speakers never answer the server's clock. They render silence while everything else says they are playing.

Such a speaker is no longer added to a group. The log also tells the three "no clock info" cases apart, which used to look identical: a slow device, a device on NTP timing, and one that will not play at all.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
