### PR TITLE
Report AirPlay artwork rejections instead of hiding them

### DIFF
--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -14,6 +14,7 @@ import re
 import time
 from contextlib import suppress
 from dataclasses import dataclass
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Final, cast
 from uuid import uuid4
 
@@ -43,6 +44,8 @@ from music_assistant.providers.airplay.helpers import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from music_assistant_models.media_items import AudioFormat
     from music_assistant_models.player import PlayerMedia
 
@@ -886,12 +889,54 @@ class AirPlayStream:
         prov.handle_remote_command(self.player, command)
 
     def _parse_mrp_status(self, line: str) -> None:
-        """Parse the [STATUS] mrp line and log the now-playing push result."""
+        """
+        Parse a [STATUS] mrp line and report how the now-playing push landed.
+
+        A push the device accepted is routine bookkeeping and stays at debug.
+        A rejection is not: it is why a now-playing screen stays blank or keeps
+        the previous track's art, with nothing else about the session looking
+        wrong, so it is reported.
+
+        :param line: The status line, in one of the shapes
+            ``[STATUS] mrp path=<command|channel> status=<int>`` or
+            ``[STATUS] mrp artwork=<posted|rejected> ...``.
+        """
         fields = dict(part.split("=", 1) for part in line.split() if "=" in part)
-        self.player.logger.info(
+        display_name = self.player.display_name
+        if artwork := fields.get("artwork"):
+            # The artwork variants carry no path=, and a rejection reports its
+            # reason plus a clear_status rather than a status of its own.
+            if artwork == "rejected":
+                self.player.logger.warning(
+                    "%s rejected the now-playing artwork (%s, %s bytes); its screen keeps "
+                    "whatever art it had",
+                    display_name,
+                    fields.get("reason", "no reason given"),
+                    fields.get("bytes", "?"),
+                )
+            else:
+                self.player.logger.debug(
+                    "MRP now-playing artwork accepted by %s (%s bytes, HTTP %s)",
+                    display_name,
+                    fields.get("bytes", "?"),
+                    fields.get("status", "?"),
+                )
+            return
+        if fields.get("path") == "channel":
+            # Not an HTTP status: 0 = the opt-in data channel was attempted and
+            # did not come up, 1 = established.
+            self.player.logger.debug(
+                "MRP data channel for %s: %s",
+                display_name,
+                "established" if fields.get("status") == "1" else "not established",
+            )
+            return
+        status = _status_int(fields, "status")
+        self.player.logger.log(
+            logging.DEBUG if HTTPStatus.OK <= status < HTTPStatus.BAD_REQUEST else logging.WARNING,
             "MRP now-playing push (%s path) for %s: HTTP %s",
             fields.get("path", "?"),
-            self.player.display_name,
+            display_name,
             fields.get("status", "?"),
         )
 
@@ -938,18 +983,21 @@ class AirPlayStream:
 
     def _parse_latency_status(self, line: str) -> None:
         """Parse and store the [STATUS] latency line reported by the binary."""
-        try:
-            fields = dict(part.split("=", 1) for part in line.split() if "=" in part)
-            self.latency_lead_ms = int(fields.get("lead_ms", 0))
-            self.device_min_frames = int(fields.get("device_min_frames", 0))
-            self.device_max_frames = int(fields.get("device_max_frames", 0))
-            self.warm_lead_ms = int(fields.get("warm_lead_ms", 0))
-        except ValueError:
-            return
+        fields = dict(part.split("=", 1) for part in line.split() if "=" in part)
+        # Read field by field: one unusable value used to abandon the rest of
+        # the line, leaving whatever came after it stale from the previous
+        # report while the values before it had already moved. Every field here
+        # means "unreported" at 0, so a missing or malformed one lands there.
+        self.latency_lead_ms = _status_int(fields, "lead_ms")
+        self.device_min_frames = _status_int(fields, "device_min_frames")
+        self.device_max_frames = _status_int(fields, "device_max_frames")
+        self.warm_lead_ms = _status_int(fields, "warm_lead_ms")
         self.player.logger.debug(
-            "Device latency for %s: lead=%dms, buffer window=%d-%d frames (0=unreported)",
+            "Device latency for %s: lead=%dms, warm lead=%dms, "
+            "buffer window=%d-%d frames (0=unreported)",
             self.player.display_name,
             self.latency_lead_ms,
+            self.warm_lead_ms,
             self.device_min_frames,
             self.device_max_frames,
         )
@@ -1498,3 +1546,20 @@ class AirPlayStream:
             self.player.display_name,
             margin_ms,
         )
+
+
+def _status_int(fields: Mapping[str, str], key: str) -> int:
+    """
+    Return one integer field of a [STATUS] line, or 0 when it is unusable.
+
+    Status lines are read field by field so a value the binary could not format
+    - or one an older build does not emit at all - does not take the rest of the
+    line down with it. Every field read this way means "unreported" at 0.
+
+    :param fields: The parsed key=value pairs of the status line.
+    :param key: The field to read.
+    """
+    try:
+        return int(fields[key])
+    except KeyError, ValueError:
+        return 0

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -931,9 +931,12 @@ class AirPlayStream:
                 "established" if fields.get("status") == "1" else "not established",
             )
             return
+        # Only a 2xx means the device took the push. Nothing else on this
+        # control channel does - a redirect is as much "not accepted" as a 4xx.
         status = _status_int(fields, "status")
+        accepted = HTTPStatus.OK <= status < HTTPStatus.MULTIPLE_CHOICES
         self.player.logger.log(
-            logging.DEBUG if HTTPStatus.OK <= status < HTTPStatus.BAD_REQUEST else logging.WARNING,
+            logging.DEBUG if accepted else logging.WARNING,
             "MRP now-playing push (%s path) for %s: HTTP %s",
             fields.get("path", "?"),
             display_name,

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -364,15 +364,16 @@ def test_mrp_push_accepted_is_not_logged_at_info(caplog: pytest.LogCaptureFixtur
     assert caplog.text == ""
 
 
-def test_mrp_push_rejection_is_reported(caplog: pytest.LogCaptureFixture) -> None:
-    """A non-2xx push is the device refusing what was sent, so it is reported."""
+@pytest.mark.parametrize("status", [302, 403, 500], ids=["redirect", "forbidden", "server-error"])
+def test_mrp_push_rejection_is_reported(status: int, caplog: pytest.LogCaptureFixture) -> None:
+    """Anything but a 2xx is the device not taking the push, so it is reported."""
     stream = AirPlayStream(_make_player())
 
     with caplog.at_level(logging.WARNING):
-        stream._parse_mrp_status("[STATUS] mrp path=command status=403")
+        stream._parse_mrp_status(f"[STATUS] mrp path=command status={status}")
 
     assert "Player A" in caplog.text
-    assert "403" in caplog.text
+    assert str(status) in caplog.text
 
 
 def test_mrp_artwork_rejection_is_reported(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -312,11 +312,95 @@ def test_parse_latency_status() -> None:
     player = _make_player()
     stream = AirPlayStream(player)
     stream._parse_latency_status(
-        "[STATUS] latency lead_ms=1750 device_min_frames=11025 device_max_frames=88200"
+        "[STATUS] latency lead_ms=1750 device_min_frames=11025 device_max_frames=88200 "
+        "warm_lead_ms=1200"
     )
     assert stream.latency_lead_ms == 1750
     assert stream.device_min_frames == 11025
     assert stream.device_max_frames == 88200
+    assert stream.warm_lead_ms == 1200
+
+
+def test_parse_latency_status_reads_every_field_on_its_own() -> None:
+    """One unusable value must not leave the fields after it stale from the last report."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    stream._parse_latency_status(
+        "[STATUS] latency lead_ms=1750 device_min_frames=11025 device_max_frames=88200 "
+        "warm_lead_ms=1200"
+    )
+
+    stream._parse_latency_status(
+        "[STATUS] latency lead_ms=900 device_min_frames=garbage device_max_frames=44100 "
+        "warm_lead_ms=300"
+    )
+
+    assert stream.latency_lead_ms == 900
+    assert stream.device_min_frames == 0  # unusable, so unreported
+    assert stream.device_max_frames == 44100
+    assert stream.warm_lead_ms == 300
+
+
+def test_parse_latency_status_logs_the_warm_lead(caplog: pytest.LogCaptureFixture) -> None:
+    """The warm lead drives every warm group anchor, so it belongs in the line."""
+    stream = AirPlayStream(_make_player())
+
+    with caplog.at_level(logging.DEBUG):
+        stream._parse_latency_status(
+            "[STATUS] latency lead_ms=1750 device_min_frames=11025 device_max_frames=88200 "
+            "warm_lead_ms=1200"
+        )
+
+    assert "warm lead=1200ms" in caplog.text
+
+
+def test_mrp_push_accepted_is_not_logged_at_info(caplog: pytest.LogCaptureFixture) -> None:
+    """A push the device accepted is bookkeeping, not something to act on."""
+    stream = AirPlayStream(_make_player())
+
+    with caplog.at_level(logging.INFO):
+        stream._parse_mrp_status("[STATUS] mrp path=command status=200")
+
+    assert caplog.text == ""
+
+
+def test_mrp_push_rejection_is_reported(caplog: pytest.LogCaptureFixture) -> None:
+    """A non-2xx push is the device refusing what was sent, so it is reported."""
+    stream = AirPlayStream(_make_player())
+
+    with caplog.at_level(logging.WARNING):
+        stream._parse_mrp_status("[STATUS] mrp path=command status=403")
+
+    assert "Player A" in caplog.text
+    assert "403" in caplog.text
+
+
+def test_mrp_artwork_rejection_is_reported(caplog: pytest.LogCaptureFixture) -> None:
+    """An artwork rejection carries no path= or status=, and must not read as a plain push."""
+    stream = AirPlayStream(_make_player())
+
+    with caplog.at_level(logging.WARNING):
+        stream._parse_mrp_status(
+            "[STATUS] mrp artwork=rejected reason=progressive_jpeg bytes=48123 "
+            "width=512 height=512 precision=8 sof=0xc2 components=3 progressive=1 "
+            "clear_status=200 staging_max_bytes=131072"
+        )
+
+    assert "rejected the now-playing artwork" in caplog.text
+    assert "progressive_jpeg" in caplog.text
+    assert "HTTP ?" not in caplog.text
+
+
+def test_mrp_channel_status_is_not_read_as_an_http_status(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The data-channel line reports 0/1, which must not be warned about as a failed push."""
+    stream = AirPlayStream(_make_player())
+
+    with caplog.at_level(logging.WARNING):
+        stream._parse_mrp_status("[STATUS] mrp path=channel status=0")
+
+    assert caplog.text == ""
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

Two status lines from the AirPlay helper were read wrong:

- a device rejecting the cover art was logged as an ordinary now-playing push at info level, so the rejection was invisible
- one bad value in the latency line stopped the rest of that line being read, leaving those values stale

Both fixed. Routine now-playing pushes moved to debug.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
