### PR TITLE
Report the real AirPlay timing state in diagnostics

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -198,3 +198,11 @@ CONF_VERBOSE_PTP_LOGGING: Final[str] = "verbose_ptp_logging"
 # The cliairplay binary tags no log levels on its output, so a genuine problem is
 # recognised by keyword and promoted to a warning that stays visible at normal levels.
 CLI_PROBLEM_MARKERS: Final[tuple[str, ...]] = ("error", "cannot", "failed", "unable")
+# Bound on how many of those promoted lines the shared PTP daemon may produce per
+# window before the rest are counted instead of logged. The markers above are
+# deliberately broad, and "error" is ordinary vocabulary in clock telemetry
+# (offset error, path delay error), so with the daemon's per-packet trace running
+# at ~10 lines/s a single matching line would otherwise fill the log at WARNING.
+# A burst still gets through, which is what a real one-shot daemon failure is.
+PTP_DAEMON_WARN_BURST: Final[int] = 5
+PTP_DAEMON_WARN_WINDOW: Final[float] = 60.0

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -47,6 +47,8 @@ from .constants import (
     EXTERNAL_ARTWORK_PATH_PREFIX,
     FALLBACK_VOLUME,
     MRP_DISCOVERY_TYPE,
+    PTP_DAEMON_WARN_BURST,
+    PTP_DAEMON_WARN_WINDOW,
     RAOP_DISCOVERY_TYPE,
     AirPlayRemoteCommand,
     StreamingProtocol,
@@ -100,6 +102,11 @@ class AirPlayProvider(PlayerProvider):
     # control channel; created/cleared per daemon start so a crash+restart
     # re-gates readiness. None until the daemon is first started.
     _ptp_daemon_ready: asyncio.Event | None = None
+    # Rate-limit state for daemon lines promoted to WARNING (see
+    # PTP_DAEMON_WARN_BURST).
+    _ptp_daemon_warn_window_start: float = 0.0
+    _ptp_daemon_warns_in_window: int = 0
+    _ptp_daemon_warns_suppressed: int = 0
 
     @property
     def bridge_manager(self) -> SendspinBridgeManager:
@@ -112,14 +119,30 @@ class AirPlayProvider(PlayerProvider):
         Return if the shared PTP clock daemon process is alive.
 
         This reflects process liveness only (spawned, not closed, still
-        running) for status/diagnostics. The streaming timing decision must use
-        :meth:`wait_ptp_daemon_ready`, which also waits for the daemon to have
-        actually bound its ports and opened its control channel.
+        running). It says nothing about whether streams can use it: a daemon
+        that never bound its ports stays alive and reports True here while every
+        group silently degrades to NTP. Use :attr:`ptp_daemon_ready` for the
+        real state, or :meth:`wait_ptp_daemon_ready` to wait for it.
         """
         return (
             self._ptp_daemon is not None
             and not self._ptp_daemon.closed
             and self._ptp_daemon.returncode is None
+        )
+
+    @property
+    def ptp_daemon_ready(self) -> bool:
+        """
+        Return whether the shared PTP clock daemon is serving streams right now.
+
+        This is the condition a session actually gates on: the daemon has bound
+        the privileged PTP ports (UDP 319/320), opened its control channel, and
+        is still alive.
+        """
+        return (
+            self.ptp_daemon_running
+            and self._ptp_daemon_ready is not None
+            and self._ptp_daemon_ready.is_set()
         )
 
     async def wait_ptp_daemon_ready(self, timeout: float = PTP_DAEMON_READY_TIMEOUT) -> bool:
@@ -324,16 +347,26 @@ class AirPlayProvider(PlayerProvider):
     async def get_diagnostics(self) -> dict[str, SerializableType]:
         """Return diagnostics info for this provider to include in diagnostics reports."""
         streams_by_type: dict[str, int] = {}
+        streams_by_route: dict[str, int] = {}
         for player in self.get_players():
             if not (player.stream and player.stream.running):
                 continue
             stream_type = "airplay2" if player.protocol == StreamingProtocol.AIRPLAY2 else "raop"
             streams_by_type[stream_type] = streams_by_type.get(stream_type, 0) + 1
+            # The route the binary resolved names the timing source each stream
+            # really got (PTP or NTP), which the daemon flags cannot: a daemon
+            # can be alive and every stream still be running on NTP. A process
+            # that has not reported its route yet is counted apart rather than
+            # folded into either.
+            route = player.stream.active_route or "unreported"
+            streams_by_route[route] = streams_by_route.get(route, 0) + 1
         return {
             "dacp_server_running": self._dacp_server.is_serving(),
             "ptp_daemon_running": self.ptp_daemon_running,
+            "ptp_daemon_ready": self.ptp_daemon_ready,
             "active_streams": sum(streams_by_type.values()),
             "streams_by_type": streams_by_type,
+            "streams_by_route": streams_by_route,
         }
 
     def get_players(self) -> list[AirPlayPlayer]:
@@ -826,7 +859,7 @@ class AirPlayProvider(PlayerProvider):
         # (the per-packet timing trace only runs at verbose in the first place).
         lowered = line.lower()
         if any(marker in lowered for marker in CLI_PROBLEM_MARKERS):
-            self.logger.warning("PTP daemon: %s", line)
+            self._warn_ptp_daemon_line(line)
         else:
             self.logger.log(VERBOSE_LOG_LEVEL, "PTP daemon: %s", line)
         # The readiness marker is matched on either pipe: the daemon's diagnostic
@@ -839,6 +872,38 @@ class AirPlayProvider(PlayerProvider):
         ):
             self.logger.debug("Shared PTP clock daemon reported ready")
             event.set()
+
+    def _warn_ptp_daemon_line(self, line: str) -> None:
+        """
+        Warn about a daemon line that reads like a problem, at a bounded rate.
+
+        The markers are broad by design, and "error" is ordinary vocabulary in
+        clock telemetry (offset error, path delay error), so one matching line
+        in the daemon's per-packet trace would fill a user's log with warnings.
+        A burst still gets through - which is what a real one-shot daemon
+        failure looks like - and the rest of the window is counted and reported
+        once instead. Suppressed lines still reach the verbose log.
+
+        :param line: The daemon output line that matched a problem marker.
+        """
+        now = time.monotonic()
+        if now - self._ptp_daemon_warn_window_start >= PTP_DAEMON_WARN_WINDOW:
+            if self._ptp_daemon_warns_suppressed:
+                self.logger.warning(
+                    "PTP daemon: %d further problem line(s) were suppressed over the last "
+                    "%.0fs; enable verbose logging to see them all",
+                    self._ptp_daemon_warns_suppressed,
+                    PTP_DAEMON_WARN_WINDOW,
+                )
+            self._ptp_daemon_warn_window_start = now
+            self._ptp_daemon_warns_in_window = 0
+            self._ptp_daemon_warns_suppressed = 0
+        if self._ptp_daemon_warns_in_window < PTP_DAEMON_WARN_BURST:
+            self._ptp_daemon_warns_in_window += 1
+            self.logger.warning("PTP daemon: %s", line)
+            return
+        self._ptp_daemon_warns_suppressed += 1
+        self.logger.log(VERBOSE_LOG_LEVEL, "PTP daemon: %s", line)
 
     async def _ptp_daemon_monitor(self, daemon: AsyncProcess) -> None:
         """Watch the PTP daemon process and restart it once if it crashes."""

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -104,7 +104,7 @@ class AirPlayProvider(PlayerProvider):
     _ptp_daemon_ready: asyncio.Event | None = None
     # Rate-limit state for daemon lines promoted to WARNING (see
     # PTP_DAEMON_WARN_BURST).
-    _ptp_daemon_warn_window_start: float = 0.0
+    _ptp_daemon_warn_window_start: float | None = None
     _ptp_daemon_warns_in_window: int = 0
     _ptp_daemon_warns_suppressed: int = 0
 
@@ -890,7 +890,7 @@ class AirPlayProvider(PlayerProvider):
                 "suppressed; enable verbose logging to see them all",
                 self._ptp_daemon_warns_suppressed,
             )
-        self._ptp_daemon_warn_window_start = 0.0
+        self._ptp_daemon_warn_window_start = None
         self._ptp_daemon_warns_in_window = 0
         self._ptp_daemon_warns_suppressed = 0
 
@@ -908,7 +908,12 @@ class AirPlayProvider(PlayerProvider):
         :param line: The daemon output line that matched a problem marker.
         """
         now = time.monotonic()
-        if now - self._ptp_daemon_warn_window_start >= PTP_DAEMON_WARN_WINDOW:
+        window_start = self._ptp_daemon_warn_window_start
+        # None means no window is open yet, which is not the same as one that
+        # started at monotonic zero: time.monotonic() counts from boot on Linux,
+        # so a server started in the first minute of uptime would otherwise get
+        # a first window shorter than the rest.
+        if window_start is None or now - window_start >= PTP_DAEMON_WARN_WINDOW:
             if self._ptp_daemon_warns_suppressed:
                 self.logger.warning(
                     "PTP daemon: %d further problem line(s) were suppressed over the last "

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -831,6 +831,7 @@ class AirPlayProvider(PlayerProvider):
             self._ptp_daemon_ready = asyncio.Event()
         else:
             self._ptp_daemon_ready.clear()
+        self._reset_ptp_daemon_warn_budget()
         await daemon.start()
         self._ptp_daemon = daemon
         self._ptp_daemon_started = time.monotonic()
@@ -872,6 +873,26 @@ class AirPlayProvider(PlayerProvider):
         ):
             self.logger.debug("Shared PTP clock daemon reported ready")
             event.set()
+
+    def _reset_ptp_daemon_warn_budget(self) -> None:
+        """
+        Give a newly spawned daemon a full warning budget of its own.
+
+        The budget is per daemon, not per provider: a daemon that spent it
+        before crashing would otherwise have its replacement's startup failure -
+        the one line worth reading - suppressed for the rest of the window.
+        Whatever the old daemon had held back is reported on the way out rather
+        than dropped.
+        """
+        if self._ptp_daemon_warns_suppressed:
+            self.logger.warning(
+                "PTP daemon: %d further problem line(s) from the previous daemon were "
+                "suppressed; enable verbose logging to see them all",
+                self._ptp_daemon_warns_suppressed,
+            )
+        self._ptp_daemon_warn_window_start = 0.0
+        self._ptp_daemon_warns_in_window = 0
+        self._ptp_daemon_warns_suppressed = 0
 
     def _warn_ptp_daemon_line(self, line: str) -> None:
         """

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -392,6 +392,24 @@ def test_ptp_daemon_reports_what_it_suppressed(
     assert any(message.endswith(trace) for message in messages)
 
 
+def test_ptp_daemon_restart_gets_a_fresh_warning_budget(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A replacement daemon's startup failure must not be eaten by the old one's budget."""
+    prov = _ptp_provider()
+    for _ in range(PTP_DAEMON_WARN_BURST + 2):
+        prov._handle_ptp_daemon_line("[15:44:56.101] [PTP] slave offset seq=7 error=0.000012")
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        prov._reset_ptp_daemon_warn_budget()
+        prov._handle_ptp_daemon_line("[15:44:57.002] [PTP] Cannot bind UDP 319: Permission denied")
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("2 further problem line(s) from the previous daemon" in m for m in messages)
+    assert any("Cannot bind UDP 319" in m for m in messages)
+
+
 async def test_diagnostics_report_daemon_readiness_and_per_stream_route() -> None:
     """A live daemon that never bound its ports must not read as healthy timing."""
     prov = _ptp_provider()

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -12,6 +12,8 @@ from music_assistant_models.enums import PlaybackState
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_COLD_GROUP_START_LEAD_MS,
+    PTP_DAEMON_WARN_BURST,
+    PTP_DAEMON_WARN_WINDOW,
     AirPlayRemoteCommand,
     StreamingProtocol,
 )
@@ -353,6 +355,60 @@ def test_ptp_daemon_line_handler_tolerates_no_event() -> None:
     prov = _ptp_provider()  # _ptp_daemon_ready is None
     # Must not raise even when the readiness gate does not exist yet.
     prov._handle_ptp_daemon_line(DAEMON_UP_LINE)
+
+
+def test_ptp_daemon_problem_lines_are_rate_limited(caplog: pytest.LogCaptureFixture) -> None:
+    """A repeating trace line matching a marker must not fill the log at WARNING."""
+    prov = _ptp_provider()
+    trace = "[15:44:56.101] [PTP] slave offset seq=7 error=0.000012"
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(PTP_DAEMON_WARN_BURST + 20):
+            prov._handle_ptp_daemon_line(trace)
+
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert len(warnings) == PTP_DAEMON_WARN_BURST
+
+
+def test_ptp_daemon_reports_what_it_suppressed(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The count of suppressed lines is reported once the window rolls over."""
+    prov = _ptp_provider()
+    trace = "[15:44:56.101] [PTP] slave offset seq=7 error=0.000012"
+    clock = 1000.0
+    monkeypatch.setattr("music_assistant.providers.airplay.provider.time.monotonic", lambda: clock)
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(PTP_DAEMON_WARN_BURST + 3):
+            prov._handle_ptp_daemon_line(trace)
+        caplog.clear()
+        clock += PTP_DAEMON_WARN_WINDOW + 1
+        prov._handle_ptp_daemon_line(trace)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("3 further problem line(s) were suppressed" in message for message in messages)
+    # and the window reopens for real problems
+    assert any(message.endswith(trace) for message in messages)
+
+
+async def test_diagnostics_report_daemon_readiness_and_per_stream_route() -> None:
+    """A live daemon that never bound its ports must not read as healthy timing."""
+    prov = _ptp_provider()
+    prov._dacp_server = MagicMock(is_serving=MagicMock(return_value=True))
+    prov._ptp_daemon = _live_ptp_daemon()
+    prov._ptp_daemon_ready = asyncio.Event()  # spawned, never reported ready
+    ntp_player = MagicMock(protocol=StreamingProtocol.AIRPLAY2)
+    ntp_player.stream = MagicMock(running=True, active_route="AirPlay 2 (buffered, NTP)")
+    raop_player = MagicMock(protocol=StreamingProtocol.RAOP)
+    raop_player.stream = MagicMock(running=True, active_route="RAOP")
+
+    with patch.object(prov, "get_players", return_value=[ntp_player, raop_player]):
+        diagnostics = await prov.get_diagnostics()
+
+    assert diagnostics["ptp_daemon_running"] is True
+    assert diagnostics["ptp_daemon_ready"] is False
+    assert diagnostics["streams_by_route"] == {"AirPlay 2 (buffered, NTP)": 1, "RAOP": 1}
 
 
 async def test_ptp_daemon_bind_failure_degrades_without_restart() -> None:

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -392,6 +392,26 @@ def test_ptp_daemon_reports_what_it_suppressed(
     assert any(message.endswith(trace) for message in messages)
 
 
+def test_ptp_daemon_warn_window_runs_from_its_first_line(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """time.monotonic() counts from boot, so a server started early must still get a full window."""
+    prov = _ptp_provider()
+    trace = "[15:44:56.101] [PTP] slave offset seq=7 error=0.000012"
+    clock = 5.0  # five seconds of uptime
+    monkeypatch.setattr("music_assistant.providers.airplay.provider.time.monotonic", lambda: clock)
+    for _ in range(PTP_DAEMON_WARN_BURST + 2):
+        prov._handle_ptp_daemon_line(trace)
+
+    # 56s into the window, so it must not have rolled over yet
+    clock += PTP_DAEMON_WARN_WINDOW - 4
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        prov._handle_ptp_daemon_line(trace)
+
+    assert caplog.text == ""
+
+
 def test_ptp_daemon_restart_gets_a_fresh_warning_budget(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Diagnostics reported whether the PTP clock daemon process was alive. That stays true even when it never bound its ports and every group has quietly fallen back to NTP timing.

It now reports whether the daemon is actually serving, plus the timing route each active stream really got. Daemon warnings are also capped so a repeating line cannot flood the log.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
