### PR TITLE
Clarify a comment about how AirPlay playback is anchored

### DIFF
--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -842,12 +842,13 @@ class SendspinAirPlayBridge:
 
         if self._airplay_stream_start_task is None:
             # Provisionally anchor byte 0 to the instant Sendspin scheduled for the
-            # first chunk it actually delivered -- the shared timeline, rather than a
-            # start of our own invention. Sendspin schedules that first sample the
-            # bridge lead ahead because that is what _refresh_bridge_timing reports as
+            # first chunk it actually delivered, which keeps the bridge on the group's
+            # shared timeline. That instant is at least the bridge lead ahead of now,
+            # because that is what _refresh_bridge_timing reports as
             # required_lead_time_ms:
-            #   * fresh track  -> the first chunk IS file position 0, so the intro is
-            #     kept;
+            #   * fresh track  -> the first chunk IS file position 0, so an anchor on
+            #     its own scheduled instant has no audio ahead of it to discard and
+            #     the intro is kept;
             #   * late join     -> the first chunk is the catch-up target, i.e. the
             #     group's current playback position, so the joiner lands in sync.
             # _anchor_stream re-bases this onto the instant the binary acks.


### PR DESCRIPTION
# What does this implement/fix?

A comment in the Sendspin AirPlay bridge described the byte-0 anchor by contrasting it with an alternative start instead of explaining the current code, and it claimed a fresh track keeps its intro without saying why.

- Reword the anchor comment to state what the code does today
- Explain why anchoring to the instant Sendspin scheduled for the first chunk leaves nothing to discard, so a track's intro is kept

No code changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
