### PR TITLE
Use original release years for Music Timeline songs

### DIFF
--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -16,6 +16,7 @@ from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import Artist, ItemMapping, Track
 
 from music_assistant.helpers.compare import compare_artist
+from music_assistant.helpers.datetime import utc
 from music_assistant.helpers.json import json_dumps
 from music_assistant.providers.music_quiz.ai_distractors import (
     AI_QUERY_TIMEOUT_SECONDS,
@@ -41,6 +42,7 @@ from music_assistant.providers.music_quiz.models import (
     TimelineRoundState,
 )
 from music_assistant.providers.music_quiz.quiz_types.base import (
+    MIN_RELEASE_YEAR,
     PLAYBACK_REPLACEMENT_RESERVE,
     QuizType,
     get_track_release_year,
@@ -330,7 +332,9 @@ class MusicTimelineQuizType(QuizType):
                     ).get_release_year_by_isrc(isrc)
                 except Exception as err:
                     LOGGER.debug("Could not date Music Quiz track %s: %s", track.uri, err)
-        if release_year is None:
+        # a year outside this range is rejected by get_track_release_year anyway, and a year
+        # below 1 cannot be expressed as a datetime at all
+        if release_year is None or not MIN_RELEASE_YEAR <= release_year <= utc().year:
             return track
         release_date = track.metadata.release_date
         if release_date is not None and release_date.year <= release_year:

--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -264,15 +264,14 @@ class MusicTimelineQuizType(QuizType):
             for resolved_track in resolved_tracks:
                 if resolved_track is not None and resolved_track.uri is not None:
                     eligible_tracks.setdefault(resolved_track.uri, resolved_track)
-        # this pass has to run after the resolution loop above and not inside it: that loop
-        # only sees tracks that failed _track_is_resolved, so a track carrying a trusted but
-        # wrong album year would never be corrected there. While the pool is short of the
-        # target, tracks the loop dropped for an untrusted year also get a second chance.
+        # this pass has to run after the resolution loop above and not inside it: only once
+        # the loop is done is it known how far the pool is short of the target, and a track
+        # the loop dropped for a missing or untrusted year can never become eligible later,
+        # so MusicBrainz is its only second chance. Tracks that already carry a year are
+        # left alone here and are corrected when they are placed on the timeline.
         shortfall = max(target_track_count - len(eligible_tracks), 0)
-        await self._apply_musicbrainz_release_years(
-            eligible_tracks,
-            [*eligible_tracks.values(), *undated_tracks[:shortfall]],
-        )
+        if shortfall and undated_tracks:
+            await self._rescue_undated_tracks(eligible_tracks, undated_tracks[:shortfall])
         self._eligible_tracks = list(eligible_tracks.values())
         if not self._eligible_tracks:
             raise InvalidDataError(
@@ -282,55 +281,66 @@ class MusicTimelineQuizType(QuizType):
             )
         return self._eligible_tracks
 
-    async def _apply_musicbrainz_release_years(
+    async def _rescue_undated_tracks(
         self,
         eligible_tracks: dict[str, Track],
         candidates: list[Track],
     ) -> None:
         """
-        Date candidate tracks with the first release year MusicBrainz knows for their recording.
+        Make tracks that only MusicBrainz can date available to the timeline.
 
         :param eligible_tracks: Tracks that can be placed on the timeline, keyed by URI and
             updated in place with every candidate that MusicBrainz could date.
-        :param candidates: Tracks to look up, including tracks that lack a usable year and
-            only become eligible once MusicBrainz supplies one.
+        :param candidates: Tracks that lack a usable release year of their own.
         """
-        musicbrainz = self.mass.get_provider("musicbrainz")
-        if musicbrainz is None:
-            return
         semaphore = asyncio.Semaphore(TRACK_ENRICHMENT_CONCURRENCY)
 
-        async def _apply_release_year(track: Track) -> None:
-            isrc = track.get_external_id(ExternalID.ISRC)
-            if not isrc:
-                return
+        async def _rescue_track(track: Track) -> None:
             async with semaphore:
+                dated_track = await self._musicbrainz_dated_track(track)
+            if dated_track.uri is not None and self._track_is_eligible(dated_track):
+                eligible_tracks[dated_track.uri] = dated_track
+
+        # game start waits for this, so tracks that cannot be dated within the budget stay
+        # out of this game and are rescued in a later one from the 30 day response cache
+        with suppress(TimeoutError):
+            async with asyncio.timeout(RELEASE_YEAR_LOOKUP_BUDGET_SECONDS):
+                await asyncio.gather(*(_rescue_track(track) for track in candidates))
+
+    async def _musicbrainz_dated_track(self, track: Track) -> Track:
+        """
+        Return the track dated with the first release year MusicBrainz knows for its recording.
+
+        The track itself is returned unchanged when MusicBrainz has nothing better to offer.
+
+        :param track: Track to date by its ISRC.
+        """
+        musicbrainz = self.mass.get_provider("musicbrainz")
+        isrc = track.get_external_id(ExternalID.ISRC)
+        if musicbrainz is None or not isrc:
+            return track
+        release_year: int | None = None
+        # callers wait for this and MusicBrainz throttles to 10 requests per 10 seconds, so a
+        # lookup that does not resolve within the budget leaves the track on its library year
+        with suppress(TimeoutError):
+            async with asyncio.timeout(RELEASE_YEAR_LOOKUP_BUDGET_SECONDS):
                 try:
                     release_year = await cast(
                         "MusicbrainzProvider", musicbrainz
                     ).get_release_year_by_isrc(isrc)
                 except Exception as err:
                     LOGGER.debug("Could not date Music Quiz track %s: %s", track.uri, err)
-                    return
-            if release_year is None:
-                return
-            # the track controller hands out objects that are shared with the library cache,
-            # so the release date is written to a copy instead of the track itself
-            dated_track = replace(
-                track,
-                metadata=replace(
-                    track.metadata, release_date=datetime(release_year, 1, 1, tzinfo=UTC)
-                ),
-            )
-            if dated_track.uri is not None and self._track_is_eligible(dated_track):
-                eligible_tracks[dated_track.uri] = dated_track
-
-        # game start waits for this and MusicBrainz throttles to 10 requests per 10 seconds,
-        # so anything that does not resolve within the budget keeps its library year and is
-        # corrected in a later game from the 30 day response cache
-        with suppress(TimeoutError):
-            async with asyncio.timeout(RELEASE_YEAR_LOOKUP_BUDGET_SECONDS):
-                await asyncio.gather(*(_apply_release_year(track) for track in candidates))
+        if release_year is None:
+            return track
+        release_date = track.metadata.release_date
+        if release_date is not None and release_date.year <= release_year:
+            return track
+        # the track controller hands out objects that are shared with the library cache,
+        # so the release date is written to a copy instead of the track itself
+        return replace(
+            track,
+            metadata=replace(track.metadata, release_date=datetime(release_year, 1, 1, tzinfo=UTC)),
+        )
 
     async def _create_entry(
         self,
@@ -340,6 +350,7 @@ class MusicTimelineQuizType(QuizType):
         existing_ids: set[str] | None = None,
     ) -> TimelineEntry:
         """Create a stable timeline entry from an eligible track."""
+        track = await self._musicbrainz_dated_track(track)
         release_year = self._release_year(track)
         if release_year is None or not track.uri or not track.artist_str:
             raise InvalidDataError("Music Timeline track is missing required timeline metadata")

--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -6,10 +6,12 @@ import asyncio
 import logging
 import secrets
 from collections.abc import Sequence
+from contextlib import suppress
 from dataclasses import replace
-from typing import TYPE_CHECKING
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, cast
 
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import ExternalID, MediaType
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import Artist, ItemMapping, Track
 
@@ -56,6 +58,7 @@ from music_assistant.providers.music_quiz.suggestions import (
 if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
     from music_assistant.providers.music_quiz.models import MusicQuizConfig
+    from music_assistant.providers.musicbrainz import MusicbrainzProvider
 
 LOGGER = logging.getLogger(__name__)
 SYSTEM_RANDOM = secrets.SystemRandom()
@@ -63,6 +66,7 @@ SYSTEM_RANDOM = secrets.SystemRandom()
 DEFAULT_BONUS_OPTION_COUNT = 4
 COMPLETED_REVEAL_AUTO_ADVANCE_SECONDS = 30.0
 TRACK_ENRICHMENT_CONCURRENCY = 10
+RELEASE_YEAR_LOOKUP_BUDGET_SECONDS = 2.0
 BONUS_CANDIDATE_LIMIT = 24
 
 
@@ -218,6 +222,7 @@ class MusicTimelineQuizType(QuizType):
         source_tracks = list((await self._get_source_track_pool()).values())
         eligible_tracks: dict[str, Track] = {}
         unresolved_tracks: list[Track] = []
+        undated_tracks: list[Track] = []
         for track in source_tracks:
             if self._track_is_resolved(track):
                 assert track.uri is not None
@@ -234,7 +239,10 @@ class MusicTimelineQuizType(QuizType):
                 return track if self._track_is_eligible(track) else None
             # the track controller can fail to resolve an album mapping, so accept the
             # best release year the enriched track offers rather than requiring an album
-            return enriched if self._track_is_eligible(enriched) else None
+            if self._track_is_eligible(enriched):
+                return enriched
+            undated_tracks.append(enriched)
+            return None
 
         target_track_count = self.config.round_count + 1 + PLAYBACK_REPLACEMENT_RESERVE
         # enrichment stops at the target count, so sample the whole source pool
@@ -256,6 +264,15 @@ class MusicTimelineQuizType(QuizType):
             for resolved_track in resolved_tracks:
                 if resolved_track is not None and resolved_track.uri is not None:
                     eligible_tracks.setdefault(resolved_track.uri, resolved_track)
+        # this pass has to run after the resolution loop above and not inside it: that loop
+        # only sees tracks that failed _track_is_resolved, so a track carrying a trusted but
+        # wrong album year would never be corrected there. While the pool is short of the
+        # target, tracks the loop dropped for an untrusted year also get a second chance.
+        shortfall = max(target_track_count - len(eligible_tracks), 0)
+        await self._apply_musicbrainz_release_years(
+            eligible_tracks,
+            [*eligible_tracks.values(), *undated_tracks[:shortfall]],
+        )
         self._eligible_tracks = list(eligible_tracks.values())
         if not self._eligible_tracks:
             raise InvalidDataError(
@@ -264,6 +281,56 @@ class MusicTimelineQuizType(QuizType):
                 translation_owner=TRANSLATION_OWNER,
             )
         return self._eligible_tracks
+
+    async def _apply_musicbrainz_release_years(
+        self,
+        eligible_tracks: dict[str, Track],
+        candidates: list[Track],
+    ) -> None:
+        """
+        Date candidate tracks with the first release year MusicBrainz knows for their recording.
+
+        :param eligible_tracks: Tracks that can be placed on the timeline, keyed by URI and
+            updated in place with every candidate that MusicBrainz could date.
+        :param candidates: Tracks to look up, including tracks that lack a usable year and
+            only become eligible once MusicBrainz supplies one.
+        """
+        musicbrainz = self.mass.get_provider("musicbrainz")
+        if musicbrainz is None:
+            return
+        semaphore = asyncio.Semaphore(TRACK_ENRICHMENT_CONCURRENCY)
+
+        async def _apply_release_year(track: Track) -> None:
+            isrc = track.get_external_id(ExternalID.ISRC)
+            if not isrc:
+                return
+            async with semaphore:
+                try:
+                    release_year = await cast(
+                        "MusicbrainzProvider", musicbrainz
+                    ).get_release_year_by_isrc(isrc)
+                except Exception as err:
+                    LOGGER.debug("Could not date Music Quiz track %s: %s", track.uri, err)
+                    return
+            if release_year is None:
+                return
+            # the track controller hands out objects that are shared with the library cache,
+            # so the release date is written to a copy instead of the track itself
+            dated_track = replace(
+                track,
+                metadata=replace(
+                    track.metadata, release_date=datetime(release_year, 1, 1, tzinfo=UTC)
+                ),
+            )
+            if dated_track.uri is not None and self._track_is_eligible(dated_track):
+                eligible_tracks[dated_track.uri] = dated_track
+
+        # game start waits for this and MusicBrainz throttles to 10 requests per 10 seconds,
+        # so anything that does not resolve within the budget keeps its library year and is
+        # corrected in a later game from the 30 day response cache
+        with suppress(TimeoutError):
+            async with asyncio.timeout(RELEASE_YEAR_LOOKUP_BUDGET_SECONDS):
+                await asyncio.gather(*(_apply_release_year(track) for track in candidates))
 
     async def _create_entry(
         self,

--- a/music_assistant/providers/musicbrainz/provider.py
+++ b/music_assistant/providers/musicbrainz/provider.py
@@ -280,6 +280,28 @@ class MusicbrainzProvider(MetadataProvider):
             return recording.isrcs or []
         return []
 
+    async def get_release_year_by_isrc(self, isrc: str) -> int | None:
+        """
+        Get the year a recording was first released, by ISRC.
+
+        :param isrc: ISRC of the recording, with or without separators.
+        :return: The earliest known release year, or None if MusicBrainz does not know it.
+        """
+        safe_isrc = isrc.replace("-", "").strip()
+        if not safe_isrc.isalnum():
+            return None
+        # the isrc resource rejects inc= parameters and already carries the release dates
+        result = await self._api_client.get_data(f"isrc/{safe_isrc}")
+        if not result or not (recordings := result.get("recordings")):
+            return None
+        # one ISRC can cover several recordings, the oldest one dates the song
+        years: list[int] = []
+        for recording in recordings:
+            release_date = recording.get("first-release-date") or ""
+            if (year := release_date[:4]).isdigit():
+                years.append(int(year))
+        return min(years, default=None)
+
     async def get_release_details(self, album_id: str) -> MusicBrainzRelease:
         """Get Release/Album details by providing a MusicBrainz Album id."""
         endpoint = f"release/{album_id}?inc=artist-credits+aliases+labels"

--- a/music_assistant/providers/musicbrainz/provider.py
+++ b/music_assistant/providers/musicbrainz/provider.py
@@ -280,6 +280,30 @@ class MusicbrainzProvider(MetadataProvider):
             return recording.isrcs or []
         return []
 
+    async def get_recordings_by_isrc(self, isrc: str) -> list[MusicBrainzRecording]:
+        """
+        Get the recordings MusicBrainz has on file for an ISRC.
+
+        Inverse of :meth:`get_isrcs_for_recording`: that one goes from a
+        recording to its ISRCs, this one goes from an ISRC back to recordings.
+
+        :param isrc: ISRC of the recording, with or without separators.
+        :return: Recordings tagged with this ISRC, or empty list if not found.
+        """
+        safe_isrc = isrc.replace("-", "").strip()
+        if not safe_isrc.isalnum():
+            return []
+        # the isrc resource rejects inc= parameters and already carries the release dates
+        result = await self._api_client.get_data(f"isrc/{safe_isrc}")
+        if not result or not (recordings := result.get("recordings")):
+            return []
+        parsed: list[MusicBrainzRecording] = []
+        for recording in recordings:
+            # a single malformed entry should not sink the recordings we did parse
+            with suppress(MissingField):
+                parsed.append(MusicBrainzRecording.from_raw(recording))
+        return parsed
+
     async def get_release_year_by_isrc(self, isrc: str) -> int | None:
         """
         Get the year a recording was first released, by ISRC.
@@ -287,17 +311,11 @@ class MusicbrainzProvider(MetadataProvider):
         :param isrc: ISRC of the recording, with or without separators.
         :return: The earliest known release year, or None if MusicBrainz does not know it.
         """
-        safe_isrc = isrc.replace("-", "").strip()
-        if not safe_isrc.isalnum():
-            return None
-        # the isrc resource rejects inc= parameters and already carries the release dates
-        result = await self._api_client.get_data(f"isrc/{safe_isrc}")
-        if not result or not (recordings := result.get("recordings")):
-            return None
+        recordings = await self.get_recordings_by_isrc(isrc)
         # one ISRC can cover several recordings, the oldest one dates the song
         years: list[int] = []
         for recording in recordings:
-            release_date = recording.get("first-release-date") or ""
+            release_date = recording.first_release_date or ""
             if (year := release_date[:4]).isdigit():
                 years.append(int(year))
         return min(years, default=None)

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -29,6 +29,7 @@ from music_assistant.providers.music_quiz.ai_distractors import AI_QUERY_TIMEOUT
 from music_assistant.providers.music_quiz.models import (
     MusicQuizConfig,
     MusicQuizDifficulty,
+    MusicQuizRound,
     TimelineBonusMode,
     TimelineBonusType,
     TimelineFreeTextBonusDefinition,
@@ -245,6 +246,18 @@ def _with_isrc(track: Track, isrc: str) -> Track:
     """Return the given track carrying an ISRC."""
     track.add_external_id(ExternalID.ISRC, isrc)
     return track
+
+
+async def _prepare_round_with_tracks(
+    quiz: MusicTimelineQuizType,
+    tracks: list[Track],
+) -> MusicQuizRound:
+    """Prepare the first round with the given tracks selected as anchor and candidate."""
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types.music_timeline.secrets.choice",
+        side_effect=tracks,
+    ):
+        return await quiz.prepare_round(0, [])
 
 
 def test_config_normalization_and_validation_are_music_timeline_specific() -> None:
@@ -704,11 +717,50 @@ async def test_musicbrainz_year_only_wins_when_it_predates_the_library_year() ->
     _with_musicbrainz(mass, {"ISRC-REISSUE": 1970, "ISRC-REMASTER": 2017})
 
     await quiz.initialize()
+    game_round = await _prepare_round_with_tracks(quiz, [reissue, remaster])
 
-    assert quiz._eligible_tracks is not None
-    eligible_tracks = {track.item_id: track for track in quiz._eligible_tracks}
-    assert MusicTimelineQuizType._release_year(eligible_tracks["reissue"]) == 1970
-    assert MusicTimelineQuizType._release_year(eligible_tracks["remaster"]) == 1967
+    assert isinstance(game_round.answer_state, TimelineRoundState)
+    assert game_round.answer_state.placement_snapshot[0].release_year == 1970
+    assert game_round.answer_state.candidate.entry.release_year == 1967
+
+
+@pytest.mark.asyncio
+async def test_an_earlier_track_release_date_survives_a_later_musicbrainz_year() -> None:
+    """Never push a release date the track already carries forward to a later year."""
+    dated = _with_isrc(
+        _track("dated", "Suspicious Minds", "Elvis Presley", release_year=1969),
+        "ISRC-DATED",
+    )
+    other = _track("other", "Genesis", "Justice", album_year=2007)
+    quiz, mass = _quiz([dated, other])
+    _with_musicbrainz(mass, {"ISRC-DATED": 1990})
+
+    await quiz.initialize()
+    game_round = await _prepare_round_with_tracks(quiz, [dated, other])
+
+    assert isinstance(game_round.answer_state, TimelineRoundState)
+    assert game_round.answer_state.placement_snapshot[0].release_year == 1969
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_lookups_do_not_scale_with_the_source_pool() -> None:
+    """Date only the tracks that reach the timeline, never the complete eligible pool."""
+    tracks = [
+        _with_isrc(
+            _track(f"track-{index}", f"Song {index}", f"Artist {index}", album_year=1990),
+            f"ISRC-{index}",
+        )
+        for index in range(60)
+    ]
+    quiz, mass = _quiz(tracks)
+    musicbrainz = _with_musicbrainz(mass, {f"ISRC-{index}": 1970 for index in range(60)})
+
+    await quiz.initialize()
+    game_round = await quiz.prepare_round(0, [])
+
+    assert isinstance(game_round.answer_state, TimelineRoundState)
+    assert game_round.answer_state.candidate.entry.release_year == 1970
+    assert musicbrainz.get_release_year_by_isrc.await_count <= quiz.config.round_count + 1
 
 
 @pytest.mark.asyncio
@@ -745,12 +797,11 @@ async def test_library_years_are_kept_without_musicbrainz() -> None:
     mass.get_provider = MagicMock(return_value=None)
 
     await quiz.initialize()
+    game_round = await _prepare_round_with_tracks(quiz, tracks)
 
-    assert quiz._eligible_tracks is not None
-    assert [MusicTimelineQuizType._release_year(track) for track in quiz._eligible_tracks] == [
-        1998,
-        2007,
-    ]
+    assert isinstance(game_round.answer_state, TimelineRoundState)
+    assert game_round.answer_state.placement_snapshot[0].release_year == 1998
+    assert game_round.answer_state.candidate.entry.release_year == 2007
 
 
 @pytest.mark.asyncio
@@ -764,13 +815,12 @@ async def test_tracks_without_an_isrc_are_not_looked_up() -> None:
     musicbrainz = _with_musicbrainz(mass, {"ISRC-ONE": 1970})
 
     await quiz.initialize()
+    game_round = await _prepare_round_with_tracks(quiz, tracks)
 
     musicbrainz.get_release_year_by_isrc.assert_not_awaited()
-    assert quiz._eligible_tracks is not None
-    assert [MusicTimelineQuizType._release_year(track) for track in quiz._eligible_tracks] == [
-        1998,
-        2007,
-    ]
+    assert isinstance(game_round.answer_state, TimelineRoundState)
+    assert game_round.answer_state.placement_snapshot[0].release_year == 1998
+    assert game_round.answer_state.candidate.entry.release_year == 2007
 
 
 @pytest.mark.asyncio
@@ -784,12 +834,40 @@ async def test_failing_musicbrainz_lookups_keep_the_library_year() -> None:
     _with_musicbrainz(mass, error=RuntimeError("musicbrainz unavailable"))
 
     await quiz.initialize()
+    game_round = await _prepare_round_with_tracks(quiz, tracks)
 
-    assert quiz._eligible_tracks is not None
-    assert [MusicTimelineQuizType._release_year(track) for track in quiz._eligible_tracks] == [
-        1998,
-        2007,
+    assert isinstance(game_round.answer_state, TimelineRoundState)
+    assert game_round.answer_state.placement_snapshot[0].release_year == 1998
+    assert game_round.answer_state.candidate.entry.release_year == 2007
+
+
+@pytest.mark.asyncio
+async def test_stalled_musicbrainz_lookups_keep_the_library_year() -> None:
+    """Never let a MusicBrainz lookup that does not answer hold up a round."""
+    tracks = [
+        _with_isrc(_track("one", "Teardrop", "Massive Attack", album_year=1998), "ISRC-ONE"),
+        _with_isrc(_track("two", "Genesis", "Justice", album_year=2007), "ISRC-TWO"),
     ]
+    quiz, mass = _quiz(tracks)
+    musicbrainz = _with_musicbrainz(mass)
+
+    async def _never_answer(_isrc: str) -> int:
+        await asyncio.sleep(30)
+        return 1970
+
+    musicbrainz.get_release_year_by_isrc.side_effect = _never_answer
+
+    await quiz.initialize()
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types."
+        "music_timeline.RELEASE_YEAR_LOOKUP_BUDGET_SECONDS",
+        0.01,
+    ):
+        game_round = await _prepare_round_with_tracks(quiz, tracks)
+
+    assert isinstance(game_round.answer_state, TimelineRoundState)
+    assert game_round.answer_state.placement_snapshot[0].release_year == 1998
+    assert game_round.answer_state.candidate.entry.release_year == 2007
 
 
 def test_release_year_uses_earliest_valid_track_or_album_year() -> None:

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -824,6 +824,25 @@ async def test_tracks_without_an_isrc_are_not_looked_up() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("release_year", [0, 999, 9999])
+async def test_musicbrainz_years_outside_the_accepted_range_are_ignored(release_year: int) -> None:
+    """Keep the library year when MusicBrainz reports a year the timeline cannot use."""
+    tracks = [
+        _with_isrc(_track("one", "Teardrop", "Massive Attack", album_year=1998), "ISRC-ONE"),
+        _with_isrc(_track("two", "Genesis", "Justice", album_year=2007), "ISRC-TWO"),
+    ]
+    quiz, mass = _quiz(tracks)
+    _with_musicbrainz(mass, {"ISRC-ONE": release_year, "ISRC-TWO": release_year})
+
+    await quiz.initialize()
+    game_round = await _prepare_round_with_tracks(quiz, tracks)
+
+    assert isinstance(game_round.answer_state, TimelineRoundState)
+    assert game_round.answer_state.placement_snapshot[0].release_year == 1998
+    assert game_round.answer_state.candidate.entry.release_year == 2007
+
+
+@pytest.mark.asyncio
 async def test_failing_musicbrainz_lookups_keep_the_library_year() -> None:
     """Start the game on library years when the MusicBrainz lookup fails."""
     tracks = [

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -225,6 +225,28 @@ def _quiz(
     return quiz, mass
 
 
+def _with_musicbrainz(
+    mass: MagicMock,
+    years: dict[str, int] | None = None,
+    error: Exception | None = None,
+) -> MagicMock:
+    """Attach a MusicBrainz provider that dates the given ISRCs to the mock MusicAssistant."""
+    provider = MagicMock()
+    provider.get_release_year_by_isrc = AsyncMock(
+        side_effect=error if error is not None else lambda isrc: (years or {}).get(isrc)
+    )
+    mass.get_provider = MagicMock(
+        side_effect=lambda domain: provider if domain == "musicbrainz" else None
+    )
+    return provider
+
+
+def _with_isrc(track: Track, isrc: str) -> Track:
+    """Return the given track carrying an ISRC."""
+    track.add_external_id(ExternalID.ISRC, isrc)
+    return track
+
+
 def test_config_normalization_and_validation_are_music_timeline_specific() -> None:
     """Use fixed option defaults without requiring guess-the-song settings."""
     config = MusicQuizConfig(
@@ -664,6 +686,110 @@ async def test_track_enrichment_concurrency_is_bounded() -> None:
 
     assert mass.music.tracks.get.await_count == len(tracks)
     assert max_active_calls <= TRACK_ENRICHMENT_CONCURRENCY
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_year_only_wins_when_it_predates_the_library_year() -> None:
+    """Keep the earliest of the library and MusicBrainz release year."""
+    reissue = _with_isrc(
+        _track("reissue", "Immigrant Song", "Led Zeppelin", album_year=2018),
+        "ISRC-REISSUE",
+    )
+    # remasters get their own ISRC, so MusicBrainz can date a song later than the library does
+    remaster = _with_isrc(
+        _track("remaster", "Penny Lane", "The Beatles", album_year=1967),
+        "ISRC-REMASTER",
+    )
+    quiz, mass = _quiz([reissue, remaster])
+    _with_musicbrainz(mass, {"ISRC-REISSUE": 1970, "ISRC-REMASTER": 2017})
+
+    await quiz.initialize()
+
+    assert quiz._eligible_tracks is not None
+    eligible_tracks = {track.item_id: track for track in quiz._eligible_tracks}
+    assert MusicTimelineQuizType._release_year(eligible_tracks["reissue"]) == 1970
+    assert MusicTimelineQuizType._release_year(eligible_tracks["remaster"]) == 1967
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_dates_tracks_dropped_as_compilations() -> None:
+    """Restore a compilation track once MusicBrainz dates its recording."""
+    compilation = _with_isrc(_track("compilation", "Africa", "Toto"), "ISRC-COMPILATION")
+    compilation.album = _full_album(
+        "album-compilation",
+        "Party Hits",
+        album_type=AlbumType.COMPILATION,
+        year=1998,
+    )
+    resolved = _track("resolved", "Genesis", "Justice", album_year=2007)
+    quiz, mass = _quiz([compilation, resolved])
+    mass.music.tracks.get.return_value = compilation
+    _with_musicbrainz(mass, {"ISRC-COMPILATION": 1982})
+
+    await quiz.initialize()
+
+    assert quiz._eligible_tracks is not None
+    eligible_tracks = {track.item_id: track for track in quiz._eligible_tracks}
+    assert set(eligible_tracks) == {"compilation", "resolved"}
+    assert MusicTimelineQuizType._release_year(eligible_tracks["compilation"]) == 1982
+
+
+@pytest.mark.asyncio
+async def test_library_years_are_kept_without_musicbrainz() -> None:
+    """Place tracks on the timeline when no MusicBrainz provider is configured."""
+    tracks = [
+        _with_isrc(_track("one", "Teardrop", "Massive Attack", album_year=1998), "ISRC-ONE"),
+        _with_isrc(_track("two", "Genesis", "Justice", album_year=2007), "ISRC-TWO"),
+    ]
+    quiz, mass = _quiz(tracks)
+    mass.get_provider = MagicMock(return_value=None)
+
+    await quiz.initialize()
+
+    assert quiz._eligible_tracks is not None
+    assert [MusicTimelineQuizType._release_year(track) for track in quiz._eligible_tracks] == [
+        1998,
+        2007,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tracks_without_an_isrc_are_not_looked_up() -> None:
+    """Never ask MusicBrainz about a track that carries no ISRC."""
+    tracks = [
+        _track("one", "Teardrop", "Massive Attack", album_year=1998),
+        _track("two", "Genesis", "Justice", album_year=2007),
+    ]
+    quiz, mass = _quiz(tracks)
+    musicbrainz = _with_musicbrainz(mass, {"ISRC-ONE": 1970})
+
+    await quiz.initialize()
+
+    musicbrainz.get_release_year_by_isrc.assert_not_awaited()
+    assert quiz._eligible_tracks is not None
+    assert [MusicTimelineQuizType._release_year(track) for track in quiz._eligible_tracks] == [
+        1998,
+        2007,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failing_musicbrainz_lookups_keep_the_library_year() -> None:
+    """Start the game on library years when the MusicBrainz lookup fails."""
+    tracks = [
+        _with_isrc(_track("one", "Teardrop", "Massive Attack", album_year=1998), "ISRC-ONE"),
+        _with_isrc(_track("two", "Genesis", "Justice", album_year=2007), "ISRC-TWO"),
+    ]
+    quiz, mass = _quiz(tracks)
+    _with_musicbrainz(mass, error=RuntimeError("musicbrainz unavailable"))
+
+    await quiz.initialize()
+
+    assert quiz._eligible_tracks is not None
+    assert [MusicTimelineQuizType._release_year(track) for track in quiz._eligible_tracks] == [
+        1998,
+        2007,
+    ]
 
 
 def test_release_year_uses_earliest_valid_track_or_album_year() -> None:

--- a/tests/providers/musicbrainz/test_provider.py
+++ b/tests/providers/musicbrainz/test_provider.py
@@ -1,0 +1,82 @@
+"""Tests for the MusicBrainz provider."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from music_assistant.providers.musicbrainz.provider import MusicbrainzProvider
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _provider(response: Any) -> tuple[MusicbrainzProvider, AsyncMock]:
+    """Return a MusicbrainzProvider whose API client answers with the given response."""
+    with patch.object(MusicbrainzProvider, "__init__", lambda *_a, **_kw: None):
+        provider = MusicbrainzProvider.__new__(MusicbrainzProvider)
+    get_data = AsyncMock(return_value=response)
+    api_client = MagicMock()
+    api_client.get_data = get_data
+    provider._api_client = api_client
+    return provider, get_data
+
+
+def _recordings(*first_release_dates: str | None) -> dict[str, Any]:
+    """Return an isrc lookup response with a recording per given release date."""
+    return {
+        "isrc": "GBAYE8600477",
+        "recordings": [
+            {"title": "stub"} if date is None else {"title": "stub", "first-release-date": date}
+            for date in first_release_dates
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# get_release_year_by_isrc
+# ---------------------------------------------------------------------------
+
+
+async def test_release_year_parses_all_date_precisions() -> None:
+    """Accept a year, year-month or full date as the first release date."""
+    for release_date in ("1986", "1986-06", "1986-06-23"):
+        provider, _ = _provider(_recordings(release_date))
+        assert await provider.get_release_year_by_isrc("GBAYE8600477") == 1986
+
+
+async def test_release_year_uses_bare_isrc_lookup() -> None:
+    """Look the recording up on the isrc resource without inc parameters."""
+    provider, get_data = _provider(_recordings("1986"))
+
+    await provider.get_release_year_by_isrc("GB-AYE-86-00477")
+
+    get_data.assert_awaited_once_with("isrc/GBAYE8600477")
+
+
+async def test_release_year_returns_earliest_of_multiple_recordings() -> None:
+    """Date the song by the oldest recording the ISRC covers."""
+    provider, _ = _provider(_recordings("2009-05-01", "1986-06", "1994"))
+    assert await provider.get_release_year_by_isrc("GBAYE8600477") == 1986
+
+
+async def test_release_year_is_none_without_a_usable_date() -> None:
+    """Return None when MusicBrainz has no parseable first release date."""
+    for response in (
+        None,
+        {"isrc": "GBAYE8600477"},
+        {"isrc": "GBAYE8600477", "recordings": []},
+        _recordings(None),
+        _recordings("????-06"),
+    ):
+        provider, _ = _provider(response)
+        assert await provider.get_release_year_by_isrc("GBAYE8600477") is None
+
+
+async def test_release_year_rejects_a_malformed_isrc() -> None:
+    """Never put an ISRC that cannot be part of a URL path in the request."""
+    provider, get_data = _provider(_recordings("1986"))
+
+    assert await provider.get_release_year_by_isrc("../artist/1") is None
+    get_data.assert_not_awaited()

--- a/tests/providers/musicbrainz/test_provider.py
+++ b/tests/providers/musicbrainz/test_provider.py
@@ -28,8 +28,10 @@ def _recordings(*first_release_dates: str | None) -> dict[str, Any]:
     return {
         "isrc": "GBAYE8600477",
         "recordings": [
-            {"title": "stub"} if date is None else {"title": "stub", "first-release-date": date}
-            for date in first_release_dates
+            {"id": f"stub-{i}", "title": "stub"}
+            if date is None
+            else {"id": f"stub-{i}", "title": "stub", "first-release-date": date}
+            for i, date in enumerate(first_release_dates)
         ],
     }
 
@@ -79,4 +81,83 @@ async def test_release_year_rejects_a_malformed_isrc() -> None:
     provider, get_data = _provider(_recordings("1986"))
 
     assert await provider.get_release_year_by_isrc("../artist/1") is None
+    get_data.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# get_recordings_by_isrc
+# ---------------------------------------------------------------------------
+
+
+_YELLOW_SUBMARINE = {
+    "isrc": "GBAYE0601498",
+    "recordings": [
+        {
+            "id": "b2181aae-5cba-496c-bb0c-b4cc0109ebf8",
+            "title": "Yellow Submarine",
+            "length": 160000,
+            "first-release-date": "1966-08-05",
+            "disambiguation": "original stereo studio mix",
+            "video": False,
+        }
+    ],
+}
+
+
+async def test_recordings_by_isrc_parses_a_realistic_payload() -> None:
+    """Parse id, title and first-release-date from a real isrc lookup response."""
+    provider, _ = _provider(_YELLOW_SUBMARINE)
+
+    recordings = await provider.get_recordings_by_isrc("GBAYE0601498")
+
+    assert len(recordings) == 1
+    recording = recordings[0]
+    assert recording.id == "b2181aae-5cba-496c-bb0c-b4cc0109ebf8"
+    assert recording.title == "Yellow Submarine"
+    assert recording.first_release_date == "1966-08-05"
+
+
+async def test_recordings_by_isrc_returns_all_recordings() -> None:
+    """Return every recording an ISRC covers, not just the first."""
+    provider, _ = _provider(_recordings("2009-05-01", "1986-06", "1994"))
+
+    recordings = await provider.get_recordings_by_isrc("GBAYE8600477")
+
+    assert len(recordings) == 3
+    assert [r.first_release_date for r in recordings] == ["2009-05-01", "1986-06", "1994"]
+
+
+async def test_recordings_by_isrc_skips_a_malformed_entry() -> None:
+    """Skip a recording missing a required field while keeping its valid siblings."""
+    response = {
+        "isrc": "GBAYE8600477",
+        "recordings": [
+            {"title": "no id here"},
+            {"id": "good-1", "title": "stub", "first-release-date": "1986"},
+        ],
+    }
+    provider, _ = _provider(response)
+
+    recordings = await provider.get_recordings_by_isrc("GBAYE8600477")
+
+    assert len(recordings) == 1
+    assert recordings[0].id == "good-1"
+
+
+async def test_recordings_by_isrc_is_empty_without_usable_data() -> None:
+    """Return an empty list for every shape of "MusicBrainz has nothing" response."""
+    for response in (
+        None,
+        {"isrc": "GBAYE8600477"},
+        {"isrc": "GBAYE8600477", "recordings": []},
+    ):
+        provider, _ = _provider(response)
+        assert await provider.get_recordings_by_isrc("GBAYE8600477") == []
+
+
+async def test_recordings_by_isrc_rejects_a_malformed_isrc() -> None:
+    """Never put an ISRC that cannot be part of a URL path in the request."""
+    provider, get_data = _provider(_YELLOW_SUBMARINE)
+
+    assert await provider.get_recordings_by_isrc("../artist/1") == []
     get_data.assert_not_awaited()


### PR DESCRIPTION
# What does this implement/fix?

Music Timeline asks you to place a song on a timeline, so the release year is the answer being scored. That year came from the album, which is wrong whenever the song sits on a compilation or a reissue — "Layla" showed up as 2018 instead of 1970, "Killer Queen" as 2009 instead of 1974. On a test library, compilation tracks were off by 15 years on average.

Songs now get their year from MusicBrainz, looked up by the track's ISRC, and we keep whichever year is earlier — the album's or MusicBrainz's. Both sources only ever err on the late side, so taking the earliest is more accurate than either on its own.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Added a MusicBrainz lookup that returns the year a recording was first released, by ISRC.
- Music Timeline dates its songs with that year and keeps the earliest of it and the album year.
- Songs that were previously skipped because they only appeared on a compilation can now be used again, once MusicBrainz can date them.
- Lookups are capped by a short time budget so starting a game never waits on MusicBrainz; anything unresolved keeps the album year and is corrected on a later game from the cached response.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
