### PR TITLE
Point the SiriusXM labels at the common strings

### DIFF
--- a/music_assistant/providers/siriusxm/strings.json
+++ b/music_assistant/providers/siriusxm/strings.json
@@ -1,10 +1,10 @@
 {
   "config_entries": {
     "sxm_email_address": {
-      "label": "Username"
+      "label": "[%key:common::config_entries::username::label%]"
     },
     "sxm_password": {
-      "label": "Password"
+      "label": "[%key:common::config_entries::password::label%]"
     },
     "sxm_region": {
       "label": "Region",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -2016,8 +2016,6 @@
   "provider.sendspin.setup_flow.enter_token.title": "Enter the pairing token",
   "provider.sendspin.setup_flow.select_method.description": "Choose how to pair with this device. PIN pairing uses a code the device shows while pairing (or a static PIN printed on it); token pairing uses a pairing token you copy from the device.",
   "provider.sendspin.setup_flow.select_method.title": "Pair this device",
-  "provider.siriusxm.config_entries.sxm_email_address.label": "Username",
-  "provider.siriusxm.config_entries.sxm_password.label": "Password",
   "provider.siriusxm.config_entries.sxm_region.label": "Region",
   "provider.siriusxm.config_entries.sxm_region.options.CA": "Canada",
   "provider.siriusxm.config_entries.sxm_region.options.US": "United States",


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The username and password labels repeated text that already exists in the common pool. 

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
