### PR TITLE
Announce preset changes when an impulse response is removed

### DIFF
--- a/music_assistant/controllers/config/dsp.py
+++ b/music_assistant/controllers/config/dsp.py
@@ -344,12 +344,20 @@ class DSPConfigMixin:
                 data=config,
             )
         raw_presets: dict[str, dict[str, Any]] = self.get(CONF_PLAYER_DSP_PRESETS, {})
+        presets_changed = False
         for preset_key, raw_preset in tuple(raw_presets.items()):
             preset = DSPConfigPreset.from_dict(raw_preset)
             if not _blank_convolution_ir(preset.config, ir_id):
                 continue
             self.set(f"{CONF_PLAYER_DSP_PRESETS}/{preset_key}", preset.to_dict())
             cleared = True
+            presets_changed = True
+
+        if presets_changed:
+            self.mass.signal_event(
+                EventType.DSP_PRESETS_UPDATED,
+                data=await self.get_dsp_presets(),
+            )
         return cleared
 
     def _validate_dsp_ir_refs(self, config: DSPConfig) -> None:

--- a/tests/controllers/config/test_dsp.py
+++ b/tests/controllers/config/test_dsp.py
@@ -456,8 +456,14 @@ async def test_remove_ir_clears_references(tmp_path: Path) -> None:
         )
     )
 
+    config.signal_event.reset_mock()
+
     await config.remove_dsp_ir("abc123")
 
+    signalled = [call.args[0] for call in config.signal_event.call_args_list]
+    assert EventType.PLAYER_DSP_CONFIG_UPDATED in signalled
+    # the blanked preset must be announced too, or a client keeps offering the deleted IR
+    assert EventType.DSP_PRESETS_UPDATED in signalled
     player_filter = config.get_player_dsp_config("player-1").filters[0]
     assert isinstance(player_filter, ConvolutionFilter)
     assert player_filter.ir_id == ""


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Found while building the convolution PR and split out of it because it is about presets rather than the impulse response library.

Removing an impulse response blanks its id from any player config and from any DSP preset that used it. The player configs were announced with an event, the rewritten presets were not. A client that already holds the preset list therefore keeps offering an impulse response that no longer exists, and applying that preset silently does nothing at playback.

The fix tracks whether any preset was actually rewritten and, if so, signals the existing `DSP_PRESETS_UPDATED` event once after the loop with the refreshed list. The flag is separate from the one that tracks player configs, otherwise removing an IR that only a player used would announce a preset change that never happened.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
