### PR TITLE
Remove dead code from the AirPlay provider

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -51,7 +51,6 @@ class ClockReadiness(StrEnum):
     UNREPORTED = "unreported"
 
 
-CONF_VOLUME_START: Final[str] = "volume_start"
 CONF_PASSWORD: Final[str] = "password"
 # Storage-only marker (no config entry) set when the device rejected the stored
 # password, so the player keeps asking for setup across restarts until a working
@@ -211,8 +210,6 @@ CONF_PAIRING_PASSWORD: Final[str] = "pairing_password"
 CONF_COMPANION_PAIRING_PIN: Final[str] = "companion_pairing_pin"
 CONF_MRP_PAIRING_PIN: Final[str] = "mrp_pairing_pin"
 CONF_PAIR_NOW: Final[str] = "pair_now"
-BACKOFF_TIME_LOWER_LIMIT: Final[int] = 15  # seconds
-BACKOFF_TIME_UPPER_LIMIT: Final[int] = 300  # Five minutes
 
 FALLBACK_VOLUME: Final[int] = 20
 AIRPLAY_VOLUME_MUTE: Final[float] = -144.0

--- a/music_assistant/providers/airplay/helpers.py
+++ b/music_assistant/providers/airplay/helpers.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from zeroconf.asyncio import AsyncServiceInfo
 
     from music_assistant.mass import MusicAssistant
-    from music_assistant.providers.airplay.player import AirPlayPlayer
 
 _LOGGER = logging.getLogger(__name__)
 _COMPANION_PAIRING_DISABLED = 0x04
@@ -345,12 +344,9 @@ def serialize_txt_records(discovery_info: AsyncServiceInfo) -> str:
     return " ".join(pairs)
 
 
-def get_final_output_format(
-    audio_format: AudioFormat,
-    airplay_player: AirPlayPlayer,  # noqa: ARG001
-) -> AudioFormat:
+def get_final_output_format(audio_format: AudioFormat) -> AudioFormat:
     """
-    Determine final output format for display purposes.
+    Determine the output format ffmpeg must encode to for the cliairplay binary.
 
     The cliairplay binary always uses ALAC encoding internally.
     """

--- a/music_assistant/providers/airplay/pairing.py
+++ b/music_assistant/providers/airplay/pairing.py
@@ -97,21 +97,8 @@ class AirPlayPairing:
         self._session: aiohttp.ClientSession | None = None
         self._base_url: str = f"http://{format_ip_for_url(address)}:{self.port}"
 
-        # Common state
-        self._is_pairing: bool = False
-
         # RAOP client identifier: 8 random bytes, the credentials are self-contained
         self._client_id = os.urandom(8)
-
-    @property
-    def is_pairing(self) -> bool:
-        """Return True if a pairing session is in progress."""
-        return self._is_pairing
-
-    @property
-    def device_provides_pin(self) -> bool:
-        """Return True if the device displays the PIN."""
-        return True  # Both HAP and RAOP display PIN on device
 
     @property
     def protocol_name(self) -> str:
@@ -133,7 +120,6 @@ class AirPlayPairing:
             self._cli_binary = await get_cli_binary()
         else:
             self._session = aiohttp.ClientSession()
-        self._is_pairing = True
 
     async def start_pin_pairing(self) -> bool:
         """
@@ -191,7 +177,6 @@ class AirPlayPairing:
 
     async def close(self) -> None:
         """Clean up resources."""
-        self._is_pairing = False
         if self._pair_proc and not self._pair_proc.closed:
             await self._pair_proc.kill()
         self._pair_proc = None

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -97,7 +97,6 @@ class AirPlayStream:
         self.mass = player.provider.mass
         self.player = player
         self.pcm_format = pcm_format or AIRPLAY_PCM_FORMAT
-        self.logger = player.provider.logger.getChild("stream")
         mac_address = self.player.device_info.mac_address or self.player.player_id
         self.active_remote_id: str = generate_active_remote_id(mac_address)
         self._stream_id = uuid4().hex

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -1129,13 +1129,7 @@ class AirPlayStreamSession:
             )
         return ready_at_unix_ms
 
-    async def _start_members(
-        self,
-        position_ms: int,
-        start_unix_ms: int,
-        *,
-        reanchor_session: bool = True,
-    ) -> None:
+    async def _start_members(self, position_ms: int, start_unix_ms: int) -> None:
         """
         Anchor every member's playback at one shared audible instant.
 
@@ -1147,7 +1141,6 @@ class AirPlayStreamSession:
 
         :param position_ms: Media position mapped to the first sample of the anchor.
         :param start_unix_ms: Shared audible-start instant in unix epoch ms.
-        :param reanchor_session: Whether this start becomes the session timeline anchor.
         """
         target_ms = start_unix_ms
         corrected_ms = start_unix_ms
@@ -1199,9 +1192,8 @@ class AirPlayStreamSession:
                 "please report this with a debug log",
                 target_ms,
             )
-        if reanchor_session:
-            self.start_unix_ms = target_ms
-            self.start_time = target_ms / 1000
+        self.start_unix_ms = target_ms
+        self.start_time = target_ms / 1000
 
     async def _flush_member(self, player: AirPlayPlayer) -> bool:
         """Flush one member's live stream in place and report the binary's ack."""
@@ -1236,7 +1228,7 @@ class AirPlayStreamSession:
         output_plan = self.mass.streams.audio.get_player_output_plan(
             player.player_id,
             input_format=self.pcm_format,
-            output_format=get_final_output_format(handoff_format, player),
+            output_format=get_final_output_format(handoff_format),
             handoff_format=handoff_format,
             queue_id=media.source_id,
             session_id=get_media_session_id(media),


### PR DESCRIPTION
Removes symbols left behind by the recent AirPlay iteration, each verified to have no remaining callers:

- `_start_members(reanchor_session=...)` — its only `False` call site went away with the warm-seek change.
- `AirPlayStream.logger` — assigned but never read.
- `CONF_VOLUME_START`, `BACKOFF_TIME_LOWER_LIMIT`, `BACKOFF_TIME_UPPER_LIMIT`.
- `AirPlayPairing.is_pairing` / `device_provides_pin` and the write-only `_is_pairing` behind them.
- The unused `airplay_player` argument of `get_final_output_format`, whose docstring also claimed the result was for display while its caller uses it as the functional ffmpeg output format.

No behaviour change. `pytest tests/providers/airplay/` (559 passed) and `pre-commit run --all-files` are green.