### PR TITLE
Name the plugin each AI/TTS engine comes from in the picker

### DIFF
--- a/music_assistant/helpers/plugin_engines.py
+++ b/music_assistant/helpers/plugin_engines.py
@@ -213,7 +213,12 @@ def _create_engine_config_entries(
         # a concrete default would make the seeded selection equal to it and therefore
         # not persisted (to_raw only stores values differing from the default)
         default_value=None,
-        options=[ConfigValueOption(engine.uid, title=engine.name) for engine in engines],
+        # the picker aggregates engines from every plugin, so each option names the
+        # plugin it came from - engine names alone are ambiguous across providers
+        options=[
+            ConfigValueOption(engine.uid, title=f"{engine.provider.name} | {engine.name}")
+            for engine in engines
+        ],
         depends_on=depends_on,
         category="features",
         read_only=not engines,

--- a/tests/helpers/test_plugin_engines.py
+++ b/tests/helpers/test_plugin_engines.py
@@ -29,10 +29,11 @@ if TYPE_CHECKING:
 CONSUMER_INSTANCE = "consumer--test"
 
 
-def _create_plugin(instance_id: str) -> MagicMock:
+def _create_plugin(instance_id: str, name: str | None = None) -> MagicMock:
     """Create a mock plugin provider exposing no engines."""
     provider = MagicMock(spec=PluginProvider)
     provider.instance_id = instance_id
+    provider.name = name or instance_id
     provider.get_ai_engines = AsyncMock(return_value=[])
     provider.get_tts_engines = AsyncMock(return_value=[])
     return provider
@@ -253,7 +254,23 @@ async def test_config_entries_list_the_concrete_engines() -> None:
     assert entry.category == "features"
     assert entry.read_only is False
     assert [(option.value, option.title) for option in entry.options] == [
-        ("plugin_a/alpha", "Alpha"),
+        ("plugin_a/alpha", "plugin_a | Alpha"),
+    ]
+
+
+async def test_config_entries_name_the_plugin_each_engine_came_from() -> None:
+    """Engines from different plugins stay distinguishable even when named the same."""
+    first = _create_plugin("plugin_a", name="Home Assistant")
+    second = _create_plugin("plugin_b", name="Chatterbox")
+    first.get_ai_engines.return_value = [AIEngine(id="shared", name="Shared", provider=first)]
+    second.get_ai_engines.return_value = [AIEngine(id="shared", name="Shared", provider=second)]
+    mass = _create_mass(first, second)
+
+    entries = await create_ai_engine_config_entries(mass, "ai_engine")
+
+    assert [(option.value, option.title) for option in entries[0].options] == [
+        ("plugin_a/shared", "Home Assistant | Shared"),
+        ("plugin_b/shared", "Chatterbox | Shared"),
     ]
 
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5253. The AI/TTS engine picker aggregates engines from every plugin that supplies them, but each option was labelled with the engine name alone — so nothing told you which plugin an engine came from. Today the Home Assistant plugin is the only supplier and it is single-instance, so nothing collides; that stops being true as soon as a second plugin provides engines.

Each option is now labelled `Provider name | Engine name`, e.g. `Home Assistant | Piper (tts.piper)`.

**Related issue (if applicable):**

- follow-up to #5253

### Changes

- Prefix each engine option in the picker with the name of the plugin providing it. Done centrally in `helpers/plugin_engines.py` rather than left to each plugin, so the labelling stays consistent whoever supplies the engine.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
