### PR TITLE
Test the instant an AirPlay start actually schedules

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -106,6 +106,11 @@ AIRPLAY_CLOCK_READY_TIMEOUT_MS: Final[int] = 2500
 # for the command reaching the binary and for the convergence error of a
 # projection made from the receiver's very first probe.
 AIRPLAY_CLOCK_READY_LEAD_MS: Final[int] = 500
+# How long a plain (non-join) START waits for the binary's [STATUS] started ack.
+# Nothing holds that ack back, so the window only has to cover the command's trip
+# down the pipe and the answer coming back - unlike a join's ack below, which is
+# withheld until the receiver clock verification resolves.
+AIRPLAY_START_ACK_TIMEOUT_MS: Final[int] = 2000
 # How long a join START waits for the binary's [STATUS] started ack. That ack is
 # held back until the clock verification above resolves, so the window must
 # cover the verification arm window plus a poll round on top of the commanded

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -30,6 +30,7 @@ from music_assistant.providers.airplay.constants import (
     AIRPLAY_CONTENT_CUT_TOLERANCE_MS,
     AIRPLAY_JOIN_START_ACK_TIMEOUT_MS,
     AIRPLAY_PCM_FORMAT,
+    AIRPLAY_START_ACK_TIMEOUT_MS,
     CLI_PROBLEM_MARKERS,
     CONF_AIRPLAY_CREDENTIALS,
     CONF_ENCRYPTION,
@@ -516,7 +517,9 @@ class AirPlayStream:
         # failure answers the wait immediately; no ack within the timeout means
         # an older binary, so fall back to trusting the commanded instant
         # (legacy clamp semantics).
-        ack_timeout = AIRPLAY_JOIN_START_ACK_TIMEOUT_MS / 1000 if join else 2.0
+        ack_timeout = (
+            AIRPLAY_JOIN_START_ACK_TIMEOUT_MS if join else AIRPLAY_START_ACK_TIMEOUT_MS
+        ) / 1000
         try:
             await asyncio.wait_for(self._started.wait(), ack_timeout)
         except TimeoutError:

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -5,7 +5,7 @@ import errno
 import logging
 import os
 import threading
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable, Coroutine
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -18,6 +18,8 @@ from music_assistant_models.media_items import AudioFormat
 from music_assistant.helpers.named_pipe import AsyncNamedPipeWriter, open_named_pipe_writer
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_ARTWORK_SIZE,
+    AIRPLAY_JOIN_START_ACK_TIMEOUT_MS,
+    AIRPLAY_START_ACK_TIMEOUT_MS,
     CONF_AIRPLAY_CREDENTIALS,
     CONF_ENCRYPTION,
     CONF_PASSWORD,
@@ -89,6 +91,31 @@ async def _build_args(player: MagicMock) -> list[str]:
 def _arg_value(args: list[str], flag: str) -> Any:
     """Return the value following the given flag in the argument list."""
     return args[args.index(flag) + 1]
+
+
+def _acking_write_cli_command(
+    stream: AirPlayStream, at_unix_ms: int | None = None
+) -> Callable[[str], Coroutine[Any, Any, bool]]:
+    """
+    Build a ``_write_cli_command`` replacement that acks a START like the binary.
+
+    :param stream: The stream whose START commands are answered.
+    :param at_unix_ms: Scheduled audible instant to report back; defaults to the
+        commanded instant, i.e. the binary found it feasible.
+    """
+
+    async def write_command(command: str) -> bool:
+        # A START nothing acks otherwise pays the real ack timeout in wall clock;
+        # feeding the ack here leaves start()'s wait already released.
+        if "ACTION=START" in command:
+            requested = int(command.split("START_UNIX_MS=")[1].split("\n", 1)[0])
+            stream._handle_status_line(
+                f"[STATUS] started requested_unix_ms={requested} "
+                f"at_unix_ms={requested if at_unix_ms is None else at_unix_ms}"
+            )
+        return True
+
+    return write_command
 
 
 @pytest.mark.asyncio
@@ -183,6 +210,38 @@ async def test_cli_args_no_interface_pin_leaves_routing_to_the_binary() -> None:
     args = await _build_args(player)
 
     assert "--if" not in args
+
+
+@pytest.mark.asyncio
+async def test_cli_args_log_the_pinned_interface(caplog: pytest.LogCaptureFixture) -> None:
+    """The resolved interface is stated outright, so a user's log shows what it bound to."""
+    player = _make_player()
+
+    with caplog.at_level(logging.DEBUG):
+        await _build_args(player)
+
+    assert (
+        "cliairplay network binding for player apaabbccddeeff: "
+        "if=192.168.1.5 publish_ip=<not configured>" in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+async def test_cli_args_log_the_unpinned_interface_and_publish_ip(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unpinned interface and a configured publish IP are named for what they are."""
+    player = _make_player()
+    player.provider.mass.streams.get_source_ip = AsyncMock(return_value=None)
+    player.provider.mass.streams.get_publish_ip = MagicMock(return_value="10.45.0.20")
+
+    with caplog.at_level(logging.DEBUG):
+        await _build_args(player)
+
+    assert (
+        "cliairplay network binding for player apaabbccddeeff: "
+        "if=<all interfaces> publish_ip=10.45.0.20" in caplog.text
+    )
 
 
 @pytest.mark.asyncio
@@ -306,6 +365,58 @@ async def test_cli_args_featureless_ap2_only_device_forces_airplay2() -> None:
 
     assert _arg_value(args, "--protocol") == "airplay2"
     assert _arg_value(args, "--port") == "7000"
+
+
+@pytest.mark.parametrize(
+    ("line", "expected_route"),
+    [
+        (
+            "[STATUS] route protocol=airplay2 flow=realtime timing=ptp buffered=0",
+            "AirPlay 2 (realtime, PTP)",
+        ),
+        # a buffered stream is named by its delivery, whatever flow it was requested as
+        (
+            "[STATUS] route protocol=airplay2 flow=realtime timing=ntp buffered=1",
+            "AirPlay 2 (buffered, NTP)",
+        ),
+        (
+            "[STATUS] route protocol=raop flow=realtime timing=ntp buffered=0",
+            "RAOP",
+        ),
+    ],
+    ids=["airplay2-realtime", "airplay2-buffered", "raop"],
+)
+def test_parse_route_status(
+    line: str, expected_route: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The [STATUS] route line resolves the route this stream took and reports it."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+
+    with caplog.at_level(logging.INFO):
+        stream._parse_route_status(line)
+
+    assert stream.active_route == expected_route
+    assert f"Streaming to Player A via {expected_route}" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stdout_reader_dispatches_the_route_line() -> None:
+    """The CLI stdout reader hands the [STATUS] route line to the route parser."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    process = MagicMock()
+    process.read = AsyncMock(
+        side_effect=[
+            b"[STATUS] route protocol=airplay2 flow=realtime timing=ptp buffered=0\n",
+            b"",
+        ]
+    )
+    stream._cli_proc = process
+
+    await stream._stdout_reader()
+
+    assert stream.active_route == "AirPlay 2 (realtime, PTP)"
 
 
 def test_parse_latency_status() -> None:
@@ -778,8 +889,13 @@ async def test_start_sends_command_and_stamps_position() -> None:
     stream._cli_proc = MagicMock(closed=False)
     stream._connected.set()
 
-    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command:
-        await stream.start(START_UNIX_MS, 12_000)
+    with patch.object(
+        stream,
+        "_write_cli_command",
+        new_callable=AsyncMock,
+        side_effect=_acking_write_cli_command(stream),
+    ) as write_command:
+        assert await stream.start(START_UNIX_MS, 12_000) == START_UNIX_MS
 
     write_command.assert_awaited_once_with(f"START_UNIX_MS={START_UNIX_MS}\nACTION=START")
     assert stream._start_position == 12.0
@@ -794,8 +910,13 @@ async def test_start_join_marks_the_command() -> None:
     stream._cli_proc = MagicMock(closed=False)
     stream._connected.set()
 
-    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command:
-        await stream.start(START_UNIX_MS, 0, join=True)
+    with patch.object(
+        stream,
+        "_write_cli_command",
+        new_callable=AsyncMock,
+        side_effect=_acking_write_cli_command(stream),
+    ) as write_command:
+        assert await stream.start(START_UNIX_MS, 0, join=True) == START_UNIX_MS
 
     write_command.assert_awaited_once_with(
         f"START_UNIX_MS={START_UNIX_MS}\nSTART_JOIN=1\nACTION=START"
@@ -850,7 +971,7 @@ async def test_start_transition_artwork_settled_or_retried(complete_before_start
             stream,
             "_write_cli_command",
             new_callable=AsyncMock,
-            return_value=True,
+            side_effect=_acking_write_cli_command(stream),
         ) as write_command,
         patch.object(
             stream,
@@ -863,7 +984,7 @@ async def test_start_transition_artwork_settled_or_retried(complete_before_start
         await render_started.wait()
         if complete_before_start:
             await pretransition_task
-        await stream.start(START_UNIX_MS, 0)
+        assert await stream.start(START_UNIX_MS, 0) == START_UNIX_MS
         await asyncio.gather(*metadata_tasks)
         release_render.set()
         await pretransition_task
@@ -1007,6 +1128,76 @@ async def test_start_failure_does_not_outlive_its_command() -> None:
             f"[STATUS] started requested_unix_ms={START_UNIX_MS} at_unix_ms={START_UNIX_MS}"
         )
         assert await start_task == START_UNIX_MS
+
+
+@pytest.mark.asyncio
+async def test_start_returns_the_instant_the_binary_scheduled() -> None:
+    """A corrected ack, not the commanded instant, is what the caller maps content onto."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+    corrected = START_UNIX_MS + 700
+
+    with patch.object(
+        stream,
+        "_write_cli_command",
+        new_callable=AsyncMock,
+        side_effect=_acking_write_cli_command(stream, corrected),
+    ):
+        assert await stream.start(START_UNIX_MS, 0) == corrected
+
+
+@pytest.mark.asyncio
+async def test_start_reports_no_instant_when_the_ack_never_arrives(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unacknowledged START reports no instant and says the commanded one is assumed."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+
+    with (
+        patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True),
+        patch("music_assistant.providers.airplay.stream.AIRPLAY_START_ACK_TIMEOUT_MS", 10),
+        caplog.at_level(logging.WARNING),
+    ):
+        assert await stream.start(START_UNIX_MS, 0) is None
+
+    assert "did not acknowledge its start" in caplog.text
+    assert str(START_UNIX_MS) in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("join", "expected_timeout"),
+    [
+        (True, AIRPLAY_JOIN_START_ACK_TIMEOUT_MS / 1000),
+        (False, AIRPLAY_START_ACK_TIMEOUT_MS / 1000),
+    ],
+    ids=["join", "plain"],
+)
+async def test_start_ack_window_matches_the_arm(join: bool, expected_timeout: float) -> None:
+    """A join's ack is held for clock verification, so it waits far longer than a plain start."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+    timeouts: list[float] = []
+
+    async def record_timeout(awaitable: Any, timeout: float) -> None:
+        timeouts.append(timeout)
+        awaitable.close()
+        raise TimeoutError
+
+    with (
+        patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True),
+        patch(
+            "music_assistant.providers.airplay.stream.asyncio.wait_for",
+            side_effect=record_timeout,
+        ),
+    ):
+        assert await stream.start(START_UNIX_MS, 0, join=join) is None
+
+    assert timeouts == [expected_timeout]
 
 
 @pytest.mark.asyncio
@@ -1315,8 +1506,13 @@ async def test_start_resets_reanchor_shift() -> None:
     stream.cumulative_shift_seconds = 3.078
     stream._reanchor_status_seen = True
 
-    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True):
-        await stream.start(START_UNIX_MS, 0)
+    with patch.object(
+        stream,
+        "_write_cli_command",
+        new_callable=AsyncMock,
+        side_effect=_acking_write_cli_command(stream),
+    ):
+        assert await stream.start(START_UNIX_MS, 0) == START_UNIX_MS
 
     assert stream.cumulative_shift_seconds == 0.0
     assert stream._reanchor_status_seen is False

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from music_assistant_models.enums import PlaybackState
 from music_assistant_models.errors import PlayerCommandFailed
 
 from music_assistant.providers.airplay.constants import (
@@ -19,6 +20,7 @@ from music_assistant.providers.airplay.constants import (
     AIRPLAY_LATE_JOIN_RING_MARGIN_SECONDS,
     AIRPLAY_LATE_JOIN_RING_MAX_BYTES,
     AIRPLAY_LATE_JOIN_RING_MIN_SECONDS,
+    AIRPLAY_SPLICE_LEAD_MARGIN_MS,
     AIRPLAY_START_LEAD_MS,
     ClockReadiness,
     StreamingProtocol,
@@ -203,7 +205,7 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
     last_connected = max(i for i, op in enumerate(operations) if op.startswith("connected:"))
     first_start = min(i for i, op in enumerate(operations) if op.startswith("started:"))
     assert last_connected < first_start
-    # start = now (100_000 ms) + the group start lead (500 ms), one shared instant
+    # start = now (100_000 ms) + the cold group start lead, one shared instant
     starts = {int(op.rsplit(":", 1)[1]) for op in operations if op.startswith("started:")}
     assert starts == {100_000 + AIRPLAY_COLD_GROUP_START_LEAD_MS}
 
@@ -517,7 +519,9 @@ async def test_standby_supports_every_connected_streaming_protocol(
     assert await session.standby()
     for player in players:
         player.stream.send_cli_command.assert_awaited_once_with("ACTION=STANDBY")
-        player.set_state_from_stream.assert_called_once()
+        player.set_state_from_stream.assert_called_once_with(
+            state=PlaybackState.PAUSED, stream=player.stream
+        )
 
 
 @pytest.mark.asyncio
@@ -614,7 +618,7 @@ async def test_warm_replace_flushes_all_before_starting_any() -> None:
     for player in players:
         player.stream.flush.assert_awaited_once_with()
         # start = now (100_000 ms) + the group start lead (500 ms), position 0
-        player.stream.start.assert_awaited_once_with(100_500, 0)
+        player.stream.start.assert_awaited_once_with(100_000 + AIRPLAY_GROUP_START_LEAD_MS, 0)
 
 
 @pytest.mark.asyncio
@@ -712,6 +716,70 @@ async def test_warm_replace_start_failure_falls_back_to_cold() -> None:
         assert await session.replace(MagicMock(), MagicMock(elapsed_time=0)) is False
 
 
+@pytest.mark.parametrize(
+    ("member_specs", "expected_requirement_ms"),
+    [
+        # the largest member requirement wins, wherever that member sits
+        (((4000, 0), (1500, 0)), 4000),
+        (((1500, 0), (4000, 0)), 4000),
+        # a negative sync_adjust widens that member's own requirement by exactly
+        # the amount it moves that member's commanded instant earlier
+        (((4000, 0), (3600, -600)), 4200),
+    ],
+)
+def test_warm_anchor_clears_the_receivers_queued_audio(
+    member_specs: tuple[tuple[int, int], ...],
+    expected_requirement_ms: int,
+) -> None:
+    """
+    A warm re-anchor lands beyond the audio the receivers still have queued.
+
+    A splice-timeline member honors the commanded instant only when it lands
+    past that member's own queued audio, so the shared anchor has to clear the
+    largest member requirement: anchoring short leaves that member behind the
+    group and every warm start pays a corrective round.
+    """
+    session = _make_session(0, 0)
+    members: list[Any] = [session.sync_clients[0]]
+    second = MagicMock(player_id="second", protocol=StreamingProtocol.AIRPLAY2)
+    second.stream = _stream_defaults(MagicMock(running=True, connected=True))
+    session.sync_clients.append(second)
+    members.append(second)
+    for player, (warm_lead_ms, adjust_ms) in zip(members, member_specs, strict=True):
+        player.stream.warm_lead_ms = warm_lead_ms
+        player.config.get_value = MagicMock(return_value=adjust_ms)
+
+    with patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0):
+        anchor = session._anchor_start_unix_ms(warm=True)
+
+    assert anchor == 100_000 + expected_requirement_ms + AIRPLAY_SPLICE_LEAD_MARGIN_MS
+
+
+def test_warm_anchor_clears_the_head_every_flushed_member_froze() -> None:
+    """
+    A warm re-anchor lands beyond the frozen head the flushed members reported.
+
+    A member renders from its own commanded instant (the anchor plus its
+    sync_adjust), so it is that instant, not the bare anchor, that has to clear
+    the head the member froze at flush, with margin for the command round-trip.
+    """
+    session = _make_session(0, 0)
+    first: Any = session.sync_clients[0]
+    first.stream.flushed_head_unix_ms = 102_000
+    first.config.get_value = MagicMock(return_value=0)
+    second = MagicMock(player_id="second", protocol=StreamingProtocol.AIRPLAY2)
+    second.stream = _stream_defaults(MagicMock(running=True, connected=True))
+    second.stream.flushed_head_unix_ms = 105_000
+    second.config.get_value = MagicMock(return_value=300)
+    session.sync_clients.append(second)
+
+    with patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0):
+        anchor = session._anchor_start_unix_ms(warm=True)
+
+    # the later head wins, and the offset its member adds comes back out of it
+    assert anchor == 105_000 - 300 + AIRPLAY_SPLICE_LEAD_MARGIN_MS
+
+
 @pytest.mark.asyncio
 async def test_start_player_ffmpeg_wires_persistent_cli_stdin() -> None:
     """The per-seek ffmpeg is wired to the member's persistent cli stdin fd and tracked."""
@@ -800,7 +868,9 @@ async def test_standby_returns_false_when_command_is_not_delivered() -> None:
 
     assert await session.standby() is False
     delivered_player.stream.send_cli_command.assert_awaited_once_with("ACTION=STANDBY")
-    delivered_player.set_state_from_stream.assert_called_once()
+    delivered_player.set_state_from_stream.assert_called_once_with(
+        state=PlaybackState.PAUSED, stream=delivered_player.stream
+    )
     dropped_player.stream.send_cli_command.assert_awaited_once_with("ACTION=STANDBY")
     dropped_player.set_state_from_stream.assert_not_called()
     pending_player.stream.send_cli_command.assert_not_awaited()


### PR DESCRIPTION
# What does this implement/fix?

`AirPlayStream.start()` returns the instant the speaker actually scheduled — the
commanded one when it was feasible, a corrected one otherwise, or nothing at all
when an older binary never answers. That answer is what a group start uses to keep
every speaker on the same instant, but no test ever looked at it: every call in the
test suite threw the value away, and none of them simulated the speaker's reply, so
four tests sat waiting out the real 2 and 5 second timeouts — about 13 seconds per
run — only to discard the result.

The AirPlay tests now run in 6.5s instead of 19.5s, and cover a few paths that had
none at all.

## Changes

- Simulate the speaker's start acknowledgement in the tests that need one, and check
  the instant it reports back — including a corrected one, and the fallback when no
  answer arrives.
- Cover the wider acknowledgement window a speaker joining a live group is given.
- Cover the warm re-start anchor: it now has tests for landing past the audio every
  speaker still has queued, including a speaker with a sync adjustment.
- Cover the route line the binary reports at startup (AirPlay 2 realtime/buffered
  and RAOP) and the network binding line, both of which are what a support log is
  read for first.
- Check that standby actually pauses, rather than only that it set some state.
- Name the plain start's acknowledgement window as a constant, next to the existing
  one for a joining speaker.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
