### PR TITLE
Use whitelist for MusicBrainz artist types in recommendations

### DIFF
--- a/music_assistant/providers/musicbrainz/recommendations.py
+++ b/music_assistant/providers/musicbrainz/recommendations.py
@@ -8,11 +8,9 @@ from typing import TYPE_CHECKING
 from music_assistant_models.enums import ArtistEntityType, ExternalID, RecommendationFolderType
 from music_assistant_models.media_items import (
     Artist,
-    MediaItemMetadata,
     RecommendationFolder,
     UniqueList,
 )
-from music_assistant_models.media_items.metadata import LifeSpan
 
 from music_assistant.helpers.datetime import utc as datetime_utc
 
@@ -131,30 +129,14 @@ class MusicBrainzRecommendationManager:
             if not mbid:
                 continue
             scanned += 1
-            entity_type: ArtistEntityType | None = (
-                artist.metadata.artist_entity_type if artist.metadata else None
-            )
+            last_refresh = artist.metadata.last_refresh if artist.metadata else None
+            if last_refresh is None:
+                self.mass.metadata.schedule_update_metadata(artist)
+                continue
             life_span = artist.metadata.life_span if artist.metadata else None
-            if life_span is None or entity_type is None:
-                try:
-                    mb_artist = await self.provider.get_artist_details(mbid)
-                except Exception as err:
-                    self.logger.debug("Skipping artist %s: %s", mbid, err)
-                    continue
-                if entity_type is None and mb_artist.type:
-                    entity_type = ArtistEntityType(mb_artist.type.lower())
-                if life_span is None and mb_artist.life_span:
-                    mb_ls = mb_artist.life_span
-                    life_span = LifeSpan(begin=mb_ls.begin, end=mb_ls.end, ended=mb_ls.ended)
-                metadata = artist.metadata or MediaItemMetadata()
-                metadata.life_span = life_span
-                metadata.artist_entity_type = entity_type
-                artist.metadata = metadata
-                await self.mass.music.artists.update_item_in_library(
-                    artist.item_id, artist, overwrite=False
-                )
             if not life_span:
                 continue
+            entity_type = artist.metadata.artist_entity_type if artist.metadata else None
             # Only process known artist types with date-based events (whitelist approach)
             if entity_type not in (
                 ArtistEntityType.PERSON,

--- a/music_assistant/providers/musicbrainz/recommendations.py
+++ b/music_assistant/providers/musicbrainz/recommendations.py
@@ -135,8 +135,7 @@ class MusicBrainzRecommendationManager:
                 artist.metadata.artist_entity_type if artist.metadata else None
             )
             life_span = artist.metadata.life_span if artist.metadata else None
-            if life_span is None:
-                # Metadata not yet populated; fall back to a direct MusicBrainz API call.
+            if life_span is None or entity_type is None:
                 try:
                     mb_artist = await self.provider.get_artist_details(mbid)
                 except Exception as err:
@@ -144,9 +143,16 @@ class MusicBrainzRecommendationManager:
                     continue
                 if entity_type is None and mb_artist.type:
                     entity_type = ArtistEntityType(mb_artist.type.lower())
-                if mb_artist.life_span:
+                if life_span is None and mb_artist.life_span:
                     mb_ls = mb_artist.life_span
                     life_span = LifeSpan(begin=mb_ls.begin, end=mb_ls.end, ended=mb_ls.ended)
+                metadata = artist.metadata or MediaItemMetadata()
+                metadata.life_span = life_span
+                metadata.artist_entity_type = entity_type
+                artist.metadata = metadata
+                await self.mass.music.artists.update_item_in_library(
+                    artist.item_id, artist, overwrite=False
+                )
             if not life_span:
                 continue
             # Only process known artist types with date-based events (whitelist approach)
@@ -163,12 +169,6 @@ class MusicBrainzRecommendationManager:
             birth_in_window = begin and len(begin) >= 10 and begin[5:10] in window
             death_in_window = life_span.ended and end and len(end) >= 10 and end[5:10] in window
             if birth_in_window or death_in_window:
-                # Ensure life_span and entity_type are stored in the artist metadata
-                # so the frontend can compute event type and date without extra API calls.
-                metadata = artist.metadata or MediaItemMetadata()
-                metadata.life_span = life_span
-                metadata.artist_entity_type = entity_type
-                artist.metadata = metadata
                 matched.append(artist)
 
         self.logger.debug(

--- a/music_assistant/providers/musicbrainz/recommendations.py
+++ b/music_assistant/providers/musicbrainz/recommendations.py
@@ -149,7 +149,13 @@ class MusicBrainzRecommendationManager:
                     life_span = LifeSpan(begin=mb_ls.begin, end=mb_ls.end, ended=mb_ls.ended)
             if not life_span:
                 continue
-            if entity_type in (ArtistEntityType.CHARACTER, ArtistEntityType.OTHER):
+            # Only process known artist types with date-based events (whitelist approach)
+            if entity_type not in (
+                ArtistEntityType.PERSON,
+                ArtistEntityType.GROUP,
+                ArtistEntityType.ORCHESTRA,
+                ArtistEntityType.CHOIR,
+            ):
                 continue
             begin = life_span.begin
             end = life_span.end
@@ -161,8 +167,7 @@ class MusicBrainzRecommendationManager:
                 # so the frontend can compute event type and date without extra API calls.
                 metadata = artist.metadata or MediaItemMetadata()
                 metadata.life_span = life_span
-                if entity_type not in (None, ArtistEntityType.UNKNOWN):
-                    metadata.artist_entity_type = entity_type
+                metadata.artist_entity_type = entity_type
                 artist.metadata = metadata
                 matched.append(artist)
 

--- a/tests/providers/musicbrainz/test_recommendations.py
+++ b/tests/providers/musicbrainz/test_recommendations.py
@@ -48,7 +48,7 @@ def _make_artist(
         artist.add_external_id(ExternalID.MB_ARTIST, mbid)
     if life_span is not None or artist_entity_type is not None:
         artist.metadata = MediaItemMetadata(
-            life_span=life_span, artist_entity_type=artist_entity_type
+            life_span=life_span, artist_entity_type=artist_entity_type, last_refresh=1
         )
     return artist
 
@@ -114,7 +114,7 @@ def provider_mock() -> Mock:
     provider.mass = Mock()
     provider.mass.create_task = Mock()
     provider.mass.call_later = Mock()
-    provider.mass.music.artists.update_item_in_library = AsyncMock()
+    provider.mass.metadata.schedule_update_metadata = Mock()
     return provider
 
 
@@ -136,9 +136,18 @@ async def test_scan_matches_birthday_in_window(
     """Artists whose birth date falls within the window are returned."""
     today_mmdd = _today_mmdd()
     mbid = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
-    _set_library(provider_mock, [_make_artist("1", "Birthday Artist", mbid=mbid)])
-    provider_mock.get_artist_details = AsyncMock(
-        return_value=_make_mb_artist(mbid, f"1980-{today_mmdd}", artist_type="person")
+    life_span = LifeSpan(begin=f"1980-{today_mmdd}")
+    _set_library(
+        provider_mock,
+        [
+            _make_artist(
+                "1",
+                "Birthday Artist",
+                mbid=mbid,
+                life_span=life_span,
+                artist_entity_type=ArtistEntityType.PERSON,
+            )
+        ],
     )
 
     artists = await manager._scan_matches()
@@ -152,11 +161,18 @@ async def test_scan_matches_memoriam_in_window(
     """Artists who passed away on a window date (ended=True) are returned."""
     today_mmdd = _today_mmdd()
     mbid = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
-    _set_library(provider_mock, [_make_artist("1", "Late Artist", mbid=mbid)])
-    provider_mock.get_artist_details = AsyncMock(
-        return_value=_make_mb_artist(
-            mbid, begin="1933-01-01", end=f"2006-{today_mmdd}", ended=True, artist_type="person"
-        )
+    life_span = LifeSpan(begin="1933-01-01", end=f"2006-{today_mmdd}", ended=True)
+    _set_library(
+        provider_mock,
+        [
+            _make_artist(
+                "1",
+                "Late Artist",
+                mbid=mbid,
+                life_span=life_span,
+                artist_entity_type=ArtistEntityType.PERSON,
+            )
+        ],
     )
 
     artists = await manager._scan_matches()
@@ -227,20 +243,66 @@ async def test_scan_matches_excludes_character_and_other(
     mbid_char = "aaaaaaaa-0000-0000-0000-000000000001"
     mbid_other = "aaaaaaaa-0000-0000-0000-000000000002"
     mbid_person = "aaaaaaaa-0000-0000-0000-000000000003"
+    life_span = LifeSpan(begin=f"1980-{today_mmdd}")
     _set_library(
         provider_mock,
         [
-            _make_artist("1", "Character", mbid=mbid_char),
-            _make_artist("2", "Other", mbid=mbid_other),
-            _make_artist("3", "Real Person", mbid=mbid_person),
+            _make_artist(
+                "1",
+                "Character",
+                mbid=mbid_char,
+                life_span=life_span,
+                artist_entity_type=ArtistEntityType.CHARACTER,
+            ),
+            _make_artist(
+                "2",
+                "Other",
+                mbid=mbid_other,
+                life_span=life_span,
+                artist_entity_type=ArtistEntityType.OTHER,
+            ),
+            _make_artist(
+                "3",
+                "Real Person",
+                mbid=mbid_person,
+                life_span=life_span,
+                artist_entity_type=ArtistEntityType.PERSON,
+            ),
         ],
     )
 
-    async def fake_details(mbid: str) -> MusicBrainzArtist:
-        types = {mbid_char: "Character", mbid_other: "Other", mbid_person: "Person"}
-        return _make_mb_artist(mbid, f"1980-{today_mmdd}", artist_type=types[mbid])
+    artists = await manager._scan_matches()
+    assert [a.name for a in artists] == ["Real Person"]
 
-    provider_mock.get_artist_details = fake_details
+
+async def test_scan_matches_excludes_unknown_and_null_types(
+    manager: MusicBrainzRecommendationManager,
+    provider_mock: Mock,
+) -> None:
+    """Artists with UNKNOWN or None entity_type are excluded."""
+    today_mmdd = _today_mmdd()
+    mbid_unknown = "aaaaaaaa-0000-0000-0000-000000000001"
+    mbid_null = "aaaaaaaa-0000-0000-0000-000000000002"
+    mbid_person = "aaaaaaaa-0000-0000-0000-000000000003"
+    life_span = LifeSpan(begin=f"1980-{today_mmdd}")
+    artist_unknown = _make_artist(
+        "1",
+        "Unknown Type",
+        mbid=mbid_unknown,
+        life_span=life_span,
+        artist_entity_type=ArtistEntityType.UNKNOWN,
+    )
+    artist_null = _make_artist("2", "Null Type", mbid=mbid_null, life_span=life_span)
+    artist_null.metadata.last_refresh = 1
+    artist_null.metadata.artist_entity_type = None
+    artist_person = _make_artist(
+        "3",
+        "Real Person",
+        mbid=mbid_person,
+        life_span=life_span,
+        artist_entity_type=ArtistEntityType.PERSON,
+    )
+    _set_library(provider_mock, [artist_unknown, artist_null, artist_person])
 
     artists = await manager._scan_matches()
     assert [a.name for a in artists] == ["Real Person"]
@@ -257,39 +319,38 @@ async def test_scan_matches_no_mbid_skipped(
     assert await manager._scan_matches() == []
 
 
-async def test_scan_matches_api_error_skipped(
+async def test_scan_matches_no_enrichment_schedules_metadata_update(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
-    """API errors for individual artists are swallowed; remaining artists still checked."""
+    """Artists without metadata enrichment (last_refresh=None) are skipped and enrichment is scheduled."""
     today_mmdd = _today_mmdd()
-    mbid_error = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
-    mbid_ok = "f59c5520-5f46-4d2c-b2c4-822eabf53419"
-    _set_library(
-        provider_mock,
-        [
-            _make_artist("1", "Error Artist", mbid=mbid_error),
-            _make_artist("2", "OK Artist", mbid=mbid_ok),
-        ],
+    mbid_not_enriched = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
+    mbid_enriched = "f59c5520-5f46-4d2c-b2c4-822eabf53419"
+    artist_not_enriched = _make_artist("1", "Not Enriched", mbid=mbid_not_enriched)
+    artist_not_enriched.metadata = MediaItemMetadata()
+    life_span = LifeSpan(begin=f"1985-{today_mmdd}")
+    artist_enriched = _make_artist(
+        "2",
+        "Enriched Artist",
+        mbid=mbid_enriched,
+        life_span=life_span,
+        artist_entity_type=ArtistEntityType.PERSON,
     )
-
-    async def fake_details(mbid: str) -> MusicBrainzArtist:
-        if mbid == mbid_error:
-            msg = "MB API unavailable"
-            raise RuntimeError(msg)
-        return _make_mb_artist(mbid, f"1985-{today_mmdd}", artist_type="person")
-
-    provider_mock.get_artist_details = fake_details
+    _set_library(provider_mock, [artist_not_enriched, artist_enriched])
 
     artists = await manager._scan_matches()
-    assert [a.name for a in artists] == ["OK Artist"]
+    assert [a.name for a in artists] == ["Enriched Artist"]
+    provider_mock.mass.metadata.schedule_update_metadata.assert_called_once_with(
+        artist_not_enriched
+    )
 
 
 async def test_scan_matches_uses_metadata_when_available(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
-    """Artists with pre-populated life_span metadata skip the API call."""
+    """Artists with enriched metadata (last_refresh set) are processed directly."""
     today_mmdd = _today_mmdd()
     mbid = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
     life_span = LifeSpan(begin=f"1980-{today_mmdd}")
@@ -305,7 +366,6 @@ async def test_scan_matches_uses_metadata_when_available(
             )
         ],
     )
-    provider_mock.get_artist_details = AsyncMock(side_effect=AssertionError("should not call"))
 
     artists = await manager._scan_matches()
     assert [a.name for a in artists] == ["Cached Artist"]
@@ -407,9 +467,18 @@ async def test_refresh_caches_artist_dicts(
     """_refresh caches a list of serialized artist dicts."""
     today_mmdd = _today_mmdd()
     mbid = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
-    _set_library(provider_mock, [_make_artist("1", "Birthday Star", mbid=mbid)])
-    provider_mock.get_artist_details = AsyncMock(
-        return_value=_make_mb_artist(mbid, f"1990-{today_mmdd}", artist_type="person")
+    life_span = LifeSpan(begin=f"1990-{today_mmdd}")
+    _set_library(
+        provider_mock,
+        [
+            _make_artist(
+                "1",
+                "Birthday Star",
+                mbid=mbid,
+                life_span=life_span,
+                artist_entity_type=ArtistEntityType.PERSON,
+            )
+        ],
     )
     provider_mock.mass.cache.set = AsyncMock()
 

--- a/tests/providers/musicbrainz/test_recommendations.py
+++ b/tests/providers/musicbrainz/test_recommendations.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from music_assistant_models.enums import ExternalID, RecommendationFolderType
+from music_assistant_models.enums import ArtistEntityType, ExternalID, RecommendationFolderType
 from music_assistant_models.media_items import (
     Artist,
     MediaItemMetadata,
@@ -35,6 +35,7 @@ def _make_artist(
     name: str,
     mbid: str | None = None,
     life_span: LifeSpan | None = None,
+    artist_entity_type: ArtistEntityType | None = None,
 ) -> Artist:
     """Return a minimal library Artist, optionally with an MB external-ID and life_span."""
     pm = ProviderMapping(
@@ -45,8 +46,10 @@ def _make_artist(
     artist = Artist(item_id=item_id, provider="test", name=name, provider_mappings={pm})
     if mbid:
         artist.add_external_id(ExternalID.MB_ARTIST, mbid)
-    if life_span is not None:
-        artist.metadata = MediaItemMetadata(life_span=life_span)
+    if life_span is not None or artist_entity_type is not None:
+        artist.metadata = MediaItemMetadata(
+            life_span=life_span, artist_entity_type=artist_entity_type
+        )
     return artist
 
 
@@ -111,6 +114,7 @@ def provider_mock() -> Mock:
     provider.mass = Mock()
     provider.mass.create_task = Mock()
     provider.mass.call_later = Mock()
+    provider.mass.music.artists.update_item_in_library = AsyncMock()
     return provider
 
 
@@ -134,7 +138,7 @@ async def test_scan_matches_birthday_in_window(
     mbid = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
     _set_library(provider_mock, [_make_artist("1", "Birthday Artist", mbid=mbid)])
     provider_mock.get_artist_details = AsyncMock(
-        return_value=_make_mb_artist(mbid, f"1980-{today_mmdd}")
+        return_value=_make_mb_artist(mbid, f"1980-{today_mmdd}", artist_type="person")
     )
 
     artists = await manager._scan_matches()
@@ -150,7 +154,9 @@ async def test_scan_matches_memoriam_in_window(
     mbid = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
     _set_library(provider_mock, [_make_artist("1", "Late Artist", mbid=mbid)])
     provider_mock.get_artist_details = AsyncMock(
-        return_value=_make_mb_artist(mbid, begin="1933-01-01", end=f"2006-{today_mmdd}", ended=True)
+        return_value=_make_mb_artist(
+            mbid, begin="1933-01-01", end=f"2006-{today_mmdd}", ended=True, artist_type="person"
+        )
     )
 
     artists = await manager._scan_matches()
@@ -271,7 +277,7 @@ async def test_scan_matches_api_error_skipped(
         if mbid == mbid_error:
             msg = "MB API unavailable"
             raise RuntimeError(msg)
-        return _make_mb_artist(mbid, f"1985-{today_mmdd}")
+        return _make_mb_artist(mbid, f"1985-{today_mmdd}", artist_type="person")
 
     provider_mock.get_artist_details = fake_details
 
@@ -288,7 +294,16 @@ async def test_scan_matches_uses_metadata_when_available(
     mbid = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
     life_span = LifeSpan(begin=f"1980-{today_mmdd}")
     _set_library(
-        provider_mock, [_make_artist("1", "Cached Artist", mbid=mbid, life_span=life_span)]
+        provider_mock,
+        [
+            _make_artist(
+                "1",
+                "Cached Artist",
+                mbid=mbid,
+                life_span=life_span,
+                artist_entity_type=ArtistEntityType.PERSON,
+            )
+        ],
     )
     provider_mock.get_artist_details = AsyncMock(side_effect=AssertionError("should not call"))
 
@@ -394,7 +409,7 @@ async def test_refresh_caches_artist_dicts(
     mbid = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
     _set_library(provider_mock, [_make_artist("1", "Birthday Star", mbid=mbid)])
     provider_mock.get_artist_details = AsyncMock(
-        return_value=_make_mb_artist(mbid, f"1990-{today_mmdd}")
+        return_value=_make_mb_artist(mbid, f"1990-{today_mmdd}", artist_type="person")
     )
     provider_mock.mass.cache.set = AsyncMock()
 


### PR DESCRIPTION
# What does this implement/fix?

Switches from blacklist to whitelist approach for filtering artist types in MusicBrainz recommendations and uses the existing metadata enrichment infrastructure to ensure artists are enriched with metadata when needed.

**Related issue (if applicable):**

- Addresses feedback from @kepstin on PR #4687: https://github.com/music-assistant/server/pull/4687#issuecomment-2568851809

## Changes

- Changed artist type filtering in `recommendations.py` from blacklist (`CHARACTER`, `OTHER` excluded) to whitelist (only `PERSON`, `GROUP`, `ORCHESTRA`, `CHOIR` included)
- Uses existing metadata enrichment flow via `last_refresh` tracking instead of direct MusicBrainz API calls
- Artists without `last_refresh` trigger `schedule_update_metadata()` and are skipped for the current scan (will be matched on next scan after enrichment)
- Artists with `last_refresh` set are processed using their already-enriched metadata (`life_span`, `artist_entity_type`)
- Respects the enrichment refresh interval and avoids duplicate API call logic
- Handles null/unknown artist types correctly: MusicBrainz `type=null` results in `None` or `UNKNOWN` after enrichment, both excluded by whitelist
- Updated tests to provide pre-enriched artist metadata with `last_refresh` set

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.