### PR TITLE
Keep Music Quiz lyrics in step with the audio

### DIFF
--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -36,8 +36,11 @@ The public game state is guest-safe by construction. Common state contains:
   the revealed shared ``timeline`` and redacted ``bonus_definitions``; the
   current song, year, correct placement and bonus answers remain protected.
 - reveal/finished rounds additionally expose common ``answer_label``,
-  ``track_uri``, ``image_url``, ``duration`` and ``ended_at`` fields. The
-  answer strategy adds the revealed correct option or timeline entry and
+  ``track_uri``, ``image_url``, ``duration``, ``audio_started_at`` and
+  ``ended_at`` fields. ``audio_started_at`` is when the round's track became
+  audible: it trails ``started_at`` by the playback startup latency, so clients
+  following the audio (e.g. synced lyrics) should prefer it over ``started_at``.
+  The answer strategy adds the revealed correct option or timeline entry and
   answer-specific player results. ``auto_advance_at`` contains the authoritative
   next-round deadline when the backend scheduled automatic advancement.
 
@@ -188,6 +191,14 @@ REPLAY_AUTO_START_SECONDS = 30
 # minimum time players get to see the reveal/scoreboard before the game
 # advances, even when the round track has (almost) finished playing
 MIN_REVEAL_SECONDS = 10.0
+
+# a track is not audible the instant playback is commanded: the stream still has to be
+# resolved, encoded and buffered by the receiver. ASSUMED_AUDIO_START_LATENCY is what we
+# assume when the player never reported a real position, while the MIN/MAX pair bounds a
+# player-reported start relative to the play command so a stale report is discarded.
+ASSUMED_AUDIO_START_LATENCY = 1.0
+MIN_REPORTED_AUDIO_START_LATENCY = -1.0
+MAX_REPORTED_AUDIO_START_LATENCY = 10.0
 
 
 class _PlaybackPreference(TypedDict):
@@ -984,6 +995,8 @@ class MusicQuizPlugin(PluginProvider):
         self.mass.cancel_timer(self._reveal_timer_id)
         current_round = get_current_round(game)
         current_round.auto_advance_at = None
+        if quiz_type.plays_track_before_answering:
+            current_round.audio_started_at = self._audio_started_at(current_round)
         now = time.time()
         advance_delay = quiz_type.completed_reveal_auto_advance_delay if completed else None
         if advance_delay is None:
@@ -1501,6 +1514,44 @@ class MusicQuizPlugin(PluginProvider):
                 await self.mass.player_queues.stop(self._playback_session.queue_id)
             except Exception as err:
                 self.logger.warning("Could not stop Music Quiz playback: %s", err)
+
+    def _audio_started_at(self, game_round: MusicQuizRound) -> float:
+        """
+        Return the timestamp at which the round's track became audible.
+
+        :param game_round: Started round whose playback should be timed.
+        """
+        started_at = game_round.started_at or 0
+        latency = ASSUMED_AUDIO_START_LATENCY
+        if (reported := self._reported_playback_start()) is not None:
+            reported_latency = reported - started_at
+            if (
+                MIN_REPORTED_AUDIO_START_LATENCY
+                <= reported_latency
+                <= MAX_REPORTED_AUDIO_START_LATENCY
+            ):
+                latency = reported_latency
+        return started_at + max(latency, 0.0)
+
+    def _reported_playback_start(self) -> float | None:
+        """Return when the playback target's reported position started, or None if it has none."""
+        if (session := self._playback_session) is None:
+            return None
+        if (player := self.mass.players.get_player(session.player_id)) is None:
+            return None
+        queue = self.mass.player_queues.get(session.queue_id)
+        # a flow stream reports its position across the whole queue rather than the
+        # current track, so its anchor is not this round's track start
+        if queue is not None and queue.flow_mode:
+            return None
+        elapsed = player.state.elapsed_time
+        last_updated = player.state.elapsed_time_last_updated
+        # providers report no position (Sendspin's play_media sets _attr_elapsed_time to None)
+        # or a zero position with a fresh timestamp before real playback progress lands,
+        # which would otherwise resolve to "audio started now"
+        if not elapsed or last_updated is None:
+            return None
+        return last_updated - elapsed
 
     async def _close_playback_session(self) -> None:
         """Close and drop the shared playback session under the playback lock."""
@@ -2060,6 +2111,7 @@ def _host_round(
         "image_url": game_round.image_url,
         "duration": game_round.duration,
         "started_at": game_round.started_at,
+        "audio_started_at": game_round.audio_started_at,
         "ended_at": game_round.ended_at,
         "auto_advance_at": game_round.auto_advance_at,
     }
@@ -2131,6 +2183,7 @@ def _public_round(
         state["track_uri"] = game_round.track_uri
         state["image_url"] = game_round.image_url
         state["duration"] = game_round.duration
+        state["audio_started_at"] = game_round.audio_started_at
         state["ended_at"] = game_round.ended_at
     return state
 

--- a/music_assistant/providers/music_quiz/models.py
+++ b/music_assistant/providers/music_quiz/models.py
@@ -391,6 +391,9 @@ class MusicQuizRound(DataClassDictMixin):
     image_url: str | None = None
     duration: float | None = None
     started_at: float | None = None
+    # when the round's track became audible; only set for rounds that play a
+    # track while answering
+    audio_started_at: float | None = None
     ended_at: float | None = None
     auto_advance_at: float | None = None
 

--- a/tests/providers/music_quiz/test_models.py
+++ b/tests/providers/music_quiz/test_models.py
@@ -124,6 +124,7 @@ def test_round_answer_state_round_trips_with_discriminator() -> None:
         "image_url": "https://example.test/artwork.jpg",
         "duration": 180.0,
         "started_at": 10.0,
+        "audio_started_at": None,
         "ended_at": 12.0,
         "auto_advance_at": 42.0,
     }

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -40,6 +40,7 @@ from music_assistant.helpers.plugin_engines import select_ai_engine
 from music_assistant.helpers.shared_playback import SharedPlaybackMode, SharedPlaybackSession
 from music_assistant.models.plugin import AIEngine, PluginProvider
 from music_assistant.providers.music_quiz import (
+    ASSUMED_AUDIO_START_LATENCY,
     CONF_AI_ENGINE,
     MUSIC_QUIZ_GUEST_USER,
     PLAYBACK_PREFERENCE_CACHE_EXPIRATION,
@@ -355,6 +356,23 @@ def _mock_playback_session(player_id: str, queue_id: str) -> SharedPlaybackSessi
     session.player_id = player_id
     session.queue_id = queue_id
     return cast("SharedPlaybackSession", session)
+
+
+def _install_reported_playback(
+    plugin: MusicQuizPlugin,
+    elapsed_time: float | None,
+    elapsed_time_last_updated: float | None,
+    *,
+    flow_mode: bool = False,
+) -> None:
+    """Attach a playback session whose venue target reports the given position anchor."""
+    plugin._playback_session = _mock_playback_session("venue_player", "venue_player")
+    venue_player = cast("MagicMock", plugin.mass.players.all_players).return_value[0]
+    venue_player.state.elapsed_time = elapsed_time
+    venue_player.state.elapsed_time_last_updated = elapsed_time_last_updated
+    cast("MagicMock", plugin.mass.player_queues).get = MagicMock(
+        return_value=SimpleNamespace(flow_mode=flow_mode)
+    )
 
 
 def _configure_venue_listener_playback(
@@ -3777,6 +3795,7 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
         "track_uri",
         "image_url",
         "duration",
+        "audio_started_at",
         "ended_at",
     }
     assert current_round["correct_suggestion_id"] == "correct_0"
@@ -3785,6 +3804,113 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
     alice = next(player for player in state["players"] if player["name"] == "Alice")
     assert set(alice) == {*public_player_keys, "last_answer"}
     assert set(alice["last_answer"]) == {"suggestion_id", "correct", "points"}
+
+
+@pytest.mark.asyncio
+async def test_reveal_anchors_audio_start_on_the_reported_playback_position() -> None:
+    """Derive the round's audible start from the playback target's reported position."""
+    plugin = _create_plugin()
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=1000.0):
+        await _create_started_game(plugin, player_names=("Alice",), round_count=1)
+    game = plugin._game
+    assert game is not None
+    assert game.rounds[0].started_at == 1000.0
+    _install_reported_playback(plugin, 2.0, 1003.5)
+
+    await plugin.reveal()
+
+    assert game.rounds[0].audio_started_at == 1001.5
+    revealed = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]["state"]
+    assert revealed["current_round"]["audio_started_at"] == 1001.5
+    host_state = await plugin.get_game()
+    assert host_state is not None
+    assert host_state["rounds"][0]["audio_started_at"] == 1001.5
+
+
+@pytest.mark.asyncio
+async def test_reveal_assumes_audio_start_latency_without_a_reported_position() -> None:
+    """Assume the startup latency when the playback target reports no position."""
+    plugin = _create_plugin()
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=1000.0):
+        await _create_started_game(plugin, player_names=("Alice",), round_count=1)
+    game = plugin._game
+    assert game is not None
+    _install_reported_playback(plugin, None, 1003.5)
+
+    await plugin.reveal()
+
+    assert game.rounds[0].audio_started_at == 1000.0 + ASSUMED_AUDIO_START_LATENCY
+
+
+@pytest.mark.asyncio
+async def test_reveal_discards_an_implausible_reported_playback_position() -> None:
+    """Fall back to the assumed latency when the reported start is out of bounds."""
+    plugin = _create_plugin()
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=1000.0):
+        await _create_started_game(plugin, player_names=("Alice",), round_count=1)
+    game = plugin._game
+    assert game is not None
+    # a stale anchor from before this round's track: 29.5s after the play command
+    _install_reported_playback(plugin, 0.5, 1030.0)
+
+    await plugin.reveal()
+
+    assert game.rounds[0].audio_started_at == 1000.0 + ASSUMED_AUDIO_START_LATENCY
+
+
+@pytest.mark.asyncio
+async def test_reveal_never_anchors_audio_before_the_round_started() -> None:
+    """Clamp a reported start that slightly predates the play command to the round start."""
+    plugin = _create_plugin()
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=1000.0):
+        await _create_started_game(plugin, player_names=("Alice",), round_count=1)
+    game = plugin._game
+    assert game is not None
+    _install_reported_playback(plugin, 2.0, 1001.5)
+
+    await plugin.reveal()
+
+    assert game.rounds[0].audio_started_at == 1000.0
+
+
+@pytest.mark.asyncio
+async def test_reveal_ignores_the_reported_position_of_a_flow_stream() -> None:
+    """Fall back to the assumed latency when the queue reports a whole-queue position."""
+    plugin = _create_plugin()
+    with patch("music_assistant.providers.music_quiz.time.time", return_value=1000.0):
+        await _create_started_game(plugin, player_names=("Alice",), round_count=1)
+    game = plugin._game
+    assert game is not None
+    _install_reported_playback(plugin, 2.0, 1003.5, flow_mode=True)
+
+    await plugin.reveal()
+
+    assert game.rounds[0].audio_started_at == 1000.0 + ASSUMED_AUDIO_START_LATENCY
+
+
+@pytest.mark.asyncio
+async def test_trivia_reveal_leaves_the_audio_start_unresolved() -> None:
+    """Skip the audible-start anchor for quiz types that only play a track on reveal."""
+    plugin = _create_plugin()
+    with (
+        patch.object(TriviaQuizType, "initialize", new=AsyncMock()),
+        patch.object(
+            TriviaQuizType,
+            "prepare_round",
+            new=AsyncMock(side_effect=_make_trivia_round),
+        ),
+    ):
+        with patch("music_assistant.providers.music_quiz.time.time", return_value=1000.0):
+            await _create_started_trivia_game(plugin, round_count=1)
+        game = plugin._game
+        assert game is not None
+        _install_reported_playback(plugin, 2.0, 1003.5)
+
+        await plugin.reveal()
+
+    assert game.rounds[0].audio_started_at is None
+    revealed = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]["state"]
+    assert revealed["current_round"]["audio_started_at"] is None
 
 
 @pytest.mark.asyncio
@@ -3965,6 +4091,7 @@ async def test_host_rounds_preserve_flat_wire_shape() -> None:
             "image_url": game_round.image_url,
             "duration": game_round.duration,
             "started_at": game_round.started_at,
+            "audio_started_at": game_round.audio_started_at,
             "ended_at": game_round.ended_at,
             "auto_advance_at": game_round.auto_advance_at,
         }


### PR DESCRIPTION
# What does this implement/fix?

In a Music Quiz round, the synced lyrics shown at the reveal ran ahead of the song you actually hear. Round timing was anchored to the moment playback was *commanded*, but a track only becomes audible a moment later, once the stream has been resolved, encoded and buffered by the speaker.

The quiz now publishes a second timestamp for when the track actually became audible, taken from the player's own reported position, so clients can follow the audio instead of the play command. When a player does not report a real position we assume one second of startup latency, which is a safe default on every playback path.

- Added `audio_started_at` to a quiz round, resolved at the reveal and exposed in the game state
- Falls back to an assumed one second of startup latency when the player reports no position
- Round start, the answering window and the answer deadline are unchanged

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked: music-assistant/frontend#2246
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.