### PR TITLE
Let plugins and music providers describe audio the same way

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -1338,12 +1338,14 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             If None, any previously stored speed for the item is preserved.
         """
         timestamp = utc_timestamp()
+        # we deliberately skip one-off items: sound effects and live inputs whoever owns
+        # them, and everything the builtin provider plays (except playlists) is a one-off url
+        if media_item.media_type in (MediaType.SOUND_EFFECT, MediaType.AUDIO_SOURCE):
+            return
         if (
             media_item.provider.startswith("builtin")
             and media_item.media_type != MediaType.PLAYLIST
         ):
-            # we deliberately skip builtin provider items as those are often
-            # one-off items like TTS or some sound effect etc.
             return
 
         params = {

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -318,21 +318,14 @@ class StreamsAudio:
                     if not provider:
                         self.logger.debug(f"Skipping {prov_media} - provider not available")
                         continue  # provider not available ?
-                    # get streamdetails from provider; AudioSource items come from a
-                    # PluginProvider which carries a different signature (queue-scoped
-                    # context rather than media_type) — branch on provider type.
+                    # get streamdetails from provider; music and plugin providers
+                    # share this signature, so either type can own the item.
                     try:
                         BYPASS_THROTTLER.set(True)
-                        if media_item.media_type == MediaType.AUDIO_SOURCE:
-                            plugin_prov = cast("PluginProvider", provider)
-                            streamdetails = await plugin_prov.get_stream_details(
-                                prov_media.item_id, queue_item.queue_id
-                            )
-                        else:
-                            music_prov = cast("MusicProvider", provider)
-                            streamdetails = await music_prov.get_stream_details(
-                                prov_media.item_id, media_item.media_type
-                            )
+                        stream_prov = cast("MusicProvider | PluginProvider", provider)
+                        streamdetails = await stream_prov.get_stream_details(
+                            prov_media.item_id, media_item.media_type
+                        )
                     except AudioError as err:
                         last_audio_error = err
                         self.logger.warning(str(err))
@@ -3424,8 +3417,8 @@ class StreamsAudio:
             provider = self.mass.get_provider(mapping.provider)
             if provider is None:
                 raise MediaNotFoundError(f"Provider {mapping.provider} is not available")
-            provider = cast("MusicProvider", provider)
-            streamdetails = await provider.get_stream_details(
+            stream_prov = cast("MusicProvider | PluginProvider", provider)
+            streamdetails = await stream_prov.get_stream_details(
                 mapping.item_id, MediaType.SOUND_EFFECT
             )
         except Exception as err:

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -88,11 +88,12 @@ class PluginProvider(Provider):
             raise NotImplementedError
         return []
 
-    async def get_stream_details(self, source_id: str, queue_id: str) -> StreamDetails:
+    async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """
-        Return StreamDetails for streaming the given AudioSource.
+        Return StreamDetails for a streamable item owned by this plugin.
 
-        Will only be called if ProviderFeature.AUDIO_SOURCE is declared.
+        Called for a playable item this plugin exposes; ``media_type`` says which kind.
+        AudioSource items require ProviderFeature.AUDIO_SOURCE to be declared.
 
         MUST be side-effect-free. MA calls this from both the streaming path
         and from queue preload (``_load_item``); claiming ownership here would
@@ -124,9 +125,9 @@ class PluginProvider(Provider):
           binary actually stops writing, the consuming ffmpeg will block and
           the player will eventually disconnect.
 
-        :param source_id: The AudioSource.item_id requested for playback.
-        :param queue_id: The queue that owns this playback session. For groups this is
-            the group's queue_id; the streams controller fans the stream out to members.
+        :param item_id: The provider-scoped id of the item requested for playback:
+            an ``AudioSource.item_id`` or the id of another item this plugin owns.
+        :param media_type: The media type of the requested item.
         """
         raise NotImplementedError
 

--- a/music_assistant/providers/_demo_plugin_provider/__init__.py
+++ b/music_assistant/providers/_demo_plugin_provider/__init__.py
@@ -215,10 +215,11 @@ class MyDemoPluginprovider(PluginProvider):
             )
         ]
 
-    async def get_stream_details(self, source_id: str, queue_id: str) -> StreamDetails:
-        """Return StreamDetails for streaming the given AudioSource to a queue."""
+    async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
+        """Return StreamDetails for streaming an item owned by this plugin."""
         # OPTIONAL
-        # Will only be called if ProviderFeature.AUDIO_SOURCE is declared.
+        # Called for any playable item this plugin exposes; media_type tells you
+        # which kind. This demo only has an AudioSource.
         #
         # MUST be side-effect-free — no exclusivity claim, no busy raise.
         # MA calls this from both the streaming path AND from queue preload, so
@@ -244,11 +245,11 @@ class MyDemoPluginprovider(PluginProvider):
         #   shairport-sync and librespot do this in passthrough mode). If
         #   the producer actually stops writing, ffmpeg will block and the
         #   player will eventually disconnect.
-        if source_id != AUDIO_SOURCE_ID:
-            raise MediaNotFoundError(f"Unknown AudioSource: {source_id}")
+        if item_id != AUDIO_SOURCE_ID:
+            raise MediaNotFoundError(f"Unknown AudioSource: {item_id}")
         return StreamDetails(
             provider=self.instance_id,
-            item_id=source_id,
+            item_id=item_id,
             audio_format=AudioFormat(
                 content_type=ContentType.PCM_S16LE,
                 sample_rate=44100,

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -209,7 +209,7 @@ class AirPlayReceiverProvider(PluginProvider):
         """Return the AudioSources this plugin currently exposes."""
         return [self._audio_source]
 
-    async def get_stream_details(self, source_id: str, queue_id: str) -> StreamDetails:
+    async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """
         Return StreamDetails for streaming the AirPlay audio to a queue.
 
@@ -221,8 +221,8 @@ class AirPlayReceiverProvider(PluginProvider):
 
         Raises AudioError when no AirPlay client is currently connected.
         """
-        if source_id != AUDIO_SOURCE_ID:
-            raise MediaNotFoundError(f"Unknown AudioSource: {source_id}")
+        if item_id != AUDIO_SOURCE_ID:
+            raise MediaNotFoundError(f"Unknown AudioSource: {item_id}")
         if not self._active_player_id:
             raise AudioError(
                 "AirPlay receiver has no active client — start playback from your "
@@ -230,7 +230,7 @@ class AirPlayReceiverProvider(PluginProvider):
             )
         return StreamDetails(
             provider=self.instance_id,
-            item_id=source_id,
+            item_id=item_id,
             audio_format=self._audio_format,
             decoded_audio_format=self._decoded_audio_format,
             media_type=MediaType.AUDIO_SOURCE,

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -226,10 +226,10 @@ class AriaCastReceiver(PluginProvider):
         """Return the single AriaCast audio source."""
         return [self._audio_source]
 
-    async def get_stream_details(self, source_id: str, queue_id: str) -> StreamDetails:
+    async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Return stream details for the given audio source."""
-        if source_id != AUDIO_SOURCE_ID:
-            raise MediaNotFoundError(f"Unknown AudioSource: {source_id}")
+        if item_id != AUDIO_SOURCE_ID:
+            raise MediaNotFoundError(f"Unknown AudioSource: {item_id}")
         # Allow through if currently playing OR if a player has played before (resume path)
         if not self._is_playing and not self._active_player_id:
             raise AudioError(
@@ -237,7 +237,7 @@ class AriaCastReceiver(PluginProvider):
             )
         return StreamDetails(
             provider=self.instance_id,
-            item_id=source_id,
+            item_id=item_id,
             audio_format=self._audio_format,
             media_type=MediaType.AUDIO_SOURCE,
             stream_type=StreamType.CUSTOM,

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -236,7 +236,7 @@ class SpotifyConnectProvider(PluginProvider):
         """Return the AudioSources this plugin currently exposes."""
         return [self._audio_source]
 
-    async def get_stream_details(self, source_id: str, queue_id: str) -> StreamDetails:
+    async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """
         Return StreamDetails for streaming the Spotify Connect audio.
 
@@ -250,8 +250,8 @@ class SpotifyConnectProvider(PluginProvider):
         playback can only be acquired while a Spotify session is connected to us
         (entry must come from the Spotify app — see can_initiate below).
         """
-        if source_id != AUDIO_SOURCE_ID:
-            raise MediaNotFoundError(f"Unknown AudioSource: {source_id}")
+        if item_id != AUDIO_SOURCE_ID:
+            raise MediaNotFoundError(f"Unknown AudioSource: {item_id}")
         # Only refuse when we can neither resume nor take playback back. If a last
         # context is known we let the stream proceed; on_source_selected then takes
         # playback back (makes us the active device) before audio is pulled.
@@ -269,7 +269,7 @@ class SpotifyConnectProvider(PluginProvider):
         # check above re-runs on every play attempt.
         return StreamDetails(
             provider=self.instance_id,
-            item_id=source_id,
+            item_id=item_id,
             audio_format=self._audio_format,
             decoded_audio_format=self._decoded_audio_format,
             media_type=MediaType.AUDIO_SOURCE,

--- a/music_assistant/providers/vban_receiver/provider.py
+++ b/music_assistant/providers/vban_receiver/provider.py
@@ -224,7 +224,7 @@ class VBANReceiverProvider(PluginProvider):
         """Return the single AudioSource this VBAN receiver exposes."""
         return [self._audio_source]
 
-    async def get_stream_details(self, source_id: str, queue_id: str) -> StreamDetails:
+    async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """
         Return StreamDetails for streaming the VBAN PCM audio to a queue.
 
@@ -234,11 +234,11 @@ class VBANReceiverProvider(PluginProvider):
         player_queues._load_item can fetch streamdetails without claiming the
         source and blocking a subsequent cross-queue handoff.
         """
-        if source_id != AUDIO_SOURCE_ID:
-            raise MediaNotFoundError(f"Unknown AudioSource: {source_id}")
+        if item_id != AUDIO_SOURCE_ID:
+            raise MediaNotFoundError(f"Unknown AudioSource: {item_id}")
         return StreamDetails(
             provider=self.instance_id,
-            item_id=source_id,
+            item_id=item_id,
             audio_format=self._audio_format,
             media_type=MediaType.AUDIO_SOURCE,
             stream_type=StreamType.CUSTOM,

--- a/music_assistant/providers/yandex_ynison/provider.py
+++ b/music_assistant/providers/yandex_ynison/provider.py
@@ -402,7 +402,7 @@ class YandexYnisonProvider(PluginProvider):
         """Return the AudioSources this plugin currently exposes."""
         return [self._audio_source]
 
-    async def get_stream_details(self, source_id: str, queue_id: str) -> StreamDetails:
+    async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """
         Return StreamDetails for streaming the Yandex Music Connect audio.
 
@@ -412,11 +412,11 @@ class YandexYnisonProvider(PluginProvider):
         player_queues._load_item can fetch streamdetails without claiming the
         source and blocking a subsequent cross-queue handoff.
         """
-        if source_id != AUDIO_SOURCE_ID:
-            raise MediaNotFoundError(f"Unknown AudioSource: {source_id}")
+        if item_id != AUDIO_SOURCE_ID:
+            raise MediaNotFoundError(f"Unknown AudioSource: {item_id}")
         return StreamDetails(
             provider=self.instance_id,
-            item_id=source_id,
+            item_id=item_id,
             # Fresh AudioFormat copy per call: MA's ffmpeg mutates
             # input_format.codec_type in place, so a shared instance would
             # propagate that mutation into future stream-details snapshots.

--- a/tests/controllers/music/test_playlog_one_off_items.py
+++ b/tests/controllers/music/test_playlog_one_off_items.py
@@ -1,0 +1,99 @@
+"""Tests that one-off items never reach the playlog, whichever provider owns them."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from uuid import uuid4
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import AudioSource, ProviderMapping, SoundEffect, Track
+
+from music_assistant.constants import DB_TABLE_PLAYLOG
+from music_assistant.mass import MusicAssistant
+
+
+def _provider_mapping(provider: str, item_id: str) -> set[ProviderMapping]:
+    """Create a single provider mapping for the given provider and item id."""
+    return {
+        ProviderMapping(
+            item_id=item_id,
+            provider_domain=provider,
+            provider_instance=provider,
+        )
+    }
+
+
+async def _playlog_rows(
+    mass: MusicAssistant, media_type: MediaType, item_id: str
+) -> list[Mapping[str, Any]]:
+    """Return every playlog row for the given media type and item id."""
+    return await mass.music.database.get_rows(
+        DB_TABLE_PLAYLOG,
+        {"media_type": media_type.value, "item_id": item_id},
+    )
+
+
+async def test_sound_effect_from_other_provider_gets_no_playlog_row(
+    mass: MusicAssistant,
+) -> None:
+    """A sound effect is a one-off clip and stays out of the playlog whoever owns it."""
+    user = await mass.webserver.auth.create_user("effectother")
+    effect = SoundEffect(
+        item_id="doorbell",
+        provider="test_effects--instance",
+        name="Doorbell",
+        provider_mappings=_provider_mapping("test_effects--instance", "doorbell"),
+    )
+
+    await mass.music.mark_item_played(effect, fully_played=True, userid=user.user_id)
+
+    assert not await _playlog_rows(mass, MediaType.SOUND_EFFECT, effect.item_id)
+
+
+async def test_sound_effect_from_builtin_provider_gets_no_playlog_row(
+    mass: MusicAssistant,
+) -> None:
+    """The pre-existing builtin behaviour is unchanged."""
+    user = await mass.webserver.auth.create_user("effectbuiltin")
+    effect = SoundEffect(
+        item_id="http://example.com/intro.mp3",
+        provider="builtin",
+        name="Intro",
+        provider_mappings=_provider_mapping("builtin", "http://example.com/intro.mp3"),
+    )
+
+    await mass.music.mark_item_played(effect, fully_played=True, userid=user.user_id)
+
+    assert not await _playlog_rows(mass, MediaType.SOUND_EFFECT, effect.item_id)
+
+
+async def test_audio_source_gets_no_playlog_row(mass: MusicAssistant) -> None:
+    """A live input is not a catalogue item, so it never lands in the playlog either."""
+    user = await mass.webserver.auth.create_user("audiosourceplugin")
+    source = AudioSource(
+        item_id="main",
+        provider="test_receiver--instance",
+        name="Test Receiver",
+        provider_mappings=_provider_mapping("test_receiver--instance", "main"),
+    )
+
+    await mass.music.mark_item_played(source, fully_played=True, userid=user.user_id)
+
+    assert not await _playlog_rows(mass, MediaType.AUDIO_SOURCE, source.item_id)
+
+
+async def test_regular_provider_track_still_gets_playlog_row(mass: MusicAssistant) -> None:
+    """Control case: the media-type guard must not suppress ordinary provider items."""
+    user = await mass.webserver.auth.create_user("regulartrack")
+    item_id = uuid4().hex
+    track = Track(
+        item_id=item_id,
+        provider="test_music_prov",
+        name="Some Track",
+        provider_mappings=_provider_mapping("test_music_prov", item_id),
+    )
+
+    await mass.music.mark_item_played(track, fully_played=True, userid=user.user_id)
+
+    assert await _playlog_rows(mass, MediaType.TRACK, item_id)

--- a/tests/controllers/streams/test_audio_sources.py
+++ b/tests/controllers/streams/test_audio_sources.py
@@ -139,15 +139,16 @@ class _FakePluginProvider:
     async def get_audio_sources(self) -> list[AudioSource]:
         return [self._audio_source]
 
-    async def get_stream_details(self, source_id: str, queue_id: str) -> StreamDetails:
+    async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         # Side-effect-free: ownership is claimed in on_source_selected. This
         # mirrors the contract every real plugin implements so preload paths
         # can fetch streamdetails without blocking a later handoff.
-        if source_id != self._audio_source.item_id:
-            raise MediaNotFoundError(f"Unknown AudioSource: {source_id}")
+        del media_type
+        if item_id != self._audio_source.item_id:
+            raise MediaNotFoundError(f"Unknown AudioSource: {item_id}")
         return StreamDetails(
             provider=self.instance_id,
-            item_id=source_id,
+            item_id=item_id,
             audio_format=_audio_format(),
             media_type=MediaType.AUDIO_SOURCE,
             stream_type=StreamType.CUSTOM,
@@ -231,14 +232,14 @@ class TestAudioSourceContract:
         # without blocking a later cross-queue handoff at the actual stream
         # request. See PluginProvider.get_stream_details docstring.
         prov = _FakePluginProvider(_audio_source())
-        sd = await prov.get_stream_details("main", "queue_a")
+        sd = await prov.get_stream_details("main", MediaType.AUDIO_SOURCE)
         assert sd.media_type == MediaType.AUDIO_SOURCE
         assert sd.stream_type == StreamType.CUSTOM
         assert sd.stream_metadata is not None
         assert prov._in_use_by_queue is None
         # Calling it again from a different queue must also be side-effect-free
         # — no busy raise, no claim — so preload from any queue is safe.
-        sd2 = await prov.get_stream_details("main", "queue_b")
+        sd2 = await prov.get_stream_details("main", MediaType.AUDIO_SOURCE)
         assert sd2.media_type == MediaType.AUDIO_SOURCE
         assert prov._in_use_by_queue is None
 
@@ -252,17 +253,17 @@ class TestAudioSourceContract:
 
     @pytest.mark.asyncio
     async def test_get_stream_details_unknown_source_raises_not_found(self) -> None:
-        """An unknown source_id should surface as MediaNotFoundError."""
+        """An unknown item_id should surface as MediaNotFoundError."""
         prov = _FakePluginProvider(_audio_source())
         with pytest.raises(MediaNotFoundError):
-            await prov.get_stream_details("bogus", "queue_a")
+            await prov.get_stream_details("bogus", MediaType.AUDIO_SOURCE)
 
     @pytest.mark.asyncio
     async def test_get_audio_stream_releases_lock_in_finally(self) -> None:
         """When the audio generator exits, the queue lock should be released."""
         prov = _FakePluginProvider(_audio_source())
         await prov.on_source_selected("main", "player_a", "queue_a", "session_1")
-        sd = await prov.get_stream_details("main", "queue_a")
+        sd = await prov.get_stream_details("main", MediaType.AUDIO_SOURCE)
         gen = prov.get_audio_stream(sd)
         await gen.__anext__()
         await gen.aclose()
@@ -287,13 +288,13 @@ class TestAudioSourceContract:
         # the previous queue's state because it does not claim or check.
         prov = _FakePluginProvider(_audio_source())
         await prov.on_source_selected("main", "player_a", "queue_a", "session_1")
-        await prov.get_stream_details("main", "queue_a")
+        await prov.get_stream_details("main", MediaType.AUDIO_SOURCE)
         assert prov._in_use_by_queue == "queue_a"
         # Different queue selects the source (cross-queue handoff).
         await prov.on_source_selected("main", "player_b", "queue_b", "session_2")
         assert prov._in_use_by_queue == "queue_b"
         # get_stream_details for the new queue still succeeds — no busy raise.
-        sd = await prov.get_stream_details("main", "queue_b")
+        sd = await prov.get_stream_details("main", MediaType.AUDIO_SOURCE)
         assert sd.media_type == MediaType.AUDIO_SOURCE
 
     @pytest.mark.asyncio
@@ -301,7 +302,7 @@ class TestAudioSourceContract:
         """on_source_unselected releases the claim when the session id matches."""
         prov = _FakePluginProvider(_audio_source())
         await prov.on_source_selected("main", "player_a", "queue_a", "session_1")
-        await prov.get_stream_details("main", "queue_a")
+        await prov.get_stream_details("main", MediaType.AUDIO_SOURCE)
         await prov.on_source_unselected("main", "queue_a", "session_1")
         assert prov._in_use_by_queue is None
         assert prov._active_session_id is None
@@ -313,10 +314,10 @@ class TestAudioSourceContract:
         # has already taken over. The session-id guard must reject it.
         prov = _FakePluginProvider(_audio_source())
         await prov.on_source_selected("main", "player_a", "queue_a", "session_1")
-        await prov.get_stream_details("main", "queue_a")
+        await prov.get_stream_details("main", MediaType.AUDIO_SOURCE)
         # Handoff: B selects the source with a fresh session id, releasing A's claim
         await prov.on_source_selected("main", "player_b", "queue_b", "session_2")
-        await prov.get_stream_details("main", "queue_b")
+        await prov.get_stream_details("main", MediaType.AUDIO_SOURCE)
         assert prov._in_use_by_queue == "queue_b"
         # Now queue A's late unselect (with the OLD session id) fires — must no-op
         await prov.on_source_unselected("main", "queue_a", "session_1")
@@ -335,7 +336,7 @@ class TestAudioSourceContract:
         prov = _FakePluginProvider(_audio_source())
         # Stream 1 starts
         await prov.on_source_selected("main", "player_a", "queue_a", "session_1")
-        sd = await prov.get_stream_details("main", "queue_a")
+        sd = await prov.get_stream_details("main", MediaType.AUDIO_SOURCE)
         gen1 = prov.get_audio_stream(sd)
         await gen1.__anext__()
         # Same-queue reconnect arrives before stream 1's generator finishes
@@ -362,7 +363,7 @@ class TestAudioSourceContract:
         prov = _FakePluginProvider(_audio_source())
         # Request 1 — full lifecycle
         await prov.on_source_selected("main", "player_a", "queue_a", "session_1")
-        await prov.get_stream_details("main", "queue_a")
+        await prov.get_stream_details("main", MediaType.AUDIO_SOURCE)
         await prov.on_source_unselected("main", "queue_a", "session_1")
         # Read into a locally-typed var so mypy's literal narrowing doesn't
         # chain across the next await (which mutates the attribute it can't see).
@@ -389,11 +390,11 @@ class TestAudioSourceContract:
         prov = _FakePluginProvider(_audio_source())
         # Queue A is actively streaming
         await prov.on_source_selected("main", "player_a", "queue_a", "session_1")
-        await prov.get_stream_details("main", "queue_a")
+        await prov.get_stream_details("main", MediaType.AUDIO_SOURCE)
         assert prov._in_use_by_queue == "queue_a"
         # Queue B's preload fetches streamdetails — must NOT raise busy, must
         # NOT alter ownership.
-        sd = await prov.get_stream_details("main", "queue_b")
+        sd = await prov.get_stream_details("main", MediaType.AUDIO_SOURCE)
         assert sd.media_type == MediaType.AUDIO_SOURCE
         assert prov._in_use_by_queue == "queue_a"
         # Queue B's actual stream request fires on_source_selected, which
@@ -413,7 +414,7 @@ class TestAudioSourceContract:
         prov = _FakePluginProvider(_audio_source())
         # Request 1 starts streaming
         await prov.on_source_selected("main", "player_a", "queue_a", "session_1")
-        await prov.get_stream_details("main", "queue_a")
+        await prov.get_stream_details("main", MediaType.AUDIO_SOURCE)
         # Request 2 (reconnect) arrives BEFORE request 1's finally runs.
         # Same queue + same player → no handoff branch, just a fresh session id.
         await prov.on_source_selected("main", "player_a", "queue_a", "session_2")

--- a/tests/providers/yandex_ynison/test_provider.py
+++ b/tests/providers/yandex_ynison/test_provider.py
@@ -2935,7 +2935,7 @@ class TestPrefetchFlowsThroughToStreamDetails:
         assert provider._normalized_params["bit_depth"] == 24
         # And get_stream_details now reflects that — MA's
         # `_select_audio_source_pcm_format` consumes this.
-        sd = await provider.get_stream_details("main", "queue1")
+        sd = await provider.get_stream_details("main", MediaType.AUDIO_SOURCE)
         assert sd.media_type == MediaType.AUDIO_SOURCE
         assert sd.audio_format.sample_rate == 96_000
         assert sd.audio_format.bit_depth == 24
@@ -2954,8 +2954,8 @@ class TestPrefetchFlowsThroughToStreamDetails:
         from music_assistant_models.enums import MediaType  # noqa: PLC0415
 
         provider = _make_provider()
-        sd1 = await provider.get_stream_details("main", "queue1")
-        sd2 = await provider.get_stream_details("main", "queue1")
+        sd1 = await provider.get_stream_details("main", MediaType.AUDIO_SOURCE)
+        sd2 = await provider.get_stream_details("main", MediaType.AUDIO_SOURCE)
 
         assert sd1.media_type == MediaType.AUDIO_SOURCE
         assert sd1.audio_format == sd2.audio_format  # value-equal


### PR DESCRIPTION
# What does this implement/fix?

Stream details describe a piece of audio that Music Assistant can play. Plugins and music providers described it through two different method signatures, so the streaming code had to branch on which kind of provider it was talking to.

While tidying that up: live inputs and sound effects were ending up in your listening history. Only real media items belong there — a live AirPlay input or a one-off sound effect has no lasting identity to look back at.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Plugins and music providers now share one `get_stream_details(item_id, media_type)` signature, so the streaming code no longer branches on provider type
- Dropped the unused `queue_id` argument from the plugin side — plugins already receive it through `on_source_selected` and on the stream details themselves
- Live inputs and sound effects no longer show up in your listening history (previously a live AirPlay or Spotify Connect input did)
- Corrected the provider type on the audio overlay lookup so it matches the shared signature (not reachable today, but it would have been wrong the moment a plugin could own the item)

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
