### PR TITLE
Name the speaker on every cliairplay log line

### DIFF
--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -1077,13 +1077,17 @@ class AirPlayStream:
             # Routine binary output is verbose-only so it never floods a user's log, but
             # its own diagnostics (a failed socket bind, a missing receiver clock) are the
             # first thing needed when triaging silent playback, so those stay visible.
-            if any(marker in line.lower() for marker in CLI_PROBLEM_MARKERS):
-                logger.warning("cliairplay for %s: %s", player.display_name, line)
-            else:
-                logger.log(VERBOSE_LOG_LEVEL, line)
+            # Every line names its speaker: the provider logger is shared, so the output
+            # of several concurrent streams is otherwise impossible to tell apart.
+            level = (
+                logging.WARNING
+                if any(marker in line.lower() for marker in CLI_PROBLEM_MARKERS)
+                else VERBOSE_LOG_LEVEL
+            )
+            logger.log(level, "cliairplay for %s: %s", player.display_name, line)
             await asyncio.sleep(0)
 
-        logger.debug("cliairplay stderr reader ended")
+        logger.debug("cliairplay stderr reader ended for %s", player.display_name)
         self._process_ended.set()
         if not self._stopped and not self._stopping:
             self._stopped = True

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -891,7 +891,9 @@ class AirPlayStream:
                     self._parse_capabilities_status(line)
                 elif line.startswith("[EVENT] remote command="):
                     self._parse_remote_event(line)
-                self.player.logger.log(VERBOSE_LOG_LEVEL, line)
+                self.player.logger.log(
+                    VERBOSE_LOG_LEVEL, "cliairplay for %s: %s", self.player.display_name, line
+                )
 
     def _parse_remote_event(self, line: str) -> None:
         """Dispatch a normalized remote command reported by cliairplay."""


### PR DESCRIPTION
# What does this implement/fix?

The AirPlay provider logger is shared by every player it owns, so the output of the `cliairplay` binary arrived with no indication of which speaker produced it. With several speakers streaming at once — a sync group, or simply two rooms playing — lines like `[STATUS] playing`, the retransmit counters and the receiver keepalive results interleave into one anonymous stream, and a log from a user reporting a problem on one speaker cannot be attributed to it.

Every line the binary emits now names its speaker, at both verbose and warning level. Warnings already did this; the routine output did not, which is the part that carries the timing and receiver detail.

**Related issue (if applicable):**

- n/a

## Changes

- Name the player on every `cliairplay` output line, not only on the ones promoted to a warning.
- Name the player when the stderr reader ends, so a binary that exits early is attributable too.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally. (logging only; verified against the test suite)
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes. No new tests — no behaviour to assert beyond the log text.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (n/a)
