### PR TITLE
Fix remote access failing to reach the built-in Sendspin server

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -128,6 +128,8 @@ CONF_BIND_IP: Final[str] = "bind_ip"
 CONF_BIND_PORT: Final[str] = "bind_port"
 CONF_PUBLISH_IP: Final[str] = "publish_ip"
 WILDCARD_BIND_IPS: Final[tuple[str, ...]] = ("0.0.0.0", "::")
+# Port used by the built-in Sendspin server (runs next to, not behind, the webserver)
+SENDSPIN_SERVER_PORT: Final[int] = 8927
 CONF_AUTO_PLAY: Final[str] = "auto_play"
 CONF_PLAY_MEDIA_OVERRIDES_GROUP: Final[str] = "play_media_overrides_group"
 CONF_GROUP_MEMBERS: Final[str] = "group_members"

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -38,6 +38,7 @@ from music_assistant.constants import (
     CONF_VALUE_AUTO,
     INGRESS_SERVER_PORT,
     RESOURCES_DIR,
+    SENDSPIN_SERVER_PORT,
     VERBOSE_LOG_LEVEL,
     WILDCARD_BIND_IPS,
 )
@@ -163,6 +164,20 @@ class WebserverController(CoreController):
         if base_url == CONF_VALUE_AUTO:
             return self._auto_base_url
         return base_url.removesuffix("/")
+
+    @property
+    def internal_sendspin_url(self) -> str:
+        """Return the URL to reach the in-process Sendspin server from this host."""
+        # the advertised address is not necessarily dialable here (e.g. a container or
+        # NAT setup), so derive the address from what the Sendspin server actually binds to
+        bind_ip = self.mass.streams.bind_ip
+        if bind_ip and bind_ip not in WILDCARD_BIND_IPS:
+            # bound to one specific interface, so loopback would not reach the server
+            connect_ip = bind_ip
+        else:
+            # Use IPv6 loopback if publish_ip is IPv6 (indicates IPv6-only host)
+            connect_ip = "::1" if ":" in str(self.mass.streams.publish_ip) else "127.0.0.1"
+        return f"ws://{format_ip_for_url(connect_ip)}:{SENDSPIN_SERVER_PORT}/sendspin"
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return all Config Entries for this core module (if any)."""

--- a/music_assistant/controllers/webserver/remote_access/__init__.py
+++ b/music_assistant/controllers/webserver/remote_access/__init__.py
@@ -19,7 +19,6 @@ from music_assistant_models.auth import Scope
 from music_assistant_models.enums import EventType
 
 from music_assistant.constants import CONF_CORE
-from music_assistant.helpers.util import format_ip_for_url
 from music_assistant.helpers.webrtc_certificate import (
     get_or_create_remote_id,
     get_or_create_webrtc_certificate_pems,
@@ -212,7 +211,7 @@ class RemoteAccessManager:
         mode = "optimized" if using_ha_cloud else "basic"
         self.logger.info("Starting remote access in %s mode", mode)
 
-        sendspin_url = f"ws://{format_ip_for_url(str(self.mass.streams.publish_ip))}:8927/sendspin"
+        sendspin_url = self.webserver.internal_sendspin_url
 
         gateway = WebRTCGateway(
             http_session=self.mass.http_session,

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -31,7 +31,7 @@ from aiolibdatachannel import (
     install_python_logger,
 )
 
-from music_assistant.constants import MASS_LOGGER_NAME, VERBOSE_LOG_LEVEL
+from music_assistant.constants import MASS_LOGGER_NAME, SENDSPIN_SERVER_PORT, VERBOSE_LOG_LEVEL
 
 if TYPE_CHECKING:
     from aiolibdatachannel import DataChannel
@@ -44,6 +44,8 @@ HTTP_PROXY_CONCURRENCY = 6
 
 # Chunk ma-api messages larger than this; libdatachannel caps data-channel messages at 256 KiB.
 MA_API_CHUNK_SIZE = 64 * 1024
+
+DEFAULT_SENDSPIN_URL = f"ws://localhost:{SENDSPIN_SERVER_PORT}/sendspin"
 
 
 @dataclass
@@ -92,7 +94,7 @@ class WebRTCGateway:
         key_pem: str,
         signaling_url: str = "wss://signaling.music-assistant.io/ws",
         local_ws_url: str = "ws://localhost:8095/ws",
-        sendspin_url: str = "ws://localhost:8927/sendspin",
+        sendspin_url: str = DEFAULT_SENDSPIN_URL,
         ice_servers: list[dict[str, Any]] | None = None,
         ice_servers_callback: Callable[[], Awaitable[list[dict[str, Any]]]] | None = None,
         set_sendspin_player_callback: Callable[[str, str], None] | None = None,

--- a/music_assistant/controllers/webserver/sendspin_proxy.py
+++ b/music_assistant/controllers/webserver/sendspin_proxy.py
@@ -22,7 +22,6 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_authenticated_user,
     is_request_from_ingress,
 )
-from music_assistant.helpers.util import format_ip_for_url
 
 if TYPE_CHECKING:
     from music_assistant_models.auth import User
@@ -44,21 +43,6 @@ class SendspinProxyHandler:
         self.webserver = webserver
         self.mass = webserver.mass
         self.logger = LOGGER
-
-    @property
-    def internal_sendspin_url(self) -> str:
-        """Return the internal sendspin URL for connecting to the internal Sendspin server."""
-        # Connect via localhost since the proxy and Sendspin server run in the same process
-        # If the server binds to 0.0.0.0 (all interfaces), use localhost for efficiency
-        # Otherwise use the actual bind IP in case it's configured to a specific interface
-        bind_ip = self.mass.streams.bind_ip
-        if bind_ip == "0.0.0.0":
-            # Use IPv6 loopback if publish_ip is IPv6 (indicates IPv6-only host)
-            publish_ip = str(self.mass.streams.publish_ip)
-            connect_ip = "::1" if ":" in publish_ip else "127.0.0.1"
-        else:
-            connect_ip = bind_ip
-        return f"ws://{format_ip_for_url(connect_ip)}:8927/sendspin"
 
     async def handle_sendspin_proxy(self, request: web.Request) -> web.WebSocketResponse:
         """
@@ -110,7 +94,7 @@ class SendspinProxyHandler:
             for attempt in range(5):
                 try:
                     internal_ws = await self.mass.http_session.ws_connect(
-                        self.internal_sendspin_url
+                        self.webserver.internal_sendspin_url
                     )
                     break
                 except ClientConnectorError:

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -32,6 +32,7 @@ from music_assistant_models.enums import EventType, IdentifierType
 from music_assistant_models.errors import PlayerCommandFailed
 from pychromecast.controllers import BaseController
 
+from music_assistant.constants import SENDSPIN_SERVER_PORT
 from music_assistant.helpers.util import format_ip_for_url, is_valid_mac_address
 from music_assistant.providers.chromecast.constants import get_cast_model_static_delay
 from music_assistant.providers.sendspin.bridge_manager import SendspinBridgeManagerBase
@@ -630,12 +631,12 @@ class SendspinChromecastBridge:
         The Cast app uses this info to connect its JS Sendspin client
         back to the server with the same client_id.
         """
-        # The Sendspin server runs on its own port (8927), NOT through
+        # The Sendspin server runs on its own port, NOT through
         # the MA webserver or streams server. Use publish_ip directly.
         publish_ip = self.mass.streams.publish_ip
         # sendspin-js's SendspinCore appends `/sendspin` to baseUrl when constructing
         # the WebSocket URL. Send the bare server URL here so it ends up correct.
-        server_url = f"ws://{format_ip_for_url(publish_ip)}:8927"
+        server_url = f"ws://{format_ip_for_url(publish_ip)}:{SENDSPIN_SERVER_PORT}"
         raw_delay = self.mass.config.get_raw_player_config_value(
             self._bridge_client_id, CONF_SENDSPIN_STATIC_DELAY
         )

--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -21,6 +21,7 @@ from aiohttp import WSMsgType, web
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat, Track
 
+from music_assistant.constants import SENDSPIN_SERVER_PORT
 from music_assistant.controllers.streams.audio_processing import get_media_session_id
 from music_assistant.controllers.webserver.helpers.auth_middleware import ImpersonatedUser
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
@@ -560,8 +561,7 @@ class MSXHTTPServer:
         safe_host: str = html_escape(request.host)  # escape for HTML display
         _raw_host: str = request.url.host or request.host.split(":")[0]  # IPv6-safe, no port
         hostname = f"[{_raw_host}]" if ":" in _raw_host else _raw_host
-        sendspin_port = "8927"
-        sendspin_url = f"http://{hostname}:{sendspin_port}"
+        sendspin_url = f"http://{hostname}:{SENDSPIN_SERVER_PORT}"
         kiosk_html5_url = f"{base}/web?kiosk=1"
         # escape the composed URL as a whole: host-derived prefix plus & separators
         sendspin_query = f"sendspin=1&sendspin_url={quote(sendspin_url, safe='')}"
@@ -621,7 +621,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
 </div>
 <div class="link-row" style="margin-top: 12px;">
 <strong>Custom Sendspin URL:</strong><br>
-<code>/web?kiosk=1&amp;sendspin=1&amp;sendspin_url=http://&lt;ma-server&gt;:8927</code>
+<code>/web?kiosk=1&amp;sendspin=1&amp;sendspin_url=http://&lt;ma-server&gt;:{SENDSPIN_SERVER_PORT}</code>
 </div>
 </div>
 

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -59,6 +59,7 @@ from music_assistant.constants import (
     CONF_LOG_LEVEL,
     CONF_PLAYERS,
     CONF_PROVIDERS,
+    SENDSPIN_SERVER_PORT,
     VERBOSE_LOG_LEVEL,
 )
 from music_assistant.helpers.util import format_ip_for_url
@@ -804,7 +805,7 @@ class SendspinProvider(PlayerProvider):
         # Start server for handling incoming Sendspin connections from clients
         # and mDNS discovery of new clients
         await self.server_api.start_server(
-            port=8927,
+            port=SENDSPIN_SERVER_PORT,
             host=self.mass.streams.bind_ip,
             advertise_addresses=[self.mass.streams.publish_ip],
         )

--- a/tests/controllers/webserver/test_internal_sendspin_url.py
+++ b/tests/controllers/webserver/test_internal_sendspin_url.py
@@ -1,0 +1,50 @@
+"""Tests for the URL used to reach the in-process Sendspin server."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from music_assistant.controllers.webserver.controller import WebserverController
+
+
+@pytest.fixture
+def mock_mass() -> MagicMock:
+    """Create a mock Music Assistant instance."""
+    mass = MagicMock()
+    mass.config.get_raw_core_config_value.return_value = "GLOBAL"
+    return mass
+
+
+@pytest.fixture
+def webserver(mock_mass: MagicMock) -> WebserverController:
+    """Create a WebserverController backed by a mocked Music Assistant instance."""
+    return WebserverController(mock_mass)
+
+
+@pytest.mark.parametrize(
+    ("bind_ip", "publish_ip", "expected"),
+    [
+        # pinned to a single interface: loopback would not reach the server
+        ("192.168.1.5", "192.168.1.5", "ws://192.168.1.5:8927/sendspin"),
+        ("fd00::5", "fd00::5", "ws://[fd00::5]:8927/sendspin"),
+        # wildcard bind: loopback reaches the server, whatever is advertised.
+        # a publish_ip that only exists outside a container/NAT must never be dialed
+        ("0.0.0.0", "203.0.113.10", "ws://127.0.0.1:8927/sendspin"),
+        ("::", "192.168.1.5", "ws://127.0.0.1:8927/sendspin"),
+        ("0.0.0.0", "fd00::1", "ws://[::1]:8927/sendspin"),
+        ("::", "fd00::1", "ws://[::1]:8927/sendspin"),
+        ("", "192.168.1.5", "ws://127.0.0.1:8927/sendspin"),
+    ],
+)
+def test_url_follows_the_bind_address(
+    webserver: WebserverController,
+    mock_mass: MagicMock,
+    bind_ip: str,
+    publish_ip: str,
+    expected: str,
+) -> None:
+    """Verify the URL resolves to an address that exists on this host."""
+    mock_mass.streams.bind_ip = bind_ip
+    mock_mass.streams.publish_ip = publish_ip
+
+    assert webserver.internal_sendspin_url == expected

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -194,10 +194,11 @@ async def test_remote_access_gateway_uses_internal_sendspin_url(
     cert_pems: tuple[str, str],
 ) -> None:
     """Bridge the Sendspin data channel to the locally reachable Sendspin server."""
+    internal_url = "ws://127.0.0.1:8927/sendspin"
     manager = _create_remote_access_manager()
     manager._remote_id = "TEST-REMOTE-ID"
     cast("Mock", manager.mass).webserver.base_url = "http://192.168.1.5:8095"
-    cast("Mock", manager.webserver).internal_sendspin_url = "ws://127.0.0.1:8927/sendspin"
+    cast("Mock", manager.webserver).internal_sendspin_url = internal_url
 
     with (
         patch(
@@ -211,7 +212,7 @@ async def test_remote_access_gateway_uses_internal_sendspin_url(
         await manager._start_gateway_locked()
 
     assert manager.gateway is not None
-    assert manager.gateway.sendspin_url == "ws://127.0.0.1:8927/sendspin"
+    assert manager.gateway.sendspin_url == internal_url
 
 
 async def test_webrtc_gateway_initialization(cert_pems: tuple[str, str]) -> None:

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -190,6 +190,30 @@ async def test_remote_access_skips_restart_after_mode_flap_settles() -> None:
     assert manager._target_using_ha_cloud is False
 
 
+async def test_remote_access_gateway_uses_internal_sendspin_url(
+    cert_pems: tuple[str, str],
+) -> None:
+    """Bridge the Sendspin data channel to the locally reachable Sendspin server."""
+    manager = _create_remote_access_manager()
+    manager._remote_id = "TEST-REMOTE-ID"
+    cast("Mock", manager.mass).webserver.base_url = "http://192.168.1.5:8095"
+    cast("Mock", manager.webserver).internal_sendspin_url = "ws://127.0.0.1:8927/sendspin"
+
+    with (
+        patch(
+            "music_assistant.controllers.webserver.remote_access"
+            ".get_or_create_webrtc_certificate_pems",
+            return_value=cert_pems,
+        ),
+        patch.object(manager, "_get_ha_cloud_status", new=AsyncMock(return_value=(False, None))),
+        patch.object(WebRTCGateway, "start", new=AsyncMock()),
+    ):
+        await manager._start_gateway_locked()
+
+    assert manager.gateway is not None
+    assert manager.gateway.sendspin_url == "ws://127.0.0.1:8927/sendspin"
+
+
 async def test_webrtc_gateway_initialization(cert_pems: tuple[str, str]) -> None:
     """Test WebRTCGateway initializes correctly."""
     cert_pem, key_pem = cert_pems

--- a/tests/test_sendspin_proxy.py
+++ b/tests/test_sendspin_proxy.py
@@ -16,7 +16,6 @@ def mock_webserver() -> MagicMock:
     """Create a mock webserver controller."""
     webserver = MagicMock()
     webserver.mass = MagicMock()
-    webserver.mass.streams.bind_ip = "0.0.0.0"
     webserver.mass.http_session = MagicMock()
     return webserver
 
@@ -31,6 +30,35 @@ def _make_connector_error() -> ClientConnectorError:
     """Create a realistic ClientConnectorError for testing."""
     connection_key = MagicMock()
     return ClientConnectorError(connection_key, OSError(111, "Connection refused"))
+
+
+async def test_proxy_dials_the_webserver_url(
+    handler: SendspinProxyHandler, mock_webserver: MagicMock
+) -> None:
+    """Verify the proxy connects to the URL resolved by the webserver controller."""
+    mock_ws_response = AsyncMock(spec=web.WebSocketResponse)
+    mock_ws_response.closed = False
+    mock_webserver.internal_sendspin_url = "ws://127.0.0.1:8927/sendspin"
+
+    mock_internal_ws = AsyncMock()
+    mock_internal_ws.closed = False
+    mock_ws_connect = AsyncMock(return_value=mock_internal_ws)
+
+    with (
+        patch.object(handler, "_authenticate", return_value=MagicMock()),
+        patch.object(handler, "_proxy_messages", new_callable=AsyncMock),
+        patch("aiohttp.web.WebSocketResponse", return_value=mock_ws_response),
+        patch.object(handler.mass, "http_session", create=True) as mock_session,
+        patch(
+            "music_assistant.controllers.webserver.sendspin_proxy.is_request_from_ingress",
+            return_value=False,
+        ),
+    ):
+        mock_session.ws_connect = mock_ws_connect
+        request = make_mocked_request("GET", "/sendspin")
+        await handler.handle_sendspin_proxy(request)
+
+    mock_ws_connect.assert_awaited_once_with("ws://127.0.0.1:8927/sendspin")
 
 
 class TestSendspinProxyRetry:

--- a/tests/test_sendspin_proxy.py
+++ b/tests/test_sendspin_proxy.py
@@ -36,9 +36,10 @@ async def test_proxy_dials_the_webserver_url(
     handler: SendspinProxyHandler, mock_webserver: MagicMock
 ) -> None:
     """Verify the proxy connects to the URL resolved by the webserver controller."""
+    internal_url = "ws://127.0.0.1:8927/sendspin"
     mock_ws_response = AsyncMock(spec=web.WebSocketResponse)
     mock_ws_response.closed = False
-    mock_webserver.internal_sendspin_url = "ws://127.0.0.1:8927/sendspin"
+    mock_webserver.internal_sendspin_url = internal_url
 
     mock_internal_ws = AsyncMock()
     mock_internal_ws.closed = False
@@ -58,7 +59,7 @@ async def test_proxy_dials_the_webserver_url(
         request = make_mocked_request("GET", "/sendspin")
         await handler.handle_sendspin_proxy(request)
 
-    mock_ws_connect.assert_awaited_once_with("ws://127.0.0.1:8927/sendspin")
+    mock_ws_connect.assert_awaited_once_with(internal_url)
 
 
 class TestSendspinProxyRetry:


### PR DESCRIPTION
# What does this implement/fix?

Remote access could not reach the built-in Sendspin server. It worked out the address from the *published* IP address instead of the address the server actually listens on. On setups where the published address does not exist on the machine itself — containers, or a router doing NAT — the remote access audio bridge failed to connect, while playing to the same web player from inside your own network kept working. That made it look like a remote-access-only fault.

Both paths now ask the same place for that address, so they can no longer drift apart.

- Remote access and the in-browser Sendspin proxy share a single `internal_sendspin_url` on the webserver controller.
- Also covers hosts bound to the IPv6 wildcard address, which previously produced an address that could not be dialled.
- The Sendspin server port is now a shared constant instead of being repeated in six places.
- Added tests for the address selection and for both callers.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
