### PR TITLE
Stop one bad join code from locking out everyone at a party

### DIFF
--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -70,8 +70,14 @@ HA_TOKEN_NAME = "Home Assistant Integration"
 JOIN_CODE_LENGTH = 12
 JOIN_CODE_CHARSET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"  # No I/O/0/1 for readability
 JOIN_CODE_DEFAULT_EXPIRY_HOURS = 8
-# No source IP available here, so throttle failed exchanges globally under one key.
+# No source IP available here, so failed exchanges all share one key. That makes the threshold
+# a room-wide one: at a party a handful of mistyped or stale codes must not lock out the guests
+# holding a valid one, so it sits far above any plausible burst of legitimate failures and drips
+# at a flat cooldown instead of escalating. Guessing is made infeasible by the code itself
+# (12 chars over a 32 symbol alphabet is ~2^60, valid for hours), not by this throttle.
 JOIN_CODE_RATE_LIMIT_KEY = "join_code_exchange"
+JOIN_CODE_FAILURE_CEILING = 1000
+JOIN_CODE_COOLDOWN_SECONDS = 60
 
 
 class AuthenticationManager:
@@ -90,7 +96,12 @@ class AuthenticationManager:
         self.logger = LOGGER
         self._has_users: bool = False
         self.jwt_helper: JWTHelper = None  # type: ignore[assignment]
-        self._join_code_rate_limiter = LoginRateLimiter()
+        self._join_code_rate_limiter = LoginRateLimiter(
+            delay_tiers=((JOIN_CODE_FAILURE_CEILING, JOIN_CODE_COOLDOWN_SECONDS),),
+            warn_threshold=JOIN_CODE_FAILURE_CEILING,
+            alert_threshold=JOIN_CODE_FAILURE_CEILING * 2,
+            subject="join code",
+        )
         # Stops concurrent exchanges from passing the rate limit check before failures land
         self._join_code_exchange_lock = asyncio.Lock()
 

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -100,7 +100,7 @@ class AuthenticationManager:
             delay_tiers=((JOIN_CODE_FAILURE_CEILING, JOIN_CODE_COOLDOWN_SECONDS),),
             warn_threshold=JOIN_CODE_FAILURE_CEILING,
             alert_threshold=JOIN_CODE_FAILURE_CEILING * 2,
-            subject="join code",
+            subject="rate limit key",
         )
         # Stops concurrent exchanges from passing the rate limit check before failures land
         self._join_code_exchange_lock = asyncio.Lock()

--- a/music_assistant/controllers/webserver/helpers/auth_providers.py
+++ b/music_assistant/controllers/webserver/helpers/auth_providers.py
@@ -137,7 +137,8 @@ class LoginRateLimiter:
         :param alert_threshold: Failure count at which a stronger warning is logged.
         :param subject: Noun describing what a key identifies, used in log messages.
         """
-        # Track failed attempts per username: {username: [timestamp1, timestamp2, ...]}
+        # Track failed attempts per key: {key: [timestamp1, timestamp2, ...]}. A key is a
+        # username on the interactive login path, but callers may group attempts differently.
         self._failed_attempts: dict[str, list[datetime]] = {}
         # Time window for tracking attempts (30 minutes)
         self._tracking_window = timedelta(minutes=30)
@@ -241,7 +242,7 @@ class LoginRateLimiter:
             elif attempt_count == self._alert_threshold:
                 LOGGER.warning(
                     "High suspicious login activity: %d failed attempts for %s '%s'. "
-                    "Consider blocking this source.",
+                    "Consider disabling the account or blocking the source at the network edge.",
                     attempt_count,
                     self._subject,
                     username,

--- a/music_assistant/controllers/webserver/helpers/auth_providers.py
+++ b/music_assistant/controllers/webserver/helpers/auth_providers.py
@@ -29,6 +29,9 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.auth")
 
+# Progressive delay tiers for interactive logins: (failure count, delay in seconds).
+DEFAULT_LOGIN_DELAY_TIERS = ((3, 30), (6, 60), (10, 120), (15, 300))
+
 
 def normalize_username(username: str) -> str:
     """
@@ -118,14 +121,32 @@ async def get_ha_user_role(
 class LoginRateLimiter:
     """Rate limiter for login attempts to prevent brute force attacks."""
 
-    def __init__(self) -> None:
-        """Initialize the rate limiter."""
+    def __init__(
+        self,
+        delay_tiers: tuple[tuple[int, int], ...] = DEFAULT_LOGIN_DELAY_TIERS,
+        warn_threshold: int = 10,
+        alert_threshold: int = 20,
+        subject: str = "username",
+    ) -> None:
+        """
+        Initialize the rate limiter.
+
+        :param delay_tiers: Ascending (failure count, delay in seconds) pairs. The highest
+            tier the failure count has reached sets the delay; below the lowest there is none.
+        :param warn_threshold: Failure count at which suspicious activity is logged.
+        :param alert_threshold: Failure count at which a stronger warning is logged.
+        :param subject: Noun describing what a key identifies, used in log messages.
+        """
         # Track failed attempts per username: {username: [timestamp1, timestamp2, ...]}
         self._failed_attempts: dict[str, list[datetime]] = {}
         # Time window for tracking attempts (30 minutes)
         self._tracking_window = timedelta(minutes=30)
         # Lock for thread-safe access to _failed_attempts
         self._lock = asyncio.Lock()
+        self._delay_tiers = delay_tiers
+        self._warn_threshold = warn_threshold
+        self._alert_threshold = alert_threshold
+        self._subject = subject
 
     def _cleanup_old_attempts(self, username: str) -> None:
         """
@@ -149,13 +170,6 @@ class LoginRateLimiter:
         """
         Get the delay in seconds before next login attempt is allowed.
 
-        Progressive delays based on failed attempts:
-        - 1-2 attempts: no delay
-        - 3-5 attempts: 30 seconds
-        - 6-9 attempts: 60 seconds
-        - 10-14 attempts: 120 seconds
-        - 15+ attempts: 300 seconds (5 minutes)
-
         :param username: The username attempting to log in.
         :return: Delay in seconds (0 if no delay needed).
         """
@@ -165,16 +179,11 @@ class LoginRateLimiter:
             return 0
 
         attempt_count = len(self._failed_attempts[username])
-
-        if attempt_count < 3:
-            return 0
-        if attempt_count < 6:
-            return 30
-        if attempt_count < 10:
-            return 60
-        if attempt_count < 15:
-            return 120
-        return 300  # 5 minutes max delay
+        delay = 0
+        for tier_count, tier_delay in self._delay_tiers:
+            if attempt_count >= tier_count:
+                delay = tier_delay
+        return delay
 
     async def check_rate_limit(self, username: str) -> tuple[bool, int]:
         """
@@ -222,14 +231,19 @@ class LoginRateLimiter:
 
             # Log warning for suspicious activity
             attempt_count = len(self._failed_attempts[username])
-            if attempt_count == 10:
+            if attempt_count == self._warn_threshold:
                 LOGGER.warning(
-                    "Suspicious login activity: 10 failed attempts for username '%s'", username
+                    "Suspicious login activity: %d failed attempts for %s '%s'",
+                    attempt_count,
+                    self._subject,
+                    username,
                 )
-            elif attempt_count == 20:
+            elif attempt_count == self._alert_threshold:
                 LOGGER.warning(
-                    "High suspicious login activity: 20 failed attempts for username '%s'. "
-                    "Consider manually disabling this account.",
+                    "High suspicious login activity: %d failed attempts for %s '%s'. "
+                    "Consider blocking this source.",
+                    attempt_count,
+                    self._subject,
                     username,
                 )
 

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -15,6 +15,8 @@ from music_assistant_models.errors import InsufficientPermissions, InvalidDataEr
 from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER
 from music_assistant.controllers.config import ConfigController
 from music_assistant.controllers.webserver.auth import (
+    JOIN_CODE_COOLDOWN_SECONDS,
+    JOIN_CODE_FAILURE_CEILING,
     JOIN_CODE_LENGTH,
     TOKEN_ABSOLUTE_MAX_EXPIRATION,
     TOKEN_GUEST_EXPIRATION,
@@ -30,7 +32,11 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
     set_current_token,
     set_current_user,
 )
-from music_assistant.controllers.webserver.helpers.auth_providers import BuiltinLoginProvider
+from music_assistant.controllers.webserver.helpers.auth_providers import (
+    DEFAULT_LOGIN_DELAY_TIERS,
+    BuiltinLoginProvider,
+    LoginRateLimiter,
+)
 from music_assistant.helpers.datetime import utc
 from music_assistant.mass import MusicAssistant
 
@@ -1528,13 +1534,54 @@ async def test_join_code_length_at_least_12() -> None:
     assert JOIN_CODE_LENGTH >= 12
 
 
-async def test_exchange_join_code_rate_limited(auth_manager: AuthenticationManager) -> None:
+def _lower_join_code_ceiling(auth_manager: AuthenticationManager, ceiling: int = 3) -> None:
     """
-    Verify repeated failed join code exchanges get throttled (security finding 7.3.2).
+    Swap in a join code rate limiter with a low ceiling so throttling is reachable in a test.
+
+    :param auth_manager: AuthenticationManager instance to patch.
+    :param ceiling: Failure count at which the cooldown starts applying.
+    """
+    auth_manager._join_code_rate_limiter = LoginRateLimiter(
+        delay_tiers=((ceiling, JOIN_CODE_COOLDOWN_SECONDS),),
+        warn_threshold=ceiling,
+        alert_threshold=ceiling * 2,
+        subject="join code",
+    )
+
+
+async def test_exchange_join_code_party_burst_not_throttled(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """
+    Verify a party-scale burst of bad codes does not throttle the shared bucket.
+
+    All guests share one rate limit key, so a handful of mistyped or stale codes must
+    never lock out the guests holding a valid one.
 
     :param auth_manager: AuthenticationManager instance.
     """
-    # Three failures trip the progressive delay threshold.
+    user = await auth_manager.create_user(username="partyguest", role=UserRole.GUEST)
+    code, _ = await auth_manager.generate_join_code(user=user, expires_in_hours=24, max_uses=0)
+
+    for _ in range(30):
+        result = await auth_manager.exchange_join_code("WRONGCODE123")
+        assert result["success"] is False
+        assert "invalid" in result["error"].lower()
+
+    # A guest with a valid code still gets in.
+    assert (await auth_manager.exchange_join_code(code))["success"] is True
+
+
+async def test_exchange_join_code_rate_limited_at_ceiling(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """
+    Verify failed join code exchanges are still throttled once the ceiling is reached.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    _lower_join_code_ceiling(auth_manager)
+
     for _ in range(3):
         result = await auth_manager.exchange_join_code("WRONGCODE123")
         assert result["success"] is False
@@ -1543,6 +1590,12 @@ async def test_exchange_join_code_rate_limited(auth_manager: AuthenticationManag
     result = await auth_manager.exchange_join_code("WRONGCODE123")
     assert result["success"] is False
     assert "too many" in result["error"].lower()
+
+
+async def test_join_code_ceiling_far_above_party_scale() -> None:
+    """Verify the shipped ceiling leaves room for a large party's worth of failures."""
+    # 100 devices retrying 5 times each must stay well inside the ceiling.
+    assert JOIN_CODE_FAILURE_CEILING >= 2 * 100 * 5
 
 
 async def test_exchange_join_code_rate_limit_concurrent_burst(
@@ -1556,6 +1609,8 @@ async def test_exchange_join_code_rate_limit_concurrent_burst(
 
     :param auth_manager: AuthenticationManager instance.
     """
+    _lower_join_code_ceiling(auth_manager)
+
     results = await asyncio.gather(
         *(auth_manager.exchange_join_code("WRONGCODE123") for _ in range(10))
     )
@@ -1574,11 +1629,12 @@ async def test_exchange_join_code_success_does_not_reset_rate_limit(
     """
     Verify a successful exchange does not clear the failed-attempt counter.
 
-    The rate limit key is global, so clearing on success would let an attacker
-    holding any valid code reset the counter at will and bypass throttling.
+    The rate limit key is shared by every caller, so clearing on success would let an
+    attacker holding any valid code reset the counter at will and bypass throttling.
 
     :param auth_manager: AuthenticationManager instance.
     """
+    _lower_join_code_ceiling(auth_manager)
     user = await auth_manager.create_user(username="norstuser", role=UserRole.GUEST)
     code, _ = await auth_manager.generate_join_code(user=user, expires_in_hours=24, max_uses=0)
 
@@ -1594,3 +1650,38 @@ async def test_exchange_join_code_success_does_not_reset_rate_limit(
     result = await auth_manager.exchange_join_code(code)
     assert result["success"] is False
     assert "too many" in result["error"].lower()
+
+
+async def test_login_rate_limiter_default_tiers_unchanged() -> None:
+    """Verify the interactive login path keeps its progressive delays."""
+    limiter = LoginRateLimiter()
+
+    expected = {2: 0, 3: 30, 5: 30, 6: 60, 9: 60, 10: 120, 14: 120, 15: 300, 40: 300}
+    recorded = 0
+    for count, delay in sorted(expected.items()):
+        while recorded < count:
+            await limiter.record_failed_attempt("someuser")
+            recorded += 1
+        assert limiter.get_delay("someuser") == delay
+
+
+async def test_login_rate_limiter_single_tier_is_a_flat_ceiling() -> None:
+    """Verify a one-tier limiter stays free below the ceiling, then applies a flat delay."""
+    limiter = LoginRateLimiter(delay_tiers=((4, 60),))
+
+    for _ in range(3):
+        await limiter.record_failed_attempt("shared")
+        assert limiter.get_delay("shared") == 0
+
+    await limiter.record_failed_attempt("shared")
+    assert limiter.get_delay("shared") == 60
+    await limiter.record_failed_attempt("shared")
+    assert limiter.get_delay("shared") == 60
+
+
+async def test_default_login_delay_tiers_ascending() -> None:
+    """Verify the default tiers are ordered, since get_delay takes the highest match."""
+    counts = [count for count, _ in DEFAULT_LOGIN_DELAY_TIERS]
+    delays = [delay for _, delay in DEFAULT_LOGIN_DELAY_TIERS]
+    assert counts == sorted(counts)
+    assert delays == sorted(delays)

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -1534,21 +1534,6 @@ async def test_join_code_length_at_least_12() -> None:
     assert JOIN_CODE_LENGTH >= 12
 
 
-def _lower_join_code_ceiling(auth_manager: AuthenticationManager, ceiling: int = 3) -> None:
-    """
-    Swap in a join code rate limiter with a low ceiling so throttling is reachable in a test.
-
-    :param auth_manager: AuthenticationManager instance to patch.
-    :param ceiling: Failure count at which the cooldown starts applying.
-    """
-    auth_manager._join_code_rate_limiter = LoginRateLimiter(
-        delay_tiers=((ceiling, JOIN_CODE_COOLDOWN_SECONDS),),
-        warn_threshold=ceiling,
-        alert_threshold=ceiling * 2,
-        subject="join code",
-    )
-
-
 async def test_exchange_join_code_party_burst_not_throttled(
     auth_manager: AuthenticationManager,
 ) -> None:
@@ -1685,3 +1670,18 @@ async def test_default_login_delay_tiers_ascending() -> None:
     delays = [delay for _, delay in DEFAULT_LOGIN_DELAY_TIERS]
     assert counts == sorted(counts)
     assert delays == sorted(delays)
+
+
+def _lower_join_code_ceiling(auth_manager: AuthenticationManager, ceiling: int = 3) -> None:
+    """
+    Swap in a join code rate limiter with a low ceiling so throttling is reachable in a test.
+
+    :param auth_manager: AuthenticationManager instance to patch.
+    :param ceiling: Failure count at which the cooldown starts applying.
+    """
+    auth_manager._join_code_rate_limiter = LoginRateLimiter(
+        delay_tiers=((ceiling, JOIN_CODE_COOLDOWN_SECONDS),),
+        warn_threshold=ceiling,
+        alert_threshold=ceiling * 2,
+        subject="rate limit key",
+    )


### PR DESCRIPTION
# What does this implement/fix?

Failed join code exchanges all share a single rate limit key, and the progressive delays start at 3 failures within a 30 minute window. At a party that means a handful of mistyped or stale codes locks out every other guest — including the ones holding a perfectly valid code — escalating to a 5 minute block, with nothing to indicate it is a throttle against someone else's mistakes. It just looks like "the QR code doesn't work".

This is the `stable`-only equivalent of #5243. That fix keys the limiter per calling client, which relies on request-context plumbing that only exists on `dev`, so it cannot be cherry-picked here. This takes the smaller route instead: keep the shared key, but move it from an escalating 3-failure threshold to a flat ceiling that sits far above any plausible burst of legitimate failures. What makes guessing infeasible is the code itself (12 chars over a 32 symbol alphabet, ~2^60, valid for hours), not the throttle.

**Related issue (if applicable):**

- n/a

## Changes

- Give `LoginRateLimiter` optional `delay_tiers`, `warn_threshold`, `alert_threshold` and `subject` arguments, defaulting to the current interactive-login behaviour (tiers unchanged, extracted to `DEFAULT_LOGIN_DELAY_TIERS`).
- Configure the join code limiter with a single tier: no delay below 1000 failures per 30 minutes, then a flat 60s cooldown that drips rather than escalating.
- Raise the suspicious-activity log thresholds for the join code bucket to match, so a party's worth of failures no longer logs a false alarm, and report the right noun instead of `username`.
- Keep the deliberate no-`clear_attempts`-on-success behaviour: the key is still shared, so a valid-code holder must not be able to reset it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes. (Run per-file: ruff, codespell and mypy are clean. The one `ruff format` diff it reports on `auth.py:151` is the pre-existing `except (...)` drift already on `stable` — left untouched.)
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (n/a)
