### PR TITLE
Fix Home Assistant connection drop on large entity registries

### DIFF
--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -14,7 +14,7 @@ import logging
 import os
 from functools import partial
 from itertools import batched
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from hass_client import HomeAssistantClient
 from hass_client.exceptions import BaseHassClientError
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
         CompressedState,
         Context,
         Device,
+        Entity,
         EntityStateEvent,
         Event,
         State,
@@ -91,6 +92,14 @@ class DeviceMediaPlayerInfo(TypedDict):
     name: str | None
     # first enabled media_player entity of the device that supports announcements
     announce_entity_id: str | None
+
+
+class HassRegistryEntity(TypedDict):
+    """Home Assistant entity registry entry, limited to the fields Music Assistant uses."""
+
+    entity_id: str
+    platform: str
+    device_id: str | None
 
 
 async def setup(
@@ -191,6 +200,9 @@ class HomeAssistantProvider(PluginProvider):
     _ai_engines: list[AIEngine]
     _tts_engines: list[TTSEngine]
     _startup_complete: bool = False
+    _entity_registry: dict[str, HassRegistryEntity] | None = None
+    _entity_registry_generation: int = 0
+    _entity_registry_lock: asyncio.Lock
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """
@@ -292,6 +304,8 @@ class HomeAssistantProvider(PluginProvider):
         ssl = bool(self.get_setup_value(CONF_VERIFY_SSL, True))
         http_session = self.mass.http_session if ssl else self.mass.http_session_no_ssl
         self.hass = HomeAssistantClient(url, token, http_session)
+        self._entity_registry = None
+        self._entity_registry_lock = asyncio.Lock()
         try:
             await self.hass.connect()
         except BaseHassClientError as err:
@@ -300,6 +314,10 @@ class HomeAssistantProvider(PluginProvider):
             raise SetupFailedError(err_msg) from err
         self._listen_task = self.mass.create_task(self._hass_listener())
         try:
+            # the registry subscription must be live before the first registry read, so no
+            # registry change can slip through unnoticed; _disconnect_hass tears the
+            # subscription down again on the failure paths below
+            await self._subscribe_entity_registry()
             await self._resolve_startup_features()
         except asyncio.CancelledError:
             await self._cleanup_failed_init()
@@ -315,7 +333,6 @@ class HomeAssistantProvider(PluginProvider):
     async def loaded_in_mass(self) -> None:
         """Call after the provider has been loaded."""
         await self._register_player_controls()
-        await self._subscribe_entity_registry()
 
     async def unload(self, is_removed: bool = False) -> None:
         """
@@ -338,6 +355,43 @@ class HomeAssistantProvider(PluginProvider):
             "listener_active": self._listen_task is not None and not self._listen_task.done(),
             "player_controls": len(self._player_controls) if self._player_controls else 0,
         }
+
+    async def get_entity_registry(self) -> dict[str, HassRegistryEntity]:
+        """
+        Return the Home Assistant entity registry, keyed by entity ID.
+
+        Entities that are disabled in Home Assistant are absent from the result, and so are
+        entities without a unique ID: those are not part of Home Assistant's registry at all.
+        """
+        if (registry := self._entity_registry) is not None:
+            return registry
+        async with self._entity_registry_lock:
+            if (registry := self._entity_registry) is None:
+                generation = self._entity_registry_generation
+                registry = await self._fetch_entity_registry()
+                # a registry change while the fetch was in flight leaves the listing stale
+                # on arrival, so serve it to this caller but keep it out of the cache
+                if generation == self._entity_registry_generation:
+                    self._entity_registry = registry
+            return registry
+
+    async def get_entity_registry_entries(self, entity_ids: Collection[str]) -> dict[str, Entity]:
+        """
+        Return the full Home Assistant entity registry entries of the given entities.
+
+        :param entity_ids: The entity IDs to look up.
+        :return: The registry entries keyed by entity ID; entities unknown to
+            Home Assistant are absent from the result.
+        """
+        if not entity_ids:
+            return {}
+        result = cast(
+            "dict[str, Entity | None]",
+            await self.hass.send_command(
+                "config/entity_registry/get_entries", entity_ids=list(entity_ids)
+            ),
+        )
+        return {entity_id: entry for entity_id, entry in result.items() if entry is not None}
 
     async def get_media_player_device_infos(
         self,
@@ -371,15 +425,13 @@ class HomeAssistantProvider(PluginProvider):
         if not device_by_mac:
             return {}
         media_players_by_device: dict[str, list[str]] = {}
-        for entry in await self.hass.get_entity_registry():
+        for entry in (await self.get_entity_registry()).values():
             if (
                 entry["platform"] == platform
                 and entry["entity_id"].startswith("media_player.")
-                and entry.get("disabled_by") is None
+                and (device_id := entry["device_id"])
             ):
-                media_players_by_device.setdefault(entry["device_id"], []).append(
-                    entry["entity_id"]
-                )
+                media_players_by_device.setdefault(device_id, []).append(entry["entity_id"])
         candidates_by_mac = {
             mac: media_players_by_device.get(device["id"], [])
             for mac, device in device_by_mac.items()
@@ -503,12 +555,8 @@ class HomeAssistantProvider(PluginProvider):
         if domains:
             # resolve domains to entity_ids via the registry, which is far smaller
             # than a full state dump (it carries no attributes)
-            registry = await self.hass.get_entity_registry()
-            ids.update(
-                entry["entity_id"]
-                for entry in registry
-                if entry["entity_id"].split(".", 1)[0] in domains
-            )
+            registry = await self.get_entity_registry()
+            ids.update(entity_id for entity_id in registry if entity_id.split(".", 1)[0] in domains)
         if not ids:
             return []
         states: list[State] = []
@@ -912,6 +960,9 @@ class HomeAssistantProvider(PluginProvider):
 
     def _on_entity_registry_update(self, event: Event) -> None:
         """Handle an entity registry update event."""
+        # any registry change invalidates the cached registry, whatever domain it concerns
+        self._entity_registry = None
+        self._entity_registry_generation += 1
         entity_id = event["data"].get("entity_id", "")
         if not entity_id.startswith(FEATURE_DOMAIN_PREFIXES):
             return
@@ -931,6 +982,23 @@ class HomeAssistantProvider(PluginProvider):
             await self._refresh_engines()
         except Exception as err:
             self.logger.warning("Failed to refresh Home Assistant engines: %s", err)
+
+    async def _fetch_entity_registry(self) -> dict[str, HassRegistryEntity]:
+        """Fetch the entity registry from Home Assistant, keyed by entity ID."""
+        # the display variant of the registry listing carries abbreviated keys and only the
+        # fields the Home Assistant frontend needs, making it several times smaller
+        result = cast(
+            "dict[str, Any]",
+            await self.hass.send_command("config/entity_registry/list_for_display"),
+        )
+        return {
+            entry["ei"]: HassRegistryEntity(
+                entity_id=entry["ei"],
+                platform=entry["pl"],
+                device_id=entry.get("di"),
+            )
+            for entry in result["entities"]
+        }
 
 
 def _decompress_state(entity_id: str, compressed_state: CompressedState) -> State:

--- a/music_assistant/providers/hass_players/helpers.py
+++ b/music_assistant/providers/hass_players/helpers.py
@@ -26,16 +26,34 @@ if TYPE_CHECKING:
     from music_assistant.providers.hass import HomeAssistantProvider
 
 
+async def get_media_player_entity_registry(
+    hass_prov: HomeAssistantProvider,
+) -> dict[str, HassEntity]:
+    """
+    Return the full registry entries of all Home Assistant media_player entities.
+
+    :param hass_prov: The Home Assistant provider to read the registry from.
+    :return: The registry entries keyed by entity ID.
+    """
+    registry = await hass_prov.get_entity_registry()
+    return await hass_prov.get_entity_registry_entries(
+        [entity_id for entity_id in registry if entity_id.startswith("media_player.")]
+    )
+
+
 async def get_hass_media_players(
     hass_prov: HomeAssistantProvider,
+    entity_registry: dict[str, HassEntity],
 ) -> AsyncGenerator[tuple[HassState, HassEntity | None]]:
-    """Return all HA state objects (with registry entry) for (valid) media_player entities."""
-    entity_registry = {x["entity_id"]: x for x in await hass_prov.hass.get_entity_registry()}
+    """
+    Return all HA state objects (with registry entry) for (valid) media_player entities.
+
+    :param hass_prov: The Home Assistant provider to fetch the entity states from.
+    :param entity_registry: The registry entries of the media_player entities to consider.
+    """
     # discover via the registry instead of a full state dump; entities without a
     # unique_id are not registered and are therefore not discovered here
-    media_player_ids = [
-        entity_id for entity_id in entity_registry if entity_id.startswith("media_player.")
-    ]
+    media_player_ids = list(entity_registry)
     for state in await hass_prov.get_states(entity_ids=media_player_ids):
         if "mass_player_type" in state["attributes"]:
             # filter out mass players

--- a/music_assistant/providers/hass_players/provider.py
+++ b/music_assistant/providers/hass_players/provider.py
@@ -26,6 +26,7 @@ from .constants import (
 from .helpers import (
     get_esphome_supported_audio_formats,
     get_hass_media_players,
+    get_media_player_entity_registry,
     native_player_macs,
     normalized_mac,
 )
@@ -70,7 +71,10 @@ class HomeAssistantPlayerProvider(PlayerProvider):
             selected_players = self._selected_players()
             device_registry = {x["id"]: x for x in await hass_prov.hass.get_device_registry()}
             native_macs = native_player_macs(self.mass)
-            async for state, entity_registry_entry in get_hass_media_players(hass_prov):
+            entity_registry = await get_media_player_entity_registry(hass_prov)
+            async for state, entity_registry_entry in get_hass_media_players(
+                hass_prov, entity_registry
+            ):
                 entity_id = state["entity_id"]
                 name = f"{state['attributes']['friendly_name']} ({entity_id})"
                 disabled_reason: str | None = None
@@ -105,11 +109,9 @@ class HomeAssistantPlayerProvider(PlayerProvider):
         player_ids = cast("list[str]", self.config.get_value(CONF_PLAYERS))
         # prefetch the device- and entity registry
         device_registry = {x["id"]: x for x in await self.hass_prov.hass.get_device_registry()}
-        entity_registry = {
-            x["entity_id"]: x for x in await self.hass_prov.hass.get_entity_registry()
-        }
+        entity_registry = await get_media_player_entity_registry(self.hass_prov)
         # setup players from hass entities
-        async for state, _ in get_hass_media_players(self.hass_prov):
+        async for state, _ in get_hass_media_players(self.hass_prov, entity_registry):
             if state["entity_id"] not in player_ids:
                 continue
             await self._setup_player(state, entity_registry, device_registry)
@@ -231,10 +233,8 @@ class HomeAssistantPlayerProvider(PlayerProvider):
         """Handle setup of Player from HA entity that became available after startup."""
         # prefetch the device- and entity registry
         device_registry = {x["id"]: x for x in await self.hass_prov.hass.get_device_registry()}
-        entity_registry = {
-            x["entity_id"]: x for x in await self.hass_prov.hass.get_entity_registry()
-        }
-        async for state, _ in get_hass_media_players(self.hass_prov):
+        entity_registry = await get_media_player_entity_registry(self.hass_prov)
+        async for state, _ in get_hass_media_players(self.hass_prov, entity_registry):
             if state["entity_id"] != entity_id:
                 continue
             await self._setup_player(state, entity_registry, device_registry)

--- a/tests/providers/hass/test_device_correlation.py
+++ b/tests/providers/hass/test_device_correlation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from types import SimpleNamespace
 from typing import Any
@@ -20,11 +21,25 @@ def _provider(
     entities: list[dict[str, Any]],
     states: list[dict[str, Any]],
 ) -> HomeAssistantProvider:
+    async def _send_command(command: str, **_kwargs: Any) -> dict[str, Any]:
+        assert command == "config/entity_registry/list_for_display"
+        # Home Assistant leaves disabled entities out of the registry listing
+        return {
+            "entity_categories": {},
+            "entities": [
+                {"ei": entity["entity_id"], "pl": entity["platform"], "di": entity["device_id"]}
+                for entity in entities
+                if entity["disabled_by"] is None
+            ],
+        }
+
     provider = HomeAssistantProvider.__new__(HomeAssistantProvider)
     provider.hass = SimpleNamespace(
         get_device_registry=AsyncMock(return_value=devices),
-        get_entity_registry=AsyncMock(return_value=entities),
+        send_command=AsyncMock(side_effect=_send_command),
     )
+    provider._entity_registry = None
+    provider._entity_registry_lock = asyncio.Lock()
     provider.get_states = AsyncMock(return_value=states)  # type: ignore[method-assign]
     provider.logger = logging.getLogger("test.hass")
     return provider

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -31,6 +31,8 @@ from music_assistant.providers.hass.constants import MediaPlayerEntityFeature
 LAST_CHANGED = 1683832716.072648
 LAST_CHANGED_ISO = "2023-05-11T19:18:36.072648+00:00"
 CONTEXT_ID = "01H0640ES8JCY1NGTNW3V41T5T"
+REGISTRY_LIST_COMMAND = "config/entity_registry/list_for_display"
+REGISTRY_ENTRIES_COMMAND = "config/entity_registry/get_entries"
 
 
 def _state(entity_id: str, friendly_name: str) -> dict[str, Any]:
@@ -118,6 +120,8 @@ class _HomeAssistantClient:
         self.active_event_subscriptions = 0
         # compressed states keyed by entity_id, as delivered over the websocket
         self.compressed_states = {state["entity_id"]: _compressed(state) for state in states}
+        # entities Home Assistant reports as disabled, so leaves out of the registry listing
+        self.disabled_entities: set[str] = set()
         # events delivered ahead of a subscription's initial state message
         self.leading_events: list[dict[str, Any]] = []
         self.deliver_initial_states = True
@@ -127,7 +131,7 @@ class _HomeAssistantClient:
         self._registry_result = (
             asyncio.get_running_loop().create_future() if block_registry else None
         )
-        self.send_command = AsyncMock(return_value={"response": {"data": "answer"}})
+        self.send_command = AsyncMock(side_effect=self._send_command)
 
     async def connect(self) -> None:
         """Connect the client."""
@@ -151,23 +155,6 @@ class _HomeAssistantClient:
             if self._registry_result and not self._registry_result.done():
                 self._registry_result.cancel()
             self.listener_stopped.set()
-
-    async def get_entity_registry(self) -> list[dict[str, Any]]:
-        """Return the entity registry after command responses can be received."""
-        await self.listener_started.wait()
-        self.calls.append("get_entity_registry")
-        self.registry_started.set()
-        try:
-            if self._registry_result:
-                await self._registry_result
-            if self._registry_error:
-                raise self._registry_error
-            return [{"entity_id": entity_id} for entity_id in self.compressed_states]
-        except asyncio.CancelledError:
-            self.registry_cancelled.set()
-            raise
-        finally:
-            self.registry_stopped.set()
 
     async def subscribe_entities(
         self, cb_func: Callable[[dict[str, Any]], None], entity_ids: list[str]
@@ -198,7 +185,8 @@ class _HomeAssistantClient:
     async def subscribe_events(
         self, cb_func: Callable[[dict[str, Any]], None], event_type: str
     ) -> Callable[[], None]:
-        """Register the event callback and return the unsubscribe callable."""
+        """Register the event callback after command responses can be received."""
+        await self.listener_started.wait()
         self.calls.append("subscribe_events")
         self.event_subscriptions.append((event_type, cb_func))
         self.active_event_subscriptions += 1
@@ -220,6 +208,56 @@ class _HomeAssistantClient:
         self.calls.append("disconnect")
         self.connected = False
         self.disconnected = True
+
+    async def _send_command(self, command: str, **kwargs: Any) -> Any:
+        """Return the response Home Assistant sends for the given websocket command."""
+        if command == REGISTRY_LIST_COMMAND:
+            return await self._registry_for_display()
+        self.calls.append(command)
+        if command == REGISTRY_ENTRIES_COMMAND:
+            return self._registry_entries(cast("list[str]", kwargs["entity_ids"]))
+        return {"response": {"data": "answer"}}
+
+    async def _registry_for_display(self) -> dict[str, Any]:
+        """Return the entity registry listing after command responses can be received."""
+        await self.listener_started.wait()
+        self.calls.append(REGISTRY_LIST_COMMAND)
+        self.registry_started.set()
+        try:
+            if self._registry_result:
+                await self._registry_result
+            if self._registry_error:
+                raise self._registry_error
+            return {
+                "entity_categories": {},
+                "entities": [
+                    {"ei": entity_id, "pl": "test"}
+                    for entity_id in self.compressed_states
+                    if entity_id not in self.disabled_entities
+                ],
+            }
+        except asyncio.CancelledError:
+            self.registry_cancelled.set()
+            raise
+        finally:
+            self.registry_stopped.set()
+
+    def _registry_entries(self, entity_ids: list[str]) -> dict[str, dict[str, Any] | None]:
+        """Return the full registry entry of every requested entity, None when unknown."""
+        return {
+            entity_id: (
+                {
+                    "entity_id": entity_id,
+                    "id": f"registry_id_{entity_id}",
+                    "platform": "test",
+                    "device_id": "device_id",
+                    "config_entry_id": "config_entry_id",
+                }
+                if entity_id in self.compressed_states
+                else None
+            )
+            for entity_id in entity_ids
+        }
 
 
 @asynccontextmanager
@@ -262,7 +300,12 @@ async def test_feature_resolution_starts_listener_first() -> None:
     ]
 
     async with _start_provider(states) as (provider, hass):
-        assert hass.calls[:3] == ["connect", "start_listening", "get_entity_registry"]
+        assert hass.calls[:4] == [
+            "connect",
+            "start_listening",
+            "subscribe_events",
+            REGISTRY_LIST_COMMAND,
+        ]
         assert ProviderFeature.AI_QUERY in provider.supported_features
         assert ProviderFeature.TTS in provider.supported_features
 
@@ -284,7 +327,14 @@ async def test_feature_resolution_failure_cleans_up_connection() -> None:
     assert hass.listener_started.is_set()
     assert hass.listener_stopped.is_set()
     assert hass.disconnected
-    assert hass.calls == ["connect", "start_listening", "get_entity_registry", "disconnect"]
+    assert hass.calls == [
+        "connect",
+        "start_listening",
+        "subscribe_events",
+        REGISTRY_LIST_COMMAND,
+        "unsubscribe_events",
+        "disconnect",
+    ]
     assert provider._listen_task is None
 
 
@@ -457,7 +507,7 @@ async def test_ai_query_uses_the_first_engine_by_default() -> None:
 
         assert ProviderFeature.AI_QUERY in provider.supported_features
         assert result == "answer"
-        hass.send_command.assert_awaited_once_with(
+        hass.send_command.assert_awaited_with(
             "call_service",
             domain="ai_task",
             service="generate_data",
@@ -584,7 +634,7 @@ async def test_burst_of_registry_updates_triggers_a_single_refresh() -> None:
     """Collect a burst of registry updates into one rebuild of the engine lists."""
     async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
         await provider.loaded_in_mass()
-        registry_fetches = hass.calls.count("get_entity_registry")
+        registry_fetches = hass.calls.count(REGISTRY_LIST_COMMAND)
 
         with patch("music_assistant.providers.hass.ENGINE_REFRESH_DEBOUNCE", 0.05):
             for index in range(3):
@@ -596,17 +646,139 @@ async def test_burst_of_registry_updates_triggers_a_single_refresh() -> None:
             async with asyncio.timeout(1):
                 await provider._engine_refresh_task
 
-        assert hass.calls.count("get_entity_registry") == registry_fetches + 1
+        assert hass.calls.count(REGISTRY_LIST_COMMAND) == registry_fetches + 1
+
+
+async def test_registry_update_of_another_domain_invalidates_the_registry() -> None:
+    """Refresh the cached registry for a registry update of any domain."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        registry_fetches = hass.calls.count(REGISTRY_LIST_COMMAND)
+        hass.compressed_states["light.kitchen"] = _compressed(_state("light.kitchen", "Kitchen"))
+
+        hass.fire_event(
+            "entity_registry_updated", {"action": "create", "entity_id": "light.kitchen"}
+        )
+
+        # an entity that can not back a feature must not trigger an engine rebuild
+        assert provider._engine_refresh_task is None
+        result = await provider.get_states(domains=("light",))
+        assert [state["entity_id"] for state in result] == ["light.kitchen"]
+        assert hass.calls.count(REGISTRY_LIST_COMMAND) == registry_fetches + 1
+
+
+async def test_domains_are_resolved_through_the_display_registry() -> None:
+    """Resolve domains through the compact registry listing only."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        await provider.get_states(domains=("tts",))
+
+        assert REGISTRY_LIST_COMMAND in hass.calls
+        assert "config/entity_registry/list" not in hass.calls
+
+
+async def test_registry_is_fetched_once_per_connection() -> None:
+    """Serve repeated domain lookups from a registry that is fetched only once."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        registry_fetches = hass.calls.count(REGISTRY_LIST_COMMAND)
+
+        await provider.get_states(domains=("tts",))
+        await provider.get_states(domains=("media_player",))
+
+        assert registry_fetches == 1
+        assert hass.calls.count(REGISTRY_LIST_COMMAND) == registry_fetches
+
+
+async def test_concurrent_domain_lookups_share_one_registry_fetch() -> None:
+    """Let concurrent domain lookups share a single registry fetch."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        registry_fetches = hass.calls.count(REGISTRY_LIST_COMMAND)
+        provider._entity_registry = None
+        # hold back the registry response until both lookups are waiting for it
+        hass._registry_result = asyncio.get_running_loop().create_future()
+
+        lookups = asyncio.gather(
+            provider.get_states(domains=("tts",)), provider.get_states(domains=("tts",))
+        )
+        await asyncio.sleep(0)
+        hass._registry_result.set_result(None)
+        async with asyncio.timeout(1):
+            results = await lookups
+
+        assert all(len(result) == 1 for result in results)
+        assert hass.calls.count(REGISTRY_LIST_COMMAND) == registry_fetches + 1
+
+
+async def test_registry_changed_during_the_fetch_is_not_cached() -> None:
+    """Keep a registry listing out of the cache when a registry update outdated it in flight."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        provider._entity_registry = None
+        # hold back the registry response until the update has been delivered
+        hass._registry_result = asyncio.get_running_loop().create_future()
+        lookup = asyncio.ensure_future(provider.get_states(domains=("tts",)))
+        await asyncio.sleep(0)
+
+        hass.fire_event(
+            "entity_registry_updated", {"action": "create", "entity_id": "light.kitchen"}
+        )
+        hass._registry_result.set_result(None)
+        async with asyncio.timeout(1):
+            await lookup
+
+        assert provider._entity_registry is None
+        registry_fetches = hass.calls.count(REGISTRY_LIST_COMMAND)
+        await provider.get_states(domains=("tts",))
+        assert hass.calls.count(REGISTRY_LIST_COMMAND) == registry_fetches + 1
+
+
+async def test_disabled_entity_is_never_requested() -> None:
+    """Leave an entity that Home Assistant disabled out of the state fetch."""
+    states = [_state("media_player.kitchen", "Kitchen"), _state("media_player.spare", "Spare")]
+
+    async with _start_provider(states) as (provider, hass):
+        # Home Assistant omits disabled entities from the registry, their state remains
+        hass.disabled_entities.add("media_player.spare")
+        hass.fire_event(
+            "entity_registry_updated", {"action": "update", "entity_id": "media_player.spare"}
+        )
+        hass.subscriptions.clear()
+
+        result = await provider.get_states(domains=("media_player",))
+
+        assert [state["entity_id"] for state in result] == ["media_player.kitchen"]
+        assert hass.subscriptions == [["media_player.kitchen"]]
+
+
+async def test_registry_entries_are_fetched_for_the_given_entities_only() -> None:
+    """Fetch the full registry entries of exactly the requested entities."""
+    async with _start_provider([_state("media_player.kitchen", "Kitchen")]) as (provider, hass):
+        entries = await provider.get_entity_registry_entries(
+            ["media_player.kitchen", "media_player.unknown"]
+        )
+
+        # an entity Home Assistant does not know is absent from the result
+        assert list(entries) == ["media_player.kitchen"]
+        assert entries["media_player.kitchen"]["config_entry_id"] == "config_entry_id"
+        hass.send_command.assert_awaited_with(
+            REGISTRY_ENTRIES_COMMAND,
+            entity_ids=["media_player.kitchen", "media_player.unknown"],
+        )
+
+
+async def test_registry_entries_of_nothing_skips_the_round_trip() -> None:
+    """Do not contact Home Assistant when no entity is requested."""
+    async with _start_provider([_state("media_player.kitchen", "Kitchen")]) as (provider, hass):
+        calls_before = list(hass.calls)
+
+        assert await provider.get_entity_registry_entries([]) == {}
+        assert hass.calls == calls_before
 
 
 async def test_entity_registry_subscription_is_replaced() -> None:
     """Replace the entity registry subscription instead of stacking a second one."""
     async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
-        await provider.loaded_in_mass()
         assert hass.active_event_subscriptions == 1
         assert hass.event_subscriptions[0][0] == "entity_registry_updated"
 
-        await provider.loaded_in_mass()
+        await provider._subscribe_entity_registry()
 
         assert hass.active_event_subscriptions == 1
         assert hass.calls[-2:] == ["unsubscribe_events", "subscribe_events"]

--- a/tests/providers/hass_players/test_native_import_guard.py
+++ b/tests/providers/hass_players/test_native_import_guard.py
@@ -51,12 +51,18 @@ def _mass(
     devices: list[dict[str, Any]] | None = None,
     native_players: list[SimpleNamespace] | None = None,
 ) -> MusicAssistant:
+    entities_by_id = {entity["entity_id"]: entity for entity in entities}
+
+    async def _registry_entries(entity_ids: list[str]) -> dict[str, dict[str, Any]]:
+        return {entity_id: entities_by_id[entity_id] for entity_id in entity_ids}
+
     hass_prov = SimpleNamespace(
         hass=SimpleNamespace(
             connected=True,
-            get_entity_registry=AsyncMock(return_value=entities),
             get_device_registry=AsyncMock(return_value=devices or []),
         ),
+        get_entity_registry=AsyncMock(return_value=entities_by_id),
+        get_entity_registry_entries=AsyncMock(side_effect=_registry_entries),
         get_states=AsyncMock(return_value=[_state(entity["entity_id"]) for entity in entities]),
         logger=logging.getLogger("test.hass"),
     )


### PR DESCRIPTION
# What does this implement/fix?

On installations with a lot of entities, Music Assistant kept losing its Home Assistant
connection. To find out which entities exist, we asked Home Assistant for its complete
entity registry, which returns every detail of every entity. On a large setup (41k
entities) that response is around 23 MB, over the 16 MB websocket limit — which does not
just fail the request, it drops the whole connection and forces the Home Assistant
provider to reload.

We now ask Home Assistant for the compact version of that list, which is about 4.5x
smaller and leaves out disabled entities, and we keep it in memory instead of re-fetching
it on every lookup. The details we still need for a handful of entities are requested for
those entities only.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/server/pull/4890

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

## Changes

- Read the entity list through Home Assistant's compact `list_for_display` listing instead of the full registry dump.
- Cache that list for as long as the connection lives, refreshing it whenever Home Assistant reports a registry change.
- Fetch the full entity details only for the specific entities that need them.
- The Home Assistant players provider no longer fetches the entity registry twice per lookup, and only looks at `media_player` entities.
- Subscribe to registry updates before the first read, so a change can no longer be missed during startup.
