### PR TITLE
Search Home Assistant entities to use as player controls

### DIFF
--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict, cast
 from hass_client import HomeAssistantClient
 from hass_client.exceptions import BaseHassClientError
 from hass_client.utils import get_websocket_url
+from music_assistant_models.auth import Scope
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import (
     ConfigEntryType,
@@ -46,13 +47,28 @@ from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.util import lock, try_parse_int
 from music_assistant.models.plugin import AIEngine, PluginProvider, TTSEngine
 
-from .constants import OFF_STATES, MediaPlayerEntityFeature, parse_supported_features
+from .constants import (
+    CONF_MUTE_CONTROLS,
+    CONF_POWER_CONTROLS,
+    CONF_VOLUME_CONTROLS,
+    CONTROL_DOMAINS,
+    OFF_STATES,
+    MediaPlayerEntityFeature,
+    parse_supported_features,
+)
+from .control_entities import (
+    SEARCH_CONTROL_ENTITIES_LIMIT,
+    ControlEntitySearch,
+    HassControlEntitySearchResult,
+)
+from .helpers import ControlCapabilities, get_control_capabilities, get_control_name
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Collection, Mapping
 
     from aiohttp import ClientSession
     from hass_client.models import (
+        Area,
         CompressedState,
         Context,
         Device,
@@ -72,9 +88,6 @@ DOMAIN = "hass"
 CONF_URL = "url"
 CONF_AUTH_TOKEN = "token"
 CONF_VERIFY_SSL = "verify_ssl"
-CONF_POWER_CONTROLS = "power_controls"
-CONF_MUTE_CONTROLS = "mute_controls"
-CONF_VOLUME_CONTROLS = "volume_controls"
 FEATURE_DISCOVERY_TIMEOUT = 30
 STATE_FETCH_TIMEOUT = 30
 STATE_FETCH_BATCH_SIZE = 500
@@ -84,9 +97,11 @@ ENGINE_REFRESH_DEBOUNCE = 2
 # window in which repeated device lookups reuse one listing, so a burst of players
 # connecting does not fetch the (unfilterable) device registry once per player
 DEVICE_REGISTRY_CACHE_TTL = 60
+# areas are renamed even less often than devices, and only ever supply a label
+AREA_REGISTRY_CACHE_TTL = 60
 
-# Home Assistant entity domains Music Assistant can offer as player controls.
-CONTROL_DOMAINS = ("media_player", "switch", "input_boolean", "number", "input_number")
+SEARCH_CONTROL_ENTITIES_COMMAND = f"{DOMAIN}/search_control_entities"
+
 # Home Assistant entity domains that back the TTS and AI Task features.
 FEATURE_DOMAINS = ("tts", "ai_task")
 FEATURE_DOMAIN_PREFIXES = tuple(f"{domain}." for domain in FEATURE_DOMAINS)
@@ -96,7 +111,7 @@ FEATURE_DOMAIN_PREFIXES = tuple(f"{domain}." for domain in FEATURE_DOMAINS)
 # config_entry_id joins them because Home Assistant can clear disabled_by while reporting
 # only the move to the other config entry.
 REGISTRY_FIELDS_AFFECTING_MIRROR = frozenset(
-    {"entity_id", "platform", "device_id", "disabled_by", "config_entry_id"}
+    {"entity_id", "platform", "device_id", "area_id", "disabled_by", "config_entry_id"}
 )
 
 
@@ -118,14 +133,8 @@ class HassRegistryEntity(NamedTuple):
 
     platform: str
     device_id: str | None
-
-
-class _ControlCapabilities(NamedTuple):
-    """The player control roles a Home Assistant entity can serve."""
-
-    power: bool = False
-    volume: bool = False
-    mute: bool = False
+    # the area the entity is assigned to directly, overriding the one of its device
+    area_id: str | None
 
 
 async def setup(
@@ -144,9 +153,9 @@ async def _get_config_entries(hass_prov: HomeAssistantProvider) -> tuple[ConfigE
         return ()
     states = await hass_prov.get_states(domains=CONTROL_DOMAINS)
     for state in states:
-        capabilities = _get_control_capabilities(state, hass_prov.logger)
+        capabilities = get_control_capabilities(state, hass_prov.logger)
         option = ConfigValueOption(
-            state["entity_id"], title=_get_control_name(state["entity_id"], state)
+            state["entity_id"], title=get_control_name(state["entity_id"], state)
         )
         if capabilities.power:
             all_power_entities.append(option)
@@ -204,8 +213,10 @@ class HomeAssistantProvider(PluginProvider):
     _entity_registry: Mapping[str, HassRegistryEntity] | None = None
     _entity_registry_generation: int = 0
     _entity_registry_lock: asyncio.Lock
-    _wanted_controls: dict[str, _ControlCapabilities] | None = None
+    _wanted_controls: dict[str, ControlCapabilities] | None = None
     _control_reconcile_lock: asyncio.Lock
+    _control_entity_search: ControlEntitySearch
+    _unregister_search_command: Callable[[], None] | None = None
 
     @property
     def url(self) -> str | None:
@@ -214,6 +225,11 @@ class HomeAssistantProvider(PluginProvider):
         if isinstance(url, str) and url:
             return url
         return None
+
+    @property
+    def entity_registry_generation(self) -> int:
+        """Return a counter that changes whenever the mirrored entity registry is dropped."""
+        return self._entity_registry_generation
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """
@@ -319,6 +335,14 @@ class HomeAssistantProvider(PluginProvider):
         self.hass = HomeAssistantClient(url, token, http_session)
         self._entity_registry = None
         self._entity_registry_lock = asyncio.Lock()
+        self._control_entity_search = ControlEntitySearch(self)
+        # registering here rather than in loaded_in_mass pairs the command with the teardown
+        # in _disconnect_hass, so a reload can never leave it registered twice
+        self._unregister_search_command = self.mass.register_api_command(
+            SEARCH_CONTROL_ENTITIES_COMMAND,
+            self.search_control_entities,
+            required_scope=Scope.CONFIG_PROVIDERS_READ,
+        )
         try:
             await self.hass.connect()
         except BaseHassClientError as err:
@@ -443,6 +467,44 @@ class HomeAssistantProvider(PluginProvider):
         device change may take up to DEVICE_REGISTRY_CACHE_TTL seconds to be reflected.
         """
         return await self._fetch_device_registry()
+
+    async def get_area_registry(self) -> dict[str, Area]:
+        """
+        Return the Home Assistant area registry, keyed by area ID.
+
+        The listing is reused for a short while, so an area change may take up to
+        AREA_REGISTRY_CACHE_TTL seconds to be reflected.
+        """
+        return await self._fetch_area_registry()
+
+    async def search_control_entities(
+        self,
+        search: str | None = None,
+        control_type: str | None = None,
+        limit: int = SEARCH_CONTROL_ENTITIES_LIMIT,
+    ) -> HassControlEntitySearchResult:
+        """
+        Search the Home Assistant entities that can be used as a player control.
+
+        Music Assistant's own players are never part of the result. Consecutive searches are
+        served from a short lived cache that an entity registry change drops right away, so a
+        newly added or removed entity shows up immediately, while a device or area rename can
+        lag by up to a minute.
+
+        :param search: Text to match, case insensitively, against the entity ID, the entity
+            name, its device name and its area name. Every whitespace separated word must
+            match one of those fields, though not necessarily the same one. All eligible
+            entities match when omitted.
+        :param control_type: Restrict the result to entities that can serve this control role,
+            given as one of the provider's control config keys (``power_controls``,
+            ``volume_controls`` or ``mute_controls``). All roles are returned when omitted.
+        :param limit: Maximum number of entities (not groups) to return, itself capped at
+            ``SEARCH_CONTROL_ENTITIES_MAX_LIMIT``.
+        :return: The matching entities grouped by the device and area they belong to, ordered
+            by area, device and entity name, plus a flag telling whether matches were left out
+            to honor the limit.
+        """
+        return await self._control_entity_search.search(search, control_type, limit)
 
     async def get_media_player_device_infos(
         self,
@@ -743,8 +805,8 @@ class HomeAssistantProvider(PluginProvider):
             power_controls = cast("list[str]", self.config.get_value(CONF_POWER_CONTROLS))
             mute_controls = cast("list[str]", self.config.get_value(CONF_MUTE_CONTROLS))
             volume_controls = cast("list[str]", self.config.get_value(CONF_VOLUME_CONTROLS))
-            wanted_controls: dict[str, _ControlCapabilities] = {
-                entity_id: _ControlCapabilities(
+            wanted_controls: dict[str, ControlCapabilities] = {
+                entity_id: ControlCapabilities(
                     power=entity_id in power_controls,
                     volume=entity_id in volume_controls,
                     mute=entity_id in mute_controls,
@@ -774,7 +836,7 @@ class HomeAssistantProvider(PluginProvider):
         self,
         entity_id: str,
         hass_state: State | None,
-        capabilities: _ControlCapabilities,
+        capabilities: ControlCapabilities,
     ) -> PlayerControl:
         """
         Return a ready to use PlayerControl for a Home Assistant entity.
@@ -787,7 +849,7 @@ class HomeAssistantProvider(PluginProvider):
         control = PlayerControl(
             id=entity_id,
             provider=self.instance_id,
-            name=_get_control_name(entity_id, hass_state),
+            name=get_control_name(entity_id, hass_state),
         )
         if capabilities.power:
             control.supports_power = True
@@ -940,6 +1002,10 @@ class HomeAssistantProvider(PluginProvider):
 
     async def _disconnect_hass(self) -> None:
         """Stop listening for Home Assistant events and disconnect the client."""
+        if unregister := self._unregister_search_command:
+            self._unregister_search_command = None
+            unregister()
+        self._control_entity_search.close()
         if unsubscribe := self._unsubscribe_controls:
             self._unsubscribe_controls = None
             unsubscribe()
@@ -1091,16 +1157,21 @@ class HomeAssistantProvider(PluginProvider):
             "dict[str, Any]",
             await self.hass.send_command("config/entity_registry/list_for_display"),
         )
-        # the listing repeats a handful of platform names and one device id per device over
-        # all of its entities, so hold on to a single string object per distinct value
+        # the listing repeats a handful of platform names, one device id per device and one
+        # area id per area over all of its entities, so hold on to a single string object
+        # per distinct value
         device_ids: dict[str, str] = {}
+        area_ids: dict[str, str] = {}
         registry: dict[str, HassRegistryEntity] = {}
         for entry in result["entities"]:
             if (device_id := entry.get("di")) is not None:
                 device_id = device_ids.setdefault(device_id, device_id)
+            if (area_id := entry.get("ai")) is not None:
+                area_id = area_ids.setdefault(area_id, area_id)
             registry[entry["ei"]] = HassRegistryEntity(
                 platform=intern(entry["pl"]),
                 device_id=device_id,
+                area_id=area_id,
             )
         return MappingProxyType(registry)
 
@@ -1115,53 +1186,13 @@ class HomeAssistantProvider(PluginProvider):
         # the Device TypedDict; get_device_registry restores the type for callers
         return {device["id"]: device for device in await self.hass.get_device_registry()}
 
-
-def _get_control_capabilities(state: State, logger: logging.Logger) -> _ControlCapabilities:
-    """
-    Return the player control roles the given Home Assistant entity can serve.
-
-    :param state: The current state of the entity to inspect.
-    :param logger: Logger to report an unparsable supported_features attribute on.
-    :return: The supported roles; all False when the entity is unusable as a player control.
-    """
-    entity_platform = state["entity_id"].split(".")[0]
-    if entity_platform in ("switch", "input_boolean"):
-        # simple on/off controls are suitable as power and mute controls
-        return _ControlCapabilities(power=True, mute=True)
-    if entity_platform in ("number", "input_number"):
-        # number and input_number are very similar, both are suitable for volume control
-        return _ControlCapabilities(volume=True)
-    # media player can be used as control, depending on features
-    if entity_platform != "media_player":
-        return _ControlCapabilities()
-    if "mass_player_type" in state["attributes"]:
-        # filter out mass players
-        return _ControlCapabilities()
-    supported_features = parse_supported_features(
-        state["attributes"].get("supported_features"),
-        state["entity_id"],
-        logger,
-    )
-    return _ControlCapabilities(
-        power=(
-            MediaPlayerEntityFeature.TURN_ON in supported_features
-            and MediaPlayerEntityFeature.TURN_OFF in supported_features
-        ),
-        volume=MediaPlayerEntityFeature.VOLUME_SET in supported_features,
-        mute=MediaPlayerEntityFeature.VOLUME_MUTE in supported_features,
-    )
-
-
-def _get_control_name(entity_id: str, state: State | None) -> str:
-    """
-    Return the human readable name to present a Home Assistant entity control under.
-
-    :param entity_id: The entity the control is based on.
-    :param state: The entity's current state, if known.
-    """
-    if state and (friendly_name := state["attributes"].get("friendly_name")):
-        return f"{friendly_name} ({entity_id})"
-    return entity_id
+    @lock
+    @use_cache(expiration=AREA_REGISTRY_CACHE_TTL)
+    async def _fetch_area_registry(self) -> dict[str, Any]:
+        """Fetch the area registry from Home Assistant, keyed by area ID."""
+        # use_cache rebuilds the cached value from this return annotation, which rules out
+        # the Area TypedDict; get_area_registry restores the type for callers
+        return {area["area_id"]: area for area in await self.hass.get_area_registry()}
 
 
 def _affects_mirrored_registry(data: Mapping[str, Any]) -> bool:
@@ -1174,9 +1205,9 @@ def _affects_mirrored_registry(data: Mapping[str, Any]) -> bool:
         # a created or removed entity always enters or leaves the listing
         return True
     # an update reports the fields it touched, so a change that only concerns fields we do
-    # not mirror (a rename, an icon, an area, a label) leaves our listing accurate. an
-    # update can also report no fields at all, as a device rename re-derives a name field
-    # that Home Assistant strips from the report, so treat that as a change of unknown reach
+    # not mirror (a rename, an icon, a label) leaves our listing accurate. an update can also
+    # report no fields at all, as a device rename re-derives a name field that Home Assistant
+    # strips from the report, so treat that as a change of unknown reach
     if not (changes := data.get("changes")):
         return True
     return not REGISTRY_FIELDS_AFFECTING_MIRROR.isdisjoint(changes)

--- a/music_assistant/providers/hass/constants.py
+++ b/music_assistant/providers/hass/constants.py
@@ -10,6 +10,13 @@ from music_assistant_models.enums import PlaybackState
 if TYPE_CHECKING:
     import logging
 
+CONF_POWER_CONTROLS = "power_controls"
+CONF_MUTE_CONTROLS = "mute_controls"
+CONF_VOLUME_CONTROLS = "volume_controls"
+
+# Home Assistant entity domains Music Assistant can offer as player controls.
+CONTROL_DOMAINS = ("media_player", "switch", "input_boolean", "number", "input_number")
+
 
 class MediaPlayerEntityFeature(IntFlag):
     """Supported features of the media player entity."""

--- a/music_assistant/providers/hass/control_entities.py
+++ b/music_assistant/providers/hass/control_entities.py
@@ -1,0 +1,310 @@
+"""Searchable listing of the Home Assistant entities that can act as a player control."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING, Final, NamedTuple, TypedDict
+
+from music_assistant_models.errors import InvalidDataError, ProviderUnavailableError
+
+from .constants import (
+    CONF_MUTE_CONTROLS,
+    CONF_POWER_CONTROLS,
+    CONF_VOLUME_CONTROLS,
+    CONTROL_DOMAINS,
+)
+from .helpers import get_control_capabilities
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from . import HomeAssistantProvider
+
+SEARCH_CONTROL_ENTITIES_LIMIT = 50
+# Ceiling on what a caller may raise the limit to, so a large Home Assistant setup can never
+# be asked for a response big enough to hurt, however the search is called.
+SEARCH_CONTROL_ENTITIES_MAX_LIMIT = 500
+# How long a search may reuse the control entity candidates of an earlier search. Resolving
+# them takes a full state sweep of Home Assistant, so a picker that searches while the user
+# types would otherwise sweep on every keystroke. The candidates carry entity, device and
+# area names plus control capabilities - none of which change often, and none of which is
+# live entity state - so briefly serving a stale listing is harmless. Which entities exist
+# at all is pinned to the entity registry instead of to this window, so an entity that
+# appears or disappears is picked up right away.
+CONTROL_ENTITY_CACHE_TTL = 30
+
+# The entity domains worth inspecting for each control role. A superset is harmless: the
+# authoritative verdict comes from get_control_capabilities on the entity's own state,
+# this only keeps the state sweep of a search away from domains that can never qualify.
+CONTROL_TYPE_DOMAINS: Final[dict[str, tuple[str, ...]]] = {
+    CONF_POWER_CONTROLS: ("media_player", "switch", "input_boolean"),
+    CONF_VOLUME_CONTROLS: ("media_player", "number", "input_number"),
+    CONF_MUTE_CONTROLS: ("media_player", "switch", "input_boolean"),
+}
+
+
+class HassControlEntity(TypedDict):
+    """A Home Assistant entity that can be used as a player control."""
+
+    entity_id: str
+    # the entity's friendly name, falling back to its entity ID when it has none
+    name: str
+    power: bool
+    volume: bool
+    mute: bool
+
+
+# Selects the entities that can serve each control role.
+CONTROL_TYPE_CAPABILITIES: Final[dict[str, Callable[[HassControlEntity], bool]]] = {
+    CONF_POWER_CONTROLS: lambda entity: entity["power"],
+    CONF_VOLUME_CONTROLS: lambda entity: entity["volume"],
+    CONF_MUTE_CONTROLS: lambda entity: entity["mute"],
+}
+
+
+class HassControlEntityGroup(TypedDict):
+    """
+    The control entities that share a device and an area.
+
+    A device holding entities that sit in different areas is reported as one group per area,
+    since Home Assistant lets an entity override the area it would inherit from its device.
+    Entities without a device are grouped by area alone.
+    """
+
+    device_id: str | None
+    # None for entities that belong to no device, respectively to no area
+    device_name: str | None
+    area_name: str | None
+    entities: list[HassControlEntity]
+
+
+class HassControlEntitySearchResult(TypedDict):
+    """The outcome of a player control entity search."""
+
+    groups: list[HassControlEntityGroup]
+    # True when matches were left out to honor the requested limit
+    truncated: bool
+
+
+class ControlEntitySearch:
+    """Searchable view on the Home Assistant entities that can act as a player control."""
+
+    def __init__(self, provider: HomeAssistantProvider) -> None:
+        """
+        Initialize the search.
+
+        :param provider: The Home Assistant provider to read the registries and states from;
+            its client must be connected before the first search.
+        """
+        self._provider = provider
+        self._lock = asyncio.Lock()
+        self._entries: dict[tuple[str, ...], _CandidateCacheEntry] = {}
+        self._closed = False
+
+    async def search(
+        self,
+        search: str | None = None,
+        control_type: str | None = None,
+        limit: int = SEARCH_CONTROL_ENTITIES_LIMIT,
+    ) -> HassControlEntitySearchResult:
+        """
+        Search the Home Assistant entities that can be used as a player control.
+
+        Music Assistant's own players are never part of the result. Consecutive searches are
+        served from a short lived cache that an entity registry change drops right away, so a
+        newly added or removed entity shows up immediately, while a device or area rename can
+        lag by up to a minute.
+
+        :param search: Text to match, case insensitively, against the entity ID, the entity
+            name, its device name and its area name. Every whitespace separated word must
+            match one of those fields, though not necessarily the same one. All eligible
+            entities match when omitted.
+        :param control_type: Restrict the result to entities that can serve this control role,
+            given as one of the provider's control config keys (``power_controls``,
+            ``volume_controls`` or ``mute_controls``). All roles are returned when omitted.
+        :param limit: Maximum number of entities (not groups) to return, itself capped at
+            ``SEARCH_CONTROL_ENTITIES_MAX_LIMIT``.
+        :return: The matching entities grouped by the device and area they belong to, ordered
+            by area, device and entity name, plus a flag telling whether matches were left out
+            to honor the limit.
+        :raises InvalidDataError: When the control type is unknown or the limit is below one.
+        :raises ProviderUnavailableError: When the provider is no longer loaded.
+        """
+        self._check_open()
+        if control_type is not None and control_type not in CONTROL_TYPE_DOMAINS:
+            msg = f"Invalid control type: {control_type}"
+            raise InvalidDataError(msg)
+        if limit < 1:
+            msg = f"Invalid limit: {limit}"
+            raise InvalidDataError(msg)
+        limit = min(limit, SEARCH_CONTROL_ENTITIES_MAX_LIMIT)
+        domains = CONTROL_DOMAINS if control_type is None else CONTROL_TYPE_DOMAINS[control_type]
+        matches = await self._get_candidates(domains)
+        if control_type is not None:
+            has_capability = CONTROL_TYPE_CAPABILITIES[control_type]
+            matches = [match for match in matches if has_capability(match.entity)]
+        if tokens := (search or "").casefold().split():
+            matches = [match for match in matches if match.matches(tokens)]
+        groups: dict[tuple[str | None, str | None], HassControlEntityGroup] = {}
+        for match in matches[:limit]:
+            group_key = (match.device_id, match.area_id)
+            if (group := groups.get(group_key)) is None:
+                group = HassControlEntityGroup(
+                    device_id=match.device_id,
+                    device_name=match.device_name,
+                    area_name=match.area_name,
+                    entities=[],
+                )
+                groups[group_key] = group
+            # the candidates outlive this response, so hand out a copy a caller may mutate
+            group["entities"].append(match.entity.copy())
+        return HassControlEntitySearchResult(
+            groups=list(groups.values()), truncated=len(matches) > limit
+        )
+
+    def close(self) -> None:
+        """Drop everything cached and refuse any further search."""
+        self._closed = True
+        self._entries.clear()
+
+    async def _get_candidates(self, domains: tuple[str, ...]) -> list[_ControlEntityMatch]:
+        """
+        Return the player control candidates found in the given entity domains.
+
+        :param domains: The entity domains to consider.
+        """
+        if (matches := self._lookup(domains)) is not None:
+            return matches
+        async with self._lock:
+            # a concurrent search may have resolved the same domains while this one waited
+            if (matches := self._lookup(domains)) is not None:
+                return matches
+            generation = self._generation()
+            matches = await self._resolve(domains)
+            # candidates resolved against a registry that changed while the sweep was in
+            # flight are stale on arrival, and a provider that unloaded meanwhile must not
+            # see its cache refilled: serve this caller either way, but do not store
+            if not self._closed and generation == self._generation():
+                self._entries[domains] = _CandidateCacheEntry(
+                    expires_at=time.monotonic() + CONTROL_ENTITY_CACHE_TTL,
+                    generation=generation,
+                    matches=matches,
+                )
+            return matches
+
+    async def _resolve(self, domains: tuple[str, ...]) -> list[_ControlEntityMatch]:
+        """
+        Return the entities of the given domains that can serve as a player control.
+
+        :param domains: The entity domains to consider.
+        :return: The candidates in presentation order, each carrying every control role it
+            can serve plus the device and area it belongs to.
+        """
+        entity_registry = await self._provider.get_entity_registry()
+        devices = await self._provider.get_device_registry()
+        areas = await self._provider.get_area_registry()
+        states = await self._provider.get_states(domains=domains)
+        self._check_open()
+        matches: list[_ControlEntityMatch] = []
+        for state in states:
+            capabilities = get_control_capabilities(state, self._provider.logger)
+            if not any(capabilities):
+                continue
+            entity_id = state["entity_id"]
+            registry_entry = entity_registry.get(entity_id)
+            device_id = registry_entry.device_id if registry_entry else None
+            device = devices.get(device_id) if device_id else None
+            # Home Assistant lets an entity override the area it inherits from its device
+            area_id = (registry_entry.area_id if registry_entry else None) or (
+                device["area_id"] if device else None
+            )
+            area = areas.get(area_id or "")
+            name = state["attributes"].get("friendly_name") or entity_id
+            device_name = (device["name_by_user"] or device["name"]) if device else None
+            area_name = area["name"] if area else None
+            matches.append(
+                _ControlEntityMatch(
+                    device_id=device_id,
+                    device_name=device_name,
+                    area_id=area_id,
+                    area_name=area_name,
+                    entity=HassControlEntity(
+                        entity_id=entity_id,
+                        name=name,
+                        power=capabilities.power,
+                        volume=capabilities.volume,
+                        mute=capabilities.mute,
+                    ),
+                    search_text="\n".join(
+                        field.casefold()
+                        for field in (entity_id, name, device_name, area_name)
+                        if field
+                    ),
+                )
+            )
+        matches.sort(key=lambda match: match.sort_key)
+        return matches
+
+    def _lookup(self, domains: tuple[str, ...]) -> list[_ControlEntityMatch] | None:
+        """Return the cached candidates of the given domains, None when there are none left."""
+        if (entry := self._entries.get(domains)) is None:
+            return None
+        if entry.generation != self._generation() or entry.expires_at <= time.monotonic():
+            del self._entries[domains]
+            return None
+        return entry.matches
+
+    def _generation(self) -> int:
+        """Return the generation of the entity registry the candidates are resolved against."""
+        # the device and area registries carry no such marker, and the provider already
+        # holds them behind a window of their own that outlives the candidates, so the
+        # entity registry is the only input a fresher sweep could actually improve on
+        return self._provider.entity_registry_generation
+
+    def _check_open(self) -> None:
+        """Raise when the provider this search belongs to is no longer loaded."""
+        if self._closed:
+            msg = "The Home Assistant provider is no longer loaded"
+            raise ProviderUnavailableError(msg)
+
+
+class _ControlEntityMatch(NamedTuple):
+    """A control entity together with the device and area it is presented under."""
+
+    device_id: str | None
+    device_name: str | None
+    area_id: str | None
+    area_name: str | None
+    entity: HassControlEntity
+    # all searchable fields, case folded and joined on a newline. a search token can never
+    # contain whitespace, so a token found in here always sits within a single field
+    search_text: str
+
+    @property
+    def sort_key(self) -> tuple[bool, str, bool, str, str, str]:
+        """Return the ranking key, placing entities without an area or device last."""
+        return (
+            self.area_name is None,
+            (self.area_name or "").casefold(),
+            self.device_name is None,
+            (self.device_name or "").casefold(),
+            self.entity["name"].casefold(),
+            self.entity["entity_id"],
+        )
+
+    def matches(self, tokens: list[str]) -> bool:
+        """
+        Return whether every search token occurs in one of the searchable fields.
+
+        :param tokens: The case folded search tokens.
+        """
+        return all(token in self.search_text for token in tokens)
+
+
+class _CandidateCacheEntry(NamedTuple):
+    """Cached control entity candidates together with what makes them go stale."""
+
+    expires_at: float
+    generation: int
+    matches: list[_ControlEntityMatch]

--- a/music_assistant/providers/hass/helpers.py
+++ b/music_assistant/providers/hass/helpers.py
@@ -1,0 +1,68 @@
+"""Helpers for interpreting Home Assistant entities as player controls."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple
+
+from .constants import MediaPlayerEntityFeature, parse_supported_features
+
+if TYPE_CHECKING:
+    import logging
+
+    from hass_client.models import State
+
+
+class ControlCapabilities(NamedTuple):
+    """The player control roles a Home Assistant entity can serve."""
+
+    power: bool = False
+    volume: bool = False
+    mute: bool = False
+
+
+def get_control_capabilities(state: State, logger: logging.Logger) -> ControlCapabilities:
+    """
+    Return the player control roles the given Home Assistant entity can serve.
+
+    :param state: The current state of the entity to inspect.
+    :param logger: Logger to report an unparsable supported_features attribute on.
+    :return: The supported roles; all False when the entity is unusable as a player control.
+    """
+    entity_platform = state["entity_id"].split(".")[0]
+    if entity_platform in ("switch", "input_boolean"):
+        # simple on/off controls are suitable as power and mute controls
+        return ControlCapabilities(power=True, mute=True)
+    if entity_platform in ("number", "input_number"):
+        # number and input_number are very similar, both are suitable for volume control
+        return ControlCapabilities(volume=True)
+    # media player can be used as control, depending on features
+    if entity_platform != "media_player":
+        return ControlCapabilities()
+    if "mass_player_type" in state["attributes"]:
+        # filter out mass players
+        return ControlCapabilities()
+    supported_features = parse_supported_features(
+        state["attributes"].get("supported_features"),
+        state["entity_id"],
+        logger,
+    )
+    return ControlCapabilities(
+        power=(
+            MediaPlayerEntityFeature.TURN_ON in supported_features
+            and MediaPlayerEntityFeature.TURN_OFF in supported_features
+        ),
+        volume=MediaPlayerEntityFeature.VOLUME_SET in supported_features,
+        mute=MediaPlayerEntityFeature.VOLUME_MUTE in supported_features,
+    )
+
+
+def get_control_name(entity_id: str, state: State | None) -> str:
+    """
+    Return the human readable name to present a Home Assistant entity control under.
+
+    :param entity_id: The entity the control is based on.
+    :param state: The entity's current state, if known.
+    """
+    if state and (friendly_name := state["attributes"].get("friendly_name")):
+        return f"{friendly_name} ({entity_id})"
+    return entity_id

--- a/tests/providers/hass/test_control_entity_search.py
+++ b/tests/providers/hass/test_control_entity_search.py
@@ -1,0 +1,612 @@
+"""Tests for the Home Assistant player control entity search."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from music_assistant_models.auth import Scope
+from music_assistant_models.errors import InvalidDataError, ProviderUnavailableError
+
+from music_assistant.constants import CONF_LOG_LEVEL
+from music_assistant.helpers.api import APICommandHandler
+from music_assistant.providers.hass import (
+    CONF_AUTH_TOKEN,
+    CONF_URL,
+    CONF_VERIFY_SSL,
+    SEARCH_CONTROL_ENTITIES_COMMAND,
+    HomeAssistantProvider,
+    setup,
+)
+from music_assistant.providers.hass.constants import (
+    CONF_MUTE_CONTROLS,
+    CONF_POWER_CONTROLS,
+    CONF_VOLUME_CONTROLS,
+    CONTROL_DOMAINS,
+    MediaPlayerEntityFeature,
+)
+from music_assistant.providers.hass.control_entities import (
+    CONTROL_TYPE_CAPABILITIES,
+    CONTROL_TYPE_DOMAINS,
+    HassControlEntity,
+    HassControlEntityGroup,
+    HassControlEntitySearchResult,
+)
+from music_assistant.providers.hass.helpers import get_control_capabilities
+from tests.common import use_real_create_task
+
+if TYPE_CHECKING:
+    from hass_client.models import State
+
+REGISTRY_LIST_COMMAND = "config/entity_registry/list_for_display"
+
+FULL_MEDIA_PLAYER_FEATURES = int(
+    MediaPlayerEntityFeature.TURN_ON
+    | MediaPlayerEntityFeature.TURN_OFF
+    | MediaPlayerEntityFeature.VOLUME_SET
+    | MediaPlayerEntityFeature.VOLUME_MUTE
+)
+
+AREAS: list[dict[str, Any]] = [
+    {"area_id": "area_living", "name": "Living Room", "aliases": [], "picture": None},
+    {"area_id": "area_kitchen", "name": "Kitchen", "aliases": [], "picture": None},
+    {"area_id": "area_office", "name": "Office", "aliases": [], "picture": None},
+]
+
+DEVICES: list[dict[str, Any]] = [
+    {"id": "dev_living", "name": "Living Room Amp", "name_by_user": None, "area_id": "area_living"},
+    {
+        "id": "dev_kitchen",
+        "name": "Speaker",
+        "name_by_user": "Kitchen Speaker",
+        "area_id": "area_kitchen",
+    },
+    {"id": "dev_attic", "name": "Attic Box", "name_by_user": None, "area_id": None},
+]
+
+# entity_id -> (device_id, area_id override, friendly_name, extra state attributes)
+ENTITIES: dict[str, tuple[str | None, str | None, str, dict[str, Any]]] = {
+    "media_player.living_amp": (
+        "dev_living",
+        None,
+        "Amplifier",
+        {"supported_features": FULL_MEDIA_PLAYER_FEATURES},
+    ),
+    "media_player.mass_player": (
+        "dev_living",
+        None,
+        "MA Player",
+        {"supported_features": FULL_MEDIA_PLAYER_FEATURES, "mass_player_type": "player"},
+    ),
+    "media_player.featureless": (None, None, "Featureless Player", {"supported_features": 0}),
+    "switch.kitchen_power": ("dev_kitchen", None, "Kitchen Power", {}),
+    "number.kitchen_volume": ("dev_kitchen", "area_office", "Kitchen Volume", {}),
+    "input_boolean.standalone": (None, "area_living", "Standalone Toggle", {}),
+    "input_number.attic_volume": ("dev_attic", None, "Attic Volume", {}),
+    # not a control domain at all, so it must never surface
+    "light.hallway": (None, "area_living", "Hallway Light", {}),
+}
+
+
+class _Cache:
+    """Provide the slice of the cache controller that @use_cache relies on."""
+
+    def __init__(self) -> None:
+        self.entries: dict[str, Any] = {}
+
+    async def get_with_freshness(self, key: str, **kwargs: Any) -> tuple[Any, bool, bool]:
+        """Return the (data, is_fresh, found) triplet for the given key."""
+        # the real controller reads the cache database here, so yield like it does:
+        # @use_cache stores in the background, and only a yield lets that store land
+        await asyncio.sleep(0)
+        if key not in self.entries:
+            return None, False, False
+        return self.entries[key], True, True
+
+    async def set(self, key: str, data: Any, **kwargs: Any) -> None:
+        """Store data under the given key."""
+        self.entries[key] = data
+
+
+class _HomeAssistantClient:
+    """Serve the registries and states of a small Home Assistant install."""
+
+    def __init__(self) -> None:
+        self.connected = False
+        self.listener_started = asyncio.Event()
+        # entity_ids per subscribe_entities call, in call order
+        self.state_requests: list[list[str]] = []
+        self.registry_list_calls = 0
+        self.device_registry_calls = 0
+        self.area_registry_calls = 0
+        self.event_subscriptions: list[tuple[str, Callable[[dict[str, Any]], None]]] = []
+        self.send_command = AsyncMock(side_effect=self._send_command)
+
+    async def connect(self) -> None:
+        """Connect the client."""
+        self.connected = True
+
+    async def start_listening(self) -> None:
+        """Listen until the provider stops the listener task."""
+        self.listener_started.set()
+        await asyncio.Event().wait()
+
+    async def disconnect(self) -> None:
+        """Disconnect the client."""
+        self.connected = False
+
+    async def get_device_registry(self) -> list[dict[str, Any]]:
+        """Return the device registry listing."""
+        self.device_registry_calls += 1
+        return DEVICES
+
+    async def get_area_registry(self) -> list[dict[str, Any]]:
+        """Return the area registry listing."""
+        self.area_registry_calls += 1
+        return AREAS
+
+    async def subscribe_entities(
+        self, cb_func: Callable[[dict[str, Any]], None], entity_ids: list[str]
+    ) -> Callable[[], None]:
+        """Deliver the requested states and return the unsubscribe callable."""
+        self.state_requests.append(list(entity_ids))
+        initial = {
+            entity_id: {"s": "idle", "a": _attributes(entity_id)}
+            for entity_id in entity_ids
+            if entity_id in ENTITIES
+        }
+        asyncio.get_running_loop().call_soon(cb_func, {"a": initial})
+        return lambda: None
+
+    async def subscribe_events(
+        self, cb_func: Callable[[dict[str, Any]], None], event_type: str
+    ) -> Callable[[], None]:
+        """Register the event callback after command responses can be received."""
+        await self.listener_started.wait()
+        self.event_subscriptions.append((event_type, cb_func))
+        return lambda: None
+
+    def fire_event(self, event_type: str, data: dict[str, Any]) -> None:
+        """Deliver an event to every subscriber of the given event type."""
+        for subscribed_type, cb_func in self.event_subscriptions:
+            if subscribed_type == event_type:
+                cb_func({"event_type": event_type, "data": data})
+
+    async def _send_command(self, command: str, **kwargs: Any) -> Any:
+        """Return the response Home Assistant sends for the given websocket command."""
+        if command != REGISTRY_LIST_COMMAND:
+            return {}
+        await self.listener_started.wait()
+        self.registry_list_calls += 1
+        return {
+            "entity_categories": {},
+            "entities": [
+                {"ei": entity_id, "pl": "test", "di": device_id, "ai": area_id}
+                for entity_id, (device_id, area_id, _, _) in ENTITIES.items()
+            ],
+        }
+
+
+def _config() -> MagicMock:
+    """Return a provider config exposing the persisted values via get_value."""
+    persisted_values: dict[str, Any] = {
+        CONF_URL: "http://homeassistant.local:8123",
+        CONF_AUTH_TOKEN: "token",
+        CONF_VERIFY_SSL: True,
+        CONF_LOG_LEVEL: "GLOBAL",
+        CONF_POWER_CONTROLS: [],
+        CONF_MUTE_CONTROLS: [],
+        CONF_VOLUME_CONTROLS: [],
+    }
+    config = MagicMock()
+    config.instance_id = "hass--test"
+    config.name = "Home Assistant"
+    config.get_value.side_effect = persisted_values.get
+    config.values = {}
+    return config
+
+
+def _mass() -> MagicMock:
+    """Return the Music Assistant dependencies used during provider startup."""
+    mass = MagicMock()
+    mass.cache = _Cache()
+    mass.http_session = MagicMock()
+    mass.http_session_no_ssl = MagicMock()
+    use_real_create_task(mass)
+    mass.players.register_or_update_player_control = AsyncMock()
+    mass.config.get = MagicMock(return_value={})
+    mass.config.get_raw_provider_config_value = MagicMock(return_value=None)
+    return mass
+
+
+def _attributes(entity_id: str) -> dict[str, Any]:
+    """Return the state attributes of the given entity."""
+    _, _, friendly_name, extra = ENTITIES[entity_id]
+    return {"friendly_name": friendly_name, **extra}
+
+
+def _entity_ids(groups: list[HassControlEntityGroup]) -> list[str]:
+    """Return the entity IDs of all groups, in result order."""
+    return [entity["entity_id"] for group in groups for entity in group["entities"]]
+
+
+@asynccontextmanager
+async def _start_provider() -> AsyncIterator[tuple[HomeAssistantProvider, _HomeAssistantClient]]:
+    """Start the provider with a connected mocked Home Assistant client."""
+    hass = _HomeAssistantClient()
+    manifest = MagicMock()
+    manifest.domain = "hass"
+    manifest.name = "Home Assistant"
+    with patch("music_assistant.providers.hass.HomeAssistantClient", return_value=hass):
+        provider = await setup(_mass(), manifest, _config())
+        assert isinstance(provider, HomeAssistantProvider)
+        async with asyncio.timeout(5):
+            await provider.handle_async_init()
+    try:
+        yield provider, hass
+    finally:
+        await provider.unload()
+
+
+async def test_search_command_is_exposed_on_the_api() -> None:
+    """Expose the search as a read-only API command for as long as the provider is loaded."""
+    async with _start_provider() as (provider, _):
+        mass = cast("MagicMock", provider.mass)
+        unregister = mass.register_api_command.return_value
+        mass.register_api_command.assert_called_once_with(
+            SEARCH_CONTROL_ENTITIES_COMMAND,
+            provider.search_control_entities,
+            required_scope=Scope.CONFIG_PROVIDERS_READ,
+        )
+        # the API layer must be able to resolve the command's signature and result type
+        handler = APICommandHandler.parse(
+            SEARCH_CONTROL_ENTITIES_COMMAND, provider.search_control_entities
+        )
+        assert handler.type_hints["return"] is HassControlEntitySearchResult
+        unregister.assert_not_called()
+
+    unregister.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("search", "expected"),
+    [
+        # entity id
+        ("kitchen_power", ["switch.kitchen_power"]),
+        # friendly name
+        ("amplifier", ["media_player.living_amp"]),
+        # device name (name_by_user wins over name)
+        ("kitchen speaker", ["switch.kitchen_power", "number.kitchen_volume"]),
+        # area name, inherited from the device
+        ("living room", ["media_player.living_amp", "input_boolean.standalone"]),
+        # area name of an entity that overrides its device's area
+        ("office", ["number.kitchen_volume"]),
+    ],
+)
+async def test_search_matches_every_searchable_field(search: str, expected: list[str]) -> None:
+    """Match the search text against entity ID, entity name, device name and area name."""
+    async with _start_provider() as (provider, _):
+        result = await provider.search_control_entities(search=search)
+
+    assert sorted(_entity_ids(result["groups"])) == sorted(expected)
+    assert result["truncated"] is False
+
+
+async def test_search_is_case_insensitive() -> None:
+    """Match regardless of the casing of the search text."""
+    async with _start_provider() as (provider, _):
+        result = await provider.search_control_entities(search="AMPLIFIER")
+
+    assert _entity_ids(result["groups"]) == ["media_player.living_amp"]
+
+
+@pytest.mark.parametrize(
+    ("search", "expected"),
+    [
+        # surrounding whitespace is not part of any field
+        ("  kitchen  ", ["switch.kitchen_power", "number.kitchen_volume"]),
+        # the words may match different fields: entity name and area name here
+        ("kitchen office", ["number.kitchen_volume"]),
+        # every word has to match something
+        ("kitchen hallway", []),
+    ],
+)
+async def test_search_matches_every_word_separately(search: str, expected: list[str]) -> None:
+    """Require each word of the search text to match a field, not the text as a whole."""
+    async with _start_provider() as (provider, _):
+        result = await provider.search_control_entities(search=search)
+
+    assert sorted(_entity_ids(result["groups"])) == sorted(expected)
+
+
+async def test_search_without_text_returns_all_eligible_entities() -> None:
+    """Return every entity that can serve a control role when no search text is given."""
+    async with _start_provider() as (provider, _):
+        result = await provider.search_control_entities()
+
+    assert sorted(_entity_ids(result["groups"])) == [
+        "input_boolean.standalone",
+        "input_number.attic_volume",
+        "media_player.living_amp",
+        "number.kitchen_volume",
+        "switch.kitchen_power",
+    ]
+
+
+async def test_search_excludes_music_assistant_players() -> None:
+    """Never offer Music Assistant's own exposed players as a control."""
+    async with _start_provider() as (provider, _):
+        result = await provider.search_control_entities(search="player")
+
+    assert "media_player.mass_player" not in _entity_ids(result["groups"])
+    # the entity without any usable feature is left out too
+    assert "media_player.featureless" not in _entity_ids(result["groups"])
+
+
+async def test_control_type_filters_on_capability() -> None:
+    """Return only the entities that can serve the requested control role."""
+    async with _start_provider() as (provider, hass):
+        hass.state_requests.clear()
+        volume = await provider.search_control_entities(control_type=CONF_VOLUME_CONTROLS)
+        volume_requests = [entity_id for request in hass.state_requests for entity_id in request]
+        power = await provider.search_control_entities(control_type=CONF_POWER_CONTROLS)
+        mute = await provider.search_control_entities(control_type=CONF_MUTE_CONTROLS)
+
+    assert sorted(_entity_ids(volume["groups"])) == [
+        "input_number.attic_volume",
+        "media_player.living_amp",
+        "number.kitchen_volume",
+    ]
+    assert sorted(_entity_ids(power["groups"])) == [
+        "input_boolean.standalone",
+        "media_player.living_amp",
+        "switch.kitchen_power",
+    ]
+    assert sorted(_entity_ids(mute["groups"])) == [
+        "input_boolean.standalone",
+        "media_player.living_amp",
+        "switch.kitchen_power",
+    ]
+    # a volume search must not sweep the states of the on/off-only domains
+    assert volume_requests == [
+        "input_number.attic_volume",
+        "media_player.featureless",
+        "media_player.living_amp",
+        "media_player.mass_player",
+        "number.kitchen_volume",
+    ]
+
+
+def test_control_type_domains_cover_every_qualifying_domain() -> None:
+    """Keep the per-role domain narrowing a superset of what can qualify for that role."""
+    logger = logging.getLogger("test.hass")
+    for control_type, domains in CONTROL_TYPE_DOMAINS.items():
+        assert set(domains) <= set(CONTROL_DOMAINS)
+        has_capability = CONTROL_TYPE_CAPABILITIES[control_type]
+        for domain in CONTROL_DOMAINS:
+            # the most capable entity the domain can hold, so no role is missed
+            state = cast(
+                "State",
+                {
+                    "entity_id": f"{domain}.probe",
+                    "attributes": {"supported_features": FULL_MEDIA_PLAYER_FEATURES},
+                },
+            )
+            capabilities = get_control_capabilities(state, logger)
+            entity = cast(
+                "HassControlEntity",
+                {"entity_id": state["entity_id"], "name": "", **capabilities._asdict()},
+            )
+            if has_capability(entity):
+                assert domain in domains, f"{domain} can serve {control_type} but is not swept"
+
+
+async def test_control_type_reports_every_supported_role() -> None:
+    """Report all roles an entity can serve, not just the one that was searched for."""
+    async with _start_provider() as (provider, _):
+        result = await provider.search_control_entities(
+            search="kitchen_power", control_type=CONF_POWER_CONTROLS
+        )
+
+    entity = result["groups"][0]["entities"][0]
+    assert (entity["power"], entity["volume"], entity["mute"]) == (True, False, True)
+
+
+async def test_unknown_control_type_is_rejected() -> None:
+    """Reject a control type that does not exist instead of returning everything."""
+    async with _start_provider() as (provider, _):
+        with pytest.raises(InvalidDataError, match="Invalid control type"):
+            await provider.search_control_entities(control_type="brightness_controls")
+
+
+@pytest.mark.parametrize("limit", [0, -1])
+async def test_limit_below_one_is_rejected(limit: int) -> None:
+    """Reject a limit that can never yield a result instead of returning nothing."""
+    async with _start_provider() as (provider, _):
+        with pytest.raises(InvalidDataError, match="Invalid limit"):
+            await provider.search_control_entities(limit=limit)
+
+
+async def test_results_are_grouped_by_device_and_area() -> None:
+    """Group the entities by device and effective area, ordered by area, device and name."""
+    async with _start_provider() as (provider, _):
+        result = await provider.search_control_entities()
+
+    assert [
+        (group["device_id"], group["device_name"], group["area_name"], _entity_ids([group]))
+        for group in result["groups"]
+    ] == [
+        ("dev_kitchen", "Kitchen Speaker", "Kitchen", ["switch.kitchen_power"]),
+        # the entity inherits the area of its device
+        ("dev_living", "Living Room Amp", "Living Room", ["media_player.living_amp"]),
+        # an entity without a device falls back to a group of its own area
+        (None, None, "Living Room", ["input_boolean.standalone"]),
+        # the entity overrides the area it would inherit from its (Kitchen) device
+        ("dev_kitchen", "Kitchen Speaker", "Office", ["number.kitchen_volume"]),
+        # a device without an area sorts last
+        ("dev_attic", "Attic Box", None, ["input_number.attic_volume"]),
+    ]
+
+
+async def test_limit_caps_entities_and_reports_truncation() -> None:
+    """Cap the number of entities and tell the caller that matches were left out."""
+    async with _start_provider() as (provider, _):
+        limited = await provider.search_control_entities(limit=2)
+        exact = await provider.search_control_entities(limit=5)
+
+    assert _entity_ids(limited["groups"]) == ["switch.kitchen_power", "media_player.living_amp"]
+    assert limited["truncated"] is True
+    assert len(_entity_ids(exact["groups"])) == 5
+    assert exact["truncated"] is False
+
+
+async def test_limit_cannot_be_raised_past_the_maximum() -> None:
+    """Cap what a caller can ask for, so no search can return an oversized response."""
+    with patch(
+        "music_assistant.providers.hass.control_entities.SEARCH_CONTROL_ENTITIES_MAX_LIMIT", 2
+    ):
+        async with _start_provider() as (provider, _):
+            result = await provider.search_control_entities(limit=1000)
+
+    assert _entity_ids(result["groups"]) == ["switch.kitchen_power", "media_player.living_amp"]
+    assert result["truncated"] is True
+
+
+async def test_result_does_not_alias_the_cached_candidates() -> None:
+    """Keep a caller that edits the response from corrupting what the next search sees."""
+    async with _start_provider() as (provider, _):
+        first = await provider.search_control_entities(search="kitchen_power")
+        first["groups"][0]["entities"][0]["name"] = "Mutated"
+        second = await provider.search_control_entities(search="kitchen_power")
+
+    assert second["groups"][0]["entities"][0]["name"] == "Kitchen Power"
+
+
+async def test_consecutive_searches_share_one_state_sweep() -> None:
+    """Sweep the Home Assistant states once and serve the next search from the cache."""
+    async with _start_provider() as (provider, hass):
+        hass.state_requests.clear()
+        await provider.search_control_entities(search="living")
+        await provider.search_control_entities(search="living room")
+        sweeps = len(hass.state_requests)
+
+    assert sweeps == 1
+
+
+async def test_concurrent_searches_share_one_state_sweep() -> None:
+    """Let searches that arrive together wait for a single state sweep."""
+    async with _start_provider() as (provider, hass):
+        hass.state_requests.clear()
+        results = await asyncio.gather(
+            provider.search_control_entities(search="kitchen"),
+            provider.search_control_entities(search="living"),
+        )
+        sweeps = len(hass.state_requests)
+
+    assert sweeps == 1
+    assert _entity_ids(results[0]["groups"]) == [
+        "switch.kitchen_power",
+        "number.kitchen_volume",
+    ]
+
+
+async def test_power_and_mute_searches_share_one_state_sweep() -> None:
+    """Reuse one sweep for the control roles that live in the same entity domains."""
+    async with _start_provider() as (provider, hass):
+        hass.state_requests.clear()
+        await provider.search_control_entities(control_type=CONF_POWER_CONTROLS)
+        await provider.search_control_entities(control_type=CONF_MUTE_CONTROLS)
+        after_power_and_mute = len(hass.state_requests)
+        await provider.search_control_entities(control_type=CONF_VOLUME_CONTROLS)
+        after_volume = len(hass.state_requests)
+
+    assert after_power_and_mute == 1
+    # the volume roles live in other domains, so they need a sweep of their own
+    assert after_volume == 2
+
+
+async def test_entity_registry_change_forces_a_fresh_state_sweep() -> None:
+    """Sweep again after Home Assistant reports an entity registry change."""
+    async with _start_provider() as (provider, hass):
+        hass.state_requests.clear()
+        await provider.search_control_entities()
+        hass.fire_event(
+            "entity_registry_updated",
+            {"action": "update", "entity_id": "media_player.living_amp"},
+        )
+        await provider.search_control_entities()
+        sweeps = len(hass.state_requests)
+
+    assert sweeps == 2
+
+
+async def test_cached_candidates_expire() -> None:
+    """Sweep again once the cached candidates have outlived their TTL."""
+    with patch("music_assistant.providers.hass.control_entities.CONTROL_ENTITY_CACHE_TTL", 0):
+        async with _start_provider() as (provider, hass):
+            hass.state_requests.clear()
+            await provider.search_control_entities()
+            await provider.search_control_entities()
+            sweeps = len(hass.state_requests)
+
+    assert sweeps == 2
+
+
+async def test_search_reuses_the_cached_registries() -> None:
+    """Consult Home Assistant for the registries once and reuse them on the next search."""
+    async with _start_provider() as (provider, hass):
+        registry_calls_after_startup = hass.registry_list_calls
+        await provider.search_control_entities()
+        after_first = (
+            hass.registry_list_calls,
+            hass.device_registry_calls,
+            hass.area_registry_calls,
+        )
+        await provider.search_control_entities(search="kitchen")
+        after_second = (
+            hass.registry_list_calls,
+            hass.device_registry_calls,
+            hass.area_registry_calls,
+        )
+
+    assert registry_calls_after_startup == 1
+    assert after_first == (1, 1, 1)
+    assert after_second == (1, 1, 1)
+
+
+async def test_search_is_refused_once_the_provider_unloaded() -> None:
+    """Refuse a search that arrives after the provider was unloaded."""
+    async with _start_provider() as (provider, _):
+        await provider.search_control_entities()
+
+    with pytest.raises(ProviderUnavailableError):
+        await provider.search_control_entities()
+
+
+async def test_search_in_flight_during_unload_leaves_no_cache_behind() -> None:
+    """Refuse a search that was suspended over the unload instead of refilling its cache."""
+    entered_sweep = asyncio.Event()
+    release_sweep = asyncio.Event()
+
+    async with _start_provider() as (provider, _):
+        original_get_states = provider.get_states
+
+        async def _blocked_get_states(**kwargs: Any) -> Any:
+            entered_sweep.set()
+            await release_sweep.wait()
+            return await original_get_states(**kwargs)
+
+        with patch.object(provider, "get_states", _blocked_get_states):
+            search = asyncio.create_task(provider.search_control_entities())
+            async with asyncio.timeout(5):
+                await entered_sweep.wait()
+
+    release_sweep.set()
+    with pytest.raises(ProviderUnavailableError):
+        await search
+    assert provider._control_entity_search._entries == {}

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -18,17 +18,19 @@ from music_assistant_models.errors import SetupFailedError, UnsupportedFeaturedE
 from music_assistant.constants import CONF_LOG_LEVEL
 from music_assistant.providers.hass import (
     CONF_AUTH_TOKEN,
-    CONF_MUTE_CONTROLS,
-    CONF_POWER_CONTROLS,
     CONF_URL,
     CONF_VERIFY_SSL,
-    CONF_VOLUME_CONTROLS,
     STATE_FETCH_BATCH_SIZE,
     HassRegistryEntity,
     HomeAssistantProvider,
     setup,
 )
-from music_assistant.providers.hass.constants import MediaPlayerEntityFeature
+from music_assistant.providers.hass.constants import (
+    CONF_MUTE_CONTROLS,
+    CONF_POWER_CONTROLS,
+    CONF_VOLUME_CONTROLS,
+    MediaPlayerEntityFeature,
+)
 from tests.common import use_real_create_task
 
 LAST_CHANGED = 1683832716.072648
@@ -887,7 +889,7 @@ async def test_registry_update_of_another_domain_invalidates_the_registry() -> N
     [
         pytest.param({"name": "Old name"}, id="rename"),
         pytest.param({"icon": None}, id="icon"),
-        pytest.param({"area_id": None, "labels": []}, id="area_and_labels"),
+        pytest.param({"labels": []}, id="labels"),
         pytest.param({"hidden_by": None}, id="hidden"),
         # an integration reload re-registers its entities, which touches these
         pytest.param({"capabilities": None, "supported_features": 0}, id="reload"),
@@ -915,6 +917,7 @@ async def test_registry_update_of_unmirrored_fields_keeps_the_registry(
         pytest.param({"entity_id": "light.old"}, id="entity_id"),
         pytest.param({"platform": "old_platform"}, id="platform"),
         pytest.param({"device_id": None}, id="device_id"),
+        pytest.param({"area_id": None}, id="area_id"),
         # the listing omits disabled entities, so this one enters or leaves it
         pytest.param({"disabled_by": None}, id="disabled_by"),
         # a device rename reports no changed fields at all
@@ -1027,21 +1030,26 @@ async def test_shared_registry_rejects_writes() -> None:
 
         with pytest.raises(TypeError):
             registry["light.kitchen"] = HassRegistryEntity(  # type: ignore[index]
-                platform="test", device_id=None
+                platform="test", device_id=None, area_id=None
             )
         with pytest.raises(AttributeError):
             registry["tts.only"].platform = "test"  # type: ignore[misc]
 
 
 async def test_registry_reuses_repeated_strings() -> None:
-    """Hold on to a single string object per distinct platform and device id."""
+    """Hold on to a single string object per distinct platform, device id and area id."""
     async with _start_provider([_state("tts.only", "Only")]) as (provider, _):
-        # decode the listing like a real response, so the repeated platform and device id
-        # arrive as distinct string objects instead of shared literals
+        # decode the listing like a real response, so the repeated platform, device id and
+        # area id arrive as distinct string objects instead of shared literals
         entities = json.loads(
             json.dumps(
                 [
-                    {"ei": f"light.lamp_{index}", "pl": "esphome", "di": "device"}
+                    {
+                        "ei": f"light.lamp_{index}",
+                        "pl": "esphome",
+                        "di": "device",
+                        "ai": "area",
+                    }
                     for index in range(3)
                 ]
             )
@@ -1053,10 +1061,32 @@ async def test_registry_reuses_repeated_strings() -> None:
 
         assert len(registry) == 3
         assert registry["light.lamp_0"] == HassRegistryEntity(
-            platform="esphome", device_id="device"
+            platform="esphome", device_id="device", area_id="area"
         )
         assert len({id(entry.platform) for entry in registry.values()}) == 1
         assert len({id(entry.device_id) for entry in registry.values()}) == 1
+        assert len({id(entry.area_id) for entry in registry.values()}) == 1
+
+
+async def test_registry_leaves_out_the_device_and_area_it_is_not_told_about() -> None:
+    """Report no device or area for the entities whose listing entry omits them."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, _):
+        entities = [
+            {"ei": "light.full", "pl": "esphome", "di": "device", "ai": "area"},
+            {"ei": "light.bare", "pl": "esphome"},
+            {"ei": "light.device_only", "pl": "esphome", "di": "other_device"},
+        ]
+        with patch.object(
+            provider.hass, "send_command", AsyncMock(return_value={"entities": entities})
+        ):
+            registry = await provider._fetch_entity_registry()
+
+        assert registry["light.bare"] == HassRegistryEntity(
+            platform="esphome", device_id=None, area_id=None
+        )
+        assert registry["light.device_only"] == HassRegistryEntity(
+            platform="esphome", device_id="other_device", area_id=None
+        )
 
 
 async def test_device_registry_is_reused_within_the_cache_window() -> None:


### PR DESCRIPTION
> Stacked on #5268 — review that one first; this PR's base retargets to `dev` automatically when it merges.

# What does this implement/fix?

Choosing a Home Assistant entity as a player's power, volume or mute control means picking it from a flat list of every eligible entity in the house — thousands of them on a sizeable setup, in a dropdown you cannot type into. This adds the search a picker can call: it matches on the entity name, its device name and the area it is in, and returns the results grouped per device so they can be shown with a heading.

Nothing changes yet for people using the current lists; the picker that consumes this follows in a frontend PR.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- add a search command to the Home Assistant plugin, optionally limited to the entities that can serve one specific control role
- report per entity which roles it can serve, so a picker can show what else an entity could be used for
- group results per device, with the area an entity is in, honouring the entity's own area when it overrides its device's
- cache the device and area listings, and the resolved candidates, so searching while typing does not re-read Home Assistant on every keystroke
- limit the number of results and report when matches were left out, so a large setup cannot produce an oversized response

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
