### PR TITLE
Reuse the Home Assistant device list instead of re-fetching it constantly

### DIFF
--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -196,6 +196,7 @@ class HomeAssistantProvider(PluginProvider):
     _player_controls: dict[str, PlayerControl] | None = None
     _unsubscribe_controls: Callable[[], None] | None = None
     _unsubscribe_entity_registry: Callable[[], None] | None = None
+    _unsubscribe_device_registry: Callable[[], None] | None = None
     _engine_refresh_task: asyncio.Task[None] | None = None
     _ai_engines: list[AIEngine]
     _tts_engines: list[TTSEngine]
@@ -203,6 +204,9 @@ class HomeAssistantProvider(PluginProvider):
     _entity_registry: dict[str, HassRegistryEntity] | None = None
     _entity_registry_generation: int = 0
     _entity_registry_lock: asyncio.Lock
+    _device_registry: dict[str, Device] | None = None
+    _device_registry_generation: int = 0
+    _device_registry_lock: asyncio.Lock
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """
@@ -306,6 +310,8 @@ class HomeAssistantProvider(PluginProvider):
         self.hass = HomeAssistantClient(url, token, http_session)
         self._entity_registry = None
         self._entity_registry_lock = asyncio.Lock()
+        self._device_registry = None
+        self._device_registry_lock = asyncio.Lock()
         try:
             await self.hass.connect()
         except BaseHassClientError as err:
@@ -314,10 +320,11 @@ class HomeAssistantProvider(PluginProvider):
             raise SetupFailedError(err_msg) from err
         self._listen_task = self.mass.create_task(self._hass_listener())
         try:
-            # the registry subscription must be live before the first registry read, so no
+            # the registry subscriptions must be live before the first registry read, so no
             # registry change can slip through unnoticed; _disconnect_hass tears the
-            # subscription down again on the failure paths below
+            # subscriptions down again on the failure paths below
             await self._subscribe_entity_registry()
+            await self._subscribe_device_registry()
             await self._resolve_startup_features()
         except asyncio.CancelledError:
             await self._cleanup_failed_init()
@@ -393,6 +400,25 @@ class HomeAssistantProvider(PluginProvider):
         )
         return {entity_id: entry for entity_id, entry in result.items() if entry is not None}
 
+    async def get_device_registry(self) -> dict[str, Device]:
+        """
+        Return the Home Assistant device registry, keyed by device ID.
+
+        Home Assistant offers no abbreviated variant of the device registry listing, so the
+        entries carry all of their fields.
+        """
+        if (registry := self._device_registry) is not None:
+            return registry
+        async with self._device_registry_lock:
+            if (registry := self._device_registry) is None:
+                generation = self._device_registry_generation
+                registry = await self._fetch_device_registry()
+                # a registry change while the fetch was in flight leaves the listing stale
+                # on arrival, so serve it to this caller but keep it out of the cache
+                if generation == self._device_registry_generation:
+                    self._device_registry = registry
+            return registry
+
     async def get_media_player_device_infos(
         self,
         mac_addresses: Collection[str],
@@ -413,10 +439,10 @@ class HomeAssistantProvider(PluginProvider):
         wanted_macs = {mac.lower() for mac in mac_addresses}
         if not wanted_macs:
             return {}
-        device_registry = await self.hass.get_device_registry()
+        device_registry = await self.get_device_registry()
         device_by_mac: dict[str, Device] = {
             connection[1].lower(): device
-            for device in device_registry
+            for device in device_registry.values()
             for connection in device.get("connections", [])
             if len(connection) == 2
             and connection[0] == "mac"
@@ -867,6 +893,9 @@ class HomeAssistantProvider(PluginProvider):
         if unsubscribe := self._unsubscribe_entity_registry:
             self._unsubscribe_entity_registry = None
             unsubscribe()
+        if unsubscribe := self._unsubscribe_device_registry:
+            self._unsubscribe_device_registry = None
+            unsubscribe()
         if refresh_task := self._engine_refresh_task:
             self._engine_refresh_task = None
             refresh_task.cancel()
@@ -968,6 +997,21 @@ class HomeAssistantProvider(PluginProvider):
             return
         self._schedule_engine_refresh()
 
+    async def _subscribe_device_registry(self) -> None:
+        """Watch the Home Assistant device registry to keep the cached registry up to date."""
+        # register for device registry updates, replacing any earlier subscription
+        if unsubscribe := self._unsubscribe_device_registry:
+            self._unsubscribe_device_registry = None
+            unsubscribe()
+        self._unsubscribe_device_registry = await self.hass.subscribe_events(
+            self._on_device_registry_update, "device_registry_updated"
+        )
+
+    def _on_device_registry_update(self, event: Event) -> None:
+        """Handle a device registry update event."""
+        self._device_registry = None
+        self._device_registry_generation += 1
+
     def _schedule_engine_refresh(self) -> None:
         """(Re)schedule the debounced rebuild of the engine lists."""
         if refresh_task := self._engine_refresh_task:
@@ -999,6 +1043,10 @@ class HomeAssistantProvider(PluginProvider):
             )
             for entry in result["entities"]
         }
+
+    async def _fetch_device_registry(self) -> dict[str, Device]:
+        """Fetch the device registry from Home Assistant, keyed by device ID."""
+        return {device["id"]: device for device in await self.hass.get_device_registry()}
 
 
 def _decompress_state(entity_id: str, compressed_state: CompressedState) -> State:

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -1014,8 +1014,9 @@ class HomeAssistantProvider(PluginProvider):
             for entry in result["entities"]
         }
 
-    # the lock sits outside the cache so a burst of lookups collapses into a single
-    # fetch: without it every caller misses the cold cache and fetches its own listing
+    # the lock sits outside the cache to keep a burst of lookups from fetching once per
+    # caller. use_cache stores in the background, so the callers that reach a still-cold
+    # cache can overlap: the burst costs a couple of fetches instead of one per player
     @lock
     @use_cache(expiration=DEVICE_REGISTRY_CACHE_TTL)
     async def _fetch_device_registry(self) -> dict[str, Any]:

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -37,9 +37,10 @@ from music_assistant_models.player_control import PlayerControl
 from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
+from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.datetime import iso_from_utc_timestamp
 from music_assistant.helpers.json import SerializableType
-from music_assistant.helpers.util import try_parse_int
+from music_assistant.helpers.util import lock, try_parse_int
 from music_assistant.models.plugin import AIEngine, PluginProvider, TTSEngine
 
 from .constants import OFF_STATES, MediaPlayerEntityFeature, parse_supported_features
@@ -77,6 +78,9 @@ STATE_FETCH_BATCH_SIZE = 500
 # window to collect entity registry updates in, so an integration registering a
 # batch of entities results in a single rebuild of the engine lists
 ENGINE_REFRESH_DEBOUNCE = 2
+# window in which repeated device lookups reuse one listing, so a burst of players
+# connecting does not fetch the (unfilterable) device registry once per player
+DEVICE_REGISTRY_CACHE_TTL = 60
 
 # Home Assistant entity domains Music Assistant can offer as player controls.
 CONTROL_DOMAINS = ("media_player", "switch", "input_boolean", "number", "input_number")
@@ -196,7 +200,6 @@ class HomeAssistantProvider(PluginProvider):
     _player_controls: dict[str, PlayerControl] | None = None
     _unsubscribe_controls: Callable[[], None] | None = None
     _unsubscribe_entity_registry: Callable[[], None] | None = None
-    _unsubscribe_device_registry: Callable[[], None] | None = None
     _engine_refresh_task: asyncio.Task[None] | None = None
     _ai_engines: list[AIEngine]
     _tts_engines: list[TTSEngine]
@@ -204,9 +207,6 @@ class HomeAssistantProvider(PluginProvider):
     _entity_registry: dict[str, HassRegistryEntity] | None = None
     _entity_registry_generation: int = 0
     _entity_registry_lock: asyncio.Lock
-    _device_registry: dict[str, Device] | None = None
-    _device_registry_generation: int = 0
-    _device_registry_lock: asyncio.Lock
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """
@@ -310,8 +310,6 @@ class HomeAssistantProvider(PluginProvider):
         self.hass = HomeAssistantClient(url, token, http_session)
         self._entity_registry = None
         self._entity_registry_lock = asyncio.Lock()
-        self._device_registry = None
-        self._device_registry_lock = asyncio.Lock()
         try:
             await self.hass.connect()
         except BaseHassClientError as err:
@@ -320,11 +318,10 @@ class HomeAssistantProvider(PluginProvider):
             raise SetupFailedError(err_msg) from err
         self._listen_task = self.mass.create_task(self._hass_listener())
         try:
-            # the registry subscriptions must be live before the first registry read, so no
+            # the registry subscription must be live before the first registry read, so no
             # registry change can slip through unnoticed; _disconnect_hass tears the
-            # subscriptions down again on the failure paths below
+            # subscription down again on the failure paths below
             await self._subscribe_entity_registry()
-            await self._subscribe_device_registry()
             await self._resolve_startup_features()
         except asyncio.CancelledError:
             await self._cleanup_failed_init()
@@ -405,19 +402,10 @@ class HomeAssistantProvider(PluginProvider):
         Return the Home Assistant device registry, keyed by device ID.
 
         Home Assistant offers no abbreviated variant of the device registry listing, so the
-        entries carry all of their fields.
+        entries carry all of their fields. The listing is reused for a short while, so a
+        device change may take up to DEVICE_REGISTRY_CACHE_TTL seconds to be reflected.
         """
-        if (registry := self._device_registry) is not None:
-            return registry
-        async with self._device_registry_lock:
-            if (registry := self._device_registry) is None:
-                generation = self._device_registry_generation
-                registry = await self._fetch_device_registry()
-                # a registry change while the fetch was in flight leaves the listing stale
-                # on arrival, so serve it to this caller but keep it out of the cache
-                if generation == self._device_registry_generation:
-                    self._device_registry = registry
-            return registry
+        return await self._fetch_device_registry()
 
     async def get_media_player_device_infos(
         self,
@@ -893,9 +881,6 @@ class HomeAssistantProvider(PluginProvider):
         if unsubscribe := self._unsubscribe_entity_registry:
             self._unsubscribe_entity_registry = None
             unsubscribe()
-        if unsubscribe := self._unsubscribe_device_registry:
-            self._unsubscribe_device_registry = None
-            unsubscribe()
         if refresh_task := self._engine_refresh_task:
             self._engine_refresh_task = None
             refresh_task.cancel()
@@ -997,21 +982,6 @@ class HomeAssistantProvider(PluginProvider):
             return
         self._schedule_engine_refresh()
 
-    async def _subscribe_device_registry(self) -> None:
-        """Watch the Home Assistant device registry to keep the cached registry up to date."""
-        # register for device registry updates, replacing any earlier subscription
-        if unsubscribe := self._unsubscribe_device_registry:
-            self._unsubscribe_device_registry = None
-            unsubscribe()
-        self._unsubscribe_device_registry = await self.hass.subscribe_events(
-            self._on_device_registry_update, "device_registry_updated"
-        )
-
-    def _on_device_registry_update(self, event: Event) -> None:
-        """Handle a device registry update event."""
-        self._device_registry = None
-        self._device_registry_generation += 1
-
     def _schedule_engine_refresh(self) -> None:
         """(Re)schedule the debounced rebuild of the engine lists."""
         if refresh_task := self._engine_refresh_task:
@@ -1044,8 +1014,14 @@ class HomeAssistantProvider(PluginProvider):
             for entry in result["entities"]
         }
 
-    async def _fetch_device_registry(self) -> dict[str, Device]:
+    # the lock sits outside the cache so a burst of lookups collapses into a single
+    # fetch: without it every caller misses the cold cache and fetches its own listing
+    @lock
+    @use_cache(expiration=DEVICE_REGISTRY_CACHE_TTL)
+    async def _fetch_device_registry(self) -> dict[str, Any]:
         """Fetch the device registry from Home Assistant, keyed by device ID."""
+        # use_cache rebuilds the cached value from this return annotation, which rules out
+        # the Device TypedDict; get_device_registry restores the type for callers
         return {device["id"]: device for device in await self.hass.get_device_registry()}
 
 

--- a/music_assistant/providers/hass_players/provider.py
+++ b/music_assistant/providers/hass_players/provider.py
@@ -69,7 +69,7 @@ class HomeAssistantPlayerProvider(PlayerProvider):
             # entities that are already imported must stay selectable,
             # so editing the provider config never drops them
             selected_players = self._selected_players()
-            device_registry = {x["id"]: x for x in await hass_prov.hass.get_device_registry()}
+            device_registry = await hass_prov.get_device_registry()
             native_macs = native_player_macs(self.mass)
             entity_registry = await get_media_player_entity_registry(hass_prov)
             async for state, entity_registry_entry in get_hass_media_players(
@@ -108,7 +108,7 @@ class HomeAssistantPlayerProvider(PlayerProvider):
         await super().loaded_in_mass()
         player_ids = cast("list[str]", self.config.get_value(CONF_PLAYERS))
         # prefetch the device- and entity registry
-        device_registry = {x["id"]: x for x in await self.hass_prov.hass.get_device_registry()}
+        device_registry = await self.hass_prov.get_device_registry()
         entity_registry = await get_media_player_entity_registry(self.hass_prov)
         # setup players from hass entities
         async for state, _ in get_hass_media_players(self.hass_prov, entity_registry):
@@ -232,7 +232,7 @@ class HomeAssistantPlayerProvider(PlayerProvider):
     async def _late_add_player(self, entity_id: str) -> None:
         """Handle setup of Player from HA entity that became available after startup."""
         # prefetch the device- and entity registry
-        device_registry = {x["id"]: x for x in await self.hass_prov.hass.get_device_registry()}
+        device_registry = await self.hass_prov.get_device_registry()
         entity_registry = await get_media_player_entity_registry(self.hass_prov)
         async for state, _ in get_hass_media_players(self.hass_prov, entity_registry):
             if state["entity_id"] != entity_id:

--- a/tests/providers/hass/test_device_correlation.py
+++ b/tests/providers/hass/test_device_correlation.py
@@ -16,6 +16,24 @@ MEDIA_ANNOUNCE = 1048576
 MAC = "aa:bb:cc:dd:ee:ff"
 
 
+class _Cache:
+    """Provide the slice of the cache controller that @use_cache relies on."""
+
+    def __init__(self) -> None:
+        self.entries: dict[str, Any] = {}
+
+    async def get_with_freshness(self, key: str, **kwargs: Any) -> tuple[Any, bool, bool]:
+        """Return the (data, is_fresh, found) triplet for the given key."""
+        await asyncio.sleep(0)
+        if key not in self.entries:
+            return None, False, False
+        return self.entries[key], True, True
+
+    async def set(self, key: str, data: Any, **kwargs: Any) -> None:
+        """Store data under the given key."""
+        self.entries[key] = data
+
+
 def _provider(
     devices: list[dict[str, Any]],
     entities: list[dict[str, Any]],
@@ -40,8 +58,12 @@ def _provider(
     )
     provider._entity_registry = None
     provider._entity_registry_lock = asyncio.Lock()
-    provider._device_registry = None
-    provider._device_registry_lock = asyncio.Lock()
+    # the device registry lookup runs through @use_cache, which needs a cache to talk to
+    provider.config = SimpleNamespace(instance_id="hass--test")  # type: ignore[assignment]
+    provider.manifest = SimpleNamespace(domain="hass")  # type: ignore[assignment]
+    provider.mass = SimpleNamespace(  # type: ignore[assignment]
+        cache=_Cache(), create_task=asyncio.create_task
+    )
     provider.get_states = AsyncMock(return_value=states)  # type: ignore[method-assign]
     provider.logger = logging.getLogger("test.hass")
     return provider

--- a/tests/providers/hass/test_device_correlation.py
+++ b/tests/providers/hass/test_device_correlation.py
@@ -40,6 +40,8 @@ def _provider(
     )
     provider._entity_registry = None
     provider._entity_registry_lock = asyncio.Lock()
+    provider._device_registry = None
+    provider._device_registry_lock = asyncio.Lock()
     provider.get_states = AsyncMock(return_value=states)  # type: ignore[method-assign]
     provider.logger = logging.getLogger("test.hass")
     return provider

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -76,10 +76,37 @@ def _config(**values: Any) -> MagicMock:
     return config
 
 
+class _Cache:
+    """Provide the slice of the cache controller that @use_cache relies on."""
+
+    def __init__(self) -> None:
+        self.entries: dict[str, Any] = {}
+        self.fresh = True
+
+    async def get_with_freshness(self, key: str, **kwargs: Any) -> tuple[Any, bool, bool]:
+        """Return the (data, is_fresh, found) triplet for the given key."""
+        # the real controller reads the cache database here, so yield like it does:
+        # @use_cache stores in the background, and only a yield lets that store land
+        await asyncio.sleep(0)
+        if key not in self.entries:
+            return None, False, False
+        if not self.fresh and not kwargs.get("include_expired"):
+            return None, False, False
+        return self.entries[key], self.fresh, True
+
+    async def set(self, key: str, data: Any, **kwargs: Any) -> None:
+        """Store data under the given key."""
+        self.entries[key] = data
+
+    def expire_all(self) -> None:
+        """Mark every stored entry as no longer fresh."""
+        self.fresh = False
+
+
 def _mass() -> MagicMock:
     """Return the Music Assistant dependencies used during provider startup."""
     mass = MagicMock()
-    mass.cache = MagicMock()
+    mass.cache = _Cache()
     mass.http_session = MagicMock()
     mass.http_session_no_ssl = MagicMock()
     mass.create_task.side_effect = asyncio.create_task
@@ -312,11 +339,9 @@ async def test_feature_resolution_starts_listener_first() -> None:
     ]
 
     async with _start_provider(states) as (provider, hass):
-        assert hass.calls[:5] == [
+        assert hass.calls[:4] == [
             "connect",
             "start_listening",
-            # the entity- and device registry subscriptions
-            "subscribe_events",
             "subscribe_events",
             REGISTRY_LIST_COMMAND,
         ]
@@ -345,9 +370,7 @@ async def test_feature_resolution_failure_cleans_up_connection() -> None:
         "connect",
         "start_listening",
         "subscribe_events",
-        "subscribe_events",
         REGISTRY_LIST_COMMAND,
-        "unsubscribe_events",
         "unsubscribe_events",
         "disconnect",
     ]
@@ -745,8 +768,8 @@ async def test_registry_changed_during_the_fetch_is_not_cached() -> None:
         assert hass.calls.count(REGISTRY_LIST_COMMAND) == registry_fetches + 1
 
 
-async def test_device_registry_is_fetched_once_per_connection() -> None:
-    """Serve repeated device lookups from a device registry that is fetched only once."""
+async def test_device_registry_is_fetched_once_within_the_cache_window() -> None:
+    """Serve repeated device lookups from a listing that is fetched only once."""
     async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
         hass.devices = [{"id": "dev1"}]
 
@@ -756,41 +779,48 @@ async def test_device_registry_is_fetched_once_per_connection() -> None:
         assert hass.calls.count(DEVICE_REGISTRY_LIST) == 1
 
 
-async def test_device_registry_update_invalidates_the_device_registry() -> None:
-    """Refetch the device registry after Home Assistant reports a device registry change."""
+async def test_device_registry_is_refetched_once_the_cache_window_passed() -> None:
+    """Fetch the device listing again once the cached entry is no longer fresh."""
     async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
         hass.devices = [{"id": "dev1"}]
         await provider.get_device_registry()
         hass.devices = [{"id": "dev1"}, {"id": "dev2"}]
 
-        hass.fire_event("device_registry_updated", {"action": "create", "device_id": "dev2"})
+        cast("_Cache", provider.mass.cache).expire_all()
 
         assert list(await provider.get_device_registry()) == ["dev1", "dev2"]
         assert hass.calls.count(DEVICE_REGISTRY_LIST) == 2
 
 
-async def test_entity_registry_update_leaves_the_device_registry_cached() -> None:
-    """Keep the cached device registry when only the entity registry changed."""
+async def test_device_entries_survive_the_cache_round_trip() -> None:
+    """Return a cached device entry with all of its fields intact."""
+    device = {
+        "id": "dev1",
+        "name": "Kitchen Speaker",
+        "name_by_user": None,
+        "connections": [["mac", "aa:bb:cc:dd:ee:ff"]],
+        "manufacturer": "ESPHome",
+    }
     async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
-        hass.devices = [{"id": "dev1"}]
-        await provider.get_device_registry()
+        hass.devices = [device]
 
-        hass.fire_event(
-            "entity_registry_updated", {"action": "create", "entity_id": "light.kitchen"}
-        )
-        await provider.get_device_registry()
+        fetched = await provider.get_device_registry()
+        cached = await provider.get_device_registry()
 
         assert hass.calls.count(DEVICE_REGISTRY_LIST) == 1
+        # the cached read is reconstructed from the return annotation, so it must not
+        # drop or reshape any of the device fields
+        assert cached == fetched == {"dev1": device}
 
 
 async def test_concurrent_device_lookups_share_one_registry_fetch() -> None:
-    """Let concurrent device lookups share a single device registry fetch."""
+    """Collapse a burst of concurrent device lookups into a single fetch."""
     async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
         hass.devices = [{"id": "dev1"}]
-        # hold back the registry response until both lookups are waiting for it
+        # hold back the listing until all three lookups are waiting for it
         hass.device_registry_result = asyncio.get_running_loop().create_future()
 
-        lookups = asyncio.gather(provider.get_device_registry(), provider.get_device_registry())
+        lookups = asyncio.gather(*(provider.get_device_registry() for _ in range(3)))
         await asyncio.sleep(0)
         hass.device_registry_result.set_result(None)
         async with asyncio.timeout(1):
@@ -798,26 +828,6 @@ async def test_concurrent_device_lookups_share_one_registry_fetch() -> None:
 
         assert all(list(result) == ["dev1"] for result in results)
         assert hass.calls.count(DEVICE_REGISTRY_LIST) == 1
-
-
-async def test_device_registry_changed_during_the_fetch_is_not_cached() -> None:
-    """Keep a device listing out of the cache when a registry update outdated it in flight."""
-    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
-        hass.devices = [{"id": "dev1"}]
-        # hold back the registry response until the update has been delivered
-        hass.device_registry_result = asyncio.get_running_loop().create_future()
-        lookup = asyncio.ensure_future(provider.get_device_registry())
-        await asyncio.sleep(0)
-
-        hass.fire_event("device_registry_updated", {"action": "create", "device_id": "dev2"})
-        hass.device_registry_result.set_result(None)
-        async with asyncio.timeout(1):
-            # the stale listing is still served to the caller that asked for it
-            assert list(await lookup) == ["dev1"]
-
-        assert provider._device_registry is None
-        hass.devices = [{"id": "dev1"}, {"id": "dev2"}]
-        assert list(await provider.get_device_registry()) == ["dev1", "dev2"]
 
 
 async def test_disabled_entity_is_never_requested() -> None:
@@ -866,28 +876,12 @@ async def test_registry_entries_of_nothing_skips_the_round_trip() -> None:
 async def test_entity_registry_subscription_is_replaced() -> None:
     """Replace the entity registry subscription instead of stacking a second one."""
     async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
-        assert hass.active_event_subscriptions == 2
+        assert hass.active_event_subscriptions == 1
         assert hass.event_subscriptions[0][0] == "entity_registry_updated"
 
         await provider._subscribe_entity_registry()
 
-        assert hass.active_event_subscriptions == 2
-        assert hass.calls[-2:] == ["unsubscribe_events", "subscribe_events"]
-
-        await provider.unload()
-
-        assert hass.active_event_subscriptions == 0
-
-
-async def test_device_registry_subscription_is_replaced() -> None:
-    """Replace the device registry subscription instead of stacking a second one."""
-    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
-        assert hass.active_event_subscriptions == 2
-        assert hass.event_subscriptions[1][0] == "device_registry_updated"
-
-        await provider._subscribe_device_registry()
-
-        assert hass.active_event_subscriptions == 2
+        assert hass.active_event_subscriptions == 1
         assert hass.calls[-2:] == ["unsubscribe_events", "subscribe_events"]
 
         await provider.unload()

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -96,6 +96,10 @@ class _Cache:
 
     async def set(self, key: str, data: Any, **kwargs: Any) -> None:
         """Store data under the given key."""
+        # the real controller serializes on a worker thread and then writes the cache
+        # database, so a store lands well after the call that scheduled it returned
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
         self.entries[key] = data
 
     def expire_all(self) -> None:
@@ -152,8 +156,6 @@ class _HomeAssistantClient:
         self.disabled_entities: set[str] = set()
         # devices as returned in full by the device registry listing
         self.devices: list[dict[str, Any]] = []
-        # set to hold back the device registry listing until the test releases it
-        self.device_registry_result: asyncio.Future[None] | None = None
         # events delivered ahead of a subscription's initial state message
         self.leading_events: list[dict[str, Any]] = []
         self.deliver_initial_states = True
@@ -232,8 +234,6 @@ class _HomeAssistantClient:
     async def get_device_registry(self) -> list[dict[str, Any]]:
         """Return the full device registry listing."""
         self.calls.append(DEVICE_REGISTRY_LIST)
-        if self.device_registry_result:
-            await self.device_registry_result
         return list(self.devices)
 
     def fire_event(self, event_type: str, data: dict[str, Any]) -> None:
@@ -318,6 +318,14 @@ async def _start_provider(
         yield provider, hass
     finally:
         await provider.unload()
+
+
+async def _wait_for_stored(provider: HomeAssistantProvider) -> None:
+    """Wait until the background store of the device listing has landed in the cache."""
+    cache = cast("_Cache", provider.mass.cache)
+    async with asyncio.timeout(1):
+        while not cache.entries:
+            await asyncio.sleep(0)
 
 
 async def _fire_registry_update(
@@ -768,12 +776,13 @@ async def test_registry_changed_during_the_fetch_is_not_cached() -> None:
         assert hass.calls.count(REGISTRY_LIST_COMMAND) == registry_fetches + 1
 
 
-async def test_device_registry_is_fetched_once_within_the_cache_window() -> None:
-    """Serve repeated device lookups from a listing that is fetched only once."""
+async def test_device_registry_is_reused_within_the_cache_window() -> None:
+    """Serve a later device lookup from the cached listing."""
     async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
         hass.devices = [{"id": "dev1"}]
 
         assert await provider.get_device_registry() == {"dev1": {"id": "dev1"}}
+        await _wait_for_stored(provider)
         await provider.get_device_registry()
 
         assert hass.calls.count(DEVICE_REGISTRY_LIST) == 1
@@ -805,6 +814,7 @@ async def test_device_entries_survive_the_cache_round_trip() -> None:
         hass.devices = [device]
 
         fetched = await provider.get_device_registry()
+        await _wait_for_stored(provider)
         cached = await provider.get_device_registry()
 
         assert hass.calls.count(DEVICE_REGISTRY_LIST) == 1
@@ -813,21 +823,19 @@ async def test_device_entries_survive_the_cache_round_trip() -> None:
         assert cached == fetched == {"dev1": device}
 
 
-async def test_concurrent_device_lookups_share_one_registry_fetch() -> None:
-    """Collapse a burst of concurrent device lookups into a single fetch."""
+async def test_concurrent_device_lookups_do_not_fetch_per_caller() -> None:
+    """Keep a burst of concurrent device lookups off a fetch-per-caller path."""
     async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
         hass.devices = [{"id": "dev1"}]
-        # hold back the listing until all three lookups are waiting for it
-        hass.device_registry_result = asyncio.get_running_loop().create_future()
 
-        lookups = asyncio.gather(*(provider.get_device_registry() for _ in range(3)))
-        await asyncio.sleep(0)
-        hass.device_registry_result.set_result(None)
         async with asyncio.timeout(1):
-            results = await lookups
+            results = await asyncio.gather(*(provider.get_device_registry() for _ in range(20)))
 
         assert all(list(result) == ["dev1"] for result in results)
-        assert hass.calls.count(DEVICE_REGISTRY_LIST) == 1
+        # the lock keeps the fetch count flat instead of growing with the burst; it does
+        # not reach one, because use_cache stores in the background and the caller right
+        # behind the first one still finds the cache cold
+        assert hass.calls.count(DEVICE_REGISTRY_LIST) <= 2
 
 
 async def test_disabled_entity_is_never_requested() -> None:

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -33,6 +33,7 @@ LAST_CHANGED_ISO = "2023-05-11T19:18:36.072648+00:00"
 CONTEXT_ID = "01H0640ES8JCY1NGTNW3V41T5T"
 REGISTRY_LIST_COMMAND = "config/entity_registry/list_for_display"
 REGISTRY_ENTRIES_COMMAND = "config/entity_registry/get_entries"
+DEVICE_REGISTRY_LIST = "get_device_registry"
 
 
 def _state(entity_id: str, friendly_name: str) -> dict[str, Any]:
@@ -122,6 +123,10 @@ class _HomeAssistantClient:
         self.compressed_states = {state["entity_id"]: _compressed(state) for state in states}
         # entities Home Assistant reports as disabled, so leaves out of the registry listing
         self.disabled_entities: set[str] = set()
+        # devices as returned in full by the device registry listing
+        self.devices: list[dict[str, Any]] = []
+        # set to hold back the device registry listing until the test releases it
+        self.device_registry_result: asyncio.Future[None] | None = None
         # events delivered ahead of a subscription's initial state message
         self.leading_events: list[dict[str, Any]] = []
         self.deliver_initial_states = True
@@ -196,6 +201,13 @@ class _HomeAssistantClient:
             self.active_event_subscriptions -= 1
 
         return _unsubscribe
+
+    async def get_device_registry(self) -> list[dict[str, Any]]:
+        """Return the full device registry listing."""
+        self.calls.append(DEVICE_REGISTRY_LIST)
+        if self.device_registry_result:
+            await self.device_registry_result
+        return list(self.devices)
 
     def fire_event(self, event_type: str, data: dict[str, Any]) -> None:
         """Deliver an event to every subscriber of the given event type."""
@@ -300,9 +312,11 @@ async def test_feature_resolution_starts_listener_first() -> None:
     ]
 
     async with _start_provider(states) as (provider, hass):
-        assert hass.calls[:4] == [
+        assert hass.calls[:5] == [
             "connect",
             "start_listening",
+            # the entity- and device registry subscriptions
+            "subscribe_events",
             "subscribe_events",
             REGISTRY_LIST_COMMAND,
         ]
@@ -331,7 +345,9 @@ async def test_feature_resolution_failure_cleans_up_connection() -> None:
         "connect",
         "start_listening",
         "subscribe_events",
+        "subscribe_events",
         REGISTRY_LIST_COMMAND,
+        "unsubscribe_events",
         "unsubscribe_events",
         "disconnect",
     ]
@@ -729,6 +745,81 @@ async def test_registry_changed_during_the_fetch_is_not_cached() -> None:
         assert hass.calls.count(REGISTRY_LIST_COMMAND) == registry_fetches + 1
 
 
+async def test_device_registry_is_fetched_once_per_connection() -> None:
+    """Serve repeated device lookups from a device registry that is fetched only once."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        hass.devices = [{"id": "dev1"}]
+
+        assert await provider.get_device_registry() == {"dev1": {"id": "dev1"}}
+        await provider.get_device_registry()
+
+        assert hass.calls.count(DEVICE_REGISTRY_LIST) == 1
+
+
+async def test_device_registry_update_invalidates_the_device_registry() -> None:
+    """Refetch the device registry after Home Assistant reports a device registry change."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        hass.devices = [{"id": "dev1"}]
+        await provider.get_device_registry()
+        hass.devices = [{"id": "dev1"}, {"id": "dev2"}]
+
+        hass.fire_event("device_registry_updated", {"action": "create", "device_id": "dev2"})
+
+        assert list(await provider.get_device_registry()) == ["dev1", "dev2"]
+        assert hass.calls.count(DEVICE_REGISTRY_LIST) == 2
+
+
+async def test_entity_registry_update_leaves_the_device_registry_cached() -> None:
+    """Keep the cached device registry when only the entity registry changed."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        hass.devices = [{"id": "dev1"}]
+        await provider.get_device_registry()
+
+        hass.fire_event(
+            "entity_registry_updated", {"action": "create", "entity_id": "light.kitchen"}
+        )
+        await provider.get_device_registry()
+
+        assert hass.calls.count(DEVICE_REGISTRY_LIST) == 1
+
+
+async def test_concurrent_device_lookups_share_one_registry_fetch() -> None:
+    """Let concurrent device lookups share a single device registry fetch."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        hass.devices = [{"id": "dev1"}]
+        # hold back the registry response until both lookups are waiting for it
+        hass.device_registry_result = asyncio.get_running_loop().create_future()
+
+        lookups = asyncio.gather(provider.get_device_registry(), provider.get_device_registry())
+        await asyncio.sleep(0)
+        hass.device_registry_result.set_result(None)
+        async with asyncio.timeout(1):
+            results = await lookups
+
+        assert all(list(result) == ["dev1"] for result in results)
+        assert hass.calls.count(DEVICE_REGISTRY_LIST) == 1
+
+
+async def test_device_registry_changed_during_the_fetch_is_not_cached() -> None:
+    """Keep a device listing out of the cache when a registry update outdated it in flight."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        hass.devices = [{"id": "dev1"}]
+        # hold back the registry response until the update has been delivered
+        hass.device_registry_result = asyncio.get_running_loop().create_future()
+        lookup = asyncio.ensure_future(provider.get_device_registry())
+        await asyncio.sleep(0)
+
+        hass.fire_event("device_registry_updated", {"action": "create", "device_id": "dev2"})
+        hass.device_registry_result.set_result(None)
+        async with asyncio.timeout(1):
+            # the stale listing is still served to the caller that asked for it
+            assert list(await lookup) == ["dev1"]
+
+        assert provider._device_registry is None
+        hass.devices = [{"id": "dev1"}, {"id": "dev2"}]
+        assert list(await provider.get_device_registry()) == ["dev1", "dev2"]
+
+
 async def test_disabled_entity_is_never_requested() -> None:
     """Leave an entity that Home Assistant disabled out of the state fetch."""
     states = [_state("media_player.kitchen", "Kitchen"), _state("media_player.spare", "Spare")]
@@ -775,12 +866,28 @@ async def test_registry_entries_of_nothing_skips_the_round_trip() -> None:
 async def test_entity_registry_subscription_is_replaced() -> None:
     """Replace the entity registry subscription instead of stacking a second one."""
     async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
-        assert hass.active_event_subscriptions == 1
+        assert hass.active_event_subscriptions == 2
         assert hass.event_subscriptions[0][0] == "entity_registry_updated"
 
         await provider._subscribe_entity_registry()
 
-        assert hass.active_event_subscriptions == 1
+        assert hass.active_event_subscriptions == 2
+        assert hass.calls[-2:] == ["unsubscribe_events", "subscribe_events"]
+
+        await provider.unload()
+
+        assert hass.active_event_subscriptions == 0
+
+
+async def test_device_registry_subscription_is_replaced() -> None:
+    """Replace the device registry subscription instead of stacking a second one."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        assert hass.active_event_subscriptions == 2
+        assert hass.event_subscriptions[1][0] == "device_registry_updated"
+
+        await provider._subscribe_device_registry()
+
+        assert hass.active_event_subscriptions == 2
         assert hass.calls[-2:] == ["unsubscribe_events", "subscribe_events"]
 
         await provider.unload()

--- a/tests/providers/hass_players/test_native_import_guard.py
+++ b/tests/providers/hass_players/test_native_import_guard.py
@@ -57,9 +57,9 @@ def _mass(
         return {entity_id: entities_by_id[entity_id] for entity_id in entity_ids}
 
     hass_prov = SimpleNamespace(
-        hass=SimpleNamespace(
-            connected=True,
-            get_device_registry=AsyncMock(return_value=devices or []),
+        hass=SimpleNamespace(connected=True),
+        get_device_registry=AsyncMock(
+            return_value={device["id"]: device for device in devices or []}
         ),
         get_entity_registry=AsyncMock(return_value=entities_by_id),
         get_entity_registry_entries=AsyncMock(side_effect=_registry_entries),


### PR DESCRIPTION
# What does this implement/fix?

Every time an ESPHome speaker connects or reconnects, Music Assistant asked Home Assistant for the complete list of devices — one full list per speaker, no batching. Speakers reconnect often (wifi blips, reboots, power cuts), so this repeated all day long, and a house full of speakers coming back at once meant one full list each.

Home Assistant has no compact device listing the way it does for entities (see #5270), so the list is now simply reused for a minute instead of being re-requested every time.

## Changes

- The device list is cached for 60 seconds instead of being fetched on every lookup.
- A burst of speakers connecting at the same time now shares a single fetch rather than one each.
- The player picker, startup and late-joining players all reuse the same list.

**Related issue (if applicable):**

- follow-up to #5270

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
