### PR TITLE
Also test IPv6 when listening on all network interfaces

### DIFF
--- a/tests/controllers/streams/test_controller.py
+++ b/tests/controllers/streams/test_controller.py
@@ -46,15 +46,30 @@ class TestGetSourceIp:
         assert await controller.get_source_ip(DEVICE_IP_V6) is None
 
     @pytest.mark.asyncio
-    async def test_wildcard_bind_ip_resolves_per_device_route(self) -> None:
-        """Without an operator pin, the interface that routes to the device is used."""
-        controller = _streams_controller(bind_ip="0.0.0.0")
+    @pytest.mark.parametrize(
+        ("bind_ip", "device_ip", "source_ip"),
+        [("0.0.0.0", DEVICE_IP, "192.168.1.5"), ("::", DEVICE_IP_V6, "fd00::5")],
+    )
+    async def test_wildcard_bind_ip_resolves_per_device_route(
+        self, bind_ip: str, device_ip: str, source_ip: str
+    ) -> None:
+        """
+        Without an operator pin, the interface that routes to the device is used.
+
+        Every wildcard bind IP takes this path, not just the IPv4 one: a wildcard is not
+        itself a bindable address, so handing it to a caller would be a broken result.
+
+        :param bind_ip: Wildcard bind IP the streamserver is bound to.
+        :param device_ip: IP address of the device the traffic is meant for.
+        :param source_ip: Local address the per-device route lookup resolves to.
+        """
+        controller = _streams_controller(bind_ip=bind_ip)
         with patch(
             "music_assistant.controllers.streams.controller.get_source_ip_for_target",
-            new=AsyncMock(return_value="192.168.1.5"),
+            new=AsyncMock(return_value=source_ip),
         ) as routing_lookup:
-            assert await controller.get_source_ip(DEVICE_IP) == "192.168.1.5"
-        routing_lookup.assert_awaited_once_with(DEVICE_IP)
+            assert await controller.get_source_ip(device_ip) == source_ip
+        routing_lookup.assert_awaited_once_with(device_ip)
 
     @pytest.mark.asyncio
     async def test_unroutable_target_pins_nothing(self) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Music Assistant can be told to listen on all network interfaces, written as `0.0.0.0` for
IPv4 and `::` for IPv6. In both cases it then has to work out which of this machine's own
addresses actually reaches a given speaker, rather than handing out the "all interfaces"
placeholder as if it were a usable address.

Our tests for that only ever used the IPv4 form. If the IPv6 form stopped being recognised,
the test suite would stay green while speakers on an IPv6 network got an address that
cannot work.

## Types of changes

- [x] Maintenance / chore — `maintenance`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

## Changes

- Run the existing "listening on all interfaces" test for the IPv6 wildcard (`::`) as well as the IPv4 one (`0.0.0.0`), using an IPv6 speaker address for the IPv6 case.
