### PR TITLE
Use one shared definition for wildcard bind addresses

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -41,6 +41,7 @@ from music_assistant.constants import (
     LIVE_INDICATORS,
     SOUNDTRACK_INDICATORS,
     VERBOSE_LOG_LEVEL,
+    WILDCARD_BIND_IPS,
 )
 from music_assistant.helpers.process import check_output
 
@@ -1154,7 +1155,7 @@ async def get_source_ip_for_target(target_ip: str) -> str:
                 _sock.settimeout(1.0)
                 _sock.connect(route_target)
                 routed_ip = str(_sock.getsockname()[0])
-                if routed_ip and routed_ip not in ("0.0.0.0", "::", ""):
+                if routed_ip and routed_ip not in WILDCARD_BIND_IPS:
                     return routed_ip
             except OSError:
                 pass

--- a/music_assistant/helpers/webserver.py
+++ b/music_assistant/helpers/webserver.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any, Final
 
 from aiohttp import web
 
+from music_assistant.constants import WILDCARD_BIND_IPS
+
 if TYPE_CHECKING:
     import logging
 
@@ -112,7 +114,7 @@ class Webserver:
             self._webapp.router.add_route("*", "/{tail:.*}", self._handle_catch_all)
         await self._apprunner.setup()
         # set host to None to bind to all addresses on both IPv4 and IPv6
-        host = None if bind_ip in ("0.0.0.0", "::") else bind_ip
+        host = None if bind_ip in WILDCARD_BIND_IPS else bind_ip
         try:
             self._tcp_site = web.TCPSite(
                 self._apprunner, host=host, port=bind_port, ssl_context=ssl_context


### PR DESCRIPTION
# What does this implement/fix?

The list of "bind to every address" values (`0.0.0.0` and `::`) already lives in one place as the `WILDCARD_BIND_IPS` constant, but two helpers still spelled it out themselves. That leaves three copies to keep in step, so anything that ever needs adding to the list is easy to miss in one of them. No behaviour changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- use the shared `WILDCARD_BIND_IPS` constant in the webserver helper when deciding whether to bind to all addresses
- use the same constant in the util helper that looks up the source IP for a target

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
