### PR TITLE
Enter text-to-speech voices as separate values

### DIFF
--- a/music_assistant/providers/openai_tts/__init__.py
+++ b/music_assistant/providers/openai_tts/__init__.py
@@ -165,8 +165,11 @@ class OpenAITTSProvider(PluginProvider):
             ConfigEntry(
                 key=CONF_VOICES,
                 type=ConfigEntryType.STRING,
+                # no options: the override exists to name voices we could not discover,
+                # and a populated options list would render as a strict select
+                multi_value=True,
                 required=False,
-                default_value=None,
+                default_value=[],
                 category="features",
                 requires_reload=True,
             ),
@@ -327,14 +330,26 @@ class OpenAITTSProvider(PluginProvider):
 
     async def _resolve_voices(self) -> list[str]:
         """Return the voices to expose, from the config override, the backend or the defaults."""
-        if override := self.get_config_value(CONF_VOICES):
-            voices = [voice.strip() for voice in str(override).split(",") if voice.strip()]
-            if voices := list(dict.fromkeys(voices)):
-                self.logger.debug("Using %s voice(s) from the config override", len(voices))
-                return voices
+        if voices := self._voice_override():
+            self.logger.debug("Using %s voice(s) from the config override", len(voices))
+            return voices
         api_key = str(self.get_setup_value(CONF_API_KEY) or "")
         if voices := await fetch_backend_voices(self.mass.http_session, self._base_url, api_key):
             self.logger.debug("Discovered %s voice(s) on the backend", len(voices))
             return voices
         self.logger.debug("Falling back to the default voices")
         return list(DEFAULT_VOICES)
+
+    def _voice_override(self) -> list[str]:
+        """Return the configured voices, empty when the override is unset."""
+        configured = self.get_config_value(CONF_VOICES)
+        # tolerate a single comma separated string next to the stored list of values
+        values: list[object]
+        if isinstance(configured, str):
+            values = list(configured.split(","))
+        elif isinstance(configured, list):
+            values = list(configured)
+        else:
+            return []
+        names = [str(value).strip() for value in values if str(value).strip()]
+        return list(dict.fromkeys(names))

--- a/music_assistant/providers/openai_tts/strings.json
+++ b/music_assistant/providers/openai_tts/strings.json
@@ -14,7 +14,7 @@
     },
     "voices": {
       "label": "Voices",
-      "description": "Comma separated list of voices to expose, overriding the voices that are normally detected automatically or fall back to the standard OpenAI voices (alloy, echo, fable, nova, onyx, shimmer)."
+      "description": "Voices to expose as engines, overriding the voices that are normally detected automatically or fall back to the standard OpenAI voices (alloy, echo, fable, nova, onyx, shimmer)."
     }
   },
   "setup_flow": {

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1615,7 +1615,7 @@
   "provider.openai_tts.config_entries.base_url.label": "API endpoint",
   "provider.openai_tts.config_entries.model.description": "The speech model to use, for example tts-1 or the higher quality gpt-4o-mini-tts on the OpenAI cloud API. Self-hosted servers use their own model names.",
   "provider.openai_tts.config_entries.model.label": "Model",
-  "provider.openai_tts.config_entries.voices.description": "Comma separated list of voices to expose, overriding the voices that are normally detected automatically or fall back to the standard OpenAI voices (alloy, echo, fable, nova, onyx, shimmer).",
+  "provider.openai_tts.config_entries.voices.description": "Voices to expose as engines, overriding the voices that are normally detected automatically or fall back to the standard OpenAI voices (alloy, echo, fable, nova, onyx, shimmer).",
   "provider.openai_tts.config_entries.voices.label": "Voices",
   "provider.openai_tts.errors.cannot_connect": "Could not reach the speech API. Please check the address and try again.",
   "provider.openai_tts.errors.endpoint_not_found": "No speech endpoint was found at this address. Please check the API endpoint.",

--- a/tests/providers/openai_tts/test_openai_tts.py
+++ b/tests/providers/openai_tts/test_openai_tts.py
@@ -47,6 +47,12 @@ def create_provider(**config_values: ConfigValueType) -> OpenAITTSProvider:
 
 async def test_resolve_voices_honours_config_override() -> None:
     """The config override wins, stripped and de-duplicated with empty entries dropped."""
+    provider = create_provider(**{CONF_VOICES: [" nova ", "alloy", "", " nova", "echo "]})
+    assert await provider._resolve_voices() == ["nova", "alloy", "echo"]
+
+
+async def test_resolve_voices_accepts_a_single_string_override() -> None:
+    """A comma separated string is accepted next to the stored list of values."""
     provider = create_provider(**{CONF_VOICES: " nova ,alloy,, nova,echo "})
     assert await provider._resolve_voices() == ["nova", "alloy", "echo"]
 


### PR DESCRIPTION
# What does this implement/fix?

The voices option on the OpenAI Text-to-speech provider expected one comma separated string, which is easy to get wrong. Voices are now entered as separate values, so each voice becomes its own chip in the settings.

**Related issue (if applicable):**

- follow-up to #5262

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- The voices option is now a multi value field, so each voice is entered as its own value
- A previously entered comma separated string is still accepted, so nothing needs re-entering
- No options are offered on purpose: the override exists to name voices that could not be detected, and offering a list would turn the field into a fixed choice

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
