### PR TITLE
Play AI Radio TTS clips that are rendered to a local file

### DIFF
--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -284,7 +284,9 @@ class PluginProvider(Provider):
         :param language: Optional language code.
         :param engine_id: The provider-scoped id of the engine to use (``TTSEngine.id``,
             not its ``uid``). Omit or pass None to use the plugin's own default engine.
-        :return: StreamDetails for the generated audio.
+        :return: StreamDetails for the generated audio. ``path`` must be either a
+            fetchable http(s)/rtsp/rtmp URL or the absolute path of an existing local
+            file, and must stay resolvable for as long as consumers may play the clip.
         """
         raise NotImplementedError
 

--- a/music_assistant/providers/ai_radio/runtime.py
+++ b/music_assistant/providers/ai_radio/runtime.py
@@ -1597,21 +1597,27 @@ class AIRadioRuntimeMixin:
         engine = await self._get_tts_engine()
         self.logger.debug("TTS render prepared: engine=%s text_chars=%d", engine.uid, len(text))
         stream_details = await engine.provider.get_tts_message(text, engine_id=engine.id)
-        uri = str(getattr(stream_details, "path", "") or "").strip()
-        if not uri:
+        source = str(getattr(stream_details, "path", "") or "").strip()
+        if not source:
             raise MusicAssistantError(
                 f"TTS engine '{engine.uid}' returned no direct stream path in StreamDetails.path"
             )
-        if uri.startswith(("http://", "https://", "rtsp://", "rtmp://")):
-            builtin_provider = self.mass.get_provider("builtin")
-            builtin_instance_id = str(getattr(builtin_provider, "instance_id", "") or "").strip()
-            duration = await self._warm_builtin_duration_cache(builtin_provider, uri, section_name)
-            wrapped = create_uri(MediaType.SOUND_EFFECT, builtin_instance_id or "builtin", uri)
-            return wrapped, duration
-        return uri, 0
+        if not source.startswith(("http://", "https://", "rtsp://", "rtmp://")) and not (
+            Path(source).is_absolute() and await asyncio.to_thread(Path(source).is_file)
+        ):
+            raise MusicAssistantError(
+                f"TTS engine '{engine.uid}' returned an unusable stream path: {source}. "
+                "StreamDetails.path must be a fetchable http(s)/rtsp/rtmp URL or the "
+                "absolute path of an existing local file."
+            )
+        builtin_provider = self.mass.get_provider("builtin")
+        builtin_instance_id = str(getattr(builtin_provider, "instance_id", "") or "").strip()
+        duration = await self._warm_builtin_duration_cache(builtin_provider, source, section_name)
+        wrapped = create_uri(MediaType.SOUND_EFFECT, builtin_instance_id or "builtin", source)
+        return wrapped, duration
 
     async def _warm_builtin_duration_cache(
-        self, builtin_provider: Any, url: str, section_name: str
+        self, builtin_provider: Any, source: str, section_name: str
     ) -> int:
         """
         Force-decode duration, set a friendly title, prefill builtin's cache.
@@ -1623,9 +1629,11 @@ class AIRadioRuntimeMixin:
         if builtin_provider is None:
             return 0
         try:
-            tags = await async_parse_tags(url, require_duration=True)
+            tags = await async_parse_tags(source, require_duration=True)
         except (InvalidDataError, OSError) as err:
-            self.logger.warning("Could not pre-compute TTS section duration for %s: %s", url, err)
+            self.logger.warning(
+                "Could not pre-compute TTS section duration for %s: %s", source, err
+            )
             return 0
         format_block = tags.raw.setdefault("format", {})
         if tags.duration:
@@ -1634,7 +1642,7 @@ class AIRadioRuntimeMixin:
         format_tags.setdefault("title", section_name)
         format_tags.setdefault("artist", "AI Radio")
         await self.mass.cache.set(
-            url,
+            source,
             tags.raw,
             provider=str(getattr(builtin_provider, "instance_id", "") or "builtin"),
             category=CACHE_CATEGORY_MEDIA_INFO,

--- a/tests/providers/ai_radio/test_runtime.py
+++ b/tests/providers/ai_radio/test_runtime.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import random
 from contextlib import suppress
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -24,7 +25,7 @@ from music_assistant_models.media_items import SoundEffect
 
 from music_assistant.helpers.datetime import now as host_now
 from music_assistant.helpers.playlists import PlaylistItem, parse_m3u, parse_m3u_playlist_image
-from music_assistant.helpers.uri import create_uri
+from music_assistant.helpers.uri import create_uri, parse_uri
 from music_assistant.models.plugin import AIEngine, PluginProvider, TTSEngine
 from music_assistant.providers.ai_radio.constants import CONF_AI_ENGINE, CONF_TTS_ENGINE
 from music_assistant.providers.ai_radio.models import AudioSection, SessionState, Slot
@@ -363,6 +364,44 @@ async def test_render_tts_converts_raw_http_path_to_builtin_sound_effect_uri() -
     assert duration == 11
     plugin.get_tts_message.assert_awaited_once_with("hello world", engine_id="tts.cloud")
     runtime._warm_builtin_duration_cache.assert_awaited_once()
+
+
+async def test_render_tts_converts_local_file_path_to_builtin_sound_effect_uri(
+    tmp_path: Path,
+) -> None:
+    """A rendered clip on disk gets the same builtin sound effect treatment as a URL."""
+    clip = tmp_path / "section.mp3"
+    clip.write_bytes(b"")
+    plugin = _create_tts_plugin("local_tts_1", "voice")
+    plugin.get_tts_message = AsyncMock(return_value=SimpleNamespace(path=str(clip)))
+
+    def get_provider(provider: str) -> Any:
+        return SimpleNamespace(instance_id="builtin_1") if provider == "builtin" else None
+
+    runtime = DummyRuntime({CONF_TTS_ENGINE: "local_tts_1/voice"})
+    _set_runtime_mass(
+        runtime, _create_engine_mass(ProviderFeature.TTS, plugin, get_provider=get_provider)
+    )
+    runtime._warm_builtin_duration_cache = AsyncMock(return_value=7)  # type: ignore[method-assign]
+
+    uri, duration = await runtime._render_tts("hello world", "Test Section")
+
+    assert uri == create_uri(MediaType.SOUND_EFFECT, "builtin_1", str(clip))
+    assert await parse_uri(uri) == (MediaType.SOUND_EFFECT, "builtin_1", str(clip))
+    assert duration == 7
+    runtime._warm_builtin_duration_cache.assert_awaited_once()
+
+
+async def test_render_tts_rejects_a_stream_path_that_is_not_playable() -> None:
+    """A path that is neither a URL nor an existing file fails loudly instead of degrading."""
+    plugin = _create_tts_plugin("local_tts_1", "voice")
+    plugin.get_tts_message = AsyncMock(return_value=SimpleNamespace(path="section.mp3"))
+
+    runtime = DummyRuntime({CONF_TTS_ENGINE: "local_tts_1/voice"})
+    _set_runtime_mass(runtime, _create_engine_mass(ProviderFeature.TTS, plugin))
+
+    with pytest.raises(MusicAssistantError, match="unusable stream path"):
+        await runtime._render_tts("hello world", "Test Section")
 
 
 async def test_render_tts_refuses_a_configured_engine_that_disappeared() -> None:


### PR DESCRIPTION
# What does this implement/fix?

`_render_tts` only wrapped `StreamDetails.path` as a builtin sound effect when it looked like an http(s)/rtsp/rtmp URL. Every other value fell through to `return uri, 0` — the raw string, no duration — which is degraded in three ways:

- `parse_uri` does route a bare absolute file path to the builtin provider (`helpers/uri.py:127`), but with `requested_media_type=MediaType.UNKNOWN`, so `builtin.parse_item` never takes the `SOUND_EFFECT` branch. The item becomes a Track — or a Radio when ffprobe reports no duration, which is exactly the auto-advance breakage `_warm_builtin_duration_cache` exists to prevent.
- duration `0`, so no length metadata is propagated.
- in builtin playlist mode it is broken outright: `_provider_mapping_infos_from_uri` returns `[]` for a uri without `://`, and `helpers/playlists.py` then falls back to the basename as `item_id`, which does not resolve.

An absolute path to an existing file now gets exactly the same treatment as a URL: warm the duration cache, wrap as `builtin://sound_effect/<path>`. `create_uri(SOUND_EFFECT, "builtin", "/abs/path.mp3")` round-trips through `parse_uri` intact (asserted in the new test), and builtin ffprobes local paths fine. Anything that is neither a URL nor an existing absolute file now raises instead of silently returning something unplayable, and `PluginProvider.get_tts_message` documents the contract.

The alternative was to drop the branch entirely and require `get_tts_message` to always return a fetchable URL. Making it work won because `helpers/uri.py` already treats a local file as a first-class builtin source, and requiring a URL would break any out-of-tree TTS plugin that renders to disk.

Nothing in-tree reaches this code path today — `hass` returns a tts_proxy URL and the new `openai_tts` provider (#5262) serves its clips over its own dynamic route — so this is latent cleanup, not a reported bug. Not live-tested for the same reason: unit tests only.

cc @swiftbird07 as ai_radio codeowner, for visibility.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
