### PR TITLE
Let players fall back when a control is taken away

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1877,8 +1877,10 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         control = self._controls.pop(control_id, None)
         if control is None:
             return
-        self._controls.pop(control_id, None)
         self.logger.info("PlayerControl removed: %s", control.name)
+        # players configured to use this control still resolve to it until they are
+        # refreshed, so let them fall back to their remaining options right away
+        self.update_player_control(control_id)
 
     def get_player_provider(self, player_id: str) -> PlayerProvider:
         """Return PlayerProvider for given player."""

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -778,13 +778,14 @@ class HomeAssistantProvider(PluginProvider):
     async def _subscribe_control_states(self) -> None:
         """Subscribe to the Home Assistant state of all currently tracked controls."""
         assert self._player_controls is not None  # for type checking
-        # register for entity state updates, replacing any earlier subscription
-        if unsubscribe := self._unsubscribe_controls:
-            self._unsubscribe_controls = None
-            unsubscribe()
+        # the earlier subscription is only released once the new one is live, so a failure
+        # to subscribe leaves the controls watched by the subscription they already had
+        previous_unsubscribe = self._unsubscribe_controls
         self._unsubscribe_controls = await self.hass.subscribe_entities(
             self._on_entity_state_update, list(self._player_controls)
         )
+        if previous_unsubscribe:
+            previous_unsubscribe()
 
     async def _handle_player_control_power_on(self, entity_id: str) -> None:
         """Handle powering on the playercontrol."""

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -37,6 +37,7 @@ from music_assistant_models.errors import (
     UnsupportedFeaturedException,
 )
 from music_assistant_models.player import OutputProtocol, PlayerMedia, PlayerSource
+from music_assistant_models.player_control import PlayerControl
 
 from music_assistant.constants import ATTR_PREVIOUS_VOLUME, CONF_MUTE_CONTROL
 from music_assistant.controllers.players import PlayerController
@@ -1804,6 +1805,46 @@ async def _skip_player_update_wait(
 ) -> AsyncIterator[None]:
     """Skip provider-driven state propagation in command-routing tests."""
     yield
+
+
+class TestRemovePlayerControl:
+    """Test removing a registered player control."""
+
+    def test_removal_refreshes_the_players_that_used_it(self, mock_mass: MagicMock) -> None:
+        """Test that only the players configured to use the removed control are refreshed."""
+        mock_mass.loop = MagicMock()
+        controller = PlayerController(mock_mass)
+        using_control = MagicMock()
+        using_control.state.power_control = "switch.amp"
+        using_control.state.volume_control = PLAYER_CONTROL_NATIVE
+        using_control.state.mute_control = PLAYER_CONTROL_NATIVE
+        unrelated = MagicMock()
+        unrelated.state.power_control = PLAYER_CONTROL_NATIVE
+        unrelated.state.volume_control = PLAYER_CONTROL_NATIVE
+        unrelated.state.mute_control = PLAYER_CONTROL_NATIVE
+        controller._players = {"using_control": using_control, "unrelated": unrelated}
+        controller._controls = {
+            "switch.amp": PlayerControl(id="switch.amp", provider="test_prov", name="Amp")
+        }
+
+        controller.remove_player_control("switch.amp")
+
+        assert controller.player_controls() == []
+        mock_mass.loop.call_soon.assert_called_once_with(using_control.refresh_state)
+
+    def test_removing_an_unknown_control_does_nothing(self, mock_mass: MagicMock) -> None:
+        """Test that removing a control that was never registered is a no-op."""
+        mock_mass.loop = MagicMock()
+        controller = PlayerController(mock_mass)
+        player = MagicMock()
+        player.state.power_control = PLAYER_CONTROL_NATIVE
+        player.state.volume_control = PLAYER_CONTROL_NATIVE
+        player.state.mute_control = PLAYER_CONTROL_NATIVE
+        controller._players = {"player": player}
+
+        controller.remove_player_control("switch.gone")
+
+        mock_mass.loop.call_soon.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -1007,12 +1007,41 @@ async def test_player_control_subscription_is_replaced() -> None:
 
         assert len(hass.subscriptions) == 4
         assert hass.active_subscriptions == 1
-        # the previous control subscription is released before the new one is created
-        assert hass.calls[-2:] == ["unsubscribe_entities", "subscribe_entities"]
+        # the previous control subscription is only released once its replacement is live
+        assert hass.calls[-2:] == ["subscribe_entities", "unsubscribe_entities"]
 
         await provider.unload()
 
         assert hass.active_subscriptions == 0
+
+
+async def test_failed_control_subscription_keeps_the_previous_one() -> None:
+    """A failed subscription attempt leaves the controls watched by the earlier one."""
+    states = [_state("media_player.kitchen", "Kitchen"), _state("switch.amp", "Amp")]
+    async with _start_provider(states, **{CONF_POWER_CONTROLS: ["media_player.kitchen"]}) as (
+        provider,
+        hass,
+    ):
+        await provider.loaded_in_mass()
+        unsubscribe_before = provider._unsubscribe_controls
+        assert hass.active_subscriptions == 1
+
+        async def _failing_subscribe(*_args: Any, **_kwargs: Any) -> Callable[[], None]:
+            raise BaseHassClientError("connection lost")
+
+        hass.subscribe_entities = _failing_subscribe  # type: ignore[method-assign]
+        provider.config = _config(
+            **{
+                CONF_POWER_CONTROLS: ["media_player.kitchen"],
+                CONF_MUTE_CONTROLS: ["switch.amp"],
+            }
+        )
+
+        with pytest.raises(BaseHassClientError):
+            await provider._register_player_controls()
+
+        assert provider._unsubscribe_controls is unsubscribe_before
+        assert hass.active_subscriptions == 1
 
 
 async def test_unchanged_control_selection_skips_home_assistant() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Removing an entity from the Home Assistant control lists left the players that used it still pointing at a control that no longer exists, so their power or volume button silently did nothing until something else happened to refresh them. Those players now fall back to their remaining options straight away.

Also spotted while looking at this: the plugin released its Home Assistant subscription before setting up the replacement, so a subscribe that failed part-way left the controls unwatched until the next reload.

Follow-up to #5268, which made changing the control selection take effect immediately and so made the stale reference much easier to run into.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- refresh the players that were using a player control when it is removed
- keep the previous Home Assistant subscription until its replacement is live

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
