### PR TITLE
Advertise all server addresses for AirPlay remote control

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -157,6 +157,29 @@ async def _wav_passthrough_stream(
         yield chunk
 
 
+def _get_publish_addresses(
+    bind_ip: str, configured_publish_ip: str | None, all_ip_addresses: tuple[str, ...]
+) -> list[str]:
+    """
+    Return the addresses this host should advertise to players on the local network.
+
+    :param bind_ip: The configured bind IP (a wildcard means all interfaces).
+    :param configured_publish_ip: The explicitly configured publish IP, or None when auto.
+    :param all_ip_addresses: All detected host IP addresses, in ranked order.
+    """
+    if configured_publish_ip:
+        # an explicitly configured address is the authoritative answer
+        return [configured_publish_ip]
+    if bind_ip and bind_ip not in WILDCARD_BIND_IPS:
+        # only one interface is served, so no other address can be reached
+        return [bind_ip]
+    # Auto-detected: the primary address is only a guess at which interface the players
+    # live on, so advertise every address (highest ranked first) and let the device pick
+    # one it can reach. On a multi-homed host - a VPN or docker interface alongside the
+    # LAN - the primary-route address is regularly not the one on the players' network.
+    return list(all_ip_addresses)
+
+
 class StreamsController(CoreController):
     """Controller to stream audio to players."""
 
@@ -177,6 +200,9 @@ class StreamsController(CoreController):
         self.announcement_renderer = AnnouncementRenderer()
         self._bind_ip: str = "0.0.0.0"
         self._configured_publish_ip: str | None = None
+        # every address players may reach this host on, best candidate first - for mDNS
+        # records, which can carry them all, unlike the single-valued publish_ip
+        self.publish_addresses: list[str] = []
         self.audio = StreamsAudio(mass)
         self.audio_processing = AudioProcessingManager(mass)
         self._audio_analysis = AudioAnalysisController(self)
@@ -421,10 +447,12 @@ class StreamsController(CoreController):
             None if configured_publish_ip == CONF_VALUE_AUTO else configured_publish_ip
         )
         # resolve the "auto" default (or an unset value) to this server's primary IP
-        self.publish_ip = (
-            self._configured_publish_ip or (await get_ip_addresses(include_ipv6=True))[0]
-        )
+        all_ip_addresses = await get_ip_addresses(include_ipv6=True)
+        self.publish_ip = self._configured_publish_ip or all_ip_addresses[0]
         self._bind_ip = bind_ip = str(config.get_value(CONF_BIND_IP))
+        self.publish_addresses = _get_publish_addresses(
+            bind_ip, self._configured_publish_ip, all_ip_addresses
+        )
         # print a big fat message in the log where the streamserver is running
         # because this is a common source of issues for people with more complex setups
         self.logger.log(

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -241,7 +241,14 @@ class AirPlayProvider(PlayerProvider):
         self._dacp_info = AsyncServiceInfo(
             DACP_DISCOVERY_TYPE,
             name=server_id,
-            addresses=[await get_ip_pton(str(self.mass.streams.publish_ip))],
+            # The DACP socket above listens on all interfaces, so advertise every address
+            # the players may reach us on. Advertising only the primary-route address
+            # leaves receivers on another interface of a multi-homed host unable to send
+            # their ActiveRemote callbacks: their transport/volume buttons and their
+            # device-prevent-playback notifications never arrive, while audio plays on.
+            addresses=[
+                await get_ip_pton(address) for address in self.mass.streams.publish_addresses
+            ],
             port=dacp_port,
             properties={
                 "txtvers": "1",

--- a/tests/controllers/streams/test_publish_addresses.py
+++ b/tests/controllers/streams/test_publish_addresses.py
@@ -1,0 +1,37 @@
+"""Tests for the streamserver publish address selection."""
+
+from music_assistant.controllers.streams.controller import _get_publish_addresses
+
+ALL_ADDRESSES = ("192.168.1.10", "10.0.0.5", "172.17.0.1", "fd00::10")
+
+
+def test_wildcard_bind_publishes_every_address() -> None:
+    """A wildcard bind publishes every detected address, best candidate first."""
+    assert _get_publish_addresses("0.0.0.0", None, ALL_ADDRESSES) == [
+        "192.168.1.10",
+        "10.0.0.5",
+        "172.17.0.1",
+        "fd00::10",
+    ]
+    assert _get_publish_addresses("::", None, ALL_ADDRESSES) == list(ALL_ADDRESSES)
+    assert _get_publish_addresses("", None, ALL_ADDRESSES) == list(ALL_ADDRESSES)
+
+
+def test_specific_bind_publishes_only_that_address() -> None:
+    """Binding to one specific address publishes only that address."""
+    assert _get_publish_addresses("192.168.1.10", None, ALL_ADDRESSES) == ["192.168.1.10"]
+    assert _get_publish_addresses("fd00::10", None, ALL_ADDRESSES) == ["fd00::10"]
+
+
+def test_configured_publish_ip_is_authoritative() -> None:
+    """An explicitly configured publish IP is published on its own, never widened."""
+    assert _get_publish_addresses("0.0.0.0", "10.0.0.5", ALL_ADDRESSES) == ["10.0.0.5"]
+    # ...even when it is not an address of this host at all (NAT/port forward setups)
+    assert _get_publish_addresses("0.0.0.0", "203.0.113.7", ALL_ADDRESSES) == ["203.0.113.7"]
+    # ...and it outranks a specific bind IP, matching how publish_ip itself resolves
+    assert _get_publish_addresses("192.168.1.10", "203.0.113.7", ALL_ADDRESSES) == ["203.0.113.7"]
+
+
+def test_single_homed_host_is_unchanged() -> None:
+    """The common single-address host keeps publishing exactly that one address."""
+    assert _get_publish_addresses("0.0.0.0", None, ("192.168.1.10",)) == ["192.168.1.10"]


### PR DESCRIPTION
# What does this implement/fix?

When the server has more than one network connection (a VPN or docker network alongside the regular LAN), we only told AirPlay speakers about one of our addresses. A speaker that cannot reach that particular address keeps playing audio just fine, but its own play/pause, next/previous and volume buttons no longer reach Music Assistant, and its "something else is playing here" notifications are lost too.

We now announce every address a speaker can reach us on, so it can pick one that works.

- streams: new `publish_addresses` list alongside the existing single publish IP, same approach the webserver already uses for its own announcement
- airplay: the remote control (DACP) announcement carries all of those addresses instead of only the primary one
- an explicitly configured publish IP still wins and is announced on its own, and so does a specific bind IP

Not live-verified against a multi-homed setup with a real speaker; covered by unit tests for the address selection.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
