### PR TITLE
Stop tests from failing on a port another process took

### DIFF
--- a/music_assistant/__main__.py
+++ b/music_assistant/__main__.py
@@ -282,8 +282,10 @@ def main() -> None:
             with suppress(NotImplementedError):
                 loop.add_signal_handler(sig, _set_stop)
 
-        await mass.start()
         try:
+            # a startup that fails part-way must be cleaned up too, or the databases it
+            # already opened keep their worker threads alive and the process never exits
+            await mass.start()
             await stop_event.wait()
         finally:
             logger.info("shutdown requested!")

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -208,7 +208,6 @@ def _default_background_scan_concurrency() -> int:
 
 # config default values
 DEFAULT_HOST: Final[str] = "0.0.0.0"
-DEFAULT_PORT: Final[int] = 8095
 DEFAULT_BACKGROUND_SCAN_CONCURRENCY: Final[int] = _default_background_scan_concurrency()
 
 

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -473,15 +473,15 @@ class StreamsController(CoreController):
                 ("*", "/announcement/{player_id}.{fmt}", self.serve_announcement_stream),
             ],
         )
-        # adopt the port the server ended up on, which differs from the configured
-        # one when that asked the OS for a free port
-        self.publish_port = self._server.port
+        # adopt the port the server actually bound to: a configured port of 0 is only
+        # resolved by the OS at bind time
+        self.publish_port = cast("int", self._server.port)
         # print a big fat message in the log where the streamserver is running
         # because this is a common source of issues for people with more complex setups
         self.logger.log(
             logging.INFO if self.mass.config.onboard_done else logging.WARNING,
             "\n\n################################################################################\n"
-            "Started streamserver on  %s:%s\n"
+            "Started streamserver on %s:%s\n"
             "This is the IP address that is communicated to players.\n"
             "If this is incorrect, audio will not play!\n"
             "See the documentation for how to configure the publish IP for the Streamserver\n"

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -58,6 +58,7 @@ from music_assistant.constants import (
     CONF_VOLUME_NORMALIZATION_RADIO,
     CONF_VOLUME_NORMALIZATION_TRACKS,
     DEFAULT_BACKGROUND_SCAN_CONCURRENCY,
+    DEFAULT_HOST,
     DEFAULT_STREAM_HEADERS,
     DLNA_CONTENT_FEATURES,
     DLNA_CONTENT_FEATURES_REALTIME,
@@ -405,8 +406,8 @@ class StreamsController(CoreController):
             ConfigEntry(
                 key=CONF_BIND_IP,
                 type=ConfigEntryType.STRING,
-                default_value="0.0.0.0",
-                options=[ConfigValueOption(x, title=x) for x in {"0.0.0.0", *ip_addresses}],
+                default_value=DEFAULT_HOST,
+                options=[ConfigValueOption(x, title=x) for x in {DEFAULT_HOST, *ip_addresses}],
                 category="generic",
                 advanced=True,
                 required=False,
@@ -453,20 +454,6 @@ class StreamsController(CoreController):
         self.publish_addresses = _get_publish_addresses(
             bind_ip, self._configured_publish_ip, all_ip_addresses
         )
-        # print a big fat message in the log where the streamserver is running
-        # because this is a common source of issues for people with more complex setups
-        self.logger.log(
-            logging.INFO if self.mass.config.onboard_done else logging.WARNING,
-            "\n\n################################################################################\n"
-            "Starting streamserver on  %s:%s\n"
-            "This is the IP address that is communicated to players.\n"
-            "If this is incorrect, audio will not play!\n"
-            "See the documentation for how to configure the publish IP for the Streamserver\n"
-            "in Settings --> System --> Streams\n"
-            "################################################################################\n",
-            self.publish_ip,
-            self.publish_port,
-        )
         await self._server.setup(
             bind_ip=bind_ip,
             bind_port=cast("int", self.publish_port),
@@ -485,6 +472,23 @@ class StreamsController(CoreController):
                 ("*", "/command/{queue_id}/{command}.mp3", self.serve_command_request),
                 ("*", "/announcement/{player_id}.{fmt}", self.serve_announcement_stream),
             ],
+        )
+        # adopt the port the server ended up on, which differs from the configured
+        # one when that asked the OS for a free port
+        self.publish_port = self._server.port
+        # print a big fat message in the log where the streamserver is running
+        # because this is a common source of issues for people with more complex setups
+        self.logger.log(
+            logging.INFO if self.mass.config.onboard_done else logging.WARNING,
+            "\n\n################################################################################\n"
+            "Started streamserver on  %s:%s\n"
+            "This is the IP address that is communicated to players.\n"
+            "If this is incorrect, audio will not play!\n"
+            "See the documentation for how to configure the publish IP for the Streamserver\n"
+            "in Settings --> System --> Streams\n"
+            "################################################################################\n",
+            self.publish_ip,
+            self.publish_port,
         )
 
     async def close(self) -> None:

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -36,6 +36,7 @@ from music_assistant.constants import (
     CONF_BIND_IP,
     CONF_BIND_PORT,
     CONF_VALUE_AUTO,
+    DEFAULT_HOST,
     INGRESS_SERVER_PORT,
     RESOURCES_DIR,
     SENDSPIN_SERVER_PORT,
@@ -287,6 +288,32 @@ class WebserverController(CoreController):
         self._auto_base_url = (
             f"{protocol}://{format_ip_for_url(self.publish_ip)}:{self.publish_port}"
         )
+
+        # Create SSL context if SSL is enabled
+        ssl_context = None
+        if ssl_enabled:
+            ssl_context = await create_server_ssl_context(
+                str(config.get_value(CONF_SSL_CERTIFICATE) or ""),
+                str(config.get_value(CONF_SSL_PRIVATE_KEY) or ""),
+                logger=self.logger,
+            )
+
+        await self._server.setup(
+            bind_ip=bind_ip,
+            bind_port=self.publish_port,
+            base_url=self._auto_base_url,
+            static_routes=routes,
+            # add assets subdir as static_content
+            static_content=("/assets", os.path.join(frontend_dir, "assets"), "assets"),
+            ingress_tcp_site_params=ingress_tcp_site_params,
+            # Add mass object to app for use by the auth helpers
+            app_state={"mass": self.mass},
+            ssl_context=ssl_context,
+        )
+        # adopt the port the server ended up on, which differs from the configured one
+        # when that asked the OS for a free port
+        self.publish_port = cast("int", self._server.port)
+        self._auto_base_url = self._server.base_url
         base_url = self.base_url
         # print a big fat message in the log where the webserver is running
         # because this is a common source of issues for people with more complex setups
@@ -317,28 +344,6 @@ class WebserverController(CoreController):
                 "################################################################################\n",
                 base_url,
             )
-
-        # Create SSL context if SSL is enabled
-        ssl_context = None
-        if ssl_enabled:
-            ssl_context = await create_server_ssl_context(
-                str(config.get_value(CONF_SSL_CERTIFICATE) or ""),
-                str(config.get_value(CONF_SSL_PRIVATE_KEY) or ""),
-                logger=self.logger,
-            )
-
-        await self._server.setup(
-            bind_ip=bind_ip,
-            bind_port=self.publish_port,
-            base_url=base_url,
-            static_routes=routes,
-            # add assets subdir as static_content
-            static_content=("/assets", os.path.join(frontend_dir, "assets"), "assets"),
-            ingress_tcp_site_params=ingress_tcp_site_params,
-            # Add mass object to app for use by the auth helpers
-            app_state={"mass": self.mass},
-            ssl_context=ssl_context,
-        )
 
         # Setup remote access after webserver is running
         await self.remote_access.setup()
@@ -516,8 +521,8 @@ class WebserverController(CoreController):
             ConfigEntry(
                 key=CONF_BIND_IP,
                 type=ConfigEntryType.STRING,
-                default_value="0.0.0.0",
-                options=[ConfigValueOption(x, title=x) for x in {"0.0.0.0", *ip_addresses}],
+                default_value=DEFAULT_HOST,
+                options=[ConfigValueOption(x, title=x) for x in {DEFAULT_HOST, *ip_addresses}],
                 category="generic",
                 advanced=True,
                 requires_reload=True,

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -310,8 +310,8 @@ class WebserverController(CoreController):
             app_state={"mass": self.mass},
             ssl_context=ssl_context,
         )
-        # adopt the port the server ended up on, which differs from the configured one
-        # when that asked the OS for a free port
+        # adopt the port the server actually bound to: a configured port of 0 is only
+        # resolved by the OS at bind time
         self.publish_port = cast("int", self._server.port)
         self._auto_base_url = self._server.base_url
         base_url = self.base_url

--- a/music_assistant/helpers/webserver.py
+++ b/music_assistant/helpers/webserver.py
@@ -78,8 +78,9 @@ class Webserver:
         Async initialize of module.
 
         :param bind_ip: IP address to bind to.
-        :param bind_port: Port to bind to, or 0 to let the OS assign a free one. The
-            assigned port is available as ``port`` and replaces the port in ``base_url``.
+        :param bind_port: Port to bind to, or 0 to let the OS assign a free one, which
+            requires a specific ``bind_ip``. The assigned port is available as the
+            ``port`` property and replaces the port in ``base_url``.
         :param base_url: Base URL for the server.
         :param static_routes: List of static routes to register.
         :param static_content: Tuple of (path, directory, name) for static content.
@@ -117,6 +118,11 @@ class Webserver:
         await self._apprunner.setup()
         # set host to None to bind to all addresses on both IPv4 and IPv6
         host = None if bind_ip in WILDCARD_BIND_IPS else bind_ip
+        if bind_port == 0 and host is None:
+            # a wildcard bind gets one socket per address family, each with its own
+            # OS-assigned port, so there is no single port to publish
+            msg = "An OS-assigned port requires a specific bind address"
+            raise ValueError(msg)
         try:
             self._tcp_site = web.TCPSite(
                 self._apprunner, host=host, port=bind_port, ssl_context=ssl_context
@@ -124,6 +130,9 @@ class Webserver:
             await self._tcp_site.start()
         except OSError:
             if host is None:
+                raise
+            if bind_port == 0:
+                # binding all interfaces is no fallback for an OS-assigned port
                 raise
             # the configured interface is not available, retry on all interfaces
             self.logger.error(

--- a/music_assistant/helpers/webserver.py
+++ b/music_assistant/helpers/webserver.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Coroutine, Mapping
 from typing import TYPE_CHECKING, Any, Final
 
 from aiohttp import web
+from yarl import URL
 
 from music_assistant.constants import WILDCARD_BIND_IPS
 
@@ -77,7 +78,8 @@ class Webserver:
         Async initialize of module.
 
         :param bind_ip: IP address to bind to.
-        :param bind_port: Port to bind to.
+        :param bind_port: Port to bind to, or 0 to let the OS assign a free one. The
+            assigned port is available as ``port`` and replaces the port in ``base_url``.
         :param base_url: Base URL for the server.
         :param static_routes: List of static routes to register.
         :param static_content: Tuple of (path, directory, name) for static content.
@@ -131,6 +133,10 @@ class Webserver:
                 self._apprunner, host=None, port=bind_port, ssl_context=ssl_context
             )
             await self._tcp_site.start()
+        # port 0 asks the OS for a free port, which it only picks at bind time
+        if bind_port == 0:
+            self._bind_port = self._apprunner.addresses[0][1]
+            self._base_url = str(URL(self._base_url).with_port(self._bind_port))
         # start additional ingress TCP site if configured
         # this is only used if we're running in the context of an HA add-on
         # which proxies our frontend and api through ingress

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -336,21 +336,31 @@ class MusicAssistant:
             *[self.unload_provider(prov_id) for prov_id in list(self._providers.keys())],
             return_exceptions=True,
         )
-        # stop core controllers
-        await self.discovery.close()
-        await self.streams.close()
-        await self.webserver.close()
-        await self.tasks.close()
-        await self.metadata.close()
-        await self.music.close()
-        await self.player_queues.close()
-        await self.players.close()
-        await self.translations.close()
-        await self.diagnostics.close()
-        await self.dashboard.close()
-        # cleanup cache and config
-        await self.config.close()
-        await self.cache.close()
+        # stop core controllers, cache and config last because the others rely on them.
+        # a failed startup may not have created (or fully set up) every controller, so
+        # each one is closed independently: leaving a database open here would keep its
+        # worker thread alive and stop the process from ever exiting.
+        for controller_name in (
+            "discovery",
+            "streams",
+            "webserver",
+            "tasks",
+            "metadata",
+            "music",
+            "player_queues",
+            "players",
+            "translations",
+            "diagnostics",
+            "dashboard",
+            "config",
+            "cache",
+        ):
+            if (controller := getattr(self, controller_name, None)) is None:
+                continue
+            try:
+                await controller.close()
+            except Exception:
+                LOGGER.exception("Error while closing the %s controller", controller_name)
         # close/cleanup shared http sessions
         if self._http_session and not self._http_session.closed:
             await self._http_session.close()
@@ -1458,4 +1468,9 @@ class MusicAssistant:
         if self._state == new_state:
             return
         self._state = new_state
+        if not hasattr(self, "webserver"):
+            # a startup that failed before the core controllers were created has no
+            # server info to report and no subscribers to report it to, while the state
+            # itself must still change so that shutdown can run to completion
+            return
         self.signal_event(EventType.CORE_STATE_UPDATED, data=self.get_server_info())

--- a/tests/common.py
+++ b/tests/common.py
@@ -74,10 +74,8 @@ def use_ephemeral_server_ports() -> Iterator[None]:
     """
     Bind a full-server test fixture's web and stream servers to a free loopback port.
 
-    Port 0 has the kernel pick the port during the bind itself, which is the only way
-    to be sure nothing else holds it: a port that is merely observed to be free can be
-    handed to any outgoing connection - of this test run or of another job on the same
-    runner - before the server gets to claim it.
+    Port 0 has the kernel pick the port during the bind itself, so nothing else can
+    claim it in the meantime.
 
     Binding loopback keeps a test run off the host's other interfaces and gives each
     server a single socket, so it has one assigned port: asyncio binds a wildcard

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,9 +4,9 @@ import asyncio
 import contextlib
 import logging
 import pathlib
-from collections.abc import AsyncGenerator, Callable, Iterator
+from collections.abc import AsyncGenerator, Iterator
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiofiles.os
 from music_assistant_models.enums import EventType, IdentifierType, PlayerFeature, PlayerType
@@ -64,20 +64,36 @@ SUPPRESSED_BUILTIN_PROVIDERS = {"local_audio"}
 
 _orig_create_builtin_provider_config = ProviderConfigMixin.create_builtin_provider_config
 
+# the address a fixture's web and stream servers bind to, so a test run never listens
+# on the host's real interfaces
+LOOPBACK_IP = "127.0.0.1"
+
 
 @contextlib.contextmanager
-def use_ephemeral_server_ports(port_factory: Callable[[], int]) -> Iterator[None]:
+def use_ephemeral_server_ports() -> Iterator[None]:
     """
-    Give a full-server test fixture unused web and stream server ports.
+    Bind a full-server test fixture's web and stream servers to a free loopback port.
 
-    :param port_factory: Callable returning an unused TCP port.
+    Port 0 has the kernel pick the port during the bind itself, which is the only way
+    to be sure nothing else holds it: a port that is merely observed to be free can be
+    handed to any outgoing connection - of this test run or of another job on the same
+    runner - before the server gets to claim it.
+
+    Binding loopback keeps a test run off the host's other interfaces and gives each
+    server a single socket, so it has one assigned port: asyncio binds a wildcard
+    address once per address family, each with its own port.
     """
     with (
+        patch("music_assistant.controllers.webserver.controller.DEFAULT_SERVER_PORT", 0),
+        patch("music_assistant.controllers.streams.controller.DEFAULT_PORT", 0),
+        patch("music_assistant.controllers.webserver.controller.DEFAULT_HOST", LOOPBACK_IP),
+        patch("music_assistant.controllers.streams.controller.DEFAULT_HOST", LOOPBACK_IP),
+        # the streamserver advertises its publish IP independently of the bind IP, so
+        # pin that too to keep the URLs it hands out pointing at the socket it listens on
         patch(
-            "music_assistant.controllers.webserver.controller.DEFAULT_SERVER_PORT",
-            port_factory(),
+            "music_assistant.controllers.streams.controller.get_ip_addresses",
+            AsyncMock(return_value=(LOOPBACK_IP,)),
         ),
-        patch("music_assistant.controllers.streams.controller.DEFAULT_PORT", port_factory()),
     ):
         yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 import threading
 from collections.abc import AsyncGenerator, Generator
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, NonCallableMagicMock, patch
 
 import pytest
@@ -112,10 +112,8 @@ async def mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
             # also stop after a failed boot: pytest holds on to the setup traceback,
             # which keeps the half-started server (and the non-daemon threads of its
             # open database connections) alive until the interpreter exits, where
-            # joining those threads then hangs the whole test process. A boot that
-            # failed before the controllers were created has nothing to stop.
-            with suppress(AttributeError):
-                await mass_instance.stop()
+            # joining those threads then hangs the whole test process
+            await mass_instance.stop()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,8 @@ import asyncio
 import logging
 import pathlib
 import threading
-from collections.abc import AsyncGenerator, Callable, Generator
-from contextlib import asynccontextmanager
+from collections.abc import AsyncGenerator, Generator
+from contextlib import asynccontextmanager, suppress
 from unittest.mock import AsyncMock, MagicMock, NonCallableMagicMock, patch
 
 import pytest
@@ -66,10 +66,7 @@ def _create_mock_zeroconf() -> MagicMock:
 
 
 @pytest.fixture
-async def mass(
-    tmp_path: pathlib.Path,
-    unused_tcp_port_factory: Callable[[], int],
-) -> AsyncGenerator[MusicAssistant]:
+async def mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
     """
     Start a Music Assistant in test mode.
 
@@ -89,7 +86,7 @@ async def mass(
     mock_browser = NonCallableMagicMock()  # Use NonCallable to avoid api_cmd issues
 
     with (
-        use_ephemeral_server_ports(unused_tcp_port_factory),
+        use_ephemeral_server_ports(),
         patch(
             "music_assistant.controllers.discovery.controller.AsyncZeroconf",
             return_value=mock_zc,
@@ -108,12 +105,17 @@ async def mass(
         # providers and no local_audio bridging the host's sound devices as players
         suppress_auto_loaded_providers(),
     ):
-        await mass_instance.start()
-
         try:
+            await mass_instance.start()
             yield mass_instance
         finally:
-            await mass_instance.stop()
+            # also stop after a failed boot: pytest holds on to the setup traceback,
+            # which keeps the half-started server (and the non-daemon threads of its
+            # open database connections) alive until the interpreter exits, where
+            # joining those threads then hangs the whole test process. A boot that
+            # failed before the controllers were created has nothing to stop.
+            with suppress(AttributeError):
+                await mass_instance.stop()
 
 
 @pytest.fixture

--- a/tests/controllers/dashboard/test_controller.py
+++ b/tests/controllers/dashboard/test_controller.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
@@ -23,22 +22,6 @@ from music_assistant.controllers.dashboard.controller import (
     _RegisteredDashboard,
 )
 from music_assistant.mass import MusicAssistant
-
-
-@pytest.fixture(autouse=True)
-def _use_ephemeral_ports() -> Generator[None]:
-    """
-    Bind the webserver and streamserver to OS-assigned ephemeral ports.
-
-    Avoids clashing with a Music Assistant instance already running on the
-    default ports (8095/8097) on the developer's machine. Autouse ensures the
-    patch is active before the `mass` fixture boots the server.
-    """
-    with (
-        patch("music_assistant.controllers.webserver.controller.DEFAULT_SERVER_PORT", 0),
-        patch("music_assistant.controllers.streams.controller.DEFAULT_PORT", 0),
-    ):
-        yield
 
 
 def _make_controller() -> DashboardController:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,7 +13,6 @@ import asyncio
 import logging
 import pathlib
 from collections.abc import AsyncGenerator, Callable
-from contextlib import suppress
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, NonCallableMagicMock, patch
 
@@ -143,5 +142,4 @@ async def e2e_mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
             # also stop after a failed boot, or the half-started server's open database
             # connections keep their non-daemon threads alive and hang the interpreter
             # at exit (see the same note in tests/conftest.py)
-            with suppress(AttributeError):
-                await mass_instance.stop()
+            await mass_instance.stop()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,6 +13,7 @@ import asyncio
 import logging
 import pathlib
 from collections.abc import AsyncGenerator, Callable
+from contextlib import suppress
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, NonCallableMagicMock, patch
 
@@ -88,10 +89,7 @@ def _create_mock_zeroconf() -> MagicMock:
 
 
 @pytest.fixture
-async def e2e_mass(
-    tmp_path: pathlib.Path,
-    unused_tcp_port_factory: Callable[[], int],
-) -> AsyncGenerator[MusicAssistant]:
+async def e2e_mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
     """
     Boot a hermetic MusicAssistant with only the fake `test` + demo player providers.
 
@@ -111,7 +109,7 @@ async def e2e_mass(
     mass_instance.dev_mode = True
 
     with (
-        use_ephemeral_server_ports(unused_tcp_port_factory),
+        use_ephemeral_server_ports(),
         patch(
             "music_assistant.controllers.discovery.controller.AsyncZeroconf",
             return_value=_create_mock_zeroconf(),
@@ -132,14 +130,18 @@ async def e2e_mass(
         # hermetic: no auto-loaded device providers and no host-audio bridging
         suppress_auto_loaded_providers(),
     ):
-        await mass_instance.start()
-        # configure the fake music + player providers
-        await mass_instance.config._create_provider_instance("test", {})
-        await mass_instance.config._create_provider_instance(
-            "_demo_player_provider", {"number_of_players": NUM_DEMO_PLAYERS}
-        )
-        await wait_for(lambda: len(demo_players(mass_instance)) >= NUM_DEMO_PLAYERS)
         try:
+            await mass_instance.start()
+            # configure the fake music + player providers
+            await mass_instance.config._create_provider_instance("test", {})
+            await mass_instance.config._create_provider_instance(
+                "_demo_player_provider", {"number_of_players": NUM_DEMO_PLAYERS}
+            )
+            await wait_for(lambda: len(demo_players(mass_instance)) >= NUM_DEMO_PLAYERS)
             yield mass_instance
         finally:
-            await mass_instance.stop()
+            # also stop after a failed boot, or the half-started server's open database
+            # connections keep their non-daemon threads alive and hang the interpreter
+            # at exit (see the same note in tests/conftest.py)
+            with suppress(AttributeError):
+                await mass_instance.stop()


### PR DESCRIPTION
# What does this implement/fix?

Tests that boot a full server occasionally failed in CI with "address already in use", even though nothing else was using that port. The fixtures asked a helper for a free port and only bound it a moment later, so any outgoing connection on the machine could be handed the same port in between - the port numbers came from exactly the range the kernel picks from.

That one failure then hung the whole job. When starting up fails part-way, the databases that were already opened are never closed, and their background threads stop the process from exiting at all - so a single flaky test turned a 7 minute run into a cancelled 30 minute one. The same gap applied when running normally: if Music Assistant could not start, for example because its port was already taken, it reported the error and then hung instead of stopping.

## Changes

- Let the OS assign the web and stream server port during the bind itself (port 0), which is the only way to be sure nothing else can take it first, and read the assigned port back for the URLs that are handed out.
- Refuse an OS-assigned port when binding all interfaces, which would need a separate port per address family.
- Always shut down after a startup that failed, and close each part independently so one failure cannot skip the rest.
- Bind test servers to localhost, so a test run no longer listens on the machine's other network interfaces.
- Removed a dead constant and a duplicate test fixture.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
