### PR TITLE
Correct how remote access builds its local websocket address

### DIFF
--- a/music_assistant/controllers/webserver/remote_access/__init__.py
+++ b/music_assistant/controllers/webserver/remote_access/__init__.py
@@ -196,10 +196,10 @@ class RemoteAccessManager:
         )
 
         # resolved once, at gateway start: changing the base URL restarts neither the
-        # webserver nor this gateway, and the address it advertises is not necessarily
-        # reachable from this host
+        # webserver nor this gateway, and behind a reverse proxy this address need not be
+        # reachable from this host at all
         base_url = self.mass.webserver.base_url
-        local_ws_url = base_url.replace("http", "ws")
+        local_ws_url = base_url.replace("http", "ws", 1)
         if not local_ws_url.endswith("/"):
             local_ws_url += "/"
         local_ws_url += "ws"
@@ -214,8 +214,9 @@ class RemoteAccessManager:
         mode = "optimized" if using_ha_cloud else "basic"
         self.logger.info("Starting remote access in %s mode", mode)
 
-        # resolved once, at gateway start: the Sendspin server binds at provider load, so a
-        # later streams reload moves this address without rebinding the socket behind it
+        # resolved once, at gateway start: this follows the streams bind IP, while the socket
+        # behind it is only bound when the Sendspin provider loads, so the two can disagree
+        # either way and re-resolving per session would be no more reliable
         sendspin_url = self.webserver.internal_sendspin_url
 
         gateway = WebRTCGateway(

--- a/music_assistant/controllers/webserver/remote_access/__init__.py
+++ b/music_assistant/controllers/webserver/remote_access/__init__.py
@@ -195,6 +195,9 @@ class RemoteAccessManager:
             self.mass.storage_path
         )
 
+        # resolved once, at gateway start: changing the base URL restarts neither the
+        # webserver nor this gateway, and the address it advertises is not necessarily
+        # reachable from this host
         base_url = self.mass.webserver.base_url
         local_ws_url = base_url.replace("http", "ws")
         if not local_ws_url.endswith("/"):
@@ -211,6 +214,8 @@ class RemoteAccessManager:
         mode = "optimized" if using_ha_cloud else "basic"
         self.logger.info("Starting remote access in %s mode", mode)
 
+        # resolved once, at gateway start: the Sendspin server binds at provider load, so a
+        # later streams reload moves this address without rebinding the socket behind it
         sendspin_url = self.webserver.internal_sendspin_url
 
         gateway = WebRTCGateway(


### PR DESCRIPTION
# What does this implement/fix?

Remote access builds the websocket address it uses to reach Music Assistant's own API by swapping `http` for `ws` in the configured base URL, but the swap wasn't limited to the scheme. Any base URL with `http` elsewhere in it — say `https://music.myhttpserver.com` — came out mangled, and the gateway then dialled an address that doesn't exist.

While in there: remote access looks up both of its local addresses once, at start-up, whereas the Sendspin browser proxy looks its address up on every connection. That difference reads like an oversight, but re-checking per session isn't any more reliable — the servers behind those addresses only rebind when they themselves restart, so the setting and the running socket can drift apart either way. So there is now a note at each lookup, to keep the difference from being "fixed" into a bug later.

- Only replace the scheme when turning the base URL into a websocket URL.
- Note why both local addresses are resolved once, at start-up.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
