### PR TITLE
Fix muting being blocked by the volume control setting

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -914,6 +914,16 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         player = self.get_player(player_id, True)
         assert player
 
+        mute_control = player.mute_control
+        # a mute command needs a mute control; fake mute is simulated by
+        # setting the volume to zero, so it also needs a volume control
+        if mute_control == PLAYER_CONTROL_NONE or (
+            mute_control == PLAYER_CONTROL_FAKE and player.volume_control == PLAYER_CONTROL_NONE
+        ):
+            raise UnsupportedFeaturedException(
+                f"Player {player.state.name} does not support muting"
+            )
+
         # Set/clear mute lock for players in a group
         # This prevents auto-unmute when group volume changes
         is_in_group = bool(player.state.synced_to or player.state.active_group)
@@ -922,15 +932,11 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         elif not muted:
             player.extra_data.pop(ATTR_MUTE_LOCK, None)
 
-        if player.volume_control == PLAYER_CONTROL_NONE:
-            raise UnsupportedFeaturedException(
-                f"Player {player.state.name} does not support muting"
-            )
-        if player.mute_control == PLAYER_CONTROL_NATIVE:
+        if mute_control == PLAYER_CONTROL_NATIVE:
             # player supports mute command natively: forward to player
             await player.volume_mute(muted)
             return
-        if player.mute_control == PLAYER_CONTROL_FAKE:
+        if mute_control == PLAYER_CONTROL_FAKE:
             # user wants to use fake mute control - so we use volume instead
             self.logger.debug(
                 "Using volume for muting for player %s",
@@ -953,7 +959,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             return
 
         # handle external player control
-        if player_control := self._controls.get(player.mute_control):
+        if player_control := self._controls.get(mute_control):
             control_name = player_control.name
             self.logger.debug("Redirecting mute command to PlayerControl %s", control_name)
             if not player_control.supports_mute:
@@ -965,7 +971,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             return
 
         # handle to protocol player as volume_mute control
-        if protocol_player := self.get_player(player.mute_control):
+        if protocol_player := self.get_player(mute_control):
             self.logger.debug(
                 "Redirecting mute command to protocol player %s",
                 protocol_player.provider.manifest.name,

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -924,11 +924,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             player.extra_data.pop(ATTR_MUTE_LOCK, None)
 
         mute_control = player.mute_control
-        # a mute command needs a mute control; fake mute is simulated by
-        # setting the volume to zero, so it also needs a volume control
-        if mute_control == PLAYER_CONTROL_NONE or (
-            mute_control == PLAYER_CONTROL_FAKE and player.volume_control == PLAYER_CONTROL_NONE
-        ):
+        if mute_control == PLAYER_CONTROL_NONE:
             raise UnsupportedFeaturedException(
                 f"Player {player.state.name} does not support muting"
             )
@@ -985,6 +981,9 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             )
             await protocol_player.volume_mute(muted)
             return
+
+        # the configured control disappeared after the mute control was resolved
+        raise UnsupportedFeaturedException(f"Player {player.state.name} does not support muting")
 
     @handle_player_command
     async def play_media(self, player_id: str, media: PlayerMedia) -> None:

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -899,6 +899,10 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             for child_player in self.iter_group_members(
                 player, only_powered=True, exclude_self=False
             ):
+                if child_player.mute_control == PLAYER_CONTROL_NONE:
+                    # members without a mute control are left alone, just like the
+                    # group mute state itself is calculated from the capable members only
+                    continue
                 coros.append(self.cmd_volume_mute(child_player.player_id, muted))
             await asyncio.gather(*coros)
 
@@ -914,6 +918,11 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         player = self.get_player(player_id, True)
         assert player
 
+        # clearing the mute lock may not depend on mute support, otherwise a lock set
+        # while the player still had a mute control would outlive a control change
+        if not muted:
+            player.extra_data.pop(ATTR_MUTE_LOCK, None)
+
         mute_control = player.mute_control
         # a mute command needs a mute control; fake mute is simulated by
         # setting the volume to zero, so it also needs a volume control
@@ -924,13 +933,11 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                 f"Player {player.state.name} does not support muting"
             )
 
-        # Set/clear mute lock for players in a group
+        # Set mute lock for players in a group
         # This prevents auto-unmute when group volume changes
         is_in_group = bool(player.state.synced_to or player.state.active_group)
         if muted and is_in_group:
             player.extra_data[ATTR_MUTE_LOCK] = True
-        elif not muted:
-            player.extra_data.pop(ATTR_MUTE_LOCK, None)
 
         if mute_control == PLAYER_CONTROL_NATIVE:
             # player supports mute command natively: forward to player
@@ -3459,7 +3466,9 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                 has_mute_lock = parent.extra_data.get(ATTR_MUTE_LOCK, False)
         if (
             not has_mute_lock
-            and player.state.mute_control not in (PLAYER_CONTROL_NONE, PLAYER_CONTROL_FAKE)
+            # the live value is what cmd_volume_mute checks, so a control change that
+            # has not reached the player state yet may not send us into a failing unmute
+            and player.mute_control not in (PLAYER_CONTROL_NONE, PLAYER_CONTROL_FAKE)
             and player.state.volume_muted
         ):
             # if player is muted and not locked, we unmute it first

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1372,6 +1372,10 @@ class Player(ABC):
     def mute_control(self) -> str:
         """Return the mute control type."""
         conf = self.mass.config.get_raw_player_config_value(self.player_id, CONF_MUTE_CONTROL)
+        if conf == PLAYER_CONTROL_FAKE and self.volume_control == PLAYER_CONTROL_NONE:
+            # fake mute is simulated by setting the volume to zero, so without a volume
+            # control to drive there is no way to mute this player at all
+            return PLAYER_CONTROL_NONE
         if conf and conf in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
             # the control type is explicitly set in the config, use that
             return str(conf)

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -41,6 +41,7 @@ from music_assistant_models.player_control import PlayerControl
 
 from music_assistant.constants import (
     ATTR_FAKE_MUTE,
+    ATTR_MUTE_LOCK,
     ATTR_PREVIOUS_VOLUME,
     CONF_MUTE_CONTROL,
     CONF_VOLUME_CONTROL,
@@ -1128,6 +1129,7 @@ class TestVolumeScalingOnRedirect:
             protocol_parent_id=None,
             extra_data={},
             volume_control=volume_control,
+            mute_control=PLAYER_CONTROL_NONE,
             volume_set=volume_set or AsyncMock(),
             update_state=MagicMock(),
             provider=MagicMock(),
@@ -1447,6 +1449,55 @@ class TestMuteControlGuard:
             await controller.cmd_volume_mute("player_1", True)
         assert ATTR_PREVIOUS_VOLUME not in player.extra_data
         assert ATTR_FAKE_MUTE not in player.extra_data
+
+    async def test_unmute_clears_mute_lock_without_mute_control(self, mock_mass: MagicMock) -> None:
+        """Unmuting clears a mute lock left behind by a since-removed mute control."""
+        controller, player = self._make_player(
+            mock_mass,
+            mute_control=PLAYER_CONTROL_NONE,
+            volume_control=PLAYER_CONTROL_NATIVE,
+        )
+        player.extra_data[ATTR_MUTE_LOCK] = True
+
+        with pytest.raises(UnsupportedFeaturedException):
+            await controller.cmd_volume_mute("player_1", False)
+        assert ATTR_MUTE_LOCK not in player.extra_data
+
+
+class TestGroupMuteMemberFilter:
+    """Group mute skips members that have no mute control of their own."""
+
+    async def test_member_without_mute_control_is_skipped(self, mock_mass: MagicMock) -> None:
+        """A member without a mute control must not fail the whole group command."""
+
+        def _conf(player_id: str, key: str, default: object = None) -> object:
+            if key == "min_volume":
+                return 0
+            if key == "max_volume":
+                return 100
+            if key == CONF_MUTE_CONTROL and player_id == "member":
+                return PLAYER_CONTROL_NONE
+            return default if default is not None else "auto"
+
+        mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_conf)
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        leader = MockPlayer(provider, "leader", "Leader")
+        leader._attr_supported_features = {PlayerFeature.VOLUME_SET, PlayerFeature.VOLUME_MUTE}
+        leader._attr_group_members = ["leader", "member"]
+        member = MockPlayer(provider, "member", "Member")
+        member._attr_supported_features = {PlayerFeature.VOLUME_SET}
+        controller._players = {"leader": leader, "member": member}
+        mock_mass.players = controller
+        mock_mass.player_queues.get = MagicMock(return_value=None)
+        for player in (leader, member):
+            player.set_initialized()
+            player.update_state(signal_event=False)
+        leader_mute = AsyncMock()
+        leader.volume_mute = leader_mute  # type: ignore[method-assign]
+
+        await controller.cmd_group_volume_mute("leader", True)
+        leader_mute.assert_awaited_once_with(True)
 
 
 class TestCurrentMediaTimeUpdates:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1450,6 +1450,29 @@ class TestMuteControlGuard:
         assert ATTR_PREVIOUS_VOLUME not in player.extra_data
         assert ATTR_FAKE_MUTE not in player.extra_data
 
+    async def test_vanished_mute_control_raises(self, mock_mass: MagicMock) -> None:
+        """A mute control that disappeared after being resolved is reported, not ignored."""
+        control = PlayerControl(
+            id="ext_mute",
+            provider="test",
+            name="External Mute",
+            supports_mute=True,
+            mute_set=AsyncMock(),
+        )
+        controller, player = self._make_player(
+            mock_mass,
+            mute_control="ext_mute",
+            volume_control=PLAYER_CONTROL_NONE,
+            controls={"ext_mute": control},
+        )
+        # the resolved control is cached on the player, so removing it here leaves
+        # the player pointing at a control that no longer exists
+        assert player.mute_control == "ext_mute"
+        controller._controls = {}
+
+        with pytest.raises(UnsupportedFeaturedException):
+            await controller.cmd_volume_mute("player_1", True)
+
     async def test_unmute_clears_mute_lock_without_mute_control(self, mock_mass: MagicMock) -> None:
         """Unmuting clears a mute lock left behind by a since-removed mute control."""
         controller, player = self._make_player(

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -37,8 +37,14 @@ from music_assistant_models.errors import (
     UnsupportedFeaturedException,
 )
 from music_assistant_models.player import OutputProtocol, PlayerMedia, PlayerSource
+from music_assistant_models.player_control import PlayerControl
 
-from music_assistant.constants import ATTR_PREVIOUS_VOLUME, CONF_MUTE_CONTROL
+from music_assistant.constants import (
+    ATTR_FAKE_MUTE,
+    ATTR_PREVIOUS_VOLUME,
+    CONF_MUTE_CONTROL,
+    CONF_VOLUME_CONTROL,
+)
 from music_assistant.controllers.players import PlayerController
 from tests.common import MockPlayer, MockProvider
 
@@ -1343,6 +1349,104 @@ class TestFakeMuteControl:
         unmuted_state = player.state
         assert unmuted_state.volume_muted is False
         assert unmuted_state.volume_level == 25
+
+
+class TestMuteControlGuard:
+    """Muting is gated on the mute control, independently of the volume control."""
+
+    def _make_player(
+        self,
+        mock_mass: MagicMock,
+        mute_control: str,
+        volume_control: str,
+        controls: dict[str, PlayerControl] | None = None,
+    ) -> tuple[PlayerController, MockPlayer]:
+        """Build a controller with a single player using the given control config."""
+
+        def _conf(_player_id: str, key: str, default: object = None) -> object:
+            if key == "min_volume":
+                return 0
+            if key == "max_volume":
+                return 100
+            if key == CONF_MUTE_CONTROL:
+                return mute_control
+            if key == CONF_VOLUME_CONTROL:
+                return volume_control
+            return default if default is not None else "auto"
+
+        mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_conf)
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+        controller._players = {"player_1": player}
+        controller._controls = controls or {}
+        mock_mass.players = controller
+        mock_mass.player_queues.get = MagicMock(return_value=None)
+        player.set_initialized()
+        player.update_state(signal_event=False)
+        return controller, player
+
+    async def test_external_mute_control_without_volume_control(self, mock_mass: MagicMock) -> None:
+        """A player without volume control still mutes through an external PlayerControl."""
+        mute_set = AsyncMock()
+        control = PlayerControl(
+            id="ext_mute",
+            provider="test",
+            name="External Mute",
+            supports_mute=True,
+            mute_set=mute_set,
+        )
+        controller, player = self._make_player(
+            mock_mass,
+            mute_control="ext_mute",
+            volume_control=PLAYER_CONTROL_NONE,
+            controls={"ext_mute": control},
+        )
+        assert player.mute_control == "ext_mute"
+
+        await controller.cmd_volume_mute("player_1", True)
+        mute_set.assert_awaited_once_with(True)
+
+    async def test_native_mute_control_without_volume_control(self, mock_mass: MagicMock) -> None:
+        """A player without volume control still mutes natively."""
+        controller, player = self._make_player(
+            mock_mass,
+            mute_control=PLAYER_CONTROL_NATIVE,
+            volume_control=PLAYER_CONTROL_NONE,
+        )
+        volume_mute = AsyncMock()
+        player.volume_mute = volume_mute  # type: ignore[method-assign]
+
+        await controller.cmd_volume_mute("player_1", True)
+        volume_mute.assert_awaited_once_with(True)
+
+    async def test_mute_control_none_raises(self, mock_mass: MagicMock) -> None:
+        """A player with volume control but no mute control rejects the command."""
+        controller, player = self._make_player(
+            mock_mass,
+            mute_control=PLAYER_CONTROL_NONE,
+            volume_control=PLAYER_CONTROL_NATIVE,
+        )
+        volume_mute = AsyncMock()
+        player.volume_mute = volume_mute  # type: ignore[method-assign]
+
+        with pytest.raises(UnsupportedFeaturedException):
+            await controller.cmd_volume_mute("player_1", True)
+        volume_mute.assert_not_awaited()
+
+    async def test_fake_mute_without_volume_control_raises(self, mock_mass: MagicMock) -> None:
+        """Fake mute needs a volume control to drive, so it rejects the command outright."""
+        controller, player = self._make_player(
+            mock_mass,
+            mute_control=PLAYER_CONTROL_FAKE,
+            volume_control=PLAYER_CONTROL_NONE,
+        )
+        player._attr_volume_level = 40
+
+        with pytest.raises(UnsupportedFeaturedException):
+            await controller.cmd_volume_mute("player_1", True)
+        assert ATTR_PREVIOUS_VOLUME not in player.extra_data
+        assert ATTR_FAKE_MUTE not in player.extra_data
 
 
 class TestCurrentMediaTimeUpdates:

--- a/tests/models/test_player_controls.py
+++ b/tests/models/test_player_controls.py
@@ -310,6 +310,29 @@ class TestMuteControlExplicitConfig:
         player = _create_player(mock_mass, features={PlayerFeature.VOLUME_MUTE})
         assert player.mute_control == PLAYER_CONTROL_NONE
 
+    def test_explicit_fake(self, mock_mass: MagicMock) -> None:
+        """Mute control returns fake when explicitly configured and a volume control exists."""
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_make_config_side_effect({CONF_MUTE_CONTROL: PLAYER_CONTROL_FAKE})
+        )
+        player = _create_player(mock_mass, features={PlayerFeature.VOLUME_SET})
+        assert player.mute_control == PLAYER_CONTROL_FAKE
+
+    def test_explicit_fake_degrades_without_volume_control(self, mock_mass: MagicMock) -> None:
+        """Fake mute drives the volume control, so it degrades to NONE without one."""
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_make_config_side_effect(
+                {
+                    CONF_MUTE_CONTROL: PLAYER_CONTROL_FAKE,
+                    CONF_VOLUME_CONTROL: PLAYER_CONTROL_NONE,
+                }
+            )
+        )
+        # a native mute capability is irrelevant here: the user explicitly picked fake
+        player = _create_player(mock_mass, features={PlayerFeature.VOLUME_MUTE})
+        assert player.mute_control == PLAYER_CONTROL_NONE
+        assert PlayerFeature.VOLUME_MUTE not in player.state.supported_features
+
 
 class TestMuteControlAutoSelect:
     """Test mute_control auto-select logic."""


### PR DESCRIPTION
# What does this implement/fix?

Muting a player was gated on the wrong setting: the mute command checked the player's **volume** control instead of its **mute** control.

Two things went wrong as a result:

- A player with *Volume control* set to `none` refused to mute with "does not support muting", even when a mute control was configured (native, or an external mute control offered by the settings UI).
- A player with *Mute control* set to `none` accepted the command and then silently did nothing, instead of reporting that muting is unsupported.

Fixing the second case meant group mute also needed attention: it fanned out to every member, so one member without a mute control would fail the whole group command. Group mute now skips those members, which is already how the group mute state itself is calculated.

Also cleaned up a related rough edge: *fake* mute simulates muting by dropping the volume to zero, so it cannot work without a volume control — but a player configured that way still advertised mute support and showed an enabled mute button that could only ever error.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Gate the mute command on the player's mute control instead of its volume control.
- Skip members without a mute control in the group mute fan-out, so a mixed group still mutes the members that can.
- Treat fake mute without a volume control as no mute control at all, so it is no longer advertised and the mute button is greyed out instead of failing.
- Report a mute control that disappeared after being resolved, instead of accepting the command and doing nothing.
- Clear a stale group mute lock even when the player no longer has a mute control.
- Added tests for each of the above.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
