### PR TITLE
Clean up unreachable checks in player control commands

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -954,9 +954,9 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
 
         # handle external player control
         if player_control := self._controls.get(player.mute_control):
-            control_name = player_control.name if player_control else player.mute_control
+            control_name = player_control.name
             self.logger.debug("Redirecting mute command to PlayerControl %s", control_name)
-            if not player_control or not player_control.supports_mute:
+            if not player_control.supports_mute:
                 raise UnsupportedFeaturedException(
                     f"Player control {control_name} is not available"
                 )
@@ -3394,9 +3394,9 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                 )
         # handle external player control
         elif player_control := self._controls.get(player.state.power_control):
-            control_name = player_control.name if player_control else player.state.power_control
+            control_name = player_control.name
             self.logger.debug("Redirecting power command to PlayerControl %s", control_name)
-            if not player_control or not player_control.supports_power:
+            if not player_control.supports_power:
                 raise UnsupportedFeaturedException(
                     f"Player control {control_name} is not available"
                 )
@@ -3499,9 +3499,9 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             )
         # handle external player control
         if player_control := self._controls.get(player.state.volume_control):
-            control_name = player_control.name if player_control else player.state.volume_control
+            control_name = player_control.name
             self.logger.debug("Redirecting volume command to PlayerControl %s", control_name)
-            if not player_control or not player_control.supports_volume:
+            if not player_control.supports_volume:
                 raise UnsupportedFeaturedException(
                     f"Player control {control_name} is not available"
                 )


### PR DESCRIPTION
# What does this implement/fix?

Three of the external player control command handlers re-checked whether the control exists after the walrus assignment had already proven it does, so those fallbacks and guards could never run. Cleaned that up — no behaviour change.

- `cmd_volume_mute`, `_handle_cmd_power` and `_handle_cmd_volume_set`: dropped the unreachable `None` fallback for the control name and the dead `not player_control or` guard, keeping the unsupported-feature check and the raise identical.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
