### PR TITLE
Split voices pasted into a single value

### DIFF
--- a/music_assistant/providers/openai_tts/__init__.py
+++ b/music_assistant/providers/openai_tts/__init__.py
@@ -347,10 +347,10 @@ class OpenAITTSProvider(PluginProvider):
         # a single value can hold a comma separated list of its own, e.g. when the whole
         # list was pasted into one field
         names = [
-            name.strip()
+            name
             for value in values
             if isinstance(value, str)
-            for name in value.split(",")
-            if name.strip()
+            for part in value.split(",")
+            if (name := part.strip())
         ]
         return list(dict.fromkeys(names))

--- a/music_assistant/providers/openai_tts/__init__.py
+++ b/music_assistant/providers/openai_tts/__init__.py
@@ -343,13 +343,14 @@ class OpenAITTSProvider(PluginProvider):
     def _voice_override(self) -> list[str]:
         """Return the configured voices, empty when the override is unset."""
         configured = self.get_config_value(CONF_VOICES)
-        # tolerate a single comma separated string next to the stored list of values
-        values: list[object]
-        if isinstance(configured, str):
-            values = list(configured.split(","))
-        elif isinstance(configured, list):
-            values = list(configured)
-        else:
-            return []
-        names = [str(value).strip() for value in values if str(value).strip()]
+        values = configured if isinstance(configured, list) else [configured]
+        # a single value can hold a comma separated list of its own, e.g. when the whole
+        # list was pasted into one field
+        names = [
+            name.strip()
+            for value in values
+            if isinstance(value, str)
+            for name in value.split(",")
+            if name.strip()
+        ]
         return list(dict.fromkeys(names))

--- a/music_assistant/providers/openai_tts/strings.json
+++ b/music_assistant/providers/openai_tts/strings.json
@@ -14,7 +14,7 @@
     },
     "voices": {
       "label": "Voices",
-      "description": "Voices to expose as engines, overriding the voices that are normally detected automatically or fall back to the standard OpenAI voices (alloy, echo, fable, nova, onyx, shimmer)."
+      "description": "Voices to expose as engines, one voice per value. Overrides the voices that are normally detected automatically or fall back to the standard OpenAI voices (alloy, echo, fable, nova, onyx, shimmer)."
     }
   },
   "setup_flow": {

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1615,7 +1615,7 @@
   "provider.openai_tts.config_entries.base_url.label": "API endpoint",
   "provider.openai_tts.config_entries.model.description": "The speech model to use, for example tts-1 or the higher quality gpt-4o-mini-tts on the OpenAI cloud API. Self-hosted servers use their own model names.",
   "provider.openai_tts.config_entries.model.label": "Model",
-  "provider.openai_tts.config_entries.voices.description": "Voices to expose as engines, overriding the voices that are normally detected automatically or fall back to the standard OpenAI voices (alloy, echo, fable, nova, onyx, shimmer).",
+  "provider.openai_tts.config_entries.voices.description": "Voices to expose as engines, one voice per value. Overrides the voices that are normally detected automatically or fall back to the standard OpenAI voices (alloy, echo, fable, nova, onyx, shimmer).",
   "provider.openai_tts.config_entries.voices.label": "Voices",
   "provider.openai_tts.errors.cannot_connect": "Could not reach the speech API. Please check the address and try again.",
   "provider.openai_tts.errors.endpoint_not_found": "No speech endpoint was found at this address. Please check the API endpoint.",

--- a/tests/providers/openai_tts/test_openai_tts.py
+++ b/tests/providers/openai_tts/test_openai_tts.py
@@ -51,10 +51,24 @@ async def test_resolve_voices_honours_config_override() -> None:
     assert await provider._resolve_voices() == ["nova", "alloy", "echo"]
 
 
-async def test_resolve_voices_accepts_a_single_string_override() -> None:
-    """A comma separated string is accepted next to the stored list of values."""
-    provider = create_provider(**{CONF_VOICES: " nova ,alloy,, nova,echo "})
+async def test_resolve_voices_splits_values_holding_commas() -> None:
+    """A whole list pasted into one value is split into the separate voices."""
+    provider = create_provider(**{CONF_VOICES: [" nova ,alloy", "echo", " nova"]})
     assert await provider._resolve_voices() == ["nova", "alloy", "echo"]
+
+
+async def test_resolve_voices_ignores_an_empty_override() -> None:
+    """An empty override is the shape stored when nothing is configured."""
+    provider = create_provider(**{CONF_VOICES: []})
+    assert await provider._resolve_voices() == list(DEFAULT_VOICES)
+
+
+async def test_voices_config_entry_defaults_to_an_empty_list() -> None:
+    """Clearing the field submits the default, which must keep the multi value shape."""
+    provider = create_provider()
+    entry = next(e for e in await provider.get_config_entries() if e.key == CONF_VOICES)
+    assert entry.multi_value is True
+    assert entry.default_value == []
 
 
 async def test_resolve_voices_falls_back_to_defaults() -> None:

--- a/tests/providers/openai_tts/test_openai_tts.py
+++ b/tests/providers/openai_tts/test_openai_tts.py
@@ -57,18 +57,23 @@ async def test_resolve_voices_splits_values_holding_commas() -> None:
     assert await provider._resolve_voices() == ["nova", "alloy", "echo"]
 
 
+async def test_resolve_voices_accepts_a_hand_edited_string() -> None:
+    """A raw string in the stored config is read as a list of voices."""
+    provider = create_provider(**{CONF_VOICES: " nova ,alloy,, nova,echo "})
+    assert await provider._resolve_voices() == ["nova", "alloy", "echo"]
+
+
 async def test_resolve_voices_ignores_an_empty_override() -> None:
     """An empty override is the shape stored when nothing is configured."""
     provider = create_provider(**{CONF_VOICES: []})
     assert await provider._resolve_voices() == list(DEFAULT_VOICES)
 
 
-async def test_voices_config_entry_defaults_to_an_empty_list() -> None:
-    """Clearing the field submits the default, which must keep the multi value shape."""
+async def test_voices_config_entry_accepts_a_cleared_field() -> None:
+    """Clearing the field submits no value, which must still parse as a list."""
     provider = create_provider()
     entry = next(e for e in await provider.get_config_entries() if e.key == CONF_VOICES)
-    assert entry.multi_value is True
-    assert entry.default_value == []
+    assert entry.parse_value(None) == []
 
 
 async def test_resolve_voices_falls_back_to_defaults() -> None:


### PR DESCRIPTION
# What does this implement/fix?

The voices field on the OpenAI Text-to-speech provider takes one voice per value, but typing or pasting a whole list into a single field kept it as one value. That became a single unusable voice name (`nova,alloy`) instead of two voices, with nothing to hint at it until playback failed.

**Related issue (if applicable):**

- follow-up to #5278

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- A voices value holding a comma separated list is split into the separate voices
- The field description now says one voice per value
- Added tests for a pasted list, an empty override, and the default the field falls back to when cleared

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
