### PR TITLE
Fix media details occasionally resolving to the wrong item

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -1970,13 +1970,28 @@ class _SupportsMass(Protocol):
 def guard_single_request[SelfT: _SupportsMass, **P, R](
     func: Callable[Concatenate[SelfT, P], Coroutine[Any, Any, R]],
 ) -> Callable[Concatenate[SelfT, P], Coroutine[Any, Any, R]]:
-    """Guard single request to a function."""
+    """
+    Ensure concurrent calls with identical arguments result in a single request.
+
+    Callers arriving while an identical call is already in flight await that same call and
+    receive its result. Cancelling one caller leaves the others unaffected; the request
+    itself always runs to completion. Calls count as identical when they are made on the
+    same object with equally represented arguments.
+
+    :param func: The coroutine method to guard.
+    """
 
     @functools.wraps(func)
     async def wrapper(self: SelfT, *args: P.args, **kwargs: P.kwargs) -> R:
         mass = self.mass
-        # create a task_id dynamically based on the function and args/kwargs
-        cache_key_parts = [func.__class__.__name__, func.__name__, *args]
+        # create a task_id dynamically based on the bound method and args/kwargs.
+        # the instance is part of the key because a decorated method may be inherited by
+        # multiple subclasses (all media controllers share
+        # MediaControllerBase.get_provider_item) and a class may have multiple instances
+        # (e.g. a provider set up twice), which must never join each other's flight.
+        # id(self) is stable while a flight is live because the task references self;
+        # the class name only serves to keep the task_id readable while debugging.
+        cache_key_parts = [type(self).__name__, id(self), func.__qualname__, *args]
         for key in sorted(kwargs.keys()):
             cache_key_parts.append(f"{key}{kwargs[key]}")
         task_id = ".".join(map(str, cache_key_parts))
@@ -1989,6 +2004,13 @@ def guard_single_request[SelfT: _SupportsMass, **P, R](
             eager_start=True,
             **kwargs,
         )
-        return await task
+        # wait for the shared task instead of awaiting it directly: a caller awaiting a
+        # task holds it as its fut_waiter, so cancelling that caller would cancel the
+        # request for every other caller too. asyncio.shield achieves the same, but hands
+        # the loop an exception to report whenever a cancelled caller leaves behind a
+        # request that ends in an exception another caller already handled.
+        if not task.done():
+            await asyncio.wait((task,))
+        return task.result()
 
     return wrapper

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -1974,9 +1974,9 @@ def guard_single_request[SelfT: _SupportsMass, **P, R](
     Ensure concurrent calls with identical arguments result in a single request.
 
     Callers arriving while an identical call is already in flight await that same call and
-    receive its result. Cancelling one caller leaves the others unaffected; the request
-    itself always runs to completion. Calls count as identical when they are made on the
-    same object with equally represented arguments.
+    receive its result. Cancelling one caller leaves both the request and the other callers
+    unaffected. Calls count as identical when they are made on the same object with equally
+    represented arguments.
 
     :param func: The coroutine method to guard.
     """
@@ -2006,9 +2006,9 @@ def guard_single_request[SelfT: _SupportsMass, **P, R](
         )
         # wait for the shared task instead of awaiting it directly: a caller awaiting a
         # task holds it as its fut_waiter, so cancelling that caller would cancel the
-        # request for every other caller too. asyncio.shield achieves the same, but hands
-        # the loop an exception to report whenever a cancelled caller leaves behind a
-        # request that ends in an exception another caller already handled.
+        # request for every other caller too. asyncio.shield achieves the same, but as of
+        # Python 3.14 a cancelled caller makes it report the request's exception through
+        # loop.call_exception_handler, even when another caller already handled it.
         if not task.done():
             await asyncio.wait((task,))
         return task.result()

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -394,7 +394,8 @@ class TestGuardSingleRequest:
         assert first.calls == 1
         assert second.calls == 1
 
-    # the tasks are created on the fixture's event loop, so the test must run on it too
+    # mass.create_task pins its tasks to mass.loop, so the test must run on the loop the
+    # class-scoped fixture was created on
     @pytest.mark.asyncio(loop_scope="class")
     async def test_controllers_sharing_a_method_get_their_own_request(
         self, music_mass_class: MusicAssistant

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -7,16 +7,22 @@ from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from music_assistant_models.media_items import Album, ProviderMapping, Track
 
 from music_assistant.helpers import util
 from music_assistant.helpers.util import (
     get_source_ip_for_target,
+    guard_single_request,
     import_module_in_thread,
     is_port_in_use,
     load_provider_module,
     sanitize_http_header_value,
     select_free_port,
 )
+from music_assistant.mass import MusicAssistant
+from music_assistant.models.music_provider import MusicProvider
+
+GUARDED_PROVIDER_ID = "test_guarded_prov"
 
 
 class TestGetSourceIpForTarget:
@@ -346,3 +352,144 @@ class TestSanitizeHttpHeaderValue:
     def test_leading_trailing_whitespace_stripped(self) -> None:
         """Control chars at the edges don't leave dangling whitespace."""
         assert sanitize_http_header_value("\x00Artist - Track\x1f") == "Artist - Track"
+
+
+class TestGuardSingleRequest:
+    """guard_single_request collapses identical concurrent calls into a single request."""
+
+    @pytest.mark.asyncio
+    async def test_cancelled_caller_does_not_affect_others(
+        self, mass_minimal: MusicAssistant
+    ) -> None:
+        """A caller giving up must not cancel the shared request for the other callers."""
+        caller = _GuardedCaller(mass_minimal)
+        calls = [asyncio.create_task(caller.fetch("123")) for _ in range(3)]
+        # give the callers a chance to line up behind the same in-flight request
+        await asyncio.sleep(0)
+        assert caller.calls == 1
+
+        calls[0].cancel()
+        caller.release.set()
+        results = await asyncio.gather(*calls, return_exceptions=True)
+
+        assert isinstance(results[0], asyncio.CancelledError)
+        assert results[1:] == ["result-123", "result-123"]
+        assert caller.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_instances_get_their_own_request(self, mass_minimal: MusicAssistant) -> None:
+        """Two objects of the same class each issue their own request."""
+        first = _GuardedCaller(mass_minimal)
+        second = _GuardedCaller(mass_minimal)
+        calls = [
+            asyncio.create_task(first.fetch("123")),
+            asyncio.create_task(second.fetch("123")),
+        ]
+        # both requests are in flight before either is released
+        await asyncio.sleep(0)
+        first.release.set()
+        second.release.set()
+
+        assert await asyncio.gather(*calls) == ["result-123", "result-123"]
+        assert first.calls == 1
+        assert second.calls == 1
+
+    # the tasks are created on the fixture's event loop, so the test must run on it too
+    @pytest.mark.asyncio(loop_scope="class")
+    async def test_controllers_sharing_a_method_get_their_own_request(
+        self, music_mass_class: MusicAssistant
+    ) -> None:
+        """The same item id requested on two media controllers resolves per media type."""
+        provider = _GatedMusicProvider()
+        with patch.object(music_mass_class, "get_provider", return_value=provider):
+            album_calls = [
+                asyncio.create_task(
+                    music_mass_class.music.albums.get_provider_item("123", GUARDED_PROVIDER_ID)
+                )
+                for _ in range(2)
+            ]
+            track_call = asyncio.create_task(
+                music_mass_class.music.tracks.get_provider_item("123", GUARDED_PROVIDER_ID)
+            )
+            await asyncio.sleep(0)
+            provider.release.set()
+            first_album, second_album = await asyncio.gather(*album_calls)
+            track = await track_call
+
+        assert isinstance(first_album, Album)
+        assert isinstance(track, Track)
+        # the two album callers shared a single request, the track caller got its own
+        assert first_album is second_album
+        assert provider.album_calls == 1
+        assert provider.track_calls == 1
+
+
+class _GuardedCaller:
+    """Minimal stand-in for a controller exposing a guarded request."""
+
+    def __init__(self, mass: MusicAssistant) -> None:
+        """
+        Initialize the caller.
+
+        :param mass: The MusicAssistant instance tracking the guarded request.
+        """
+        self.mass = mass
+        self.calls = 0
+        self.release = asyncio.Event()
+
+    @guard_single_request
+    async def fetch(self, item_id: str) -> str:
+        """Return the result for the given item id, once released."""
+        self.calls += 1
+        await self.release.wait()
+        return f"result-{item_id}"
+
+
+class _GatedMusicProvider(MusicProvider):
+    """Minimal music provider returning items only once released."""
+
+    def __init__(self) -> None:
+        """Initialize the provider."""
+        self.release = asyncio.Event()
+        self.album_calls = 0
+        self.track_calls = 0
+        self.config = MagicMock()
+        self.config.instance_id = GUARDED_PROVIDER_ID
+        self.manifest = MagicMock()
+        self.manifest.domain = GUARDED_PROVIDER_ID
+        self.logger = MagicMock()
+
+    async def get_album(self, prov_album_id: str) -> Album:
+        """Return the album for the given provider album id."""
+        self.album_calls += 1
+        await self.release.wait()
+        return Album(
+            item_id=prov_album_id,
+            provider=GUARDED_PROVIDER_ID,
+            name="Album",
+            provider_mappings={_provider_mapping(prov_album_id)},
+        )
+
+    async def get_track(self, prov_track_id: str) -> Track:
+        """Return the track for the given provider track id."""
+        self.track_calls += 1
+        await self.release.wait()
+        return Track(
+            item_id=prov_track_id,
+            provider=GUARDED_PROVIDER_ID,
+            name="Track",
+            provider_mappings={_provider_mapping(prov_track_id)},
+        )
+
+
+def _provider_mapping(item_id: str) -> ProviderMapping:
+    """
+    Build a provider mapping for the gated test provider.
+
+    :param item_id: The provider item id to map.
+    """
+    return ProviderMapping(
+        item_id=item_id,
+        provider_domain=GUARDED_PROVIDER_ID,
+        provider_instance=GUARDED_PROVIDER_ID,
+    )


### PR DESCRIPTION
# What does this implement/fix?

Music Assistant recognises when several parts of the server ask for the same thing at the same time and turns that into a single request (used when fetching item details and playlist tracks from a music provider). That sharing was a bit too eager:

- If one of the waiting callers gave up (for example because a UI view was closed), the shared request was cancelled and every other caller waiting for the same result was cancelled with it.
- The key used to recognise an identical request did not include the object it was called on. Because all media controllers share the same inherited method, an album and a track request for the same item id on the same provider looked identical, so a caller could receive an item of the wrong media type. This can happen on providers that use the same id for different media types, such as Deezer and Yandex Music.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- A caller that is cancelled no longer cancels the shared request, so the other callers still get their result.
- The deduplication key now includes the object the guarded method was called on, so requests are only shared within the same controller (or provider instance).
- Added tests for both, plus one covering that requests are still shared where they should be.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
