### PR TITLE
Announce only the stable address of each IPv6 network

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -993,6 +993,7 @@ def _enumerate_ip_addresses(include_ipv6: bool) -> tuple[str, ...]:
             _sock6.close()
     # get all IP addresses of all network interfaces
     adapters = ifaddr.get_adapters()
+    seen_ipv6_prefixes: set[tuple[str, bytes]] = set()
     for adapter in adapters:
         for ip in adapter.ips:
             if ip.is_IPv6 and not include_ipv6:
@@ -1005,6 +1006,15 @@ def _enumerate_ip_addresses(include_ipv6: bool) -> tuple[str, ...]:
             if ip_str.startswith(("::1", "::ffff:", "fe80")):
                 # filter out IPv6 loopback/link-local address
                 continue
+            if ip.is_IPv6:
+                # keep only the first address of each /64: SLAAC privacy extensions add
+                # a new temporary address per rotation within the same prefix while the
+                # first one is the stable address, so announcing the rest only fills the
+                # mDNS records with addresses the host stops holding
+                ipv6_prefix = (adapter.name, ip_address(ip_str).packed[:8])
+                if ipv6_prefix in seen_ipv6_prefixes:
+                    continue
+                seen_ipv6_prefixes.add(ipv6_prefix)
             if ip_str == primary_ip:
                 score = 10
             elif ip_str.startswith(("192.168.",)):

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -321,6 +321,127 @@ class TestGetIpAddresses:
         assert enumerate_mock.call_count == 1
 
 
+class TestEnumerateIpAddresses:
+    """_enumerate_ip_addresses filters and ranks the addresses of all adapters."""
+
+    @pytest.fixture(autouse=True)
+    def _no_primary_ip(self) -> Iterator[None]:
+        """Neutralize the primary-IP probe so ranking never depends on the test host."""
+        with patch("music_assistant.helpers.util.socket.socket") as mock_socket:
+            mock_socket.return_value.connect.side_effect = OSError
+            yield
+
+    def test_temporary_addresses_within_one_prefix_are_dropped(self) -> None:
+        """Only the first IPv6 address of a /64 is kept (the rest are rotating temporaries)."""
+        adapters = [
+            _make_adapter(
+                "eth0",
+                ipv6_addrs=[
+                    "2001:db8:0:1:45f:fbc1:f274:46ab",
+                    "2001:db8:0:1:2cfa:5e0c:b80d:dac6",
+                    "2001:db8:0:1:1d31:37fa:bc4d:e2f4",
+                ],
+            ),
+        ]
+        with patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters):
+            result = util._enumerate_ip_addresses(include_ipv6=True)
+        assert result == ("2001:db8:0:1:45f:fbc1:f274:46ab",)
+
+    def test_distinct_prefixes_on_one_adapter_are_kept(self) -> None:
+        """Addresses in different /64s on the same adapter all survive."""
+        adapters = [
+            _make_adapter(
+                "eth0",
+                ipv6_addrs=[
+                    "fd3a:ce91:4b25:0:1cb3:49d2:d3d5:4001",
+                    "2001:db8:0:1:45f:fbc1:f274:46ab",
+                    "2001:db8:0:2:45f:fbc1:f274:46ab",
+                ],
+            ),
+        ]
+        with patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters):
+            result = util._enumerate_ip_addresses(include_ipv6=True)
+        assert result == (
+            "fd3a:ce91:4b25:0:1cb3:49d2:d3d5:4001",
+            "2001:db8:0:1:45f:fbc1:f274:46ab",
+            "2001:db8:0:2:45f:fbc1:f274:46ab",
+        )
+
+    def test_prefix_is_tracked_per_adapter(self) -> None:
+        """The same /64 on two adapters keeps one address per adapter."""
+        adapters = [
+            _make_adapter(
+                "eth0",
+                ipv6_addrs=["2001:db8:0:1:1::1", "2001:db8:0:1:1::2"],
+            ),
+            _make_adapter(
+                "eth1",
+                ipv6_addrs=["2001:db8:0:1:2::1", "2001:db8:0:1:2::2"],
+            ),
+        ]
+        with patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters):
+            result = util._enumerate_ip_addresses(include_ipv6=True)
+        assert result == ("2001:db8:0:1:1::1", "2001:db8:0:1:2::1")
+
+    def test_ipv4_addresses_are_not_deduplicated(self) -> None:
+        """Multiple IPv4 addresses in one subnet on one adapter are all kept."""
+        adapters = [
+            _make_adapter("eth0", ipv4_addrs=["192.168.1.10", "192.168.1.11"]),
+        ]
+        with patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters):
+            result = util._enumerate_ip_addresses(include_ipv6=False)
+        assert result == ("192.168.1.10", "192.168.1.11")
+
+    def test_ipv6_is_skipped_when_not_requested(self) -> None:
+        """Without include_ipv6 only the IPv4 addresses are returned."""
+        adapters = [
+            _make_adapter("eth0", ipv4_addrs=["192.168.1.10"], ipv6_addrs=["2001:db8:0:1::1"]),
+        ]
+        with patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters):
+            result = util._enumerate_ip_addresses(include_ipv6=False)
+        assert result == ("192.168.1.10",)
+
+    def test_loopback_and_link_local_are_filtered(self) -> None:
+        """Loopback, APIPA and link-local addresses never make it into the result."""
+        adapters = [
+            _make_adapter("lo", ipv4_addrs=["127.0.0.1"], ipv6_addrs=["::1"]),
+            _make_adapter(
+                "eth0",
+                ipv4_addrs=["169.254.1.5", "192.168.1.10"],
+                ipv6_addrs=["fe80::186f:912f:998:e451", "::ffff:192.168.1.10"],
+            ),
+        ]
+        with patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters):
+            result = util._enumerate_ip_addresses(include_ipv6=True)
+        assert result == ("192.168.1.10",)
+
+    def test_filtered_addresses_do_not_claim_a_prefix(self) -> None:
+        """A filtered link-local address does not stop a routable address from being kept."""
+        adapters = [
+            _make_adapter(
+                "eth0",
+                ipv6_addrs=["fe80::186f:912f:998:e451", "2001:db8:0:1::1"],
+            ),
+        ]
+        with patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters):
+            result = util._enumerate_ip_addresses(include_ipv6=True)
+        assert result == ("2001:db8:0:1::1",)
+
+    def test_ranking_puts_the_primary_address_first(self) -> None:
+        """The address of the default route outranks the other private addresses."""
+        adapters = [
+            _make_adapter("eth0", ipv4_addrs=["192.168.1.10"]),
+            _make_adapter("eth1", ipv4_addrs=["10.0.0.5"]),
+        ]
+        with (
+            patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters),
+            patch("music_assistant.helpers.util.socket.socket") as mock_socket,
+        ):
+            mock_socket.return_value.getsockname.return_value = ("10.0.0.5", 0)
+            result = util._enumerate_ip_addresses(include_ipv6=False)
+        assert result == ("10.0.0.5", "192.168.1.10")
+
+
 class TestSanitizeHttpHeaderValue:
     """sanitize_http_header_value strips characters aiohttp forbids in response headers."""
 
@@ -481,6 +602,36 @@ class _GatedMusicProvider(MusicProvider):
             name="Track",
             provider_mappings={_provider_mapping(prov_track_id)},
         )
+
+
+def _make_adapter(
+    name: str,
+    ipv4_addrs: list[str] | None = None,
+    ipv6_addrs: list[str] | None = None,
+) -> MagicMock:
+    """
+    Build a stand-in for an ifaddr.Adapter holding the given addresses.
+
+    :param name: The adapter name.
+    :param ipv4_addrs: The IPv4 addresses of the adapter.
+    :param ipv6_addrs: The IPv6 addresses of the adapter.
+    """
+    adapter = MagicMock()
+    adapter.name = name
+    ips = []
+    for addr in ipv4_addrs or []:
+        ip_mock = MagicMock()
+        ip_mock.is_IPv6 = False
+        ip_mock.ip = addr
+        ips.append(ip_mock)
+    for addr in ipv6_addrs or []:
+        ip_mock = MagicMock()
+        ip_mock.is_IPv6 = True
+        # ifaddr reports IPv6 addresses as (address, flowinfo, scope_id) tuples
+        ip_mock.ip = (addr, 0, 0)
+        ips.append(ip_mock)
+    adapter.ips = ips
+    return adapter
 
 
 def _provider_mapping(item_id: str) -> ProviderMapping:


### PR DESCRIPTION
# What does this implement/fix?

On networks using IPv6 privacy extensions the host adds a fresh temporary address every rotation, and the old ones stick around for a while before expiring. We announce every address we can find, so on a normal machine that list was 11 entries: the LAN address, a VPN address, two real IPv6 addresses, and seven rotating temporaries — six of which the system had already retired. The list is only built once at startup, so those entries also go stale as the day goes on.

Speakers and clients pick an address out of that list to reach us, so most of what we were offering them was unusable.

We now announce a single address per network per interface, which is the stable one.

- helpers: when collecting our own addresses, keep only the first address of each IPv6 network

On the test machine this takes the announced list from 11 addresses down to 4, keeping both real IPv6 addresses and dropping only the temporaries.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
