### PR TITLE
Remove spurious error log entries for shared requests

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -957,6 +957,7 @@ async def get_ip_addresses(include_ipv6: bool = False) -> tuple[str, ...]:
     # so concurrent callers always end up awaiting the same probe
     if not (pending := _ip_addresses_pending.get(include_ipv6)):
         pending = asyncio.create_task(_probe())
+        pending.add_done_callback(_log_ip_probe_failure)
         _ip_addresses_pending[include_ipv6] = pending
     # wait for the shared probe instead of awaiting it directly: a caller awaiting a task
     # holds it as its fut_waiter, so cancelling that caller would otherwise cancel the probe
@@ -966,6 +967,17 @@ async def get_ip_addresses(include_ipv6: bool = False) -> tuple[str, ...]:
     if not pending.done():
         await asyncio.wait((pending,))
     return pending.result()
+
+
+def _log_ip_probe_failure(probe: asyncio.Task[tuple[str, ...]]) -> None:
+    """Log (and thereby retrieve) the exception of a finished address probe, if any."""
+    if probe.cancelled():
+        return
+    # every waiter that is still around reports the failure itself, so a debug line is
+    # enough here; retrieving the exception is what keeps asyncio from reporting it as
+    # "Task exception was never retrieved" once the probe is garbage collected
+    if (err := probe.exception()) is not None:
+        LOGGER.debug("Enumerating IP addresses failed: %s", err)
 
 
 def _enumerate_ip_addresses(include_ipv6: bool) -> tuple[str, ...]:

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -958,9 +958,14 @@ async def get_ip_addresses(include_ipv6: bool = False) -> tuple[str, ...]:
     if not (pending := _ip_addresses_pending.get(include_ipv6)):
         pending = asyncio.create_task(_probe())
         _ip_addresses_pending[include_ipv6] = pending
-    # shield the shared probe: a caller awaiting a task holds it as its fut_waiter,
-    # so cancelling that caller would otherwise cancel the probe for all other callers
-    return await asyncio.shield(pending)
+    # wait for the shared probe instead of awaiting it directly: a caller awaiting a task
+    # holds it as its fut_waiter, so cancelling that caller would otherwise cancel the probe
+    # for all other callers. asyncio.shield achieves the same, but as of Python 3.14 a
+    # cancelled caller makes it report the probe's exception through
+    # loop.call_exception_handler, even when another caller already handled it.
+    if not pending.done():
+        await asyncio.wait((pending,))
+    return pending.result()
 
 
 def _enumerate_ip_addresses(include_ipv6: bool) -> tuple[str, ...]:

--- a/music_assistant/models/recommendation_payload.py
+++ b/music_assistant/models/recommendation_payload.py
@@ -52,8 +52,8 @@ class RecommendationPayloadMixin(_MixinBase):
       read; a stale persisted payload is likewise served while one refresh runs.
 
     Concurrent callers share one in-flight fetch (single-flight); the shared fetch is
-    shielded so a timed-out caller cannot cancel it for the other waiters and its
-    result still lands in memory and cache.
+    isolated from caller cancellation, so a timed-out caller cannot cancel it for the
+    other waiters and its result still lands in memory and cache.
 
     All background work runs in tasks created via mass.create_task, so it is cancelled
     on server stop; the mixin's unload() additionally cancels any in-flight fetch or
@@ -136,9 +136,14 @@ class RecommendationPayloadMixin(_MixinBase):
                 task_id=f"recommendation_payload_fetch.{self.instance_id}",
             )
             self._recommendation_payload_task = task
-        # shield: a timed-out caller must not cancel the shared load out from under
-        # the other waiters (and the load must still complete to warm memory + cache)
-        return await asyncio.shield(task)
+        # wait for the shared load instead of awaiting it directly: a timed-out caller must
+        # not cancel it out from under the other waiters (and the load must still complete
+        # to warm memory + cache). asyncio.shield achieves the same, but as of Python 3.14 a
+        # cancelled caller makes it report the load's exception through
+        # loop.call_exception_handler, even when another caller already handled it.
+        if not task.done():
+            await asyncio.wait((task,))
+        return task.result()
 
     async def _refresh_recommendation_payload(self) -> list[RecommendationFolder]:
         """
@@ -148,8 +153,11 @@ class RecommendationPayloadMixin(_MixinBase):
         cached payload is known to be outdated (e.g. after detecting rotated backend ids).
         Subsequent _recommendation_payload calls serve the refreshed payload.
         """
-        # shield: see _recommendation_payload
-        return await asyncio.shield(self._schedule_recommendation_refresh())
+        # wait for the shared refresh rather than awaiting it: see _recommendation_payload
+        task = self._schedule_recommendation_refresh()
+        if not task.done():
+            await asyncio.wait((task,))
+        return task.result()
 
     def _schedule_recommendation_refresh(self) -> asyncio.Task[list[RecommendationFolder]]:
         """Return the in-flight refresh task, starting one if none is running."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 import pathlib
 from collections.abc import AsyncGenerator, Iterator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiofiles.os
@@ -35,6 +35,26 @@ async def get_fixtures_dir(
     for file in await aiofiles.os.listdir(dir_path):
         async with aiofiles.open(dir_path / file, "rb") as fp:
             yield (file, await fp.read())
+
+
+@contextlib.contextmanager
+def collect_loop_errors() -> Iterator[list[dict[str, Any]]]:
+    """
+    Capture everything the running loop reports to its exception handler.
+
+    Yields the (initially empty) list the captured contexts are appended to; the loop's
+    own handler is restored on exit. Use it to assert that an operation does not surface
+    an error the server itself already handles, which would otherwise reach the user as
+    an ERROR log entry with a traceback.
+    """
+    loop = asyncio.get_running_loop()
+    previous = loop.get_exception_handler()
+    reported: list[dict[str, Any]] = []
+    loop.set_exception_handler(lambda _loop, context: reported.append(context))
+    try:
+        yield reported
+    finally:
+        loop.set_exception_handler(previous)
 
 
 @contextlib.asynccontextmanager

--- a/tests/controllers/music/test_recommendations_timeouts.py
+++ b/tests/controllers/music/test_recommendations_timeouts.py
@@ -142,12 +142,12 @@ async def test_payload_mixin_rows_timeout_does_not_cancel_shared_fetch(
     mass: MusicAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """
-    The controller's rows timeout degrades gracefully without killing the shielded fetch.
+    The controller's rows timeout degrades gracefully without killing the shared fetch.
 
     A RecommendationPayloadMixin provider's shared payload fetch outlives the controller's
     own RECOMMENDATIONS_ROWS_TIMEOUT: the timed-out rows call returns without this provider's
     rows, but the fetch keeps running in the background, warms the cache, and a later rows
-    call serves it without hitting the backend again (pins shield-vs-controller-timeout).
+    call serves it without hitting the backend again.
     """
     monkeypatch.setattr(rec_controller, "RECOMMENDATIONS_ROWS_TIMEOUT", 0.05)
     gate = asyncio.Event()
@@ -191,7 +191,7 @@ async def test_payload_mixin_rows_timeout_does_not_cancel_shared_fetch(
     assert any(f.provider == "library" for f in folders)  # other rows unaffected
     assert provider.fetch_count == 1  # the fetch started but did not finish in time
 
-    # release the gate: the shielded fetch, still running in the background, completes
+    # release the gate: the shared fetch, still running in the background, completes
     gate.set()
     payload_task = provider._recommendation_payload_task
     assert payload_task is not None

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -320,6 +320,38 @@ class TestGetIpAddresses:
             assert await task_b == ("192.168.1.10",)
         assert enumerate_mock.call_count == 1
 
+    @pytest.mark.asyncio
+    async def test_cancelled_caller_of_a_failing_probe_logs_no_loop_error(self) -> None:
+        """A probe failing after a caller gave up is not reported to the loop handler."""
+
+        def failing_enumerate(_include_ipv6: bool) -> tuple[str, ...]:
+            time.sleep(0.1)
+            raise OSError("probe failed")
+
+        loop = asyncio.get_running_loop()
+        reported: list[dict[str, object]] = []
+        loop.set_exception_handler(lambda _loop, context: reported.append(context))
+        try:
+            with patch(
+                "music_assistant.helpers.util._enumerate_ip_addresses",
+                side_effect=failing_enumerate,
+            ):
+                task_a = asyncio.create_task(util.get_ip_addresses())
+                task_b = asyncio.create_task(util.get_ip_addresses())
+                # let both callers await the (same) in-flight probe, then cancel one
+                await asyncio.sleep(0.02)
+                task_a.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task_a
+                with pytest.raises(OSError, match="probe failed"):
+                    await task_b
+            # let any done callback left on the probe run before asserting
+            await asyncio.sleep(0)
+        finally:
+            loop.set_exception_handler(None)
+
+        assert reported == []
+
 
 class TestSanitizeHttpHeaderValue:
     """sanitize_http_header_value strips characters aiohttp forbids in response headers."""

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -1,7 +1,9 @@
 """Tests for music_assistant.helpers.util helpers."""
 
 import asyncio
+import gc
 import socket
+import threading
 import time
 from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
@@ -21,6 +23,7 @@ from music_assistant.helpers.util import (
 )
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.music_provider import MusicProvider
+from tests.common import collect_loop_errors
 
 GUARDED_PROVIDER_ID = "test_guarded_prov"
 
@@ -323,32 +326,63 @@ class TestGetIpAddresses:
     @pytest.mark.asyncio
     async def test_cancelled_caller_of_a_failing_probe_logs_no_loop_error(self) -> None:
         """A probe failing after a caller gave up is not reported to the loop handler."""
+        release = threading.Event()
 
         def failing_enumerate(_include_ipv6: bool) -> tuple[str, ...]:
-            time.sleep(0.1)
+            release.wait()
             raise OSError("probe failed")
 
-        loop = asyncio.get_running_loop()
-        reported: list[dict[str, object]] = []
-        loop.set_exception_handler(lambda _loop, context: reported.append(context))
-        try:
-            with patch(
+        with (
+            collect_loop_errors() as reported,
+            patch(
                 "music_assistant.helpers.util._enumerate_ip_addresses",
                 side_effect=failing_enumerate,
-            ):
-                task_a = asyncio.create_task(util.get_ip_addresses())
-                task_b = asyncio.create_task(util.get_ip_addresses())
-                # let both callers await the (same) in-flight probe, then cancel one
-                await asyncio.sleep(0.02)
-                task_a.cancel()
-                with pytest.raises(asyncio.CancelledError):
-                    await task_a
-                with pytest.raises(OSError, match="probe failed"):
-                    await task_b
-            # let any done callback left on the probe run before asserting
+            ) as enumerate_mock,
+        ):
+            task_a = asyncio.create_task(util.get_ip_addresses())
+            task_b = asyncio.create_task(util.get_ip_addresses())
+            # let both callers await the (same) in-flight probe, then cancel one
             await asyncio.sleep(0)
-        finally:
-            loop.set_exception_handler(None)
+            task_a.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task_a
+            # release the probe only once the cancellation is fully processed, so the
+            # failure reliably lands after the giving-up caller is gone
+            release.set()
+            with pytest.raises(OSError, match="probe failed"):
+                await task_b
+
+        assert enumerate_mock.call_count == 1
+        assert reported == []
+
+    @pytest.mark.asyncio
+    async def test_sole_cancelled_caller_of_a_failing_probe_logs_no_loop_error(self) -> None:
+        """A probe failing with no caller left to receive it is not reported either."""
+        release = threading.Event()
+
+        def failing_enumerate(_include_ipv6: bool) -> tuple[str, ...]:
+            release.wait()
+            raise OSError("probe failed")
+
+        with (
+            collect_loop_errors() as reported,
+            patch(
+                "music_assistant.helpers.util._enumerate_ip_addresses",
+                side_effect=failing_enumerate,
+            ),
+        ):
+            caller = asyncio.create_task(util.get_ip_addresses())
+            await asyncio.sleep(0)
+            probe = util._ip_addresses_pending[False]
+            caller.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await caller
+            release.set()
+            await asyncio.wait((probe,))
+            # drop the last reference so asyncio would report an unretrieved exception
+            del probe
+            gc.collect()
+            await asyncio.sleep(0)
 
         assert reported == []
 

--- a/tests/models/test_recommendation_payload.py
+++ b/tests/models/test_recommendation_payload.py
@@ -433,11 +433,11 @@ async def test_refresh_single_flight_concurrent_calls_fetch_once() -> None:
 @pytest.mark.asyncio
 async def test_cancelled_waiter_does_not_cancel_shared_fetch() -> None:
     """
-    A timed-out caller is shielded from the shared fetch: other waiters still get the payload.
+    A timed-out caller leaves the shared fetch alone: other waiters still get the payload.
 
-    Regression test: the controller's asyncio.timeout cancels the calling task; without
-    asyncio.shield that cancellation would propagate into the shared single-flight task,
-    raising CancelledError in every other waiter and preventing the cache from warming.
+    Regression test: the controller's asyncio.timeout cancels the calling task; if that
+    cancellation propagated into the shared single-flight task it would raise
+    CancelledError in every other waiter and prevent the cache from warming.
     """
     payload = _make_payload()
     gate = asyncio.Event()
@@ -486,7 +486,7 @@ async def test_sole_cancelled_waiter_fetch_still_warms_memory_and_cache() -> Non
     gate.set()
     await _drain_background(provider)
 
-    # the shielded fetch completed anyway: memory and cache are warm, no second fetch
+    # the fetch completed anyway: memory and cache are warm, no second fetch
     assert await provider._recommendation_payload() == payload
     fetch.assert_awaited_once()
     assert provider._cache_store[_PAYLOAD_CACHE_KEY] == _payload_dicts(payload)
@@ -517,6 +517,39 @@ async def test_failed_fetch_propagates_to_all_waiters_and_retries() -> None:
     fetch.return_value = payload
     assert await provider._recommendation_payload() == payload
     assert fetch.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cancelled_waiter_of_a_failing_fetch_logs_no_loop_error() -> None:
+    """A fetch failing after a caller timed out is not reported to the loop handler."""
+    gate = asyncio.Event()
+
+    async def _failing_fetch() -> list[RecommendationFolder]:
+        await gate.wait()
+        raise RuntimeError("backend down")
+
+    provider = _PayloadProvider(AsyncMock(side_effect=_failing_fetch))
+
+    loop = asyncio.get_running_loop()
+    reported: list[dict[str, Any]] = []
+    loop.set_exception_handler(lambda _loop, context: reported.append(context))
+    try:
+        fast_caller = asyncio.create_task(provider._recommendation_payload())
+        slow_caller = asyncio.create_task(provider._recommendation_payload())
+        await asyncio.sleep(0)
+        # simulate the rows call timing out before the fetch fails
+        fast_caller.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await fast_caller
+        gate.set()
+        with pytest.raises(RuntimeError, match="backend down"):
+            await slow_caller
+        # let any done callback left on the fetch run before asserting
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(None)
+
+    assert reported == []
 
 
 @pytest.mark.asyncio

--- a/tests/models/test_recommendation_payload.py
+++ b/tests/models/test_recommendation_payload.py
@@ -16,6 +16,7 @@ from music_assistant.models.recommendation_payload import (
     _PAYLOAD_CACHE_KEY,
     RecommendationPayloadMixin,
 )
+from tests.common import collect_loop_errors
 
 INSTANCE_ID = "test_payload--instance1"
 
@@ -530,10 +531,7 @@ async def test_cancelled_waiter_of_a_failing_fetch_logs_no_loop_error() -> None:
 
     provider = _PayloadProvider(AsyncMock(side_effect=_failing_fetch))
 
-    loop = asyncio.get_running_loop()
-    reported: list[dict[str, Any]] = []
-    loop.set_exception_handler(lambda _loop, context: reported.append(context))
-    try:
+    with collect_loop_errors() as reported:
         fast_caller = asyncio.create_task(provider._recommendation_payload())
         slow_caller = asyncio.create_task(provider._recommendation_payload())
         await asyncio.sleep(0)
@@ -544,10 +542,6 @@ async def test_cancelled_waiter_of_a_failing_fetch_logs_no_loop_error() -> None:
         gate.set()
         with pytest.raises(RuntimeError, match="backend down"):
             await slow_caller
-        # let any done callback left on the fetch run before asserting
-        await asyncio.sleep(0)
-    finally:
-        loop.set_exception_handler(None)
 
     assert reported == []
 


### PR DESCRIPTION
# What does this implement/fix?

Some requests are shared between callers: when several parts of the server ask for the same thing at once, only one actual request is made and everyone waits for it. If one of those waiters gives up (a timeout, for example) and the shared request then fails, Python 3.14 reports that failure a second time on its own, which showed up in the log as a scary `Error doing task: ... exception in shielded future` entry with a full traceback — even though the failure was already handled and reported properly elsewhere.

This applies the same fix already used for library item lookups (#5288) to two more places that share a request this way: the network address lookup and the provider recommendations payload. A few other spots share requests the same way and will follow separately.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Network address lookup (`get_ip_addresses`) and the provider recommendations payload now join a shared request the same way library item lookups do, instead of via `asyncio.shield`.
- The address lookup also logs its own failure at debug level, so a failing lookup nobody is waiting for any more can no longer turn up as a stray error later on.
- No behaviour change for callers: a giving-up caller still leaves the shared request running for everyone else, and the result or error still reaches every other waiter unchanged.
- Added tests covering both spots.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
