### PR TITLE
Fix remote access failing to reach the Music Assistant API

### DIFF
--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -114,6 +114,20 @@ def _get_publish_addresses(
     return addresses
 
 
+def _get_internal_connect_ip(bind_ip: str | None, publish_ip: str) -> str:
+    """
+    Return the IP address to reach a server running on this host.
+
+    :param bind_ip: The server's configured bind IP (None or a wildcard means all interfaces).
+    :param publish_ip: The server's resolved publish IP.
+    """
+    if bind_ip and bind_ip not in WILDCARD_BIND_IPS:
+        # bound to one specific interface, so loopback would not reach the server
+        return bind_ip
+    # Use IPv6 loopback if publish_ip is IPv6 (indicates IPv6-only host)
+    return "::1" if ":" in publish_ip else "127.0.0.1"
+
+
 def _locale_from_request(request: web.Request) -> str | None:
     """
     Determine the UI locale for an HTTP request from the standard ``Accept-Language`` header.
@@ -167,17 +181,24 @@ class WebserverController(CoreController):
         return base_url.removesuffix("/")
 
     @property
+    def internal_base_url(self) -> str:
+        """Return the URL to reach this webserver's own API from this host."""
+        # the advertised address is not necessarily dialable here: a configured base URL
+        # routes out through DNS and a reverse proxy just to come back in, and a published
+        # IP need not exist on this host at all (e.g. a container or NAT setup), so derive
+        # the address from what the webserver actually binds to
+        connect_ip = _get_internal_connect_ip(self.bind_ip, self.publish_ip)
+        protocol = "https" if self.config.get_value(CONF_ENABLE_SSL, False) else "http"
+        return f"{protocol}://{format_ip_for_url(connect_ip)}:{self.publish_port}"
+
+    @property
     def internal_sendspin_url(self) -> str:
         """Return the URL to reach the in-process Sendspin server from this host."""
         # the advertised address is not necessarily dialable here (e.g. a container or
         # NAT setup), so derive the address from what the Sendspin server actually binds to
-        bind_ip = self.mass.streams.bind_ip
-        if bind_ip and bind_ip not in WILDCARD_BIND_IPS:
-            # bound to one specific interface, so loopback would not reach the server
-            connect_ip = bind_ip
-        else:
-            # Use IPv6 loopback if publish_ip is IPv6 (indicates IPv6-only host)
-            connect_ip = "::1" if ":" in str(self.mass.streams.publish_ip) else "127.0.0.1"
+        connect_ip = _get_internal_connect_ip(
+            self.mass.streams.bind_ip, str(self.mass.streams.publish_ip)
+        )
         return f"ws://{format_ip_for_url(connect_ip)}:{SENDSPIN_SERVER_PORT}/sendspin"
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:

--- a/music_assistant/controllers/webserver/remote_access/__init__.py
+++ b/music_assistant/controllers/webserver/remote_access/__init__.py
@@ -195,14 +195,9 @@ class RemoteAccessManager:
             self.mass.storage_path
         )
 
-        # resolved once, at gateway start: changing the base URL restarts neither the
-        # webserver nor this gateway, and behind a reverse proxy this address need not be
-        # reachable from this host at all
-        base_url = self.mass.webserver.base_url
-        local_ws_url = base_url.replace("http", "ws", 1)
-        if not local_ws_url.endswith("/"):
-            local_ws_url += "/"
-        local_ws_url += "ws"
+        # resolved once, at gateway start: this follows the webserver's bind address, which
+        # can only change through a reload of the webserver - and that restarts this gateway
+        local_ws_url = self.webserver.internal_base_url.replace("http", "ws", 1) + "/ws"
 
         ha_cloud_available, ice_servers = await self._get_ha_cloud_status()
         using_ha_cloud = bool(ha_cloud_available and ice_servers)

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -107,7 +107,7 @@ class WebRTCGateway:
         :param cert_pem: Persistent DTLS certificate (PEM), enabling client-side pinning.
         :param key_pem: Private key (PEM) matching the DTLS certificate.
         :param signaling_url: WebSocket URL of the signaling server.
-        :param local_ws_url: Local WebSocket URL to bridge to.
+        :param local_ws_url: Same-host WebSocket URL of the Music Assistant API to bridge to.
         :param sendspin_url: Internal Sendspin WebSocket URL to bridge to.
         :param ice_servers: List of ICE server configurations (used at registration time).
         :param ice_servers_callback: Optional callback to fetch fresh ICE servers for each session.
@@ -501,8 +501,10 @@ class WebRTCGateway:
         async with self._http_proxy_semaphore:
             try:
                 # Use shared HTTP session for this request
+                # TLS verification would fail on the bind address and adds nothing to a dial
+                # that never leaves this host
                 async with self.http_session.request(
-                    method, local_http_url, headers=headers
+                    method, local_http_url, headers=headers, ssl=False
                 ) as response:
                     body = await response.read()
                     await self._send_http_proxy_response(
@@ -633,7 +635,9 @@ class WebRTCGateway:
         try:
             # Include session_id in URL so server can track WebRTC sessions
             ws_url = f"{self.local_ws_url}?webrtc_session_id={session.session_id}"
-            session.local_ws = await self.http_session.ws_connect(ws_url)
+            # TLS verification would fail on the bind address and adds nothing to a dial
+            # that never leaves this host
+            session.local_ws = await self.http_session.ws_connect(ws_url, ssl=False)
         except Exception:
             self.logger.exception("Failed to connect to local WebSocket")
             channel.close()

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -501,10 +501,10 @@ class WebRTCGateway:
         async with self._http_proxy_semaphore:
             try:
                 # Use shared HTTP session for this request
-                # TLS verification would fail on the bind address and adds nothing to a dial
-                # that never leaves this host
+                # this dial never leaves the host: TLS verification would fail on the bind
+                # address, and an unfollowed redirect cannot take the unverified dial off-host
                 async with self.http_session.request(
-                    method, local_http_url, headers=headers, ssl=False
+                    method, local_http_url, headers=headers, ssl=False, allow_redirects=False
                 ) as response:
                     body = await response.read()
                     await self._send_http_proxy_response(
@@ -639,7 +639,7 @@ class WebRTCGateway:
             # that never leaves this host
             session.local_ws = await self.http_session.ws_connect(ws_url, ssl=False)
         except Exception:
-            self.logger.exception("Failed to connect to local WebSocket")
+            self.logger.exception("Failed to connect to local WebSocket %s", self.local_ws_url)
             channel.close()
             self._schedule_close(session.session_id)
             return

--- a/tests/controllers/webserver/test_internal_base_url.py
+++ b/tests/controllers/webserver/test_internal_base_url.py
@@ -1,0 +1,87 @@
+"""Tests for the URL used to reach the webserver's own API from this host."""
+
+from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from music_assistant.controllers.webserver.controller import (
+    CONF_BASE_URL,
+    CONF_ENABLE_SSL,
+    WebserverController,
+)
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import CoreConfig
+
+
+@pytest.fixture
+def mock_mass() -> MagicMock:
+    """Create a mock Music Assistant instance."""
+    mass = MagicMock()
+    mass.config.get_raw_core_config_value.return_value = "GLOBAL"
+    return mass
+
+
+@pytest.fixture
+def webserver(mock_mass: MagicMock) -> WebserverController:
+    """Create a WebserverController carrying the state that setup() resolves."""
+    webserver = WebserverController(mock_mass)
+    config = MagicMock()
+    config.get_value.return_value = False
+    webserver.config = cast("CoreConfig", config)
+    webserver.publish_port = 8095
+    return webserver
+
+
+@pytest.mark.parametrize(
+    ("bind_ip", "publish_ip", "expected"),
+    [
+        # pinned to a single interface: loopback would not reach the server
+        ("192.168.1.5", "192.168.1.5", "http://192.168.1.5:8095"),
+        ("fd00::5", "fd00::5", "http://[fd00::5]:8095"),
+        # wildcard bind: loopback reaches the server, whatever is advertised.
+        # a publish_ip that only exists outside a container/NAT must never be dialed
+        ("0.0.0.0", "203.0.113.10", "http://127.0.0.1:8095"),
+        ("::", "192.168.1.5", "http://127.0.0.1:8095"),
+        ("0.0.0.0", "fd00::1", "http://[::1]:8095"),
+        ("::", "fd00::1", "http://[::1]:8095"),
+        ("", "192.168.1.5", "http://127.0.0.1:8095"),
+        (None, "192.168.1.5", "http://127.0.0.1:8095"),
+    ],
+)
+def test_url_follows_the_bind_address(
+    webserver: WebserverController,
+    bind_ip: str | None,
+    publish_ip: str,
+    expected: str,
+) -> None:
+    """Verify the URL resolves to an address that exists on this host."""
+    webserver.bind_ip = bind_ip
+    webserver.publish_ip = publish_ip
+
+    assert webserver.internal_base_url == expected
+
+
+def test_url_ignores_a_configured_base_url(webserver: WebserverController) -> None:
+    """Verify an external base URL is not dialed back in through DNS and a reverse proxy."""
+    cast("MagicMock", webserver.config).get_value.side_effect = lambda key, default=None: {
+        CONF_BASE_URL: "https://ma.example.com",
+        CONF_ENABLE_SSL: False,
+    }.get(key, default)
+    webserver.bind_ip = "0.0.0.0"
+    webserver.publish_ip = "192.168.1.5"
+
+    assert webserver.base_url == "https://ma.example.com"
+    assert webserver.internal_base_url == "http://127.0.0.1:8095"
+
+
+def test_url_uses_tls_when_ssl_is_enabled(webserver: WebserverController) -> None:
+    """Verify the scheme matches what the webserver serves."""
+    cast("MagicMock", webserver.config).get_value.side_effect = lambda key, default=None: {
+        CONF_ENABLE_SSL: True
+    }.get(key, default)
+    webserver.bind_ip = "0.0.0.0"
+    webserver.publish_ip = "192.168.1.5"
+
+    assert webserver.internal_base_url == "https://127.0.0.1:8095"

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -8,7 +8,7 @@ import logging
 from collections.abc import AsyncIterator, Callable, Coroutine
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from urllib.parse import urlparse
 
 import aiohttp
@@ -710,6 +710,73 @@ async def test_http_proxy_request_cannot_change_host(
     assert parsed.port == 8095
     assert parsed.username is None
     assert "evil.com" not in (parsed.netloc or "")
+
+
+async def test_http_proxy_request_keeps_the_unverified_dial_on_this_host(
+    cert_pems: tuple[str, str],
+) -> None:
+    """The proxy must not carry its unverified TLS dial off this host."""
+    cert_pem, key_pem = cert_pems
+    mock_session = Mock()
+    captured_kwargs: dict[str, object] = {}
+
+    def fake_request(_method: str, _url: str, **kwargs: object) -> AsyncMock:
+        captured_kwargs.update(kwargs)
+        response = AsyncMock()
+        response.status = 200
+        response.headers = {}
+        response.read = AsyncMock(return_value=b"")
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=response)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    mock_session.request = fake_request
+
+    gateway = WebRTCGateway(
+        http_session=mock_session,
+        remote_id="TEST-REMOTE-ID",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+        local_ws_url="wss://127.0.0.1:8095/ws",
+    )
+    session = WebRTCSession(session_id="s1", pc=Mock())
+
+    await gateway._handle_http_proxy_request(session, {"id": "1", "method": "GET", "path": "/info"})
+
+    assert captured_kwargs["ssl"] is False
+    assert captured_kwargs["allow_redirects"] is False
+
+
+async def test_local_websocket_dial_skips_certificate_verification(
+    cert_pems: tuple[str, str],
+) -> None:
+    """Reach the local API on the bind address, which no certificate is issued for."""
+    cert_pem, key_pem = cert_pems
+    mock_session = Mock()
+    captured_kwargs: dict[str, object] = {}
+
+    async def fake_ws_connect(_url: str, **kwargs: object) -> AsyncMock:
+        captured_kwargs.update(kwargs)
+        return AsyncMock()
+
+    mock_session.ws_connect = fake_ws_connect
+
+    gateway = WebRTCGateway(
+        http_session=mock_session,
+        remote_id="TEST-REMOTE-ID",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+        local_ws_url="wss://127.0.0.1:8095/ws",
+    )
+    session = WebRTCSession(session_id="s1", pc=Mock())
+    channel = MagicMock()
+    channel.wait_open = AsyncMock()
+
+    with patch.object(gateway, "_schedule_close"):
+        await gateway._bridge_ma_api(session, channel)
+
+    assert captured_kwargs["ssl"] is False
 
 
 # ---- aiolibdatachannel loopback tests --------------------------------------

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -197,7 +197,7 @@ async def test_remote_access_gateway_uses_internal_sendspin_url(
     internal_url = "ws://127.0.0.1:8927/sendspin"
     manager = _create_remote_access_manager()
     manager._remote_id = "TEST-REMOTE-ID"
-    cast("Mock", manager.mass).webserver.base_url = "http://192.168.1.5:8095"
+    cast("Mock", manager.webserver).internal_base_url = "http://127.0.0.1:8095"
     cast("Mock", manager.webserver).internal_sendspin_url = internal_url
 
     with (
@@ -213,6 +213,40 @@ async def test_remote_access_gateway_uses_internal_sendspin_url(
 
     assert manager.gateway is not None
     assert manager.gateway.sendspin_url == internal_url
+
+
+@pytest.mark.parametrize(
+    ("internal_base_url", "expected"),
+    [
+        ("http://127.0.0.1:8095", "ws://127.0.0.1:8095/ws"),
+        ("https://127.0.0.1:8095", "wss://127.0.0.1:8095/ws"),
+    ],
+)
+async def test_remote_access_gateway_uses_internal_base_url(
+    cert_pems: tuple[str, str],
+    internal_base_url: str,
+    expected: str,
+) -> None:
+    """Bridge the API data channel to the locally reachable webserver."""
+    manager = _create_remote_access_manager()
+    manager._remote_id = "TEST-REMOTE-ID"
+    # an external base URL must never be dialed back into this host
+    cast("Mock", manager.mass).webserver.base_url = "https://ma.example.com"
+    cast("Mock", manager.webserver).internal_base_url = internal_base_url
+
+    with (
+        patch(
+            "music_assistant.controllers.webserver.remote_access"
+            ".get_or_create_webrtc_certificate_pems",
+            return_value=cert_pems,
+        ),
+        patch.object(manager, "_get_ha_cloud_status", new=AsyncMock(return_value=(False, None))),
+        patch.object(WebRTCGateway, "start", new=AsyncMock()),
+    ):
+        await manager._start_gateway_locked()
+
+    assert manager.gateway is not None
+    assert manager.gateway.local_ws_url == expected
 
 
 async def test_webrtc_gateway_initialization(cert_pems: tuple[str, str]) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Remote access reached Music Assistant's own API through the *advertised* address: either the base URL you configured, or the published IP address. Neither is guaranteed to work from the machine itself — a published address does not always exist on the machine (containers, or a router doing NAT), and a configured external URL sends the call out through DNS and your reverse proxy just to come back in. When that failed, remote access stopped working while everything on your own network kept playing fine.

It now uses the address the webserver actually listens on, the same way the Sendspin connection was fixed in #5267.

- Remote access reaches the API and its HTTP proxy on the webserver's own bind address, or loopback when it listens on all interfaces.
- With SSL enabled, the certificate is not verified for this one connection: it never leaves the machine, and a certificate is issued for your hostname rather than for a local address.
- The address rule shared with the Sendspin connection now lives in one place.
- Added tests for the address selection and for the caller.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
