### PR TITLE
Keep bridged AirPlay speakers in sync after an audio dropout

### DIFF
--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -109,6 +109,14 @@ MAX_HELD_AUDIO_US: int = 45_000_000
 # bridge role delivers across MAX_HELD_AUDIO_US.
 MAX_HELD_CHUNKS: int = 4_000
 
+# Silence is queued as repeats of one shared block when filling a hole in the
+# Sendspin timeline. A timeline rebase can open a hole of tens of seconds, whose
+# silence as one buffer would be megabytes built on the event loop; repeating an
+# immutable block leaves only the sub-block remainder to allocate, whatever the
+# hole's length.
+PAD_BLOCK_FRAMES: int = BRIDGE_SAMPLE_RATE
+SILENCE_BLOCK: bytes = b"\x00" * (PAD_BLOCK_FRAMES * BRIDGE_CHANNELS * BRIDGE_BYTES_PER_SAMPLE)
+
 
 def get_bridge_client_id(airplay_player: AirPlayPlayer) -> str | None:
     """
@@ -241,6 +249,14 @@ class SendspinAirPlayBridge:
         # counter is also the write cursor's position on the Sendspin timeline.
         self._queued_frames: int = 0
         self._drop_until_us: int = 0
+        # Playout shift (seconds) already folded into the anchor from the binary's
+        # own mid-stream re-anchors. The binary zeroes its running total on every
+        # START, so this baseline is cleared wherever the anchor is (re)established.
+        self._applied_shift_seconds: float = 0.0
+        # Whether a folded playout shift is still being trimmed off the content.
+        # Distinguishes the realignment that correction produces from Sendspin
+        # timeline drift, which is the only one worth reporting.
+        self._absorbing_shift: bool = False
         # Unix-epoch ms at which byte 0 written to the CLI is audible (0 = unset).
         # Used to pace writes so the device buffer stays bounded (see _cli_writer).
         self._start_unix_ms: int = 0
@@ -717,6 +733,10 @@ class SendspinAirPlayBridge:
         self._start_unix_ms = acked_adjusted
         self._drop_until_us = anchor_us
         self._queued_frames = 0
+        # A START re-anchors the binary's playout from scratch and zeroes the
+        # total it reports, so the bridge's baseline starts over with it.
+        self._applied_shift_seconds = 0.0
+        self._absorbing_shift = False
         self._anchor_settled = True
         self._started = True
         # Replay what arrived while the anchor was being settled before yielding
@@ -874,12 +894,48 @@ class SendspinAirPlayBridge:
             self._hold_chunk(chunk)
             return
 
+        self._absorb_playout_shift()
+
         # Drop chunks that end entirely before the target start time.
         chunk_end_us = chunk.timestamp_us + chunk.duration_us
         if self._drop_until_us and chunk_end_us <= self._drop_until_us:
             return
 
         self._align_chunk(chunk)
+
+    def _absorb_playout_shift(self) -> None:
+        """
+        Fold the binary's own mid-stream re-anchors into the bridge's timeline mapping.
+
+        cliairplay re-anchors its playout later when it runs out of PCM on stdin,
+        which makes every byte it was handed audible that much later than the
+        anchor promised. Moving the anchor by the same amount keeps the content
+        the bridge feeds on the group's timeline instead of leaving the device
+        permanently behind the rest of it.
+        """
+        stream = self._airplay_stream
+        if stream is None:
+            return
+        shift_seconds = stream.cumulative_shift_seconds
+        delta_seconds = shift_seconds - self._applied_shift_seconds
+        if delta_seconds <= 0:
+            # The binary zeroes its running total on every START, so a total that
+            # went backwards means the stream re-anchored outside _anchor_stream:
+            # take the new baseline rather than walking a mapping that START has
+            # already replaced.
+            self._applied_shift_seconds = shift_seconds
+            return
+        self._applied_shift_seconds = shift_seconds
+        self._drop_until_us += round(delta_seconds * 1_000_000)
+        self._start_unix_ms += round(delta_seconds * 1000)
+        self._absorbing_shift = True
+        self.logger.warning(
+            "%s re-anchored its playout %.0f ms later after running out of audio; "
+            "re-aligning its content with the group (%.0f ms in total)",
+            self.airplay_player.display_name,
+            delta_seconds * 1000,
+            shift_seconds * 1000,
+        )
 
     def _hold_chunk(self, chunk: AudioChunk) -> None:
         """
@@ -901,12 +957,12 @@ class SendspinAirPlayBridge:
         """
         Queue a chunk at the byte offset its timestamp claims on the CLI stream.
 
-        The device plays the stream at a fixed rate from a start anchor that is
-        never revised, so a chunk only stays on the group's clock when it is
-        written at the offset matching its timestamp. A hole in the Sendspin
-        timeline is filled with silence and an overlapping head is trimmed;
-        without that, the device would run permanently ahead of (or behind) the
-        rest of the group by the size of the discontinuity.
+        The device plays the stream at a fixed rate from the anchor, so a chunk
+        only stays on the group's clock when it is written at the offset matching
+        its timestamp. A hole in the Sendspin timeline is filled with silence and
+        an overlapping head is trimmed; without that, the device would run
+        permanently ahead of (or behind) the rest of the group by the size of the
+        discontinuity.
 
         :param chunk: The audio chunk to queue.
         """
@@ -915,11 +971,17 @@ class SendspinAirPlayBridge:
             (chunk.timestamp_us - self._drop_until_us) * BRIDGE_SAMPLE_RATE / 1_000_000
         )
         drift_frames = target_frames - self._queued_frames
+        if drift_frames >= 0:
+            # The cursor caught back up, so any shift folded into the anchor has
+            # been worked off and a later realignment is timeline drift again.
+            self._absorbing_shift = False
         drift_us = round(drift_frames * 1_000_000 / BRIDGE_SAMPLE_RATE)
         # The first placement after an anchor sits at the gap between the anchor
         # and the chunk by construction, which is not drift; only a cursor that
-        # already advanced can have drifted away from the timeline.
-        if self._queued_frames and abs(drift_us) > 1_000:
+        # already advanced can have drifted away from the timeline. Trimming off a
+        # folded playout shift is a correction the bridge asked for, so it stays
+        # quiet as well until the cursor is back on the timeline.
+        if self._queued_frames and abs(drift_us) > 1_000 and not self._absorbing_shift:
             self.logger.warning(
                 "Realigned %d µs of Sendspin timeline drift for %s",
                 drift_us,
@@ -934,11 +996,24 @@ class SendspinAirPlayBridge:
                 return
             data = data[trim_bytes:]
         elif drift_frames > 0:
-            self._write_queue.put_nowait(b"\x00" * (drift_frames * bytes_per_frame))
+            self._queue_silence(drift_frames)
             self._queued_frames += drift_frames
 
         self._write_queue.put_nowait(data)
         self._queued_frames += len(data) // bytes_per_frame
+
+    def _queue_silence(self, frames: int) -> None:
+        """
+        Hand the CLI a run of silence to fill a hole in the Sendspin timeline.
+
+        :param frames: Number of silent frames to queue.
+        """
+        bytes_per_frame = BRIDGE_CHANNELS * BRIDGE_BYTES_PER_SAMPLE
+        whole_blocks, remainder = divmod(frames, PAD_BLOCK_FRAMES)
+        for _ in range(whole_blocks):
+            self._write_queue.put_nowait(SILENCE_BLOCK)
+        if remainder:
+            self._write_queue.put_nowait(b"\x00" * (remainder * bytes_per_frame))
 
     async def _cli_writer(self) -> None:
         """
@@ -1007,6 +1082,8 @@ class SendspinAirPlayBridge:
         """Stop streaming (internal, called with lock held)."""
         self._is_streaming = False
         self._queued_frames = 0
+        self._applied_shift_seconds = 0.0
+        self._absorbing_shift = False
         self._airplay_stream_ready.clear()
         self._started = False
         self._anchor_settled = False

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -918,12 +918,15 @@ class SendspinAirPlayBridge:
             return
         shift_seconds = stream.cumulative_shift_seconds
         delta_seconds = shift_seconds - self._applied_shift_seconds
-        if delta_seconds <= 0:
+        if delta_seconds < 0:
             # The binary zeroes its running total on every START, so a total that
             # went backwards means the stream re-anchored outside _anchor_stream:
             # take the new baseline rather than walking a mapping that START has
-            # already replaced.
+            # already replaced, and drop a correction that mapping no longer owes.
             self._applied_shift_seconds = shift_seconds
+            self._absorbing_shift = False
+            return
+        if not delta_seconds:
             return
         self._applied_shift_seconds = shift_seconds
         self._drop_until_us += round(delta_seconds * 1_000_000)

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -1,7 +1,7 @@
 """
 Unit tests for the Sendspin -> AirPlay bridge timing.
 
-Cover seven things, with the Sendspin clock mocked via ``ManualClock`` so the
+Cover eight things, with the Sendspin clock mocked via ``ManualClock`` so the
 tests are deterministic and independent of the host wall-clock:
 
 * the clock-domain conversion turning a Sendspin audible instant (Sendspin's own
@@ -16,6 +16,8 @@ tests are deterministic and independent of the host wall-clock:
 * the timeline alignment that keeps every chunk at the byte offset its timestamp
   claims, so a discontinuity in the Sendspin timeline does not shift the device
   off the group's clock for the rest of the stream;
+* the playout shift the binary reports after a PCM starvation, which moves the
+  anchor so the device does not stay behind the group once it re-anchors itself;
 * the write pacing that keeps the device buffered a bounded amount ahead of real
   time so a late-join catch-up backlog is not dumped into the CLI;
 * the warm handover: a running, connected stream is kept (not torn down) across
@@ -47,6 +49,8 @@ from music_assistant.providers.airplay.sendspin_bridge import (
     MAX_DEVICE_BUFFER_SECONDS,
     MAX_HELD_AUDIO_US,
     MAX_HELD_CHUNKS,
+    PAD_BLOCK_FRAMES,
+    SILENCE_BLOCK,
     SendspinAirPlayBridge,
     device_buffer_ahead_seconds,
     sendspin_audible_instant_to_unix_ms,
@@ -455,10 +459,13 @@ def _make_anchor_stream(
     """
     Build an AirPlayStream mock the anchor math can run against.
 
-    ``warm_lead_ms`` / ``flushed_head_unix_ms`` must be real ints: the anchor
-    compares them with ``> 0``, which a bare MagicMock cannot answer.
+    The bridge reads these off the stream and does arithmetic on them, so they
+    must be real numbers: the anchor compares ``warm_lead_ms`` /
+    ``flushed_head_unix_ms`` with ``> 0`` and the shift fold subtracts
+    ``cumulative_shift_seconds``, none of which a bare MagicMock can answer.
     """
     stream = MagicMock()
+    stream.cumulative_shift_seconds = 0.0
     stream.connect = AsyncMock()
     stream.wait_for_connection = AsyncMock()
     stream.stop = AsyncMock()
@@ -842,6 +849,192 @@ def test_first_chunk_after_an_anchor_is_not_reported_as_drift() -> None:
     cast("MagicMock", bridge.logger).warning.assert_called_once()
 
 
+def test_a_long_timeline_gap_is_padded_from_one_shared_block() -> None:
+    """
+    A long hole is queued as repeats of one silence block, not as a single buffer.
+
+    Sendspin rebases the shared timeline forward when audio production stalls,
+    which can open a hole of tens of seconds. Building that as one bytes object
+    puts megabytes on the event loop in a single synchronous allocation.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    first_ts = SENDSPIN_EPOCH_US + 250_000
+    _start_stream_at(bridge, first_ts)
+    _drain_queued_bytes(bridge)
+
+    gap_us = 60_000_000
+    next_ts = first_ts + 100_000 + gap_us
+    bridge._on_audio_chunk(_pcm_chunk(next_ts))
+
+    queued: list[bytes] = []
+    while not bridge._write_queue.empty():
+        block = bridge._write_queue.get_nowait()
+        assert block is not None
+        queued.append(block)
+
+    pad, data = queued[:-1], queued[-1]
+    gap_frames = round(gap_us * BRIDGE_SAMPLE_RATE / 1_000_000)
+    assert len(pad) == gap_frames // PAD_BLOCK_FRAMES
+    # Identity, not equality: the whole hole costs one allocation.
+    assert all(block is SILENCE_BLOCK for block in pad)
+    # The hole is still filled exactly, so the device stays on the group's clock.
+    assert sum(len(block) for block in pad) == gap_frames * BRIDGE_BYTES_PER_FRAME
+    assert len(data) == 100_000 * BRIDGE_BYTES_PER_SECOND // 1_000_000
+
+
+# --- Playout shift: the binary's own mid-stream re-anchors move the mapping ---
+
+
+def _shifted_bridge(shift_seconds: float) -> tuple[SendspinAirPlayBridge, MagicMock, int]:
+    """
+    Start a streaming bridge whose CLI reports a mid-stream playout shift.
+
+    :param shift_seconds: Cumulative shift the binary reports since its START.
+    :return: The bridge, its stream mock and the first chunk's timestamp.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    first_ts = SENDSPIN_EPOCH_US + 250_000
+    _start_stream_at(bridge, first_ts)
+    bridge._start_unix_ms = UNIX_NOW_MS
+    _drain_queued_bytes(bridge)
+    stream = MagicMock()
+    # A real float: the fold subtracts it from the applied baseline, which a bare
+    # MagicMock cannot answer.
+    stream.cumulative_shift_seconds = shift_seconds
+    bridge._airplay_stream = stream
+    return bridge, stream, first_ts
+
+
+def test_reported_reanchor_moves_the_anchor_and_the_pacing_start() -> None:
+    """
+    A starvation re-anchor makes every byte audible later, so the anchor follows it.
+
+    cliairplay shifts its playout forward when it runs out of PCM on stdin.
+    Leaving the bridge's mapping where it was would place all following content
+    ahead of where the device actually plays it, for the rest of the stream.
+    """
+    shift_s = 1.5
+    bridge, _, first_ts = _shifted_bridge(shift_s)
+    anchor_before = bridge._drop_until_us
+
+    bridge._on_audio_chunk(_pcm_chunk(first_ts + 100_000))
+
+    assert bridge._drop_until_us == anchor_before + round(shift_s * 1_000_000)
+    # The write pacing measures from the same instant, so it moves with it.
+    assert bridge._start_unix_ms == UNIX_NOW_MS + round(shift_s * 1000)
+
+
+def test_reported_reanchor_skips_content_until_the_device_catches_up() -> None:
+    """The device plays the shift late, so exactly that much content is dropped."""
+    shift_s = 0.5
+    bridge, _, first_ts = _shifted_bridge(shift_s)
+
+    fed_us = 1_000_000
+    for index in range(fed_us // 100_000):
+        bridge._on_audio_chunk(_pcm_chunk(first_ts + 100_000 * (index + 1)))
+
+    assert bridge._queued_frames == _expected_frames(bridge, first_ts + 100_000 + fed_us)
+    assert _drain_queued_bytes(bridge) == round(
+        (fed_us / 1_000_000 - shift_s) * BRIDGE_BYTES_PER_SECOND
+    )
+
+
+def test_absorbing_a_reanchor_is_not_reported_as_timeline_drift() -> None:
+    """The trim that works a folded shift off is a correction, not Sendspin drift."""
+    bridge, _, first_ts = _shifted_bridge(0.5)
+    logger = cast("MagicMock", bridge.logger)
+
+    # Straddles the shifted anchor, so it is trimmed rather than dropped outright.
+    bridge._on_audio_chunk(_pcm_chunk(first_ts + 550_000))
+
+    assert bridge._queued_frames == _expected_frames(bridge, first_ts + 650_000)
+    # Only the re-anchor itself is reported; the trim it caused stays quiet.
+    logger.warning.assert_called_once()
+    logger.warning.reset_mock()
+
+    # Back on the timeline: the shift is worked off and nothing is realigned.
+    bridge._on_audio_chunk(_pcm_chunk(first_ts + 650_000))
+    assert not bridge._absorbing_shift
+    logger.warning.assert_not_called()
+
+    # A real discontinuity is reported again.
+    bridge._on_audio_chunk(_pcm_chunk(first_ts + 1_500_000))
+    logger.warning.assert_called_once()
+
+
+def test_a_cursor_off_the_frame_grid_still_absorbs_quietly() -> None:
+    """
+    The trim stays quiet however the cursor happens to sit when the shift lands.
+
+    ``_align_chunk`` re-targets each chunk against the anchor independently, so
+    the cursor routinely rests a frame either side of the timeline. The trim a
+    fold asks for is a correction at any of those offsets, never Sendspin drift.
+    """
+    bridge, stream, first_ts = _shifted_bridge(0.0)
+    logger = cast("MagicMock", bridge.logger)
+
+    # Play on a while first, so the cursor sits well past the anchor the way it
+    # does mid-stream when a starvation hits.
+    for index in range(1, 11):
+        bridge._on_audio_chunk(_pcm_chunk(first_ts + 100_000 * index))
+    logger.warning.assert_not_called()
+
+    # A frame past the timeline: the trim the fold asks for then runs one frame
+    # deeper than the shift itself.
+    bridge._queued_frames += 1
+    stream.cumulative_shift_seconds = 0.5
+    bridge._on_audio_chunk(_pcm_chunk(first_ts + 1_100_000))
+
+    # Only the re-anchor itself is reported.
+    logger.warning.assert_called_once()
+
+
+def test_an_unchanged_reanchor_total_is_folded_only_once() -> None:
+    """The binary reports a running total, so only what is new moves the anchor."""
+    bridge, _, first_ts = _shifted_bridge(0.5)
+    bridge._on_audio_chunk(_pcm_chunk(first_ts + 600_000))
+    anchor_after_fold = bridge._drop_until_us
+    assert anchor_after_fold == first_ts + 500_000
+
+    bridge._on_audio_chunk(_pcm_chunk(first_ts + 700_000))
+
+    assert bridge._drop_until_us == anchor_after_fold
+
+
+def test_a_reset_reanchor_total_rebaselines_without_moving_the_anchor() -> None:
+    """
+    A total that went backwards means a START already replaced the mapping.
+
+    The binary zeroes its running total on every START, so the drop is not the
+    device un-shifting: the bridge takes the new baseline and leaves the anchor
+    to the START that set it.
+    """
+    bridge, stream, first_ts = _shifted_bridge(0.5)
+    bridge._on_audio_chunk(_pcm_chunk(first_ts + 600_000))
+    anchor_after_fold = bridge._drop_until_us
+    assert anchor_after_fold == first_ts + 500_000
+
+    stream.cumulative_shift_seconds = 0.0
+    bridge._on_audio_chunk(_pcm_chunk(first_ts + 700_000))
+
+    assert bridge._drop_until_us == anchor_after_fold
+    assert bridge._applied_shift_seconds == 0.0
+
+
+async def test_anchoring_clears_the_folded_shift_baseline() -> None:
+    """A START re-anchors the binary from scratch, so the fold starts over with it."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    stream = _make_anchor_stream(ack=UNIX_NOW_MS + COLD_LEAD_MS)
+    _prepare_anchor(bridge, stream, COLD_LEAD_MS)
+    bridge._applied_shift_seconds = 1.5
+    bridge._absorbing_shift = True
+
+    assert await _anchor(bridge, stream)
+
+    assert bridge._applied_shift_seconds == 0.0
+    assert not bridge._absorbing_shift
+
+
 @pytest.mark.parametrize(
     ("warm_lead_ms", "flushed_head_offset_ms", "adjust_ms", "expected_anchor_offset_ms"),
     [
@@ -935,6 +1128,9 @@ def _make_kept_stream(*, running: bool = True, connected: bool = True) -> MagicM
     stream = MagicMock()
     stream.running = running
     stream.connected = connected
+    # A real float: the shift fold subtracts it from the applied baseline, which
+    # a bare MagicMock cannot answer.
+    stream.cumulative_shift_seconds = 0.0
     return stream
 
 

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -989,6 +989,28 @@ def test_a_cursor_off_the_frame_grid_still_absorbs_quietly() -> None:
     logger.warning.assert_called_once()
 
 
+def test_an_absorption_spanning_chunks_reports_only_the_reanchor() -> None:
+    """
+    A shift takes several chunks to trim off, and stays one report throughout.
+
+    The binary keeps reporting the same running total while the trim works, so
+    every chunk until the cursor is back on the timeline realigns by design.
+    """
+    bridge, stream, first_ts = _shifted_bridge(0.0)
+    logger = cast("MagicMock", bridge.logger)
+    for index in range(1, 11):
+        bridge._on_audio_chunk(_pcm_chunk(first_ts + 100_000 * index))
+    logger.warning.assert_not_called()
+
+    stream.cumulative_shift_seconds = 0.5
+    # Five chunks of content are trimmed away before the cursor catches up.
+    for index in range(11, 17):
+        bridge._on_audio_chunk(_pcm_chunk(first_ts + 100_000 * index))
+
+    logger.warning.assert_called_once()
+    assert not bridge._absorbing_shift
+
+
 def test_an_unchanged_reanchor_total_is_folded_only_once() -> None:
     """The binary reports a running total, so only what is new moves the anchor."""
     bridge, _, first_ts = _shifted_bridge(0.5)
@@ -1019,6 +1041,27 @@ def test_a_reset_reanchor_total_rebaselines_without_moving_the_anchor() -> None:
 
     assert bridge._drop_until_us == anchor_after_fold
     assert bridge._applied_shift_seconds == 0.0
+
+
+def test_a_reset_reanchor_total_ends_the_absorption() -> None:
+    """
+    A total that went backwards leaves no correction outstanding to stay quiet for.
+
+    The START that zeroed the total replaced the mapping the trim was working
+    against, so a realignment after it is Sendspin timeline drift again and
+    worth reporting.
+    """
+    bridge, stream, first_ts = _shifted_bridge(0.5)
+    logger = cast("MagicMock", bridge.logger)
+    # Mid-absorption: the trim has not caught the cursor up to the timeline yet.
+    bridge._on_audio_chunk(_pcm_chunk(first_ts + 550_000))
+    logger.warning.reset_mock()
+
+    stream.cumulative_shift_seconds = 0.0
+    bridge._on_audio_chunk(_pcm_chunk(first_ts + 600_000))
+
+    assert not bridge._absorbing_shift
+    logger.warning.assert_called_once()
 
 
 async def test_anchoring_clears_the_folded_shift_baseline() -> None:


### PR DESCRIPTION
# What does this implement/fix?

A bridged AirPlay speaker in a Sendspin group could end up permanently out of sync with the rest of the group after a single audio hiccup.

When the AirPlay helper runs out of audio it shifts its own playback slightly later and reports by how much, but the Sendspin bridge never looked at that report. The speaker stayed behind the group for the rest of the track, with nothing to pull it back.

The bridge now follows those reports and re-aligns the audio it feeds. Also fixes a related rough edge: a long gap in the audio timeline was filled with silence built in one go, which could be several megabytes at once.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- The bridge now reads the playback shift the AirPlay helper reports and moves its own timing reference by the same amount, so the speaker catches back up with the group.
- Write pacing follows the same correction, so the speaker is not over-filled after a dropout.
- The re-alignment that correction causes is no longer logged as timeline drift; only the dropout itself is reported.
- A gap in the audio timeline is now filled from a shared block of silence instead of being built as one large chunk.
- Tests added for all of the above.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
