### PR TITLE
Generate AI Radio segments at airtime instead of at run start

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1676,18 +1676,18 @@ class StreamsAudio:
                         streamdetails.uri,
                         asyncio.get_event_loop().time() - stream_started_at,
                     )
-                # trigger pre-buffering of the next track well before end
-                # to ensure the raw PCM is ready when the next track needs to be streamed.
-                # only do this for tracks: live sources (radio, audio_source) open an
-                # upstream connection that would sit idle and likely time out before the
-                # player actually consumes it.
+                # trigger pre-buffering of the next item well before end
+                # to ensure the raw PCM is ready when the next item needs to be streamed.
+                # tracks and sound effects are finite files that fill and close immediately;
+                # live sources (radio, audio_source) open an upstream connection that would
+                # sit idle and likely time out before the player actually consumes it.
                 if (
                     not next_buffer_triggered
                     and streamdetails.duration
                     and (queue := self.mass.player_queues.get_active_queue(queue_item.queue_id))
                     and queue.next_item
                     and queue.next_item.queue_item_id != queue_item.queue_item_id
-                    and queue.next_item.media_type == MediaType.TRACK
+                    and queue.next_item.media_type in (MediaType.TRACK, MediaType.SOUND_EFFECT)
                     and (bytes_received / pcm_format.pcm_sample_size + seek_position)
                     >= streamdetails.duration - 60
                 ):

--- a/music_assistant/providers/ai_radio/constants.py
+++ b/music_assistant/providers/ai_radio/constants.py
@@ -27,9 +27,27 @@ DEFAULT_WEATHER_PROVIDER = "open_meteo"
 DEFAULT_WEATHER_TIMEOUT_SECONDS = 20
 DEFAULT_MAX_CONCURRENT_RUNS = 1
 MAX_FINISHED_SESSIONS = 20
-DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS = 300
+
+# a show whose playback never starts within this window is declared failed
+SHOW_START_TIMEOUT_SECONDS = 300
 
 SUPPORTED_FEATURES: set[Any] = set()
 EMPTY_SECTION_ID = "EMPTY_SECTION"
 VALID_WEB_SEARCH_MODES = {"disabled", "allow", "force"}
 WEB_SEARCH_MODE_RANK = {"disabled": 0, "allow": 1, "force": 2}
+
+# QueueItem.extra_attributes keys carrying a clip's pending render state. Scalars only —
+# extra_attributes is serialized to clients and persisted with the queue.
+ATTR_SESSION_ID = "ai_radio_session_id"
+ATTR_STATION_ID = "ai_radio_station_id"
+ATTR_PROMPT = "ai_radio_prompt"
+ATTR_MAX_CHARS = "ai_radio_max_chars"
+ATTR_WEB_SEARCH_MODE = "ai_radio_web_search_mode"
+ATTR_RENDERED_TEXT = "ai_radio_rendered_text"
+
+# placeholders resolved at render time rather than at plan time, so the aired script
+# reflects the moment it plays
+DEFERRED_PLACEHOLDERS = frozenset({"<timestamp>", "<weather_hourly>", "<weather_daily>"})
+
+# HA drops a tts_proxy token 60s after its last use at the lowest configurable time_memory
+CLIP_STREAMDETAILS_EXPIRATION = 60

--- a/music_assistant/providers/ai_radio/models.py
+++ b/music_assistant/providers/ai_radio/models.py
@@ -26,6 +26,7 @@ class PlannedSection:
     """A section that should be generated for a run."""
 
     order: int
+    clip_id: str
     section_id: str
     section_name: str
     when: str
@@ -36,36 +37,11 @@ class PlannedSection:
 
 
 @dataclass(slots=True)
-class GeneratedSection:
-    """A generated section with final text."""
-
-    order: int
-    section_id: str
-    section_name: str
-    when: str
-    insert_at_index: int
-    text: str
-
-
-@dataclass(slots=True)
-class AudioSection:
-    """Audio artifact for a generated section."""
-
-    order: int
-    section_id: str
-    section_name: str
-    insert_at_index: int
-    uri: str
-    duration: int = 0
-
-
-@dataclass(slots=True)
 class SessionState:
     """State container for an AI Radio run."""
 
     session_id: str
     station_id: str
-    mode: str
     status: str = "running"
     created_at: str = field(default_factory=lambda: utc().isoformat())
     started_at: str | None = None
@@ -73,6 +49,8 @@ class SessionState:
     progress: dict[str, Any] = field(default_factory=dict)
     result: dict[str, Any] = field(default_factory=dict)
     error: str | None = None
+    skipped_sections: int = 0
+    last_render_error: str | None = None
     task: asyncio.Task[Any] | None = field(default=None, repr=False, compare=False)
     queue_id: str | None = field(default=None, repr=False, compare=False)
 
@@ -81,7 +59,6 @@ class SessionState:
         return {
             "session_id": self.session_id,
             "station_id": self.station_id,
-            "mode": self.mode,
             "status": self.status,
             "created_at": self.created_at,
             "started_at": self.started_at,
@@ -89,4 +66,6 @@ class SessionState:
             "progress": self.progress,
             "result": self.result,
             "error": self.error,
+            "skipped_sections": self.skipped_sections,
+            "last_render_error": self.last_render_error,
         }

--- a/music_assistant/providers/ai_radio/provider.py
+++ b/music_assistant/providers/ai_radio/provider.py
@@ -30,6 +30,7 @@ from .constants import (
 )
 from .helpers import utc_now_iso
 from .models import SessionState
+from .rendering import AIRadioRenderMixin
 from .runtime import AIRadioRuntimeMixin
 from .storage import AIRadioStorageMixin
 
@@ -48,7 +49,7 @@ async def setup(
     return AIRadioProvider(mass, manifest, config, SUPPORTED_FEATURES)
 
 
-class AIRadioProvider(AIRadioRuntimeMixin, AIRadioStorageMixin, PluginProvider):
+class AIRadioProvider(AIRadioRuntimeMixin, AIRadioRenderMixin, AIRadioStorageMixin, PluginProvider):
     """Implementation of the AI Radio plugin provider."""
 
     def __init__(
@@ -244,17 +245,12 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioStorageMixin, PluginProvider):
     async def start_run(
         self,
         station_id: str,
-        mode: str = "playlist",
         source_playlist_id_override: str | None = None,
         source_playlist_provider_override: str | None = None,
         player_id_override: str | None = None,
         dynamic_source_playtime_cap_override: int | float | None = None,  # noqa: PYI041
-        dynamic_batch_size_override: int | None = None,
     ) -> dict[str, Any]:
         """Start a new AI Radio run."""
-        selected_mode = mode.strip().lower()
-        if selected_mode not in {"playlist", "dynamic"}:
-            raise InvalidDataError("mode must be 'playlist' or 'dynamic'")
         if station_id not in self._stations:
             raise KeyError(f"Unknown station id: {station_id}")
 
@@ -271,21 +267,16 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioStorageMixin, PluginProvider):
             if float(dynamic_source_playtime_cap_override) < 0:
                 raise InvalidDataError("dynamic_source_playtime_cap_override must be >= 0")
             station["max_duration_minutes"] = float(dynamic_source_playtime_cap_override)
-        if dynamic_batch_size_override is not None:
-            if int(dynamic_batch_size_override) < 1:
-                raise InvalidDataError("dynamic_batch_size_override must be >= 1")
-            station["dynamic_batch_size"] = int(dynamic_batch_size_override)
-        if selected_mode == "dynamic":
-            player_id = str(station.get("default_player_id") or "").strip()
-            if not player_id:
-                raise InvalidDataError("Dynamic mode requires a target player_id")
-            player = self.mass.players.get_player(player_id)
-            if player is None:
-                raise InvalidDataError(f"Unknown target player: {player_id}")
-            if player.available is False:
-                raise InvalidDataError(f"Target player is unavailable: {player_id}")
-            if player.enabled is False:
-                raise InvalidDataError(f"Target player is disabled: {player_id}")
+        player_id = str(station.get("default_player_id") or "").strip()
+        if not player_id:
+            raise InvalidDataError("AI Radio requires a target player")
+        player = self.mass.players.get_player(player_id)
+        if player is None:
+            raise InvalidDataError(f"Unknown target player: {player_id}")
+        if player.available is False:
+            raise InvalidDataError(f"Target player is unavailable: {player_id}")
+        if player.enabled is False:
+            raise InvalidDataError(f"Target player is disabled: {player_id}")
 
         # the run guards and the session insert must stay one critical section, or a future
         # await between them would let concurrent callers slip past the concurrency limits
@@ -308,7 +299,6 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioStorageMixin, PluginProvider):
             session = SessionState(
                 session_id=session_id,
                 station_id=station_id,
-                mode=selected_mode,
             )
             self._sessions[session_id] = session
             self._prune_finished_sessions()
@@ -317,10 +307,9 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioStorageMixin, PluginProvider):
                 task_id=f"ai_radio_session_{session_id}",
             )
         self.logger.debug(
-            "AI Radio session started: session=%s station=%s mode=%s",
+            "AI Radio session started: session=%s station=%s",
             session_id,
             station_id,
-            selected_mode,
         )
         return session.as_dict()
 
@@ -339,10 +328,9 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioStorageMixin, PluginProvider):
         selected.ended_at = utc_now_iso()
         await self._stop_session_queue(selected)
         self.logger.info(
-            "AI Radio session stopped: session=%s station=%s mode=%s",
+            "AI Radio session stopped: session=%s station=%s",
             selected.session_id,
             selected.station_id,
-            selected.mode,
         )
         return selected.as_dict()
 

--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -1,0 +1,216 @@
+"""Just-in-time clip rendering for AI Radio."""
+# mypy: disable-error-code="attr-defined"
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from music_assistant_models.enums import ContentType, StreamType
+from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.streamdetails import StreamDetails
+
+from music_assistant.helpers.tags import async_parse_tags
+
+from .constants import (
+    ATTR_MAX_CHARS,
+    ATTR_PROMPT,
+    ATTR_RENDERED_TEXT,
+    ATTR_SESSION_ID,
+    ATTR_STATION_ID,
+    ATTR_WEB_SEARCH_MODE,
+    CLIP_STREAMDETAILS_EXPIRATION,
+    DEFERRED_PLACEHOLDERS,
+)
+from .helpers import soft_limit_text
+
+if TYPE_CHECKING:
+    from music_assistant_models.enums import MediaType
+    from music_assistant_models.queue_item import QueueItem
+
+    from music_assistant.mass import MusicAssistant
+
+    from .models import SessionState
+
+
+class AIRadioRenderMixin:
+    """Renders an AI Radio clip at the moment MA needs its audio."""
+
+    if TYPE_CHECKING:
+        mass: MusicAssistant
+        logger: logging.Logger
+        _stations: dict[str, dict[str, Any]]
+        _sessions: dict[str, SessionState]
+
+    _render_locks: dict[str, asyncio.Lock]
+
+    async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
+        """
+        Render the AI Radio clip with the given id and return its StreamDetails.
+
+        :param item_id: The clip id of the queue item MA wants to play.
+        :param media_type: The media type of the requested item.
+        """
+        queue_item = self._find_clip_item(item_id)
+        if queue_item is None:
+            raise MediaNotFoundError(f"AI Radio clip {item_id} is not in any queue")
+        prompt = str(queue_item.extra_attributes.get(ATTR_PROMPT) or "")
+        if not prompt:
+            self._record_skip(queue_item, "clip has no prompt to render")
+            raise MediaNotFoundError(f"AI Radio clip {item_id} has no prompt to render")
+
+        async with self._lock_for(item_id):
+            text = str(queue_item.extra_attributes.get(ATTR_RENDERED_TEXT) or "")
+            if not text:
+                text = await self._generate_script(queue_item, prompt, item_id)
+                queue_item.extra_attributes[ATTR_RENDERED_TEXT] = text
+                # the signal is what marks the items cache dirty and schedules the persist
+                self.mass.player_queues.signal_update(queue_item.queue_id, items_changed=True)
+            path, stream_type, audio_format = await self._mint_clip_media(queue_item, text, item_id)
+
+        duration = await self._probe_duration(path)
+        return StreamDetails(
+            provider=self.instance_id,
+            item_id=item_id,
+            audio_format=audio_format,
+            media_type=media_type,
+            stream_type=stream_type,
+            path=path,
+            duration=duration,
+            # a talk clip has nothing worth seeking to, and a seek is the one path that
+            # would re-fetch a possibly-expired HA url mid-playback
+            can_seek=False,
+            allow_seek=False,
+            expiration=CLIP_STREAMDETAILS_EXPIRATION,
+        )
+
+    def _lock_for(self, clip_id: str) -> asyncio.Lock:
+        """Return the per-clip render lock, creating it on first use."""
+        if not hasattr(self, "_render_locks"):
+            self._render_locks = {}
+        if clip_id not in self._render_locks:
+            self._render_locks[clip_id] = asyncio.Lock()
+        return self._render_locks[clip_id]
+
+    def _find_clip_item(self, clip_id: str) -> QueueItem | None:
+        """Return the queue item holding the given clip, or None when no queue holds it."""
+        for queue_id in self._candidate_queue_ids(clip_id):
+            if (item := self._find_clip_in_queue(clip_id, queue_id)) is not None:
+                return item
+        return None
+
+    def _candidate_queue_ids(self, clip_id: str) -> list[str]:
+        """
+        Return the queue ids to search for a clip, the most likely one first.
+
+        The owning session knows its queue, but the session registry is empty after a
+        restart while the clip lives on in the persisted queue, so every queue stays a
+        candidate. Clip ids carry a uuid4-based session id, so a hit is unambiguous.
+        """
+        queue_ids = [queue.queue_id for queue in self.mass.player_queues.all()]
+        session = self._sessions.get(clip_id.rpartition("_")[0])
+        if session is not None and session.queue_id in queue_ids:
+            queue_ids.remove(session.queue_id)
+            queue_ids.insert(0, session.queue_id)
+        return queue_ids
+
+    def _find_clip_in_queue(self, clip_id: str, queue_id: str) -> QueueItem | None:
+        """Return the queue item holding the given clip, paging through the queue."""
+        page_size = 500
+        offset = 0
+        while True:
+            page = self.mass.player_queues.items(queue_id, limit=page_size, offset=offset)
+            if not page:
+                return None
+            for item in page:
+                if item.media_item is not None and item.media_item.item_id == clip_id:
+                    return item
+            if len(page) < page_size:
+                return None
+            offset += page_size
+
+    async def _generate_script(self, queue_item: QueueItem, prompt: str, clip_id: str) -> str:
+        """Resolve the deferred placeholders and generate the spoken script."""
+        attributes = queue_item.extra_attributes
+        station = self._stations.get(str(attributes.get(ATTR_STATION_ID) or "")) or {}
+        deferred = await self._resolve_deferred_placeholders(station)
+        resolved = prompt
+        for key, value in deferred.items():
+            resolved = resolved.replace(key, value)
+        max_chars = int(attributes.get(ATTR_MAX_CHARS) or 0)
+        web_mode = str(attributes.get(ATTR_WEB_SEARCH_MODE) or "disabled")
+        try:
+            text = cast(
+                "str",
+                await self._generate_text(station=station, prompt=resolved, web_mode=web_mode),
+            )
+        except Exception as err:
+            self.logger.warning(
+                "AI Radio clip %s (%s) failed to generate: %s", clip_id, queue_item.name, err
+            )
+            self._record_skip(queue_item, f"generation failed: {err}")
+            raise MediaNotFoundError(f"AI Radio clip {clip_id} failed to generate") from err
+        if max_chars > 0:
+            text = soft_limit_text(text, max_chars=max_chars)
+        self.logger.debug(
+            "AI Radio clip %s (%s) rendered: %d chars", clip_id, queue_item.name, len(text)
+        )
+        return text
+
+    async def _resolve_deferred_placeholders(self, station: dict[str, Any]) -> dict[str, str]:
+        """Return freshly resolved values for the placeholders deferred until airtime."""
+        values = dict.fromkeys(DEFERRED_PLACEHOLDERS, "")
+        values["<timestamp>"] = self._configured_now().strftime("%Y-%m-%d %H:%M %Z")
+        values.update(await self._prepare_runtime_tokens(station))
+        return values
+
+    async def _mint_clip_media(
+        self, queue_item: QueueItem, text: str, clip_id: str
+    ) -> tuple[str, StreamType, AudioFormat]:
+        """Convert the script to playable audio via the configured TTS engine."""
+        try:
+            return await self._render_tts_media(text)
+        except Exception as err:
+            self.logger.warning("AI Radio clip %s failed TTS: %s", clip_id, err)
+            self._record_skip(queue_item, f"TTS failed: {err}")
+            raise MediaNotFoundError(f"AI Radio clip {clip_id} failed TTS") from err
+
+    async def _render_tts_media(self, text: str) -> tuple[str, StreamType, AudioFormat]:
+        """Ask the TTS engine for audio and return the path, stream type and format to play it."""
+        engine = await self._get_tts_engine()
+        stream_details = await engine.provider.get_tts_message(text, engine_id=engine.id)
+        path = str(getattr(stream_details, "path", "") or "").strip()
+        if path.startswith(("http://", "https://", "rtsp://", "rtmp://")):
+            stream_type = StreamType.HTTP
+        elif path and Path(path).is_absolute() and await asyncio.to_thread(Path(path).is_file):
+            stream_type = StreamType.LOCAL_FILE
+        else:
+            raise InvalidDataError(
+                f"TTS engine '{engine.uid}' returned an unusable stream path: "
+                f"{path or '<empty>'}. StreamDetails.path must be a fetchable "
+                "http(s)/rtsp/rtmp URL or the absolute path of an existing local file."
+            )
+        audio_format = stream_details.audio_format
+        if audio_format.content_type == ContentType.UNKNOWN:
+            audio_format = AudioFormat(content_type=ContentType.MP3)
+        return path, stream_type, audio_format
+
+    async def _probe_duration(self, path: str) -> int | None:
+        """Return the clip duration in seconds, or None when it cannot be determined."""
+        try:
+            tags = await async_parse_tags(path, require_duration=True)
+        except (InvalidDataError, OSError) as err:
+            self.logger.warning("Could not determine AI Radio clip duration: %s", err)
+            return None
+        return int(tags.duration) if tags.duration else None
+
+    def _record_skip(self, queue_item: QueueItem, error: str) -> None:
+        """Record a skipped clip on its owning session."""
+        session_id = str(queue_item.extra_attributes.get(ATTR_SESSION_ID) or "")
+        if (session := self._sessions.get(session_id)) is None:
+            return
+        session.skipped_sections += 1
+        session.last_render_error = error

--- a/music_assistant/providers/ai_radio/runtime.py
+++ b/music_assistant/providers/ai_radio/runtime.py
@@ -10,19 +10,17 @@ import random
 from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
-from time import perf_counter
 from typing import TYPE_CHECKING, Any, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from aiohttp import ClientTimeout
 from music_assistant_models.enums import (
+    EventType,
     ImageType,
     MediaType,
     PlaybackState,
-    QueueOption,
-    TaskStatus,
 )
-from music_assistant_models.errors import InvalidDataError, MusicAssistantError
+from music_assistant_models.errors import MusicAssistantError
 from music_assistant_models.media_items import (
     MediaItemImage,
     ProviderMapping,
@@ -30,31 +28,28 @@ from music_assistant_models.media_items import (
     UniqueList,
 )
 
+from music_assistant.controllers.player_queues.helpers import build_queue_item
 from music_assistant.helpers.datetime import now, utc
 from music_assistant.helpers.json import json_loads
-from music_assistant.helpers.playlists import (
-    ArtistInfo,
-    ImageInfo,
-    PlaylistItem,
-    ProviderMappingInfo,
-    generate_m3u,
-    media_item_to_playlist_item,
-)
 from music_assistant.helpers.plugin_engines import resolve_ai_engine, resolve_tts_engine
-from music_assistant.helpers.tags import async_parse_tags
 from music_assistant.helpers.uri import create_uri
-from music_assistant.providers.builtin import CACHE_CATEGORY_MEDIA_INFO
 
 from .constants import (
+    ATTR_MAX_CHARS,
+    ATTR_PROMPT,
+    ATTR_SESSION_ID,
+    ATTR_STATION_ID,
+    ATTR_WEB_SEARCH_MODE,
     CONF_AI_ENGINE,
     CONF_TIMEZONE,
     CONF_TTS_ENGINE,
     CONF_WEATHER_CITY,
     CONF_WEATHER_COUNTRY,
-    DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS,
     DEFAULT_LLM_INSTRUCTIONS,
     DEFAULT_WEATHER_PROVIDER,
     DEFAULT_WEATHER_TIMEOUT_SECONDS,
+    DEFERRED_PLACEHOLDERS,
+    SHOW_START_TIMEOUT_SECONDS,
     VALID_WEB_SEARCH_MODES,
     WEB_SEARCH_MODE_RANK,
 )
@@ -65,13 +60,10 @@ from .helpers import (
     is_empty_section,
     pick_weighted_choice,
     slugify,
-    soft_limit_text,
     track_songinfo,
     utc_now_iso,
 )
 from .models import (
-    AudioSection,
-    GeneratedSection,
     PlannedSection,
     SessionState,
     Slot,
@@ -79,7 +71,9 @@ from .models import (
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigValueType, ProviderConfig
+    from music_assistant_models.event import MassEvent
     from music_assistant_models.media_items import PlayableMediaItemType
+    from music_assistant_models.queue_item import QueueItem
 
     from music_assistant.mass import MusicAssistant
     from music_assistant.models.plugin import AIEngine, TTSEngine
@@ -116,33 +110,27 @@ class AIRadioRuntimeMixin:
         session = self._sessions[session_id]
         session.started_at = utc_now_iso()
         self.logger.info(
-            "AI Radio run started: session=%s station=%s mode=%s",
+            "AI Radio run started: session=%s station=%s",
             session.session_id,
             session.station_id,
-            session.mode,
         )
         try:
-            if session.mode == "playlist":
-                result = await self._run_playlist_mode(session, station)
-            else:
-                result = await self._run_dynamic_mode(session, station)
+            result = await self._run_show(session, station)
             session.result = result
             queue_stopped = result.get("ended_reason") == "queue_stopped"
             session.status = "stopped" if queue_stopped else "completed"
             self.logger.info(
-                "AI Radio run %s: session=%s station=%s mode=%s",
+                "AI Radio run %s: session=%s station=%s",
                 session.status,
                 session.session_id,
                 session.station_id,
-                session.mode,
             )
         except asyncio.CancelledError:
             session.status = "stopped"
             self.logger.info(
-                "AI Radio run cancelled: session=%s station=%s mode=%s",
+                "AI Radio run cancelled: session=%s station=%s",
                 session.session_id,
                 session.station_id,
-                session.mode,
             )
             raise
         except Exception as err:
@@ -152,133 +140,25 @@ class AIRadioRuntimeMixin:
         finally:
             session.ended_at = utc_now_iso()
 
-    async def _run_playlist_mode(
+    async def _run_show(
         self,
         session: SessionState,
         station: dict[str, Any],
     ) -> dict[str, Any]:
-        """Generate one target playlist run."""
+        """Plan and queue the whole show in one pass, then start playback."""
         station = deepcopy(station)
         self.logger.debug(
-            "Playlist mode starting for station '%s' (%s)",
+            "Show starting for station '%s' (%s)",
             station.get("name", "AI Radio"),
             station.get("id", ""),
         )
         self._set_session_progress(session, "fetch_source_tracks")
-        runtime_tokens = await self._prepare_runtime_tokens(station)
-        tracks, playlist_name = await self._fetch_source_tracks(station)
-        tracks = self._apply_source_shuffle(tracks, station)
-        tracks = self._apply_track_duration_limit(tracks, station)
-        if not tracks:
-            raise MusicAssistantError("No source tracks available after applying station limits")
-        self._set_session_progress(
-            session,
-            "planning_sections",
-            source_tracks=len(tracks),
-        )
-
-        planned_sections, _history = self._plan_sections(
-            tracks=tracks,
-            station=station,
-            track_index_offset=0,
-            minute_offset=0.0,
-            history_state={},
-            allowed_slot_when=None,
-            runtime_tokens=runtime_tokens,
-        )
-        self._set_session_progress(
-            session,
-            "generating_llm",
-            source_tracks=len(tracks),
-            sections_planned=len(planned_sections),
-        )
-        generated_sections = await self._generate_sections(station, planned_sections)
-        self._set_session_progress(
-            session,
-            "generating_tts",
-            source_tracks=len(tracks),
-            sections=len(generated_sections),
-        )
-        target_provider = str(station.get("target_playlist_provider") or "builtin")
-        run_id = session.session_id[:8]
-        station_name = str(station.get("name") or "AI Radio").strip()
-        now_local = self._configured_now()
-        date_suffix = f"{now_local.strftime('%a')}. {now_local.strftime('%d.%m.')}"
-        target_playlist_name = f"AI Radio: {station_name} ({date_suffix}) [{run_id}]"
-
-        audio_sections = await self._synthesize_sections(generated_sections=generated_sections)
-        if self._is_builtin_provider_reference(target_provider):
-            playlist_items, track_count = self._compose_builtin_playlist_items(
-                tracks=tracks,
-                sections=audio_sections,
-            )
-            if not playlist_items:
-                raise MusicAssistantError("No playlist entries were generated")
-            self._set_session_progress(
-                session,
-                "publishing_playlist",
-                entries=len(playlist_items),
-                tracks=track_count,
-            )
-            playlist = await self._import_builtin_playlist(
-                target_playlist_name,
-                playlist_items,
-            )
-            entries_added = len(playlist_items)
-        else:
-            entries, _source_positions, track_count = self._compose_entries(
-                tracks=tracks, sections=audio_sections
-            )
-            if not entries:
-                raise MusicAssistantError("No playlist entries were generated")
-            self._set_session_progress(
-                session,
-                "publishing_playlist",
-                entries=len(entries),
-                tracks=track_count,
-            )
-            playlist = await self.mass.music.playlists.create_playlist(
-                target_playlist_name,
-                provider_instance_or_domain=target_provider,
-            )
-            add_task = await self.mass.music.playlists.add_playlist_tracks(
-                int(playlist.item_id), entries
-            )
-            await self._wait_for_background_task_completion(add_task.id, timeout_seconds=120)
-            entries_added = len(entries)
-        self.logger.info(
-            "Playlist mode published '%s' (%s entries, %s generated sections)",
-            target_playlist_name,
-            entries_added,
-            len(audio_sections),
-        )
-        return {
-            "mode": "playlist",
-            "source_playlist_name": playlist_name,
-            "source_tracks": len(tracks),
-            "generated_sections": len(audio_sections),
-            "target_playlist_id": playlist.item_id,
-            "target_playlist_name": target_playlist_name,
-            "entries_added": entries_added,
-        }
-
-    async def _run_dynamic_mode(  # noqa: PLR0915
-        self,
-        session: SessionState,
-        station: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Run dynamic generation mode."""
-        station = deepcopy(station)
-        self.logger.debug(
-            "Dynamic mode starting for station '%s' (%s)",
-            station.get("name", "AI Radio"),
-            station.get("id", ""),
-        )
-        self._set_session_progress(session, "fetch_source_tracks")
+        # runtime_tokens only feeds the require_placeholders_present guards below; its
+        # resolved text is discarded here and re-fetched fresh when each clip renders
         runtime_tokens = await self._prepare_runtime_tokens(station)
         player_id = str(station.get("default_player_id") or "").strip()
         if not player_id:
-            raise MusicAssistantError("Dynamic mode requires a target player_id")
+            raise MusicAssistantError("AI Radio requires a target player")
         if not self.mass.players.get_player(player_id):
             raise MusicAssistantError(f"Unknown target player: {player_id}")
 
@@ -288,34 +168,12 @@ class AIRadioRuntimeMixin:
         if not tracks:
             raise MusicAssistantError("No source tracks available after applying station limits")
 
-        batch_size = max(1, int(station.get("dynamic_batch_size", 3) or 3))
-        poll_seconds = max(1, int(station.get("dynamic_poll_seconds", 5) or 5))
-        # the trigger must fall inside the current batch, or the next batch starts
-        # generating the instant this one starts playing, leaving no buffer at all
-        prefetch_remaining_tracks = min(
-            max(1, batch_size - 1),
-            max(1, int(station.get("dynamic_prefetch_remaining_tracks", 2) or 2)),
-        )
-        self.logger.debug(
-            "Dynamic runtime settings: batch_size=%d poll_seconds=%d prefetch_remaining_tracks=%d",
-            batch_size,
-            poll_seconds,
-            prefetch_remaining_tracks,
-        )
         # a grouped player plays from the group leader's queue, so resolve the
         # active queue up front and target that one for queueing and polling
         queue_id = player_id
         active_queue = self.mass.player_queues.get_active_queue(player_id)
         if active_queue is not None:
             queue_id = str(active_queue.queue_id)
-        self._set_session_progress(
-            session,
-            "initializing_queue",
-            total_tracks=len(tracks),
-            batch_size=batch_size,
-            prefetch_remaining_tracks=prefetch_remaining_tracks,
-            queue_id=queue_id,
-        )
         self.mass.player_queues.clear(queue_id)
         session.queue_id = queue_id
 
@@ -330,199 +188,181 @@ class AIRadioRuntimeMixin:
             )
             cumulative_minutes.append(cumulative_minutes[-1] + (seconds / 60.0))
 
-        cursor = 0
-        batch_index = 0
-        total_entries_queued = 0
-        wait_trigger_global_index = -1
-        playback_seen = False
-        queue_stopped = False
-        history_state: dict[str, list[tuple[int, float]]] = {}
+        self._set_session_progress(session, "planning_sections", total_tracks=len(tracks))
+        planned_sections, _history = self._plan_sections(
+            session_id=session.session_id,
+            tracks=tracks,
+            station=station,
+            track_index_offset=0,
+            minute_offset=0.0,
+            history_state={},
+            allowed_slot_when=None,
+            runtime_tokens=runtime_tokens,
+        )
+        queue_items = self._compose_queue_items(
+            queue_id=queue_id,
+            session=session,
+            station=station,
+            tracks=tracks,
+            sections=planned_sections,
+        )
+        if not queue_items:
+            raise MusicAssistantError("No queue entries were generated")
+
+        self._set_session_progress(
+            session,
+            "initializing_queue",
+            total_tracks=len(tracks),
+            queue_entries=len(queue_items),
+            queue_id=queue_id,
+        )
+        # load() stages the items without starting playback, so every clip already carries its
+        # prompt by the time anything can ask for its audio
+        await self.mass.player_queues.load(
+            queue_id,
+            queue_items=queue_items,
+            keep_remaining=False,
+            keep_played=False,
+            shuffle=False,
+        )
+        await self.mass.player_queues.play_index(queue_id, 0)
         self._set_session_progress(
             session,
             "running",
-            queued_tracks=0,
             total_tracks=len(tracks),
-            batch_index=0,
-            queue_entries=0,
+            queue_entries=len(queue_items),
+            queue_id=queue_id,
         )
-
-        while cursor < len(tracks):
-            batch_tracks = tracks[cursor : cursor + batch_size]
-            is_first = cursor == 0
-            is_last = (cursor + len(batch_tracks)) >= len(tracks)
-            lookahead = None if is_last else tracks[cursor + len(batch_tracks)]
-            generation_tracks = [*batch_tracks, lookahead] if lookahead else batch_tracks
-
-            if is_first and is_last:
-                allowed_slot_when = ["start_of_playlist", "between_songs", "end_of_playlist"]
-            elif is_first:
-                allowed_slot_when = ["start_of_playlist", "between_songs"]
-            elif is_last:
-                allowed_slot_when = ["between_songs", "end_of_playlist"]
-            else:
-                allowed_slot_when = ["between_songs"]
-
-            self._set_session_progress(
-                session,
-                "planning_sections",
-                queued_tracks=cursor,
-                total_tracks=len(tracks),
-                batch_index=batch_index + 1,
-            )
-            planned_sections, history_state = self._plan_sections(
-                tracks=generation_tracks,
-                station=station,
-                track_index_offset=cursor,
-                minute_offset=cumulative_minutes[cursor],
-                history_state=history_state,
-                allowed_slot_when=allowed_slot_when,
-                runtime_tokens=runtime_tokens,
-            )
-            filtered_sections = [
-                item
-                for item in planned_sections
-                if item.insert_at_index <= len(batch_tracks)
-                and not (item.when == "start_of_playlist" and not is_first)
-                and not (item.when == "end_of_playlist" and not is_last)
-            ]
-            self._set_session_progress(
-                session,
-                "generating_llm",
-                queued_tracks=cursor,
-                total_tracks=len(tracks),
-                batch_index=batch_index + 1,
-                sections_planned=len(filtered_sections),
-            )
-            generated_sections = await self._generate_sections(station, filtered_sections)
-            self._set_session_progress(
-                session,
-                "generating_tts",
-                queued_tracks=cursor,
-                total_tracks=len(tracks),
-                batch_index=batch_index + 1,
-                sections=len(generated_sections),
-            )
-            audio_sections = await self._synthesize_sections(generated_sections=generated_sections)
-            entries, source_positions, _track_count = self._compose_entries(
-                batch_tracks, audio_sections
-            )
-            if not entries:
-                raise MusicAssistantError("Dynamic batch produced no queue entries")
-
-            self._set_session_progress(
-                session,
-                "queueing_batch",
-                queued_tracks=cursor,
-                total_tracks=len(tracks),
-                batch_index=batch_index + 1,
-                batch_entries=len(entries),
-                queue_entries=total_entries_queued,
-            )
-            section_by_uri = {audio.uri: audio for audio in audio_sections}
-            media_entries: list[Any] = [
-                self._section_to_queue_sound_effect(section_by_uri[entry])
-                if entry in section_by_uri
-                else entry
-                for entry in entries
-            ]
-            option = QueueOption.REPLACE if is_first else QueueOption.ADD
-            await self.mass.player_queues.play_media(
-                queue_id=queue_id,
-                media=media_entries,
-                option=option,
-            )
-            batch_start_global = total_entries_queued
-            total_entries_queued += len(entries)
-            if source_positions:
-                trigger_position = max(0, len(source_positions) - prefetch_remaining_tracks)
-                trigger_track_local_index = source_positions[trigger_position]
-                wait_trigger_global_index = batch_start_global + trigger_track_local_index
-
-            cursor += len(batch_tracks)
-            batch_index += 1
-            self.logger.debug(
-                "Dynamic batch %d queued (%d tracks processed, %d queue entries total)",
-                batch_index,
-                cursor,
-                total_entries_queued,
-            )
-            self._set_session_progress(
-                session,
-                "running",
-                queued_tracks=cursor,
-                total_tracks=len(tracks),
-                batch_index=batch_index,
-                queue_entries=total_entries_queued,
-            )
-
-            if cursor >= len(tracks):
-                break
-            self._set_session_progress(
-                session,
-                "waiting_for_playback",
-                queued_tracks=cursor,
-                total_tracks=len(tracks),
-                batch_index=batch_index,
-                queue_entries=total_entries_queued,
-                wait_trigger_index=wait_trigger_global_index,
-                prefetch_remaining_tracks=prefetch_remaining_tracks,
-            )
-            stall_timeout = DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS
-            inactivity_deadline = asyncio.get_running_loop().time() + stall_timeout
-            last_seen_index = -1
-            last_elapsed_time: float | None = None
-            while True:
-                queue = self.mass.player_queues.get(queue_id)
-                current_index = queue.current_index if queue else None
-                playback_alive = False
-                if current_index is not None:
-                    if current_index >= wait_trigger_global_index:
-                        break
-                    if current_index > last_seen_index:
-                        last_seen_index = current_index
-                        playback_alive = True
-                # a long track or a deliberate pause is not a stall: the raw
-                # elapsed_time only moves when the player reports real progress,
-                # while PAUSED means the user intentionally halted playback
-                queue_state = getattr(queue, "state", None)
-                elapsed_time = getattr(queue, "elapsed_time", None)
-                if queue_state == PlaybackState.PAUSED:
-                    playback_alive = True
-                elif elapsed_time is not None and elapsed_time != last_elapsed_time:
-                    last_elapsed_time = elapsed_time
-                    playback_alive = True
-                # elapsed_time also "moves" on the first poll of an idle queue
-                if queue_state in (PlaybackState.PLAYING, PlaybackState.PAUSED):
-                    playback_seen = True
-                if playback_alive:
-                    inactivity_deadline = asyncio.get_running_loop().time() + stall_timeout
-                if playback_seen and queue_state == PlaybackState.IDLE:
-                    self.logger.info(
-                        "Queue %s was stopped, ending dynamic run (last_index=%s)",
-                        queue_id,
-                        last_seen_index,
-                    )
-                    queue_stopped = True
-                    break
-                if asyncio.get_running_loop().time() >= inactivity_deadline:
-                    raise MusicAssistantError(
-                        f"Queue {queue_id} stopped advancing for {stall_timeout}s "
-                        f"while waiting for prefetch trigger (last_index={last_seen_index})"
-                    )
-                await asyncio.sleep(poll_seconds)
-
-            if queue_stopped:
-                break
-
+        has_clips = any(ATTR_SESSION_ID in item.extra_attributes for item in queue_items)
+        ended_reason = await self._await_show_end(
+            session, queue_id, len(queue_items) - 1, has_clips=has_clips
+        )
         return {
-            "mode": "dynamic",
-            "ended_reason": "queue_stopped" if queue_stopped else "source_exhausted",
+            "ended_reason": ended_reason,
             "source_playlist_name": playlist_name,
             "source_tracks": len(tracks),
-            "queued_tracks": cursor,
             "queue_id": queue_id,
-            "queue_entries": total_entries_queued,
+            "queue_entries": len(queue_items),
+            "planned_sections": len(planned_sections),
+            "skipped_sections": session.skipped_sections,
         }
+
+    async def _await_show_end(
+        self, session: SessionState, queue_id: str, last_index: int, *, has_clips: bool
+    ) -> str:
+        """
+        Block until this session's show is over and report why it ended.
+
+        :param session: The session whose clips are in the queue.
+        :param queue_id: The queue playing the show.
+        :param last_index: Queue index of the final entry this session enqueued.
+        :param has_clips: Whether this run enqueued any AI Radio clips at all. A clip-free
+            show (every section was skipped by its rules) must not be mistaken for one whose
+            clips were cleared out from under it, so that rule is skipped entirely here.
+        :return: ``"source_exhausted"`` when the show played out, ``"queue_stopped"`` when the
+            queue was stopped or taken over before reaching the end.
+        :raises MusicAssistantError: if playback never starts within
+            :data:`SHOW_START_TIMEOUT_SECONDS`.
+        """
+        finished = asyncio.Event()
+        playback_started = asyncio.Event()
+        # a queue that has not started yet must never be mistaken for a stopped one
+        playback_seen = False
+        ended_reason = "queue_stopped"
+
+        def _check_show_state() -> None:
+            nonlocal playback_seen, ended_reason
+            queue = self.mass.player_queues.get(queue_id)
+            if queue is None:
+                finished.set()
+                return
+            if queue.state in (PlaybackState.PLAYING, PlaybackState.PAUSED):
+                playback_seen = True
+                playback_started.set()
+            if has_clips and not self._session_has_clips(queue_id, session.session_id):
+                finished.set()
+                return
+            if not playback_seen or queue.state != PlaybackState.IDLE:
+                return
+            # playing out and being stopped both end IDLE, so position is the discriminator
+            current_index = queue.current_index
+            if current_index is not None and current_index >= last_index:
+                ended_reason = "source_exhausted"
+            self.logger.info(
+                "Queue %s went idle at index %s of %s, ending show (%s)",
+                queue_id,
+                current_index,
+                last_index,
+                ended_reason,
+            )
+            finished.set()
+
+        def _on_queue_event(_event: MassEvent) -> None:
+            _check_show_state()
+
+        unsubscribe = self.mass.subscribe(
+            _on_queue_event,
+            (EventType.QUEUE_UPDATED, EventType.QUEUE_ITEMS_UPDATED, EventType.PLAYER_REMOVED),
+            id_filter=queue_id,
+        )
+        try:
+            # the queue may already have gone away, or (for a show with clips) already lost
+            # them, by the time this subscribes; IDLE-after-playout still needs a fresh event,
+            # since playback_seen is not latched yet
+            _check_show_state()
+            await self._await_playback_start(playback_started, finished)
+            await finished.wait()
+        finally:
+            unsubscribe()
+        return ended_reason
+
+    async def _await_playback_start(
+        self, playback_started: asyncio.Event, finished: asyncio.Event
+    ) -> None:
+        """
+        Wait for the show to either start playing or end before it ever did.
+
+        :param playback_started: Set once the queue is first observed playing or paused.
+        :param finished: Set once the show is over, however that came about.
+        :raises MusicAssistantError: if neither happens within
+            :data:`SHOW_START_TIMEOUT_SECONDS`.
+        """
+        if playback_started.is_set() or finished.is_set():
+            return
+        # a player that never comes online (or whose clips all fail) must not pin this
+        # session's "running" status, and its max-concurrent-runs slot, forever
+        wait_tasks = (
+            asyncio.ensure_future(playback_started.wait()),
+            asyncio.ensure_future(finished.wait()),
+        )
+        try:
+            done, _pending = await asyncio.wait(
+                wait_tasks,
+                timeout=SHOW_START_TIMEOUT_SECONDS,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            for task in wait_tasks:
+                if not task.done():
+                    task.cancel()
+        if not done:
+            raise MusicAssistantError(
+                f"Playback did not start within {SHOW_START_TIMEOUT_SECONDS}s"
+            )
+
+    def _session_has_clips(self, queue_id: str, session_id: str) -> bool:
+        """Return whether any queue item still belongs to the given session."""
+        page_size = 500
+        offset = 0
+        while True:
+            page = self.mass.player_queues.items(queue_id, limit=page_size, offset=offset)
+            if not page:
+                return False
+            if any(item.extra_attributes.get(ATTR_SESSION_ID) == session_id for item in page):
+                return True
+            if len(page) < page_size:
+                return False
+            offset += page_size
 
     async def _fetch_source_tracks(
         self, station: dict[str, Any]
@@ -551,15 +391,6 @@ class AIRadioRuntimeMixin:
                     track.item_id,
                 )
                 continue
-            try:
-                playlist_item = media_item_to_playlist_item(track)
-            except Exception:
-                self.logger.debug(
-                    "Could not build source playlist metadata for uri=%s",
-                    uri,
-                    exc_info=True,
-                )
-                playlist_item = None
             normalized.append(
                 {
                     "index": len(normalized),
@@ -569,7 +400,7 @@ class AIRadioRuntimeMixin:
                     "songinfo": f"{artist} - {track.name}".strip(" -"),
                     "duration": track.duration,
                     "uri": uri,
-                    "playlist_item": playlist_item,
+                    "media_item": track,
                 }
             )
         return normalized, playlist_name
@@ -640,6 +471,7 @@ class AIRadioRuntimeMixin:
 
     def _plan_sections(  # noqa: PLR0915
         self,
+        session_id: str,
         tracks: list[dict[str, Any]],
         station: dict[str, Any],
         track_index_offset: int,
@@ -682,12 +514,15 @@ class AIRadioRuntimeMixin:
             ]
             if not matching_rules:
                 continue
-            placeholders = self._resolve_placeholders(
+            static, deferred = self._resolve_placeholders(
                 station=station,
                 tracks=tracks,
                 slot=slot,
                 runtime_tokens=runtime_tokens,
             )
+            # guards may require a deferred token to be present, so they see the merged view;
+            # only the static half is substituted into the stored prompt
+            guard_values = {**deferred, **static}
             for rule in matching_rules:
                 flow = rule.get("flow", [])
                 if not isinstance(flow, list):
@@ -701,7 +536,7 @@ class AIRadioRuntimeMixin:
                             continue
                         if is_empty_section(section_id):
                             continue
-                        selected.append((section_id, slot, placeholders))
+                        selected.append((section_id, slot, static))
                         register_event(section_id, slot)
                         continue
                     if "ALTERNATIVE" in flow_item:
@@ -711,7 +546,7 @@ class AIRadioRuntimeMixin:
                         section_id = pick_weighted_choice(alternative.get("choices", []), rng)
                         if is_empty_section(section_id):
                             continue
-                        selected.append((section_id, slot, placeholders))
+                        selected.append((section_id, slot, static))
                         register_event(section_id, slot)
                         continue
                     if "OPTIONAL" in flow_item:
@@ -732,14 +567,14 @@ class AIRadioRuntimeMixin:
                             history=history,
                             slot=slot,
                             tracks=tracks,
-                            placeholders=placeholders,
+                            placeholders=guard_values,
                             track_index_offset=track_index_offset,
                             minute_offset=minute_offset,
                         ):
                             continue
                         if is_empty_section(section_id):
                             continue
-                        selected.append((section_id, slot, placeholders))
+                        selected.append((section_id, slot, static))
                         register_event(section_id, slot)
 
         merge_section_id = str(station.get("merge_section_id", "")).strip()
@@ -769,6 +604,7 @@ class AIRadioRuntimeMixin:
                     placeholders=placeholders,
                     order=order_index,
                     section_by_id=section_by_id,
+                    session_id=session_id,
                 )
                 planned.append(merged)
                 order_index += 1
@@ -790,6 +626,7 @@ class AIRadioRuntimeMixin:
             planned.append(
                 PlannedSection(
                     order=order_index,
+                    clip_id=f"{session_id}_{order_index:03d}",
                     section_id=section_id,
                     section_name=self._resolve_section_name(section, section_id),
                     when=slot.when,
@@ -843,6 +680,7 @@ class AIRadioRuntimeMixin:
         placeholders: dict[str, str],
         order: int,
         section_by_id: dict[str, dict[str, Any]],
+        session_id: str,
     ) -> PlannedSection:
         """Build a merged ai_meta section for one slot."""
         section_ids = [item[0] for item in grouped_items]
@@ -882,6 +720,7 @@ class AIRadioRuntimeMixin:
         section_name = " + ".join(dict.fromkeys(merged_names))
         return PlannedSection(
             order=order,
+            clip_id=f"{session_id}_{order:03d}",
             section_id=section_id,
             section_name=section_name,
             when=slot.when,
@@ -891,210 +730,59 @@ class AIRadioRuntimeMixin:
             web_search_mode=max_web_mode,
         )
 
-    async def _generate_sections(
+    def _compose_queue_items(
         self,
+        queue_id: str,
+        session: SessionState,
         station: dict[str, Any],
-        planned_sections: list[PlannedSection],
-    ) -> list[GeneratedSection]:
-        """Generate section texts from planning entries."""
-        generated: list[GeneratedSection] = []
-        sorted_sections = sorted(planned_sections, key=lambda section: section.order)
-        self.logger.debug(
-            "LLM generation started: station=%s sections=%d",
-            station.get("id", "unknown"),
-            len(sorted_sections),
-        )
-        for index, item in enumerate(sorted_sections, start=1):
-            started = perf_counter()
-            self.logger.debug(
-                "LLM section %d/%d: section=%s when=%s web_mode=%s",
-                index,
-                len(sorted_sections),
-                item.section_id,
-                item.when,
-                item.web_search_mode,
-            )
-            try:
-                text = await self._generate_text(
-                    station=station,
-                    prompt=item.prompt,
-                    web_mode=item.web_search_mode,
-                )
-            except Exception:
-                self.logger.exception(
-                    "LLM generation failed: section=%s when=%s",
-                    item.section_id,
-                    item.when,
-                )
-                raise
-            if item.max_chars > 0:
-                text = soft_limit_text(text, max_chars=item.max_chars)
-            self.logger.debug(
-                "LLM section done: section=%s chars=%d elapsed=%.2fs",
-                item.section_id,
-                len(text),
-                perf_counter() - started,
-            )
-            generated.append(
-                GeneratedSection(
-                    order=item.order,
-                    section_id=item.section_id,
-                    section_name=item.section_name,
-                    when=item.when,
-                    insert_at_index=item.insert_at_index,
-                    text=text,
-                )
-            )
-        self.logger.debug("LLM generation finished: generated_sections=%d", len(generated))
-        return generated
-
-    async def _synthesize_sections(
-        self,
-        generated_sections: list[GeneratedSection],
-    ) -> list[AudioSection]:
-        """Convert generated section texts to playable TTS URIs."""
-        output: list[AudioSection] = []
-        if not generated_sections:
-            return output
-        self.logger.debug("TTS synthesis started: sections=%d", len(generated_sections))
-        for index, section in enumerate(generated_sections):
-            started = perf_counter()
-            self.logger.debug(
-                "TTS section %d/%d: section=%s chars=%d",
-                index + 1,
-                len(generated_sections),
-                section.section_id,
-                len(section.text),
-            )
-            try:
-                section_uri, section_duration = await self._render_tts(
-                    text=section.text, section_name=section.section_name
-                )
-            except Exception:
-                self.logger.exception(
-                    "TTS synthesis failed: section=%s",
-                    section.section_id,
-                )
-                raise
-            self.logger.debug(
-                "TTS section done: section=%s elapsed=%.2fs uri=%s duration=%ss",
-                section.section_id,
-                perf_counter() - started,
-                section_uri,
-                section_duration,
-            )
-            output.append(
-                AudioSection(
-                    order=section.order,
-                    section_id=section.section_id,
-                    section_name=section.section_name,
-                    insert_at_index=section.insert_at_index,
-                    uri=section_uri,
-                    duration=section_duration,
-                )
-            )
-        self.logger.debug("TTS synthesis finished: sections=%d", len(output))
-        return output
-
-    def _compose_entries(
-        self,
         tracks: list[dict[str, Any]],
-        sections: list[AudioSection],
-    ) -> tuple[list[str], list[int], int]:
-        """Compose final queue/playlist entries with insert positions."""
-        sections_by_index: dict[int, list[AudioSection]] = defaultdict(list)
+        sections: list[PlannedSection],
+    ) -> list[QueueItem]:
+        """
+        Build the queue items for a whole show.
+
+        Clips carry their render state in ``extra_attributes`` from the moment they are built, so
+        a clip is renderable as soon as the queue holds it.
+
+        :param queue_id: The queue the items are built for.
+        :param session: The session that owns the show.
+        :param station: The station profile being played.
+        :param tracks: The normalized source tracks, in play order.
+        :param sections: The planned sections to interleave between them.
+        """
+        sections_by_index: dict[int, list[PlannedSection]] = defaultdict(list)
         for item in sections:
             sections_by_index[item.insert_at_index].append(item)
-        entries: list[str] = []
-        source_track_positions: list[int] = []
-        track_count = 0
+        station_id = str(station.get("id") or "")
+        items: list[QueueItem] = []
         for index in range(len(tracks) + 1):
             for section in sorted(sections_by_index.get(index, []), key=lambda item: item.order):
-                entries.append(section.uri)
-            if index < len(tracks):
-                track_uri = str(tracks[index].get("uri", "")).strip()
-                if track_uri:
-                    source_track_positions.append(len(entries))
-                    entries.append(track_uri)
-                    track_count += 1
-        return entries, source_track_positions, track_count
+                items.append(self._section_to_clip_item(queue_id, session, station_id, section))
+            if index < len(tracks) and (media_item := tracks[index].get("media_item")) is not None:
+                items.append(build_queue_item(queue_id, media_item))
+        return items
 
-    def _compose_builtin_playlist_items(
+    def _section_to_clip_item(
         self,
-        tracks: list[dict[str, Any]],
-        sections: list[AudioSection],
-    ) -> tuple[list[PlaylistItem], int]:
-        """Compose builtin playlist items with stable AI Radio section metadata."""
-        sections_by_index: dict[int, list[AudioSection]] = defaultdict(list)
-        for item in sections:
-            sections_by_index[item.insert_at_index].append(item)
-        entries: list[PlaylistItem] = []
-        track_count = 0
-        for index in range(len(tracks) + 1):
-            for section in sorted(sections_by_index.get(index, []), key=lambda item: item.order):
-                entries.append(self._section_to_playlist_item(section))
-            if index < len(tracks):
-                track_item = self._track_to_playlist_item(tracks[index])
-                if track_item:
-                    entries.append(track_item)
-                    track_count += 1
-        return entries, track_count
-
-    def _track_to_playlist_item(self, track: dict[str, Any]) -> PlaylistItem | None:
-        """Return the prebuilt source track playlist item, falling back to URI metadata."""
-        playlist_item = track.get("playlist_item")
-        if isinstance(playlist_item, PlaylistItem):
-            return deepcopy(playlist_item)
-        track_uri = str(track.get("uri", "")).strip()
-        if not track_uri:
-            return None
-        name = str(track.get("name") or track_uri).strip()
-        title = str(track.get("songinfo") or name).strip()
-        return PlaylistItem(
-            path=track_uri,
-            title=title,
-            length=str(track["duration"]) if track.get("duration") else None,
-            metadata={
-                "media_type": MediaType.TRACK.value,
-                "name": name,
-            },
-            providers=self._provider_mapping_infos_from_uri(track_uri),
-        )
-
-    def _section_to_queue_sound_effect(self, section: AudioSection) -> SoundEffect | str:
-        """
-        Build a rich SoundEffect for queueing (dynamic mode).
-
-        Falls back to the raw URI when the URI cannot be split into a builtin
-        provider reference (e.g. unexpected scheme).
-        """
-        uri = str(section.uri).strip()
-        if "://" not in uri:
-            return uri
-        provider_ref, rest = uri.split("://", 1)
-        if "/" not in rest:
-            return uri
-        media_type, item_id = rest.split("/", 1)
-        if not item_id or media_type != MediaType.SOUND_EFFECT.value:
-            return uri
-        provider = self.mass.get_provider(provider_ref)
-        provider_domain = str(getattr(provider, "domain", "") or provider_ref).strip()
-        provider_instance = str(getattr(provider, "instance_id", "") or provider_ref).strip()
-        sound_effect = SoundEffect(
-            item_id=item_id,
-            provider=provider_instance,
+        queue_id: str,
+        session: SessionState,
+        station_id: str,
+        section: PlannedSection,
+    ) -> QueueItem:
+        """Build the queue item for a not-yet-rendered clip."""
+        clip = SoundEffect(
+            item_id=section.clip_id,
+            provider=self.instance_id,
             name=section.section_name,
             provider_mappings={
                 ProviderMapping(
-                    item_id=item_id,
-                    provider_domain=provider_domain,
-                    provider_instance=provider_instance,
+                    item_id=section.clip_id,
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
                 )
             },
         )
-        if section.duration:
-            sound_effect.duration = int(section.duration)
-        sound_effect.metadata.images = UniqueList(
+        clip.metadata.images = UniqueList(
             [
                 MediaItemImage(
                     type=ImageType.THUMB,
@@ -1104,128 +792,23 @@ class AIRadioRuntimeMixin:
                 )
             ]
         )
-        return sound_effect
-
-    def _section_to_playlist_item(self, section: AudioSection) -> PlaylistItem:
-        """Create a fully described playlist item for a generated AI Radio section."""
-        uri = str(section.uri).strip()
-        title = section.section_name
-        media_type = self._extract_media_type_from_uri(uri) or MediaType.SOUND_EFFECT.value
-        providers = self._provider_mapping_infos_from_uri(uri)
-        artist_provider_domain = providers[0].domain if providers else "builtin"
-        artist_provider_instance = providers[0].instance_id if providers else "builtin"
-        length = str(int(section.duration)) if section.duration else "-1"
-        return PlaylistItem(
-            path=uri,
-            title=title,
-            length=length,
-            metadata={
-                "media_type": media_type,
-                "name": title,
-            },
-            providers=providers,
-            artists=[
-                ArtistInfo(
-                    name="AI Radio",
-                    provider_domain=artist_provider_domain,
-                    item_id="AI Radio",
-                    provider_instance=artist_provider_instance,
-                )
-            ],
-            images=[self._ai_radio_cover_image_info()],
+        queue_item = build_queue_item(queue_id, clip)
+        # the section name already travels as the item's own name, so it is not duplicated here
+        queue_item.extra_attributes.update(
+            {
+                ATTR_SESSION_ID: session.session_id,
+                ATTR_STATION_ID: station_id,
+                ATTR_PROMPT: section.prompt,
+                ATTR_MAX_CHARS: section.max_chars,
+                ATTR_WEB_SEARCH_MODE: section.web_search_mode,
+            }
         )
-
-    async def _import_builtin_playlist(
-        self,
-        playlist_name: str,
-        items: list[PlaylistItem],
-    ) -> Any:
-        """Create a builtin playlist by importing an M3U with preserved metadata."""
-        m3u_data = generate_m3u(
-            playlist_name,
-            items,
-            self._ai_radio_cover_image_path(),
-        )
-        return await self.mass.music.playlists.import_playlist(m3u_data)
-
-    @staticmethod
-    def _extract_media_type_from_uri(uri: str) -> str | None:
-        """Extract MediaType string from an MA URI."""
-        if "://" not in uri:
-            return None
-        _provider, rest = uri.split("://", 1)
-        if "/" not in rest:
-            return None
-        media_type, _item_id = rest.split("/", 1)
-        return media_type or None
+        return queue_item
 
     @staticmethod
     def _ai_radio_cover_image_path() -> str:
         """Return the explicit AI Radio playlist cover image path."""
         return str(Path(__file__).with_name("air.png"))
-
-    def _ai_radio_cover_image_info(self) -> ImageInfo:
-        """Return the AI Radio thumbnail image metadata for M3U entries."""
-        return ImageInfo(
-            type=ImageType.THUMB.value,
-            path=self._ai_radio_cover_image_path(),
-            provider="builtin",
-            remotely_accessible=False,
-        )
-
-    def _provider_mapping_infos_from_uri(self, uri: str) -> list[ProviderMappingInfo]:
-        """Build minimal provider mapping metadata for a Music Assistant URI."""
-        if "://" not in uri:
-            return []
-        provider_ref, rest = uri.split("://", 1)
-        if "/" not in rest:
-            return []
-        _media_type, item_id = rest.split("/", 1)
-        if not item_id:
-            return []
-        provider = self.mass.get_provider(provider_ref)
-        provider_domain = str(getattr(provider, "domain", "") or provider_ref).strip()
-        provider_instance = str(getattr(provider, "instance_id", "") or provider_ref).strip()
-        return [
-            ProviderMappingInfo(
-                domain=provider_domain,
-                item_id=item_id,
-                instance_id=provider_instance,
-            )
-        ]
-
-    async def _wait_for_background_task_completion(
-        self, task_id: str, timeout_seconds: int
-    ) -> None:
-        """Wait for a background task to complete so dependent file operations can run safely."""
-        deadline = asyncio.get_running_loop().time() + max(1, timeout_seconds)
-        while True:
-            try:
-                task = self.mass.tasks.get_task(task_id)
-            except Exception:
-                # If task history is gone, assume it is no longer active.
-                return
-            status = task.status
-            if status in {TaskStatus.SUCCESS, TaskStatus.PARTIAL_SUCCESS, TaskStatus.IDLE}:
-                return
-            if status in {TaskStatus.FAILED, TaskStatus.CANCELLED}:
-                raise MusicAssistantError(
-                    f"Background task {task_id} ended with status '{status.value}' "
-                    "before AI Radio post-processing"
-                )
-            if asyncio.get_running_loop().time() >= deadline:
-                raise MusicAssistantError(
-                    f"Timed out waiting for background task {task_id} (last status={status.value})"
-                )
-            await asyncio.sleep(0.1)
-
-    def _is_builtin_provider_reference(self, provider_ref: str) -> bool:
-        """Return True when provider reference points to builtin provider."""
-        value = str(provider_ref or "").strip()
-        if value == "builtin":
-            return True
-        provider = self.mass.get_provider(value)
-        return str(getattr(provider, "domain", "") or "").strip() == "builtin"
 
     async def _prepare_runtime_tokens(self, station: dict[str, Any]) -> dict[str, str]:
         """Prepare runtime tokens (including weather placeholders) for one run."""
@@ -1498,21 +1081,34 @@ class AIRadioRuntimeMixin:
         tracks: list[dict[str, Any]],
         slot: Slot,
         runtime_tokens: dict[str, str],
-    ) -> dict[str, str]:
-        """Resolve placeholders for one slot."""
-        now_local = self._configured_now()
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        """
+        Resolve placeholders for one slot, split by when they are substituted.
 
-        values: dict[str, str] = {str(key): str(value) for key, value in runtime_tokens.items()}
+        :param station: The station profile being planned.
+        :param tracks: The track list the slot indexes into.
+        :param slot: The insertion slot being filled.
+        :param runtime_tokens: Weather tokens fetched for this run.
+        :return: ``(static, deferred)`` — static values are fixed by the track order and are
+            substituted at plan time; deferred values describe the moment of airing and are
+            substituted at render time.
+        """
         prev_track = tracks[slot.prev_index] if slot.prev_index is not None else None
         next_track = tracks[slot.next_index] if slot.next_index is not None else None
         very_next_track = tracks[slot.very_next_index] if slot.very_next_index is not None else None
-        values["<prev_songinfo>"] = track_songinfo(prev_track)
-        values["<next_songinfo>"] = track_songinfo(next_track)
-        values["<very_next_songinfo>"] = track_songinfo(very_next_track)
-        values["<timestamp>"] = now_local.strftime("%Y-%m-%d %H:%M %Z")
-        values.setdefault("<weather_hourly>", "")
-        values.setdefault("<weather_daily>", "")
-        return values
+        static = {
+            "<prev_songinfo>": track_songinfo(prev_track),
+            "<next_songinfo>": track_songinfo(next_track),
+            "<very_next_songinfo>": track_songinfo(very_next_track),
+        }
+        deferred = dict.fromkeys(DEFERRED_PLACEHOLDERS, "")
+        deferred["<timestamp>"] = self._configured_now().strftime("%Y-%m-%d %H:%M %Z")
+        for key, value in runtime_tokens.items():
+            if str(key) in DEFERRED_PLACEHOLDERS:
+                deferred[str(key)] = str(value)
+            else:
+                static[str(key)] = str(value)
+        return static, deferred
 
     def _apply_placeholders(self, prompt: str, values: dict[str, str]) -> str:
         """Apply placeholder replacements in a prompt."""
@@ -1537,7 +1133,7 @@ class AIRadioRuntimeMixin:
         return mode
 
     async def _generate_text(self, station: dict[str, Any], prompt: str, web_mode: str) -> str:
-        """Generate one section text using the configured AI_QUERY plugin feature."""
+        """Generate one section text using the configured AI engine."""
         general = cast("dict[str, Any]", station.get("general", {}))
         instructions = str(general.get("instructions") or DEFAULT_LLM_INSTRUCTIONS).strip()
         query_parts: list[str] = []
@@ -1591,63 +1187,6 @@ class AIRadioRuntimeMixin:
             len(text),
         )
         return text
-
-    async def _render_tts(self, text: str, section_name: str) -> tuple[str, int]:
-        """Render text to a playable URI using the configured TTS engine."""
-        engine = await self._get_tts_engine()
-        self.logger.debug("TTS render prepared: engine=%s text_chars=%d", engine.uid, len(text))
-        stream_details = await engine.provider.get_tts_message(text, engine_id=engine.id)
-        source = str(getattr(stream_details, "path", "") or "").strip()
-        if not source:
-            raise MusicAssistantError(
-                f"TTS engine '{engine.uid}' returned no direct stream path in StreamDetails.path"
-            )
-        if not source.startswith(("http://", "https://", "rtsp://", "rtmp://")) and not (
-            Path(source).is_absolute() and await asyncio.to_thread(Path(source).is_file)
-        ):
-            raise MusicAssistantError(
-                f"TTS engine '{engine.uid}' returned an unusable stream path: {source}. "
-                "StreamDetails.path must be a fetchable http(s)/rtsp/rtmp URL or the "
-                "absolute path of an existing local file."
-            )
-        builtin_provider = self.mass.get_provider("builtin")
-        builtin_instance_id = str(getattr(builtin_provider, "instance_id", "") or "").strip()
-        duration = await self._warm_builtin_duration_cache(builtin_provider, source, section_name)
-        wrapped = create_uri(MediaType.SOUND_EFFECT, builtin_instance_id or "builtin", source)
-        return wrapped, duration
-
-    async def _warm_builtin_duration_cache(
-        self, builtin_provider: Any, source: str, section_name: str
-    ) -> int:
-        """
-        Force-decode duration, set a friendly title, prefill builtin's cache.
-
-        Returns the resolved duration in seconds, or 0 if unknown. Without this,
-        ffprobe of HA tts_proxy URLs returns no duration and the builtin provider
-        classifies the item as Radio, breaking auto-advance.
-        """
-        if builtin_provider is None:
-            return 0
-        try:
-            tags = await async_parse_tags(source, require_duration=True)
-        except (InvalidDataError, OSError) as err:
-            self.logger.warning(
-                "Could not pre-compute TTS section duration for %s: %s", source, err
-            )
-            return 0
-        format_block = tags.raw.setdefault("format", {})
-        if tags.duration:
-            format_block["duration"] = str(tags.duration)
-        format_tags = format_block.setdefault("tags", {})
-        format_tags.setdefault("title", section_name)
-        format_tags.setdefault("artist", "AI Radio")
-        await self.mass.cache.set(
-            source,
-            tags.raw,
-            provider=str(getattr(builtin_provider, "instance_id", "") or "builtin"),
-            category=CACHE_CATEGORY_MEDIA_INFO,
-        )
-        return int(tags.duration or 0)
 
     async def _get_ai_engine(self) -> AIEngine:
         """Return the engine used for AI_QUERY tasks, honouring the configured selection."""

--- a/music_assistant/providers/ai_radio/storage.py
+++ b/music_assistant/providers/ai_radio/storage.py
@@ -314,7 +314,6 @@ class AIRadioStorageMixin:
             "name": name,
             "source_playlist_id": source_playlist_id,
             "source_playlist_provider": source_playlist_provider,
-            "target_playlist_provider": str(station.get("target_playlist_provider") or "builtin"),
             "default_player_id": str(station.get("default_player_id") or ""),
             "max_duration_minutes": max(
                 0.0,
@@ -323,25 +322,6 @@ class AIRadioStorageMixin:
                 ),
             ),
             "shuffle_source_tracks": bool(station.get("shuffle_source_tracks", True)),
-            "dynamic_batch_size": max(
-                1,
-                _require_number("dynamic_batch_size", station.get("dynamic_batch_size"), 3, int),
-            ),
-            "dynamic_poll_seconds": max(
-                1,
-                _require_number(
-                    "dynamic_poll_seconds", station.get("dynamic_poll_seconds"), 5, int
-                ),
-            ),
-            "dynamic_prefetch_remaining_tracks": max(
-                1,
-                _require_number(
-                    "dynamic_prefetch_remaining_tracks",
-                    station.get("dynamic_prefetch_remaining_tracks"),
-                    2,
-                    int,
-                ),
-            ),
             "merge_section_id": merge_section_id,
             "general": general,
             "section_ids": section_ids,
@@ -522,13 +502,9 @@ class AIRadioStorageMixin:
             "name": "Example AI Radio Station",
             "source_playlist_id": "",
             "source_playlist_provider": "library",
-            "target_playlist_provider": "builtin",
             "default_player_id": "",
             "max_duration_minutes": 0,
             "shuffle_source_tracks": True,
-            "dynamic_batch_size": 3,
-            "dynamic_poll_seconds": 5,
-            "dynamic_prefetch_remaining_tracks": 2,
             "merge_section_id": "Between_Songs_Smoother",
             "general": {
                 "instructions": DEFAULT_LLM_INSTRUCTIONS,

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -8,13 +8,16 @@ from collections.abc import AsyncGenerator
 from contextlib import suppress
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import ContentType, MediaType, StreamType
 from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.queue_item import QueueItem
 from music_assistant_models.streamdetails import StreamDetails
 
+import music_assistant.controllers.streams.audio as audio_mod
+from music_assistant.controllers.streams.audio import StreamsAudio
 from music_assistant.controllers.streams.audio_buffer import (
     AudioBuffer,
     AudioBufferDiscarded,
@@ -27,6 +30,7 @@ from music_assistant.controllers.streams.constants import (
     BufferMode,
     BufferSize,
 )
+from music_assistant.mass import MusicAssistant
 
 # Standard test PCM format: 44100Hz, 16-bit, stereo
 TEST_PCM_FORMAT = AudioFormat(
@@ -742,3 +746,91 @@ async def test_inactivity_monitor_keeps_active_buffer() -> None:
     monitor.cancel()
     with suppress(asyncio.CancelledError):
         await monitor
+
+
+# -- Pre-buffering of the next queue item --
+
+
+@pytest.fixture
+async def mass_minimal(mass_minimal: MusicAssistant) -> MusicAssistant:
+    """Extend the base fixture with the player_queues/streams stand-ins get_queue_item_stream needs."""
+    mass_minimal.player_queues = SimpleNamespace(  # type: ignore[assignment]
+        get_active_queue=lambda _queue_id: None,
+        prepare_next_audio_buffer=lambda _queue_id: None,
+    )
+    mass_minimal.streams = MagicMock()
+    return mass_minimal
+
+
+class _FakeAudioBuffer:
+    """AudioBuffer test double that streams a fixed run of 1-second chunks."""
+
+    has_error = False
+    pcm_format = TEST_PCM_FORMAT
+
+    @classmethod
+    async def get_buffer(cls, **_kwargs: Any) -> _FakeAudioBuffer:
+        return cls()
+
+    async def get_stream(self, **_kwargs: Any) -> AsyncGenerator[bytes]:
+        async for chunk in _make_source(90):
+            yield chunk
+
+
+async def _stream_until_prebuffer_window(
+    mass: MusicAssistant, *, next_item_media_type: MediaType, queue_id: str
+) -> None:
+    """
+    Drive get_queue_item_stream for a 90s current TRACK item past the pre-buffer trigger point.
+
+    Sets up a queue whose next item has ``next_item_media_type`` and streams the current
+    item to completion, so the pre-buffer trigger condition (evaluated once more than
+    duration - 60 seconds of PCM has been yielded) gets a chance to fire.
+    """
+    streamdetails = _make_stream_details(MediaType.TRACK, duration=90, allow_seek=True)
+    streamdetails.loudness = -10.0  # skip the audio-analysis hydration call
+    current_item = QueueItem(
+        queue_id=queue_id,
+        queue_item_id="current",
+        name="Current",
+        duration=90,
+        streamdetails=streamdetails,
+    )
+    next_item = SimpleNamespace(queue_item_id="next", media_type=next_item_media_type)
+    queue = SimpleNamespace(next_item=next_item)
+    mass.player_queues.get_active_queue = lambda _player_id: queue  # type: ignore[method-assign, assignment, return-value]
+
+    controller = StreamsAudio(mass)
+    with patch.object(audio_mod, "AudioBuffer", _FakeAudioBuffer):
+        async for _chunk in controller.get_queue_item_stream(current_item, TEST_PCM_FORMAT):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_sound_effect_next_item_triggers_prebuffer(mass_minimal: MusicAssistant) -> None:
+    """A SOUND_EFFECT next item is pre-buffered like a track."""
+    calls: list[str] = []
+    mass_minimal.player_queues.prepare_next_audio_buffer = (  # type: ignore[method-assign]
+        lambda queue_id: calls.append(queue_id)
+    )
+
+    await _stream_until_prebuffer_window(
+        mass_minimal, next_item_media_type=MediaType.SOUND_EFFECT, queue_id="player_a"
+    )
+
+    assert calls == ["player_a"]
+
+
+@pytest.mark.asyncio
+async def test_audio_source_next_item_is_not_prebuffered(mass_minimal: MusicAssistant) -> None:
+    """A live AUDIO_SOURCE next item is still excluded from pre-buffering."""
+    calls: list[str] = []
+    mass_minimal.player_queues.prepare_next_audio_buffer = (  # type: ignore[method-assign]
+        lambda queue_id: calls.append(queue_id)
+    )
+
+    await _stream_until_prebuffer_window(
+        mass_minimal, next_item_media_type=MediaType.AUDIO_SOURCE, queue_id="player_a"
+    )
+
+    assert calls == []

--- a/tests/controllers/streams/test_audio_sources.py
+++ b/tests/controllers/streams/test_audio_sources.py
@@ -16,15 +16,25 @@ from music_assistant_models.enums import (
     PlayerType,
     SourceControl,
     StreamType,
+    VolumeNormalizationMode,
 )
 from music_assistant_models.errors import (
     MediaNotFoundError,
     UnsupportedFeaturedException,
 )
-from music_assistant_models.media_items import AudioFormat, AudioSource, ProviderMapping
+from music_assistant_models.media_items import (
+    AudioFormat,
+    AudioSource,
+    ProviderMapping,
+    SoundEffect,
+)
+from music_assistant_models.queue_item import QueueItem
 from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
 
+from music_assistant.constants import CONF_VOLUME_NORMALIZATION_TARGET
 from music_assistant.controllers.players import PlayerController
+from music_assistant.controllers.streams.audio import StreamsAudio
+from music_assistant.mass import MusicAssistant
 from music_assistant.models.plugin import PluginProvider
 from tests.common import MockPlayer, MockProvider
 
@@ -923,3 +933,97 @@ class TestAudioSourceLibraryRejection:
         controller.mass = MagicMock()
         with pytest.raises(UnsupportedFeaturedException, match="can not be library items"):
             await controller.add_item_to_library("stale_plugin://audio_source/main")
+
+
+# ------------------------------------------------ streamdetails dispatch for plugin-owned items
+
+
+def _register_stub_plugin(
+    mass: MusicAssistant, provider_cls: type[PluginProvider], *, instance_id: str
+) -> PluginProvider:
+    """Instantiate a real PluginProvider subclass with a stub manifest/config and register it."""
+    manifest = MagicMock()
+    manifest.domain = instance_id
+    config = MagicMock()
+    config.instance_id = instance_id
+    config.get_value = MagicMock(return_value="GLOBAL")
+    provider = provider_cls(mass, manifest, config)
+    # get_provider() only returns providers marked available; the real load pipeline sets
+    # this after handle_async_init, which we skip here.
+    provider.available = True
+    mass._providers[instance_id] = provider
+    return provider
+
+
+def _ready_streams_audio(mass: MusicAssistant) -> StreamsAudio:
+    """
+    Attach a minimal streams/player_queues stand-in to `mass` and return its StreamsAudio.
+
+    mass_minimal only wires config/cache/discovery; get_stream_details also reads
+    mass.streams (volume-normalization config) and mass.player_queues (preferred-provider
+    lookup), so dispatch tests stub those in directly rather than booting the full server.
+    """
+    mass.player_queues = MagicMock()
+    mass.player_queues.queue_data_or_none = MagicMock(return_value=None)
+    mass.streams = MagicMock()
+    mass.streams.get_config_value = MagicMock(
+        side_effect=lambda key, *_a, **_k: (
+            -14
+            if key == CONF_VOLUME_NORMALIZATION_TARGET
+            else VolumeNormalizationMode.DISABLED.value
+        )
+    )
+    mass.streams.audio = StreamsAudio(mass)
+    return mass.streams.audio  # type: ignore[no-any-return]
+
+
+def _queue_item_for_sound_effect(
+    *, queue_id: str, provider_instance: str, item_id: str
+) -> QueueItem:
+    """Build a QueueItem wrapping a SoundEffect owned by `provider_instance`."""
+    media_item = SoundEffect(
+        item_id=item_id,
+        provider=provider_instance,
+        name="Clip",
+        provider_mappings={
+            ProviderMapping(
+                item_id=item_id,
+                provider_domain=provider_instance,
+                provider_instance=provider_instance,
+            )
+        },
+    )
+    return QueueItem(
+        queue_id=queue_id, queue_item_id=item_id, name="Clip", duration=None, media_item=media_item
+    )
+
+
+async def test_plugin_owned_sound_effect_uses_plugin_stream_details(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A SOUND_EFFECT owned by a plugin provider is served by the plugin hook."""
+    received: list[tuple[str, MediaType]] = []
+
+    class ClipPlugin(PluginProvider):
+        async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
+            received.append((item_id, media_type))
+            return StreamDetails(
+                provider=self.instance_id,
+                item_id=item_id,
+                audio_format=AudioFormat(content_type=ContentType.MP3),
+                media_type=media_type,
+                stream_type=StreamType.HTTP,
+                path="http://example.invalid/clip.mp3",
+                duration=12,
+            )
+
+    audio = _ready_streams_audio(mass_minimal)
+    plugin = _register_stub_plugin(mass_minimal, ClipPlugin, instance_id="clipper")
+    queue_item = _queue_item_for_sound_effect(
+        queue_id="player_a", provider_instance=plugin.instance_id, item_id="clip_007"
+    )
+
+    streamdetails = await audio.get_stream_details(queue_item)
+
+    assert received == [("clip_007", MediaType.SOUND_EFFECT)]
+    assert streamdetails.media_type == MediaType.SOUND_EFFECT

--- a/tests/providers/ai_radio/test_provider.py
+++ b/tests/providers/ai_radio/test_provider.py
@@ -73,7 +73,7 @@ def _make_dynamic_provider(player_obj: object | None, default_player_id: str) ->
 def test_resolve_session_for_stop_by_session_id() -> None:
     """Resolve explicit session id directly."""
     provider = _make_provider()
-    session = SessionState(session_id="s1", station_id="st", mode="playlist")
+    session = SessionState(session_id="s1", station_id="st")
     provider._sessions[session.session_id] = session
 
     resolved = provider._resolve_session_for_stop(session_id="s1", station_id=None)
@@ -87,19 +87,16 @@ def test_resolve_session_for_stop_uses_latest_running_for_station() -> None:
     older = SessionState(
         session_id="s_old",
         station_id="station_a",
-        mode="playlist",
         created_at="2026-01-01T10:00:00+00:00",
     )
     newer = SessionState(
         session_id="s_new",
         station_id="station_a",
-        mode="dynamic",
         created_at="2026-01-01T11:00:00+00:00",
     )
     other = SessionState(
         session_id="s_other",
         station_id="station_b",
-        mode="playlist",
         created_at="2026-01-01T12:00:00+00:00",
     )
     provider._sessions = {s.session_id: s for s in (older, newer, other)}
@@ -122,8 +119,8 @@ async def test_start_run_dynamic_requires_player_id() -> None:
     """Reject dynamic run start when no player is configured."""
     provider = _make_dynamic_provider(player_obj=None, default_player_id="")
 
-    with pytest.raises(InvalidDataError, match="requires a target player_id"):
-        await provider.start_run(station_id="station_a", mode="dynamic")
+    with pytest.raises(InvalidDataError, match="requires a target player"):
+        await provider.start_run(station_id="station_a")
 
 
 @pytest.mark.asyncio
@@ -133,7 +130,7 @@ async def test_start_run_rejects_unknown_station() -> None:
     provider._stations = {}
 
     with pytest.raises(KeyError, match="Unknown station id: missing_station"):
-        await provider.start_run(station_id="missing_station", mode="playlist")
+        await provider.start_run(station_id="missing_station")
 
 
 @pytest.mark.asyncio
@@ -146,7 +143,7 @@ async def test_start_run_dynamic_rejects_unavailable_player() -> None:
     )
 
     with pytest.raises(InvalidDataError, match="Target player is unavailable"):
-        await provider.start_run(station_id="station_a", mode="dynamic")
+        await provider.start_run(station_id="station_a")
 
 
 @pytest.mark.asyncio
@@ -157,7 +154,6 @@ async def test_start_run_dynamic_rejects_negative_source_playtime_cap_override()
     with pytest.raises(InvalidDataError, match="dynamic_source_playtime_cap_override must be >= 0"):
         await provider.start_run(
             station_id="station_a",
-            mode="dynamic",
             dynamic_source_playtime_cap_override=-1,
         )
 
@@ -172,7 +168,7 @@ async def test_start_run_dynamic_rejects_disabled_player() -> None:
     )
 
     with pytest.raises(InvalidDataError, match="Target player is disabled"):
-        await provider.start_run(station_id="station_a", mode="dynamic")
+        await provider.start_run(station_id="station_a")
 
 
 @pytest.mark.asyncio
@@ -186,7 +182,6 @@ async def test_stop_run_rejects_already_completed_session() -> None:
     provider._sessions["s_done"] = SessionState(
         session_id="s_done",
         station_id="st",
-        mode="playlist",
         status="completed",
         ended_at="2026-01-01T10:00:00+00:00",
     )
@@ -206,7 +201,6 @@ async def test_stop_run_accepts_running_session_by_id() -> None:
     provider._sessions["s_run"] = SessionState(
         session_id="s_run",
         station_id="st",
-        mode="playlist",
         status="running",
     )
 
@@ -223,29 +217,33 @@ async def test_start_run_prunes_oldest_finished_sessions() -> None:
         "Any",
         SimpleNamespace(debug=lambda *_a, **_kw: None, info=lambda *_a, **_kw: None),
     )
+    player = SimpleNamespace(player_id="living_room", available=True, enabled=True)
     provider._stations = {
         "station_a": {
             "id": "station_a",
             "name": "Station A",
             "source_playlist_id": "1",
             "source_playlist_provider": "library",
+            "default_player_id": "living_room",
         }
     }
     provider.mass = cast(
         "Any",
-        SimpleNamespace(create_task=lambda coro, **_kw: coro.close()),
+        SimpleNamespace(
+            players=SimpleNamespace(get_player=lambda _player_id: player),
+            create_task=lambda coro, **_kw: coro.close(),
+        ),
     )
     for index in range(MAX_FINISHED_SESSIONS + 5):
         session_id = f"s_{index}"
         provider._sessions[session_id] = SessionState(
             session_id=session_id,
             station_id="station_a",
-            mode="playlist",
             status="completed",
             created_at=f"2026-01-01T10:{index:02d}:00+00:00",
         )
 
-    await provider.start_run(station_id="station_a", mode="playlist")
+    await provider.start_run(station_id="station_a")
 
     finished = [s for s in provider._sessions.values() if s.status != "running"]
     assert len(finished) == MAX_FINISHED_SESSIONS
@@ -300,31 +298,6 @@ async def test_save_station_discards_section_changes_when_station_invalid() -> N
 
 
 @pytest.mark.asyncio
-async def test_start_run_dynamic_rejects_zero_batch_size_override() -> None:
-    """Reject dynamic run start when batch size override is zero."""
-    player = SimpleNamespace(player_id="living_room", available=True, enabled=True)
-    provider = _make_dynamic_provider(player_obj=player, default_player_id="living_room")
-    provider.logger = cast(
-        "Any",
-        SimpleNamespace(debug=lambda *_a, **_kw: None, info=lambda *_a, **_kw: None),
-    )
-    provider.mass = cast(
-        "Any",
-        SimpleNamespace(
-            players=SimpleNamespace(get_player=lambda _player_id: player),
-            create_task=lambda *_a, **_kw: None,
-        ),
-    )
-
-    with pytest.raises(InvalidDataError, match="dynamic_batch_size_override"):
-        await provider.start_run(
-            station_id="station_a",
-            mode="dynamic",
-            dynamic_batch_size_override=0,
-        )
-
-
-@pytest.mark.asyncio
 async def test_concurrent_start_run_calls_respect_the_run_limit() -> None:
     """
     Concurrent start_run calls must not both get past the concurrency guards.
@@ -332,13 +305,28 @@ async def test_concurrent_start_run_calls_respect_the_run_limit() -> None:
     The guards and the session insert are one critical section; without it an await
     introduced between them would let both callers observe zero running sessions.
     """
+    player = SimpleNamespace(player_id="living_room", available=True, enabled=True)
     provider = _make_provider()
     provider.logger = logging.getLogger("tests.ai_radio.provider")
     provider._stations = {
-        "station_a": {"id": "station_a", "name": "Station A"},
-        "station_b": {"id": "station_b", "name": "Station B"},
+        "station_a": {
+            "id": "station_a",
+            "name": "Station A",
+            "default_player_id": "living_room",
+        },
+        "station_b": {
+            "id": "station_b",
+            "name": "Station B",
+            "default_player_id": "living_room",
+        },
     }
-    provider.mass = cast("Any", SimpleNamespace(create_task=lambda coro, **_kw: _close(coro)))
+    provider.mass = cast(
+        "Any",
+        SimpleNamespace(
+            players=SimpleNamespace(get_player=lambda _player_id: player),
+            create_task=lambda coro, **_kw: _close(coro),
+        ),
+    )
 
     results = await asyncio.gather(
         provider.start_run(station_id="station_a"),
@@ -374,7 +362,6 @@ async def test_stop_run_stops_the_queue_it_owns() -> None:
     provider._sessions["s_run"] = SessionState(
         session_id="s_run",
         station_id="st",
-        mode="dynamic",
         status="running",
         queue_id="living_room",
     )
@@ -409,7 +396,6 @@ async def test_stop_run_survives_an_unavailable_player() -> None:
     provider._sessions["s_run"] = SessionState(
         session_id="s_run",
         station_id="st",
-        mode="dynamic",
         status="running",
         queue_id="living_room",
     )

--- a/tests/providers/ai_radio/test_rendering.py
+++ b/tests/providers/ai_radio/test_rendering.py
@@ -1,0 +1,366 @@
+"""Unit tests for AI Radio just-in-time clip rendering."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
+from music_assistant_models.media_items import AudioFormat, ProviderMapping, SoundEffect
+from music_assistant_models.queue_item import QueueItem
+
+from music_assistant.models.plugin import PluginProvider, TTSEngine
+from music_assistant.providers.ai_radio.constants import (
+    ATTR_MAX_CHARS,
+    ATTR_PROMPT,
+    ATTR_RENDERED_TEXT,
+    ATTR_SESSION_ID,
+    ATTR_STATION_ID,
+    ATTR_WEB_SEARCH_MODE,
+)
+from music_assistant.providers.ai_radio.models import SessionState
+from music_assistant.providers.ai_radio.rendering import AIRadioRenderMixin
+
+
+class DummyRenderer(AIRadioRenderMixin):
+    """Minimal harness exposing the render path."""
+
+    domain = "ai_radio"
+    instance_id = "ai_radio--test"
+
+    def __init__(self) -> None:
+        """Initialize the harness with recording stubs."""
+        self.logger = logging.getLogger("tests.ai_radio.rendering")
+        self._sessions: dict[str, Any] = {}
+        self._stations: dict[str, dict[str, Any]] = {
+            "st": {"id": "st", "general": {"instructions": "be warm"}}
+        }
+        self.llm_prompts: list[str] = []
+        self.tts_texts: list[str] = []
+        self.weather_calls = 0
+        self.fail_generation = False
+
+    def _configured_now(self) -> Any:
+        return __import__("datetime").datetime(2026, 7, 30, 18, 30)
+
+    async def _generate_text(self, station: dict[str, Any], prompt: str, web_mode: str) -> str:
+        # a real suspension point so concurrent callers actually interleave under
+        # asyncio.gather, otherwise the lock in get_stream_details is never exercised
+        await asyncio.sleep(0)
+        if self.fail_generation:
+            raise RuntimeError("llm down")
+        self.llm_prompts.append(prompt)
+        return "Good evening, it is warm out."
+
+    async def _prepare_runtime_tokens(self, station: dict[str, Any]) -> dict[str, str]:
+        self.weather_calls += 1
+        return {"<weather_hourly>": f"fresh weather {self.weather_calls}"}
+
+    async def _render_tts_media(self, text: str) -> tuple[str, StreamType, AudioFormat]:
+        self.tts_texts.append(text)
+        return (
+            f"http://ha.invalid/api/tts_proxy/{len(self.tts_texts)}.mp3",
+            StreamType.HTTP,
+            AudioFormat(content_type=ContentType.MP3),
+        )
+
+    async def _probe_duration(self, path: str) -> int | None:
+        return 9
+
+
+class RealTtsRenderer(DummyRenderer):
+    """Harness that exercises the mixin's real TTS path instead of the DummyRenderer stub."""
+
+    _render_tts_media = AIRadioRenderMixin._render_tts_media
+
+
+def _tts_renderer(path: str, audio_format: AudioFormat | None = None) -> RealTtsRenderer:
+    """Build a renderer whose TTS engine returns StreamDetails carrying the given path."""
+    renderer = RealTtsRenderer()
+    plugin = MagicMock(spec=PluginProvider)
+    plugin.instance_id = "hass_1"
+    plugin.get_tts_message = AsyncMock(
+        return_value=SimpleNamespace(
+            path=path, audio_format=audio_format or AudioFormat(content_type=ContentType.UNKNOWN)
+        )
+    )
+    engine = TTSEngine(id="tts.cloud", name="Cloud", provider=plugin)
+    cast("Any", renderer)._get_tts_engine = AsyncMock(return_value=engine)
+    return renderer
+
+
+def _clip_item(clip_id: str, queue_id: str = "player_a", **overrides: Any) -> QueueItem:
+    """Build a queue item for a pending AI Radio clip."""
+    attributes: dict[str, Any] = {
+        ATTR_SESSION_ID: "sess",
+        ATTR_STATION_ID: "st",
+        ATTR_PROMPT: "It is <timestamp>. Weather: <weather_hourly>.",
+        ATTR_MAX_CHARS: 300,
+        ATTR_WEB_SEARCH_MODE: "disabled",
+    }
+    attributes.update(overrides)
+    media_item = SoundEffect(
+        item_id=clip_id,
+        provider="ai_radio--test",
+        name="Weather",
+        provider_mappings={
+            ProviderMapping(
+                item_id=clip_id,
+                provider_domain="ai_radio",
+                provider_instance="ai_radio--test",
+            )
+        },
+    )
+    return QueueItem(
+        queue_id=queue_id,
+        queue_item_id=f"qi_{clip_id}",
+        name="Weather",
+        duration=None,
+        media_item=media_item,
+        extra_attributes=attributes,
+    )
+
+
+def _attach_queues(renderer: DummyRenderer, queues: dict[str, list[QueueItem]]) -> list[bool]:
+    """Wire a minimal player_queues stub and return the signal_update call log."""
+    signals: list[bool] = []
+    cast("Any", renderer).mass = SimpleNamespace(
+        player_queues=SimpleNamespace(
+            all=lambda: tuple(SimpleNamespace(queue_id=queue_id) for queue_id in queues),
+            items=lambda queue_id, limit=500, offset=0: queues.get(queue_id, [])[
+                offset : offset + limit
+            ],
+            signal_update=lambda _queue_id, items_changed=False: signals.append(items_changed),
+        ),
+        metadata=SimpleNamespace(locale="en_US"),
+    )
+    return signals
+
+
+def _attach_queue(renderer: DummyRenderer, items: list[QueueItem]) -> list[bool]:
+    """Wire a single-queue player_queues stub and return the signal_update call log."""
+    return _attach_queues(renderer, {"player_a": items})
+
+
+async def test_render_resolves_deferred_placeholders_at_render_time() -> None:
+    """The prompt sent to the LLM carries render-time weather, not plan-time."""
+    renderer = DummyRenderer()
+    item = _clip_item("sess_001")
+    _attach_queue(renderer, [item])
+
+    streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert renderer.weather_calls == 1
+    assert "fresh weather 1" in renderer.llm_prompts[0]
+    assert "<timestamp>" not in renderer.llm_prompts[0]
+    assert streamdetails.media_type == MediaType.SOUND_EFFECT
+    assert streamdetails.stream_type == StreamType.HTTP
+    assert streamdetails.duration == 9
+    assert streamdetails.expiration == 60
+    assert streamdetails.can_seek is False
+    assert streamdetails.allow_seek is False
+
+
+async def test_render_caches_the_script_and_remints_the_url() -> None:
+    """A second render reuses the stored script but mints a fresh URL."""
+    renderer = DummyRenderer()
+    item = _clip_item("sess_001")
+    signals = _attach_queue(renderer, [item])
+
+    first = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+    second = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert len(renderer.llm_prompts) == 1
+    assert renderer.tts_texts == [
+        "Good evening, it is warm out.",
+        "Good evening, it is warm out.",
+    ]
+    assert first.path != second.path
+    assert item.extra_attributes[ATTR_RENDERED_TEXT] == "Good evening, it is warm out."
+    assert signals == [True]
+
+
+async def test_concurrent_renders_call_the_llm_once() -> None:
+    """Two simultaneous requests for one clip render a single script."""
+    renderer = DummyRenderer()
+    _attach_queue(renderer, [_clip_item("sess_001")])
+
+    await asyncio.gather(
+        renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT),
+        renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT),
+    )
+
+    assert len(renderer.llm_prompts) == 1
+
+
+async def test_clip_is_found_in_the_owning_sessions_queue() -> None:
+    """The session registry points the lookup at the queue that holds the clip."""
+    renderer = DummyRenderer()
+    session = SessionState(session_id="sess", station_id="st", queue_id="player_b")
+    renderer._sessions = {"sess": session}
+    _attach_queues(
+        renderer,
+        {"player_a": [], "player_b": [_clip_item("sess_001", queue_id="player_b")]},
+    )
+
+    streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert streamdetails.item_id == "sess_001"
+
+
+async def test_clip_is_found_by_scanning_every_queue_after_a_restart() -> None:
+    """With the session registry gone, the clip is still located in its persisted queue."""
+    renderer = DummyRenderer()
+    _attach_queues(
+        renderer,
+        {"player_a": [], "player_b": [_clip_item("sess_001", queue_id="player_b")]},
+    )
+
+    streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert streamdetails.item_id == "sess_001"
+
+
+async def test_unknown_clip_raises_media_not_found() -> None:
+    """A clip id that is not in any queue is reported as missing media."""
+    renderer = DummyRenderer()
+    _attach_queue(renderer, [_clip_item("sess_001")])
+
+    with pytest.raises(MediaNotFoundError):
+        await renderer.get_stream_details("sess_999", MediaType.SOUND_EFFECT)
+
+
+async def test_clip_without_prompt_raises_media_not_found() -> None:
+    """A clip whose attributes were lost is reported as missing media."""
+    renderer = DummyRenderer()
+    item = _clip_item("sess_001")
+    item.extra_attributes.pop(ATTR_PROMPT)
+    _attach_queue(renderer, [item])
+
+    with pytest.raises(MediaNotFoundError):
+        await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+
+async def test_llm_failure_raises_media_not_found() -> None:
+    """An LLM failure surfaces as missing media so the core skips the clip."""
+    renderer = DummyRenderer()
+    renderer.fail_generation = True
+    _attach_queue(renderer, [_clip_item("sess_001")])
+
+    with pytest.raises(MediaNotFoundError):
+        await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+
+async def test_render_failure_increments_the_session_skip_counter() -> None:
+    """A skipped clip is recorded on its session without failing the run."""
+    renderer = DummyRenderer()
+    session = SessionState(session_id="sess", station_id="st")
+    renderer._sessions = {"sess": session}
+    _attach_queue(renderer, [_clip_item("sess_001")])
+    renderer.fail_generation = True
+
+    with pytest.raises(MediaNotFoundError):
+        await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert session.skipped_sections == 1
+    assert session.last_render_error
+
+
+async def test_tts_failure_raises_media_not_found_and_records_skip() -> None:
+    """A TTS failure surfaces as missing media and is recorded on the owning session."""
+
+    class UnspeakableRenderer(DummyRenderer):
+        async def _render_tts_media(self, text: str) -> tuple[str, StreamType, AudioFormat]:
+            raise RuntimeError("tts down")
+
+    renderer = UnspeakableRenderer()
+    session = SessionState(session_id="sess", station_id="st")
+    renderer._sessions = {"sess": session}
+    _attach_queue(renderer, [_clip_item("sess_001")])
+
+    with pytest.raises(MediaNotFoundError):
+        await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert session.skipped_sections == 1
+    assert session.last_render_error
+
+
+async def test_probe_failure_is_not_fatal() -> None:
+    """A failed duration probe yields streamdetails without a duration."""
+
+    class UnprobableRenderer(DummyRenderer):
+        async def _probe_duration(self, path: str) -> int | None:
+            return None
+
+    renderer = UnprobableRenderer()
+    _attach_queue(renderer, [_clip_item("sess_001")])
+
+    streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert streamdetails.duration is None
+
+
+async def test_render_tts_media_streams_a_url_over_http() -> None:
+    """A TTS engine returning a proxy URL yields an HTTP stream with the MP3 default format."""
+    renderer = _tts_renderer("http://example.test/api/tts_proxy/abc123.mp3")
+
+    path, stream_type, audio_format = await renderer._render_tts_media("hello world")
+
+    assert path == "http://example.test/api/tts_proxy/abc123.mp3"
+    assert stream_type == StreamType.HTTP
+    assert audio_format.content_type == ContentType.MP3
+    engine = cast("Any", renderer)._get_tts_engine.return_value
+    # the provider-scoped engine.id, never engine.uid, and never omitted
+    engine.provider.get_tts_message.assert_awaited_once_with("hello world", engine_id="tts.cloud")
+
+
+async def test_render_tts_media_streams_a_local_file_from_disk(tmp_path: Path) -> None:
+    """A TTS engine that renders to disk is played as a local file rather than fetched."""
+    clip = tmp_path / "section.mp3"
+    clip.write_bytes(b"")
+    renderer = _tts_renderer(str(clip))
+    _attach_queue(renderer, [_clip_item("sess_001")])
+
+    path, stream_type, _ = await renderer._render_tts_media("hello world")
+
+    assert path == str(clip)
+    assert stream_type == StreamType.LOCAL_FILE
+
+
+async def test_render_tts_media_keeps_a_declared_audio_format(tmp_path: Path) -> None:
+    """A TTS engine that declares its own format has it carried into the clip streamdetails."""
+    clip = tmp_path / "section.wav"
+    clip.write_bytes(b"")
+    renderer = _tts_renderer(str(clip), AudioFormat(content_type=ContentType.WAV))
+
+    _, _, audio_format = await renderer._render_tts_media("hello world")
+
+    assert audio_format.content_type == ContentType.WAV
+
+
+@pytest.mark.parametrize("path", ["", "section.mp3", "/does/not/exist.mp3"])
+async def test_render_tts_media_rejects_an_unplayable_path(path: str) -> None:
+    """A path that is neither a URL nor an existing file fails loudly instead of degrading."""
+    renderer = _tts_renderer(path)
+
+    with pytest.raises(InvalidDataError, match="unusable stream path"):
+        await renderer._render_tts_media("hello world")
+
+
+async def test_local_file_clip_yields_local_file_streamdetails(tmp_path: Path) -> None:
+    """A disk-rendered clip reaches the core as LOCAL_FILE streamdetails."""
+    clip = tmp_path / "section.mp3"
+    clip.write_bytes(b"")
+    renderer = _tts_renderer(str(clip))
+    _attach_queue(renderer, [_clip_item("sess_001")])
+
+    streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert streamdetails.stream_type == StreamType.LOCAL_FILE
+    assert streamdetails.path == str(clip)

--- a/tests/providers/ai_radio/test_runtime.py
+++ b/tests/providers/ai_radio/test_runtime.py
@@ -5,30 +5,36 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+from collections.abc import Awaitable, Callable
 from contextlib import suppress
-from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.background_task import BackgroundTask
 from music_assistant_models.enums import (
+    EventType,
     MediaType,
     PlaybackState,
     ProviderFeature,
     ProviderType,
-    TaskStatus,
 )
 from music_assistant_models.errors import MusicAssistantError
-from music_assistant_models.media_items import SoundEffect
+from music_assistant_models.event import MassEvent
+from music_assistant_models.media_items import ProviderMapping, Track
 
 from music_assistant.helpers.datetime import now as host_now
-from music_assistant.helpers.playlists import PlaylistItem, parse_m3u, parse_m3u_playlist_image
-from music_assistant.helpers.uri import create_uri, parse_uri
 from music_assistant.models.plugin import AIEngine, PluginProvider, TTSEngine
-from music_assistant.providers.ai_radio.constants import CONF_AI_ENGINE, CONF_TTS_ENGINE
-from music_assistant.providers.ai_radio.models import AudioSection, SessionState, Slot
+from music_assistant.providers.ai_radio.constants import (
+    ATTR_MAX_CHARS,
+    ATTR_PROMPT,
+    ATTR_SESSION_ID,
+    ATTR_STATION_ID,
+    ATTR_WEB_SEARCH_MODE,
+    CONF_AI_ENGINE,
+    CONF_TTS_ENGINE,
+)
+from music_assistant.providers.ai_radio.models import PlannedSection, SessionState, Slot
 from music_assistant.providers.ai_radio.runtime import AIRadioRuntimeMixin
 
 
@@ -52,33 +58,19 @@ class DummyRuntime(AIRadioRuntimeMixin):
         self.logger = logging.getLogger("tests.ai_radio.runtime")
         self._sessions: dict[str, SessionState] = {}
         self.config = cast("Any", StubConfig())
+        self.instance_id = "ai_radio_test"
+        self.domain = "ai_radio"
         self._setup_values = setup_values or {}
 
     def get_setup_value(self, key: str, default: Any = None) -> Any:
         """Return the stubbed setup flow value for key, or default when absent."""
         return self._setup_values.get(key, default)
 
-    async def _run_playlist_mode(
-        self,
-        session: SessionState,
-        station: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Return a successful playlist-mode result."""
-        return {"ok": True}
-
-    async def _run_dynamic_mode(
-        self,
-        session: SessionState,
-        station: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Return a successful dynamic-mode result."""
-        return {"ok": True}
-
 
 class FailingRuntime(DummyRuntime):
-    """Runtime harness that forces playlist execution failure."""
+    """Runtime harness that forces show execution failure."""
 
-    async def _run_playlist_mode(
+    async def _run_show(
         self,
         session: SessionState,
         station: dict[str, Any],
@@ -135,8 +127,18 @@ def _create_engine_mass(feature: ProviderFeature, *providers: Any, **attrs: Any)
 
 async def test_run_session_sets_completed_and_logs(caplog: Any) -> None:
     """Complete a session and emit start/completion logs."""
-    runtime = DummyRuntime()
-    session = SessionState(session_id="s1", station_id="station_a", mode="playlist")
+
+    class SuccessfulRuntime(DummyRuntime):
+        async def _run_show(
+            self,
+            session: SessionState,
+            station: dict[str, Any],
+        ) -> dict[str, Any]:
+            """Return a successful show run result."""
+            return {"ok": True}
+
+    runtime = SuccessfulRuntime()
+    session = SessionState(session_id="s1", station_id="station_a")
     runtime._sessions[session.session_id] = session
 
     with caplog.at_level(logging.INFO):
@@ -151,7 +153,7 @@ async def test_run_session_sets_completed_and_logs(caplog: Any) -> None:
 async def test_run_session_sets_failed_state(caplog: Any) -> None:
     """Fail a session and keep the error message in state."""
     runtime = FailingRuntime()
-    session = SessionState(session_id="s2", station_id="station_b", mode="playlist")
+    session = SessionState(session_id="s2", station_id="station_b")
     runtime._sessions[session.session_id] = session
 
     with caplog.at_level(logging.ERROR):
@@ -168,7 +170,7 @@ async def test_run_session_sets_failed_state_with_empty_exception_message() -> N
         """Exception with empty default message."""
 
     class EmptyFailingRuntime(DummyRuntime):
-        async def _run_playlist_mode(
+        async def _run_show(
             self,
             session: SessionState,
             station: dict[str, Any],
@@ -176,7 +178,7 @@ async def test_run_session_sets_failed_state_with_empty_exception_message() -> N
             raise EmptyError
 
     runtime = EmptyFailingRuntime()
-    session = SessionState(session_id="s2b", station_id="station_b", mode="playlist")
+    session = SessionState(session_id="s2b", station_id="station_b")
     runtime._sessions[session.session_id] = session
 
     await runtime._run_session(session.session_id, {"id": "station_b"})
@@ -189,7 +191,7 @@ async def test_run_session_sets_stopped_state_on_cancellation(caplog: Any) -> No
     """Mark session as stopped when runtime execution is cancelled."""
 
     class CancelledRuntime(DummyRuntime):
-        async def _run_playlist_mode(
+        async def _run_show(
             self,
             session: SessionState,
             station: dict[str, Any],
@@ -197,7 +199,7 @@ async def test_run_session_sets_stopped_state_on_cancellation(caplog: Any) -> No
             raise asyncio.CancelledError
 
     runtime = CancelledRuntime()
-    session = SessionState(session_id="s3", station_id="station_c", mode="playlist")
+    session = SessionState(session_id="s3", station_id="station_c")
     runtime._sessions[session.session_id] = session
 
     with caplog.at_level(logging.INFO), suppress(asyncio.CancelledError):
@@ -326,6 +328,7 @@ def test_plan_sections_ignores_invalid_optional_chance() -> None:
     ]
 
     planned, _history = runtime._plan_sections(
+        session_id="sess",
         tracks=tracks,
         station=station,
         track_index_offset=0,
@@ -336,82 +339,6 @@ def test_plan_sections_ignores_invalid_optional_chance() -> None:
     )
 
     assert planned == []
-
-
-async def test_render_tts_converts_raw_http_path_to_builtin_sound_effect_uri() -> None:
-    """Wrap raw TTS HTTP paths as builtin sound effect URIs for queue progression."""
-    plugin = _create_tts_plugin("hass_1", "tts.cloud")
-    plugin.get_tts_message = AsyncMock(
-        return_value=SimpleNamespace(path="http://example.test/api/tts_proxy/abc123.mp3")
-    )
-
-    def get_provider(provider: str) -> Any:
-        return SimpleNamespace(instance_id="builtin_1") if provider == "builtin" else None
-
-    runtime = DummyRuntime({CONF_TTS_ENGINE: "hass_1/tts.cloud"})
-    _set_runtime_mass(
-        runtime, _create_engine_mass(ProviderFeature.TTS, plugin, get_provider=get_provider)
-    )
-    runtime._warm_builtin_duration_cache = AsyncMock(return_value=11)  # type: ignore[method-assign]
-
-    uri, duration = await runtime._render_tts("hello world", "Test Section")
-
-    assert uri == create_uri(
-        MediaType.SOUND_EFFECT,
-        "builtin_1",
-        "http://example.test/api/tts_proxy/abc123.mp3",
-    )
-    assert duration == 11
-    plugin.get_tts_message.assert_awaited_once_with("hello world", engine_id="tts.cloud")
-    runtime._warm_builtin_duration_cache.assert_awaited_once()
-
-
-async def test_render_tts_converts_local_file_path_to_builtin_sound_effect_uri(
-    tmp_path: Path,
-) -> None:
-    """A rendered clip on disk gets the same builtin sound effect treatment as a URL."""
-    clip = tmp_path / "section.mp3"
-    clip.write_bytes(b"")
-    plugin = _create_tts_plugin("local_tts_1", "voice")
-    plugin.get_tts_message = AsyncMock(return_value=SimpleNamespace(path=str(clip)))
-
-    def get_provider(provider: str) -> Any:
-        return SimpleNamespace(instance_id="builtin_1") if provider == "builtin" else None
-
-    runtime = DummyRuntime({CONF_TTS_ENGINE: "local_tts_1/voice"})
-    _set_runtime_mass(
-        runtime, _create_engine_mass(ProviderFeature.TTS, plugin, get_provider=get_provider)
-    )
-    runtime._warm_builtin_duration_cache = AsyncMock(return_value=7)  # type: ignore[method-assign]
-
-    uri, duration = await runtime._render_tts("hello world", "Test Section")
-
-    assert uri == create_uri(MediaType.SOUND_EFFECT, "builtin_1", str(clip))
-    assert await parse_uri(uri) == (MediaType.SOUND_EFFECT, "builtin_1", str(clip))
-    assert duration == 7
-    runtime._warm_builtin_duration_cache.assert_awaited_once()
-
-
-async def test_render_tts_rejects_a_stream_path_that_is_not_playable() -> None:
-    """A path that is neither a URL nor an existing file fails loudly instead of degrading."""
-    plugin = _create_tts_plugin("local_tts_1", "voice")
-    plugin.get_tts_message = AsyncMock(return_value=SimpleNamespace(path="section.mp3"))
-
-    runtime = DummyRuntime({CONF_TTS_ENGINE: "local_tts_1/voice"})
-    _set_runtime_mass(runtime, _create_engine_mass(ProviderFeature.TTS, plugin))
-
-    with pytest.raises(MusicAssistantError, match="unusable stream path"):
-        await runtime._render_tts("hello world", "Test Section")
-
-
-async def test_render_tts_refuses_a_configured_engine_that_disappeared() -> None:
-    """A concrete TTS selection is never silently replaced by another available engine."""
-    plugin = _create_tts_plugin("hass_1", "tts.cloud")
-    runtime = DummyRuntime({CONF_TTS_ENGINE: "hass_1/tts.gone"})
-    _set_runtime_mass(runtime, _create_engine_mass(ProviderFeature.TTS, plugin))
-
-    with pytest.raises(MusicAssistantError, match="No text-to-speech engine available"):
-        await runtime._render_tts("hello world", "Test Section")
 
 
 async def test_generate_text_wraps_not_connected_error() -> None:
@@ -462,265 +389,230 @@ async def test_generate_text_asks_for_the_system_locale_language() -> None:
     assert plugin.ai_query.await_args.kwargs == {"engine_id": "ai_task.default"}
 
 
-def test_compose_builtin_playlist_items_preserves_section_metadata() -> None:
-    """Compose builtin M3U items without relying on provider-side title parsing."""
-
-    class DummyProvider:
-        domain = "builtin"
-        instance_id = "builtin_1"
-
-    class DummyMass:
-        def get_provider(self, provider: str) -> Any:
-            if provider in {"builtin", "builtin_1"}:
-                return DummyProvider()
-            return None
-
+def test_resolve_placeholders_keeps_time_and_weather_deferred() -> None:
+    """Static track placeholders resolve at plan time; time and weather stay deferred."""
     runtime = DummyRuntime()
-    _set_runtime_mass(runtime, DummyMass())
-    section_url = "http://example.test/api/tts_proxy/section-random-id.mp3"
-    source_item = PlaylistItem(
-        path=create_uri(MediaType.TRACK, "library", "123"),
-        title="Artist - Song",
-        metadata={"media_type": MediaType.TRACK.value, "name": "Song"},
+    _set_runtime_mass(runtime, SimpleNamespace(metadata=SimpleNamespace(locale="en_US")))
+    tracks = [
+        {"index": 0, "songinfo": "A - One", "duration": 200},
+        {"index": 1, "songinfo": "B - Two", "duration": 200},
+    ]
+    slot = Slot(
+        when="between_songs",
+        at_index=1,
+        prev_index=0,
+        next_index=1,
+        very_next_index=None,
+        minute_mark=3.3,
     )
 
-    items, track_count = runtime._compose_builtin_playlist_items(
-        tracks=[
+    static, deferred = runtime._resolve_placeholders(
+        station={},
+        tracks=tracks,
+        slot=slot,
+        runtime_tokens={"<weather_hourly>": "12 degrees"},
+    )
+
+    assert static["<prev_songinfo>"] == "A - One"
+    assert static["<next_songinfo>"] == "B - Two"
+    assert "<timestamp>" not in static
+    assert "<weather_hourly>" not in static
+    assert deferred["<weather_hourly>"] == "12 degrees"
+    assert "<timestamp>" in deferred
+
+
+def test_plan_sections_leaves_deferred_tokens_in_the_prompt() -> None:
+    """A planned section's prompt keeps its deferred tokens verbatim."""
+    runtime = DummyRuntime()
+    _set_runtime_mass(runtime, SimpleNamespace(metadata=SimpleNamespace(locale="en_US")))
+    station = {
+        "sections": [
             {
-                "uri": source_item.path,
-                "name": "Song",
-                "songinfo": "Artist - Song",
-                "duration": 180,
-                "playlist_item": source_item,
+                "id": "Weather",
+                "name": "Weather",
+                "prompt": "It is <timestamp>. Weather: <weather_hourly>. Next: <next_songinfo>.",
+                "constraints": {"max_chars": 300},
+                "web_search": "disabled",
             }
         ],
-        sections=[
-            AudioSection(
-                order=1,
-                section_id="intro",
-                section_name="Intro",
-                insert_at_index=0,
-                uri=create_uri(MediaType.SOUND_EFFECT, "builtin_1", section_url),
-            )
-        ],
-    )
-
-    assert track_count == 1
-    assert len(items) == 2
-    assert items[0].title == "Intro"
-    assert items[0].metadata == {
-        "media_type": MediaType.SOUND_EFFECT.value,
-        "name": "Intro",
+        "section_order": [{"when": "between_songs", "flow": [{"MUST": "Weather"}]}],
     }
-    assert items[0].images
-    assert items[0].images[0].path == runtime._ai_radio_cover_image_path()
-    assert items[0].providers
-    assert items[0].providers[0].domain == "builtin"
-    assert items[0].providers[0].instance_id == "builtin_1"
-    assert items[0].providers[0].item_id == section_url
-    assert items[0].artists
-    assert items[0].artists[0].name == "AI Radio"
-    assert items[1] == source_item
-
-
-def test_section_to_queue_sound_effect_preserves_display_data() -> None:
-    """Build a rich SoundEffect for dynamic-mode queue inserts."""
-
-    class DummyProvider:
-        domain = "builtin"
-        instance_id = "builtin_1"
-
-    class DummyMass:
-        def get_provider(self, provider: str) -> Any:
-            if provider in {"builtin", "builtin_1"}:
-                return DummyProvider()
-            return None
-
-    runtime = DummyRuntime()
-    _set_runtime_mass(runtime, DummyMass())
-    section = AudioSection(
-        order=1,
-        section_id="intro",
-        section_name="Intro",
-        insert_at_index=0,
-        uri=create_uri(MediaType.SOUND_EFFECT, "builtin_1", "http://example.test/intro.mp3"),
-        duration=12,
-    )
-
-    item = runtime._section_to_queue_sound_effect(section)
-
-    assert isinstance(item, SoundEffect)
-    assert item.name == "Intro"
-    assert item.duration == 12
-    assert item.provider_mappings
-    mapping = next(iter(item.provider_mappings))
-    assert mapping.provider_domain == "builtin"
-    assert mapping.provider_instance == "builtin_1"
-    assert mapping.item_id == "http://example.test/intro.mp3"
-    assert item.metadata.images
-    assert item.metadata.images[0].path == runtime._ai_radio_cover_image_path()
-
-
-async def test_import_builtin_playlist_preserves_m3u_metadata() -> None:
-    """Import builtin playlist from a fully described M3U payload."""
-
-    class DummyPlaylistsController:
-        def __init__(self) -> None:
-            self.m3u_data = ""
-
-        async def import_playlist(self, m3u_data: str) -> dict[str, str]:
-            self.m3u_data = m3u_data
-            return {"item_id": "42", "name": "AI Radio: Test"}
-
-    class DummyMass:
-        def __init__(self) -> None:
-            self.music = type("DummyMusic", (), {})()
-            self.music.playlists = DummyPlaylistsController()
-
-        def get_provider(self, provider: str) -> None:
-            return None
-
-    runtime = DummyRuntime()
-    mass = DummyMass()
-    _set_runtime_mass(runtime, mass)
-    item = runtime._section_to_playlist_item(
-        AudioSection(
-            order=1,
-            section_id="intro",
-            section_name="Intro",
-            insert_at_index=0,
-            uri=create_uri(MediaType.SOUND_EFFECT, "builtin", "http://example.test/intro.mp3"),
-        )
-    )
-
-    playlist = await runtime._import_builtin_playlist("AI Radio: Test", [item])
-
-    assert playlist == {"item_id": "42", "name": "AI Radio: Test"}
-    assert parse_m3u_playlist_image(mass.music.playlists.m3u_data) == (
-        runtime._ai_radio_cover_image_path()
-    )
-    parsed = parse_m3u(mass.music.playlists.m3u_data)
-    assert parsed[0].title == "Intro"
-    assert parsed[0].metadata == {
-        "media_type": MediaType.SOUND_EFFECT.value,
-        "name": "Intro",
-    }
-    assert parsed[0].images[0].path == runtime._ai_radio_cover_image_path()
-    assert parsed[0].artists
-    assert parsed[0].artists[0].name == "AI Radio"
-
-
-async def test_wait_for_background_task_completion_returns_on_success() -> None:
-    """Return immediately when background task is already successful."""
-
-    class DummyTasks:
-        def get_task(self, task_id: str) -> BackgroundTask:
-            return BackgroundTask(name="add", id=task_id, status=TaskStatus.SUCCESS)
-
-    class DummyMass:
-        tasks = DummyTasks()
-
-    runtime = DummyRuntime()
-    _set_runtime_mass(runtime, DummyMass())
-
-    await runtime._wait_for_background_task_completion("task_1", timeout_seconds=1)
-
-
-async def test_wait_for_background_task_completion_waits_until_success() -> None:
-    """Poll task status until completion."""
-    statuses = [TaskStatus.PENDING, TaskStatus.RUNNING, TaskStatus.SUCCESS]
-
-    class DummyTasks:
-        def __init__(self) -> None:
-            self._index = 0
-
-        def get_task(self, task_id: str) -> BackgroundTask:
-            status = statuses[self._index]
-            if self._index < len(statuses) - 1:
-                self._index += 1
-            return BackgroundTask(name="add", id=task_id, status=status)
-
-    class DummyMass:
-        tasks = DummyTasks()
-
-    runtime = DummyRuntime()
-    _set_runtime_mass(runtime, DummyMass())
-
-    await runtime._wait_for_background_task_completion("task_2", timeout_seconds=1)
-
-
-def test_compose_entries_returns_correct_source_track_positions() -> None:
-    """_compose_entries returns explicit source-track positions, not substring-derived (C1)."""
-    runtime = DummyRuntime()
     tracks = [
-        {
-            "uri": "library://track/1",
-            "name": "T1",
-            "songinfo": "A - T1",
-            "duration": 180,
-            "playlist_item": None,
-            "item_id": "1",
-            "artist": "A",
-            "index": 0,
+        {"index": 0, "songinfo": "A - One", "duration": 200},
+        {"index": 1, "songinfo": "B - Two", "duration": 200},
+    ]
+
+    planned, _history = runtime._plan_sections(
+        session_id="sess",
+        tracks=tracks,
+        station=station,
+        track_index_offset=0,
+        minute_offset=0.0,
+        history_state={},
+        allowed_slot_when=["between_songs"],
+        runtime_tokens={"<weather_hourly>": "12 degrees"},
+    )
+
+    assert planned
+    prompt = planned[0].prompt
+    assert "<timestamp>" in prompt
+    assert "<weather_hourly>" in prompt
+    assert "B - Two" in prompt
+
+
+def _weather_guarded_station() -> dict[str, Any]:
+    """Return a station whose only section requires the weather-hourly token to be present."""
+    return {
+        "sections": [
+            {
+                "id": "Weather",
+                "name": "Weather",
+                "type": "ai_text",
+                "web_search": "disabled",
+                "prompt": "Current weather: <weather_hourly>.",
+                "constraints": {"max_chars": 200},
+            }
+        ],
+        "section_order": [
+            {
+                "when": "between_songs",
+                "flow": [
+                    {
+                        "OPTIONAL": {
+                            "section": "Weather",
+                            "chance": 100,
+                            "guards": {"require_placeholders_present": ["<weather_hourly>"]},
+                        }
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_plan_sections_suppresses_section_when_required_placeholder_is_missing() -> None:
+    """A guarded section plans zero entries when its required placeholder never resolved."""
+    runtime = DummyRuntime()
+    _set_runtime_mass(runtime, SimpleNamespace(metadata=SimpleNamespace(locale="en_US")))
+    tracks = [
+        {"index": 0, "songinfo": "A - One", "duration": 200},
+        {"index": 1, "songinfo": "B - Two", "duration": 200},
+    ]
+
+    planned, _history = runtime._plan_sections(
+        session_id="sess",
+        tracks=tracks,
+        station=_weather_guarded_station(),
+        track_index_offset=0,
+        minute_offset=0.0,
+        history_state={},
+        allowed_slot_when=["between_songs"],
+        runtime_tokens={},
+    )
+
+    assert planned == []
+
+
+def test_plan_sections_includes_section_when_required_placeholder_is_present() -> None:
+    """The same guarded section plans normally once its required placeholder resolved."""
+    runtime = DummyRuntime()
+    _set_runtime_mass(runtime, SimpleNamespace(metadata=SimpleNamespace(locale="en_US")))
+    tracks = [
+        {"index": 0, "songinfo": "A - One", "duration": 200},
+        {"index": 1, "songinfo": "B - Two", "duration": 200},
+    ]
+
+    planned, _history = runtime._plan_sections(
+        session_id="sess",
+        tracks=tracks,
+        station=_weather_guarded_station(),
+        track_index_offset=0,
+        minute_offset=0.0,
+        history_state={},
+        allowed_slot_when=["between_songs"],
+        runtime_tokens={"<weather_hourly>": "12 degrees"},
+    )
+
+    assert len(planned) == 1
+    assert planned[0].section_id == "Weather"
+
+
+def _stub_track(item_id: str) -> Track:
+    """Build a minimal Track with one available ProviderMapping, for build_queue_item."""
+    return Track(
+        item_id=item_id,
+        provider="library",
+        name=f"Track {item_id}",
+        provider_mappings={
+            ProviderMapping(
+                item_id=item_id,
+                provider_domain="library",
+                provider_instance="library",
+            )
         },
-        {
-            "uri": "library://track/2",
-            "name": "T2",
-            "songinfo": "A - T2",
-            "duration": 180,
-            "playlist_item": None,
-            "item_id": "2",
-            "artist": "A",
-            "index": 1,
-        },
+    )
+
+
+def test_compose_queue_items_places_clips_at_planned_indices() -> None:
+    """Clips are interleaved at their planned indices, carrying their render state."""
+    runtime = DummyRuntime()
+    _set_runtime_mass(runtime, SimpleNamespace())
+    tracks = [
+        {"index": 0, "uri": "library://track/1", "media_item": _stub_track("1")},
+        {"index": 1, "uri": "library://track/2", "media_item": _stub_track("2")},
     ]
     sections = [
-        AudioSection(
-            order=1,
-            section_id="intro",
+        PlannedSection(
+            order=0,
+            clip_id="sess_000",
+            section_id="Intro",
             section_name="Intro",
+            when="start_of_playlist",
             insert_at_index=0,
-            uri=create_uri(MediaType.SOUND_EFFECT, "builtin_1", "http://x/intro.mp3"),
+            prompt="hello <timestamp>",
+            max_chars=200,
+            web_search_mode="disabled",
         ),
-        AudioSection(
+        PlannedSection(
             order=1,
-            section_id="outro",
-            section_name="Outro",
-            insert_at_index=2,
-            uri=create_uri(MediaType.SOUND_EFFECT, "builtin_1", "http://x/outro.mp3"),
+            clip_id="sess_001",
+            section_id="Between",
+            section_name="Between",
+            when="between_songs",
+            insert_at_index=1,
+            prompt="middle <weather_hourly>",
+            max_chars=200,
+            web_search_mode="allow",
         ),
     ]
 
-    entries, source_positions, _track_count = runtime._compose_entries(tracks, sections)
+    items = runtime._compose_queue_items(
+        queue_id="player_a",
+        session=SessionState(session_id="sess", station_id="st"),
+        station={"id": "st"},
+        tracks=tracks,
+        sections=sections,
+    )
 
-    source_uris = {cast("str", track["uri"]) for track in tracks}
-    expected_source_indices = [i for i, uri in enumerate(entries) if uri in source_uris]
-
-    assert source_positions == expected_source_indices
-    assert source_positions == [1, 2]
-
-
-@pytest.mark.parametrize(
-    "stub_status",
-    [TaskStatus.FAILED, TaskStatus.CANCELLED, TaskStatus.PENDING],
-)
-async def test_wait_for_background_task_completion_raises_on_failure(
-    stub_status: TaskStatus,
-) -> None:
-    """Surface failures, cancellations and timeouts as MusicAssistantError (P4)."""
-
-    class DummyTasks:
-        def get_task(self, task_id: str) -> BackgroundTask:
-            return BackgroundTask(name="add", id=task_id, status=stub_status)
-
-    class DummyMass:
-        tasks = DummyTasks()
-
-    runtime = DummyRuntime()
-    _set_runtime_mass(runtime, DummyMass())
-
-    with pytest.raises(MusicAssistantError):
-        await runtime._wait_for_background_task_completion("task_x", timeout_seconds=1)
+    assert [item.media_item.item_id for item in items if item.media_item is not None] == [
+        "sess_000",
+        "1",
+        "sess_001",
+        "2",
+    ]
+    intro = items[0]
+    assert intro.media_item is not None
+    assert intro.media_item.media_type == MediaType.SOUND_EFFECT
+    assert intro.extra_attributes[ATTR_PROMPT] == "hello <timestamp>"
+    assert intro.extra_attributes[ATTR_SESSION_ID] == "sess"
+    assert intro.extra_attributes[ATTR_STATION_ID] == "st"
+    assert intro.extra_attributes[ATTR_MAX_CHARS] == 200
+    assert items[2].extra_attributes[ATTR_WEB_SEARCH_MODE] == "allow"
+    # the section name travels as the item's own name, not as an attribute
+    assert intro.name == "Intro"
+    assert "ai_radio_section_name" not in intro.extra_attributes
+    # track items carry no AI Radio state
+    assert items[1].extra_attributes == {}
 
 
 async def test_get_ai_engine_requires_a_configured_selection() -> None:
@@ -780,487 +672,454 @@ async def test_get_tts_engine_refuses_a_configured_engine_that_disappeared() -> 
         await runtime._get_tts_engine()
 
 
-async def test_run_dynamic_mode_has_watchdog_for_stalled_playback(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Surface stalled dynamic playback (queue not advancing) as MusicAssistantError (P7)."""
-    monkeypatch.setattr(
-        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
-        0.2,
-    )
-
-    class StalledRuntime(AIRadioRuntimeMixin):
-        def __init__(self) -> None:
-            self.logger = logging.getLogger("tests.ai_radio.runtime.p7")
-            self._sessions: dict[str, SessionState] = {}
-
-        async def _fetch_source_tracks(
-            self, station: dict[str, Any]
-        ) -> tuple[list[dict[str, Any]], str]:
-            tracks = [
-                {
-                    "uri": "library://track/1",
-                    "duration": 180,
-                    "name": "T1",
-                    "artist": "A",
-                    "songinfo": "A - T1",
-                    "index": 0,
-                    "playlist_item": None,
-                    "item_id": "1",
-                },
-                {
-                    "uri": "library://track/2",
-                    "duration": 180,
-                    "name": "T2",
-                    "artist": "A",
-                    "songinfo": "A - T2",
-                    "index": 1,
-                    "playlist_item": None,
-                    "item_id": "2",
-                },
-            ]
-            return tracks, "Source"
-
-        def _apply_track_duration_limit(
-            self, tracks: list[dict[str, Any]], station: dict[str, Any]
-        ) -> list[dict[str, Any]]:
-            return tracks
-
-        def _plan_sections(self, *args: Any, **kwargs: Any) -> tuple[list[Any], dict[str, Any]]:
-            return [], {}
-
-        async def _generate_sections(self, *args: Any, **kwargs: Any) -> list[Any]:
-            return []
-
-        async def _synthesize_sections(self, *args: Any, **kwargs: Any) -> list[Any]:
-            return []
-
-        async def _prepare_runtime_tokens(self, station: dict[str, Any]) -> dict[str, str]:
-            return {}
-
-    class DummyPlayers:
-        def get_player(self, player_id: str) -> Any:
-            return object()
-
-    class DummyQueue:
-        current_index: int | None = None
-
-    class DummyPlayerQueues:
-        def clear(self, queue_id: str) -> None:
-            return None
-
-        async def set_shuffle(self, queue_id: str, shuffle_enabled: bool) -> None:
-            return None
-
-        async def play_media(self, **kwargs: Any) -> None:
-            return None
-
-        async def play_index(self, queue_id: str, index: int) -> None:
-            return None
-
-        def get_active_queue(self, player_id: str) -> Any:
-            return None
-
-        def get(self, queue_id: str) -> Any:
-            return DummyQueue()
-
-    class DummyMass:
-        players = DummyPlayers()
-        player_queues = DummyPlayerQueues()
-
-    runtime = StalledRuntime()
-    _set_runtime_mass(runtime, DummyMass())
-    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
-    runtime._sessions[session.session_id] = session
-    station = {
-        "id": "st",
-        "name": "Stalled Station",
-        "default_player_id": "living_room",
-        "dynamic_batch_size": 1,
-        "dynamic_poll_seconds": 1,
-        "dynamic_prefetch_remaining_tracks": 1,
-        "general": {"timezone": "UTC"},
-        "sections": [],
-        "section_order": [],
-    }
-
-    with pytest.raises(MusicAssistantError, match=r"stall|stopped advancing|watchdog|inactive"):
-        await asyncio.wait_for(runtime._run_dynamic_mode(session, station), timeout=3.0)
-
-
-@pytest.mark.parametrize(
-    ("batch_size", "prefetch_config", "expected_prefetch"),
-    [
-        (3, 2, 2),
-        (3, 5, 2),
-        (1, 2, 1),
-        (5, 1, 1),
-    ],
-)
-async def test_run_dynamic_mode_clamps_prefetch_to_batch_size(
-    batch_size: int, prefetch_config: int, expected_prefetch: int
-) -> None:
+def _show_mass_stub(**handlers: Any) -> SimpleNamespace:
     """
-    Clamp dynamic_prefetch_remaining_tracks so the trigger falls inside the batch.
+    Build a minimal mass stub for exercising _run_show.
 
-    Only exercises the setup segment of _run_dynamic_mode: the clamped value is
-    captured via the "initializing_queue" progress update, short-circuiting before
-    the batch-queueing loop runs. This does NOT cover trigger_position math further
-    down in the loop, nor the storage-layer normalization clamp in storage.py.
+    Any player_queues/players/music/metadata handler not passed gets a no-op default.
     """
 
-    class ProbeStop(Exception):
-        """Raised to short-circuit _run_dynamic_mode once the clamp is captured."""
-
-        def __init__(self, prefetch_remaining_tracks: int) -> None:
-            self.prefetch_remaining_tracks = prefetch_remaining_tracks
-
-    class ProbeRuntime(AIRadioRuntimeMixin):
-        def __init__(self) -> None:
-            self.logger = logging.getLogger("tests.ai_radio.runtime.clamp_probe")
-            self._sessions: dict[str, SessionState] = {}
-
-        async def _fetch_source_tracks(
-            self, station: dict[str, Any]
-        ) -> tuple[list[dict[str, Any]], str]:
-            return [{"uri": "library://track/1", "duration": 180}], "Source"
-
-        def _apply_track_duration_limit(
-            self, tracks: list[dict[str, Any]], station: dict[str, Any]
-        ) -> list[dict[str, Any]]:
-            return tracks
-
-        async def _prepare_runtime_tokens(self, station: dict[str, Any]) -> dict[str, str]:
-            return {}
-
-        def _set_session_progress(self, session: SessionState, phase: str, **details: Any) -> None:
-            if phase == "initializing_queue":
-                raise ProbeStop(cast("int", details["prefetch_remaining_tracks"]))
-
-    class DummyPlayers:
-        def get_player(self, player_id: str) -> Any:
-            return object()
-
-    class DummyPlayerQueues:
-        def get_active_queue(self, player_id: str) -> Any:
-            return None
-
-    class DummyMass:
-        players = DummyPlayers()
-        player_queues = DummyPlayerQueues()
-
-    runtime = ProbeRuntime()
-    _set_runtime_mass(runtime, DummyMass())
-    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
-    runtime._sessions[session.session_id] = session
-    station = {
-        "id": "st",
-        "name": "Probe Station",
-        "default_player_id": "living_room",
-        "dynamic_batch_size": batch_size,
-        "dynamic_prefetch_remaining_tracks": prefetch_config,
-        "general": {"timezone": "UTC"},
-    }
-
-    with pytest.raises(ProbeStop) as excinfo:
-        await runtime._run_dynamic_mode(session, station)
-
-    assert excinfo.value.prefetch_remaining_tracks == expected_prefetch
-
-
-def _make_watchdog_runtime_classes() -> tuple[type, type]:
-    """Build the reusable dynamic-mode runtime and player-queues test harness."""
-
-    class WatchdogRuntime(AIRadioRuntimeMixin):
-        def __init__(self) -> None:
-            self.logger = logging.getLogger("tests.ai_radio.runtime.watchdog")
-            self._sessions: dict[str, SessionState] = {}
-
-        async def _fetch_source_tracks(
-            self, station: dict[str, Any]
-        ) -> tuple[list[dict[str, Any]], str]:
-            tracks = []
-            for index in (1, 2, 3):
-                tracks.append(
-                    {
-                        "uri": f"library://track/{index}",
-                        "duration": 400,
-                        "name": f"T{index}",
-                        "artist": "A",
-                        "songinfo": f"A - T{index}",
-                        "index": index - 1,
-                        "playlist_item": None,
-                        "item_id": str(index),
-                    }
-                )
-            return tracks, "Source"
-
-        def _apply_track_duration_limit(
-            self, tracks: list[dict[str, Any]], station: dict[str, Any]
-        ) -> list[dict[str, Any]]:
-            return tracks
-
-        def _plan_sections(self, *args: Any, **kwargs: Any) -> tuple[list[Any], dict[str, Any]]:
-            return [], {}
-
-        async def _generate_sections(self, *args: Any, **kwargs: Any) -> list[Any]:
-            return []
-
-        async def _synthesize_sections(self, *args: Any, **kwargs: Any) -> list[Any]:
-            return []
-
-        async def _prepare_runtime_tokens(self, station: dict[str, Any]) -> dict[str, str]:
-            return {}
-
-    class SteppingPlayerQueues:
-        """Player queues stub whose queue reports a scripted playback state."""
-
-        def __init__(self, queue: Any) -> None:
-            self.queue = queue
-
-        def clear(self, queue_id: str) -> None:
-            return None
-
-        async def set_shuffle(self, queue_id: str, shuffle_enabled: bool) -> None:
-            return None
-
-        async def play_media(self, **kwargs: Any) -> None:
-            return None
-
-        def get_active_queue(self, player_id: str) -> Any:
-            return None
-
-        def get(self, queue_id: str) -> Any:
-            self.queue.polls += 1
-            return self.queue
-
-    return WatchdogRuntime, SteppingPlayerQueues
-
-
-def _watchdog_station() -> dict[str, Any]:
-    """Return a dynamic-mode station config for watchdog tests."""
-    return {
-        "id": "st",
-        "name": "Watchdog Station",
-        "default_player_id": "living_room",
-        "dynamic_batch_size": 2,
-        "dynamic_poll_seconds": 1,
-        "dynamic_prefetch_remaining_tracks": 1,
-        "general": {"timezone": "UTC"},
-        "sections": [],
-        "section_order": [],
-    }
-
-
-async def test_dynamic_watchdog_tolerates_long_track_while_playing(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Keep waiting while a long track plays and elapsed time keeps advancing."""
-    monkeypatch.setattr(
-        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
-        0.2,
-    )
-    watchdog_runtime_cls, stepping_queues_cls = _make_watchdog_runtime_classes()
-
-    class PlayingQueue:
-        """Queue stuck on index 0 (long track) but with advancing elapsed time."""
-
-        polls = 0
-        state = PlaybackState.PLAYING
-
-        @property
-        def current_index(self) -> int:
-            return 0 if self.polls < 4 else 1
-
-        @property
-        def elapsed_time(self) -> float:
-            return float(self.polls * 10)
-
-    class DummyPlayers:
-        def get_player(self, player_id: str) -> Any:
-            return object()
-
-    class DummyMass:
-        players = DummyPlayers()
-        player_queues = stepping_queues_cls(PlayingQueue())
-
-    runtime = watchdog_runtime_cls()
-    _set_runtime_mass(runtime, DummyMass())
-    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
-    runtime._sessions[session.session_id] = session
-
-    result = await asyncio.wait_for(
-        runtime._run_dynamic_mode(session, _watchdog_station()), timeout=10.0
-    )
-
-    assert result["queued_tracks"] == 3
-
-
-class RecordingPlayerQueues:
-    """Player queues stub that records queue mutations for assertions."""
-
-    def __init__(self, queue: Any) -> None:
-        """Initialize recorder around one fake queue object."""
-        self.queue = queue
-        self.clear_calls: list[str] = []
-        self.set_shuffle_calls: list[tuple[str, bool]] = []
-        self.play_media_calls: list[tuple[Any, int]] = []
-        self.play_index_calls: list[tuple[str, int]] = []
-        # combined call order across the methods below, for ordering assertions
-        self.call_order: list[str] = []
-
-    def clear(self, queue_id: str) -> None:
-        """Record a queue clear call."""
-        self.clear_calls.append(queue_id)
-        self.call_order.append("clear")
-
-    async def set_shuffle(self, queue_id: str, shuffle_enabled: bool) -> None:
-        """Record a set_shuffle call."""
-        self.set_shuffle_calls.append((queue_id, shuffle_enabled))
-        self.call_order.append("set_shuffle")
-
-    async def play_media(self, **kwargs: Any) -> None:
-        """Record a play_media call with the poll count at call time."""
-        self.play_media_calls.append((kwargs.get("option"), self.queue.polls))
-        self.call_order.append("play_media")
-
-    async def play_index(self, queue_id: str, index: int) -> None:
-        """Record a play_index call and mark the queue as started."""
-        self.play_index_calls.append((queue_id, index))
-        self.queue.started = True
-
-    def get_active_queue(self, player_id: str) -> Any:
-        """Return no active queue to force the direct queue lookup."""
+    async def _noop_async(*_args: Any, **_kwargs: Any) -> None:
         return None
 
-    def get(self, queue_id: str) -> Any:
-        """Return the fake queue and count the poll."""
-        self.queue.polls += 1
-        return self.queue
+    def _noop_sync(*_args: Any, **_kwargs: Any) -> None:
+        return None
 
+    def _noop_get_active_queue(_player_id: str) -> Any:
+        return None
 
-async def test_dynamic_mode_targets_active_group_queue(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Queue all batches on the active (group) queue when the player is a group member."""
-    monkeypatch.setattr(
-        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
-        0.2,
+    def _noop_get_player(_player_id: str) -> Any:
+        return object()
+
+    def _noop_items(_queue_id: str, limit: int = 500, offset: int = 0) -> list[Any]:  # noqa: ARG001
+        return []
+
+    subscribers: list[Callable[[Any], None]] = []
+
+    def _recording_subscribe(
+        cb_func: Callable[[Any], None],
+        event_filter: Any = None,  # noqa: ARG001
+        id_filter: Any = None,  # noqa: ARG001
+    ) -> Callable[[], None]:
+        subscribers.append(cb_func)
+
+        def _unsubscribe() -> None:
+            subscribers.remove(cb_func)
+
+        return _unsubscribe
+
+    def _emit_queue_updated(queue_id: str) -> None:
+        event = MassEvent(event=EventType.QUEUE_UPDATED, object_id=queue_id)
+        for cb_func in subscribers:
+            cb_func(event)
+
+    def _emit_player_removed(player_id: str) -> None:
+        event = MassEvent(event=EventType.PLAYER_REMOVED, object_id=player_id)
+        for cb_func in subscribers:
+            cb_func(event)
+
+    player_queues = SimpleNamespace(
+        clear=handlers.get("clear", _noop_sync),
+        get=handlers.get("get", lambda _queue_id: None),
+        get_active_queue=handlers.get("get_active_queue", _noop_get_active_queue),
+        set_shuffle=handlers.get("set_shuffle", _noop_async),
+        load=handlers.get("load", _noop_async),
+        play_index=handlers.get("play_index", _noop_async),
+        items=handlers.get("items", _noop_items),
+        signal_update=handlers.get("signal_update", _noop_sync),
+        stop=handlers.get("stop", _noop_async),
     )
-    watchdog_runtime_cls, _ = _make_watchdog_runtime_classes()
+    return SimpleNamespace(
+        player_queues=player_queues,
+        players=SimpleNamespace(get_player=handlers.get("get_player", _noop_get_player)),
+        music=SimpleNamespace(playlists=handlers.get("playlists", SimpleNamespace())),
+        metadata=SimpleNamespace(locale=handlers.get("locale", "en_US")),
+        create_task=handlers.get("create_task", _noop_sync),
+        subscribe=handlers.get("subscribe", _recording_subscribe),
+        emit_queue_updated=_emit_queue_updated,
+        emit_player_removed=_emit_player_removed,
+    )
 
-    class GroupQueue:
-        """Group queue owned by the sync-group leader, not the target player."""
 
-        queue_id = "group_1"
-        polls = 0
-        items = 0
-        state = PlaybackState.PLAYING
-        started = False
-        current_index = 4
-        elapsed_time = 10.0
+def _stub_queue(state: PlaybackState, current_index: int | None) -> SimpleNamespace:
+    """Build a mutable queue stand-in exposing the fields _await_show_end reads."""
+    return SimpleNamespace(state=state, current_index=current_index)
 
-    class GroupPlayerQueues:
-        """Player queues stub where the player's active queue is a group queue."""
 
-        def __init__(self, queue: Any) -> None:
-            """Initialize recorder around the fake group queue."""
-            self.queue = queue
-            self.clear_calls: list[str] = []
-            self.play_media_queue_ids: list[str] = []
+def _stub_clip_queue_item(clip_id: str, session_id: str) -> SimpleNamespace:
+    """Build a queue item stand-in whose extra_attributes carry a session id."""
+    return SimpleNamespace(extra_attributes={ATTR_SESSION_ID: session_id}, item_id=clip_id)
 
-        def clear(self, queue_id: str) -> None:
-            """Record a queue clear call."""
-            self.clear_calls.append(queue_id)
 
-        async def set_shuffle(self, queue_id: str, shuffle_enabled: bool) -> None:
-            """No-op shuffle toggle for the group queue."""
-            return
+def _recording_set_shuffle(log: list[str]) -> Callable[[str, bool], Awaitable[None]]:
+    """Return an async set_shuffle stub that appends "set_shuffle" to the given call-order log."""
 
-        async def play_media(self, **kwargs: Any) -> None:
-            """Record the queue targeted by a play_media call."""
-            self.play_media_queue_ids.append(kwargs.get("queue_id", ""))
+    async def _set_shuffle(_queue_id: str, _shuffle_enabled: bool) -> None:
+        log.append("set_shuffle")
 
-        async def play_index(self, queue_id: str, index: int) -> None:
-            """Start playback on the fake queue."""
-            self.queue.started = True
+    return _set_shuffle
 
-        def get_active_queue(self, player_id: str) -> Any:
-            """Return the group queue as the player's active queue."""
-            return self.queue
 
-        def get(self, queue_id: str) -> Any:
-            """Return the fake group queue."""
-            self.queue.polls += 1
-            return self.queue
+def _show_station() -> dict[str, Any]:
+    """Return a station config for _run_show tests, whose section_order yields clips."""
+    return {
+        "id": "st",
+        "name": "Show Station",
+        "default_player_id": "living_room",
+        "source_playlist_id": "playlist-1",
+        "source_playlist_provider": "library",
+        "shuffle_source_tracks": False,
+        "general": {"timezone": "UTC"},
+        "sections": [
+            {
+                "id": "Song_Introduction_Start",
+                "name": "Intro",
+                "type": "ai_text",
+                "web_search": "disabled",
+                "prompt": "Welcome, next up is <next_songinfo>.",
+                "constraints": {"max_chars": 200},
+            },
+            {
+                "id": "Song_Transition",
+                "name": "Transition",
+                "type": "ai_text",
+                "web_search": "disabled",
+                "prompt": "From <prev_songinfo> to <next_songinfo>.",
+                "constraints": {"max_chars": 200},
+            },
+        ],
+        "section_order": [
+            {"when": "start_of_playlist", "flow": [{"MUST": "Song_Introduction_Start"}]},
+            {"when": "between_songs", "flow": [{"MUST": "Song_Transition"}]},
+        ],
+    }
 
-    class DummyPlayers:
-        def get_player(self, player_id: str) -> Any:
-            return object()
 
-    player_queues = GroupPlayerQueues(GroupQueue())
+class ShowRuntime(DummyRuntime):
+    """Runtime harness exercising the real _run_show with stubbed track sourcing."""
 
-    class DummyMass:
-        def __init__(self) -> None:
-            self.players = DummyPlayers()
-            self.player_queues = player_queues
+    async def _fetch_source_tracks(
+        self, station: dict[str, Any]
+    ) -> tuple[list[dict[str, Any]], str]:
+        """Return two fixed tracks, each carrying its resolved media item."""
+        return [
+            {"index": 0, "songinfo": "A - One", "duration": 200, "media_item": _stub_track("1")},
+            {"index": 1, "songinfo": "B - Two", "duration": 200, "media_item": _stub_track("2")},
+        ], "Source Playlist"
 
-    mass = DummyMass()
-    runtime = watchdog_runtime_cls()
-    _set_runtime_mass(runtime, mass)
-    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
-    runtime._sessions[session.session_id] = session
-    station = _watchdog_station()
+    async def _prepare_runtime_tokens(self, station: dict[str, Any]) -> dict[str, str]:
+        """Skip the weather lookup; runtime tokens are irrelevant to these tests."""
+        return {}
 
-    result = await asyncio.wait_for(runtime._run_dynamic_mode(session, station), timeout=10.0)
+
+async def test_run_show_loads_the_whole_show_then_plays_index_zero() -> None:
+    """The show is loaded in one call, fully stamped, before playback is started."""
+    runtime = ShowRuntime()
+    call_order: list[str] = []
+    loaded: list[tuple[Any, dict[str, Any]]] = []
+
+    async def _load(_queue_id: str, queue_items: list[Any], **kwargs: Any) -> None:
+        call_order.append("load")
+        # snapshot media_item + extra_attributes now: asserting on the live queue_item
+        # objects after _run_show returns would pass even if stamping happened later
+        loaded.extend((item.media_item, dict(item.extra_attributes)) for item in queue_items)
+        assert kwargs["shuffle"] is False
+        assert kwargs["keep_remaining"] is False
+        assert kwargs["keep_played"] is False
+
+    async def _play_index(_queue_id: str, index: int) -> None:
+        call_order.append(f"play_index:{index}")
+
+    _set_runtime_mass(
+        runtime,
+        _show_mass_stub(
+            load=_load,
+            play_index=_play_index,
+            clear=lambda _queue_id: call_order.append("clear"),
+            set_shuffle=_recording_set_shuffle(call_order),
+        ),
+    )
+
+    await runtime._run_show(SessionState(session_id="sess", station_id="st"), _show_station())
+
+    assert call_order == ["clear", "set_shuffle", "load", "play_index:0"]
+    clips = [
+        (media_item, attrs)
+        for media_item, attrs in loaded
+        if media_item.media_type == MediaType.SOUND_EFFECT
+    ]
+    assert clips
+    # every clip was already fully stamped at the moment load() was called
+    assert all(attrs[ATTR_PROMPT] for _media_item, attrs in clips)
+    assert all(attrs[ATTR_SESSION_ID] == "sess" for _media_item, attrs in clips)
+
+
+async def test_run_show_targets_active_group_queue() -> None:
+    """Queue and start the show on the active (group) queue when the player is grouped."""
+    runtime = ShowRuntime()
+    clear_calls: list[str] = []
+    load_queue_ids: list[str] = []
+    play_index_queue_ids: list[str] = []
+
+    async def _load(queue_id: str, **_kwargs: Any) -> None:
+        load_queue_ids.append(queue_id)
+
+    async def _play_index(queue_id: str, _index: int) -> None:
+        play_index_queue_ids.append(queue_id)
+
+    _set_runtime_mass(
+        runtime,
+        _show_mass_stub(
+            get_active_queue=lambda _player_id: SimpleNamespace(queue_id="group_1"),
+            clear=clear_calls.append,
+            load=_load,
+            play_index=_play_index,
+        ),
+    )
+    session = SessionState(session_id="s1", station_id="st")
+
+    result = await runtime._run_show(session, _show_station())
 
     assert result["queue_id"] == "group_1"
-    assert player_queues.clear_calls == ["group_1"]
-    assert player_queues.play_media_queue_ids == ["group_1", "group_1"]
+    assert clear_calls == ["group_1"]
+    assert load_queue_ids == ["group_1"]
+    assert play_index_queue_ids == ["group_1"]
+    assert session.queue_id == "group_1"
 
 
-async def test_dynamic_watchdog_tolerates_paused_queue(
+async def test_run_show_ends_as_stopped_when_the_user_stops_the_queue() -> None:
+    """A queue stopped part-way through the show ends the run as a user stop."""
+    runtime = DummyRuntime()
+    session = SessionState(session_id="sess", station_id="st")
+    queue = _stub_queue(state=PlaybackState.PLAYING, current_index=0)
+    mass = _show_mass_stub(
+        get=lambda _queue_id: queue,
+        items=lambda _queue_id, limit=500, offset=0: [  # noqa: ARG005
+            _stub_clip_queue_item("sess_000", session_id="sess")
+        ],
+    )
+    _set_runtime_mass(runtime, mass)
+
+    task = asyncio.create_task(
+        runtime._await_show_end(session, "player_a", last_index=5, has_clips=True)
+    )
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    queue.state = PlaybackState.IDLE
+    mass.emit_queue_updated("player_a")
+
+    assert await asyncio.wait_for(task, timeout=1) == "queue_stopped"
+
+
+async def test_run_show_ends_as_exhausted_when_the_show_plays_out() -> None:
+    """Reaching the last enqueued entry ends the run as a normal completion."""
+    runtime = DummyRuntime()
+    session = SessionState(session_id="sess", station_id="st")
+    queue = _stub_queue(state=PlaybackState.PLAYING, current_index=5)
+    mass = _show_mass_stub(
+        get=lambda _queue_id: queue,
+        items=lambda _queue_id, limit=500, offset=0: [  # noqa: ARG005
+            _stub_clip_queue_item("sess_000", session_id="sess")
+        ],
+    )
+    _set_runtime_mass(runtime, mass)
+
+    task = asyncio.create_task(
+        runtime._await_show_end(session, "player_a", last_index=5, has_clips=True)
+    )
+    await asyncio.sleep(0)
+
+    queue.state = PlaybackState.IDLE
+    mass.emit_queue_updated("player_a")
+
+    assert await asyncio.wait_for(task, timeout=1) == "source_exhausted"
+
+
+async def test_run_show_ignores_an_idle_queue_before_playback_starts() -> None:
+    """A queue that has not started yet is not mistaken for a stopped one."""
+    runtime = DummyRuntime()
+    session = SessionState(session_id="sess", station_id="st")
+    queue = _stub_queue(state=PlaybackState.IDLE, current_index=None)
+    mass = _show_mass_stub(
+        get=lambda _queue_id: queue,
+        items=lambda _queue_id, limit=500, offset=0: [  # noqa: ARG005
+            _stub_clip_queue_item("sess_000", session_id="sess")
+        ],
+    )
+    _set_runtime_mass(runtime, mass)
+
+    task = asyncio.create_task(
+        runtime._await_show_end(session, "player_a", last_index=5, has_clips=True)
+    )
+    mass.emit_queue_updated("player_a")
+    await asyncio.sleep(0)
+
+    assert not task.done()
+    task.cancel()
+
+
+async def test_run_show_keeps_a_paused_queue_on_air() -> None:
+    """A paused queue keeps the show running."""
+    runtime = DummyRuntime()
+    session = SessionState(session_id="sess", station_id="st")
+    queue = _stub_queue(state=PlaybackState.PLAYING, current_index=1)
+    mass = _show_mass_stub(
+        get=lambda _queue_id: queue,
+        items=lambda _queue_id, limit=500, offset=0: [  # noqa: ARG005
+            _stub_clip_queue_item("sess_000", session_id="sess")
+        ],
+    )
+    _set_runtime_mass(runtime, mass)
+
+    task = asyncio.create_task(
+        runtime._await_show_end(session, "player_a", last_index=5, has_clips=True)
+    )
+    await asyncio.sleep(0)
+
+    queue.state = PlaybackState.PAUSED
+    mass.emit_queue_updated("player_a")
+    await asyncio.sleep(0)
+
+    assert not task.done()
+    task.cancel()
+
+
+async def test_run_show_ends_when_the_queue_no_longer_holds_its_clips() -> None:
+    """A queue cleared or taken over by other playback ends the run."""
+    runtime = DummyRuntime()
+    session = SessionState(session_id="sess", station_id="st")
+    queue = _stub_queue(state=PlaybackState.PLAYING, current_index=1)
+    queue_items = [_stub_clip_queue_item("sess_000", session_id="sess")]
+    mass = _show_mass_stub(
+        get=lambda _queue_id: queue,
+        items=lambda _queue_id, limit=500, offset=0: queue_items[offset : offset + limit],
+    )
+    _set_runtime_mass(runtime, mass)
+
+    task = asyncio.create_task(
+        runtime._await_show_end(session, "player_a", last_index=5, has_clips=True)
+    )
+    await asyncio.sleep(0)
+
+    queue_items.clear()
+    mass.emit_queue_updated("player_a")
+
+    assert await asyncio.wait_for(task, timeout=1) == "queue_stopped"
+
+
+async def test_run_show_ends_when_its_player_is_removed() -> None:
+    """Removing the target player must not pin the session's slot forever."""
+    runtime = DummyRuntime()
+    session = SessionState(session_id="sess", station_id="st")
+    queue = _stub_queue(state=PlaybackState.PLAYING, current_index=1)
+    queue_holder: list[Any] = [queue]
+    mass = _show_mass_stub(
+        get=lambda _queue_id: queue_holder[0],
+        items=lambda _queue_id, limit=500, offset=0: [  # noqa: ARG005
+            _stub_clip_queue_item("sess_000", session_id="sess")
+        ],
+    )
+    _set_runtime_mass(runtime, mass)
+
+    task = asyncio.create_task(
+        runtime._await_show_end(session, "player_a", last_index=5, has_clips=True)
+    )
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    # on_player_remove pops the queue data before PLAYER_REMOVED is signaled
+    queue_holder[0] = None
+    mass.emit_player_removed("player_a")
+
+    assert await asyncio.wait_for(task, timeout=1) == "queue_stopped"
+
+
+async def test_run_show_keeps_waiting_when_the_show_has_no_clips_to_lose() -> None:
+    """A clip-free show is not mistaken for one whose clips got cleared out."""
+    runtime = DummyRuntime()
+    session = SessionState(session_id="sess", station_id="st")
+    queue = _stub_queue(state=PlaybackState.PLAYING, current_index=0)
+    # track-only queue: no item carries ATTR_SESSION_ID, exactly like a show whose
+    # section rules never selected anything to insert
+    mass = _show_mass_stub(
+        get=lambda _queue_id: queue,
+        items=lambda _queue_id, limit=500, offset=0: [  # noqa: ARG005
+            SimpleNamespace(extra_attributes={})
+        ],
+    )
+    _set_runtime_mass(runtime, mass)
+
+    task = asyncio.create_task(
+        runtime._await_show_end(session, "player_a", last_index=5, has_clips=False)
+    )
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    queue.current_index = 5
+    queue.state = PlaybackState.IDLE
+    mass.emit_queue_updated("player_a")
+
+    assert await asyncio.wait_for(task, timeout=1) == "source_exhausted"
+
+
+async def test_await_show_end_fails_when_playback_never_starts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Keep waiting while the queue is deliberately paused by the user."""
+    """A show whose playback never starts is declared failed instead of waiting forever."""
     monkeypatch.setattr(
-        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
-        0.2,
+        "music_assistant.providers.ai_radio.runtime.SHOW_START_TIMEOUT_SECONDS", 0.05
     )
-    watchdog_runtime_cls, stepping_queues_cls = _make_watchdog_runtime_classes()
-
-    class PausedQueue:
-        """Queue paused on index 0 with frozen elapsed time, resuming later."""
-
-        polls = 0
-        elapsed_time = 42.0
-
-        @property
-        def state(self) -> PlaybackState:
-            return PlaybackState.PAUSED if self.polls < 4 else PlaybackState.PLAYING
-
-        @property
-        def current_index(self) -> int:
-            return 0 if self.polls < 4 else 1
-
-    class DummyPlayers:
-        def get_player(self, player_id: str) -> Any:
-            return object()
-
-    class DummyMass:
-        players = DummyPlayers()
-        player_queues = stepping_queues_cls(PausedQueue())
-
-    runtime = watchdog_runtime_cls()
-    _set_runtime_mass(runtime, DummyMass())
-    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
-    runtime._sessions[session.session_id] = session
-
-    result = await asyncio.wait_for(
-        runtime._run_dynamic_mode(session, _watchdog_station()), timeout=10.0
+    runtime = DummyRuntime()
+    session = SessionState(session_id="sess", station_id="st")
+    queue = _stub_queue(state=PlaybackState.IDLE, current_index=None)
+    mass = _show_mass_stub(
+        get=lambda _queue_id: queue,
+        items=lambda _queue_id, limit=500, offset=0: [  # noqa: ARG005
+            _stub_clip_queue_item("sess_000", session_id="sess")
+        ],
     )
+    _set_runtime_mass(runtime, mass)
 
-    assert result["queued_tracks"] == 3
+    with pytest.raises(MusicAssistantError, match="did not start"):
+        await runtime._await_show_end(session, "player_a", last_index=5, has_clips=True)
+
+
+async def test_await_show_end_does_not_time_out_once_playback_starts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Playback starting before the start-timeout elapses lets the show proceed as normal."""
+    monkeypatch.setattr(
+        "music_assistant.providers.ai_radio.runtime.SHOW_START_TIMEOUT_SECONDS", 0.2
+    )
+    runtime = DummyRuntime()
+    session = SessionState(session_id="sess", station_id="st")
+    queue = _stub_queue(state=PlaybackState.IDLE, current_index=None)
+    mass = _show_mass_stub(
+        get=lambda _queue_id: queue,
+        items=lambda _queue_id, limit=500, offset=0: [  # noqa: ARG005
+            _stub_clip_queue_item("sess_000", session_id="sess")
+        ],
+    )
+    _set_runtime_mass(runtime, mass)
+
+    task = asyncio.create_task(
+        runtime._await_show_end(session, "player_a", last_index=5, has_clips=True)
+    )
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    queue.state = PlaybackState.PLAYING
+    queue.current_index = 0
+    mass.emit_queue_updated("player_a")
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    queue.current_index = 5
+    queue.state = PlaybackState.IDLE
+    mass.emit_queue_updated("player_a")
+
+    assert await asyncio.wait_for(task, timeout=1) == "source_exhausted"
 
 
 def test_passes_optional_guards_handles_non_numeric_guard_values() -> None:
@@ -1335,6 +1194,8 @@ async def test_fetch_source_tracks_skips_tracks_with_no_resolvable_uri(caplog: A
     assert playlist_name == "Source Playlist"
     assert [track["item_id"] for track in tracks] == ["1", "3"]
     assert [track["index"] for track in tracks] == [0, 1]
+    # the resolved media item travels on the normalized dict, unchanged
+    assert [track["media_item"] for track in tracks] == [good_track_1, good_track_2]
     assert any("Track Two" in record.message for record in caplog.records)
 
 
@@ -1403,182 +1264,81 @@ def test_apply_track_duration_limit_zero_cap_is_noop() -> None:
     assert result is tracks
 
 
-async def test_dynamic_mode_disables_shuffle_before_first_play_media(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Disable queue shuffle before the first batch is queued, so batches keep their order."""
-    monkeypatch.setattr(
-        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
-        0.2,
+async def test_run_show_disables_shuffle_before_load() -> None:
+    """Disable queue shuffle before the items are loaded, so sections keep their planned order."""
+    runtime = ShowRuntime()
+    call_order: list[str] = []
+    set_shuffle_calls: list[tuple[str, bool]] = []
+
+    async def _set_shuffle(queue_id: str, shuffle_enabled: bool) -> None:
+        set_shuffle_calls.append((queue_id, shuffle_enabled))
+        call_order.append("set_shuffle")
+
+    async def _load(_queue_id: str, **_kwargs: Any) -> None:
+        call_order.append("load")
+
+    _set_runtime_mass(runtime, _show_mass_stub(set_shuffle=_set_shuffle, load=_load))
+    session = SessionState(session_id="s1", station_id="st")
+
+    await runtime._run_show(session, _show_station())
+
+    assert set_shuffle_calls == [("living_room", False)]
+    assert call_order.index("set_shuffle") < call_order.index("load")
+
+
+async def test_run_show_stays_running_while_the_queue_plays_and_stop_cancels_it() -> None:
+    """The session stays 'running' for as long as the show plays; a stop cancels it mid-show."""
+    runtime = ShowRuntime()
+    queue = _stub_queue(state=PlaybackState.PLAYING, current_index=0)
+    unsubscribed = False
+
+    def _subscribe(
+        cb_func: Callable[[Any], None],  # noqa: ARG001
+        event_filter: Any = None,  # noqa: ARG001
+        id_filter: Any = None,  # noqa: ARG001
+    ) -> Callable[[], None]:
+        def _unsubscribe() -> None:
+            nonlocal unsubscribed
+            unsubscribed = True
+
+        return _unsubscribe
+
+    mass = _show_mass_stub(
+        get=lambda _queue_id: queue,
+        items=lambda _queue_id, limit=500, offset=0: [  # noqa: ARG005
+            _stub_clip_queue_item("sess_000", session_id="s1")
+        ],
+        subscribe=_subscribe,
     )
-    watchdog_runtime_cls, _ = _make_watchdog_runtime_classes()
-
-    class BusyQueue:
-        """Queue already playing 3 pre-existing items."""
-
-        polls = 0
-        items = 3
-        state = PlaybackState.PLAYING
-        started = False
-
-        @property
-        def current_index(self) -> int:
-            return 2 if self.polls < 4 else 4
-
-        @property
-        def elapsed_time(self) -> float:
-            return float(self.polls * 10)
-
-    class DummyPlayers:
-        def get_player(self, player_id: str) -> Any:
-            return object()
-
-    player_queues = RecordingPlayerQueues(BusyQueue())
-
-    class DummyMass:
-        def __init__(self) -> None:
-            self.players = DummyPlayers()
-            self.player_queues = player_queues
-
-    mass = DummyMass()
-    runtime = watchdog_runtime_cls()
     _set_runtime_mass(runtime, mass)
-    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
+    session = SessionState(session_id="s1", station_id="st")
     runtime._sessions[session.session_id] = session
 
-    await asyncio.wait_for(runtime._run_dynamic_mode(session, _watchdog_station()), timeout=10.0)
+    task = asyncio.create_task(runtime._run_session(session.session_id, _show_station()))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
 
-    assert player_queues.set_shuffle_calls == [("living_room", False)]
-    assert player_queues.call_order.index("set_shuffle") < player_queues.call_order.index(
-        "play_media"
-    )
+    # the show is on air: the session must stay running, exactly like start_run's
+    # max-concurrent-runs and station-already-active guards require
+    assert session.status == "running"
+    assert not task.done()
 
+    # this is what stop_run does to end a run mid-show
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
-async def test_dynamic_mode_ends_run_when_user_stops_the_queue(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """End the run right away when the target queue is stopped after playing."""
-    monkeypatch.setattr(
-        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
-        30.0,
-    )
-    watchdog_runtime_cls, stepping_queues_cls = _make_watchdog_runtime_classes()
-
-    class StoppedQueue:
-        """Queue that plays index 0 and is then stopped by the user."""
-
-        polls = 0
-        elapsed_time = 12.0
-
-        @property
-        def state(self) -> PlaybackState:
-            return PlaybackState.PLAYING if self.polls < 4 else PlaybackState.IDLE
-
-        @property
-        def current_index(self) -> int:
-            return 0
-
-    class DummyPlayers:
-        def get_player(self, player_id: str) -> Any:
-            return object()
-
-    class DummyMass:
-        players = DummyPlayers()
-        player_queues = stepping_queues_cls(StoppedQueue())
-
-    runtime = watchdog_runtime_cls()
-    _set_runtime_mass(runtime, DummyMass())
-    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
-    runtime._sessions[session.session_id] = session
-
-    result = await asyncio.wait_for(
-        runtime._run_dynamic_mode(session, _watchdog_station()), timeout=10.0
-    )
-
-    assert result["ended_reason"] == "queue_stopped"
-    # only the first batch was queued; the run did not wait out the stall timeout
-    assert result["queued_tracks"] == 2
+    assert session.status == "stopped"
+    assert unsubscribed
 
 
-async def test_dynamic_mode_ignores_idle_queue_before_playback_starts(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Do not treat a not-yet-started queue as a user stop."""
-    monkeypatch.setattr(
-        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
-        30.0,
-    )
-    watchdog_runtime_cls, _ = _make_watchdog_runtime_classes()
+async def test_run_show_binds_the_session_to_the_target_queue() -> None:
+    """Record the queue a show plays on so stopping the show can stop it."""
+    runtime = ShowRuntime()
+    _set_runtime_mass(runtime, _show_mass_stub())
+    session = SessionState(session_id="s1", station_id="st")
 
-    class SlowStartQueue:
-        """Queue that stays idle for a few polls before playback starts."""
-
-        polls = 0
-        elapsed_time = 0.0
-
-        @property
-        def state(self) -> PlaybackState:
-            return PlaybackState.IDLE if self.polls < 3 else PlaybackState.PLAYING
-
-        @property
-        def current_index(self) -> int | None:
-            return None if self.polls < 3 else 2
-
-    class DummyPlayers:
-        def get_player(self, player_id: str) -> Any:
-            return object()
-
-    class DummyMass:
-        players = DummyPlayers()
-        player_queues = RecordingPlayerQueues(SlowStartQueue())
-
-    runtime = watchdog_runtime_cls()
-    _set_runtime_mass(runtime, DummyMass())
-    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
-    runtime._sessions[session.session_id] = session
-
-    result = await asyncio.wait_for(
-        runtime._run_dynamic_mode(session, _watchdog_station()), timeout=10.0
-    )
-
-    assert result["queued_tracks"] == 3
-    assert result["ended_reason"] == "source_exhausted"
-
-
-async def test_dynamic_mode_binds_the_session_to_the_target_queue(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Record the queue a dynamic run plays on so stopping the show can stop it."""
-    monkeypatch.setattr(
-        "music_assistant.providers.ai_radio.runtime.DEFAULT_DYNAMIC_STALL_TIMEOUT_SECONDS",
-        30.0,
-    )
-    watchdog_runtime_cls, stepping_queues_cls = _make_watchdog_runtime_classes()
-
-    class PlayingQueue:
-        polls = 0
-        items = 4
-        elapsed_time = 1.0
-        state = PlaybackState.PLAYING
-
-        @property
-        def current_index(self) -> int:
-            return 9
-
-    class DummyPlayers:
-        def get_player(self, player_id: str) -> Any:
-            return object()
-
-    class DummyMass:
-        players = DummyPlayers()
-        player_queues = stepping_queues_cls(PlayingQueue())
-
-    runtime = watchdog_runtime_cls()
-    _set_runtime_mass(runtime, DummyMass())
-    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
-    runtime._sessions[session.session_id] = session
-
-    await asyncio.wait_for(runtime._run_dynamic_mode(session, _watchdog_station()), timeout=10.0)
+    await runtime._run_show(session, _show_station())
 
     assert session.queue_id == "living_room"
 
@@ -1591,13 +1351,11 @@ async def test_run_session_reports_a_queue_stop_as_stopped() -> None:
             self.logger = logging.getLogger("tests.ai_radio.runtime.queue_stopped")
             self._sessions: dict[str, SessionState] = {}
 
-        async def _run_dynamic_mode(
-            self, session: SessionState, station: dict[str, Any]
-        ) -> dict[str, Any]:
-            return {"mode": "dynamic", "ended_reason": "queue_stopped"}
+        async def _run_show(self, session: SessionState, station: dict[str, Any]) -> dict[str, Any]:
+            return {"ended_reason": "queue_stopped"}
 
     runtime = QueueStoppedRuntime()
-    session = SessionState(session_id="s1", station_id="st", mode="dynamic")
+    session = SessionState(session_id="s1", station_id="st")
     runtime._sessions[session.session_id] = session
 
     await runtime._run_session(session.session_id, {"id": "st"})

--- a/tests/providers/ai_radio/test_storage.py
+++ b/tests/providers/ai_radio/test_storage.py
@@ -372,15 +372,7 @@ def test_normalize_general_replaces_null_instructions_with_default() -> None:
     assert result["instructions"] == DEFAULT_LLM_INSTRUCTIONS
 
 
-@pytest.mark.parametrize(
-    "field",
-    [
-        "max_duration_minutes",
-        "dynamic_batch_size",
-        "dynamic_poll_seconds",
-        "dynamic_prefetch_remaining_tracks",
-    ],
-)
+@pytest.mark.parametrize("field", ["max_duration_minutes"])
 def test_normalize_station_rejects_non_numeric_numeric_field(field: str) -> None:
     """Reject station numeric fields containing non-numeric values."""
     storage = DummyStorage()


### PR DESCRIPTION
# What does this implement/fix?

AI Radio generated every host segment (LLM script + TTS audio) when a show *started*. That broke playback in two ways: Home Assistant's `tts_proxy` URLs expire ~5 minutes after last use, so clips further into a show 404'd by the time they aired; and time-sensitive content (weather, timestamps) described the moment the show started, not the moment the clip played.

Segments are now generated just-in-time: each clip is enqueued as a lightweight sound-effect item carrying its prompt, and the full weather→LLM→TTS chain runs when Music Assistant asks for the clip's stream details — roughly 60 seconds before it airs, inside the normal pre-buffer window. Measured on a live setup: worst-case render 20s against the 60s window.

- generate each segment at airtime instead of run start: prompts are stamped on the queue items (restart-safe), `<timestamp>`/`<weather_*>` placeholders resolve at render, the generated script is cached on the item and only the TTS URL is re-minted on a re-resolve
- plan and enqueue the whole show in one pass; the batch loop, poll interval, prefetch tuning and stall watchdog are gone, and the queue shows the complete show immediately
- end shows via queue events instead of polling: stopping the queue ends the session, playing it out completes it, pause keeps it on air, a removed player ends it, and a show whose playback never starts fails after a timeout
- skipped segments (LLM/TTS failure) no longer kill the run: the music keeps playing and the session reports a skip count
- remove the "generate as playlist" mode: a saved playlist cannot hold just-in-time content, and its URLs were dead on arrival
- pre-buffer sound effects like tracks, so clips get the same head start (also lets the loudness analyzer measure them)

Behaviour changes to note: playback stops at the end of a show instead of drifting into autoplay (a run owns its queue outright, per #5130), and `ai_radio/start` no longer takes `mode` or `dynamic_batch_size_override`. Stations drop their now-unused batch tuning fields on next save.

**Related issue (if applicable):**

- supersedes the mechanism of #5173: host instructions and weather config are read live at render time, so edits apply from the next clip; per-segment prompt/flow edits apply on the next show start, which JIT makes cheap (~12s to first audio)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked: music-assistant/frontend#2263
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

Verified end to end on a live setup (HA TTS + ai_task): clips render ~60s before airing, weather segments describe the current hour, a clip 10+ minutes into a show plays without a 404, stop/pause/play-out semantics hold, and a mid-show server restart resumes rendering from the restored queue.

