### PR TITLE
Ensure login providers endpoint doesn't crash when HA provider has no config URL

### DIFF
--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -10,7 +10,7 @@ import secrets
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 from sqlite3 import IntegrityError, OperationalError
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import jwt as pyjwt
 from music_assistant_models.auth import (
@@ -53,6 +53,7 @@ from music_assistant.helpers.jwt_auth import JWTHelper
 
 if TYPE_CHECKING:
     from music_assistant.controllers.webserver import WebserverController
+    from music_assistant.providers.hass import HomeAssistantProvider
 
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.auth")
 
@@ -1793,10 +1794,9 @@ class AuthenticationManager:
                 break
 
         if ha_provider:
-            # the connection URL is collected by the HA provider's setup flow
-            # (with fallback to a config entry value for add-on installs)
-            ha_url = ha_provider.get_setup_value("url")
-            if not isinstance(ha_url, str) or not ha_url:
+            ha_provider = cast("HomeAssistantProvider", ha_provider)
+            ha_url = ha_provider.url
+            if not ha_url:
                 self.logger.warning(
                     "Home Assistant provider has no URL configured, "
                     "Home Assistant OAuth login is not available"
@@ -1827,10 +1827,9 @@ class AuthenticationManager:
         if ha_provider:
             # HA provider exists and is available - ensure OAuth provider is registered
             if "homeassistant" not in self.login_providers:
-                # the connection URL is collected by the HA provider's setup flow
-                # (with fallback to a config entry value for add-on installs)
-                ha_url = ha_provider.get_setup_value("url")
-                if not isinstance(ha_url, str) or not ha_url:
+                ha_provider = cast("HomeAssistantProvider", ha_provider)
+                ha_url = ha_provider.url
+                if not ha_url:
                     # missing URL must never break the login providers endpoint,
                     # simply leave the HA OAuth provider unregistered
                     self.logger.debug(

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -1793,9 +1793,15 @@ class AuthenticationManager:
                 break
 
         if ha_provider:
-            # Get URL from the HA provider config
-            ha_url = ha_provider.config.get_value("url")
-            assert isinstance(ha_url, str)
+            # the connection URL is collected by the HA provider's setup flow
+            # (with fallback to a config entry value for add-on installs)
+            ha_url = ha_provider.get_setup_value("url")
+            if not isinstance(ha_url, str) or not ha_url:
+                self.logger.warning(
+                    "Home Assistant provider has no URL configured, "
+                    "Home Assistant OAuth login is not available"
+                )
+                return
             ha_config: HomeAssistantProviderConfig = {"ha_url": ha_url}
             self.login_providers["homeassistant"] = HomeAssistantOAuthProvider(
                 self.mass, "homeassistant", ha_config
@@ -1821,9 +1827,17 @@ class AuthenticationManager:
         if ha_provider:
             # HA provider exists and is available - ensure OAuth provider is registered
             if "homeassistant" not in self.login_providers:
-                # Get URL from the HA provider config
-                ha_url = ha_provider.config.get_value("url")
-                assert isinstance(ha_url, str)
+                # the connection URL is collected by the HA provider's setup flow
+                # (with fallback to a config entry value for add-on installs)
+                ha_url = ha_provider.get_setup_value("url")
+                if not isinstance(ha_url, str) or not ha_url:
+                    # missing URL must never break the login providers endpoint,
+                    # simply leave the HA OAuth provider unregistered
+                    self.logger.debug(
+                        "Home Assistant provider has no URL configured, "
+                        "Home Assistant OAuth login is not available"
+                    )
+                    return
                 ha_config: HomeAssistantProviderConfig = {"ha_url": ha_url}
                 self.login_providers["homeassistant"] = HomeAssistantOAuthProvider(
                     self.mass, "homeassistant", ha_config

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -193,6 +193,14 @@ class HomeAssistantProvider(PluginProvider):
     _wanted_controls: dict[str, _ControlCapabilities] | None = None
     _control_reconcile_lock: asyncio.Lock
 
+    @property
+    def url(self) -> str | None:
+        """Return the configured Home Assistant URL, or None if not configured."""
+        url = self.get_setup_value(CONF_URL)
+        if isinstance(url, str) and url:
+            return url
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """
         Return the (options) config entries for the Home Assistant provider.

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -723,11 +723,10 @@ class _FakeHassProvider:
     def __init__(self, url: str | None) -> None:
         self._url = url
 
-    def get_setup_value(self, key: str, default: Any = None) -> Any:
-        """Return the setup flow value for the given key."""
-        if key == "url":
-            return self._url if self._url is not None else default
-        return default
+    @property
+    def url(self) -> str | None:
+        """Return the configured Home Assistant URL, or None if not configured."""
+        return self._url
 
 
 async def test_get_login_providers_with_ha_provider(

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -714,6 +714,58 @@ async def test_get_login_providers(auth_manager: AuthenticationManager) -> None:
     assert any(p["provider_id"] == "builtin" for p in providers)
 
 
+class _FakeHassProvider:
+    """Minimal stand-in for the Home Assistant provider."""
+
+    domain = "hass"
+    available = True
+
+    def __init__(self, url: str | None) -> None:
+        self._url = url
+
+    def get_setup_value(self, key: str, default: Any = None) -> Any:
+        """Return the setup flow value for the given key."""
+        if key == "url":
+            return self._url if self._url is not None else default
+        return default
+
+
+async def test_get_login_providers_with_ha_provider(
+    auth_manager: AuthenticationManager, mass_minimal: MusicAssistant
+) -> None:
+    """
+    Test that the HA OAuth login provider is registered when the HA provider has a URL.
+
+    :param auth_manager: AuthenticationManager instance.
+    :param mass_minimal: Minimal MusicAssistant instance.
+    """
+    mass_minimal._providers["hass"] = _FakeHassProvider("http://homeassistant.local:8123")  # type: ignore[assignment]
+
+    providers = await auth_manager.get_login_providers()
+
+    assert any(p["provider_id"] == "homeassistant" for p in providers)
+
+
+async def test_get_login_providers_ha_provider_without_url(
+    auth_manager: AuthenticationManager, mass_minimal: MusicAssistant
+) -> None:
+    """
+    Test that a HA provider without a URL does not break the login providers endpoint.
+
+    Regression test for the HA provider storing its URL in setup data instead of
+    config: builtin login must remain available and the endpoint must not raise.
+
+    :param auth_manager: AuthenticationManager instance.
+    :param mass_minimal: Minimal MusicAssistant instance.
+    """
+    mass_minimal._providers["hass"] = _FakeHassProvider(None)  # type: ignore[assignment]
+
+    providers = await auth_manager.get_login_providers()
+
+    assert any(p["provider_id"] == "builtin" for p in providers)
+    assert not any(p["provider_id"] == "homeassistant" for p in providers)
+
+
 async def test_create_user_with_api(auth_manager: AuthenticationManager) -> None:
     """
     Test creating user via API command.


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Fixes a bug from the setup flow refactor that made login impossible on standalone installs with a Home Assistant provider configured. The `auth/providers` endpoint crashed with an HTTP 500 before the login form could load, blocking all login methods including username/password.

The HA provider now keeps its URL in setup data, but the auth controller still reads it from provider config. On standalone installs that returns `None`, tripping a bare `assert`. The fix reads the URL with `get_setup_value("url")`, which the hass provider itself already uses and which falls back to config entries, so add-on installs are unaffected. If no URL is available the HA OAuth option is skipped instead of raising, so built-in login always stays reachable.

I have not reproduced this live on a standalone install, but the traceback in the issue points at this exact assert, and I've added regression tests for both the missing URL case and the normal case.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5987

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
