### PR TITLE
Run the Test workflow on merge groups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - stable
       - dev
+  merge_group:
   workflow_dispatch:
   workflow_call:
     inputs:
@@ -29,6 +30,7 @@ env:
 
 concurrency:
   group: test-${{ github.event_name }}-${{ github.event.pull_request.number || inputs.ref || github.ref }}
+  # Not merge_group: a cancelled run reports no check, hanging the queue entry until timeout.
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
@@ -49,7 +51,8 @@ jobs:
       # On PRs, run only the tests affected by the changed files: a PR touching a
       # single provider runs just that provider's tests. A change to shared code
       # (incl. translations under music_assistant/), dependencies or the CI itself
-      # runs the full suite, as do pushes, manual runs and reusable-workflow calls.
+      # runs the full suite, as do pushes, merge groups, manual runs and
+      # reusable-workflow calls.
       # PRs that only touch docs or other non-code files run nothing.
       - name: Determine test scope
         id: scope


### PR DESCRIPTION
# What does this implement/fix?

The `dev` branch has a merge queue rule in its ruleset, with `lint` and `test` as required status checks. The merge queue re-runs those checks against the merge group — a temporary `gh-readonly-queue/dev/...` ref containing current `dev` plus the queued pull requests — but no workflow in this repo subscribes to the `merge_group` event, so neither check ever reports there.

The result is that any pull request added to the queue sits at "awaiting checks" and is ejected when the ruleset's 60 minute `check_response_timeout_minutes` expires. It never merges, and nothing explains why. The queue has been configured for months without a single `merge_group` workflow run, because the button had not been used until today.

`changes` already falls back to `mode=full` for any non-`pull_request` event, so a merge group runs the whole suite — correct here, since a group has no single pull request to scope tests to. `provider-scope` stays gated on `pull_request` (it needs PR context and is advisory only); it is not a required check, so skipping it does not block the queue.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
