### PR TITLE
Stop logging spurious errors when an artwork request is cancelled

### DIFF
--- a/music_assistant/helpers/colors.py
+++ b/music_assistant/helpers/colors.py
@@ -270,7 +270,14 @@ async def get_palette(
         task_id=f"palette.{key}",
         abort_existing=False,
     )
-    return await asyncio.shield(task)
+    # wait for the shared extraction instead of awaiting it directly: a caller awaiting a
+    # task holds it as its fut_waiter, so cancelling that caller would cancel the
+    # extraction for every other caller too. asyncio.shield achieves the same, but as of
+    # Python 3.14 a cancelled caller makes it report the extraction's exception through
+    # loop.call_exception_handler, even when another caller already handled it.
+    if not task.done():
+        await asyncio.wait((task,))
+    return task.result()
 
 
 async def invalidate_cached_palette(mass: MusicAssistant, provider: str, path_or_url: str) -> None:

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -325,7 +325,14 @@ async def get_image_data(
         task_id=f"imgsrc.{cache_key}",
         abort_existing=False,
     )
-    return await asyncio.shield(task)
+    # wait for the shared fetch instead of awaiting it directly: a caller awaiting a task
+    # holds it as its fut_waiter, so cancelling that caller would cancel the fetch for
+    # every other caller too. asyncio.shield achieves the same, but as of Python 3.14 a
+    # cancelled caller makes it report the fetch's exception through
+    # loop.call_exception_handler, even when another caller already handled it.
+    if not task.done():
+        await asyncio.wait((task,))
+    return task.result()
 
 
 async def _resolve_own_imageproxy_url(mass: MusicAssistant, url: str) -> tuple[str, str] | None:
@@ -632,7 +639,10 @@ async def _get_image_thumb(
         task_id=f"thumb.{cache_filename}",
         abort_existing=False,
     )
-    thumb_data = await asyncio.shield(task)
+    # wait for the shared generation rather than awaiting it: see get_image_data
+    if not task.done():
+        await asyncio.wait((task,))
+    thumb_data = task.result()
     _put_in_memory_cache(cache_filename, thumb_data)
     return thumb_data, cache_filepath
 

--- a/tests/helpers/test_colors.py
+++ b/tests/helpers/test_colors.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import io
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
+import pytest
 from aiohttp.client_exceptions import ClientError
 from PIL import Image, ImageDraw
 
@@ -21,10 +23,9 @@ from music_assistant.helpers.colors import (
     get_palette,
 )
 from music_assistant.helpers.images import invalidate_cached_image
+from tests.common import collect_loop_errors
 
 if TYPE_CHECKING:
-    import pytest
-
     from music_assistant.mass import MusicAssistant
 
 _MIN_CONTRAST = 4.5
@@ -138,6 +139,40 @@ def test_extract_palette_end_to_end() -> None:
     assert palette.primary is not None
     if palette.background_dark is not None:
         assert _contrast_ratio(palette.background_dark, (255, 255, 255)) >= _MIN_CONTRAST
+
+
+async def test_cancelled_caller_of_a_failing_extraction_logs_no_loop_error(
+    mass_minimal: MusicAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Palette extraction failing after its caller gave up is not reported to the loop handler."""
+    # mass_minimal constructs the cache controller without initializing it
+    cache_config = await mass_minimal.config.get_core_config(mass_minimal.cache.domain)
+    await mass_minimal.cache.setup(cache_config)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    extraction: list[asyncio.Task[Any]] = []
+
+    async def failing_source(_mass: MusicAssistant, path_or_url: str, _provider: str) -> bytes:
+        current = asyncio.current_task()
+        assert current is not None
+        extraction.append(current)
+        entered.set()
+        await release.wait()
+        raise PermissionError(f"Permission denied: {path_or_url}")
+
+    monkeypatch.setattr("music_assistant.helpers.colors.get_image_data", failing_source)
+    with collect_loop_errors() as reported:
+        caller = asyncio.create_task(get_palette(mass_minimal, "/some/image.png", "builtin"))
+        await entered.wait()
+        caller.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await caller
+        # only fail the extraction once the cancellation is fully processed
+        release.set()
+        await asyncio.wait(extraction)
+
+    assert isinstance(extraction[0].exception(), PermissionError)
+    assert reported == []
 
 
 async def test_get_palette_tolerates_unavailable_image(

--- a/tests/helpers/test_images.py
+++ b/tests/helpers/test_images.py
@@ -10,7 +10,7 @@ import time
 from base64 import b64encode
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -34,6 +34,7 @@ from music_assistant.helpers.images import (
 )
 from music_assistant.models.metadata_provider import MetadataProvider
 from music_assistant.models.player_provider import PlayerProvider
+from tests.common import collect_loop_errors
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -180,6 +181,72 @@ async def test_concurrent_requests_share_one_fetch(
     results = await asyncio.gather(*tasks)
     assert results == [b"image-bytes"] * 3
     assert calls == ["/some/image.png"]
+
+
+async def test_cancelled_caller_of_a_failing_fetch_logs_no_loop_error(
+    mass_minimal: MusicAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A source fetch failing after a caller gave up is not reported to the loop handler."""
+    release = asyncio.Event()
+    calls: list[str] = []
+
+    async def failing_fetch(
+        _mass: MusicAssistant, path_or_url: str, _provider: str, _depth: int
+    ) -> tuple[bytes, bool]:
+        calls.append(path_or_url)
+        await release.wait()
+        raise FileNotFoundError(f"Image not found: {path_or_url}")
+
+    monkeypatch.setattr(images, "_fetch_source_image", failing_fetch)
+    with collect_loop_errors() as reported:
+        task_a = asyncio.create_task(get_image_data(mass_minimal, "/some/image.png", "builtin"))
+        task_b = asyncio.create_task(get_image_data(mass_minimal, "/some/image.png", "builtin"))
+        # let both callers await the (same) in-flight fetch, then cancel one
+        await asyncio.sleep(0)
+        task_a.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task_a
+        # release the fetch only once the cancellation is fully processed, so the
+        # failure reliably lands after the giving-up caller is gone
+        release.set()
+        with pytest.raises(FileNotFoundError):
+            await task_b
+
+    assert calls == ["/some/image.png"]
+    assert reported == []
+
+
+async def test_cancelled_caller_of_a_failing_thumb_logs_no_loop_error(
+    mass_minimal: MusicAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Thumbnail generation failing after its caller gave up is not reported either."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    generation: list[asyncio.Task[Any]] = []
+
+    async def failing_source(_mass: MusicAssistant, path_or_url: str, _provider: str) -> bytes:
+        current = asyncio.current_task()
+        assert current is not None
+        generation.append(current)
+        entered.set()
+        await release.wait()
+        raise FileNotFoundError(f"Image not found: {path_or_url}")
+
+    monkeypatch.setattr(images, "get_image_data", failing_source)
+    with collect_loop_errors() as reported:
+        caller = asyncio.create_task(
+            get_image_thumb(mass_minimal, "/some/image.png", 256, "builtin")
+        )
+        await entered.wait()
+        caller.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await caller
+        # only fail the generation once the cancellation is fully processed
+        release.set()
+        await asyncio.wait(generation)
+
+    assert isinstance(generation[0].exception(), FileNotFoundError)
+    assert reported == []
 
 
 async def test_data_uri_is_decoded_without_caching(


### PR DESCRIPTION
# What does this implement/fix?

Whenever a client walks away from an artwork request (a page closing while covers are still loading, the app backgrounding), the server could log a scary `ERROR: Error doing task: ... exception in shielded future` with a full traceback — even though nothing actually went wrong that we hadn't already handled.

Image fetches, thumbnail generation and colour palette extraction all share one piece of work between everyone asking for the same artwork, so that one slow request does not become ten. On Python 3.14 the mechanism used to protect that shared work from a cancelled request started reporting its failure a second time, straight into the logs. The image proxy and the palette endpoint are the busiest places where requests get cancelled, so this was a frequent source of confusing errors.

Same fix as #5288 / #5295, now applied to the artwork caches.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Wait for the shared work instead of shielding it in the image, thumbnail and palette caches
- Added tests covering all three, each verified to fail without the fix

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
