### PR TITLE
Notice when AI Radio loses its AI or text-to-speech engine

### DIFF
--- a/music_assistant/providers/ai_radio/constants.py
+++ b/music_assistant/providers/ai_radio/constants.py
@@ -15,7 +15,7 @@ CONF_WEATHER_COUNTRY = "weather_country"
 ENGINE_DISCOVERY_TIMEOUT = 30
 
 # grace period for an engine that disappears while AI Radio is loaded. Generous enough
-# to sit out a Home Assistant restart, so a running show survives it untouched
+# to sit out a Home Assistant restart, so a running show is not torn down for it
 ENGINE_RECHECK_GRACE = 300
 
 # how long to wait before reloading after an engine stayed missing, matching the

--- a/music_assistant/providers/ai_radio/constants.py
+++ b/music_assistant/providers/ai_radio/constants.py
@@ -16,6 +16,10 @@ CONF_WEATHER_COUNTRY = "weather_country"
 # so that a plugin reload does not unload AI Radio for the blink it is gone
 ENGINE_DISCOVERY_TIMEOUT = 30
 
+# how long to wait before reloading after an engine stayed missing, matching the
+# cadence the load path uses for its own retries
+ENGINE_RETRY_DELAY = 120
+
 TRANSLATION_OWNER = "provider.ai_radio"
 
 DEFAULT_LLM_INSTRUCTIONS = (

--- a/music_assistant/providers/ai_radio/constants.py
+++ b/music_assistant/providers/ai_radio/constants.py
@@ -11,10 +11,12 @@ CONF_WEATHER_CITY = "weather_city"
 CONF_WEATHER_COUNTRY = "weather_country"
 
 # providers load concurrently, so the plugin supplying the engines may still be
-# loading when AI Radio initializes: wait this long for it before giving up.
-# doubles as the grace period when an engine disappears while AI Radio is loaded,
-# so that a plugin reload does not unload AI Radio for the blink it is gone
+# loading when AI Radio initializes: wait this long for it before giving up
 ENGINE_DISCOVERY_TIMEOUT = 30
+
+# grace period for an engine that disappears while AI Radio is loaded. Generous enough
+# to sit out a Home Assistant restart, so a running show survives it untouched
+ENGINE_RECHECK_GRACE = 300
 
 # how long to wait before reloading after an engine stayed missing, matching the
 # cadence the load path uses for its own retries

--- a/music_assistant/providers/ai_radio/constants.py
+++ b/music_assistant/providers/ai_radio/constants.py
@@ -11,7 +11,9 @@ CONF_WEATHER_CITY = "weather_city"
 CONF_WEATHER_COUNTRY = "weather_country"
 
 # providers load concurrently, so the plugin supplying the engines may still be
-# loading when AI Radio initializes: wait this long for it before giving up
+# loading when AI Radio initializes: wait this long for it before giving up.
+# doubles as the grace period when an engine disappears while AI Radio is loaded,
+# so that a plugin reload does not unload AI Radio for the blink it is gone
 ENGINE_DISCOVERY_TIMEOUT = 30
 
 TRANSLATION_OWNER = "provider.ai_radio"

--- a/music_assistant/providers/ai_radio/provider.py
+++ b/music_assistant/providers/ai_radio/provider.py
@@ -402,7 +402,7 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioRenderMixin, AIRadioStorageMix
 
     async def _on_providers_updated(self, _event: MassEvent) -> None:
         """Re-check the engine selection whenever the set of loaded providers changes."""
-        # engines going away with an instance that is itself going away needs no action
+        # nothing to watch when this instance, or the whole server, is shutting down anyway
         if self._unloading or self.mass.closing:
             return
         if self._engine_recheck_task and not self._engine_recheck_task.done():

--- a/music_assistant/providers/ai_radio/provider.py
+++ b/music_assistant/providers/ai_radio/provider.py
@@ -36,6 +36,7 @@ from .storage import AIRadioStorageMixin
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
+    from music_assistant_models.event import MassEvent
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -64,6 +65,8 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioRenderMixin, AIRadioStorageMix
         self._station_lock = asyncio.Lock()
         self._session_lock = asyncio.Lock()
         self._unregister_handles: list[Callable[[], None]] = []
+        self._unloading = False
+        self._engine_recheck_task: asyncio.Task[None] | None = None
         self._sessions: dict[str, SessionState] = {}
         self._stations: dict[str, dict[str, Any]] = {}
         self._sections: dict[str, dict[str, Any]] = {}
@@ -117,13 +120,19 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioRenderMixin, AIRadioStorageMix
             self._unregister_handles.append(
                 self.mass.register_api_command(command, handler, required_scope=required_scope)
             )
+        self._unregister_handles.append(
+            self.mass.subscribe(self._on_providers_updated, EventType.PROVIDERS_UPDATED)
+        )
         self.logger.info(
             "AI Radio API routes registered (%d handlers)",
-            len(self._unregister_handles),
+            len(api_handlers),
         )
 
     async def unload(self, is_removed: bool = False) -> None:
         """Handle close/cleanup of the provider."""
+        self._unloading = True
+        if self._engine_recheck_task and not self._engine_recheck_task.done():
+            self._engine_recheck_task.cancel()
         cancelled = 0
         for session in self._sessions.values():
             if session.task and not session.task.done():
@@ -387,6 +396,30 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioRenderMixin, AIRadioStorageMix
                 translation_owner=TRANSLATION_OWNER,
             )
         return None
+
+    async def _on_providers_updated(self, _event: MassEvent) -> None:
+        """Re-check the engine selection whenever the set of loaded providers changes."""
+        # during (server) shutdown every provider unloads, so the engines disappearing
+        # along with their plugin is not something the user has to act on
+        if self._unloading or self.mass.closing:
+            return
+        if self._engine_recheck_task and not self._engine_recheck_task.done():
+            return
+        if await self._engine_selection_error() is None:
+            return
+        self._engine_recheck_task = self.mass.create_task(self._unload_when_engines_stay_missing())
+
+    async def _unload_when_engines_stay_missing(self) -> None:
+        """Unload with an error when a vanished engine does not come back in time."""
+        # a plugin reload takes its engines with it for a moment, so reuse the bounded
+        # wait from the load path instead of tearing the provider down right away
+        try:
+            await self._wait_for_engines()
+        except SetupFailedError as err:
+            if self._unloading or self.mass.closing:
+                return
+            self.logger.warning("%s - unloading the provider", err)
+            self.unload_with_error(err)
 
     def _prune_finished_sessions(self) -> None:
         """Drop the oldest finished sessions beyond the retention limit."""

--- a/music_assistant/providers/ai_radio/provider.py
+++ b/music_assistant/providers/ai_radio/provider.py
@@ -24,6 +24,7 @@ from .constants import (
     CONF_TTS_ENGINE,
     DEFAULT_MAX_CONCURRENT_RUNS,
     ENGINE_DISCOVERY_TIMEOUT,
+    ENGINE_RETRY_DELAY,
     MAX_FINISHED_SESSIONS,
     SUPPORTED_FEATURES,
     TRANSLATION_OWNER,
@@ -399,8 +400,6 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioRenderMixin, AIRadioStorageMix
 
     async def _on_providers_updated(self, _event: MassEvent) -> None:
         """Re-check the engine selection whenever the set of loaded providers changes."""
-        # during (server) shutdown every provider unloads, so the engines disappearing
-        # along with their plugin is not something the user has to act on
         if self._unloading or self.mass.closing:
             return
         if self._engine_recheck_task and not self._engine_recheck_task.done():
@@ -416,10 +415,22 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioRenderMixin, AIRadioStorageMix
         try:
             await self._wait_for_engines()
         except SetupFailedError as err:
+            # a shutdown (or our own unload) landing during the wait can surface as the
+            # timeout instead of a cancellation, and needs no error for the user
             if self._unloading or self.mass.closing:
                 return
             self.logger.warning("%s - unloading the provider", err)
             self.unload_with_error(err)
+            # unloading records the error but arms no retry of its own, so schedule the
+            # reload that picks the provider back up once the engines return. The load
+            # path's task id owns the timer, so any earlier load cancels this one.
+            self.mass.call_later(
+                ENGINE_RETRY_DELAY,
+                self.mass.load_provider,
+                self.instance_id,
+                allow_retry=True,
+                task_id=f"load_provider_{self.instance_id}",
+            )
 
     def _prune_finished_sessions(self) -> None:
         """Drop the oldest finished sessions beyond the retention limit."""

--- a/music_assistant/providers/ai_radio/provider.py
+++ b/music_assistant/providers/ai_radio/provider.py
@@ -24,6 +24,7 @@ from .constants import (
     CONF_TTS_ENGINE,
     DEFAULT_MAX_CONCURRENT_RUNS,
     ENGINE_DISCOVERY_TIMEOUT,
+    ENGINE_RECHECK_GRACE,
     ENGINE_RETRY_DELAY,
     MAX_FINISHED_SESSIONS,
     SUPPORTED_FEATURES,
@@ -353,10 +354,11 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioRenderMixin, AIRadioStorageMix
         sessions = sorted(self._sessions.values(), key=lambda item: item.created_at, reverse=True)
         return {"sessions": [session.as_dict() for session in sessions]}
 
-    async def _wait_for_engines(self) -> None:
+    async def _wait_for_engines(self, timeout: float | None = None) -> None:
         """
         Wait (bounded) until a concrete AI and TTS engine are selected for this instance.
 
+        :param timeout: How long to wait, defaulting to the engine discovery timeout.
         :raises SetupFailedError: When either engine is still unavailable at the deadline.
         """
         engines_changed = asyncio.Event()
@@ -364,7 +366,7 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioRenderMixin, AIRadioStorageMix
             lambda _event: engines_changed.set(), EventType.PROVIDERS_UPDATED
         )
         try:
-            async with asyncio.timeout(ENGINE_DISCOVERY_TIMEOUT):
+            async with asyncio.timeout(ENGINE_DISCOVERY_TIMEOUT if timeout is None else timeout):
                 while (error := await self._engine_selection_error()) is not None:
                     await engines_changed.wait()
                     # clearing only after the wait keeps an update that lands during the
@@ -400,6 +402,7 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioRenderMixin, AIRadioStorageMix
 
     async def _on_providers_updated(self, _event: MassEvent) -> None:
         """Re-check the engine selection whenever the set of loaded providers changes."""
+        # engines going away with an instance that is itself going away needs no action
         if self._unloading or self.mass.closing:
             return
         if self._engine_recheck_task and not self._engine_recheck_task.done():
@@ -410,10 +413,10 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioRenderMixin, AIRadioStorageMix
 
     async def _unload_when_engines_stay_missing(self) -> None:
         """Unload with an error when a vanished engine does not come back in time."""
-        # a plugin reload takes its engines with it for a moment, so reuse the bounded
-        # wait from the load path instead of tearing the provider down right away
+        # a plugin reload or a Home Assistant restart takes its engines with it for a
+        # while, so wait that out instead of tearing the provider down right away
         try:
-            await self._wait_for_engines()
+            await self._wait_for_engines(ENGINE_RECHECK_GRACE)
         except SetupFailedError as err:
             # a shutdown (or our own unload) landing during the wait can surface as the
             # timeout instead of a cancellation, and needs no error for the user
@@ -422,8 +425,8 @@ class AIRadioProvider(AIRadioRuntimeMixin, AIRadioRenderMixin, AIRadioStorageMix
             self.logger.warning("%s - unloading the provider", err)
             self.unload_with_error(err)
             # unloading records the error but arms no retry of its own, so schedule the
-            # reload that picks the provider back up once the engines return. The load
-            # path's task id owns the timer, so any earlier load cancels this one.
+            # reload that picks the provider back up once the engines return. Armed under
+            # the load path's task id, so any (re)load starting before it fires cancels it.
             self.mass.call_later(
                 ENGINE_RETRY_DELAY,
                 self.mass.load_provider,

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -1028,7 +1028,8 @@ class HomeAssistantProvider(PluginProvider):
         if ai_engines:
             self._supported_features.add(ProviderFeature.AI_QUERY)
         # the entities can come and go without this provider (un)loading, so tell the
-        # consumers of our engines that their selection may need re-evaluating.
+        # consumers of our engines that their selection may need re-evaluating. They read
+        # the lists straight from their handler, so this has to stay below the assignments.
         # during startup the load itself signals once we are done.
         if changed and self._startup_complete:
             self.mass.signal_event(EventType.PROVIDERS_UPDATED, data=self.mass.get_providers())

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -25,6 +25,7 @@ from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import (
     ConfigEntryType,
     ContentType,
+    EventType,
     MediaType,
     ProviderFeature,
     StreamType,
@@ -1017,6 +1018,7 @@ class HomeAssistantProvider(PluginProvider):
                 ai_engines.append(AIEngine(id=entity_id, name=name, provider=self))
         tts_engines.sort(key=lambda engine: engine.name)
         ai_engines.sort(key=lambda engine: engine.name)
+        changed = (self._tts_engines, self._ai_engines) != (tts_engines, ai_engines)
         self._tts_engines = tts_engines
         self._ai_engines = ai_engines
         self._supported_features.discard(ProviderFeature.TTS)
@@ -1025,6 +1027,11 @@ class HomeAssistantProvider(PluginProvider):
             self._supported_features.add(ProviderFeature.TTS)
         if ai_engines:
             self._supported_features.add(ProviderFeature.AI_QUERY)
+        # the entities can come and go without this provider (un)loading, so tell the
+        # consumers of our engines that their selection may need re-evaluating.
+        # during startup the load itself signals once we are done.
+        if changed and self._startup_complete:
+            self.mass.signal_event(EventType.PROVIDERS_UPDATED, data=self.mass.get_providers())
 
     async def _subscribe_entity_registry(self) -> None:
         """Watch the Home Assistant entity registry to keep the engine lists up to date."""

--- a/tests/providers/ai_radio/test_provider.py
+++ b/tests/providers/ai_radio/test_provider.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.enums import PlaybackState, ProviderFeature
+from music_assistant_models.enums import EventType, PlaybackState, ProviderFeature
 from music_assistant_models.errors import (
     InvalidDataError,
     PlayerUnavailableError,
@@ -21,6 +21,7 @@ from music_assistant.providers.ai_radio import provider as ai_radio_provider
 from music_assistant.providers.ai_radio.constants import (
     CONF_AI_ENGINE,
     CONF_TTS_ENGINE,
+    ENGINE_RETRY_DELAY,
     MAX_FINISHED_SESSIONS,
 )
 from music_assistant.providers.ai_radio.models import SessionState
@@ -431,7 +432,11 @@ def _make_engine_provider(
     mass = MagicMock()
     mass.closing = False
     mass.subscribe.side_effect = _subscribe
-    mass.create_task.side_effect = lambda coro, **_kwargs: asyncio.create_task(coro)
+    # mirror mass.create_task, which runs the coroutine up to its first suspension
+    # before handing back the task
+    mass.create_task.side_effect = lambda coro, **_kwargs: asyncio.Task(
+        coro, loop=asyncio.get_running_loop(), eager_start=True
+    )
     mass.get_providers_supporting_feature.side_effect = _providers
     mass.config.get_provider_setup_value.side_effect = lambda _instance_id, key, default=None: (
         stored.get(key, default)
@@ -440,6 +445,7 @@ def _make_engine_provider(
     provider.logger = logging.getLogger("test.ai_radio")
     provider._unloading = False
     provider._engine_recheck_task = None
+    provider._unregister_handles = []
     provider._update_setup_data = cast(  # type: ignore[method-assign]
         "Any", lambda key, value, **_kwargs: stored.__setitem__(key, value)
     )
@@ -600,8 +606,7 @@ async def test_providers_updated_survives_a_supplier_reload() -> None:
 
     await provider._on_providers_updated(MagicMock())
     assert provider._engine_recheck_task is not None
-    while not subscribers:
-        await asyncio.sleep(0)
+    assert subscribers
     plugins.append(_make_engine_plugin("p1", ["ai"], ["tts"]))
     for callback in list(subscribers):
         callback(MagicMock())
@@ -611,8 +616,8 @@ async def test_providers_updated_survives_a_supplier_reload() -> None:
     assert subscribers == []
 
 
-async def test_providers_updated_ignores_the_shutdown_sweep() -> None:
-    """Every provider unloads at shutdown, which is not an error the user has to act on."""
+async def test_providers_updated_ignored_while_closing() -> None:
+    """The watch does not act on a providers change while the server is closing."""
     provider, _, _ = _make_engine_provider(
         [], setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"}
     )
@@ -651,8 +656,7 @@ async def test_providers_updated_keeps_a_single_recheck_in_flight() -> None:
     await provider._on_providers_updated(MagicMock())
     first_task = provider._engine_recheck_task
     assert first_task is not None
-    while not subscribers:
-        await asyncio.sleep(0)
+    assert subscribers
     await provider._on_providers_updated(MagicMock())
 
     assert provider._engine_recheck_task is first_task
@@ -661,3 +665,101 @@ async def test_providers_updated_keeps_a_single_recheck_in_flight() -> None:
     for callback in list(subscribers):
         callback(MagicMock())
     await first_task
+
+
+async def test_loaded_in_mass_watches_the_loaded_providers() -> None:
+    """Loading the provider wires up the engine watch, and unloading tears it down."""
+    provider, subscribers, _ = _make_engine_provider(
+        [_make_engine_plugin("p1", ["ai"], ["tts"])],
+        setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"},
+    )
+
+    await provider.loaded_in_mass()
+
+    assert cast("Any", provider.mass).subscribe.call_args.args == (
+        provider._on_providers_updated,
+        EventType.PROVIDERS_UPDATED,
+    )
+    assert subscribers == [provider._on_providers_updated]
+
+    await provider.unload()
+
+    assert subscribers == []
+
+
+async def test_unload_cancels_an_in_flight_engine_recheck() -> None:
+    """Unloading stops a running grace period instead of letting it report an error."""
+    provider, subscribers, _ = _make_engine_provider(
+        [], setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"}
+    )
+    errors = _record_unload_with_error(provider)
+
+    await provider._on_providers_updated(MagicMock())
+    recheck_task = provider._engine_recheck_task
+    assert recheck_task is not None
+    assert subscribers
+    await provider.unload()
+
+    with pytest.raises(asyncio.CancelledError):
+        await recheck_task
+    assert provider._unloading is True
+    assert errors == []
+
+
+async def test_engine_recheck_stays_silent_when_the_provider_unloads_during_the_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unload surfacing as the wait's timeout is not reported as an engine error."""
+    provider, _, _ = _make_engine_provider(
+        [], setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"}
+    )
+    errors = _record_unload_with_error(provider)
+    monkeypatch.setattr(ai_radio_provider, "ENGINE_DISCOVERY_TIMEOUT", 0.05)
+
+    await provider._on_providers_updated(MagicMock())
+    recheck_task = provider._engine_recheck_task
+    assert recheck_task is not None
+    provider._unloading = True
+    await recheck_task
+
+    assert errors == []
+
+
+async def test_engine_recheck_stays_silent_when_the_server_closes_during_the_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shutdown surfacing as the wait's timeout is not reported as an engine error."""
+    provider, _, _ = _make_engine_provider(
+        [], setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"}
+    )
+    errors = _record_unload_with_error(provider)
+    monkeypatch.setattr(ai_radio_provider, "ENGINE_DISCOVERY_TIMEOUT", 0.05)
+
+    await provider._on_providers_updated(MagicMock())
+    recheck_task = provider._engine_recheck_task
+    assert recheck_task is not None
+    cast("Any", provider.mass).closing = True
+    await recheck_task
+
+    assert errors == []
+
+
+async def test_engine_watchdog_arms_a_reload_after_unloading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The unload arms the reload that picks the provider back up once engines return."""
+    provider, _, _ = _make_engine_provider(
+        [], setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"}
+    )
+    errors = _record_unload_with_error(provider)
+    monkeypatch.setattr(ai_radio_provider, "ENGINE_DISCOVERY_TIMEOUT", 0.05)
+
+    await provider._on_providers_updated(MagicMock())
+    recheck_task = provider._engine_recheck_task
+    assert recheck_task is not None
+    await recheck_task
+
+    assert [error.translation_key for error in errors] == ["ai_radio_no_ai_engine"]
+    retry = cast("Any", provider.mass).call_later.call_args
+    assert retry.args == (ENGINE_RETRY_DELAY, provider.mass.load_provider, "ai_radio")
+    assert retry.kwargs == {"allow_retry": True, "task_id": "load_provider_ai_radio"}

--- a/tests/providers/ai_radio/test_provider.py
+++ b/tests/providers/ai_radio/test_provider.py
@@ -506,7 +506,8 @@ async def test_wait_for_engines_fails_the_load_when_no_engine_appears(
     monkeypatch.setattr(ai_radio_provider, "ENGINE_DISCOVERY_TIMEOUT", 0.05)
 
     with pytest.raises(SetupFailedError) as error:
-        await provider._wait_for_engines()
+        async with asyncio.timeout(1):
+            await provider._wait_for_engines()
 
     assert error.value.translation_key == "ai_radio_no_ai_engine"
     assert stored == {}
@@ -521,7 +522,8 @@ async def test_wait_for_engines_fails_when_only_the_tts_engine_is_missing(
     monkeypatch.setattr(ai_radio_provider, "ENGINE_DISCOVERY_TIMEOUT", 0.05)
 
     with pytest.raises(SetupFailedError) as error:
-        await provider._wait_for_engines()
+        async with asyncio.timeout(1):
+            await provider._wait_for_engines()
 
     assert error.value.translation_key == "ai_radio_no_tts_engine"
 
@@ -555,7 +557,8 @@ async def test_wait_for_engines_rejects_a_configured_engine_that_disappeared(
     monkeypatch.setattr(ai_radio_provider, "ENGINE_DISCOVERY_TIMEOUT", 0.05)
 
     with pytest.raises(SetupFailedError) as error:
-        await provider._wait_for_engines()
+        async with asyncio.timeout(1):
+            await provider._wait_for_engines()
 
     assert error.value.translation_key == "ai_radio_no_ai_engine"
     assert stored[CONF_AI_ENGINE] == "p1/gone"
@@ -590,7 +593,8 @@ async def test_providers_updated_unloads_when_an_engine_stays_gone(
 
     await provider._on_providers_updated(MagicMock())
     assert provider._engine_recheck_task is not None
-    await provider._engine_recheck_task
+    async with asyncio.timeout(1):
+        await provider._engine_recheck_task
 
     assert [error.translation_key for error in errors] == ["ai_radio_no_ai_engine"]
 

--- a/tests/providers/ai_radio/test_provider.py
+++ b/tests/providers/ai_radio/test_provider.py
@@ -429,16 +429,30 @@ def _make_engine_provider(
         return [plugin for plugin in plugins if getattr(plugin, attribute).return_value]
 
     mass = MagicMock()
+    mass.closing = False
     mass.subscribe.side_effect = _subscribe
+    mass.create_task.side_effect = lambda coro, **_kwargs: asyncio.create_task(coro)
     mass.get_providers_supporting_feature.side_effect = _providers
     mass.config.get_provider_setup_value.side_effect = lambda _instance_id, key, default=None: (
         stored.get(key, default)
     )
     provider.mass = cast("Any", mass)
+    provider.logger = logging.getLogger("test.ai_radio")
+    provider._unloading = False
+    provider._engine_recheck_task = None
     provider._update_setup_data = cast(  # type: ignore[method-assign]
         "Any", lambda key, value, **_kwargs: stored.__setitem__(key, value)
     )
     return provider, subscribers, stored
+
+
+def _record_unload_with_error(provider: AIRadioProvider) -> list[Any]:
+    """Capture the errors the provider unloads itself with instead of really unloading."""
+    errors: list[Any] = []
+    provider.unload_with_error = cast(  # type: ignore[method-assign]
+        "Any", errors.append
+    )
+    return errors
 
 
 def _make_engine_plugin(instance_id: str, ai_ids: list[str], tts_ids: list[str]) -> MagicMock:
@@ -539,3 +553,111 @@ async def test_wait_for_engines_rejects_a_configured_engine_that_disappeared(
 
     assert error.value.translation_key == "ai_radio_no_ai_engine"
     assert stored[CONF_AI_ENGINE] == "p1/gone"
+
+
+async def test_providers_updated_leaves_a_healthy_selection_alone() -> None:
+    """A providers change that does not affect the engines is a no-op."""
+    provider, _, _ = _make_engine_provider(
+        [_make_engine_plugin("p1", ["ai"], ["tts"])],
+        setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"},
+    )
+    errors = _record_unload_with_error(provider)
+
+    await provider._on_providers_updated(MagicMock())
+
+    assert provider._engine_recheck_task is None
+    assert errors == []
+
+
+async def test_providers_updated_unloads_when_an_engine_stays_gone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An engine removed after the load surfaces as a provider error instead of at playtime."""
+    plugins: list[Any] = [_make_engine_plugin("p1", ["ai"], ["tts"])]
+    provider, _, _ = _make_engine_provider(
+        plugins,
+        setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"},
+    )
+    errors = _record_unload_with_error(provider)
+    monkeypatch.setattr(ai_radio_provider, "ENGINE_DISCOVERY_TIMEOUT", 0.05)
+    plugins.clear()
+
+    await provider._on_providers_updated(MagicMock())
+    assert provider._engine_recheck_task is not None
+    await provider._engine_recheck_task
+
+    assert [error.translation_key for error in errors] == ["ai_radio_no_ai_engine"]
+
+
+async def test_providers_updated_survives_a_supplier_reload() -> None:
+    """A plugin reload briefly takes its engines with it, which must not unload AI Radio."""
+    plugins: list[Any] = []
+    provider, subscribers, _ = _make_engine_provider(
+        plugins,
+        setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"},
+    )
+    errors = _record_unload_with_error(provider)
+
+    await provider._on_providers_updated(MagicMock())
+    assert provider._engine_recheck_task is not None
+    while not subscribers:
+        await asyncio.sleep(0)
+    plugins.append(_make_engine_plugin("p1", ["ai"], ["tts"]))
+    for callback in list(subscribers):
+        callback(MagicMock())
+    await provider._engine_recheck_task
+
+    assert errors == []
+    assert subscribers == []
+
+
+async def test_providers_updated_ignores_the_shutdown_sweep() -> None:
+    """Every provider unloads at shutdown, which is not an error the user has to act on."""
+    provider, _, _ = _make_engine_provider(
+        [], setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"}
+    )
+    errors = _record_unload_with_error(provider)
+    cast("Any", provider.mass).closing = True
+
+    await provider._on_providers_updated(MagicMock())
+
+    assert provider._engine_recheck_task is None
+    assert errors == []
+
+
+async def test_providers_updated_ignored_while_unloading() -> None:
+    """A providers change landing during our own unload is not acted on."""
+    provider, _, _ = _make_engine_provider(
+        [], setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"}
+    )
+    errors = _record_unload_with_error(provider)
+    provider._unloading = True
+
+    await provider._on_providers_updated(MagicMock())
+
+    assert provider._engine_recheck_task is None
+    assert errors == []
+
+
+async def test_providers_updated_keeps_a_single_recheck_in_flight() -> None:
+    """Providers changes arriving during the grace period do not stack up rechecks."""
+    plugins: list[Any] = []
+    provider, subscribers, _ = _make_engine_provider(
+        plugins,
+        setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"},
+    )
+    _record_unload_with_error(provider)
+
+    await provider._on_providers_updated(MagicMock())
+    first_task = provider._engine_recheck_task
+    assert first_task is not None
+    while not subscribers:
+        await asyncio.sleep(0)
+    await provider._on_providers_updated(MagicMock())
+
+    assert provider._engine_recheck_task is first_task
+    assert cast("Any", provider.mass).create_task.call_count == 1
+    plugins.append(_make_engine_plugin("p1", ["ai"], ["tts"]))
+    for callback in list(subscribers):
+        callback(MagicMock())
+    await first_task

--- a/tests/providers/ai_radio/test_provider.py
+++ b/tests/providers/ai_radio/test_provider.py
@@ -585,7 +585,7 @@ async def test_providers_updated_unloads_when_an_engine_stays_gone(
         setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"},
     )
     errors = _record_unload_with_error(provider)
-    monkeypatch.setattr(ai_radio_provider, "ENGINE_DISCOVERY_TIMEOUT", 0.05)
+    monkeypatch.setattr(ai_radio_provider, "ENGINE_RECHECK_GRACE", 0.05)
     plugins.clear()
 
     await provider._on_providers_updated(MagicMock())
@@ -714,7 +714,7 @@ async def test_engine_recheck_stays_silent_when_the_provider_unloads_during_the_
         [], setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"}
     )
     errors = _record_unload_with_error(provider)
-    monkeypatch.setattr(ai_radio_provider, "ENGINE_DISCOVERY_TIMEOUT", 0.05)
+    monkeypatch.setattr(ai_radio_provider, "ENGINE_RECHECK_GRACE", 0.05)
 
     await provider._on_providers_updated(MagicMock())
     recheck_task = provider._engine_recheck_task
@@ -723,6 +723,7 @@ async def test_engine_recheck_stays_silent_when_the_provider_unloads_during_the_
     await recheck_task
 
     assert errors == []
+    assert cast("Any", provider.mass).call_later.call_count == 0
 
 
 async def test_engine_recheck_stays_silent_when_the_server_closes_during_the_wait(
@@ -733,7 +734,7 @@ async def test_engine_recheck_stays_silent_when_the_server_closes_during_the_wai
         [], setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"}
     )
     errors = _record_unload_with_error(provider)
-    monkeypatch.setattr(ai_radio_provider, "ENGINE_DISCOVERY_TIMEOUT", 0.05)
+    monkeypatch.setattr(ai_radio_provider, "ENGINE_RECHECK_GRACE", 0.05)
 
     await provider._on_providers_updated(MagicMock())
     recheck_task = provider._engine_recheck_task
@@ -742,6 +743,7 @@ async def test_engine_recheck_stays_silent_when_the_server_closes_during_the_wai
     await recheck_task
 
     assert errors == []
+    assert cast("Any", provider.mass).call_later.call_count == 0
 
 
 async def test_engine_watchdog_arms_a_reload_after_unloading(
@@ -752,12 +754,14 @@ async def test_engine_watchdog_arms_a_reload_after_unloading(
         [], setup_values={CONF_AI_ENGINE: "p1/ai", CONF_TTS_ENGINE: "p1/tts"}
     )
     errors = _record_unload_with_error(provider)
-    monkeypatch.setattr(ai_radio_provider, "ENGINE_DISCOVERY_TIMEOUT", 0.05)
+    monkeypatch.setattr(ai_radio_provider, "ENGINE_RECHECK_GRACE", 0.05)
 
     await provider._on_providers_updated(MagicMock())
     recheck_task = provider._engine_recheck_task
     assert recheck_task is not None
-    await recheck_task
+    # the watch waits out the grace, not the (much shorter) discovery timeout of the load
+    async with asyncio.timeout(1):
+        await recheck_task
 
     assert [error.translation_key for error in errors] == ["ai_radio_no_ai_engine"]
     retry = cast("Any", provider.mass).call_later.call_args

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -712,6 +712,41 @@ async def test_changed_engines_notify_the_consumers_once() -> None:
         assert events[0].kwargs["data"] is mass.get_providers.return_value
 
 
+async def test_a_lost_ai_engine_notifies_the_consumers() -> None:
+    """Announce a vanished AI engine, the selection AI Radio depends on."""
+    states = [_state("tts.only", "Only"), _state("ai_task.only", "Only")]
+
+    async with _start_provider(states) as (provider, hass):
+        await provider.loaded_in_mass()
+        cast("MagicMock", provider.mass).signal_event.reset_mock()
+
+        del hass.compressed_states["ai_task.only"]
+        await _fire_registry_update(provider, hass, "ai_task.only", "remove")
+
+        assert await provider.get_ai_engines() == []
+        assert [engine.id for engine in await provider.get_tts_engines()] == ["tts.only"]
+        assert len(_providers_updated_events(provider)) == 1
+
+
+async def test_engines_are_in_place_before_the_consumers_are_told() -> None:
+    """Expose the rebuilt engine lists before signalling, as consumers read them at once."""
+    states = [_state("tts.only", "Only"), _state("ai_task.only", "Only")]
+
+    async with _start_provider(states) as (provider, hass):
+        await provider.loaded_in_mass()
+        signal_event = cast("MagicMock", provider.mass.signal_event)
+        signal_event.reset_mock()
+        engines_when_told: list[list[str]] = []
+        signal_event.side_effect = lambda *_args, **_kwargs: engines_when_told.append(
+            [engine.id for engine in provider._tts_engines]
+        )
+
+        del hass.compressed_states["tts.only"]
+        await _fire_registry_update(provider, hass, "tts.only", "remove")
+
+        assert engines_when_told == [[]]
+
+
 async def test_unchanged_engines_do_not_notify_the_consumers() -> None:
     """Stay silent when a refresh rebuilds the very same engine lists."""
     states = [_state("tts.only", "Only"), _state("ai_task.only", "Only")]

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from hass_client.exceptions import BaseHassClientError
-from music_assistant_models.enums import ProviderFeature
+from music_assistant_models.enums import EventType, ProviderFeature
 from music_assistant_models.errors import SetupFailedError, UnsupportedFeaturedException
 
 from music_assistant.constants import CONF_LOG_LEVEL
@@ -355,6 +355,20 @@ async def _fire_registry_update(
             await provider._engine_refresh_task
 
 
+def _providers_updated_events(provider: HomeAssistantProvider) -> list[Any]:
+    """
+    Return the PROVIDERS_UPDATED events the provider signalled so far.
+
+    :param provider: The provider whose Music Assistant mock is inspected.
+    """
+    signal_event = cast("MagicMock", provider.mass.signal_event)
+    return [
+        call
+        for call in signal_event.call_args_list
+        if call.args[:1] == (EventType.PROVIDERS_UPDATED,)
+    ]
+
+
 async def test_feature_resolution_starts_listener_first() -> None:
     """Resolve startup features only after the Home Assistant listener starts."""
     states = [
@@ -679,6 +693,79 @@ async def test_registry_update_discards_the_feature_of_a_removed_engine() -> Non
         assert ProviderFeature.TTS not in provider.supported_features
         # the AI Task entity is untouched, so its feature stays declared
         assert ProviderFeature.AI_QUERY in provider.supported_features
+
+
+async def test_changed_engines_notify_the_consumers_once() -> None:
+    """Announce a refresh that changed the engine lists with a single PROVIDERS_UPDATED."""
+    states = [_state("tts.only", "Only"), _state("ai_task.only", "Only")]
+
+    async with _start_provider(states) as (provider, hass):
+        await provider.loaded_in_mass()
+        mass = cast("MagicMock", provider.mass)
+        mass.signal_event.reset_mock()
+
+        del hass.compressed_states["tts.only"]
+        await _fire_registry_update(provider, hass, "tts.only", "remove")
+
+        events = _providers_updated_events(provider)
+        assert len(events) == 1
+        assert events[0].kwargs["data"] is mass.get_providers.return_value
+
+
+async def test_unchanged_engines_do_not_notify_the_consumers() -> None:
+    """Stay silent when a refresh rebuilds the very same engine lists."""
+    states = [_state("tts.only", "Only"), _state("ai_task.only", "Only")]
+
+    async with _start_provider(states) as (provider, hass):
+        await provider.loaded_in_mass()
+        cast("MagicMock", provider.mass).signal_event.reset_mock()
+
+        # registry churn that leaves the feature entities as they are, as in a rename of
+        # an entity that the engine name does not depend on
+        await _fire_registry_update(provider, hass, "tts.only", "update")
+
+        assert [engine.id for engine in await provider.get_tts_engines()] == ["tts.only"]
+        assert [engine.id for engine in await provider.get_ai_engines()] == ["ai_task.only"]
+        assert _providers_updated_events(provider) == []
+
+
+async def test_startup_refresh_does_not_notify_the_consumers() -> None:
+    """Leave the announcement of the engines found during startup to the load path."""
+    states = [_state("tts.only", "Only"), _state("ai_task.only", "Only")]
+
+    async with _start_provider(states) as (provider, _):
+        # the refresh that filled the empty lists ran before startup was marked complete
+        assert provider._startup_complete
+        assert [engine.id for engine in await provider.get_tts_engines()] == ["tts.only"]
+        assert _providers_updated_events(provider) == []
+
+
+async def test_refresh_tracks_engines_and_features_in_both_directions() -> None:
+    """Follow the engine lists and their features as feature entities appear and vanish."""
+    async with _start_provider([_state("sensor.example", "Example")]) as (provider, hass):
+        await provider.loaded_in_mass()
+        cast("MagicMock", provider.mass).signal_event.reset_mock()
+        assert ProviderFeature.TTS not in provider.supported_features
+        assert ProviderFeature.AI_QUERY not in provider.supported_features
+
+        hass.compressed_states["tts.new"] = _compressed(_state("tts.new", "New TTS"))
+        hass.compressed_states["ai_task.new"] = _compressed(_state("ai_task.new", "New AI"))
+        await _fire_registry_update(provider, hass, "tts.new", "create")
+
+        assert [engine.id for engine in await provider.get_tts_engines()] == ["tts.new"]
+        assert [engine.id for engine in await provider.get_ai_engines()] == ["ai_task.new"]
+        assert ProviderFeature.TTS in provider.supported_features
+        assert ProviderFeature.AI_QUERY in provider.supported_features
+
+        del hass.compressed_states["tts.new"]
+        del hass.compressed_states["ai_task.new"]
+        await _fire_registry_update(provider, hass, "tts.new", "remove")
+
+        assert await provider.get_tts_engines() == []
+        assert await provider.get_ai_engines() == []
+        assert ProviderFeature.TTS not in provider.supported_features
+        assert ProviderFeature.AI_QUERY not in provider.supported_features
+        assert len(_providers_updated_events(provider)) == 2
 
 
 async def test_registry_update_of_another_domain_is_ignored() -> None:


### PR DESCRIPTION
# What does this implement/fix?

AI Radio checks that an AI and a text-to-speech engine are available when it starts up, but it never looked again afterwards. So if the Home Assistant plugin was removed or disabled later, or the selected AI/text-to-speech entity was deleted, AI Radio kept looking perfectly healthy and only broke when a station tried to produce its next spoken bit.

It now keeps an eye on those engines for as long as it is running and reports the problem in the providers list (with a Reconfigure button) as soon as an engine goes missing, so you can act on it before the radio stops talking. A short grace period keeps a normal plugin restart from tripping it, and AI Radio picks itself back up once the engine is available again.

- Keep checking the AI/text-to-speech engine selection while AI Radio runs, not only at startup
- Show the same clear error as at startup when an engine is gone for good, and reload automatically once it is back
- Ignore engines that disappear only briefly, such as during a plugin reload or a server shutdown
- Home Assistant now reports when its AI/text-to-speech entities appear or disappear, so a deleted entity is noticed as well
- Tests for the watch and for the new Home Assistant notification

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

