### PR TITLE
Stop AI Radio and Smart Playlist from hanging on a stalled AI engine

### DIFF
--- a/music_assistant/providers/ai_radio/constants.py
+++ b/music_assistant/providers/ai_radio/constants.py
@@ -31,6 +31,10 @@ MAX_FINISHED_SESSIONS = 20
 # a show whose playback never starts within this window is declared failed
 SHOW_START_TIMEOUT_SECONDS = 300
 
+# generous, since sections are prose and the engine may be a slow local model,
+# but bounded so a wedged engine fails the clip instead of hanging the session
+AI_QUERY_TIMEOUT_SECONDS = 120
+
 SUPPORTED_FEATURES: set[Any] = set()
 EMPTY_SECTION_ID = "EMPTY_SECTION"
 VALID_WEB_SEARCH_MODES = {"disabled", "allow", "force"}

--- a/music_assistant/providers/ai_radio/constants.py
+++ b/music_assistant/providers/ai_radio/constants.py
@@ -31,9 +31,11 @@ MAX_FINISHED_SESSIONS = 20
 # a show whose playback never starts within this window is declared failed
 SHOW_START_TIMEOUT_SECONDS = 300
 
-# generous, since sections are prose and the engine may be a slow local model,
-# but bounded so a wedged engine fails the clip instead of hanging the session
-AI_QUERY_TIMEOUT_SECONDS = 120
+# last-resort guards so a wedged engine fails the clip instead of hanging the session.
+# Kept above the deadlines the engines apply themselves (120s in the OpenAI-compatible
+# providers), so their own, more specific error is the one that surfaces.
+AI_QUERY_TIMEOUT_SECONDS = 180
+TTS_QUERY_TIMEOUT_SECONDS = 180
 
 SUPPORTED_FEATURES: set[Any] = set()
 EMPTY_SECTION_ID = "EMPTY_SECTION"

--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -9,7 +9,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.enums import ContentType, StreamType
-from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
+from music_assistant_models.errors import (
+    InvalidDataError,
+    MediaNotFoundError,
+    MusicAssistantError,
+)
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails
 
@@ -24,6 +28,7 @@ from .constants import (
     ATTR_WEB_SEARCH_MODE,
     CLIP_STREAMDETAILS_EXPIRATION,
     DEFERRED_PLACEHOLDERS,
+    TTS_QUERY_TIMEOUT_SECONDS,
 )
 from .helpers import soft_limit_text
 
@@ -181,7 +186,16 @@ class AIRadioRenderMixin:
     async def _render_tts_media(self, text: str) -> tuple[str, StreamType, AudioFormat]:
         """Ask the TTS engine for audio and return the path, stream type and format to play it."""
         engine = await self._get_tts_engine()
-        stream_details = await engine.provider.get_tts_message(text, engine_id=engine.id)
+        try:
+            async with asyncio.timeout(TTS_QUERY_TIMEOUT_SECONDS) as query_timeout:
+                stream_details = await engine.provider.get_tts_message(text, engine_id=engine.id)
+        except TimeoutError as err:
+            # expired() tells our own cap apart from a timeout raised inside the engine
+            if not query_timeout.expired():
+                raise
+            raise MusicAssistantError(
+                f"TTS engine '{engine.uid}' did not respond within {TTS_QUERY_TIMEOUT_SECONDS}s"
+            ) from err
         path = str(getattr(stream_details, "path", "") or "").strip()
         if path.startswith(("http://", "https://", "rtsp://", "rtmp://")):
             stream_type = StreamType.HTTP

--- a/music_assistant/providers/ai_radio/runtime.py
+++ b/music_assistant/providers/ai_radio/runtime.py
@@ -35,6 +35,7 @@ from music_assistant.helpers.plugin_engines import resolve_ai_engine, resolve_tt
 from music_assistant.helpers.uri import create_uri
 
 from .constants import (
+    AI_QUERY_TIMEOUT_SECONDS,
     ATTR_MAX_CHARS,
     ATTR_PROMPT,
     ATTR_SESSION_ID,
@@ -1164,8 +1165,14 @@ class AIRadioRuntimeMixin:
             len(query),
         )
         try:
-            response = await engine.provider.ai_query(query, engine_id=engine.id)
+            async with asyncio.timeout(AI_QUERY_TIMEOUT_SECONDS) as query_timeout:
+                response = await engine.provider.ai_query(query, engine_id=engine.id)
         except Exception as err:
+            # expired() tells our own cap apart from a timeout raised inside the engine
+            if isinstance(err, TimeoutError) and query_timeout.expired():
+                raise MusicAssistantError(
+                    f"AI engine '{engine.uid}' did not respond within {AI_QUERY_TIMEOUT_SECONDS}s"
+                ) from err
             error_name = err.__class__.__name__
             error_text = str(err).strip()
             if error_name == "NotConnected":

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -82,6 +82,8 @@ DYNAMIC_SAMPLE_CACHE_EXPIRATION = 24 * 3600  # 24h; stale entries are still serv
 CONF_AI_DESCRIPTIONS = "ai_descriptions"
 CONF_AI_ENGINE = "ai_engine"
 DESCRIPTION_PREFIX = "[Smart Playlist] "
+# descriptions are a sentence or two, so this only has to cover a slow local model
+AI_QUERY_TIMEOUT_SECONDS = 60
 
 SUPPORTED_FEATURES: set[ProviderFeature] = {
     ProviderFeature.BROWSE,
@@ -1389,11 +1391,18 @@ class SmartPlaylistProvider(PluginProvider):
         if engine is None:
             return None
         try:
-            response = await engine.provider.ai_query(
-                self._build_ai_prompt(name, rules, locale), engine_id=engine.id
-            )
+            async with asyncio.timeout(AI_QUERY_TIMEOUT_SECONDS) as query_timeout:
+                response = await engine.provider.ai_query(
+                    self._build_ai_prompt(name, rules, locale), engine_id=engine.id
+                )
         except Exception as exc:
-            self.logger.debug("AI description generation failed for '%s': %s", name, exc)
+            # expired() tells our own cap apart from a timeout raised inside the engine
+            details: str | Exception = (
+                f"no response within {AI_QUERY_TIMEOUT_SECONDS}s"
+                if isinstance(exc, TimeoutError) and query_timeout.expired()
+                else exc
+            )
+            self.logger.debug("AI description generation failed for '%s': %s", name, details)
             return None
         return response.strip() or None
 

--- a/tests/providers/ai_radio/test_rendering.py
+++ b/tests/providers/ai_radio/test_rendering.py
@@ -11,7 +11,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import ContentType, MediaType, StreamType
-from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
+from music_assistant_models.errors import (
+    InvalidDataError,
+    MediaNotFoundError,
+    MusicAssistantError,
+)
 from music_assistant_models.media_items import AudioFormat, ProviderMapping, SoundEffect
 from music_assistant_models.queue_item import QueueItem
 
@@ -351,6 +355,40 @@ async def test_render_tts_media_rejects_an_unplayable_path(path: str) -> None:
 
     with pytest.raises(InvalidDataError, match="unusable stream path"):
         await renderer._render_tts_media("hello world")
+
+
+async def test_render_tts_media_gives_up_on_a_stalled_engine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stalled TTS engine fails the clip instead of pinning the render path."""
+    monkeypatch.setattr(
+        "music_assistant.providers.ai_radio.rendering.TTS_QUERY_TIMEOUT_SECONDS", 0.01
+    )
+
+    async def _answers_too_late(*_args: Any, **_kwargs: Any) -> SimpleNamespace:
+        await asyncio.sleep(5)
+        return SimpleNamespace(
+            path="http://example.test/late.mp3",
+            audio_format=AudioFormat(content_type=ContentType.MP3),
+        )
+
+    renderer = _tts_renderer("http://example.test/late.mp3")
+    engine = cast("Any", renderer)._get_tts_engine.return_value
+    engine.provider.get_tts_message = AsyncMock(side_effect=_answers_too_late)
+
+    with pytest.raises(MusicAssistantError, match="did not respond within"):
+        await renderer._render_tts_media("hello world")
+
+
+async def test_render_tts_media_reports_an_engine_side_timeout_as_is() -> None:
+    """A timeout raised by the TTS engine itself is not reported as our own cap."""
+    renderer = _tts_renderer("http://example.test/late.mp3")
+    engine = cast("Any", renderer)._get_tts_engine.return_value
+    engine.provider.get_tts_message = AsyncMock(side_effect=TimeoutError)
+
+    with pytest.raises(TimeoutError) as error:
+        await renderer._render_tts_media("hello world")
+    assert "did not respond within" not in str(error.value)
 
 
 async def test_local_file_clip_yields_local_file_streamdetails(tmp_path: Path) -> None:

--- a/tests/providers/ai_radio/test_runtime.py
+++ b/tests/providers/ai_radio/test_runtime.py
@@ -367,6 +367,56 @@ async def test_generate_text_wraps_not_connected_error() -> None:
     assert "hass_1/ai_task.default" in str(error.value)
 
 
+async def test_generate_text_fails_the_section_when_the_engine_stalls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stalled AI engine fails the section instead of hanging the session."""
+    monkeypatch.setattr("music_assistant.providers.ai_radio.runtime.AI_QUERY_TIMEOUT_SECONDS", 0.01)
+
+    async def _never_returns(*_args: Any, **_kwargs: Any) -> str:
+        await asyncio.Event().wait()
+        return ""
+
+    plugin = _create_ai_plugin("hass_1", "ai_task.default")
+    plugin.ai_query = AsyncMock(side_effect=_never_returns)
+    runtime = DummyRuntime({CONF_AI_ENGINE: "hass_1/ai_task.default"})
+    _set_runtime_mass(
+        runtime,
+        _create_engine_mass(
+            ProviderFeature.AI_QUERY, plugin, metadata=SimpleNamespace(locale="en_US")
+        ),
+    )
+
+    with pytest.raises(MusicAssistantError) as error:
+        await runtime._generate_text(
+            station={"general": {"instructions": "test"}},
+            prompt="test prompt",
+            web_mode="disabled",
+        )
+    assert "did not respond within" in str(error.value)
+
+
+async def test_generate_text_reports_an_engine_side_timeout_as_a_query_failure() -> None:
+    """A timeout raised by the engine itself is reported as a query failure, not our cap."""
+    plugin = _create_ai_plugin("hass_1", "ai_task.default")
+    plugin.ai_query = AsyncMock(side_effect=TimeoutError)
+    runtime = DummyRuntime({CONF_AI_ENGINE: "hass_1/ai_task.default"})
+    _set_runtime_mass(
+        runtime,
+        _create_engine_mass(
+            ProviderFeature.AI_QUERY, plugin, metadata=SimpleNamespace(locale="en_US")
+        ),
+    )
+
+    with pytest.raises(MusicAssistantError) as error:
+        await runtime._generate_text(
+            station={"general": {"instructions": "test"}},
+            prompt="test prompt",
+            web_mode="disabled",
+        )
+    assert "query failed: TimeoutError" in str(error.value)
+
+
 async def test_generate_text_asks_for_the_system_locale_language() -> None:
     """The AI query states the server locale so sections are written in that language."""
     plugin = _create_ai_plugin("hass_1", "ai_task.default")

--- a/tests/providers/ai_radio/test_runtime.py
+++ b/tests/providers/ai_radio/test_runtime.py
@@ -373,12 +373,12 @@ async def test_generate_text_fails_the_section_when_the_engine_stalls(
     """A stalled AI engine fails the section instead of hanging the session."""
     monkeypatch.setattr("music_assistant.providers.ai_radio.runtime.AI_QUERY_TIMEOUT_SECONDS", 0.01)
 
-    async def _never_returns(*_args: Any, **_kwargs: Any) -> str:
-        await asyncio.Event().wait()
-        return ""
+    async def _answers_too_late(*_args: Any, **_kwargs: Any) -> str:
+        await asyncio.sleep(5)
+        return "section text"
 
     plugin = _create_ai_plugin("hass_1", "ai_task.default")
-    plugin.ai_query = AsyncMock(side_effect=_never_returns)
+    plugin.ai_query = AsyncMock(side_effect=_answers_too_late)
     runtime = DummyRuntime({CONF_AI_ENGINE: "hass_1/ai_task.default"})
     _set_runtime_mass(
         runtime,

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -1979,6 +1979,26 @@ async def test_generate_ai_description_provider_error_returns_none(tmp_path: Any
 
 
 @pytest.mark.asyncio
+async def test_generate_ai_description_stalled_provider_returns_none(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stalled AI provider gives up instead of leaving the task pending forever."""
+    monkeypatch.setattr("music_assistant.providers.smart_playlist.AI_QUERY_TIMEOUT_SECONDS", 0.01)
+
+    async def _never_returns(*_args: Any, **_kwargs: Any) -> str:
+        await asyncio.Event().wait()
+        return ""
+
+    ai_provider = _make_ai_provider()
+    ai_provider.ai_query = AsyncMock(side_effect=_never_returns)
+    plugin = _make_ai_plugin(tmp_path, ai_enabled=True, ai_provider=ai_provider)
+
+    result = await plugin._generate_ai_description("X", SmartPlaylistRules(favorites_only=True))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_generate_ai_description_stays_on_the_configured_engine(tmp_path: Any) -> None:
     """A failing selection yields no description instead of asking another engine."""
     failing = _make_ai_provider(instance_id="ai--bad")

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import time
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -1980,22 +1981,40 @@ async def test_generate_ai_description_provider_error_returns_none(tmp_path: Any
 
 @pytest.mark.asyncio
 async def test_generate_ai_description_stalled_provider_returns_none(
-    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A stalled AI provider gives up instead of leaving the task pending forever."""
     monkeypatch.setattr("music_assistant.providers.smart_playlist.AI_QUERY_TIMEOUT_SECONDS", 0.01)
 
-    async def _never_returns(*_args: Any, **_kwargs: Any) -> str:
-        await asyncio.Event().wait()
-        return ""
+    async def _answers_too_late(*_args: Any, **_kwargs: Any) -> str:
+        await asyncio.sleep(5)
+        return "A mellow mix for the evening."
 
     ai_provider = _make_ai_provider()
-    ai_provider.ai_query = AsyncMock(side_effect=_never_returns)
+    ai_provider.ai_query = AsyncMock(side_effect=_answers_too_late)
     plugin = _make_ai_plugin(tmp_path, ai_enabled=True, ai_provider=ai_provider)
+    caplog.set_level(logging.DEBUG, logger=plugin.logger.name)
 
     result = await plugin._generate_ai_description("X", SmartPlaylistRules(favorites_only=True))
 
     assert result is None
+    assert "no response within" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_description_reports_a_provider_side_timeout_as_a_failure(
+    tmp_path: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A timeout raised by the provider itself is not reported as our own cap."""
+    ai_provider = _make_ai_provider()
+    ai_provider.ai_query = AsyncMock(side_effect=TimeoutError)
+    plugin = _make_ai_plugin(tmp_path, ai_enabled=True, ai_provider=ai_provider)
+    caplog.set_level(logging.DEBUG, logger=plugin.logger.name)
+
+    result = await plugin._generate_ai_description("X", SmartPlaylistRules(favorites_only=True))
+
+    assert result is None
+    assert "no response within" not in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

AI Radio and Smart Playlist called their AI engine without any time limit. If the engine stalls
(a slow or wedged local model, or a backend that never answers), the AI Radio session sits in
"generating" forever with no progress and no failure, and a Smart Playlist description task stays
pending indefinitely. Both now give up after a while, like the Music Quiz provider already does.

- AI Radio: AI text and text-to-speech requests now give up after 180s, and the section fails with
  a clear error so the session ends properly instead of hanging. The limit sits above the 120s the
  AI providers already apply themselves, so their own (more specific) error is still the one shown.
- Smart Playlist: AI description requests give up after 60s and the description is skipped —
  descriptions are only a sentence or two, and the playlist itself is unaffected.
- A timeout coming from the engine itself is still reported as an engine failure, so the message
  doesn't wrongly point at our own limit.
- Tests for each timeout path.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
