### PR TITLE
Recover a bridged AirPlay speaker when its stream process dies

### DIFF
--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -631,6 +631,14 @@ The bridge consists of:
 - **`SendspinAirPlayBridge`**: Manages the bridge for a single AirPlay player
 - **`SendspinBridgeManager`**: Manages bridges for all AirPlay players
 
+### Transport Loss
+
+The CLI accepts and discards audio once its process is gone, so a lost transport is only visible on the `AirPlayStream` itself. The bridge checks it on every chunk: the dead stream is released and a fresh one is cold-started and re-anchored on the group's live timeline, so the speaker rejoins where the rest of the group is playing.
+
+Giving up comes in two strengths, and what separates them is whether the transport was ever playing. A start that simply failed — a sleeping device, one connect timeout, a protocol that never became ready — only stops the current stream; the bridge stays grouped and the next Sendspin stream starts it over. Giving up on a transport that *had* been playing means the speaker went away mid-stream: either its recovery could not reconnect, or it dropped the transport again within `BRIDGE_TRANSPORT_RECOVERY_GUARD_SECONDS` of the last one. The bridge then also leaves the Sendspin session, because that silence is not going to end on its own and the visible player must stop reporting playback nobody can hear.
+
+The group re-join recovery in `stream.py` only covers native AirPlay grouping — a bridged player's group membership lives on its Sendspin player, not on the AirPlay one.
+
 ### Requirements
 
 - Sendspin provider must be enabled

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -117,6 +117,15 @@ MAX_HELD_CHUNKS: int = 4_000
 PAD_BLOCK_FRAMES: int = BRIDGE_SAMPLE_RATE
 SILENCE_BLOCK: bytes = b"\x00" * (PAD_BLOCK_FRAMES * BRIDGE_CHANNELS * BRIDGE_BYTES_PER_SAMPLE)
 
+# A transport that dies again this soon after a recovery is not coming back by
+# itself (a rebooting device, a receiver that accepts the connection and drops
+# it again). Re-anchoring once more would only churn CLI processes, so the
+# bridge gives up instead. Measured from the moment the loss is noticed, which
+# includes the several seconds a cold recovery needs before audio resumes (a
+# process spawn, the clock-readiness wait and the join headroom), so this sits
+# far enough beyond that for a recovered transport to prove itself.
+BRIDGE_TRANSPORT_RECOVERY_GUARD_SECONDS: float = 30.0
+
 
 def get_bridge_client_id(airplay_player: AirPlayPlayer) -> str | None:
     """
@@ -277,6 +286,13 @@ class SendspinAirPlayBridge:
         # the cap does not re-sum the whole backlog on every chunk.
         self._held_us: int = 0
         self._cleanup_task: asyncio.Task[None] | None = None
+        # Monotonic instant of the last recovery from a lost transport (None when
+        # none happened yet), used to tell a one-off loss from a flapping device.
+        self._last_transport_recovery: float | None = None
+        # Whether the transport being started is replacing one that was already
+        # playing. Giving up then means a speaker that went away mid-stream, as
+        # opposed to one that was never reachable to begin with.
+        self._recovering_transport = False
         # Timer id for the deferred teardown on stream end. A seek/next ends the
         # sendspin stream and immediately starts a new one; deferring the CLI
         # teardown across that gap lets the next stream reuse the connected
@@ -435,6 +451,12 @@ class SendspinAirPlayBridge:
             self.airplay_player.display_name,
             request.connection_reason,
         )
+        # Each Sendspin stream gets its own recovery budget: a loss on the
+        # previous one says nothing about the device's health on this one. This
+        # is settled before anything can return early, so no stream ever
+        # inherits the previous one's verdict.
+        self._last_transport_recovery = None
+        self._recovering_transport = False
         if not self.airplay_player.available:
             self.logger.warning(
                 "Cannot start Sendspin stream for %s: player not available",
@@ -488,6 +510,20 @@ class SendspinAirPlayBridge:
         Called via the BridgePlayerRole.on_stream_start callback when the
         PushStream begins delivering audio chunks.
         """
+        self._restart_transport()
+
+    def _restart_transport(self) -> None:
+        """
+        Release the current transport and arm a fresh one for the next chunk.
+
+        Leaves the bridge unanchored with a running writer, so the next chunk
+        Sendspin delivers starts a transport and anchors it where that chunk
+        sits on the group's timeline. A warm-eligible stream is the exception:
+        it is kept so the new media rides its flush-refill instead.
+        """
+        # A teardown deferred by an earlier stream end would otherwise fire into
+        # the transport armed here, so it is dropped along with the old one.
+        self.mass.cancel_timer(self._teardown_timer_id)
         # The stream might not yet be cleaned up completely (on rapid skips for example).
         # A warm-eligible stream is kept out of the snapshot so it survives into the
         # new stream instead of being torn down (see _stream_is_warm_eligible).
@@ -575,12 +611,7 @@ class SendspinAirPlayBridge:
                     self.airplay_player.display_name,
                 )
                 return
-            # Stop accepting chunks, unblock the writer, and schedule full cleanup
-            self._is_streaming = False
-            self._held_chunks.clear()
-            self._held_us = 0
-            self._airplay_stream_ready.set()
-            self._schedule_cleanup()
+            self._abandon_streaming()
 
     async def _start_cold_stream(self, stream: AirPlayStream) -> bool:
         """
@@ -807,6 +838,47 @@ class SendspinAirPlayBridge:
         """
         self._cleanup_task = self.mass.create_task(self._stop_streaming_locked())
 
+    def _abandon_streaming(self) -> None:
+        """
+        Give up on this stream: stop accepting chunks and tear the transport down.
+
+        A transport that was never established (a sleeping device, one connect
+        timeout) leaves the bridge grouped, so the next Sendspin stream simply
+        starts it over. Giving up on one that was already playing means the
+        speaker went away for good, and the bridge leaves the session so its
+        silence reaches the player instead of hiding behind the group state.
+        """
+        self._is_streaming = False
+        self._held_chunks.clear()
+        self._held_us = 0
+        # unblock a writer still waiting for a stream that will never be ready
+        self._airplay_stream_ready.set()
+        self._schedule_cleanup()
+        if self._recovering_transport:
+            self._recovering_transport = False
+            self.mass.create_task(self._leave_sendspin_session())
+
+    async def _leave_sendspin_session(self) -> None:
+        """
+        Take the bridge out of Sendspin playback, keeping it registered.
+
+        Sendspin reports playback from the group's own state, so a bridge whose
+        speaker is unreachable would hold the visible player on PLAYING while
+        nothing is audible. Leaving surfaces that silence: a shared group plays
+        on without this speaker, a solo one stops. The client stays registered,
+        so the player survives to be grouped again.
+        """
+        if not (client := self._sendspin_client):
+            return
+        try:
+            await client.quiesce_to_solo_stopped()
+        except Exception as err:
+            self.logger.warning(
+                "Could not take %s out of its Sendspin session: %s",
+                self.airplay_player.display_name,
+                err,
+            )
+
     async def _stop_streaming_locked(self) -> None:
         """Serialize streaming teardown with other stop/start operations."""
         async with self._lock:
@@ -866,9 +938,11 @@ class SendspinAirPlayBridge:
                     "Protocol start task failed for %s, stopping streaming",
                     self.airplay_player.display_name,
                 )
-                self._is_streaming = False
-                self._schedule_cleanup()
+                self._abandon_streaming()
                 return
+
+        if self._transport_lost() and not self._recover_transport():
+            return
 
         if self._airplay_stream_start_task is None:
             # Provisionally anchor byte 0 to the instant Sendspin scheduled for the
@@ -939,6 +1013,53 @@ class SendspinAirPlayBridge:
             delta_seconds * 1000,
             shift_seconds * 1000,
         )
+
+    def _transport_lost(self) -> bool:
+        """
+        Return whether the anchored transport died while the bridge kept feeding it.
+
+        The CLI drops writes without raising once its process is gone, so a dead
+        transport is only visible on the stream itself. Only an anchored stream
+        with no start in flight can be judged: while a cold start or a warm
+        handover runs it owns the transport and reports its own failures.
+        """
+        start_task = self._airplay_stream_start_task
+        if start_task is None or not start_task.done():
+            return False
+        stream = self._airplay_stream
+        return self._started and stream is not None and not stream.running
+
+    def _recover_transport(self) -> bool:
+        """
+        Re-anchor the bridge after a transport loss, unless the device keeps dropping.
+
+        :return: True when a fresh transport is armed for the current chunk,
+            False when the bridge gave up and stopped streaming.
+        """
+        now = time.monotonic()
+        last_recovery = self._last_transport_recovery
+        if (
+            last_recovery is not None
+            and now - last_recovery < BRIDGE_TRANSPORT_RECOVERY_GUARD_SECONDS
+        ):
+            self.logger.error(
+                "AirPlay transport for %s died again within %.0fs of the previous recovery, "
+                "giving up and taking it out of the Sendspin session",
+                self.airplay_player.display_name,
+                BRIDGE_TRANSPORT_RECOVERY_GUARD_SECONDS,
+            )
+            self._abandon_streaming()
+            return False
+        self._last_transport_recovery = now
+        self.logger.warning(
+            "AirPlay transport for %s was lost mid-stream, re-joining the Sendspin timeline",
+            self.airplay_player.display_name,
+        )
+        # From here the bridge is replacing a transport that was playing, so
+        # failing to bring it back means the speaker is gone rather than late.
+        self._recovering_transport = True
+        self._restart_transport()
+        return True
 
     def _hold_chunk(self, chunk: AudioChunk) -> None:
         """
@@ -1051,8 +1172,11 @@ class SendspinAirPlayBridge:
                     "Timed out waiting for AirPlay protocol to become ready for %s",
                     self.airplay_player.display_name,
                 )
-                self._is_streaming = False
-                self._schedule_cleanup()
+                if self._writer_task is asyncio.current_task():
+                    # Only the writer that still feeds the bridge may give up on
+                    # it; one left behind by a slow teardown speaks for a stream
+                    # that is already gone.
+                    self._abandon_streaming()
                 return
             while True:
                 data = await self._write_queue.get()

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -1,7 +1,7 @@
 """
 Unit tests for the Sendspin -> AirPlay bridge timing.
 
-Cover eight things, with the Sendspin clock mocked via ``ManualClock`` so the
+Cover nine things, with the Sendspin clock mocked via ``ManualClock`` so the
 tests are deterministic and independent of the host wall-clock:
 
 * the clock-domain conversion turning a Sendspin audible instant (Sendspin's own
@@ -24,7 +24,12 @@ tests are deterministic and independent of the host wall-clock:
   a new Sendspin stream and rides the persistent-stdin flush-refill (FLUSH +
   re-anchoring START) instead of a cold reconnect -- with flush-timeout and
   superseded-task fallback, and the supersession handling that keeps a stale
-  start from tearing down the stream a newer one owns.
+  start from tearing down the stream a newer one owns;
+* the recovery from a transport lost mid-stream: the dead CLI is released and
+  re-anchored on the group's live timeline, while a start that merely failed
+  only stops the current stream. Only a device that drops its transport again
+  right after a recovery is taken out of the Sendspin session, so the player
+  stops reporting playback nobody can hear.
 """
 
 import asyncio
@@ -45,6 +50,7 @@ from music_assistant.providers.airplay.constants import (
 from music_assistant.providers.airplay.sendspin_bridge import (
     BRIDGE_COLD_START_LEAD_MS,
     BRIDGE_MIN_BUFFER_MS,
+    BRIDGE_TRANSPORT_RECOVERY_GUARD_SECONDS,
     BRIDGE_WARM_START_LEAD_MS,
     MAX_DEVICE_BUFFER_SECONDS,
     MAX_HELD_AUDIO_US,
@@ -1481,3 +1487,458 @@ def test_stream_start_reads_the_lead_before_rewinding_the_stream_state() -> None
     role.set_timing.assert_called_once_with(
         required_lead_time_ms=BRIDGE_WARM_START_LEAD_MS, min_buffer_ms=BRIDGE_MIN_BUFFER_MS
     )
+
+
+# --- Mid-stream transport loss: re-anchoring, and giving up when it keeps dropping ---
+
+
+def _make_completed_start_task(*, failed: bool = False) -> MagicMock:
+    """
+    Build a start-task mock the chunk handler reads as a finished protocol start.
+
+    Every predicate must answer a real bool: a bare MagicMock reports itself as
+    cancelled, which the handler reads as a failed start.
+    """
+    task = MagicMock()
+    task.done.return_value = True
+    task.cancelled.return_value = failed
+    task.exception.return_value = None
+    return task
+
+
+def _make_anchored_bridge(*, running: bool) -> tuple[SendspinAirPlayBridge, MagicMock]:
+    """Return a bridge anchored on a transport in the given running state, plus that transport."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    stream = _make_kept_stream(running=running)
+    bridge._airplay_stream = stream
+    bridge.airplay_player.stream = stream
+    bridge._airplay_stream_start_task = _make_completed_start_task()
+    bridge._started = True
+    bridge._anchor_settled = True
+    bridge._drop_until_us = SENDSPIN_EPOCH_US
+    return bridge, stream
+
+
+def test_lost_transport_rearms_a_cold_start_on_the_current_chunk() -> None:
+    """
+    A transport that died mid-stream is released and re-anchored on the live timeline.
+
+    The CLI accepts and discards writes once its process is gone, so the loss is
+    only visible on the stream itself. The chunk that exposes it is also the one
+    the fresh transport anchors to, which is where the group is playing now.
+    """
+    bridge, _ = _make_anchored_bridge(running=False)
+    chunk_ts = SENDSPIN_EPOCH_US + 30_000_000
+
+    bridge._on_audio_chunk(_pcm_chunk(chunk_ts))
+
+    assert bridge._airplay_stream is None
+    assert bridge.airplay_player.stream is None
+    assert bridge._started is False
+    assert bridge._anchor_settled is False
+    # a fresh start is armed and anchored where the group is playing right now
+    assert bridge._drop_until_us == chunk_ts
+    # the chunk is held until the new anchor is acked, not placed against the dead one
+    assert len(bridge._held_chunks) == 1
+
+
+def test_lost_transport_and_its_writer_are_torn_down() -> None:
+    """The dead transport and the writer feeding it are handed to the cleanup path."""
+    bridge, dead_stream = _make_anchored_bridge(running=False)
+    writer_task = MagicMock()
+    bridge._writer_task = writer_task
+    start_task = bridge._airplay_stream_start_task
+
+    with patch.object(bridge, "_cleanup_old_stream", MagicMock()) as cleanup:
+        bridge._on_audio_chunk(_pcm_chunk(SENDSPIN_EPOCH_US + 1_000_000))
+
+    assert cleanup.call_args.args[:3] == (dead_stream, writer_task, start_task)
+
+
+def test_live_transport_keeps_streaming_untouched() -> None:
+    """A running transport is left alone: chunks keep flowing to the same stream."""
+    bridge, stream = _make_anchored_bridge(running=True)
+    start_task = bridge._airplay_stream_start_task
+
+    bridge._on_audio_chunk(_pcm_chunk(SENDSPIN_EPOCH_US + 1_000_000))
+
+    assert bridge._airplay_stream is stream
+    assert bridge._airplay_stream_start_task is start_task
+    assert bridge._started is True
+    assert not bridge._write_queue.empty()
+
+
+def test_transport_is_not_judged_while_a_start_is_in_flight() -> None:
+    """
+    A start owns its transport, so a stream it is tearing down is not a loss.
+
+    A warm handover that fails stops the kept stream before dropping it, leaving
+    a window where the bridge still points at a stopped stream. Restarting from
+    that window would fight the start already falling back to a cold reconnect.
+    """
+    bridge, stopped_stream = _make_anchored_bridge(running=False)
+    cast("MagicMock", bridge._airplay_stream_start_task).done.return_value = False
+
+    bridge._on_audio_chunk(_pcm_chunk(SENDSPIN_EPOCH_US + 1_000_000))
+
+    assert bridge._airplay_stream is stopped_stream
+    assert bridge._started is True
+
+
+def test_unanchored_transport_is_not_treated_as_a_loss() -> None:
+    """
+    A stream that never anchored is the start's to report, not a mid-stream loss.
+
+    Recovery re-joins the group where the current chunk sits, which only means
+    anything once an anchor existed. A start that finished without one has
+    already taken the bridge out of streaming through its own failure path.
+    """
+    bridge, stopped_stream = _make_anchored_bridge(running=False)
+    start_task = bridge._airplay_stream_start_task
+    bridge._started = False
+
+    bridge._on_audio_chunk(_pcm_chunk(SENDSPIN_EPOCH_US + 1_000_000))
+
+    assert bridge._airplay_stream is stopped_stream
+    assert bridge._airplay_stream_start_task is start_task
+
+
+def test_restarting_the_transport_drops_a_deferred_teardown() -> None:
+    """
+    A teardown deferred by an earlier stream end must not fire into the new transport.
+
+    The restart arms a transport that pending timer knows nothing about, so it is
+    cancelled along with the stream it was scheduled for.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+
+    bridge._restart_transport()
+
+    cast("MagicMock", bridge.mass).cancel_timer.assert_called_once_with(bridge._teardown_timer_id)
+
+
+def test_a_new_sendspin_stream_restores_the_recovery_budget() -> None:
+    """
+    Every Sendspin stream starts with a full recovery budget.
+
+    A loss on the previous stream says nothing about the device's health on this
+    one; carrying the stamp over would abandon a speaker on its very first loss,
+    and carrying the recovery mark over would pull it out of the group the first
+    time a start on the new stream fails.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._last_transport_recovery = 100.0
+    bridge._recovering_transport = True
+
+    bridge._on_stream_start(MagicMock())
+
+    assert bridge._last_transport_recovery is None
+    assert bridge._recovering_transport is False  # type: ignore[unreachable]
+
+
+def test_a_stream_start_on_an_unavailable_player_still_restores_the_budget() -> None:
+    """
+    The recovery budget is settled before any early return can skip it.
+
+    The stream-start callback bails out when the player is unavailable, but the
+    role-side entry point has no such gate; leaving the verdict of the previous
+    stream in place would pull the speaker out of the group the first time a
+    start on the next one fails.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    cast("MagicMock", bridge.airplay_player).available = False
+    bridge._last_transport_recovery = 100.0
+    bridge._recovering_transport = True
+
+    bridge._on_stream_start(MagicMock())
+
+    assert bridge._last_transport_recovery is None
+    assert bridge._recovering_transport is False  # type: ignore[unreachable]
+
+
+def test_second_transport_loss_within_the_guard_window_gives_up() -> None:
+    """A device dropping its transport again right away is abandoned, not re-anchored."""
+    bridge, _ = _make_anchored_bridge(running=False)
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.monotonic",
+            side_effect=[100.0, 100.0 + BRIDGE_TRANSPORT_RECOVERY_GUARD_SECONDS - 1],
+        ),
+        patch.object(bridge, "_restart_transport", MagicMock()) as restart,
+        patch.object(bridge, "_abandon_streaming", MagicMock()) as abandon,
+    ):
+        assert bridge._recover_transport() is True
+        assert bridge._recover_transport() is False
+
+    restart.assert_called_once_with()
+    abandon.assert_called_once_with()
+
+
+def test_transport_loss_after_the_guard_window_recovers_again() -> None:
+    """A single blip hours apart is a new incident, not a flapping device."""
+    bridge, _ = _make_anchored_bridge(running=False)
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.monotonic",
+            side_effect=[100.0, 100.0 + BRIDGE_TRANSPORT_RECOVERY_GUARD_SECONDS + 1],
+        ),
+        patch.object(bridge, "_restart_transport", MagicMock()) as restart,
+        patch.object(bridge, "_abandon_streaming", MagicMock()) as abandon,
+    ):
+        assert bridge._recover_transport() is True
+        assert bridge._recover_transport() is True
+
+    assert restart.call_count == 2
+    abandon.assert_not_called()
+
+
+def test_giving_up_does_not_queue_the_chunk_that_exposed_the_loss() -> None:
+    """
+    The chunk that trips the give-up is dropped, not written into the dead stream.
+
+    Giving up leaves the anchor and the stream reference untouched, so a chunk
+    that carried on through the handler would still be placed and queued.
+    """
+    bridge, _ = _make_anchored_bridge(running=False)
+    bridge._last_transport_recovery = 100.0
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.monotonic",
+            return_value=100.0 + BRIDGE_TRANSPORT_RECOVERY_GUARD_SECONDS - 1,
+        ),
+        patch.object(bridge, "_restart_transport", MagicMock()) as restart,
+    ):
+        bridge._on_audio_chunk(_pcm_chunk(SENDSPIN_EPOCH_US + 1_000_000))
+
+    restart.assert_not_called()
+    assert bridge._write_queue.empty()
+
+
+async def test_a_failed_protocol_start_gives_up_without_leaving_the_group() -> None:
+    """
+    A cold start that raised stops this stream but keeps the speaker in its group.
+
+    A start fails for reasons that pass (a sleeping device, one connect timeout),
+    and the next Sendspin stream starts it over. Dropping the speaker out of the
+    group here would make the user re-add it for a hiccup that healed itself.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    stream = _make_anchor_stream()
+    stream.connect = AsyncMock(side_effect=OSError("no route to device"))
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=stream,
+        ),
+        patch.object(bridge, "_leave_sendspin_session", MagicMock()) as leave,
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    assert bridge._is_streaming is False
+    leave.assert_not_called()
+
+
+async def test_losing_a_speaker_for_good_runs_the_whole_chain() -> None:
+    """
+    End to end: a transport dies, the reconnect is refused, the speaker leaves the group.
+
+    Every step here is the real one -- detection, the recovery decision, the
+    re-arm and the cold start -- so a reset of the recovery mark introduced
+    anywhere along that chain shows up as a speaker that stays silently
+    "playing" instead of dropping out.
+    """
+    bridge, _ = _make_anchored_bridge(running=False)
+    stream = _make_anchor_stream()
+    stream.connect = AsyncMock(side_effect=OSError("device gone"))
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=stream,
+        ),
+        patch.object(bridge, "_leave_sendspin_session", MagicMock()) as leave,
+    ):
+        # the chunk that exposes the loss re-arms and anchors a replacement
+        bridge._on_audio_chunk(_pcm_chunk(SENDSPIN_EPOCH_US + 1_000_000))
+        assert bridge._airplay_stream_start_task is not None
+        leave.assert_not_called()
+        # run the replacement start the chunk handler scheduled
+        start = cast("MagicMock", bridge.mass).create_task.call_args.args[0]
+        bridge._airplay_stream_start_task = asyncio.current_task()
+        await start
+
+    assert bridge._is_streaming is False
+    leave.assert_called_once_with()
+
+
+async def test_a_failed_recovery_takes_the_bridge_out_of_the_session() -> None:
+    """
+    A speaker that cannot be brought back mid-stream stops reporting playback.
+
+    Losing the transport once is recoverable, but a device that then refuses the
+    reconnect is gone for this stream; the group would otherwise hold the player
+    on PLAYING for the rest of it.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    # the state a recovery leaves behind while its replacement transport starts
+    bridge._recovering_transport = True
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    stream = _make_anchor_stream()
+    stream.connect = AsyncMock(side_effect=OSError("device gone"))
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=stream,
+        ),
+        patch.object(bridge, "_leave_sendspin_session", MagicMock()) as leave,
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    assert bridge._is_streaming is False
+    leave.assert_called_once_with()
+
+
+def test_abandoning_streaming_stops_the_feed_but_stays_in_the_session() -> None:
+    """Giving up stops accepting chunks and unblocks the writer, keeping the group intact."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._held_chunks.append(_pcm_chunk(SENDSPIN_EPOCH_US))
+    bridge._held_us = 100_000
+
+    with patch.object(bridge, "_leave_sendspin_session", MagicMock()) as leave:
+        bridge._abandon_streaming()
+
+    assert bridge._is_streaming is False
+    assert not bridge._held_chunks
+    assert bridge._held_us == 0
+    assert bridge._airplay_stream_ready.is_set()
+    leave.assert_not_called()
+
+
+def test_a_flapping_device_is_taken_out_of_the_sendspin_session() -> None:
+    """
+    Only a device that cannot hold a transport is dropped from the group.
+
+    Its silence is real and permanent, so the visible player must stop reporting
+    playback; the rest of the group keeps going without it.
+    """
+    bridge, _ = _make_anchored_bridge(running=False)
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.monotonic",
+            side_effect=[100.0, 100.0 + BRIDGE_TRANSPORT_RECOVERY_GUARD_SECONDS - 1],
+        ),
+        patch.object(bridge, "_restart_transport", MagicMock()),
+        patch.object(bridge, "_leave_sendspin_session", MagicMock()) as leave,
+    ):
+        assert bridge._recover_transport() is True
+        # the first loss is recoverable, so the speaker keeps its place
+        leave.assert_not_called()
+        assert bridge._recover_transport() is False
+
+    # scheduled, not merely constructed: an unscheduled coroutine never leaves
+    leave.assert_called_once_with()
+    scheduled = [call.args[0] for call in cast("MagicMock", bridge.mass).create_task.call_args_list]
+    assert leave.return_value in scheduled
+
+
+def test_failed_start_task_gives_up_on_the_stream() -> None:
+    """A protocol start that failed stops the feed, without dropping out of the group."""
+    bridge, _ = _make_anchored_bridge(running=True)
+    bridge._airplay_stream_start_task = _make_completed_start_task(failed=True)
+
+    with patch.object(bridge, "_leave_sendspin_session", MagicMock()) as leave:
+        bridge._on_audio_chunk(_pcm_chunk(SENDSPIN_EPOCH_US + 1_000_000))
+
+    assert bridge._is_streaming is False
+    leave.assert_not_called()
+
+
+async def test_writer_readiness_timeout_gives_up_on_the_stream() -> None:
+    """A protocol that never becomes ready stops the feed, without dropping out of the group."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._writer_task = asyncio.current_task()
+    bridge._airplay_stream_ready = MagicMock(wait=AsyncMock(side_effect=TimeoutError))
+
+    with patch.object(bridge, "_leave_sendspin_session", MagicMock()) as leave:
+        await bridge._cli_writer()
+
+    assert bridge._is_streaming is False
+    leave.assert_not_called()
+
+
+async def test_a_readiness_timeout_during_a_recovery_leaves_the_session() -> None:
+    """
+    A reconnect that hangs instead of failing still drops the speaker from the group.
+
+    It is the other half of "the recovery could not bring the speaker back": the
+    replacement transport never becomes ready, so the silence is just as final as
+    a refused connection.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._writer_task = asyncio.current_task()
+    bridge._recovering_transport = True
+    bridge._airplay_stream_ready = MagicMock(wait=AsyncMock(side_effect=TimeoutError))
+
+    with patch.object(bridge, "_leave_sendspin_session", MagicMock()) as leave:
+        await bridge._cli_writer()
+
+    leave.assert_called_once_with()
+
+
+async def test_a_stale_writer_cannot_give_up_on_a_newer_stream() -> None:
+    """
+    Only the writer still feeding the bridge may abandon it.
+
+    A writer left behind by a slow teardown speaks for a stream that is already
+    gone; letting it give up would stop, and possibly un-group, its successor.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    # a newer stream owns the bridge; this writer is the previous stream's
+    bridge._writer_task = MagicMock()
+    bridge._recovering_transport = True
+    bridge._airplay_stream_ready = MagicMock(wait=AsyncMock(side_effect=TimeoutError))
+
+    with patch.object(bridge, "_leave_sendspin_session", MagicMock()) as leave:
+        await bridge._cli_writer()
+
+    assert bridge._is_streaming is True
+    leave.assert_not_called()
+
+
+async def test_leaving_the_session_quiesces_the_bridge_client() -> None:
+    """The bridge leaves a shared group (or stops a solo one) but stays registered."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    client = MagicMock()
+    client.quiesce_to_solo_stopped = AsyncMock()
+    bridge._sendspin_client = client
+
+    await bridge._leave_sendspin_session()
+
+    client.quiesce_to_solo_stopped.assert_awaited_once_with()
+    # staying registered is what keeps the player around for the next stream
+    cast("MagicMock", bridge.sendspin_server).remove_client.assert_not_called()
+
+
+async def test_leaving_the_session_without_a_client_is_a_noop() -> None:
+    """
+    Giving up before registration completed has no session to leave.
+
+    The call has to return without touching anything: swallowing an error from
+    an absent client would look identical from the outside, so the absence of a
+    complaint is what distinguishes the two.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    logger = MagicMock()
+    bridge.logger = logger
+    assert bridge._sendspin_client is None
+
+    await bridge._leave_sendspin_session()
+
+    logger.warning.assert_not_called()


### PR DESCRIPTION
# What does this implement/fix?

When an AirPlay speaker is played through Sendspin (so it can be grouped with Sendspin players) and its streaming process dies mid-song, the speaker went quiet and never came back. The player — and the whole group it was in — kept showing "playing" until the track ended, because the bridge kept handing audio to a process that was gone and every write was silently accepted.

The existing automatic recovery only knew how to re-join a *native* AirPlay group, so it did nothing at all for a bridged speaker.

Changes:

- The bridge now notices its stream process is gone and starts a fresh one, re-joining the group at the position it is playing right now instead of restarting the song.
- A speaker that drops its connection again shortly after such a recovery is given up on, rather than being reconnected over and over.
- Only in that case — a speaker that demonstrably cannot hold a connection — does the bridge leave the Sendspin group, so the player stops reporting playback nobody can hear and the other speakers carry on.

Deliberately left alone: a speaker whose *very first* connection of a track fails (asleep, briefly offline) still shows as playing until the next track picks it up again, exactly as it does today. Dropping it from the group for a hiccup that heals itself would cost the user a manual regroup, so that path only stops the current track.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
