### PR TITLE
Stop AirPlay speaker starts from logging a false warning

### DIFF
--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -59,12 +59,15 @@ class AsyncNamedPipeWriter:
         """
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
-        while not self._ensure_write_fd():
+        while True:
+            # a concurrent write opens the same descriptor from its worker thread
+            async with self._write_lock:
+                if self._ensure_write_fd():
+                    return True
             remaining = deadline - loop.time()
             if remaining <= 0:
                 return False
             await asyncio.sleep(min(0.05, remaining))
-        return True
 
     async def write(self, data: bytes) -> bool:
         """

--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -6,7 +6,6 @@ import asyncio
 import errno as errno_module
 import logging
 import os
-import time
 from collections.abc import AsyncGenerator
 from contextlib import suppress
 from functools import partial
@@ -46,6 +45,26 @@ class AsyncNamedPipeWriter:
             os.mkfifo(self._pipe_path)
 
         await asyncio.to_thread(_create)
+
+    async def wait_for_reader(self, timeout: float) -> bool:
+        """
+        Wait until the pipe has a reader attached, so writes are no longer dropped.
+
+        A pipe without a reader accepts nothing, so a writer that is spawning its
+        reader alongside itself waits here before its first write.
+
+        :param timeout: Maximum time to wait for the reader in seconds.
+        :return: True once the pipe can be written to, False if no reader
+            attached before the timeout.
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while not self._ensure_write_fd():
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+            await asyncio.sleep(min(0.05, remaining))
+        return True
 
     async def write(self, data: bytes) -> bool:
         """
@@ -126,58 +145,18 @@ class AsyncNamedPipeWriter:
         return self._owner_id or self._pipe_path
 
     def _ensure_write_fd(self) -> bool:
-        """Ensure we have a write fd open. Returns True if successful."""
+        """Open the write end while a reader is attached. Returns True if successful."""
         if self._write_fd is not None:
             return True
         if not Path(self._pipe_path).exists():
             return False
-        # Retry opening until reader is available (up to 1s)
-        for _ in range(20):
-            try:
-                self._write_fd = os.open(self._pipe_path, os.O_WRONLY | os.O_NONBLOCK)
-                return True
-            except OSError as e:
-                if e.errno in (errno_module.ENXIO, errno_module.ENOENT):
-                    time.sleep(0.05)
-                    continue
-                raise
-        _LOGGER.warning(
-            "Could not open pipe %s (owner=%s): no reader after retries",
-            self._pipe_path,
-            self._log_owner,
-        )
-        return False
-
-
-async def open_named_pipe_writer(pipe_path: str, timeout: float = 1.0) -> int:
-    """
-    Open a named pipe writer after its reader is expected to be ready.
-
-    :param pipe_path: Filesystem path of the named pipe.
-    :param timeout: Maximum time to wait for the reader in seconds.
-    :return: A blocking file descriptor suitable for subprocess inheritance.
-    :raises TimeoutError: If no reader becomes available before the timeout.
-    :raises OSError: If opening or configuring the pipe fails.
-    """
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout
-    while True:
         try:
-            fd = os.open(pipe_path, os.O_WRONLY | os.O_NONBLOCK)
-        except OSError as err:
-            if err.errno not in (errno_module.ENXIO, errno_module.ENOENT):
-                raise
-            remaining = deadline - loop.time()
-            if remaining <= 0:
-                raise TimeoutError(f"Timed out opening named pipe writer: {pipe_path}") from err
-            await asyncio.sleep(min(0.05, remaining))
-            continue
-        try:
-            os.set_blocking(fd, True)
-        except BaseException:
-            os.close(fd)
+            self._write_fd = os.open(self._pipe_path, os.O_WRONLY | os.O_NONBLOCK)
+        except OSError as e:
+            if e.errno in (errno_module.ENXIO, errno_module.ENOENT):
+                return False
             raise
-        return fd
+        return True
 
 
 async def read_named_pipe(

--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -57,17 +57,16 @@ class AsyncNamedPipeWriter:
         :return: True once the pipe can be written to, False if no reader
             attached before the timeout.
         """
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + timeout
-        while True:
-            # a concurrent write opens the same descriptor from its worker thread
-            async with self._write_lock:
-                if self._ensure_write_fd():
-                    return True
-            remaining = deadline - loop.time()
-            if remaining <= 0:
-                return False
-            await asyncio.sleep(min(0.05, remaining))
+        try:
+            async with asyncio.timeout(timeout):
+                while True:
+                    # a concurrent write opens the same descriptor from its worker thread
+                    async with self._write_lock:
+                        if self._ensure_write_fd():
+                            return True
+                    await asyncio.sleep(0.05)
+        except TimeoutError:
+            return False
 
     async def write(self, data: bytes) -> bool:
         """
@@ -129,14 +128,17 @@ class AsyncNamedPipeWriter:
 
     async def remove(self) -> None:
         """Close write fd and remove the pipe."""
-        if self._write_fd is not None:
-            with suppress(Exception):
-                os.close(self._write_fd)
-            self._write_fd = None
-        pipe_path = Path(self._pipe_path)
-        if pipe_path.exists():
-            with suppress(Exception):
-                pipe_path.unlink()
+        # the lock keeps a write in flight on its worker thread from reopening
+        # the descriptor between the close and the unlink
+        async with self._write_lock:
+            if self._write_fd is not None:
+                with suppress(Exception):
+                    os.close(self._write_fd)
+                self._write_fd = None
+            pipe_path = Path(self._pipe_path)
+            if pipe_path.exists():
+                with suppress(Exception):
+                    pipe_path.unlink()
 
     def __str__(self) -> str:
         """Return string representation."""

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -70,6 +70,10 @@ _CLI_ERROR_CODE_RE = re.compile(r"\bcode=(\S+)")
 _CLI_ERROR_HTTP_RE = re.compile(r"\bhttp=(\d+)")
 _CLI_ERROR_DETAIL_RE = re.compile(r'\bdetail="([^"]*)"')
 
+# Seconds to wait for the binary's command pipe reader. It attaches right after
+# the connection is reported, so this only bridges the reader thread starting up.
+_COMMAND_PIPE_READER_TIMEOUT: Final[float] = 2.0
+
 
 @dataclass
 class CliError:
@@ -252,7 +256,6 @@ class AirPlayStream:
             await self._cli_proc.start()
             self._cli_proc.attach_stderr_reader(self.mass.create_task(self._stderr_reader()))
             self._stdout_reader_task = self.mass.create_task(self._stdout_reader())
-            await self._send_current_metadata(send_artwork=False)
         except BaseException:
             try:
                 await self._cleanup_failed_start()
@@ -262,7 +265,7 @@ class AirPlayStream:
 
     async def wait_for_connection(self) -> None:
         """
-        Wait for device connection to be established.
+        Wait until the device connection is established and commands can be sent.
 
         :raises PlayerCommandFailed: If the binary reported that the device needs
             a password, or rejected the configured one.
@@ -272,6 +275,25 @@ class AirPlayStream:
         if not self._cli_proc:
             raise RuntimeError("cliairplay process is not running")
         await self._await_connected()
+        # The binary attaches to its command pipe only once it is connected, so
+        # the first command waits for that reader instead of being dropped. A
+        # stream torn down while connecting takes its pipe along, which is not a
+        # fault worth reporting.
+        if not await self.commands_pipe.wait_for_reader(_COMMAND_PIPE_READER_TIMEOUT):
+            if self.running:
+                self.player.logger.warning(
+                    "cliairplay did not open its command pipe for %s; "
+                    "playback commands cannot be delivered",
+                    self.player.display_name,
+                )
+        # Nothing has reached this binary yet, so clear the delivery state to
+        # make sure the pushes below are really sent.
+        async with self._metadata_lock:
+            self._metadata_text_checksum = ""
+            self._metadata_artwork_checksum = ""
+            self._pending_metadata_checksum = ""
+            self._metadata_generation += 1
+        await self._send_current_metadata(send_artwork=False)
         # Send the mute-aware volume right away — audio can start within a
         # second now that metadata goes out immediately — and repeat it after
         # 2 seconds because some players ignore the first volume command
@@ -279,11 +301,6 @@ class AirPlayStream:
         volume = 0 if self.player.volume_muted else self.player.volume_level
         await self.send_cli_command(f"VOLUME={volume}")
         self.mass.call_later(2, self.send_cli_command(f"VOLUME={volume}"))
-        async with self._metadata_lock:
-            self._metadata_text_checksum = ""
-            self._metadata_artwork_checksum = ""
-            self._pending_metadata_checksum = ""
-            self._metadata_generation += 1
         # Push track metadata before START. Some receivers (notably Sonos) hold
         # back audio rendering until they receive track metadata; deferring it
         # can keep them silent past the commanded start.

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -265,7 +265,11 @@ class AirPlayStream:
 
     async def wait_for_connection(self) -> None:
         """
-        Wait until the device connection is established and commands can be sent.
+        Wait for device connection to be established.
+
+        Also gives the binary's command pipe a moment to open, so the first
+        commands are not dropped. A pipe that never opens is reported but does
+        not fail the wait.
 
         :raises PlayerCommandFailed: If the binary reported that the device needs
             a password, or rejected the configured one.
@@ -293,6 +297,9 @@ class AirPlayStream:
             self._metadata_artwork_checksum = ""
             self._pending_metadata_checksum = ""
             self._metadata_generation += 1
+        # Push track metadata before START. Some receivers (notably Sonos) hold
+        # back audio rendering until they receive track metadata; deferring it
+        # can keep them silent past the commanded start.
         await self._send_current_metadata(send_artwork=False)
         # Send the mute-aware volume right away — audio can start within a
         # second now that metadata goes out immediately — and repeat it after
@@ -301,9 +308,7 @@ class AirPlayStream:
         volume = 0 if self.player.volume_muted else self.player.volume_level
         await self.send_cli_command(f"VOLUME={volume}")
         self.mass.call_later(2, self.send_cli_command(f"VOLUME={volume}"))
-        # Push track metadata before START. Some receivers (notably Sonos) hold
-        # back audio rendering until they receive track metadata; deferring it
-        # can keep them silent past the commanded start.
+        # settle artwork and the position on top of the identity push above
         self.player._on_player_media_updated()
 
     async def stop(self, force: bool = False) -> None:

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -69,6 +69,9 @@ SUPPORTED_FEATURES = {ProviderFeature.AUDIO_SOURCE}
 # combined with the provider instance_id this forms the persistent uri
 AUDIO_SOURCE_ID = "main"
 
+# seconds the silence nudge waits for the audio pipe's consumer to reattach
+AUDIO_PIPE_READER_TIMEOUT = 1.0
+
 
 def airplay_receiver_port(instance_id: str) -> int:
     """
@@ -533,6 +536,11 @@ class AirPlayReceiverProvider(PluginProvider):
         """
         self.logger.debug("Writing silence to audio pipe to unblock stream")
         silence = b"\x00" * 176400  # 1 second of silence in PCM_S16LE stereo 44.1kHz
+        # the consumer reopens the pipe shortly after shairport-sync drops it, so the
+        # nudge waits for it to come back instead of landing in that gap
+        if not await self.audio_pipe.wait_for_reader(AUDIO_PIPE_READER_TIMEOUT):
+            self.logger.debug("No reader on the audio pipe, skipping the silence write")
+            return
         await self.audio_pipe.write(silence)
 
     def _process_shairport_log_line(self, line: str) -> None:

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -619,13 +619,23 @@ def test_command_pipe_paths_are_unique_per_stream() -> None:
 
 
 @pytest.mark.asyncio
-async def test_command_pipe_write_returns_false_without_reader(tmp_path: Path) -> None:
-    """A command pipe write reports when no reader can receive the command."""
+async def test_command_pipe_write_returns_false_without_reader(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A command pipe write reports a missing reader without retrying or warning."""
     pipe_path = tmp_path / "commands"
     os.mkfifo(pipe_path)
     writer = AsyncNamedPipeWriter(str(pipe_path))
 
-    assert await writer.write(b"ACTION=STANDBY\n") is False
+    with (
+        caplog.at_level(logging.WARNING),
+        patch("music_assistant.helpers.named_pipe.os.open", wraps=os.open) as open_pipe,
+    ):
+        assert await writer.write(b"ACTION=STANDBY\n") is False
+
+    # the missing reader is reported once, without retrying or crying wolf
+    open_pipe.assert_called_once()
+    assert not [record for record in caplog.records if record.levelno >= logging.WARNING]
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -805,6 +805,29 @@ async def test_command_pipe_wait_for_reader_uses_no_worker_thread(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_command_pipe_wait_for_reader_defers_to_an_in_flight_write(tmp_path: Path) -> None:
+    """The reader wait leaves the descriptor to a write that is already under way."""
+    pipe_path = tmp_path / "commands"
+    os.mkfifo(pipe_path)
+    writer = AsyncNamedPipeWriter(str(pipe_path))
+    read_fd = os.open(pipe_path, os.O_RDONLY | os.O_NONBLOCK)
+
+    try:
+        await writer._write_lock.acquire()
+        wait = asyncio.create_task(writer.wait_for_reader(timeout=1))
+        await asyncio.sleep(0)
+
+        # a reader is attached the whole time, so only the write lock holds this up
+        assert not wait.done()
+
+        writer._write_lock.release()
+        assert await wait is True
+    finally:
+        os.close(read_fd)
+        await writer.remove()
+
+
+@pytest.mark.asyncio
 async def test_command_pipe_write_reuses_the_fd_from_the_reader_wait(tmp_path: Path) -> None:
     """A command written after the reader wait rides the descriptor that wait opened."""
     pipe_path = tmp_path / "commands"

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -15,7 +15,7 @@ from music_assistant_models.enums import ContentType, PlaybackState
 from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import AudioFormat
 
-from music_assistant.helpers.named_pipe import AsyncNamedPipeWriter, open_named_pipe_writer
+from music_assistant.helpers.named_pipe import AsyncNamedPipeWriter
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_ARTWORK_SIZE,
     AIRPLAY_JOIN_START_ACK_TIMEOUT_MS,
@@ -625,8 +625,7 @@ async def test_command_pipe_write_returns_false_without_reader(tmp_path: Path) -
     os.mkfifo(pipe_path)
     writer = AsyncNamedPipeWriter(str(pipe_path))
 
-    with patch("music_assistant.helpers.named_pipe.time.sleep"):
-        assert await writer.write(b"ACTION=STANDBY\n") is False
+    assert await writer.write(b"ACTION=STANDBY\n") is False
 
 
 @pytest.mark.asyncio
@@ -745,6 +744,88 @@ async def test_command_pipe_write_propagates_non_epipe_errors() -> None:
 
 
 @pytest.mark.asyncio
+async def test_command_pipe_wait_for_reader_resolves_when_the_reader_attaches(
+    tmp_path: Path,
+) -> None:
+    """The reader wait ends as soon as the binary opens its end of the command pipe."""
+    pipe_path = tmp_path / "commands"
+    os.mkfifo(pipe_path)
+    writer = AsyncNamedPipeWriter(str(pipe_path))
+    read_fds: list[int] = []
+
+    async def attach_reader() -> None:
+        await asyncio.sleep(0.01)
+        read_fds.append(os.open(pipe_path, os.O_RDONLY | os.O_NONBLOCK))
+
+    reader = asyncio.create_task(attach_reader())
+    try:
+        assert await writer.wait_for_reader(timeout=1) is True
+        assert read_fds  # resolved on the attach, not before it
+    finally:
+        await reader
+        for read_fd in read_fds:
+            os.close(read_fd)
+        await writer.remove()
+
+
+@pytest.mark.asyncio
+async def test_command_pipe_wait_for_reader_gives_up_at_its_timeout(tmp_path: Path) -> None:
+    """A command pipe nothing ever reads fails the wait within the requested window."""
+    pipe_path = tmp_path / "commands"
+    os.mkfifo(pipe_path)
+    writer = AsyncNamedPipeWriter(str(pipe_path))
+    loop = asyncio.get_running_loop()
+
+    started = loop.time()
+    assert await writer.wait_for_reader(timeout=0.1) is False
+
+    assert 0.1 <= loop.time() - started < 1
+
+
+@pytest.mark.asyncio
+async def test_command_pipe_wait_for_reader_uses_no_worker_thread(tmp_path: Path) -> None:
+    """Waiting for the binary's reader never strands a blocking worker thread."""
+    pipe_path = tmp_path / "commands"
+    os.mkfifo(pipe_path)
+    writer = AsyncNamedPipeWriter(str(pipe_path))
+
+    with (
+        patch(
+            "music_assistant.helpers.named_pipe.os.open",
+            side_effect=OSError(errno.ENXIO, "no reader"),
+        ),
+        patch(
+            "music_assistant.helpers.named_pipe.asyncio.to_thread",
+            new_callable=AsyncMock,
+        ) as to_thread,
+    ):
+        assert await writer.wait_for_reader(timeout=0.1) is False
+
+    to_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_command_pipe_write_reuses_the_fd_from_the_reader_wait(tmp_path: Path) -> None:
+    """A command written after the reader wait rides the descriptor that wait opened."""
+    pipe_path = tmp_path / "commands"
+    os.mkfifo(pipe_path)
+    writer = AsyncNamedPipeWriter(str(pipe_path))
+    read_fd = os.open(pipe_path, os.O_RDONLY | os.O_NONBLOCK)
+
+    try:
+        assert await writer.wait_for_reader(timeout=1) is True
+
+        with patch("music_assistant.helpers.named_pipe.os.open") as open_pipe:
+            assert await writer.write(b"ACTION=STANDBY\n") is True
+
+        open_pipe.assert_not_called()
+        assert os.read(read_fd, 64) == b"ACTION=STANDBY\n"
+    finally:
+        os.close(read_fd)
+        await writer.remove()
+
+
+@pytest.mark.asyncio
 async def test_cli_command_updates_timestamp_after_successful_delivery() -> None:
     """A delivered command updates the player's last command timestamp."""
     player = _make_player()
@@ -797,12 +878,12 @@ async def test_cli_command_preserves_timestamp_when_delivery_raises() -> None:
 
 
 @pytest.mark.asyncio
-async def test_connect_queues_text_metadata_before_connection() -> None:
-    """Text metadata is queued as soon as cliairplay starts."""
+async def test_connect_does_not_write_before_the_binary_can_read() -> None:
+    """Connecting lays out the command pipe and starts cliairplay, pushing nothing into it."""
     player = _make_player()
     stream = AirPlayStream(player)
-    metadata = MagicMock(corrected_elapsed_time=12.5)
-    player.current_media = metadata
+    # media is available, so a push that never happens is by design and not a missing source
+    player.current_media = MagicMock(corrected_elapsed_time=12.5)
     process = MagicMock(closed=False)
     process.start = AsyncMock(return_value=None)
     operation_order: list[str] = []
@@ -812,9 +893,6 @@ async def test_connect_queues_text_metadata_before_connection() -> None:
 
     async def start_process() -> None:
         operation_order.append("process")
-
-    async def send_metadata(*_args: Any, **_kwargs: Any) -> None:
-        operation_order.append("metadata")
 
     def consume_task(awaitable: Any) -> MagicMock:
         awaitable.close()
@@ -831,32 +909,23 @@ async def test_connect_queues_text_metadata_before_connection() -> None:
             return_value=process,
         ),
         patch.object(stream.commands_pipe, "create", side_effect=create_pipe),
-        patch.object(stream, "send_metadata", side_effect=send_metadata) as send_metadata_mock,
+        patch.object(stream, "send_metadata", new_callable=AsyncMock) as send_metadata_mock,
     ):
         await stream.connect()
 
-    assert operation_order == ["pipe", "process", "metadata"]
-    send_metadata_mock.assert_awaited_once_with(12, metadata, send_artwork=False)
+    assert operation_order == ["pipe", "process"]
+    send_metadata_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_connect_failure_cleans_up_process_and_pipe() -> None:
-    """A metadata write failure cannot leave a live cliairplay process or FIFO."""
+    """A cliairplay process that fails to start cannot leave a live process or FIFO."""
     player = _make_player()
     stream = AirPlayStream(player)
-    metadata = MagicMock(corrected_elapsed_time=0)
-    player.current_media = metadata
     process = MagicMock(closed=False)
-    process.start = AsyncMock(return_value=None)
+    process.start = AsyncMock(side_effect=OSError("process start failed"))
     process.kill = AsyncMock()
 
-    def consume_task(awaitable: Any) -> MagicMock:
-        awaitable.close()
-        task = MagicMock()
-        task.done.return_value = True
-        return task
-
-    player.provider.mass.create_task.side_effect = consume_task
     with (
         patch.object(stream, "_build_cli_args", new_callable=AsyncMock, return_value=["binary"]),
         patch(
@@ -865,13 +934,7 @@ async def test_connect_failure_cleans_up_process_and_pipe() -> None:
         ),
         patch.object(stream.commands_pipe, "create", new_callable=AsyncMock),
         patch.object(stream.commands_pipe, "remove", new_callable=AsyncMock) as remove_pipe,
-        patch.object(
-            stream,
-            "send_metadata",
-            new_callable=AsyncMock,
-            side_effect=OSError("metadata write failed"),
-        ),
-        pytest.raises(OSError, match="metadata write failed"),
+        pytest.raises(OSError, match="process start failed"),
     ):
         await stream.connect()
 
@@ -1213,59 +1276,6 @@ async def test_flush_returns_false_when_not_connected() -> None:
     write_command.assert_not_awaited()
 
 
-@pytest.mark.asyncio
-async def test_named_pipe_writer_open_is_bounded_without_worker_thread() -> None:
-    """A missing FIFO reader times out without stranding a blocking worker thread."""
-    open_error = OSError(errno.ENXIO, "no reader")
-    with (
-        patch(
-            "music_assistant.helpers.named_pipe.os.open",
-            side_effect=open_error,
-        ),
-        patch(
-            "music_assistant.helpers.named_pipe.asyncio.to_thread",
-            new_callable=AsyncMock,
-        ) as to_thread,
-        pytest.raises(TimeoutError, match="Timed out opening named pipe writer"),
-    ):
-        await open_named_pipe_writer("/tmp/generation.pcm", timeout=0)  # noqa: S108
-
-    to_thread.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_named_pipe_writer_open_cancellation_has_no_fd_to_leak() -> None:
-    """Cancellation while waiting for a reader leaves no worker or descriptor behind."""
-    with (
-        patch(
-            "music_assistant.helpers.named_pipe.os.open",
-            side_effect=OSError(errno.ENXIO, "no reader"),
-        ),
-        patch("music_assistant.helpers.named_pipe.os.close") as close_fd,
-    ):
-        open_task = asyncio.create_task(
-            open_named_pipe_writer("/tmp/generation.pcm", timeout=10)  # noqa: S108
-        )
-        await asyncio.sleep(0)
-        open_task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await open_task
-
-    close_fd.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_named_pipe_writer_open_restores_blocking_mode() -> None:
-    """The descriptor inherited by ffmpeg is switched out of nonblocking mode."""
-    with (
-        patch("music_assistant.helpers.named_pipe.os.open", return_value=42),
-        patch("music_assistant.helpers.named_pipe.os.set_blocking") as set_blocking,
-    ):
-        assert await open_named_pipe_writer("/tmp/generation.pcm") == 42  # noqa: S108
-
-    set_blocking.assert_called_once_with(42, True)
-
-
 def test_flushed_status_sets_flush_event() -> None:
     """The [STATUS] flushed line releases the flush acknowledgement event."""
     stream = AirPlayStream(_make_player())
@@ -1525,7 +1535,6 @@ async def test_connect_resets_accumulated_shift() -> None:
     stream = AirPlayStream(player)
     stream.cumulative_shift_seconds = 5.0
     stream._reanchor_status_seen = True
-    player.current_media = MagicMock(corrected_elapsed_time=0)
     process = MagicMock(closed=False)
     process.start = AsyncMock(return_value=None)
 
@@ -1540,7 +1549,6 @@ async def test_connect_resets_accumulated_shift() -> None:
         patch.object(stream, "_build_cli_args", new_callable=AsyncMock, return_value=["binary"]),
         patch("music_assistant.providers.airplay.stream.AsyncProcess", return_value=process),
         patch.object(stream.commands_pipe, "create", new_callable=AsyncMock),
-        patch.object(stream, "send_metadata", new_callable=AsyncMock),
     ):
         await stream.connect()
 
@@ -1583,7 +1591,7 @@ async def test_initial_metadata_skips_artwork() -> None:
 @pytest.mark.asyncio
 async def test_wait_for_connection_pushes_metadata_immediately() -> None:
     """
-    Track metadata is pushed the instant the device connects.
+    Track metadata is pushed the instant the binary can receive it.
 
     Receivers that gate audio rendering on receiving timeline-anchored metadata
     (e.g. Sonos over native AirPlay 2) must not be left silent while a deferred
@@ -1595,13 +1603,25 @@ async def test_wait_for_connection_pushes_metadata_immediately() -> None:
     stream = AirPlayStream(player)
     stream._connected.set()  # connection already established
     player.provider.mass.call_later = MagicMock()
+    operation_order: list[str] = []
+
+    async def wait_for_reader(_timeout: float) -> bool:
+        operation_order.append("reader")
+        return True
+
+    async def send_current_metadata(**_kwargs: Any) -> None:
+        operation_order.append("metadata")
 
     with (
         patch.object(stream, "_cli_proc", MagicMock()),  # non-None so the method proceeds
+        patch.object(stream.commands_pipe, "wait_for_reader", side_effect=wait_for_reader),
+        patch.object(stream, "_send_current_metadata", side_effect=send_current_metadata),
         patch.object(stream, "send_cli_command", return_value=None),  # avoid a real coroutine
     ):
         await stream.wait_for_connection()
 
+    # Nothing is written before the binary has a reader on the command pipe.
+    assert operation_order == ["reader", "metadata"]
     # Metadata pushed synchronously on connect...
     player._on_player_media_updated.assert_called_once_with()
     # ...and never routed through the delayed call_later path.
@@ -1610,6 +1630,51 @@ async def test_wait_for_connection_pushes_metadata_immediately() -> None:
     # The volume resend is still deferred (existing behavior preserved).
     assert player.provider.mass.call_later.call_count == 1
     assert player.provider.mass.call_later.call_args_list[0].args[0] == 2
+
+
+@pytest.mark.asyncio
+async def test_wait_for_connection_reports_an_unread_command_pipe() -> None:
+    """A binary that never attaches to the command pipe is reported for the player it serves."""
+    player = _make_player()
+    player.logger = MagicMock()
+    player.volume_muted = False
+    stream = AirPlayStream(player)
+    stream._connected.set()
+    stream._cli_proc = MagicMock(closed=False)
+
+    with (
+        patch.object(
+            stream.commands_pipe, "wait_for_reader", new=AsyncMock(return_value=False)
+        ) as wait_for_reader,
+        patch.object(stream, "_send_current_metadata", new_callable=AsyncMock),
+        patch.object(stream, "send_cli_command", return_value=None),
+    ):
+        await stream.wait_for_connection()
+
+    wait_for_reader.assert_awaited_once()
+    player.logger.warning.assert_called_once()
+    assert player.display_name in player.logger.warning.call_args.args
+
+
+@pytest.mark.asyncio
+async def test_wait_for_connection_stays_quiet_about_a_stopped_stream() -> None:
+    """A stream torn down while connecting took its command pipe along, which is no fault."""
+    player = _make_player()
+    player.logger = MagicMock()
+    player.volume_muted = False
+    stream = AirPlayStream(player)
+    stream._connected.set()
+    stream._cli_proc = MagicMock(closed=False)
+    stream._stopping = True
+
+    with (
+        patch.object(stream.commands_pipe, "wait_for_reader", new=AsyncMock(return_value=False)),
+        patch.object(stream, "_send_current_metadata", new_callable=AsyncMock),
+        patch.object(stream, "send_cli_command", return_value=None),
+    ):
+        await stream.wait_for_connection()
+
+    player.logger.warning.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay_receiver/test_silence_nudge.py
+++ b/tests/providers/airplay_receiver/test_silence_nudge.py
@@ -1,0 +1,40 @@
+"""Tests for the silence nudge that unblocks a stopped AirPlay Receiver stream."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant.providers.airplay_receiver import AirPlayReceiverProvider
+
+
+def _make_provider(reader_attaches: bool) -> MagicMock:
+    """
+    Build a mock provider whose audio pipe reports the given reader state.
+
+    :param reader_attaches: Whether a consumer attaches to the audio pipe.
+    """
+    provider = MagicMock()
+    provider.logger = MagicMock()
+    provider.audio_pipe.wait_for_reader = AsyncMock(return_value=reader_attaches)
+    provider.audio_pipe.write = AsyncMock(return_value=True)
+    return provider
+
+
+async def test_silence_nudge_waits_for_the_returning_reader() -> None:
+    """The nudge is delivered once the stream's consumer has reattached to the pipe."""
+    provider = _make_provider(reader_attaches=True)
+
+    await AirPlayReceiverProvider._write_silence_to_unblock_stream(provider)
+
+    provider.audio_pipe.wait_for_reader.assert_awaited_once()
+    # one second of PCM_S16LE stereo 44.1kHz, enough for the consumer to emit a chunk
+    assert len(provider.audio_pipe.write.await_args.args[0]) == 176400
+
+
+async def test_silence_nudge_skipped_when_no_reader_returns() -> None:
+    """A pipe that nothing reads back is left alone instead of taking a dropped write."""
+    provider = _make_provider(reader_attaches=False)
+
+    await AirPlayReceiverProvider._write_silence_to_unblock_stream(provider)
+
+    provider.audio_pipe.write.assert_not_awaited()


### PR DESCRIPTION
# What does this implement/fix?

Starting an AirPlay speaker logged a warning that looks like a fault but isn't:

```
WARNING [named_pipe] Could not open pipe /tmp/2-<player>-...-cmd: no reader after retries
```

The cliairplay binary opens its command pipe only once it reports that it is connected, so the metadata push we sent right after spawning it never had a reader. That push was retried blindly for a second and then dropped, which is what happens on a busy network or when a group of six speakers starts at once. Nothing was actually lost, because the metadata push after the connection still delivers, but every speaker start also parked a worker thread for up to a second.

Changes:

- Wait for the command pipe's reader once the binary reports the connection, instead of writing before it can read anything
- Keep a warning for the real fault: a connected binary whose command pipe never gets a reader
- Drop the blind one second retry from the named pipe writer, so a missing reader no longer blocks a worker thread
- Give the AirPlay Receiver's silence nudge the same explicit wait, since it did rely on that retry to bridge its consumer reattaching
- Remove `open_named_pipe_writer()`, unused since #4977, along with its tests

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
