### PR TITLE
Keep grouped AirPlay speakers on the same clock

### DIFF
--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -448,8 +448,10 @@ Native AirPlay 2 receivers that advertise `SupportsPTP` are timed via PTP
 (UDP 319/320) and every receiver in a sync group must lock to the same
 grandmaster, so the provider runs **one** `cliairplay --ptp-daemon` for its
 whole lifetime (spawned at setup, terminated at unload, restarted once if it
-crashes). Every AirPlay 2-capable stream is started with `--ptp-shared` while
-the daemon runs, attaching it to the daemon's elected clock via shared memory.
+crashes). AirPlay 2-capable streams are started with `--ptp-shared` once the
+daemon reports it is serving, attaching them to its elected clock via shared
+memory. A sync group resolves that choice once and applies it to every member,
+so a group never mixes members on the shared clock with members off it.
 
 The official Music Assistant container runs as root, allowing the daemon to bind
 these ports. A custom container running Music Assistant as a non-root user must

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -237,8 +237,7 @@ class AirPlayStream:
         :param use_shared_ptp: Session-wide decision on whether native AirPlay 2
             members attach to the shared PTP clock daemon. The stream session
             passes the same value to every member so a group never mixes PTP and
-            NTP timing. None (single-stream callers) falls back to the daemon's
-            live state.
+            NTP timing. None lets the stream decide from the daemon's readiness.
         """
         self._check_password_preflight()
         # A fresh cliairplay process re-anchors from scratch, so drop any shift
@@ -714,7 +713,7 @@ class AirPlayStream:
         :param use_shared_ptp: Whether a native AirPlay 2 stream attaches to the
             shared PTP clock daemon. The stream session passes an explicit
             group-wide decision so members never mix PTP and NTP timing; None
-            (single-stream callers) falls back to the daemon's live state.
+            waits for the daemon to be ready to serve and decides from that.
         """
         cli_binary = await get_cli_binary()
         prov = cast("AirPlayProvider", self.prov)
@@ -811,10 +810,14 @@ class AirPlayStream:
         # Shared PTP daemon clock (multi-room sync for native AP2 streams). The
         # decision is made once per session and passed in, so every native AP2
         # member of a sync group uses the same timing source and cannot drift.
-        # A single-stream caller (use_shared_ptp is None) falls back to the
-        # daemon's live state.
+        # Without a caller-supplied decision (use_shared_ptp is None) the stream
+        # gates on the daemon actually serving: only one process per host can bind
+        # the privileged PTP ports, so attaching to a daemon that is alive but has
+        # not bound them yet fails and drops that stream to NTP without saying so.
         if target_protocol == StreamingProtocol.AIRPLAY2:
-            shared_ptp = prov.ptp_daemon_running if use_shared_ptp is None else use_shared_ptp
+            shared_ptp = (
+                await prov.wait_ptp_daemon_ready() if use_shared_ptp is None else use_shared_ptp
+            )
             if shared_ptp:
                 args += ["--ptp-shared"]
 

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -713,7 +713,7 @@ class AirPlayStream:
         :param use_shared_ptp: Whether a native AirPlay 2 stream attaches to the
             shared PTP clock daemon. The stream session passes an explicit
             group-wide decision so members never mix PTP and NTP timing; None
-            waits for the daemon to be ready to serve and decides from that.
+            reads the daemon's current readiness and decides from that.
         """
         cli_binary = await get_cli_binary()
         prov = cast("AirPlayProvider", self.prov)
@@ -811,13 +811,11 @@ class AirPlayStream:
         # decision is made once per session and passed in, so every native AP2
         # member of a sync group uses the same timing source and cannot drift.
         # Without a caller-supplied decision (use_shared_ptp is None) the stream
-        # gates on the daemon actually serving: only one process per host can bind
-        # the privileged PTP ports, so attaching to a daemon that is alive but has
-        # not bound them yet fails and drops that stream to NTP without saying so.
+        # gates on the daemon serving rather than merely running: between spawn and
+        # the daemon publishing its clock there is nothing to attach to, and a
+        # stream that asks anyway silently takes its own timing instead.
         if target_protocol == StreamingProtocol.AIRPLAY2:
-            shared_ptp = (
-                await prov.wait_ptp_daemon_ready() if use_shared_ptp is None else use_shared_ptp
-            )
+            shared_ptp = prov.ptp_daemon_ready if use_shared_ptp is None else use_shared_ptp
             if shared_ptp:
                 args += ["--ptp-shared"]
 

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -757,7 +757,7 @@ def _stream_player(*, ptp_daemon_ready: bool) -> MagicMock:
 
     prov = MagicMock()
     prov.dacp_id = "ABCDEF0123456789"
-    prov.wait_ptp_daemon_ready = AsyncMock(return_value=ptp_daemon_ready)
+    prov.ptp_daemon_ready = ptp_daemon_ready
     prov.logger = logging.getLogger("test.airplay.prov")
     prov.mass.streams.publish_ip = "192.168.1.99"
     prov.mass.streams.get_source_ip = AsyncMock(return_value="192.168.1.5")

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -735,10 +735,10 @@ async def test_session_start_calculates_anchor_after_ptp_resolution() -> None:
         assert player.stream.start.await_args.args[0] == expected
 
 
-# --- Session decision reaches the CLI args (overrides bare liveness) ------------
+# --- Session decision reaches the CLI args (overrides bare readiness) ----------
 
 
-def _stream_player(*, ptp_daemon_running: bool) -> MagicMock:
+def _stream_player(*, ptp_daemon_ready: bool) -> MagicMock:
     """Build a minimal AirPlay player mock sufficient for _build_cli_args."""
     player = MagicMock()
     player.player_id = "apaabbccddeeff"
@@ -757,7 +757,7 @@ def _stream_player(*, ptp_daemon_running: bool) -> MagicMock:
 
     prov = MagicMock()
     prov.dacp_id = "ABCDEF0123456789"
-    prov.ptp_daemon_running = ptp_daemon_running
+    prov.wait_ptp_daemon_ready = AsyncMock(return_value=ptp_daemon_ready)
     prov.logger = logging.getLogger("test.airplay.prov")
     prov.mass.streams.publish_ip = "192.168.1.99"
     prov.mass.streams.get_source_ip = AsyncMock(return_value="192.168.1.5")
@@ -776,31 +776,31 @@ async def _build_args(player: MagicMock, use_shared_ptp: bool | None) -> list[st
         return await stream._build_cli_args(use_shared_ptp)
 
 
-async def test_build_cli_args_explicit_shared_ptp_overrides_dead_daemon() -> None:
-    """An explicit True adds --ptp-shared even when the daemon reads as not-live."""
-    player = _stream_player(ptp_daemon_running=False)
+async def test_build_cli_args_explicit_shared_ptp_overrides_unready_daemon() -> None:
+    """An explicit True adds --ptp-shared even when the daemon reads as not-ready."""
+    player = _stream_player(ptp_daemon_ready=False)
 
     args = await _build_args(player, use_shared_ptp=True)
 
     assert "--ptp-shared" in args
 
 
-async def test_build_cli_args_explicit_no_shared_ptp_overrides_live_daemon() -> None:
-    """An explicit False omits --ptp-shared even while the daemon is live."""
-    player = _stream_player(ptp_daemon_running=True)
+async def test_build_cli_args_explicit_no_shared_ptp_overrides_ready_daemon() -> None:
+    """An explicit False omits --ptp-shared even while the daemon is ready."""
+    player = _stream_player(ptp_daemon_ready=True)
 
     args = await _build_args(player, use_shared_ptp=False)
 
     assert "--ptp-shared" not in args
 
 
-async def test_build_cli_args_none_falls_back_to_daemon_liveness() -> None:
-    """Legacy single-stream callers (None) still gate --ptp-shared on daemon liveness."""
+async def test_build_cli_args_none_falls_back_to_daemon_readiness() -> None:
+    """Callers without a group-wide decision (None) gate --ptp-shared on daemon readiness."""
     assert "--ptp-shared" in await _build_args(
-        _stream_player(ptp_daemon_running=True), use_shared_ptp=None
+        _stream_player(ptp_daemon_ready=True), use_shared_ptp=None
     )
     assert "--ptp-shared" not in await _build_args(
-        _stream_player(ptp_daemon_running=False), use_shared_ptp=None
+        _stream_player(ptp_daemon_ready=False), use_shared_ptp=None
     )
 
 

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -67,7 +67,7 @@ def _make_player() -> MagicMock:
 
     prov = MagicMock()
     prov.dacp_id = "ABCDEF0123456789"
-    prov.wait_ptp_daemon_ready = AsyncMock(return_value=True)
+    prov.ptp_daemon_ready = True
     prov.logger = logging.getLogger("test.airplay.prov")
     # auto-detected publish ip: reachable address of this host, but not the interface
     # the stream to this device leaves from - so it is never handed to the binary
@@ -260,22 +260,6 @@ async def test_cli_args_raop_override() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cli_args_raop_override_skips_the_ptp_daemon_wait() -> None:
-    """
-    A forced RAOP protocol never waits on the PTP daemon's readiness.
-
-    RAOP has no shared clock to attach to, so paying the bounded readiness
-    wait here would only eat into a bridge's cold-connect budget for nothing.
-    """
-    player = _make_player()
-    player.protocol_override = StreamingProtocol.RAOP
-    args = await _build_args(player)
-
-    assert "--ptp-shared" not in args
-    player.provider.wait_ptp_daemon_ready.assert_not_awaited()
-
-
-@pytest.mark.asyncio
 async def test_cli_args_raop_encryption_can_be_disabled() -> None:
     """The legacy encryption preference remains available for incompatible receivers."""
     player = _make_player()
@@ -290,26 +274,17 @@ async def test_cli_args_raop_encryption_can_be_disabled() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cli_args_no_ptp_shared_when_daemon_not_ready() -> None:
-    """--ptp-shared is only passed once the provider's PTP daemon reports ready."""
-    player = _make_player()
-    player.provider.wait_ptp_daemon_ready = AsyncMock(return_value=False)
-    args = await _build_args(player)
-    assert "--ptp-shared" not in args
-
-
-@pytest.mark.asyncio
 async def test_cli_args_no_ptp_shared_when_daemon_alive_but_not_ready() -> None:
     """
     A daemon that is merely alive must not get --ptp-shared.
 
-    Only one process per host can bind the privileged PTP ports, so liveness
-    alone does not mean the daemon is serving: attaching to one that is alive
-    but has not bound them yet fails and silently drops the stream to NTP.
+    Liveness does not mean the daemon is serving: until it publishes its clock
+    there is nothing to attach to, and a stream that asks anyway silently takes
+    its own timing instead - drifting away from the members that got the clock.
     """
     player = _make_player()
     player.provider.ptp_daemon_running = True
-    player.provider.wait_ptp_daemon_ready = AsyncMock(return_value=False)
+    player.provider.ptp_daemon_ready = False
     args = await _build_args(player)
     assert "--ptp-shared" not in args
 

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -67,7 +67,7 @@ def _make_player() -> MagicMock:
 
     prov = MagicMock()
     prov.dacp_id = "ABCDEF0123456789"
-    prov.ptp_daemon_running = True
+    prov.wait_ptp_daemon_ready = AsyncMock(return_value=True)
     prov.logger = logging.getLogger("test.airplay.prov")
     # auto-detected publish ip: reachable address of this host, but not the interface
     # the stream to this device leaves from - so it is never handed to the binary
@@ -260,6 +260,22 @@ async def test_cli_args_raop_override() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cli_args_raop_override_skips_the_ptp_daemon_wait() -> None:
+    """
+    A forced RAOP protocol never waits on the PTP daemon's readiness.
+
+    RAOP has no shared clock to attach to, so paying the bounded readiness
+    wait here would only eat into a bridge's cold-connect budget for nothing.
+    """
+    player = _make_player()
+    player.protocol_override = StreamingProtocol.RAOP
+    args = await _build_args(player)
+
+    assert "--ptp-shared" not in args
+    player.provider.wait_ptp_daemon_ready.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_cli_args_raop_encryption_can_be_disabled() -> None:
     """The legacy encryption preference remains available for incompatible receivers."""
     player = _make_player()
@@ -274,10 +290,26 @@ async def test_cli_args_raop_encryption_can_be_disabled() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cli_args_no_ptp_shared_without_daemon() -> None:
-    """--ptp-shared is only passed while the provider's PTP daemon is running."""
+async def test_cli_args_no_ptp_shared_when_daemon_not_ready() -> None:
+    """--ptp-shared is only passed once the provider's PTP daemon reports ready."""
     player = _make_player()
-    player.provider.ptp_daemon_running = False
+    player.provider.wait_ptp_daemon_ready = AsyncMock(return_value=False)
+    args = await _build_args(player)
+    assert "--ptp-shared" not in args
+
+
+@pytest.mark.asyncio
+async def test_cli_args_no_ptp_shared_when_daemon_alive_but_not_ready() -> None:
+    """
+    A daemon that is merely alive must not get --ptp-shared.
+
+    Only one process per host can bind the privileged PTP ports, so liveness
+    alone does not mean the daemon is serving: attaching to one that is alive
+    but has not bound them yet fails and silently drops the stream to NTP.
+    """
+    player = _make_player()
+    player.provider.ptp_daemon_running = True
+    player.provider.wait_ptp_daemon_ready = AsyncMock(return_value=False)
     args = await _build_args(player)
     assert "--ptp-shared" not in args
 


### PR DESCRIPTION
# What does this implement/fix?

When several AirPlay speakers play together, they all need to agree on one clock. One of them could quietly end up on a different clock than the rest and drift out of sync.

An AirPlay stream that isn't handed a group-wide timing decision picked its clock based on whether our shared clock helper was *running*, rather than whether it was actually ready to serve. A stream that attaches while the helper is still starting up finds nothing to attach to, quietly takes its own timing instead, and says nothing about it — leaving that speaker out of step with its neighbours.

- Decide on the shared clock from the helper being ready, not just alive
- Correct the provider README, which still described the flag as always-on while the helper runs
- Tests updated for the readiness behaviour

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
