### PR TITLE
Update documentation links

### DIFF
--- a/music_assistant/providers/filesystem_google_drive/manifest.json
+++ b/music_assistant/providers/filesystem_google_drive/manifest.json
@@ -2,7 +2,7 @@
   "domain": "filesystem_google_drive",
   "name": "Google Drive",
   "description": "Stream music, audiobooks and podcasts stored in Google Drive",
-  "documentation": "https://music-assistant.io/music-providers/filesystem/",
+  "documentation": "https://music-assistant.io/music-providers/local-files/",
   "type": "music",
   "requirements": ["python-google-drive-api==0.1.0"],
   "codeowners": ["@ozgav"],

--- a/music_assistant/providers/filesystem_local/constants.py
+++ b/music_assistant/providers/filesystem_local/constants.py
@@ -14,7 +14,7 @@ CONF_ENTRY_MISSING_ALBUM_ARTIST = ConfigEntry(
     key=CONF_MISSING_ALBUM_ARTIST_ACTION,
     type=ConfigEntryType.STRING,
     default_value="various_artists",
-    help_link="https://music-assistant.io/music-providers/filesystem/#tagging-files",
+    help_link="https://music-assistant.io/music-providers/local-files/#tagging-files",
     required=False,
     options=[
         ConfigValueOption("track_artist"),

--- a/music_assistant/providers/filesystem_local/manifest.json
+++ b/music_assistant/providers/filesystem_local/manifest.json
@@ -6,7 +6,7 @@
   "description": "Play music and audiobooks stored on locally connected drives.",
   "codeowners": ["@music-assistant"],
   "requirements": [],
-  "documentation": "https://music-assistant.io/music-providers/filesystem/",
+  "documentation": "https://music-assistant.io/music-providers/local-files/",
   "multi_instance": true,
   "icon": "harddisk"
 }

--- a/music_assistant/providers/filesystem_nfs/manifest.json
+++ b/music_assistant/providers/filesystem_nfs/manifest.json
@@ -6,7 +6,7 @@
   "description": "Play music and audiobooks stored on NFS connected network drives.",
   "codeowners": ["@ozgav"],
   "requirements": [],
-  "documentation": "https://music-assistant.io/music-providers/filesystem/",
+  "documentation": "https://music-assistant.io/music-providers/local-files/",
   "multi_instance": true,
   "icon": "network"
 }

--- a/music_assistant/providers/filesystem_onedrive/manifest.json
+++ b/music_assistant/providers/filesystem_onedrive/manifest.json
@@ -2,7 +2,7 @@
   "domain": "filesystem_onedrive",
   "name": "OneDrive",
   "description": "Stream music, audiobooks and podcasts stored in OneDrive",
-  "documentation": "https://music-assistant.io/music-providers/filesystem/",
+  "documentation": "https://music-assistant.io/music-providers/local-files/",
   "type": "music",
   "requirements": ["onedrive-personal-sdk==0.1.7"],
   "codeowners": ["@ozgav"],

--- a/music_assistant/providers/filesystem_smb/manifest.json
+++ b/music_assistant/providers/filesystem_smb/manifest.json
@@ -6,7 +6,7 @@
   "description": "Play music and audiobooks stored on SMB connected network drives.",
   "codeowners": ["@music-assistant"],
   "requirements": [],
-  "documentation": "https://music-assistant.io/music-providers/filesystem/",
+  "documentation": "https://music-assistant.io/music-providers/local-files/",
   "multi_instance": true,
   "icon": "network"
 }

--- a/music_assistant/providers/hass_players/manifest.json
+++ b/music_assistant/providers/hass_players/manifest.json
@@ -5,7 +5,7 @@
   "name": "Home Assistant MediaPlayers",
   "description": "Control and play music on (supported) Home Assistant media players in your smart home.",
   "codeowners": ["@music-assistant"],
-  "documentation": "https://music-assistant.io/player-support/ha/",
+  "documentation": "https://music-assistant.io/player-support/home-assistant/",
   "multi_instance": false,
   "builtin": false,
   "icon": "md:webhook",

--- a/music_assistant/providers/mpd/manifest.json
+++ b/music_assistant/providers/mpd/manifest.json
@@ -6,6 +6,6 @@
   "description": "Stream music from Music Assistant to any device running MPD (Music Player Daemon).",
   "codeowners": ["@OzGav"],
   "requirements": ["python-mpd2>=3.1.1"],
-  "documentation": "https://music-assistant.io/music-providers/mpd/",
+  "documentation": "https://music-assistant.io/player-support/music-player-daemon/",
   "multi_instance": false
 }

--- a/music_assistant/providers/orf_radiothek/manifest.json
+++ b/music_assistant/providers/orf_radiothek/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "stage": "stable",
   "description": "Stream live radio and on-demand content from ORF Radiothek (Austrian public service broadcaster). Supports live streams from Ö1, Ö3, FM4, and regional stations, plus on-demand broadcasts and podcasts.",
-  "documentation": "https://music-assistant.io/music-providers/radiothek",
+  "documentation": "https://music-assistant.io/music-providers/orf-radiothek",
   "requirements": [],
   "icon": "mdi:radio",
   "type": "music",


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

To reduce admin burden when creating new music source and player provider pages I have switched to using auto generation for the menu for those sections. As that is done alphabetically by slug this needed a couple of renames. Also found one typo in a link. This is all fixed with this PR and the docs site has redirects in until this is tidied up

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
