### PR TITLE
Follow-up fixes for the AirPlay status contract and solo starts

### DIFF
--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -376,7 +376,7 @@ class AirPlayStream:
         """
         if not self.running or not self.connected:
             return False
-        self._flushed.clear()
+        self._arm_flush_answer()
         # The flush drain re-arms the binary's one-shot audio signal; the next
         # [STATUS] audio belongs to the new track.
         self._audio_present.clear()
@@ -478,8 +478,7 @@ class AirPlayStream:
         # the binary's first status arrives, interpolation would otherwise keep
         # extending the previous anchor's clock, briefly mapping a bogus position.
         self.player.set_state_from_stream(elapsed_time=self._start_position, stream=self)
-        self._started.clear()
-        self._start_ack = None
+        self._arm_start_answer()
         self._start_was_join = join
         start_cmd = f"START_UNIX_MS={start_unix_ms}\nACTION=START"
         if join:
@@ -979,10 +978,14 @@ class AirPlayStream:
             return
         # Only a 2xx means the device took the push. Nothing else on this
         # control channel does - a redirect is as much "not accepted" as a 4xx.
+        # A status of 0 is the "unreported" reading (the field is missing or
+        # unusable), which says nothing about how the push landed, so only a
+        # reported status is judged - warning about a field the binary never
+        # sent would report a rejection that nothing observed.
         status = _status_int(fields, "status")
-        accepted = HTTPStatus.OK <= status < HTTPStatus.MULTIPLE_CHOICES
+        rejected = bool(status) and not (HTTPStatus.OK <= status < HTTPStatus.MULTIPLE_CHOICES)
         self.player.logger.log(
-            logging.DEBUG if accepted else logging.WARNING,
+            logging.WARNING if rejected else logging.DEBUG,
             "MRP now-playing push (%s path) for %s: HTTP %s",
             fields.get("path", "?"),
             display_name,
@@ -1234,6 +1237,11 @@ class AirPlayStream:
             self._flushed.set()
         elif "[STATUS] audio " in line:
             self._audio_present.set()
+        elif "[STATUS] mrp" in line:
+            # The artwork reports arrive on stderr; the now-playing push
+            # status arrives on stdout. One parser serves both shapes, so
+            # each reader dispatches the mrp lines its own pipe carries.
+            self._parse_mrp_status(line)
         elif "[STATUS] idle_timeout" in line:
             # a parked (paused) session outlived the binary's idle cap;
             # treat it as a normal end of stream
@@ -1395,6 +1403,21 @@ class AirPlayStream:
             self._cleanup_complete = True
             self._cli_proc = None
 
+    def _arm_start_answer(self) -> None:
+        """Clear the slots the binary answers a START in, so only this one's answer is read."""
+        # The ack and the failure are filled by the stderr reader while start()
+        # waits, so both slots have to be emptied at the command itself: a
+        # rejection left over from the previous START would otherwise be read
+        # as this one's answer the moment an ack releases the wait.
+        self._started.clear()
+        self._start_ack = None
+        self._start_error = None
+
+    def _arm_flush_answer(self) -> None:
+        """Clear the slots the binary answers a FLUSH in, so only this one's answer is read."""
+        self._flushed.clear()
+        self._flush_error = None
+
     async def _write_cli_command(self, command: str) -> bool:
         """Write an interactive command regardless of stream teardown state."""
         if not self._cli_proc or self._cli_proc.closed:
@@ -1547,7 +1570,11 @@ class AirPlayStream:
         # The binary's elapsed counts only the retained content, so the
         # position base moves by the cut to keep reported progress exact.
         self._start_position += content_cut_ms / 1000
-        self._pending_content_cut_ms = content_cut_ms
+        # Track the cut owed the same way the base above tracks it: both
+        # accumulate over an anchor and both are zeroed at every anchor
+        # boundary. Overwriting here would settle only the newest correction
+        # against a base that carries all of them.
+        self._pending_content_cut_ms += content_cut_ms
         # Routine for a join start: the low join headroom defers to this
         # correction, which lands the anchor at exact receiver readiness. A
         # post-commit correction on any other START stays loud.
@@ -1600,8 +1627,12 @@ class AirPlayStream:
                 cut_ms,
             )
             return
+        # A cut can miss the amount it was asked for in either direction, and
+        # both leave the base wrong by the difference, so the magnitude decides
+        # whether it settled cleanly. Re-basing by the signed difference then
+        # corrects either one; only the report differs.
         shortfall_ms = applied_ms - cut_ms
-        if shortfall_ms < AIRPLAY_CONTENT_CUT_TOLERANCE_MS:
+        if abs(shortfall_ms) < AIRPLAY_CONTENT_CUT_TOLERANCE_MS:
             self.player.logger.debug(
                 "AirPlay content cut on %s took the full %d ms (%d bytes in %d ms)",
                 self.player.display_name,
@@ -1611,17 +1642,32 @@ class AirPlayStream:
             )
             return
         self._start_position -= shortfall_ms / 1000
+        if shortfall_ms > 0:
+            self.player.logger.warning(
+                "AirPlay content cut on %s fell %d ms short: the corrected anchor asked "
+                "for %d ms and the cut took %d ms (%d bytes in %d ms). Reported position "
+                "re-based by -%d ms; playback is that much ahead of the group timeline.",
+                self.player.display_name,
+                shortfall_ms,
+                applied_ms,
+                cut_ms,
+                cut_bytes,
+                drain_ms,
+                shortfall_ms,
+            )
+            return
+        overcut_ms = -shortfall_ms
         self.player.logger.warning(
-            "AirPlay content cut on %s fell %d ms short: the corrected anchor asked "
+            "AirPlay content cut on %s overran by %d ms: the corrected anchor asked "
             "for %d ms and the cut took %d ms (%d bytes in %d ms). Reported position "
-            "re-based by -%d ms; playback is that much ahead of the group timeline.",
+            "was under-advanced by that much and is re-based by +%d ms.",
             self.player.display_name,
-            shortfall_ms,
+            overcut_ms,
             applied_ms,
             cut_ms,
             cut_bytes,
             drain_ms,
-            shortfall_ms,
+            overcut_ms,
         )
 
     def _parse_clock_ready(self, line: str) -> None:

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -40,14 +40,14 @@ if TYPE_CHECKING:
     from .player import AirPlayPlayer
     from .provider import AirPlayProvider
 
-# What each readiness outcome means for the join anchor. They all end up
-# anchoring on the join floor, so only the reason distinguishes a device that
-# needs longer from one that will not play at all.
+# What each readiness outcome means for the join anchor: only a projection moves
+# it, every other outcome leaves the join floor carrying it alone, so the note
+# says which of the two happened and why. STALLED has no note because it never
+# reaches an anchor - a stalled joiner is refused the join before that.
 _CLOCK_READINESS_NOTES: dict[ClockReadiness, str] = {
     ClockReadiness.PROJECTED: "usable in {out:.2f}s; anchoring just past that",
     ClockReadiness.NOT_APPLICABLE: "runs on NTP timing, so there is none to wait for; "
     "anchoring on the join floor",
-    ClockReadiness.STALLED: "never answered ours; anchoring on the join floor",
     ClockReadiness.UNREPORTED: "was not reported within {timeout:.1f}s (a slow device, or a "
     "binary too old to report it); anchoring on the join floor",
 }
@@ -1098,9 +1098,12 @@ class AirPlayStreamSession:
             caller then anchors on its lead alone.
         """
         if len(self.sync_clients) == 1:
-            # A lone receiver seats a fresh session by itself within ~20 ms and
-            # has no partner to be late against, so waiting only delays it. The
-            # instant matters once members have to agree on one.
+            # A lone receiver has no partner to be late against, so waiting only
+            # delays it; the instant matters once members have to agree on one.
+            # This assumes it seats a fresh session quickly, which holds for the
+            # receivers measured (Sonos, Apple, Samsung) but not for every one:
+            # a receiver that does need its clock up front - a multiroom master,
+            # say - is covered by a separate readiness decision, not this one.
             return 0
         results = await asyncio.gather(
             *[
@@ -1138,6 +1141,8 @@ class AirPlayStreamSession:
         misplaced). When any member was corrected, every member is re-STARTed
         at the largest reported instant so the group converges on one shared
         instant; the recorded session anchor is always the verified truth.
+        A solo member is never re-STARTed: its corrected instant is simply
+        adopted as the anchor, since there is no partner to converge with.
 
         :param position_ms: Media position mapped to the first sample of the anchor.
         :param start_unix_ms: Shared audible-start instant in unix epoch ms.
@@ -1168,6 +1173,17 @@ class AirPlayStreamSession:
                     continue  # older binary without a started ack
                 corrected_ms = max(corrected_ms, actual - adjust_ms)
             if corrected_ms <= target_ms + 2:
+                break
+            if len(member_tasks) == 1:
+                # A lone member has no partner to converge with and its binary
+                # already scheduled the corrected instant exactly, so adopt that
+                # as the anchor. Re-STARTing it only does damage: the command
+                # re-bases reported position on the raw position_ms (start()
+                # writes that base unconditionally), throwing away the
+                # correction the anchor already folded into it, and if the
+                # second ack times out the session records an instant the
+                # binary never played on.
+                target_ms = corrected_ms
                 break
             self.prov.logger.warning(
                 "AirPlay group start corrected: a member could not honor %d, "

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -504,6 +504,23 @@ def test_mrp_artwork_rejection_is_reported(caplog: pytest.LogCaptureFixture) -> 
     assert "HTTP ?" not in caplog.text
 
 
+def test_mrp_artwork_rejection_reaches_the_parser_from_the_stderr_reader(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The binary reports artwork on stderr, so the status dispatcher must route it."""
+    stream = AirPlayStream(_make_player())
+
+    with caplog.at_level(logging.WARNING):
+        ends_the_loop = stream._handle_status_line(
+            "[STATUS] mrp artwork=rejected reason=progressive_jpeg bytes=48123 "
+            "width=512 height=512 precision=8 sof=0xc2 components=3 progressive=1 "
+            "clear_status=200 staging_max_bytes=131072"
+        )
+
+    assert ends_the_loop is False
+    assert "rejected the now-playing artwork" in caplog.text
+
+
 def test_mrp_channel_status_is_not_read_as_an_http_status(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -285,18 +285,26 @@ async def test_solo_start_does_not_wait_for_a_clock_projection() -> None:
 async def test_group_start_that_never_converges_anchors_where_members_landed() -> None:
     """A group that keeps correcting is anchored at the members' own last instant."""
     session = _make_session(0, 0)
-    player: Any = session.sync_clients[0]
-    player.config.get_value = MagicMock(return_value=0)
-    stream = _stream_defaults(MagicMock(running=True))
+    first: Any = session.sync_clients[0]
+    first.config.get_value = MagicMock(return_value=0)
+    second = MagicMock(player_id="second")
+    second.protocol = StreamingProtocol.RAOP
+    second.config.get_value = MagicMock(return_value=0)
+    session.sync_clients.append(second)
     commanded: list[int] = []
 
-    async def start(start_unix_ms: int, _position_ms: int) -> int:
+    async def correcting_start(start_unix_ms: int, _position_ms: int) -> int:
         # Correct every round, so the loop exhausts without ever converging.
         commanded.append(start_unix_ms)
         return start_unix_ms + 100
 
-    stream.start = AsyncMock(side_effect=start)
-    player.stream = stream
+    async def honoring_start(start_unix_ms: int, _position_ms: int) -> int:
+        return start_unix_ms
+
+    first.stream = _stream_defaults(MagicMock(running=True))
+    first.stream.start = AsyncMock(side_effect=correcting_start)
+    second.stream = _stream_defaults(MagicMock(running=True))
+    second.stream.start = AsyncMock(side_effect=honoring_start)
 
     await session._start_members(0, 100_000)
 
@@ -304,6 +312,25 @@ async def test_group_start_that_never_converges_anchors_where_members_landed() -
     # the session anchor: that would map every later joiner behind the group.
     assert session.start_unix_ms == commanded[-1] + 100
     assert session.start_unix_ms not in commanded
+
+
+@pytest.mark.asyncio
+async def test_corrected_solo_start_adopts_the_instant_without_reanchoring() -> None:
+    """A corrected solo start is anchored at the binary's instant with no re-START."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.config.get_value = MagicMock(return_value=0)
+    stream = _stream_defaults(MagicMock(running=True))
+    # The binary corrects the commanded instant forward; a re-START would only
+    # re-base reported position on the raw one, so exactly one START may be
+    # commanded and its corrected ack becomes the anchor.
+    stream.start = AsyncMock(return_value=101_500)
+    player.stream = stream
+
+    await session._start_members(0, 100_000)
+
+    stream.start.assert_awaited_once_with(100_000, 0)
+    assert session.start_unix_ms == 101_500
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

A batch of small verified fixes from a full audit of the AirPlay code after
the recent timing work, plus adoption of a fix that was written in another
session and never opened as a pull request.

The artwork-rejection warning added recently could never fire: those report
lines arrive on the binary's stderr, while the parser was only wired into the
stdout reader. A single speaker whose start was corrected forward was then
re-started a second time for no benefit - the re-start corrupts the reported
track position, and when its acknowledgement times out the session records a
start instant the binary never used (seen in a user log as the progress bar
jumping backwards). Several smaller correctness holes rode along.

- Dispatch the binary's MRP report lines from the stderr reader too, with a
  reader-level test that fails if the wiring is removed
- Adopt a corrected solo start's instant instead of re-starting it
- Clear stale start/flush error state when a new command is issued
- Stop warning about an MRP status the binary never reported
- Accumulate repeated pending content cuts instead of keeping only the last
- Catch an over-cut in the content-cut reconciliation, not just a shortfall
- Correct two comments that stated assumptions measurement has disproven, and
  remove a note describing a code path that no longer exists

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
