### PR TITLE
Only show library sync deletions setting for providers with library sync

### DIFF
--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -686,6 +686,21 @@ class ProviderConfigMixin:
             }
         ):
             extra_entries.append(CONF_ENTRY_LIBRARY_SYNC_BACK)
-        if provider and isinstance(provider, MusicProvider) and provider.is_streaming_provider:
+        if (
+            provider
+            and isinstance(provider, MusicProvider)
+            and provider.is_streaming_provider
+            and supported_features.intersection(
+                {
+                    ProviderFeature.LIBRARY_ARTISTS,
+                    ProviderFeature.LIBRARY_ALBUMS,
+                    ProviderFeature.LIBRARY_TRACKS,
+                    ProviderFeature.LIBRARY_PLAYLISTS,
+                    ProviderFeature.LIBRARY_AUDIOBOOKS,
+                    ProviderFeature.LIBRARY_PODCASTS,
+                    ProviderFeature.LIBRARY_RADIOS,
+                }
+            )
+        ):
             extra_entries.append(CONF_ENTRY_LIBRARY_SYNC_DELETIONS)
         return extra_entries

--- a/tests/controllers/config/test_build_sync_entries.py
+++ b/tests/controllers/config/test_build_sync_entries.py
@@ -10,10 +10,12 @@ from music_assistant_models.enums import ProviderFeature, ProviderType
 from music_assistant.constants import (
     CONF_ENTRY_LIBRARY_SYNC_ARTISTS,
     CONF_ENTRY_LIBRARY_SYNC_BACK,
+    CONF_ENTRY_LIBRARY_SYNC_DELETIONS,
     CONF_ENTRY_LIBRARY_SYNC_PODCASTS,
     CONF_ENTRY_LIBRARY_SYNC_TRACKS,
 )
 from music_assistant.controllers.config import ConfigController
+from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigEntry
@@ -70,3 +72,30 @@ def test_no_features_yields_no_entries() -> None:
     entries = _controller()._build_sync_entries(manifest, set(), provider=None)
 
     assert entries == []
+
+
+def _music_provider() -> MusicProvider:
+    """Build a bare MusicProvider (is_streaming_provider defaults to True)."""
+    return MusicProvider.__new__(MusicProvider)
+
+
+def test_streaming_provider_with_library_sync_gets_deletions_entry() -> None:
+    """The deletions option shows for streaming providers that sync a library."""
+    manifest = SimpleNamespace(type=ProviderType.MUSIC)
+
+    entries = _controller()._build_sync_entries(
+        manifest, {ProviderFeature.LIBRARY_TRACKS}, provider=_music_provider()
+    )
+
+    assert CONF_ENTRY_LIBRARY_SYNC_DELETIONS.key in _keys(entries)
+
+
+def test_streaming_provider_without_library_sync_has_no_deletions_entry() -> None:
+    """Without any library feature there is nothing to sync, so no deletions option."""
+    manifest = SimpleNamespace(type=ProviderType.MUSIC)
+
+    entries = _controller()._build_sync_entries(
+        manifest, {ProviderFeature.BROWSE, ProviderFeature.SEARCH}, provider=_music_provider()
+    )
+
+    assert CONF_ENTRY_LIBRARY_SYNC_DELETIONS.key not in _keys(entries)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The `library_sync_deletions` config entry was added for every streaming music provider, including those without any `LIBRARY_*` feature where nothing is ever synced and the setting has no effect. Gate it on the provider declaring at least one library sync feature, in line with the other sync-related entries.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
