### PR TITLE
Sonos speakers now recover on their own after a network interruption

### DIFF
--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -14,12 +14,12 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
-from aiohttp import ClientConnectorError
+from aiohttp import ClientError
 from aiosonos.api.models import Container, ContainerType, MusicService, SonosCapability
 from aiosonos.client import SonosLocalApiClient
 from aiosonos.const import EventType as SonosEventType
 from aiosonos.const import SonosEvent
-from aiosonos.exceptions import ConnectionFailed, FailedCommand
+from aiosonos.exceptions import CannotConnect, ConnectionFailed, FailedCommand
 from music_assistant_models.enums import (
     IdentifierType,
     MediaType,
@@ -736,7 +736,7 @@ class SonosPlayer(Player):
             return
         try:
             await self.client.connect()
-        except (ConnectionFailed, ClientConnectorError) as err:
+        except (ConnectionFailed, CannotConnect, ClientError) as err:
             self.logger.warning("Failed to connect to Sonos player: %s", err)
             if not retry_on_fail or not self.mass.players.get_player(self.player_id):
                 raise

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -1,0 +1,71 @@
+"""Tests for the Sonos player connection/reconnect handling."""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import ConnectionTimeoutError
+from aiosonos.exceptions import CannotConnect
+
+from music_assistant.providers.sonos.player import SonosPlayer
+
+
+def _make_player() -> tuple[SonosPlayer, MagicMock]:
+    """Create a SonosPlayer with mocked connection dependencies."""
+    player = SonosPlayer.__new__(SonosPlayer)
+    mass = MagicMock()
+    mass.closing = False
+    mass.players.get_player.return_value = MagicMock()
+    player.mass = mass
+    player.logger = logging.getLogger("test.sonos.player")
+    player._player_id = "sonos_player"
+    player._listen_task = None
+    player.connected = False
+    player.client = MagicMock()
+    player.update_state = MagicMock()  # type: ignore[misc, method-assign]
+    return player, mass
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_reschedules_reconnect() -> None:
+    """Test a blackholed connection (timeout, not refused) still schedules a retry."""
+    player, mass = _make_player()
+    player.client.connect = AsyncMock(  # type: ignore[method-assign]
+        side_effect=ConnectionTimeoutError("Connection timeout to host https://x:1443")
+    )
+
+    await player._connect(retry_on_fail=30)
+
+    assert player._attr_available is False
+    mass.call_later.assert_called_once()
+    args, _ = mass.call_later.call_args
+    assert args[0] == min(30 + 30, 3600)
+    assert args[1] == player._connect
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_without_retry_raises() -> None:
+    """Test a connection failure without retry_on_fail still propagates."""
+    player, mass = _make_player()
+    player.client.connect = AsyncMock(  # type: ignore[method-assign]
+        side_effect=ConnectionTimeoutError("Connection timeout to host https://x:1443")
+    )
+
+    with pytest.raises(ConnectionTimeoutError):
+        await player._connect(retry_on_fail=0)
+
+    mass.call_later.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_connect_websocket_handshake_failure_reschedules_reconnect() -> None:
+    """Test a websocket handshake failure also reschedules a retry."""
+    player, mass = _make_player()
+    player.client.connect = AsyncMock(  # type: ignore[method-assign]
+        side_effect=CannotConnect(OSError("handshake failed"))
+    )
+
+    await player._connect(retry_on_fail=30)
+
+    assert player._attr_available is False
+    mass.call_later.assert_called_once()


### PR DESCRIPTION
# What does this implement/fix?

Sonos speakers never came back on their own after an event that blackholes established
connections (a firewall state table reset, a router reboot, a VLAN hiccup). Only restarting
Music Assistant brought them back.

The reconnect handler in `_connect` caught `ClientConnectorError`, but a blackholed
connection raises `aiohttp.ConnectionTimeoutError` — a `ClientError`, not a
`ClientConnectorError`. The exception escaped the `call_later`-scheduled reconnect task
(surfacing only as "Task exception was never retrieved"), so the retry chain was never
re-armed and the player stayed unavailable indefinitely.

- Widen the reconnect catch from `ClientConnectorError` to `ClientError`
- Also catch aiosonos' `CannotConnect` for websocket handshake failures
- Add regression tests for both cases

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/5979

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
