### PR TITLE
Apply a changed stream server address without a restart

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1680,6 +1680,7 @@ class StreamsController(CoreController):
                     "Error reloading provider %s: %s",
                     instance_id,
                     str(err) or err.__class__.__name__,
+                    exc_info=err,
                 )
         # only mark the new network as applied once every provider moved over, so a run
         # cut short by a second config change is retried on the next reload

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1682,8 +1682,8 @@ class StreamsController(CoreController):
                     str(err) or err.__class__.__name__,
                     exc_info=err,
                 )
-        # only mark the new network as applied once every provider moved over, so a run
-        # cut short by a second config change is retried on the next reload
+        # only mark the new network as applied once the loop completed, so a run cut short
+        # by a second config change runs again on the next reload
         self._network_fingerprint = current
 
     def _setup_smart_fades_logger(self, config: CoreConfig) -> None:

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -204,6 +204,8 @@ class StreamsController(CoreController):
         # every address players may reach this host on, best candidate first - for mDNS
         # records, which can carry them all, unlike the single-valued publish_ip
         self.publish_addresses: list[str] = []
+        # the network as it was at the previous setup, to spot a runtime change
+        self._network_fingerprint: tuple[str, str, int, tuple[str, ...]] | None = None
         self.audio = StreamsAudio(mass)
         self.audio_processing = AudioProcessingManager(mass)
         self._audio_analysis = AudioAnalysisController(self)
@@ -490,6 +492,7 @@ class StreamsController(CoreController):
             self.publish_ip,
             self.publish_port,
         )
+        await self._reload_network_dependent_providers()
 
     async def close(self) -> None:
         """Cleanup on exit."""
@@ -1644,6 +1647,43 @@ class StreamsController(CoreController):
             self.logger.debug(
                 "Got %s request to %s from %s", request.method, request.path, request.remote
             )
+
+    async def _reload_network_dependent_providers(self) -> None:
+        """Reload the providers that captured the streamserver network, if it changed."""
+        previous = self._network_fingerprint
+        current = (
+            self._bind_ip,
+            str(self.publish_ip),
+            cast("int", self.publish_port),
+            tuple(self.publish_addresses),
+        )
+        if previous is None or previous == current:
+            self._network_fingerprint = current
+            return
+        # these providers bind or advertise the network while they load, so a plain
+        # reload is what moves them over - they share no lighter rebind path
+        instance_ids = [
+            prov.instance_id
+            for prov in self.mass.providers
+            if prov.reload_on_streams_network_change
+        ]
+        for instance_id in instance_ids:
+            try:
+                config = await self.mass.config.get_provider_config(instance_id)
+                self.logger.info(
+                    "Streamserver network changed, reloading provider %s",
+                    config.name or config.domain,
+                )
+                await self.mass.load_provider_config(config)
+            except Exception as err:
+                self.logger.warning(
+                    "Error reloading provider %s: %s",
+                    instance_id,
+                    str(err) or err.__class__.__name__,
+                )
+        # only mark the new network as applied once every provider moved over, so a run
+        # cut short by a second config change is retried on the next reload
+        self._network_fingerprint = current
 
     def _setup_smart_fades_logger(self, config: CoreConfig) -> None:
         """Set up smart fades logger level."""

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -34,6 +34,9 @@ class Provider:
     mass: MusicAssistant
     manifest: ProviderManifest
     config: ProviderConfig
+    # set to True in providers that capture a mass.streams address or port while loading,
+    # to have them reloaded onto the new one when the streamserver config changes
+    reload_on_streams_network_change: bool = False
 
     def __init__(
         self,

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -35,7 +35,7 @@ class Provider:
     manifest: ProviderManifest
     config: ProviderConfig
     # set to True in providers that capture a mass.streams address or port while loading,
-    # to have them reloaded onto the new one when the streamserver config changes
+    # to have them reloaded onto the new one when the streamserver network changes
     reload_on_streams_network_change: bool = False
 
     def __init__(

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -89,6 +89,7 @@ ENV_PYATV_DEBUG: Final[str] = "MASS_PYATV_DEBUG"
 class AirPlayProvider(PlayerProvider):
     """Player provider for AirPlay based players."""
 
+    reload_on_streams_network_change = True
     _dacp_server: asyncio.Server
     _dacp_info: AsyncServiceInfo
     _bridge_manager: SendspinBridgeManager

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -93,6 +93,8 @@ async def setup(
 class AirPlayReceiverProvider(PluginProvider):
     """Implementation of an AirPlay Receiver Plugin."""
 
+    reload_on_streams_network_change = True
+
     def __init__(
         self, mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
     ) -> None:

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -84,6 +84,8 @@ class AriaCastReceiver(PluginProvider):
     yielded by get_audio_stream exactly like the VBAN receiver.
     """
 
+    reload_on_streams_network_change = True
+
     @property
     def supported_features(self) -> set[ProviderFeature]:
         """Return the features supported by this provider."""

--- a/music_assistant/providers/plex_connect/__init__.py
+++ b/music_assistant/providers/plex_connect/__init__.py
@@ -55,6 +55,8 @@ async def setup(
 class PlexConnectProvider(PluginProvider):
     """Plex Connect plugin provider implementation."""
 
+    reload_on_streams_network_change = True
+
     def __init__(
         self, mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
     ) -> None:

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -236,6 +236,7 @@ def _manual_client_url(address: str) -> str:
 class SendspinProvider(PlayerProvider):
     """Player Provider for Sendspin."""
 
+    reload_on_streams_network_change = True
     server_api: SendspinServer
     unregister_cbs: list[Callable[[], None]]
     _pending_unregisters: dict[str, asyncio.Event]

--- a/music_assistant/providers/snapcast/provider.py
+++ b/music_assistant/providers/snapcast/provider.py
@@ -76,6 +76,7 @@ async def _create_cntrl_server(
 class SnapCastProvider(PlayerProvider):
     """SnapCastProvider."""
 
+    reload_on_streams_network_change = True
     _snapserver: SnapserverProto
     _snapserver_runner: asyncio.Task[None] | None
     _snapserver_started: asyncio.Event | None

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -110,6 +110,8 @@ async def setup(
 class SpotifyConnectProvider(PluginProvider):
     """Implementation of a Spotify Connect Plugin (backed by go-librespot)."""
 
+    reload_on_streams_network_change = True
+
     def __init__(
         self, mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
     ) -> None:

--- a/music_assistant/providers/squeezelite/provider.py
+++ b/music_assistant/providers/squeezelite/provider.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 class SqueezelitePlayerProvider(PlayerProvider):
     """Player provider for players using slimproto (like Squeezelite)."""
 
+    reload_on_streams_network_change = True
     slimproto: SlimServer | None = None
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:

--- a/tests/controllers/streams/test_network_change_reload.py
+++ b/tests/controllers/streams/test_network_change_reload.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from music_assistant.controllers.streams.controller import StreamsController
+from music_assistant.models.provider import Provider
 
 BIND_IP = "0.0.0.0"
 PUBLISH_IP = "192.168.1.5"
@@ -111,8 +112,8 @@ async def test_applied_network_is_not_reloaded_again() -> None:
 
 
 @pytest.mark.asyncio
-async def test_interrupted_run_is_retried_on_the_next_reload() -> None:
-    """A second config change cancels the reload, so the new network must not count as applied."""
+async def test_interrupted_run_does_not_mark_the_network_applied() -> None:
+    """A second config change cancels the run, so the next reload goes over them again."""
     controller = _streams_controller(_provider("sendspin", follows_network=True))
     await controller._reload_network_dependent_providers()
     controller.publish_ip = "10.45.0.20"
@@ -120,8 +121,41 @@ async def test_interrupted_run_is_retried_on_the_next_reload() -> None:
     with pytest.raises(asyncio.CancelledError):
         await controller._reload_network_dependent_providers()
     await controller._reload_network_dependent_providers()
-    # the cancelled attempt plus the retry that the stale fingerprint triggered
+    # the cancelled attempt plus the one the still-unapplied network triggered
     assert _reloaded(controller) == ["sendspin", "sendspin"]
+
+
+def test_providers_do_not_follow_the_network_by_default() -> None:
+    """Only a provider that opts in is ever disturbed by a network change."""
+    assert Provider.reload_on_streams_network_change is False
+
+
+@pytest.mark.asyncio
+async def test_unreadable_config_does_not_block_the_others() -> None:
+    """A provider removed while the loop runs no longer has a config to reload it from."""
+    controller = _streams_controller(
+        _provider("snapcast", follows_network=True),
+        _provider("sendspin", follows_network=True),
+    )
+    _mass(controller).config.get_provider_config = AsyncMock(
+        side_effect=[KeyError("gone"), _provider_config("sendspin")]
+    )
+    await controller._reload_network_dependent_providers()
+    controller.publish_ip = "10.45.0.20"
+    await controller._reload_network_dependent_providers()
+    assert _reloaded(controller) == ["sendspin"]
+
+
+@pytest.mark.asyncio
+async def test_failed_reload_still_marks_the_network_applied() -> None:
+    """A provider that stays broken must not re-bounce the others on every later reload."""
+    controller = _streams_controller(_provider("sendspin", follows_network=True))
+    _mass(controller).load_provider_config = AsyncMock(side_effect=RuntimeError("boom"))
+    await controller._reload_network_dependent_providers()
+    controller.publish_ip = "10.45.0.20"
+    await controller._reload_network_dependent_providers()
+    await controller._reload_network_dependent_providers()
+    assert _reloaded(controller) == ["sendspin"]
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/streams/test_network_change_reload.py
+++ b/tests/controllers/streams/test_network_change_reload.py
@@ -1,0 +1,138 @@
+"""Tests for reloading providers when the streamserver network changes."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from music_assistant.controllers.streams.controller import StreamsController
+
+BIND_IP = "0.0.0.0"
+PUBLISH_IP = "192.168.1.5"
+PUBLISH_PORT = 8097
+PUBLISH_ADDRESSES = ["192.168.1.5", "10.0.0.5"]
+
+
+def _provider(instance_id: str, *, follows_network: bool) -> MagicMock:
+    """Build a stand-in provider that does or does not capture the streamserver network."""
+    provider = MagicMock()
+    provider.instance_id = instance_id
+    provider.reload_on_streams_network_change = follows_network
+    return provider
+
+
+def _provider_config(instance_id: str) -> MagicMock:
+    """Build the stored config a provider would be reloaded from."""
+    config = MagicMock()
+    config.name = instance_id
+    config.domain = instance_id
+    return config
+
+
+def _streams_controller(*providers: MagicMock) -> StreamsController:
+    """Build a streams controller with only the network state populated."""
+    mass = MagicMock()
+    mass.config.get_raw_core_config_value.return_value = "GLOBAL"
+    mass.providers = list(providers)
+    mass.config.get_provider_config = AsyncMock(side_effect=_provider_config)
+    mass.load_provider_config = AsyncMock()
+    controller = StreamsController(mass)
+    controller._bind_ip = BIND_IP
+    controller.publish_ip = PUBLISH_IP
+    controller.publish_port = PUBLISH_PORT
+    controller.publish_addresses = list(PUBLISH_ADDRESSES)
+    return controller
+
+
+def _mass(controller: StreamsController) -> MagicMock:
+    """Return the mocked server object the controller was built with."""
+    return cast("MagicMock", controller.mass)
+
+
+def _reloaded(controller: StreamsController) -> list[str]:
+    """Return the names of the providers that were reloaded."""
+    return [call.args[0].name for call in _mass(controller).load_provider_config.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_startup_network_is_only_recorded() -> None:
+    """The network at startup is the baseline, not a change to react to."""
+    controller = _streams_controller(_provider("sendspin", follows_network=True))
+    await controller._reload_network_dependent_providers()
+    assert _reloaded(controller) == []
+
+
+@pytest.mark.asyncio
+async def test_reload_without_network_change_reloads_nothing() -> None:
+    """Any other streams setting is reloadable on its own, so nobody else is disturbed."""
+    controller = _streams_controller(_provider("sendspin", follows_network=True))
+    await controller._reload_network_dependent_providers()
+    await controller._reload_network_dependent_providers()
+    assert _reloaded(controller) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("attribute", "new_value"),
+    [
+        ("_bind_ip", "192.168.1.9"),
+        ("publish_ip", "10.45.0.20"),
+        ("publish_port", 8098),
+        # narrowing "auto" to one literal address leaves publish_ip itself untouched
+        ("publish_addresses", ["192.168.1.5"]),
+    ],
+)
+async def test_changed_network_reloads_only_dependent_providers(
+    attribute: str, new_value: str | int | list[str]
+) -> None:
+    """Every part of the network is captured while a provider loads, so each must count."""
+    controller = _streams_controller(
+        _provider("sendspin", follows_network=True),
+        _provider("spotify", follows_network=False),
+    )
+    await controller._reload_network_dependent_providers()
+    setattr(controller, attribute, new_value)
+    await controller._reload_network_dependent_providers()
+    assert _reloaded(controller) == ["sendspin"]
+
+
+@pytest.mark.asyncio
+async def test_applied_network_is_not_reloaded_again() -> None:
+    """A later reload compares against the applied network, not the one seen at startup."""
+    controller = _streams_controller(_provider("sendspin", follows_network=True))
+    await controller._reload_network_dependent_providers()
+    controller.publish_ip = "10.45.0.20"
+    await controller._reload_network_dependent_providers()
+    await controller._reload_network_dependent_providers()
+    assert _reloaded(controller) == ["sendspin"]
+
+
+@pytest.mark.asyncio
+async def test_interrupted_run_is_retried_on_the_next_reload() -> None:
+    """A second config change cancels the reload, so the new network must not count as applied."""
+    controller = _streams_controller(_provider("sendspin", follows_network=True))
+    await controller._reload_network_dependent_providers()
+    controller.publish_ip = "10.45.0.20"
+    _mass(controller).load_provider_config = AsyncMock(side_effect=[asyncio.CancelledError, None])
+    with pytest.raises(asyncio.CancelledError):
+        await controller._reload_network_dependent_providers()
+    await controller._reload_network_dependent_providers()
+    # the cancelled attempt plus the retry that the stale fingerprint triggered
+    assert _reloaded(controller) == ["sendspin", "sendspin"]
+
+
+@pytest.mark.asyncio
+async def test_failing_reload_does_not_block_the_others() -> None:
+    """One provider that cannot come back up must not strand the rest on the old network."""
+    controller = _streams_controller(
+        _provider("snapcast", follows_network=True),
+        _provider("sendspin", follows_network=True),
+    )
+    _mass(controller).load_provider_config = AsyncMock(side_effect=[RuntimeError("boom"), None])
+    await controller._reload_network_dependent_providers()
+    controller.publish_ip = "10.45.0.20"
+    await controller._reload_network_dependent_providers()
+    assert _reloaded(controller) == ["snapcast", "sendspin"]


### PR DESCRIPTION
# What does this implement/fix?

Changing the stream server's **Publish IP** or **Bind IP** only restarted the stream server itself. Providers that pick up that address while they start kept listening on — and advertising over mDNS — the old one until Music Assistant was restarted. Sendspin players (including the web player) were the most visible victim: they stayed unreachable after the change.

Those providers are now reloaded automatically when the stream server's address or port changes, so the new setting takes effect straight away.

- The streams controller notices when its bind IP, publish IP, port or published addresses differ from the previous setup
- Providers that capture any of those while loading are reloaded onto the new ones: Sendspin, AirPlay, AirPlay Receiver, Spotify Connect, Snapcast, Squeezelite, Plex Connect and AriaCast Receiver
- Those providers are marked with a new `reload_on_streams_network_change` flag on the provider base class, so nothing else is disturbed
- A run cut short by a second config change does not count as applied, so the next reload goes over the providers again

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
