### PR TITLE
Wait for a full audio pipe to drain instead of erroring out

### DIFF
--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -7,6 +7,7 @@ import errno as errno_module
 import logging
 import os
 import select
+import time
 from collections.abc import AsyncGenerator
 from contextlib import suppress
 from functools import partial
@@ -14,8 +15,12 @@ from pathlib import Path
 
 _LOGGER = logging.getLogger("named_pipe")
 
-# How long a write waits for a full pipe buffer to drain before giving up.
+# How long a write waits on a full pipe buffer that the reader never drains.
 WRITE_STALL_TIMEOUT = 2.0
+# Upper bound for a single write, so a barely-moving reader cannot park it for minutes.
+WRITE_TOTAL_TIMEOUT = 30.0
+# Length of one wait slice, which caps how long a reader that left goes unnoticed.
+WRITE_POLL_INTERVAL_MS = 250
 
 
 class AsyncNamedPipeWriter:
@@ -91,18 +96,27 @@ class AsyncNamedPipeWriter:
                     len(data),
                 )
                 return False
+            # hold on to the descriptor a concurrent remove() may swap out from under us
+            write_fd = self._write_fd
+            assert write_fd is not None
             data_view = memoryview(data)
             total_bytes_written = 0
+            give_up_at = time.monotonic() + WRITE_TOTAL_TIMEOUT
+            stall_ends_at: float | None = None
             try:
-                assert self._write_fd is not None
                 while total_bytes_written < len(data_view):
                     try:
-                        bytes_written = os.write(self._write_fd, data_view[total_bytes_written:])
+                        bytes_written = os.write(write_fd, data_view[total_bytes_written:])
                     except BlockingIOError:
-                        # A full buffer means the reader is behind, not gone, so wait for
-                        # it to drain. A reader that did go away also reports as writable,
-                        # which lets the retried write surface its EPIPE as usual.
-                        if self._wait_writable():
+                        # A full buffer means the reader is behind, not gone, so wait for it
+                        # to drain and try again. Only the write itself tells the two apart:
+                        # a full pipe whose reader left is not reported as broken everywhere,
+                        # so the wait is sliced rather than trusted to end on its own.
+                        now = time.monotonic()
+                        if stall_ends_at is None:
+                            stall_ends_at = now + WRITE_STALL_TIMEOUT
+                        if now < stall_ends_at and now < give_up_at:
+                            self._wait_writable(write_fd)
                             continue
                         _LOGGER.debug(
                             "Named pipe write stalled on %s "
@@ -113,6 +127,7 @@ class AsyncNamedPipeWriter:
                             len(data),
                         )
                         return False
+                    stall_ends_at = None
                     if bytes_written == 0:
                         _LOGGER.debug(
                             "Named pipe write made no progress on %s "
@@ -127,10 +142,11 @@ class AsyncNamedPipeWriter:
                 return True
             except OSError as e:
                 if e.errno == errno_module.EPIPE:
-                    # Reader closed, reset fd for next attempt
-                    if self._write_fd is not None:
+                    # Reader closed, reset fd for next attempt. A concurrent remove()
+                    # may already have replaced it, and then owns it instead.
+                    if self._write_fd == write_fd:
                         with suppress(Exception):
-                            os.close(self._write_fd)
+                            os.close(write_fd)
                         self._write_fd = None
                     _LOGGER.debug(
                         "Named pipe write failed (EPIPE) on %s "
@@ -169,11 +185,16 @@ class AsyncNamedPipeWriter:
         """Return a short descriptor for logging (owner_id or pipe path)."""
         return self._owner_id or self._pipe_path
 
-    def _wait_writable(self) -> bool:
-        """Wait for the pipe to accept data again. Returns False if it stayed full."""
-        assert self._write_fd is not None
-        _, writable, _ = select.select([], [self._write_fd], [], WRITE_STALL_TIMEOUT)
-        return bool(writable)
+    def _wait_writable(self, write_fd: int) -> None:
+        """
+        Wait a short while for the pipe to accept data again.
+
+        :param write_fd: Descriptor of the pipe's write end.
+        """
+        # poll() rather than select(), which rejects a descriptor of 1024 or above
+        poller = select.poll()
+        poller.register(write_fd, select.POLLOUT)
+        poller.poll(WRITE_POLL_INTERVAL_MS)
 
     def _ensure_write_fd(self) -> bool:
         """Open the write end while a reader is attached. Returns True if successful."""

--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -117,6 +117,10 @@ class AsyncNamedPipeWriter:
                             stall_ends_at = now + WRITE_STALL_TIMEOUT
                         if now < stall_ends_at and now < give_up_at:
                             self._wait_writable(write_fd)
+                            # a cancelled write releases the lock but keeps this thread
+                            # going, so stop once remove() has taken the descriptor
+                            if self._write_fd != write_fd:
+                                return False
                             continue
                         _LOGGER.debug(
                             "Named pipe write stalled on %s "

--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -105,6 +105,10 @@ class AsyncNamedPipeWriter:
             stall_ends_at: float | None = None
             try:
                 while total_bytes_written < len(data_view):
+                    # a cancelled write releases the lock but keeps this thread going,
+                    # so stop once remove() has taken the descriptor
+                    if self._write_fd != write_fd:
+                        return False
                     try:
                         bytes_written = os.write(write_fd, data_view[total_bytes_written:])
                     except BlockingIOError:
@@ -117,10 +121,6 @@ class AsyncNamedPipeWriter:
                             stall_ends_at = now + WRITE_STALL_TIMEOUT
                         if now < stall_ends_at and now < give_up_at:
                             self._wait_writable(write_fd)
-                            # a cancelled write releases the lock but keeps this thread
-                            # going, so stop once remove() has taken the descriptor
-                            if self._write_fd != write_fd:
-                                return False
                             continue
                         _LOGGER.debug(
                             "Named pipe write stalled on %s "

--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -6,12 +6,16 @@ import asyncio
 import errno as errno_module
 import logging
 import os
+import select
 from collections.abc import AsyncGenerator
 from contextlib import suppress
 from functools import partial
 from pathlib import Path
 
 _LOGGER = logging.getLogger("named_pipe")
+
+# How long a write waits for a full pipe buffer to drain before giving up.
+WRITE_STALL_TIMEOUT = 2.0
 
 
 class AsyncNamedPipeWriter:
@@ -92,7 +96,23 @@ class AsyncNamedPipeWriter:
             try:
                 assert self._write_fd is not None
                 while total_bytes_written < len(data_view):
-                    bytes_written = os.write(self._write_fd, data_view[total_bytes_written:])
+                    try:
+                        bytes_written = os.write(self._write_fd, data_view[total_bytes_written:])
+                    except BlockingIOError:
+                        # A full buffer means the reader is behind, not gone, so wait for
+                        # it to drain. A reader that did go away also reports as writable,
+                        # which lets the retried write surface its EPIPE as usual.
+                        if self._wait_writable():
+                            continue
+                        _LOGGER.debug(
+                            "Named pipe write stalled on %s "
+                            "(owner=%s, %d of %d bytes written): reader is not draining",
+                            self._pipe_path,
+                            self._log_owner,
+                            total_bytes_written,
+                            len(data),
+                        )
+                        return False
                     if bytes_written == 0:
                         _LOGGER.debug(
                             "Named pipe write made no progress on %s "
@@ -148,6 +168,12 @@ class AsyncNamedPipeWriter:
     def _log_owner(self) -> str:
         """Return a short descriptor for logging (owner_id or pipe path)."""
         return self._owner_id or self._pipe_path
+
+    def _wait_writable(self) -> bool:
+        """Wait for the pipe to accept data again. Returns False if it stayed full."""
+        assert self._write_fd is not None
+        _, writable, _ = select.select([], [self._write_fd], [], WRITE_STALL_TIMEOUT)
+        return bool(writable)
 
     def _ensure_write_fd(self) -> bool:
         """Open the write end while a reader is attached. Returns True if successful."""

--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -98,7 +98,8 @@ class AsyncNamedPipeWriter:
                 return False
             # hold on to the descriptor a concurrent remove() may swap out from under us
             write_fd = self._write_fd
-            assert write_fd is not None
+            if write_fd is None:
+                return False
             data_view = memoryview(data)
             total_bytes_written = 0
             give_up_at = time.monotonic() + WRITE_TOTAL_TIMEOUT

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -4,6 +4,7 @@ import asyncio
 import errno
 import logging
 import os
+import select
 import threading
 from collections.abc import AsyncGenerator, Callable, Coroutine
 from contextlib import suppress
@@ -16,7 +17,7 @@ from music_assistant_models.enums import ContentType, PlaybackState
 from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import AudioFormat
 
-from music_assistant.helpers.named_pipe import WRITE_STALL_TIMEOUT, AsyncNamedPipeWriter
+from music_assistant.helpers.named_pipe import WRITE_POLL_INTERVAL_MS, AsyncNamedPipeWriter
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_ARTWORK_SIZE,
     AIRPLAY_JOIN_START_ACK_TIMEOUT_MS,
@@ -798,9 +799,9 @@ async def test_pipe_write_completes_a_large_write_while_the_reader_drains(
     read_fd = os.open(pipe_path, os.O_RDONLY | os.O_NONBLOCK)
     payload = b"\x00" * 176400
 
-    async def drain() -> int:
-        received = 0
-        while received < len(payload):
+    async def drain() -> bytes:
+        received = bytearray()
+        while len(received) < len(payload):
             try:
                 chunk = os.read(read_fd, 65536)
             except BlockingIOError:
@@ -809,14 +810,53 @@ async def test_pipe_write_completes_a_large_write_while_the_reader_drains(
                 # no writer attached yet or nothing buffered: yield instead of spinning
                 await asyncio.sleep(0.001)
                 continue
-            received += len(chunk)
-        return received
+            received += chunk
+        return bytes(received)
 
     reader = asyncio.create_task(drain())
     try:
         async with asyncio.timeout(10):
             assert await writer.write(payload) is True
+            # every byte arrives exactly once, so a resumed write never repeats itself
+            assert await reader == payload
+    finally:
+        reader.cancel()
+        with suppress(asyncio.CancelledError):
+            await reader
+        os.close(read_fd)
+        await writer.remove()
+
+
+@pytest.mark.asyncio
+async def test_pipe_write_outlasts_a_reader_slower_than_the_stall_timeout(
+    tmp_path: Path,
+) -> None:
+    """The stall budget covers a lack of progress, not the total time a write takes."""
+    pipe_path = tmp_path / "audio"
+    os.mkfifo(pipe_path)
+    writer = AsyncNamedPipeWriter(str(pipe_path))
+    read_fd = os.open(pipe_path, os.O_RDONLY | os.O_NONBLOCK)
+    payload = b"\x00" * 176400
+    stall_timeout = 0.15
+
+    async def drain_slowly() -> int:
+        received = 0
+        while received < len(payload):
+            await asyncio.sleep(0.02)
+            with suppress(BlockingIOError):
+                received += len(os.read(read_fd, 8192))
+        return received
+
+    reader = asyncio.create_task(drain_slowly())
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    try:
+        async with asyncio.timeout(30):
+            with patch("music_assistant.helpers.named_pipe.WRITE_STALL_TIMEOUT", stall_timeout):
+                assert await writer.write(payload) is True
             assert await reader == len(payload)
+        # a reader this slow only completes because each pause resets the budget
+        assert loop.time() - started > stall_timeout
     finally:
         reader.cancel()
         with suppress(asyncio.CancelledError):
@@ -837,47 +877,48 @@ async def test_pipe_write_resumes_after_the_buffer_drains() -> None:
             "music_assistant.helpers.named_pipe.os.write",
             side_effect=[4, BlockingIOError(errno.EAGAIN, "buffer full"), 6],
         ) as write,
-        patch(
-            "music_assistant.helpers.named_pipe.select.select",
-            return_value=([], [42], []),
-        ) as wait_writable,
+        patch("music_assistant.helpers.named_pipe.select.poll") as poll,
     ):
         assert await writer.write(data) is True
 
+    # the retry picks up where the short write stopped, it never resends
     assert write.call_args_list == [
         call(42, memoryview(data)),
         call(42, memoryview(data)[4:]),
         call(42, memoryview(data)[4:]),
     ]
-    wait_writable.assert_called_once_with([], [42], [], WRITE_STALL_TIMEOUT)
+    poll.return_value.register.assert_called_once_with(42, select.POLLOUT)
+    poll.return_value.poll.assert_called_once_with(WRITE_POLL_INTERVAL_MS)
 
 
 @pytest.mark.asyncio
-async def test_pipe_write_resets_fd_when_the_reader_closes_during_a_stall() -> None:
+async def test_pipe_write_resets_fd_when_the_reader_closes_during_a_stall(
+    tmp_path: Path,
+) -> None:
     """A reader that goes away while the buffer is full still resets the writer."""
-    data = b"\x00" * 10
-    writer = AsyncNamedPipeWriter("/tmp/audio")  # noqa: S108
-    writer._write_fd = 42
+    pipe_path = tmp_path / "audio"
+    os.mkfifo(pipe_path)
+    writer = AsyncNamedPipeWriter(str(pipe_path))
+    read_fd = os.open(pipe_path, os.O_RDONLY | os.O_NONBLOCK)
 
-    with (
-        patch(
-            "music_assistant.helpers.named_pipe.os.write",
-            side_effect=[
-                4,
-                BlockingIOError(errno.EAGAIN, "buffer full"),
-                OSError(errno.EPIPE, "reader closed"),
-            ],
-        ),
-        patch(
-            "music_assistant.helpers.named_pipe.select.select",
-            return_value=([], [42], []),
-        ),
-        patch("music_assistant.helpers.named_pipe.os.close") as close_fd,
-    ):
-        assert await writer.write(data) is False
+    async def close_reader_mid_stall() -> None:
+        await asyncio.sleep(0.05)
+        os.close(read_fd)
 
-    close_fd.assert_called_once_with(42)
-    assert writer._write_fd is None
+    closer = asyncio.create_task(close_reader_mid_stall())
+    try:
+        async with asyncio.timeout(30):
+            assert await writer.write(b"\x00" * 176400) is False
+            await closer
+        # the departed reader is what ends the write, so it must not be left mid-stall
+        assert writer._write_fd is None
+    finally:
+        closer.cancel()
+        with suppress(asyncio.CancelledError):
+            await closer
+        with suppress(OSError):
+            os.close(read_fd)
+        await writer.remove()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -6,6 +6,7 @@ import logging
 import os
 import threading
 from collections.abc import AsyncGenerator, Callable, Coroutine
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -801,18 +802,25 @@ async def test_pipe_write_completes_a_large_write_while_the_reader_drains(
         received = 0
         while received < len(payload):
             try:
-                received += len(os.read(read_fd, 65536))
+                chunk = os.read(read_fd, 65536)
             except BlockingIOError:
-                await asyncio.sleep(0)
+                chunk = b""
+            if not chunk:
+                # no writer attached yet or nothing buffered: yield instead of spinning
+                await asyncio.sleep(0.001)
+                continue
+            received += len(chunk)
         return received
 
     reader = asyncio.create_task(drain())
     try:
-        assert await writer.write(payload) is True
-        async with asyncio.timeout(5):
+        async with asyncio.timeout(10):
+            assert await writer.write(payload) is True
             assert await reader == len(payload)
     finally:
         reader.cancel()
+        with suppress(asyncio.CancelledError):
+            await reader
         os.close(read_fd)
         await writer.remove()
 

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -892,6 +892,28 @@ async def test_pipe_write_resumes_after_the_buffer_drains() -> None:
 
 
 @pytest.mark.asyncio
+async def test_pipe_write_stops_when_the_descriptor_is_taken_mid_stall() -> None:
+    """A stalled write gives up once the pipe is removed out from under it."""
+    writer = AsyncNamedPipeWriter("/tmp/audio")  # noqa: S108
+    writer._write_fd = 42
+
+    def take_descriptor(pipe_writer: AsyncNamedPipeWriter, _write_fd: int) -> None:
+        pipe_writer._write_fd = None
+
+    with (
+        patch(
+            "music_assistant.helpers.named_pipe.os.write",
+            side_effect=[4, BlockingIOError(errno.EAGAIN, "buffer full")],
+        ) as write,
+        patch.object(AsyncNamedPipeWriter, "_wait_writable", take_descriptor),
+    ):
+        assert await writer.write(b"\x00" * 10) is False
+
+    # writing on would land in whatever reopened that descriptor number
+    assert write.call_count == 2
+
+
+@pytest.mark.asyncio
 async def test_pipe_write_resets_fd_when_the_reader_closes_during_a_stall(
     tmp_path: Path,
 ) -> None:

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -15,7 +15,7 @@ from music_assistant_models.enums import ContentType, PlaybackState
 from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import AudioFormat
 
-from music_assistant.helpers.named_pipe import AsyncNamedPipeWriter
+from music_assistant.helpers.named_pipe import WRITE_STALL_TIMEOUT, AsyncNamedPipeWriter
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_ARTWORK_SIZE,
     AIRPLAY_JOIN_START_ACK_TIMEOUT_MS,
@@ -758,6 +758,118 @@ async def test_command_pipe_write_propagates_non_epipe_errors() -> None:
         pytest.raises(OSError, match="bad file descriptor"),
     ):
         await writer.write(b"ACTION=STANDBY\n")
+
+
+@pytest.mark.asyncio
+async def test_pipe_write_reports_a_stalled_reader_without_raising(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A write bigger than the pipe buffer reports failure instead of raising."""
+    pipe_path = tmp_path / "audio"
+    os.mkfifo(pipe_path)
+    writer = AsyncNamedPipeWriter(str(pipe_path))
+    # a reader that never reads, so the pipe buffer fills up and stays full
+    read_fd = os.open(pipe_path, os.O_RDONLY | os.O_NONBLOCK)
+
+    try:
+        with (
+            caplog.at_level(logging.WARNING),
+            patch("music_assistant.helpers.named_pipe.WRITE_STALL_TIMEOUT", 0.05),
+        ):
+            assert await writer.write(b"\x00" * 176400) is False
+
+        # the reader is still attached, so the descriptor stays usable
+        assert writer._write_fd is not None
+        assert not [record for record in caplog.records if record.levelno >= logging.WARNING]
+    finally:
+        os.close(read_fd)
+        await writer.remove()
+
+
+@pytest.mark.asyncio
+async def test_pipe_write_completes_a_large_write_while_the_reader_drains(
+    tmp_path: Path,
+) -> None:
+    """A write bigger than the pipe buffer completes against a reader that keeps up."""
+    pipe_path = tmp_path / "audio"
+    os.mkfifo(pipe_path)
+    writer = AsyncNamedPipeWriter(str(pipe_path))
+    read_fd = os.open(pipe_path, os.O_RDONLY | os.O_NONBLOCK)
+    payload = b"\x00" * 176400
+
+    async def drain() -> int:
+        received = 0
+        while received < len(payload):
+            try:
+                received += len(os.read(read_fd, 65536))
+            except BlockingIOError:
+                await asyncio.sleep(0)
+        return received
+
+    reader = asyncio.create_task(drain())
+    try:
+        assert await writer.write(payload) is True
+        async with asyncio.timeout(5):
+            assert await reader == len(payload)
+    finally:
+        reader.cancel()
+        os.close(read_fd)
+        await writer.remove()
+
+
+@pytest.mark.asyncio
+async def test_pipe_write_resumes_after_the_buffer_drains() -> None:
+    """A write that fills the pipe buffer continues once the reader catches up."""
+    data = b"\x00" * 10
+    writer = AsyncNamedPipeWriter("/tmp/audio")  # noqa: S108
+    writer._write_fd = 42
+
+    with (
+        patch(
+            "music_assistant.helpers.named_pipe.os.write",
+            side_effect=[4, BlockingIOError(errno.EAGAIN, "buffer full"), 6],
+        ) as write,
+        patch(
+            "music_assistant.helpers.named_pipe.select.select",
+            return_value=([], [42], []),
+        ) as wait_writable,
+    ):
+        assert await writer.write(data) is True
+
+    assert write.call_args_list == [
+        call(42, memoryview(data)),
+        call(42, memoryview(data)[4:]),
+        call(42, memoryview(data)[4:]),
+    ]
+    wait_writable.assert_called_once_with([], [42], [], WRITE_STALL_TIMEOUT)
+
+
+@pytest.mark.asyncio
+async def test_pipe_write_resets_fd_when_the_reader_closes_during_a_stall() -> None:
+    """A reader that goes away while the buffer is full still resets the writer."""
+    data = b"\x00" * 10
+    writer = AsyncNamedPipeWriter("/tmp/audio")  # noqa: S108
+    writer._write_fd = 42
+
+    with (
+        patch(
+            "music_assistant.helpers.named_pipe.os.write",
+            side_effect=[
+                4,
+                BlockingIOError(errno.EAGAIN, "buffer full"),
+                OSError(errno.EPIPE, "reader closed"),
+            ],
+        ),
+        patch(
+            "music_assistant.helpers.named_pipe.select.select",
+            return_value=([], [42], []),
+        ),
+        patch("music_assistant.helpers.named_pipe.os.close") as close_fd,
+    ):
+        assert await writer.write(data) is False
+
+    close_fd.assert_called_once_with(42)
+    assert writer._write_fd is None
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -892,6 +892,20 @@ async def test_pipe_write_resumes_after_the_buffer_drains() -> None:
 
 
 @pytest.mark.asyncio
+async def test_pipe_write_gives_up_when_the_pipe_goes_before_the_first_write() -> None:
+    """A pipe removed the instant a write starts fails cleanly rather than blowing up."""
+    writer = AsyncNamedPipeWriter("/tmp/audio")  # noqa: S108
+
+    with (
+        patch.object(AsyncNamedPipeWriter, "_ensure_write_fd", return_value=True),
+        patch("music_assistant.helpers.named_pipe.os.write") as write,
+    ):
+        assert await writer.write(b"\x00" * 10) is False
+
+    write.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_pipe_write_stops_when_the_descriptor_is_taken_mid_stall() -> None:
     """A stalled write gives up once the pipe is removed out from under it."""
     writer = AsyncNamedPipeWriter("/tmp/audio")  # noqa: S108


### PR DESCRIPTION
# What does this implement/fix?

The named pipe writer opens its descriptor in non-blocking mode but never handled a full pipe buffer. When the reader is behind, the write raises `BlockingIOError` at the caller instead of waiting for it to catch up.

The AirPlay Receiver runs into this when playback stops: it writes one second of silence (176 KB) in a single call to nudge ffmpeg along, far more than a pipe holds (64 KB on Linux, 8 KB on macOS). So the write blows up as soon as ffmpeg is behind, which is exactly the situation the nudge exists for. Because it runs as a background task, that surfaced as an `Exception in task` warning in the log and the nudge silently never happened.

Changes:

- Wait for the reader to drain a full pipe buffer and then continue, instead of raising at the caller
- Report a reader that never drains as a failed write, in line with the existing "no reader" and "reader closed" cases
- Keep a reader that went away visible: the write itself still surfaces it, so it is never retried blindly
- Wait with `poll()` rather than `select()`, which rejects descriptors of 1024 and above — we raise the open file limit at startup, so those do occur
- Cap the total time a single write can hold the pipe, so a barely-moving reader cannot stall teardown
- Add tests for a stalled reader, a reader that keeps up, a reader slower than the stall budget, and a reader that disappears mid-write

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
