### PR TITLE
Keep AirPlay speakers on the same clock when they start at different times

### DIFF
--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -453,6 +453,12 @@ daemon reports it is serving, attaching them to its elected clock via shared
 memory. A sync group resolves that choice once and applies it to every member,
 so a group never mixes members on the shared clock with members off it.
 
+Sendspin-bridged players hold the same line across their Sendspin group. Their
+processes are spawned independently and can outlive several tracks, so a bridge
+adopts the choice a live group member is already running with and only asks the
+daemon when the group has no such member. That keeps members which start minutes
+apart, or which keep a warm process across a track change, on one clock.
+
 The official Music Assistant container runs as root, allowing the daemon to bind
 these ports. A custom container running Music Assistant as a non-root user must
 grant the binary `CAP_NET_BIND_SERVICE` (for example,

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -48,6 +48,7 @@ from .constants import (
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
     AIRPLAY_SPLICE_LEAD_MARGIN_MS,
     ClockReadiness,
+    StreamingProtocol,
 )
 from .helpers import player_id_to_mac_address
 from .stream import AirPlayStream
@@ -267,6 +268,11 @@ class SendspinAirPlayBridge:
         self._bridge_role: BridgePlayerRole | None = None
         self._airplay_stream: AirPlayStream | None = None
         self._is_streaming = False
+        # Shared-PTP decision the bridge's current cli process was spawned with
+        # (None when no process carries one). A warm reuse keeps the flag baked
+        # into that process, so the group matches what is really running instead
+        # of deciding again per stream.
+        self._use_shared_ptp: bool | None = None
         # Frames handed to the CLI since the start anchor. Byte 0 of that stream is
         # audible at _drop_until_us and the device plays on at a fixed rate, so this
         # counter is also the write cursor's position on the Sendspin timeline.
@@ -331,6 +337,25 @@ class SendspinAirPlayBridge:
         return (
             self._airplay_stream is not None and self.airplay_player.stream is self._airplay_stream
         )
+
+    @property
+    def sendspin_group(self) -> SendspinGroup | None:
+        """Return the Sendspin group this bridge belongs to, or None when unregistered."""
+        return self._sendspin_client.group if self._sendspin_client else None
+
+    @property
+    def active_shared_ptp(self) -> bool | None:
+        """
+        Return the shared-PTP decision this bridge's live cli process runs with.
+
+        None when the bridge has no process carrying one, so a group member
+        resolving its own start never matches a decision nothing is running. A
+        process kept for a warm reuse still answers: the next stream rides it
+        with the flag it was spawned with.
+        """
+        if self._is_streaming or self._stream_is_warm_eligible():
+            return self._use_shared_ptp
+        return None
 
     async def start(self) -> None:
         """Register the AirPlay player as an external Sendspin client."""
@@ -435,7 +460,7 @@ class SendspinAirPlayBridge:
             return
         lead_ms = (
             BRIDGE_WARM_START_LEAD_MS
-            if self._stream_is_warm_eligible()
+            if self._can_reuse_stream_warm()
             else BRIDGE_COLD_START_LEAD_MS
         )
         self._bridge_role.set_timing(
@@ -453,6 +478,30 @@ class SendspinAirPlayBridge:
         """
         stream = self._airplay_stream
         return stream is not None and stream.running and stream.connected and self._started
+
+    def _can_reuse_stream_warm(self) -> bool:
+        """
+        Return whether the next Sendspin stream can ride the current cli process.
+
+        On top of the process being reusable, the shared-PTP flag it was spawned
+        with has to still be the one its group runs on: a bridge regrouped onto
+        the other timing source needs a fresh process to change that flag.
+        """
+        if not self._stream_is_warm_eligible():
+            return False
+        group_decision = self.provider.bridge_manager.group_shared_ptp(self)
+        return group_decision is None or group_decision == self._use_shared_ptp
+
+    def _resolve_shared_ptp(self) -> bool | None:
+        """
+        Decide whether the cli process about to be spawned attaches to the shared PTP clock.
+
+        None for a player that does not stream native AirPlay 2, whose process
+        carries no timing decision for the group to match.
+        """
+        if self.airplay_player.protocol != StreamingProtocol.AIRPLAY2:
+            return None
+        return self.provider.bridge_manager.resolve_shared_ptp(self)
 
     def _on_stream_start(self, request: ExternalStreamStartRequest) -> None:
         """
@@ -491,7 +540,7 @@ class SendspinAirPlayBridge:
         # stream's resources, which reuse the same instance variables. A warm-
         # eligible stream is kept out of the snapshot entirely so it survives
         # into the new stream instead of being torn down.
-        keep_stream = self._stream_is_warm_eligible()
+        keep_stream = self._can_reuse_stream_warm()
         old_stream = None if keep_stream else self._airplay_stream
         old_writer_task = self._writer_task
         old_stream_start_task = self._airplay_stream_start_task
@@ -543,8 +592,8 @@ class SendspinAirPlayBridge:
         self.mass.cancel_timer(self._teardown_timer_id)
         # The stream might not yet be cleaned up completely (on rapid skips for example).
         # A warm-eligible stream is kept out of the snapshot so it survives into the
-        # new stream instead of being torn down (see _stream_is_warm_eligible).
-        keep_stream = self._stream_is_warm_eligible()
+        # new stream instead of being torn down (see _can_reuse_stream_warm).
+        keep_stream = self._can_reuse_stream_warm()
         old_stream = None if keep_stream else self._airplay_stream
         old_writer_task = self._writer_task
         old_stream_start_task = self._airplay_stream_start_task
@@ -638,7 +687,10 @@ class SendspinAirPlayBridge:
         :return: True when the stream is anchored, False when superseded.
         """
         try:
-            await stream.connect()
+            # Resolving and recording the decision never awaits, so two bridges
+            # starting together cannot both find their group still undecided.
+            self._use_shared_ptp = self._resolve_shared_ptp()
+            await stream.connect(self._use_shared_ptp)
             await stream.wait_for_connection()
             if asyncio.current_task() is not self._airplay_stream_start_task:
                 await stream.stop(force=True)
@@ -1312,6 +1364,7 @@ class SendspinAirPlayBridge:
     async def _stop_streaming(self) -> None:
         """Stop streaming (internal, called with lock held)."""
         self._is_streaming = False
+        self._use_shared_ptp = None
         self._queued_frames = 0
         self._applied_shift_seconds = 0.0
         self._absorbing_shift = False
@@ -1340,6 +1393,42 @@ class SendspinAirPlayBridge:
 
 class SendspinBridgeManager(SendspinBridgeManagerBase[SendspinAirPlayBridge]):
     """Manages Sendspin bridges for all AirPlay players."""
+
+    def resolve_shared_ptp(self, bridge: SendspinAirPlayBridge) -> bool:
+        """
+        Return whether a bridge's next cli process attaches to the shared PTP clock.
+
+        One Sendspin group must not mix the two timing sources: a member that
+        does not attach times itself off NTP instead, which the binary anchors
+        differently from PTP, and the two drift audibly apart. Bridges in a group
+        can start minutes apart and keep a warm process across a track change, so
+        the decision its group already runs on wins; only a group without one
+        asks the daemon.
+
+        :param bridge: The bridge about to spawn a cli process.
+        """
+        decision = self.group_shared_ptp(bridge)
+        if decision is None:
+            decision = cast("AirPlayProvider", self.provider).ptp_daemon_ready
+        return decision
+
+    def group_shared_ptp(self, bridge: SendspinAirPlayBridge) -> bool | None:
+        """
+        Return the shared-PTP decision the rest of a bridge's Sendspin group runs on.
+
+        None when no other member of the group has a cli process carrying one,
+        which leaves the bridge free to decide for the group itself.
+
+        :param bridge: The bridge asking about its group.
+        """
+        if not (group := bridge.sendspin_group):
+            return None
+        for sibling in self._bridges.values():
+            if sibling is bridge or sibling.sendspin_group is not group:
+                continue
+            if (decision := sibling.active_shared_ptp) is not None:
+                return decision
+        return None
 
     def get_transport_command_target(self, airplay_player_id: str) -> str | None:
         """

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -489,6 +489,10 @@ class SendspinAirPlayBridge:
         """
         if not self._stream_is_warm_eligible():
             return False
+        if self._use_shared_ptp is None:
+            # A legacy RAOP process carries no timing decision, so it cannot be
+            # on the wrong one and respawning it would change nothing.
+            return True
         group_decision = self.provider.bridge_manager.group_shared_ptp(self)
         return group_decision is None or group_decision == self._use_shared_ptp
 
@@ -660,6 +664,7 @@ class SendspinAirPlayBridge:
                     await kept_stream.stop(force=True)
                 self._airplay_stream = None
                 self.airplay_player.stream = None
+                self._use_shared_ptp = None
 
             # On a rapid skip, _on_bridge_stream_start snapshots self._airplay_stream
             # for cleanup. If we assigned it earlier, the new stream would be missed
@@ -691,12 +696,8 @@ class SendspinAirPlayBridge:
         try:
             # Resolving and recording the decision never awaits, so two bridges
             # starting together cannot both find their group still undecided.
-            # A start that has already been superseded still spawns the process
-            # it is holding, but the record belongs to whoever owns the bridge.
-            decision = self._resolve_shared_ptp()
-            if asyncio.current_task() is self._airplay_stream_start_task:
-                self._use_shared_ptp = decision
-            await stream.connect(decision)
+            self._use_shared_ptp = self._resolve_shared_ptp()
+            await stream.connect(self._use_shared_ptp)
             await stream.wait_for_connection()
             if asyncio.current_task() is not self._airplay_stream_start_task:
                 await stream.stop(force=True)
@@ -923,6 +924,7 @@ class SendspinAirPlayBridge:
         so that silence reaches the player.
         """
         self._is_streaming = False
+        self._use_shared_ptp = None
         self._held_chunks.clear()
         self._held_us = 0
         # unblock a writer still waiting for a stream that will never be ready
@@ -1410,6 +1412,12 @@ class SendspinBridgeManager(SendspinBridgeManagerBase[SendspinAirPlayBridge]):
         can start minutes apart and keep a warm process across a track change, so
         the decision its group already runs on wins; only a group without one
         asks the daemon.
+
+        The daemon is read as it stands rather than waited for (unlike a native
+        sync group, which can afford the wait): a bridge's start lead is fixed
+        before this point, so waiting here would push its anchor past the audio
+        Sendspin already scheduled. A group starting inside the daemon's spawn
+        window therefore degrades to NTP together, for that session.
 
         :param bridge: The bridge about to spawn a cli process.
         """

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -548,6 +548,7 @@ class SendspinAirPlayBridge:
         if not keep_stream:
             self._airplay_stream = None
             self.airplay_player.stream = None
+            self._use_shared_ptp = None
         self._writer_task = None
         self._airplay_stream_start_task = None
         self._airplay_stream_ready.clear()
@@ -601,6 +602,7 @@ class SendspinAirPlayBridge:
         if not keep_stream:
             self._airplay_stream = None
             self.airplay_player.stream = None
+            self._use_shared_ptp = None
         self._writer_task = None
         self._airplay_stream_start_task = None
 
@@ -689,8 +691,12 @@ class SendspinAirPlayBridge:
         try:
             # Resolving and recording the decision never awaits, so two bridges
             # starting together cannot both find their group still undecided.
-            self._use_shared_ptp = self._resolve_shared_ptp()
-            await stream.connect(self._use_shared_ptp)
+            # A start that has already been superseded still spawns the process
+            # it is holding, but the record belongs to whoever owns the bridge.
+            decision = self._resolve_shared_ptp()
+            if asyncio.current_task() is self._airplay_stream_start_task:
+                self._use_shared_ptp = decision
+            await stream.connect(decision)
             await stream.wait_for_connection()
             if asyncio.current_task() is not self._airplay_stream_start_task:
                 await stream.stop(force=True)

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -2479,3 +2479,53 @@ def test_a_group_without_a_live_decision_reuses_the_warm_process() -> None:
     _group_bridges(solo, daemon_ready=False)
 
     assert solo._can_reuse_stream_warm() is True
+
+
+async def test_a_superseded_cold_start_does_not_record_its_decision() -> None:
+    """
+    Only the start that owns the bridge records what its process runs with.
+
+    A superseded start still spawns the process it is holding and tears it down,
+    so recording its decision would advertise a dead process to the group.
+    """
+    superseded = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    _group_bridges(superseded, daemon_ready=False)
+    # the newer start already spawned its process on the shared clock, while a
+    # fresh resolve would now answer the other way
+    superseded._use_shared_ptp = True
+    # ...and that newer start owns the bridge, so this one is stale
+    superseded._airplay_stream_start_task = MagicMock()
+    stream = _make_anchor_stream()
+
+    with patch(
+        "music_assistant.providers.airplay.sendspin_bridge.time.time",
+        return_value=UNIX_NOW_S,
+    ):
+        assert await superseded._start_cold_stream(stream) is False
+
+    assert superseded._use_shared_ptp is True
+    stream.stop.assert_awaited_once_with(force=True)
+
+
+@pytest.mark.parametrize("arm", ["sendspin_stream_start", "transport_restart"])
+def test_a_released_process_stops_deciding_for_its_group(arm: str) -> None:
+    """
+    A process the bridge is about to tear down no longer speaks for its group.
+
+    Arming the bridge for its next stream happens well before that stream
+    resolves, so a decision left over from the released process would be handed
+    to a sibling resolving in between - and after a regroup it is the wrong one.
+    """
+    regrouped = _make_warm_bridge(use_shared_ptp=False)
+    playing = _make_warm_bridge(use_shared_ptp=True)
+    _group_bridges(regrouped, playing, daemon_ready=True)
+
+    if arm == "sendspin_stream_start":
+        regrouped._on_stream_start(MagicMock())
+    else:
+        regrouped._on_bridge_stream_start()
+
+    assert regrouped._is_streaming is True
+    assert regrouped.active_shared_ptp is None
+    # the sibling still holding a live process keeps deciding for the group
+    assert playing.active_shared_ptp is True

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -32,6 +32,7 @@ tests are deterministic and independent of the host wall-clock:
 """
 
 import asyncio
+from collections.abc import Coroutine
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -2423,13 +2424,19 @@ async def test_a_torn_down_bridge_stops_deciding() -> None:
     assert bridge.active_shared_ptp is None
 
 
-def _make_warm_bridge(*, use_shared_ptp: bool) -> SendspinAirPlayBridge:
+def _make_warm_bridge(
+    *,
+    use_shared_ptp: bool | None,
+    protocol: StreamingProtocol = StreamingProtocol.AIRPLAY2,
+) -> SendspinAirPlayBridge:
     """
     Build a bridge holding a connected, anchored cli process on the given flag.
 
-    :param use_shared_ptp: The shared-PTP flag its process was spawned with.
+    :param use_shared_ptp: The shared-PTP flag its process was spawned with,
+        None for a process that carries no such decision.
+    :param protocol: The streaming protocol the bridged player speaks.
     """
-    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US, protocol=protocol)
     bridge._airplay_stream = _make_kept_stream()
     bridge._started = True
     bridge._use_shared_ptp = use_shared_ptp
@@ -2481,30 +2488,75 @@ def test_a_group_without_a_live_decision_reuses_the_warm_process() -> None:
     assert solo._can_reuse_stream_warm() is True
 
 
-async def test_a_superseded_cold_start_does_not_record_its_decision() -> None:
+def test_a_raop_member_keeps_its_warm_process_beside_an_ap2_member() -> None:
     """
-    Only the start that owns the bridge records what its process runs with.
+    A RAOP process is never respawned over a group's shared-clock decision.
 
-    A superseded start still spawns the process it is holding and tears it down,
-    so recording its decision would advertise a dead process to the group.
+    It carries no such decision of its own, and no respawn could give it one, so
+    comparing it against an AirPlay 2 sibling's would cost the group a cold
+    reconnect (and its longer start lead) on every track change for nothing.
     """
-    superseded = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    _group_bridges(superseded, daemon_ready=False)
-    # the newer start already spawned its process on the shared clock, while a
-    # fresh resolve would now answer the other way
-    superseded._use_shared_ptp = True
-    # ...and that newer start owns the bridge, so this one is stale
-    superseded._airplay_stream_start_task = MagicMock()
-    stream = _make_anchor_stream()
+    raop = _make_warm_bridge(use_shared_ptp=None, protocol=StreamingProtocol.RAOP)
+    ap2 = _make_warm_bridge(use_shared_ptp=True)
+    _group_bridges(raop, ap2, daemon_ready=True)
+    raop._bridge_role = MagicMock()
 
-    with patch(
-        "music_assistant.providers.airplay.sendspin_bridge.time.time",
-        return_value=UNIX_NOW_S,
+    assert raop._can_reuse_stream_warm() is True
+
+    raop._refresh_bridge_timing()
+
+    raop._bridge_role.set_timing.assert_called_once_with(
+        required_lead_time_ms=BRIDGE_WARM_START_LEAD_MS, min_buffer_ms=BRIDGE_MIN_BUFFER_MS
+    )
+
+
+async def test_the_real_chunk_path_records_the_decision_it_spawns_with() -> None:
+    """
+    Driving the bridge the way Sendspin does still records what the CLI got.
+
+    The start task is created eagerly, so it runs to its first await before the
+    caller has published the task handle. Anything in the start path that reads
+    that handle before then sees None, and a decision gated on it would be lost
+    while the process it describes is already running.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    _group_bridges(bridge, daemon_ready=True)
+    stream = _make_anchor_stream(ack=UNIX_NOW_MS + COLD_LEAD_MS)
+    started: list[asyncio.Task[None]] = []
+
+    async def connect(_use_shared_ptp: bool | None) -> None:
+        # a real connect does I/O, so the eagerly started task suspends here and
+        # its caller gets to publish the task handle
+        await asyncio.sleep(0)
+
+    stream.connect = AsyncMock(side_effect=connect)
+
+    loop = asyncio.get_running_loop()
+
+    def create_task(coro: Coroutine[None, None, None], **_kwargs: object) -> asyncio.Task[None]:
+        # mirrors mass.create_task, whose eager start runs the coroutine to its
+        # first await before this returns
+        task = asyncio.Task(coro, loop=loop, eager_start=True)
+        started.append(task)
+        return task
+
+    cast("MagicMock", bridge.mass).create_task = create_task
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=stream,
+        ),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.time",
+            return_value=UNIX_NOW_S,
+        ),
     ):
-        assert await superseded._start_cold_stream(stream) is False
+        bridge._on_audio_chunk(_pcm_chunk(SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000))
+        await asyncio.gather(*started)
 
-    assert superseded._use_shared_ptp is True
-    stream.stop.assert_awaited_once_with(force=True)
+    stream.connect.assert_awaited_once_with(True)
+    assert bridge.active_shared_ptp is True
 
 
 @pytest.mark.parametrize("arm", ["sendspin_stream_start", "transport_restart"])
@@ -2529,3 +2581,14 @@ def test_a_released_process_stops_deciding_for_its_group(arm: str) -> None:
     assert regrouped.active_shared_ptp is None
     # the sibling still holding a live process keeps deciding for the group
     assert playing.active_shared_ptp is True
+
+
+def test_an_abandoned_process_stops_deciding_for_its_group() -> None:
+    """Giving up on a transport takes its decision out of the group with it."""
+    abandoned = _make_warm_bridge(use_shared_ptp=True)
+    _group_bridges(abandoned, daemon_ready=True)
+
+    abandoned._abandon_streaming()
+
+    assert abandoned._use_shared_ptp is None
+    assert abandoned.active_shared_ptp is None

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -1,7 +1,7 @@
 """
 Unit tests for the Sendspin -> AirPlay bridge timing.
 
-Cover nine things, with the Sendspin clock mocked via ``ManualClock`` so the
+Cover ten things, with the Sendspin clock mocked via ``ManualClock`` so the
 tests are deterministic and independent of the host wall-clock:
 
 * the clock-domain conversion turning a Sendspin audible instant (Sendspin's own
@@ -57,6 +57,7 @@ from music_assistant.providers.airplay.sendspin_bridge import (
     PAD_BLOCK_FRAMES,
     SILENCE_BLOCK,
     SendspinAirPlayBridge,
+    SendspinBridgeManager,
     device_buffer_ahead_seconds,
     sendspin_audible_instant_to_unix_ms,
     unix_ms_to_sendspin_audible_instant,
@@ -200,6 +201,11 @@ def _make_bridge(
     """Build a bridge with mocked provider/player/server and a ManualClock."""
     provider = MagicMock()
     provider.mass = MagicMock()
+    # Real values: the decision is handed to the CLI verbatim and the group's is
+    # compared against it, both of which a MagicMock would answer truthily
+    # whatever was resolved. None models a group with no live decision.
+    provider.bridge_manager.resolve_shared_ptp = MagicMock(return_value=False)
+    provider.bridge_manager.group_shared_ptp = MagicMock(return_value=None)
     airplay_player = MagicMock()
     airplay_player.player_id = "apc43875e9e53a"
     airplay_player.display_name = "Test Player"
@@ -505,7 +511,7 @@ async def test_cold_start_connects_then_anchors_first_start() -> None:
     ):
         await bridge._start_protocol_from_chunk()
 
-    stream.connect.assert_awaited_once_with()
+    stream.connect.assert_awaited_once_with(False)
     stream.wait_for_connection.assert_awaited_once_with()
     stream.start.assert_awaited_once_with(commanded, join=True)
     assert bridge._airplay_stream is stream
@@ -1395,7 +1401,7 @@ async def test_superseded_start_failure_leaves_the_newer_stream_alone() -> None:
     newer_stream = _make_anchor_stream()
     stale_stream = _make_anchor_stream()
 
-    async def connect() -> None:
+    async def connect(_use_shared_ptp: bool | None) -> None:
         # The newer start won the receiver, so this one cannot have it.
         bridge._airplay_stream_start_task = MagicMock()
         bridge._airplay_stream = newer_stream
@@ -2237,3 +2243,239 @@ async def test_leaving_the_session_without_a_client_is_a_noop() -> None:
     await bridge._leave_sendspin_session()
 
     logger.warning.assert_not_called()
+
+
+# --- One shared-PTP decision per Sendspin group --------------------------------
+
+
+def _group_bridges(*bridges: SendspinAirPlayBridge, daemon_ready: bool) -> SendspinBridgeManager:
+    """
+    Put the given bridges in one Sendspin group behind a shared bridge manager.
+
+    :param bridges: Bridges to place in the group.
+    :param daemon_ready: What the shared PTP daemon answers a fresh resolve.
+    """
+    provider = MagicMock()
+    provider.ptp_daemon_ready = daemon_ready
+    manager = SendspinBridgeManager(provider)
+    provider.bridge_manager = manager
+    group = MagicMock()
+    for index, bridge in enumerate(bridges):
+        bridge.provider = provider
+        bridge._sendspin_client = MagicMock()
+        bridge._sendspin_client.group = group
+        manager._bridges[f"player{index}"] = bridge
+    return manager
+
+
+def test_the_first_group_member_asks_the_daemon() -> None:
+    """With no live decision in the group, the daemon's readiness decides."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    _group_bridges(bridge, daemon_ready=True)
+
+    assert bridge._resolve_shared_ptp() is True
+
+
+@pytest.mark.parametrize(("live_decision", "daemon_ready"), [(True, False), (False, True)])
+def test_a_later_member_adopts_the_groups_live_decision(
+    live_decision: bool, daemon_ready: bool
+) -> None:
+    """
+    A member starting later joins on the clock the group is already running.
+
+    Bridges in one group can start minutes apart, so what the daemon answers at
+    the second start says nothing about the source the first member's process
+    was spawned against. Parametrised both ways so the decision is proven to
+    follow the sibling rather than the daemon.
+    """
+    playing = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    joiner = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    _group_bridges(playing, joiner, daemon_ready=daemon_ready)
+    playing._use_shared_ptp = live_decision
+
+    assert joiner._resolve_shared_ptp() is live_decision
+
+
+def test_a_warm_member_still_speaks_for_the_group() -> None:
+    """
+    A process kept for a warm reuse keeps deciding for its group.
+
+    Its Sendspin stream ended, but the next one rides that same cli process with
+    the flag it was spawned with, so a sibling cold-starting alongside it has to
+    match that flag rather than resolve against the daemon.
+    """
+    warm = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    joiner = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    _group_bridges(warm, joiner, daemon_ready=False)
+    warm._use_shared_ptp = True
+    warm._airplay_stream = _make_kept_stream()
+    warm._started = True
+    warm._is_streaming = False
+
+    assert warm.active_shared_ptp is True
+    assert joiner._resolve_shared_ptp() is True
+
+
+def test_an_idle_member_does_not_decide() -> None:
+    """A bridge with no cli process left leaves the group to resolve fresh."""
+    idle = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    starter = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    _group_bridges(idle, starter, daemon_ready=True)
+    idle._use_shared_ptp = False
+    idle._is_streaming = False
+
+    assert idle.active_shared_ptp is None
+    assert starter._resolve_shared_ptp() is True
+
+
+def test_another_groups_decision_is_not_adopted() -> None:
+    """Only members of the same Sendspin group share one timing source."""
+    stranger = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    starter = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    _group_bridges(stranger, starter, daemon_ready=False)
+    stranger._use_shared_ptp = True
+    # the stranger moved on to a group of its own
+    stranger_client = MagicMock()
+    stranger_client.group = MagicMock()
+    stranger._sendspin_client = stranger_client
+
+    assert starter._resolve_shared_ptp() is False
+
+
+def test_a_raop_member_carries_no_decision() -> None:
+    """A legacy RAOP process has no shared-clock flag to hand its group."""
+    raop = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US, protocol=StreamingProtocol.RAOP)
+    _group_bridges(raop, daemon_ready=True)
+
+    assert raop._resolve_shared_ptp() is None
+
+
+async def test_a_cold_start_spawns_the_cli_with_the_groups_decision() -> None:
+    """The adopted decision reaches the cli process and is recorded on the bridge."""
+    playing = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    joiner = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    _group_bridges(playing, joiner, daemon_ready=False)
+    playing._use_shared_ptp = True
+    joiner._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    joiner._airplay_stream_start_task = asyncio.current_task()
+    stream = _make_anchor_stream(ack=UNIX_NOW_MS + COLD_LEAD_MS)
+
+    with patch(
+        "music_assistant.providers.airplay.sendspin_bridge.time.time",
+        return_value=UNIX_NOW_S,
+    ):
+        assert await joiner._start_cold_stream(stream) is True
+
+    stream.connect.assert_awaited_once_with(True)
+    assert joiner.active_shared_ptp is True
+
+
+async def test_a_daemon_lost_mid_start_cannot_split_the_group() -> None:
+    """
+    Members starting together agree even when the daemon goes away between them.
+
+    The first member records its decision before it awaits its connect, so the
+    second one finds it however the daemon answers by the time it resolves.
+    """
+    first = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    second = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    manager = _group_bridges(first, second, daemon_ready=True)
+    first_stream = _make_anchor_stream(ack=UNIX_NOW_MS + COLD_LEAD_MS)
+    second_stream = _make_anchor_stream(ack=UNIX_NOW_MS + COLD_LEAD_MS)
+
+    async def connect(_use_shared_ptp: bool | None) -> None:
+        # the daemon dies while the first member is still connecting
+        cast("MagicMock", manager.provider).ptp_daemon_ready = False
+        await asyncio.sleep(0)
+
+    first_stream.connect = AsyncMock(side_effect=connect)
+
+    async def cold_start(bridge: SendspinAirPlayBridge, stream: MagicMock) -> None:
+        bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+        bridge._airplay_stream_start_task = asyncio.current_task()
+        await bridge._start_cold_stream(stream)
+
+    with patch(
+        "music_assistant.providers.airplay.sendspin_bridge.time.time",
+        return_value=UNIX_NOW_S,
+    ):
+        await asyncio.gather(cold_start(first, first_stream), cold_start(second, second_stream))
+
+    assert first.active_shared_ptp is True
+    assert second.active_shared_ptp is True
+    second_stream.connect.assert_awaited_once_with(True)
+
+
+async def test_a_torn_down_bridge_stops_deciding() -> None:
+    """
+    The decision dies with the cli process it was spawned for.
+
+    A new Sendspin stream arms the bridge before it resolves, so a decision left
+    behind by the torn-down process would be handed to the group on its behalf.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._use_shared_ptp = True
+
+    await bridge._stop_streaming()
+    bridge._on_stream_start(MagicMock())
+
+    assert bridge._is_streaming is True
+    assert bridge.active_shared_ptp is None
+
+
+def _make_warm_bridge(*, use_shared_ptp: bool) -> SendspinAirPlayBridge:
+    """
+    Build a bridge holding a connected, anchored cli process on the given flag.
+
+    :param use_shared_ptp: The shared-PTP flag its process was spawned with.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._airplay_stream = _make_kept_stream()
+    bridge._started = True
+    bridge._use_shared_ptp = use_shared_ptp
+    return bridge
+
+
+def test_a_regrouped_warm_process_is_not_reused() -> None:
+    """
+    A process whose flag no longer matches its group has to be respawned.
+
+    The flag is baked in at spawn, so reusing the process would keep the bridge
+    on the clock its old group ran on. Its start lead has to report the cold
+    figure too, or the respawn lands past the audio Sendspin already scheduled.
+    """
+    regrouped = _make_warm_bridge(use_shared_ptp=False)
+    playing = _make_warm_bridge(use_shared_ptp=True)
+    _group_bridges(regrouped, playing, daemon_ready=True)
+    regrouped._bridge_role = MagicMock()
+
+    assert regrouped._stream_is_warm_eligible() is True
+    assert regrouped._can_reuse_stream_warm() is False
+
+    regrouped._refresh_bridge_timing()
+
+    regrouped._bridge_role.set_timing.assert_called_once_with(
+        required_lead_time_ms=BRIDGE_COLD_START_LEAD_MS, min_buffer_ms=BRIDGE_MIN_BUFFER_MS
+    )
+
+
+def test_a_warm_process_matching_its_group_is_reused() -> None:
+    """A group already on the process's flag costs it no respawn."""
+    warm = _make_warm_bridge(use_shared_ptp=True)
+    playing = _make_warm_bridge(use_shared_ptp=True)
+    _group_bridges(warm, playing, daemon_ready=False)
+
+    assert warm._can_reuse_stream_warm() is True
+
+
+def test_a_group_without_a_live_decision_reuses_the_warm_process() -> None:
+    """
+    A bridge whose group has no other live decision keeps its process.
+
+    Its own process is the group's decision, so a daemon that changed state
+    since must not churn the transport on every track change.
+    """
+    solo = _make_warm_bridge(use_shared_ptp=True)
+    _group_bridges(solo, daemon_ready=False)
+
+    assert solo._can_reuse_stream_warm() is True


### PR DESCRIPTION
# What does this implement/fix?

When several AirPlay speakers play together they must all use the same clock,
or they slowly drift apart. Speakers that are grouped through Sendspin each
picked their clock on their own, at the moment their own playback started.

That is fine when they all start together, but not when they don't: a speaker
joining minutes later, or one that keeps its connection alive across a track
change while another reconnects, could end up on a different clock than the
rest of the group and drift audibly out of sync.

A speaker now takes the clock its group is already playing on, and only decides
for itself when it is the first one up.

- Resolve the clock once per group instead of once per speaker
- A speaker joining an existing group adopts that group's clock
- Moving a speaker to a group on the other clock reconnects it rather than
  reusing its connection, so it can actually switch
- Provider README updated for the group-wide behaviour

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
