### PR TITLE
Fix AirPlay volume changes being lost around stream start

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -482,9 +482,11 @@ class AirPlayPlayer(Player):
 
     async def volume_set(self, volume_level: int) -> None:
         """Send VOLUME_SET command to given player."""
+        # Record before sending: the connect-time volume resync reads this attribute,
+        # so a send that suspends first would let the resync push the stale level.
+        self._attr_volume_level = volume_level
         if self.stream and self.stream.running and self.volume_muted is not True:
             await self.stream.send_cli_command(f"VOLUME={volume_level}")
-        self._attr_volume_level = volume_level
         self.update_state()
         # store last state in playerconfig
         self.mass.config.set_raw_player_config_value(

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -303,10 +303,10 @@ class AirPlayStream:
         # Send the mute-aware volume right away — audio can start within a
         # second now that metadata goes out immediately — and repeat it after
         # 2 seconds because some players ignore the first volume command
-        # (https://github.com/music-assistant/support/issues/3330).
-        volume = 0 if self.player.volume_muted else self.player.volume_level
-        await self.send_cli_command(f"VOLUME={volume}")
-        self.mass.call_later(2, self.send_cli_command(f"VOLUME={volume}"))
+        # (https://github.com/music-assistant/support/issues/3330). The repeat reads
+        # the level when it fires, so it never replays a value that changed since.
+        await self._send_current_volume()
+        self.mass.call_later(2, self._send_current_volume)
         # settle artwork and the position on top of the identity push above
         self.player._on_player_media_updated()
 
@@ -1396,6 +1396,11 @@ class AirPlayStream:
         if not metadata:
             return
         await self.send_metadata(None, metadata)
+
+    async def _send_current_volume(self) -> None:
+        """Send the player's current volume level to the device, muted as zero."""
+        volume = 0 if self.player.volume_muted else self.player.volume_level
+        await self.send_cli_command(f"VOLUME={volume}")
 
     async def _cleanup_failed_start(self) -> None:
         """Release all resources owned by a cliairplay process that failed to start."""

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -659,6 +659,43 @@ async def test_volume_set_skipped_while_muted(airplay_player: AirPlayPlayer) -> 
 
 
 @pytest.mark.asyncio
+async def test_volume_set_records_level_before_sending(airplay_player: AirPlayPlayer) -> None:
+    """A resync reading the level mid-send must observe the new volume, not the old one."""
+    send_cmd = _setup_running_stream(airplay_player)
+    airplay_player._attr_volume_level = 20
+    observed: list[int | None] = []
+
+    async def read_level_while_sending(_command: str) -> bool:
+        # stands in for the connect-time volume resync, which reads the player's
+        # level while this send is still suspended
+        await asyncio.sleep(0)
+        observed.append(airplay_player.volume_level)
+        return True
+
+    send_cmd.side_effect = read_level_while_sending
+
+    await airplay_player.volume_set(80)
+
+    assert observed == [80]
+    assert airplay_player.volume_level == 80
+
+
+@pytest.mark.asyncio
+async def test_volume_set_records_level_when_the_send_fails(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """A dropped command must not lose the requested level; the resync repairs the device."""
+    send_cmd = _setup_running_stream(airplay_player)
+    send_cmd.return_value = False
+    airplay_player._attr_volume_level = 20
+
+    await airplay_player.volume_set(80)
+
+    send_cmd.assert_awaited_once_with("VOLUME=80")
+    assert airplay_player.volume_level == 80
+
+
+@pytest.mark.asyncio
 async def test_volume_unmute_restores_volume(airplay_player: AirPlayPlayer) -> None:
     """Unmuting with a running stream should send VOLUME={current_volume}."""
     send_cmd = _setup_running_stream(airplay_player)

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -1673,8 +1673,8 @@ async def test_wait_for_connection_pushes_metadata_immediately() -> None:
 
 
 @pytest.mark.asyncio
-async def test_deferred_volume_resend_reads_the_level_when_it_fires() -> None:
-    """The repeated volume push must carry the level at fire time, not at connect time."""
+async def test_deferred_volume_resend_reads_the_state_when_it_fires() -> None:
+    """The repeated volume push must carry the volume at fire time, not at connect time."""
     player = _make_player()
     player.volume_muted = False
     player.volume_level = 40
@@ -1690,13 +1690,18 @@ async def test_deferred_volume_resend_reads_the_level_when_it_fires() -> None:
     ):
         await stream.wait_for_connection()
         send_command.assert_awaited_with("VOLUME=40")
+        deferred = player.provider.mass.call_later.call_args_list[0].args[1]
 
-        # the volume changes between the connect and the deferred resend firing
+        # a volume change between the connect and the resend firing must survive
         player.volume_level = 75
-        deferred = player.provider.mass.call_later.call_args.args[1]
+        await deferred()
+        send_command.assert_awaited_with("VOLUME=75")
+
+        # ...and so must a mute
+        player.volume_muted = True
         await deferred()
 
-    send_command.assert_awaited_with("VOLUME=75")
+    send_command.assert_awaited_with("VOLUME=0")
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -1673,6 +1673,33 @@ async def test_wait_for_connection_pushes_metadata_immediately() -> None:
 
 
 @pytest.mark.asyncio
+async def test_deferred_volume_resend_reads_the_level_when_it_fires() -> None:
+    """The repeated volume push must carry the level at fire time, not at connect time."""
+    player = _make_player()
+    player.volume_muted = False
+    player.volume_level = 40
+    stream = AirPlayStream(player)
+    stream._connected.set()  # connection already established
+    player.provider.mass.call_later = MagicMock()
+
+    with (
+        patch.object(stream, "_cli_proc", MagicMock()),  # non-None so the method proceeds
+        patch.object(stream.commands_pipe, "wait_for_reader", new=AsyncMock(return_value=True)),
+        patch.object(stream, "_send_current_metadata", new_callable=AsyncMock),
+        patch.object(stream, "send_cli_command", new_callable=AsyncMock) as send_command,
+    ):
+        await stream.wait_for_connection()
+        send_command.assert_awaited_with("VOLUME=40")
+
+        # the volume changes between the connect and the deferred resend firing
+        player.volume_level = 75
+        deferred = player.provider.mass.call_later.call_args.args[1]
+        await deferred()
+
+    send_command.assert_awaited_with("VOLUME=75")
+
+
+@pytest.mark.asyncio
 async def test_wait_for_connection_reports_an_unread_command_pipe() -> None:
     """A binary that never attaches to the command pipe is reported for the player it serves."""
     player = _make_player()


### PR DESCRIPTION
# What does this implement/fix?

Changing the volume of an AirPlay speaker right around the moment playback starts could leave the speaker at its old level while Music Assistant already showed the new one, with nothing correcting it afterwards.

When a speaker connects, Music Assistant re-sends the current volume to it (and repeats that 2 seconds later, because some speakers ignore the first one). Two things went wrong there:

- `volume_set` sent the command to the speaker *before* storing the new level. The resync reads that stored level, so it could read and push the old value while the send was still in flight.
- The repeat 2 seconds later had its value fixed at connect time, so it replayed the old level over anything changed in the meantime — including a mute.

**Related issue (if applicable):**

- n/a — spotted during review of #5312

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Store the new volume level before sending it to the speaker
- Let the delayed volume resend read the current level when it fires, so it can no longer replay a stale value or undo a mute
- Regression tests for both

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
