### PR TITLE
Make the Mono output channels option work on all players

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1210,21 +1210,25 @@ class StreamsAudio:
         channel_value = self._get_output_channels(player, player_id)
         source_channel = None
         channel_mix = ""
-        if channel_value == "left":
-            source_channel = AudioChannel.FL
-            channel_mix = "FL"
-        elif channel_value == "right":
-            source_channel = AudioChannel.FR
-            channel_mix = "FR"
-        elif channel_value == "mono":
-            # both source channels feed the downmix, so report ALL to keep the
-            # output from ever being presented as bit perfect
-            source_channel = AudioChannel.ALL
-            channel_mix = "0.5*FL+0.5*FR"
+        # a single channel source is already the downmix and holds no FL/FR to select
+        # from, where a pan would silently resolve every gain to zero
+        if input_format.channels > 1:
+            if channel_value == "left":
+                source_channel = AudioChannel.FL
+                channel_mix = "FL"
+            elif channel_value == "right":
+                source_channel = AudioChannel.FR
+                channel_mix = "FR"
+            elif channel_value == "mono":
+                # both source channels feed the downmix, so report ALL to keep the
+                # output from ever being presented as bit perfect
+                source_channel = AudioChannel.ALL
+                channel_mix = "0.5*FL+0.5*FR"
         if channel_mix:
-            # every output channel is fed explicitly: leaving ffmpeg to upmix from a
-            # single channel costs 3 dB through its rematrix
-            if output_format.channels == 1:
+            # the pan runs in the command that emits the handoff format, and it feeds
+            # every channel of it explicitly: leaving ffmpeg to upmix from a single
+            # channel costs 3 dB through its rematrix
+            if (handoff_format or output_format).channels == 1:
                 filter_params.append(f"pan=mono|c0={channel_mix}")
             else:
                 filter_params.append(f"pan=stereo|c0={channel_mix}|c1={channel_mix}")

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1209,12 +1209,25 @@ class StreamsAudio:
 
         channel_value = self._get_output_channels(player, player_id)
         source_channel = None
+        channel_mix = ""
         if channel_value == "left":
             source_channel = AudioChannel.FL
-            filter_params.append("pan=mono|c0=FL")
+            channel_mix = "FL"
         elif channel_value == "right":
             source_channel = AudioChannel.FR
-            filter_params.append("pan=mono|c0=FR")
+            channel_mix = "FR"
+        elif channel_value == "mono":
+            # both source channels feed the downmix, so report ALL to keep the
+            # output from ever being presented as bit perfect
+            source_channel = AudioChannel.ALL
+            channel_mix = "0.5*FL+0.5*FR"
+        if channel_mix:
+            # every output channel is fed explicitly: leaving ffmpeg to upmix from a
+            # single channel costs 3 dB through its rematrix
+            if output_format.channels == 1:
+                filter_params.append(f"pan=mono|c0={channel_mix}")
+            else:
+                filter_params.append(f"pan=stereo|c0={channel_mix}|c1={channel_mix}")
 
         output_details = AudioOutputDetails(
             player_ids=sorted(destination_player_ids),

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -665,8 +665,10 @@ def get_ffmpeg_args(
     # append (final) output path at the end of the args
     output_args.append(output_path)
 
-    # edge case: source file is not stereo - downmix to stereo
-    if input_format.channels > 2 and output_format.channels == 2:
+    # edge case: source file is not stereo - downmix to stereo. a single channel
+    # output needs this too, otherwise a mono/left/right pan filter would only see
+    # the front channels and silently drop the center and surround content.
+    if input_format.channels > 2 and output_format.channels <= 2:
         filter_params = [
             "pan=stereo|FL=1.0*FL+0.707*FC+0.707*SL+0.707*LFE|FR=1.0*FR+0.707*FC+0.707*SR+0.707*LFE",
             *filter_params,

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -597,6 +597,50 @@ def test_player_output_plan_feeds_every_output_channel() -> None:
     assert plan.output_details.source_channel == AudioChannel.ALL
 
 
+def test_player_output_plan_skips_channel_selection_for_mono_source() -> None:
+    """A single channel source has no channels to select, so it is left untouched."""
+    mass = MagicMock()
+    mass.players.get_player.return_value = None
+    mass.config.get_player_dsp_config.return_value = DSPConfig(enabled=False)
+    mass.config.get_raw_player_config_value.return_value = "mono"
+    audio = StreamsAudio(cast("Any", mass))
+    audio_format = _format(ContentType.PCM_F32LE, 48000, 32, channels=1)
+
+    plan = audio.get_player_output_plan(
+        "player-1",
+        audio_format,
+        audio_format,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+
+    assert plan.filter_params == []
+    assert plan.output_details.source_channel is None
+
+
+def test_player_output_plan_pans_for_the_handoff_format() -> None:
+    """The pan follows the format FFmpeg emits, not a later provider side encode."""
+    mass = MagicMock()
+    mass.players.get_player.return_value = None
+    mass.config.get_player_dsp_config.return_value = DSPConfig(enabled=False)
+    mass.config.get_raw_player_config_value.return_value = "mono"
+    audio = StreamsAudio(cast("Any", mass))
+    pcm_format = _format(ContentType.PCM_F32LE, 48000, 32)
+
+    plan = audio.get_player_output_plan(
+        "player-1",
+        pcm_format,
+        _format(ContentType.FLAC, 48000, 16, channels=1),
+        handoff_format=pcm_format,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+
+    assert plan.filter_params == ["pan=stereo|c0=0.5*FL+0.5*FR|c1=0.5*FL+0.5*FR"]
+
+
 def test_mono_downmix_prevents_bit_perfect_claim() -> None:
     """A mono downmix alters the samples, even when every format stays stereo."""
     manager, _mass, _queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -552,6 +552,68 @@ def test_player_output_plan_matches_ffmpeg_filters() -> None:
     )
 
 
+def test_player_output_plan_downmixes_to_mono() -> None:
+    """The mono output mode folds both source channels into a single channel."""
+    mass = MagicMock()
+    mass.players.get_player.return_value = None
+    mass.config.get_player_dsp_config.return_value = DSPConfig(enabled=False)
+    mass.config.get_raw_player_config_value.return_value = "mono"
+    audio = StreamsAudio(cast("Any", mass))
+    input_format = _format(ContentType.PCM_F32LE, 48000, 32)
+    output_format = _format(ContentType.FLAC, 48000, 16, channels=1)
+
+    plan = audio.get_player_output_plan(
+        "player-1",
+        input_format,
+        output_format,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+
+    assert plan.filter_params == ["pan=mono|c0=0.5*FL+0.5*FR"]
+    assert plan.output_details.source_channel == AudioChannel.ALL
+
+
+def test_player_output_plan_feeds_every_output_channel() -> None:
+    """A stereo output carries the downmix on both channels instead of being upmixed."""
+    mass = MagicMock()
+    mass.players.get_player.return_value = None
+    mass.config.get_player_dsp_config.return_value = DSPConfig(enabled=False)
+    mass.config.get_raw_player_config_value.return_value = "mono"
+    audio = StreamsAudio(cast("Any", mass))
+    audio_format = _format(ContentType.PCM_F32LE, 48000, 32)
+
+    plan = audio.get_player_output_plan(
+        "player-1",
+        audio_format,
+        audio_format,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+
+    assert plan.filter_params == ["pan=stereo|c0=0.5*FL+0.5*FR|c1=0.5*FL+0.5*FR"]
+    assert plan.output_details.source_channel == AudioChannel.ALL
+
+
+def test_mono_downmix_prevents_bit_perfect_claim() -> None:
+    """A mono downmix alters the samples, even when every format stays stereo."""
+    manager, _mass, _queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()
+    output_plan.output_details.source_channel = AudioChannel.ALL
+
+    manager.update_output(
+        "player-1",
+        output_plan,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+
+    assert streamdetails.audio_processing is not None
+    assert streamdetails.audio_processing.outputs[0].fidelity.bit_perfect is False
+
+
 def test_player_output_plan_excludes_neutral_filters() -> None:
     """A filter that emits no FFmpeg params is left out of the reported chain."""
     mass = MagicMock()
@@ -643,7 +705,7 @@ def test_player_output_plan_prefers_rendering_player_channels() -> None:
     )
 
     assert plan.output_details.source_channel == AudioChannel.FL
-    assert "pan=mono|c0=FL" in plan.filter_params
+    assert "pan=stereo|c0=FL|c1=FL" in plan.filter_params
     # processing attribution still points at the visible parent player
     assert mass.streams.audio_processing.update_output.call_args.args[0] == "parent-1"
 

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -44,6 +44,27 @@ def test_get_ffmpeg_args_does_not_mutate_filters() -> None:
     assert filter_params == ["volume=-1dB"]
 
 
+def test_get_ffmpeg_args_downmixes_multichannel_for_single_channel_output() -> None:
+    """A surround source is folded to stereo before the output is narrowed to one channel."""
+    input_format = AudioFormat(
+        content_type=ContentType.PCM_F32LE,
+        sample_rate=48000,
+        bit_depth=32,
+        channels=6,
+    )
+    output_format = AudioFormat(
+        content_type=ContentType.FLAC,
+        sample_rate=48000,
+        bit_depth=16,
+        channels=1,
+    )
+
+    args = get_ffmpeg_args(input_format, output_format, ["pan=mono|c0=0.5*FL+0.5*FR"])
+
+    filter_graph = args[args.index("-af") + 1]
+    assert filter_graph.index("pan=stereo|FL=") < filter_graph.index("pan=mono|c0=0.5*FL+0.5*FR")
+
+
 # -- parse_ffmpeg_stream_info --
 
 


### PR DESCRIPTION
# What does this implement/fix?

Selecting **Mono (both channels)** for a player's output channels did nothing for most players. It only worked by accident on players streaming FLAC or raw PCM over HTTP — on Sendspin, AirPlay, Snapcast, universal groups, the MSX bridge, and on any WAV/MP3/AAC stream, the setting was silently ignored.

While fixing that it turned out the existing **Left** and **Right** options play about 3 dB too quiet on those same players, so that is corrected in the same place.

- Mono now really mixes both channels together, on every player and stream format
- Left/Right/Mono no longer lose 3 dB of volume on players that need a stereo stream
- Mono recordings no longer play as silence when Left or Right is selected
- Mono is now correctly reported as "not bit perfect" in the stream details

Note for release notes: players already set to Left or Right will sound slightly louder after updating — that is the corrected level.

The `helpers/ffmpeg.py` change makes the existing surround downmix apply to single channel outputs too, so the center and surround content is not dropped by the pan. It cannot take effect yet for multichannel sources: we hand ffmpeg `-ac 6 -channel_layout stereo` for those, the layout argument wins, and the stream is read as stereo. That is pre-existing and tracked separately.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
