### PR TITLE
Show the right address when the SSL certificate can't be loaded

### DIFF
--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -158,6 +158,8 @@ class WebserverController(CoreController):
         self.clients: set[WebsocketClientHandler] = set()
         # the URL that the "auto" base_url setting resolves to, detected at setup
         self._auto_base_url: str = ""
+        # whether the webserver actually serves TLS, resolved at setup
+        self._ssl_active: bool = False
         self.bind_ip: str | None = None
         self.publish_addresses: list[str] = []
         self.manifest.name = "Web Server (frontend and api)"
@@ -188,7 +190,7 @@ class WebserverController(CoreController):
         # IP need not exist on this host at all (e.g. a container or NAT setup), so derive
         # the address from what the webserver actually binds to
         connect_ip = _get_internal_connect_ip(self.bind_ip, self.publish_ip)
-        protocol = "https" if self.config.get_value(CONF_ENABLE_SSL, False) else "http"
+        protocol = "https" if self._ssl_active else "http"
         return f"{protocol}://{format_ip_for_url(connect_ip)}:{self.publish_port}"
 
     @property
@@ -296,18 +298,19 @@ class WebserverController(CoreController):
         assert isinstance(port_value, int)
         self.publish_port = port_value
         bind_ip = cast("str | None", config.get_value(CONF_BIND_IP))
-        ssl_enabled = config.get_value(CONF_ENABLE_SSL, False)
-        protocol = "https" if ssl_enabled else "http"
-        self._resolve_publish_state(bind_ip, all_ip_addresses, protocol)
-
         # Create SSL context if SSL is enabled
         ssl_context = None
-        if ssl_enabled:
+        if config.get_value(CONF_ENABLE_SSL, False):
             ssl_context = await create_server_ssl_context(
                 str(config.get_value(CONF_SSL_CERTIFICATE) or ""),
                 str(config.get_value(CONF_SSL_PRIVATE_KEY) or ""),
                 logger=self.logger,
             )
+        # a missing or invalid certificate falls back to plain HTTP, so every URL we hand
+        # out must follow the context that was actually created, not the configured value
+        self._ssl_active = ssl_context is not None
+        protocol = "https" if self._ssl_active else "http"
+        self._resolve_publish_state(bind_ip, all_ip_addresses, protocol)
 
         await self._server.setup(
             bind_ip=bind_ip,

--- a/tests/controllers/webserver/test_internal_base_url.py
+++ b/tests/controllers/webserver/test_internal_base_url.py
@@ -5,11 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from music_assistant.controllers.webserver.controller import (
-    CONF_BASE_URL,
-    CONF_ENABLE_SSL,
-    WebserverController,
-)
+from music_assistant.controllers.webserver.controller import CONF_BASE_URL, WebserverController
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import CoreConfig
@@ -67,7 +63,6 @@ def test_url_ignores_a_configured_base_url(webserver: WebserverController) -> No
     """Verify an external base URL is not dialed back in through DNS and a reverse proxy."""
     cast("MagicMock", webserver.config).get_value.side_effect = lambda key, default=None: {
         CONF_BASE_URL: "https://ma.example.com",
-        CONF_ENABLE_SSL: False,
     }.get(key, default)
     webserver.bind_ip = "0.0.0.0"
     webserver.publish_ip = "192.168.1.5"
@@ -76,7 +71,7 @@ def test_url_ignores_a_configured_base_url(webserver: WebserverController) -> No
     assert webserver.internal_base_url == "http://127.0.0.1:8095"
 
 
-def test_url_uses_tls_when_ssl_is_enabled(webserver: WebserverController) -> None:
+def test_url_uses_tls_when_ssl_is_active(webserver: WebserverController) -> None:
     """Verify the scheme matches what the webserver serves."""
     webserver._ssl_active = True
     webserver.bind_ip = "0.0.0.0"

--- a/tests/controllers/webserver/test_internal_base_url.py
+++ b/tests/controllers/webserver/test_internal_base_url.py
@@ -78,9 +78,7 @@ def test_url_ignores_a_configured_base_url(webserver: WebserverController) -> No
 
 def test_url_uses_tls_when_ssl_is_enabled(webserver: WebserverController) -> None:
     """Verify the scheme matches what the webserver serves."""
-    cast("MagicMock", webserver.config).get_value.side_effect = lambda key, default=None: {
-        CONF_ENABLE_SSL: True
-    }.get(key, default)
+    webserver._ssl_active = True
     webserver.bind_ip = "0.0.0.0"
     webserver.publish_ip = "192.168.1.5"
 

--- a/tests/controllers/webserver/test_ssl_base_url.py
+++ b/tests/controllers/webserver/test_ssl_base_url.py
@@ -12,6 +12,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.x509.oid import NameOID
 
+from music_assistant.constants import WILDCARD_BIND_IPS
 from music_assistant.controllers.webserver.controller import WebserverController
 from music_assistant.helpers.datetime import utc
 
@@ -61,45 +62,50 @@ async def test_valid_certificate_advertises_tls(
 ) -> None:
     """Verify a usable certificate results in https URLs."""
     certificate, private_key = self_signed_cert
-    webserver = await _setup_webserver(
+    webserver, server = await _setup_webserver(
         mock_mass, tmp_path, certificate=certificate, private_key=private_key
     )
 
     assert webserver.base_url == "https://192.168.1.5:8095"
     assert webserver.internal_base_url == "https://127.0.0.1:8095"
+    assert server.setup.await_args.kwargs["ssl_context"] is not None
 
 
 async def test_missing_certificate_advertises_plain_http(
     mock_mass: MagicMock, tmp_path: Path
 ) -> None:
     """Verify the URLs follow the plain HTTP fallback when no certificate is configured."""
-    webserver = await _setup_webserver(mock_mass, tmp_path, certificate="", private_key="")
+    webserver, server = await _setup_webserver(mock_mass, tmp_path, certificate="", private_key="")
 
     assert webserver.base_url == "http://192.168.1.5:8095"
     assert webserver.internal_base_url == "http://127.0.0.1:8095"
+    assert server.setup.await_args.kwargs["ssl_context"] is None
 
 
 async def test_invalid_certificate_advertises_plain_http(
     mock_mass: MagicMock, tmp_path: Path
 ) -> None:
     """Verify the URLs follow the plain HTTP fallback when the certificate is unusable."""
-    webserver = await _setup_webserver(
+    webserver, server = await _setup_webserver(
         mock_mass, tmp_path, certificate="not a certificate", private_key="not a private key"
     )
 
     assert webserver.base_url == "http://192.168.1.5:8095"
     assert webserver.internal_base_url == "http://127.0.0.1:8095"
+    assert server.setup.await_args.kwargs["ssl_context"] is None
 
 
 def _make_server_mock() -> MagicMock:
-    """Create a Webserver double that echoes back the base URL it is set up with."""
+    """Create a Webserver double that adopts the address it is set up with."""
     server = MagicMock()
-    server.port = 8095
 
-    async def _echo_base_url(**kwargs: Any) -> None:
+    async def _adopt_setup_args(**kwargs: Any) -> None:
         server.base_url = kwargs["base_url"]
+        server.port = kwargs["bind_port"]
+        bind_ip = kwargs["bind_ip"]
+        server.bind_ip = None if bind_ip in WILDCARD_BIND_IPS else bind_ip
 
-    server.setup = AsyncMock(side_effect=_echo_base_url)
+    server.setup = AsyncMock(side_effect=_adopt_setup_args)
     return server
 
 
@@ -109,7 +115,7 @@ async def _setup_webserver(
     *,
     certificate: str,
     private_key: str,
-) -> WebserverController:
+) -> tuple[WebserverController, MagicMock]:
     """
     Run the real setup of a WebserverController with SSL enabled.
 
@@ -117,9 +123,11 @@ async def _setup_webserver(
     :param tmp_path: Directory to serve as the frontend, in place of the bundled one.
     :param certificate: Value for the ssl_certificate config option.
     :param private_key: Value for the ssl_private_key config option.
+    :return: The controller and the Webserver double it was set up against.
     """
     webserver = WebserverController(mock_mass)
-    webserver._server = _make_server_mock()
+    server = _make_server_mock()
+    webserver._server = server
     webserver.auth = MagicMock(setup=AsyncMock())
     webserver.remote_access = MagicMock(setup=AsyncMock())
 
@@ -144,4 +152,4 @@ async def _setup_webserver(
         ),
     ):
         await webserver.setup(cast("CoreConfig", config))
-    return webserver
+    return webserver, server

--- a/tests/controllers/webserver/test_ssl_base_url.py
+++ b/tests/controllers/webserver/test_ssl_base_url.py
@@ -1,0 +1,147 @@
+"""Tests for the URL scheme the webserver advertises when SSL is enabled."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from music_assistant.controllers.webserver.controller import WebserverController
+from music_assistant.helpers.datetime import utc
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from music_assistant_models.config_entries import CoreConfig
+
+
+@pytest.fixture(scope="module")
+def self_signed_cert() -> tuple[str, str]:
+    """Return a self-signed certificate and its private key, as PEM content."""
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    now = utc()
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(days=1))
+        .not_valid_after(now + timedelta(days=1))
+        .sign(private_key, hashes.SHA256())
+    )
+    return (
+        cert.public_bytes(serialization.Encoding.PEM).decode(),
+        private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode(),
+    )
+
+
+@pytest.fixture
+def mock_mass() -> MagicMock:
+    """Create a mock Music Assistant instance."""
+    mass = MagicMock()
+    mass.config.get_raw_core_config_value.return_value = "GLOBAL"
+    mass.running_as_hass_addon = False
+    return mass
+
+
+async def test_valid_certificate_advertises_tls(
+    mock_mass: MagicMock, tmp_path: Path, self_signed_cert: tuple[str, str]
+) -> None:
+    """Verify a usable certificate results in https URLs."""
+    certificate, private_key = self_signed_cert
+    webserver = await _setup_webserver(
+        mock_mass, tmp_path, certificate=certificate, private_key=private_key
+    )
+
+    assert webserver.base_url == "https://192.168.1.5:8095"
+    assert webserver.internal_base_url == "https://127.0.0.1:8095"
+
+
+async def test_missing_certificate_advertises_plain_http(
+    mock_mass: MagicMock, tmp_path: Path
+) -> None:
+    """Verify the URLs follow the plain HTTP fallback when no certificate is configured."""
+    webserver = await _setup_webserver(mock_mass, tmp_path, certificate="", private_key="")
+
+    assert webserver.base_url == "http://192.168.1.5:8095"
+    assert webserver.internal_base_url == "http://127.0.0.1:8095"
+
+
+async def test_invalid_certificate_advertises_plain_http(
+    mock_mass: MagicMock, tmp_path: Path
+) -> None:
+    """Verify the URLs follow the plain HTTP fallback when the certificate is unusable."""
+    webserver = await _setup_webserver(
+        mock_mass, tmp_path, certificate="not a certificate", private_key="not a private key"
+    )
+
+    assert webserver.base_url == "http://192.168.1.5:8095"
+    assert webserver.internal_base_url == "http://127.0.0.1:8095"
+
+
+def _make_server_mock() -> MagicMock:
+    """Create a Webserver double that echoes back the base URL it is set up with."""
+    server = MagicMock()
+    server.port = 8095
+
+    async def _echo_base_url(**kwargs: Any) -> None:
+        server.base_url = kwargs["base_url"]
+
+    server.setup = AsyncMock(side_effect=_echo_base_url)
+    return server
+
+
+async def _setup_webserver(
+    mock_mass: MagicMock,
+    tmp_path: Path,
+    *,
+    certificate: str,
+    private_key: str,
+) -> WebserverController:
+    """
+    Run the real setup of a WebserverController with SSL enabled.
+
+    :param mock_mass: Mocked Music Assistant instance to build the controller on.
+    :param tmp_path: Directory to serve as the frontend, in place of the bundled one.
+    :param certificate: Value for the ssl_certificate config option.
+    :param private_key: Value for the ssl_private_key config option.
+    """
+    webserver = WebserverController(mock_mass)
+    webserver._server = _make_server_mock()
+    webserver.auth = MagicMock(setup=AsyncMock())
+    webserver.remote_access = MagicMock(setup=AsyncMock())
+
+    config_values: dict[str, Any] = {
+        "bind_port": 8095,
+        "bind_ip": None,
+        "enable_ssl": True,
+        "ssl_certificate": certificate,
+        "ssl_private_key": private_key,
+    }
+    config = MagicMock()
+    config.get_value.side_effect = lambda key, default=None: config_values.get(key, default)
+
+    with (
+        patch(
+            "music_assistant.controllers.webserver.controller.get_ip_addresses",
+            AsyncMock(return_value=("192.168.1.5",)),
+        ),
+        patch(
+            "music_assistant.controllers.webserver.controller.locate_frontend",
+            return_value=str(tmp_path),
+        ),
+    ):
+        await webserver.setup(cast("CoreConfig", config))
+    return webserver


### PR DESCRIPTION
# What does this implement/fix?

With SSL enabled but a missing or unusable certificate, the webserver logs the problem and starts on plain HTTP - but it kept handing out `https://` addresses anyway. The address printed at startup, the login redirect URLs and the URLs passed to provider setup flows all pointed at a scheme the server does not serve, so none of them worked.

The advertised scheme now follows the connection that was actually set up instead of the setting.

Changes:

- Set up SSL before composing the server address, and take the scheme from the result
- Do the same for the internal API address, which read the setting directly
- Add tests covering a valid, a missing and an unusable certificate

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
