### PR TITLE
Report the address the webserver actually bound to

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -450,10 +450,7 @@ class StreamsController(CoreController):
         # resolve the "auto" default (or an unset value) to this server's primary IP
         all_ip_addresses = await get_ip_addresses(include_ipv6=True)
         self.publish_ip = self._configured_publish_ip or all_ip_addresses[0]
-        self._bind_ip = bind_ip = str(config.get_value(CONF_BIND_IP))
-        self.publish_addresses = _get_publish_addresses(
-            bind_ip, self._configured_publish_ip, all_ip_addresses
-        )
+        bind_ip = str(config.get_value(CONF_BIND_IP))
         await self._server.setup(
             bind_ip=bind_ip,
             bind_port=cast("int", self.publish_port),
@@ -473,9 +470,13 @@ class StreamsController(CoreController):
                 ("*", "/announcement/{player_id}.{fmt}", self.serve_announcement_stream),
             ],
         )
-        # adopt the port the server actually bound to: a configured port of 0 is only
-        # resolved by the OS at bind time
+        # adopt what the server actually bound to: a configured port of 0 is only resolved
+        # by the OS at bind time and an unavailable bind IP falls back to all interfaces
         self.publish_port = cast("int", self._server.port)
+        self._bind_ip = self._server.bind_ip or DEFAULT_HOST
+        self.publish_addresses = _get_publish_addresses(
+            self._bind_ip, self._configured_publish_ip, all_ip_addresses
+        )
         # print a big fat message in the log where the streamserver is running
         # because this is a common source of issues for people with more complex setups
         self.logger.log(

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -283,12 +283,11 @@ class WebserverController(CoreController):
         await self.auth.setup()
         # start the webserver
         all_ip_addresses = await get_ip_addresses(include_ipv6=True)
-        default_publish_ip = all_ip_addresses[0]
         if self.mass.running_as_hass_addon:
             # if we're running on the HA supervisor we start an additional TCP site
             # on the internal ("172.30.32.) IP for the HA ingress proxy
             ingress_host = next(
-                (x for x in all_ip_addresses if x.startswith("172.30.32.")), default_publish_ip
+                (x for x in all_ip_addresses if x.startswith("172.30.32.")), all_ip_addresses[0]
             )
             ingress_tcp_site_params = (ingress_host, INGRESS_SERVER_PORT)
         else:
@@ -297,18 +296,9 @@ class WebserverController(CoreController):
         assert isinstance(port_value, int)
         self.publish_port = port_value
         bind_ip = cast("str | None", config.get_value(CONF_BIND_IP))
-        self.bind_ip = bind_ip
-        if bind_ip and bind_ip not in WILDCARD_BIND_IPS:
-            self.publish_ip = bind_ip
-        else:
-            self.publish_ip = default_publish_ip
-        self.publish_addresses = _get_publish_addresses(bind_ip, self.publish_ip, all_ip_addresses)
         ssl_enabled = config.get_value(CONF_ENABLE_SSL, False)
-        # resolve the URL that the "auto" base_url default (or an unset value) translates to
         protocol = "https" if ssl_enabled else "http"
-        self._auto_base_url = (
-            f"{protocol}://{format_ip_for_url(self.publish_ip)}:{self.publish_port}"
-        )
+        self._resolve_publish_state(bind_ip, all_ip_addresses, protocol)
 
         # Create SSL context if SSL is enabled
         ssl_context = None
@@ -331,10 +321,10 @@ class WebserverController(CoreController):
             app_state={"mass": self.mass},
             ssl_context=ssl_context,
         )
-        # adopt the port the server actually bound to: a configured port of 0 is only
-        # resolved by the OS at bind time
+        # adopt what the server actually bound to: a configured port of 0 is only resolved
+        # by the OS at bind time and an unavailable bind IP falls back to all interfaces
         self.publish_port = cast("int", self._server.port)
-        self._auto_base_url = self._server.base_url
+        self._resolve_publish_state(self._server.bind_ip, all_ip_addresses, protocol)
         base_url = self.base_url
         # print a big fat message in the log where the webserver is running
         # because this is a common source of issues for people with more complex setups
@@ -473,6 +463,28 @@ class WebserverController(CoreController):
             async for chunk in preview_stream:
                 await resp.write(chunk)
         return resp
+
+    def _resolve_publish_state(
+        self, bind_ip: str | None, all_ip_addresses: tuple[str, ...], protocol: str
+    ) -> None:
+        """
+        Resolve the addresses and base URL to advertise for the given bind address.
+
+        Reads ``self.publish_port``, so set that first.
+
+        :param bind_ip: Address the webserver binds to (None or a wildcard means all interfaces).
+        :param all_ip_addresses: All detected host IP addresses, in ranked order.
+        :param protocol: URL scheme the webserver serves.
+        """
+        self.bind_ip = bind_ip
+        if bind_ip and bind_ip not in WILDCARD_BIND_IPS:
+            self.publish_ip = bind_ip
+        else:
+            self.publish_ip = all_ip_addresses[0]
+        self.publish_addresses = _get_publish_addresses(bind_ip, self.publish_ip, all_ip_addresses)
+        self._auto_base_url = (
+            f"{protocol}://{format_ip_for_url(self.publish_ip)}:{self.publish_port}"
+        )
 
     async def _build_config_entries(self, ssl_verify_result: str = "") -> tuple[ConfigEntry, ...]:
         """Build this module's config entries, optionally carrying an SSL verify result."""

--- a/music_assistant/helpers/webserver.py
+++ b/music_assistant/helpers/webserver.py
@@ -188,7 +188,7 @@ class Webserver:
 
     @property
     def bind_ip(self) -> str | None:
-        """Return the IP address this webserver is bound to, or None when bound to all interfaces."""
+        """Return the IP address this webserver is bound to (None for all interfaces)."""
         return self._bind_ip
 
     def register_dynamic_route(

--- a/music_assistant/helpers/webserver.py
+++ b/music_assistant/helpers/webserver.py
@@ -61,6 +61,7 @@ class Webserver:
             {} if enable_dynamic_routes else None
         )
         self._bind_port: int | None = None
+        self._bind_ip: str | None = None
         self._ingress_tcp_site: web.TCPSite | None = None
 
     async def setup(
@@ -77,7 +78,8 @@ class Webserver:
         """
         Async initialize of module.
 
-        :param bind_ip: IP address to bind to.
+        :param bind_ip: IP address to bind to. An unavailable address falls back to all
+            interfaces. The effective address is available as the ``bind_ip`` property.
         :param bind_port: Port to bind to, or 0 to let the OS assign a free one, which
             requires a specific ``bind_ip``. The assigned port is available as the
             ``port`` property and replaces the port in ``base_url``.
@@ -138,10 +140,12 @@ class Webserver:
             self.logger.error(
                 "Could not bind to %s, will start on all interfaces as fallback!", host
             )
+            host = None
             self._tcp_site = web.TCPSite(
-                self._apprunner, host=None, port=bind_port, ssl_context=ssl_context
+                self._apprunner, host=host, port=bind_port, ssl_context=ssl_context
             )
             await self._tcp_site.start()
+        self._bind_ip = host
         # port 0 asks the OS for a free port, which it only picks at bind time
         if bind_port == 0:
             self._bind_port = self._apprunner.addresses[0][1]
@@ -181,6 +185,11 @@ class Webserver:
     def port(self) -> int | None:
         """Return the port of this webserver."""
         return self._bind_port
+
+    @property
+    def bind_ip(self) -> str | None:
+        """Return the IP address this webserver is bound to, or None when bound to all interfaces."""
+        return self._bind_ip
 
     def register_dynamic_route(
         self,

--- a/tests/controllers/streams/test_bind_fallback.py
+++ b/tests/controllers/streams/test_bind_fallback.py
@@ -1,0 +1,80 @@
+"""Tests for the streamserver adopting the address it actually bound to."""
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aiohttp.test_utils import unused_port
+
+from music_assistant.constants import CONF_BIND_IP, CONF_BIND_PORT
+from music_assistant.controllers.streams.controller import StreamsController
+from music_assistant.controllers.tasks import TasksController
+from music_assistant.mass import MusicAssistant
+
+# TEST-NET-3 (RFC 5737) is never assigned to a host, so binding it always fails
+UNBINDABLE_IP = "203.0.113.7"
+ALL_ADDRESSES = ("192.168.1.10", "fd00::10")
+
+
+@pytest.fixture
+async def controller(mass_minimal: MusicAssistant) -> AsyncGenerator[StreamsController]:
+    """
+    Yield a StreamsController attached to a minimal server, closed afterwards.
+
+    :param mass_minimal: Minimal MusicAssistant instance.
+    """
+    mass_minimal.tasks = TasksController(mass_minimal)
+    await mass_minimal.tasks.setup(await mass_minimal.config.get_core_config("tasks"))
+    streams = StreamsController(mass_minimal)
+    mass_minimal.streams = streams
+    try:
+        yield streams
+    finally:
+        # close unconditionally: a failed assertion must not leave the socket bound
+        await streams.close()
+        await mass_minimal.tasks.close()
+
+
+async def _setup_with_bind_ip(
+    controller: StreamsController, mass: MusicAssistant, bind_ip: str
+) -> None:
+    """
+    Run the streamserver's setup against a config that binds the given address.
+
+    :param controller: The StreamsController to set up.
+    :param mass: The MusicAssistant instance owning the controller.
+    :param bind_ip: Address to configure as bind IP.
+    """
+    config = await mass.config.get_core_config(controller.domain)
+    config.update({CONF_BIND_IP: bind_ip, CONF_BIND_PORT: unused_port()})
+    with (
+        patch(
+            "music_assistant.controllers.streams.controller.get_ip_addresses",
+            AsyncMock(return_value=ALL_ADDRESSES),
+        ),
+        patch(
+            "music_assistant.controllers.streams.controller.check_ffmpeg_version",
+            AsyncMock(),
+        ),
+    ):
+        await controller.setup(config)
+
+
+async def test_unavailable_bind_ip_publishes_dialable_addresses(
+    controller: StreamsController, mass_minimal: MusicAssistant
+) -> None:
+    """An address that cannot be bound leaves the streamserver advertising reachable addresses."""
+    await _setup_with_bind_ip(controller, mass_minimal, UNBINDABLE_IP)
+
+    assert controller.bind_ip == "0.0.0.0"
+    assert controller.publish_addresses == list(ALL_ADDRESSES)
+
+
+async def test_available_bind_ip_publishes_only_that_address(
+    controller: StreamsController, mass_minimal: MusicAssistant
+) -> None:
+    """A bind that succeeded advertises exactly the interface the streamserver is pinned to."""
+    await _setup_with_bind_ip(controller, mass_minimal, "127.0.0.1")
+
+    assert controller.bind_ip == "127.0.0.1"
+    assert controller.publish_addresses == ["127.0.0.1"]

--- a/tests/controllers/webserver/test_bind_fallback.py
+++ b/tests/controllers/webserver/test_bind_fallback.py
@@ -3,14 +3,16 @@
 import logging
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
 from aiohttp.test_utils import unused_port
 
+from music_assistant.constants import CONF_BIND_IP, CONF_BIND_PORT
 from music_assistant.controllers.webserver.controller import WebserverController
 from music_assistant.helpers.webserver import Webserver
+from music_assistant.mass import MusicAssistant
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import CoreConfig
@@ -41,6 +43,22 @@ def controller() -> WebserverController:
     webserver.config = cast("CoreConfig", config)
     webserver.publish_port = 8095
     return webserver
+
+
+@pytest.fixture
+async def booted_controller(mass_minimal: MusicAssistant) -> AsyncGenerator[WebserverController]:
+    """
+    Yield a WebserverController attached to a minimal server, closed afterwards.
+
+    :param mass_minimal: Minimal MusicAssistant instance.
+    """
+    controller = WebserverController(mass_minimal)
+    mass_minimal.webserver = controller
+    try:
+        yield controller
+    finally:
+        # close unconditionally: a failed assertion must not leave the socket bound
+        await controller.close()
 
 
 async def test_unavailable_bind_ip_falls_back_to_all_interfaces(server: Webserver) -> None:
@@ -104,3 +122,23 @@ def test_successful_bind_pins_to_the_configured_address(controller: WebserverCon
     assert controller.publish_addresses == ["192.168.1.10"]
     assert controller.base_url == "http://192.168.1.10:8095"
     assert controller.internal_base_url == "http://192.168.1.10:8095"
+
+
+async def test_setup_publishes_dialable_addresses_after_fallback(
+    booted_controller: WebserverController, mass_minimal: MusicAssistant
+) -> None:
+    """Setting up on an un-bindable address leaves the webserver advertising what answers."""
+    port = unused_port()
+    config = await mass_minimal.config.get_core_config(booted_controller.domain)
+    config.update({CONF_BIND_IP: UNBINDABLE_IP, CONF_BIND_PORT: port})
+
+    with patch(
+        "music_assistant.controllers.webserver.controller.get_ip_addresses",
+        AsyncMock(return_value=ALL_ADDRESSES),
+    ):
+        await booted_controller.setup(config)
+
+    assert booted_controller.bind_ip is None
+    assert booted_controller.publish_addresses == list(ALL_ADDRESSES)
+    assert booted_controller.base_url == f"http://192.168.1.10:{port}"
+    assert booted_controller.internal_base_url == f"http://127.0.0.1:{port}"

--- a/tests/controllers/webserver/test_bind_fallback.py
+++ b/tests/controllers/webserver/test_bind_fallback.py
@@ -1,0 +1,106 @@
+"""Tests for the fallback to all interfaces when the configured bind IP is unavailable."""
+
+import logging
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock
+
+import aiohttp
+import pytest
+from aiohttp.test_utils import unused_port
+
+from music_assistant.controllers.webserver.controller import WebserverController
+from music_assistant.helpers.webserver import Webserver
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import CoreConfig
+
+# TEST-NET-3 (RFC 5737) is never assigned to a host, so binding it always fails
+UNBINDABLE_IP = "203.0.113.7"
+ALL_ADDRESSES = ("192.168.1.10", "fd00::10")
+
+
+@pytest.fixture
+async def server() -> AsyncGenerator[Webserver]:
+    """Yield a bare Webserver, guaranteeing its socket is released afterwards."""
+    webserver = Webserver(logging.getLogger(__name__))
+    try:
+        yield webserver
+    finally:
+        await webserver.close()
+
+
+@pytest.fixture
+def controller() -> WebserverController:
+    """Create a WebserverController carrying the state that setup() resolves."""
+    mass = MagicMock()
+    mass.config.get_raw_core_config_value.return_value = "GLOBAL"
+    webserver = WebserverController(mass)
+    config = MagicMock()
+    config.get_value.return_value = False
+    webserver.config = cast("CoreConfig", config)
+    webserver.publish_port = 8095
+    return webserver
+
+
+async def test_unavailable_bind_ip_falls_back_to_all_interfaces(server: Webserver) -> None:
+    """An address that cannot be bound starts the server on all interfaces instead."""
+    port = unused_port()
+
+    await server.setup(
+        bind_ip=UNBINDABLE_IP, bind_port=port, base_url=f"http://{UNBINDABLE_IP}:{port}"
+    )
+
+    assert server.bind_ip is None
+    assert server.port == port
+    # no routes are registered on a bare Webserver, so a 404 proves it is really serving
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(f"http://127.0.0.1:{port}/info") as response,
+    ):
+        assert response.status == 404
+
+
+async def test_available_bind_ip_is_reported(server: Webserver) -> None:
+    """A bind that succeeded reports the address it is pinned to."""
+    port = unused_port()
+
+    await server.setup(bind_ip="127.0.0.1", bind_port=port, base_url=f"http://127.0.0.1:{port}")
+
+    assert server.bind_ip == "127.0.0.1"
+    assert server.port == port
+
+
+async def test_wildcard_bind_ip_is_reported_as_all_interfaces(server: Webserver) -> None:
+    """A configured wildcard is reported the same way as a fallback: no pinned address."""
+    port = unused_port()
+
+    await server.setup(bind_ip="0.0.0.0", bind_port=port, base_url=f"http://0.0.0.0:{port}")
+
+    assert server.bind_ip is None
+
+
+def test_fallback_publishes_only_dialable_addresses(controller: WebserverController) -> None:
+    """After a fallback, the un-bindable address is neither advertised nor dialed."""
+    # what setup() resolves from the configured address, before the bind is attempted
+    controller._resolve_publish_state(UNBINDABLE_IP, ALL_ADDRESSES, "http")
+    assert controller.base_url == f"http://{UNBINDABLE_IP}:8095"
+
+    # ...and what it resolves once the webserver reports it fell back to all interfaces
+    controller._resolve_publish_state(None, ALL_ADDRESSES, "http")
+
+    assert controller.bind_ip is None
+    assert controller.internal_base_url == "http://127.0.0.1:8095"
+    assert controller.publish_addresses == ["192.168.1.10", "fd00::10"]
+    assert controller.base_url == "http://192.168.1.10:8095"
+
+
+def test_successful_bind_pins_to_the_configured_address(controller: WebserverController) -> None:
+    """A bind that succeeded keeps advertising exactly the address it is pinned to."""
+    controller._resolve_publish_state("192.168.1.10", ALL_ADDRESSES, "http")
+
+    assert controller.bind_ip == "192.168.1.10"
+    assert controller.publish_ip == "192.168.1.10"
+    assert controller.publish_addresses == ["192.168.1.10"]
+    assert controller.base_url == "http://192.168.1.10:8095"
+    assert controller.internal_base_url == "http://192.168.1.10:8095"


### PR DESCRIPTION
# What does this implement/fix?

When the bind IP configured for the webserver or streamserver is not available on the host (for example after the network interface changed), the server already falls back to starting on all interfaces so Music Assistant keeps running. Until now it kept reporting the configured address afterwards, so everything derived from it pointed at an address nothing answers on: remote access could not bridge back to the local API, and the addresses advertised to players and over mDNS were unreachable.

The server now reports the address it actually bound to, and both controllers adopt it - the same way they already adopt the port the OS assigned.

## Changes

- `Webserver` records and exposes the address it really bound to (`None` when serving all interfaces).
- The webserver controller re-derives its publish IP, published addresses and base URL from that address after startup.
- The streamserver controller does the same for its bind IP and published addresses, so source-IP selection and mDNS advertising follow the real bind.
- Tests for the fallback path.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
