### PR TITLE
Apple Music: recover from throttled requests in ~1s instead of stalling playback

### DIFF
--- a/music_assistant/providers/apple_music/api_client.py
+++ b/music_assistant/providers/apple_music/api_client.py
@@ -73,11 +73,8 @@ def _raise_on_auth_error(status: int, endpoint: str) -> None:
 class AppleMusicAPIClient:
     """Handles all HTTP communication with the Apple Music API."""
 
-    # period=0.25 -> 4 req/s. Apple throttles per developer account, so these 429s come
-    # from the fleet-wide load on the bundled token rather than from this rate: measured
-    # against the catalog search endpoint, every 429 cleared on a retry, 97% of them
-    # after 0.5s and all within 3.5s. So retry quickly (and let the backoff escalate)
-    # instead of stalling playback for 15s.
+    # period=0.25 -> 4 req/s. Apple throttles per developer account, so 429s follow the
+    # fleet-wide load on the bundled token, not our rate - and they clear within a second.
     throttler = ThrottlerManager(rate_limit=1, period=0.25, initial_backoff=1)
 
     def __init__(self, provider: AppleMusicProvider) -> None:

--- a/music_assistant/providers/apple_music/api_client.py
+++ b/music_assistant/providers/apple_music/api_client.py
@@ -75,7 +75,9 @@ class AppleMusicAPIClient:
 
     # period=0.25 -> 4 req/s. Apple throttles per developer account, so 429s follow the
     # fleet-wide load on the bundled token, not our rate - and they clear within a second.
-    throttler = ThrottlerManager(rate_limit=1, period=0.25, initial_backoff=1)
+    # 8 attempts keep the 1/2/4/8/16/32/64s ladder spanning ~2 minutes, so a sustained
+    # throttle (or outage) is still ridden out instead of failing the request in ~15s.
+    throttler = ThrottlerManager(rate_limit=1, period=0.25, retry_attempts=8, initial_backoff=1)
 
     def __init__(self, provider: AppleMusicProvider) -> None:
         """Initialize the API client."""

--- a/music_assistant/providers/apple_music/api_client.py
+++ b/music_assistant/providers/apple_music/api_client.py
@@ -73,10 +73,11 @@ def _raise_on_auth_error(status: int, endpoint: str) -> None:
 class AppleMusicAPIClient:
     """Handles all HTTP communication with the Apple Music API."""
 
-    # period=0.25 -> 4 req/s. Apple's 429s are momentary edge throttling that is not
-    # governed by this rate: measured against the catalog search endpoint, every 429
-    # cleared on a retry, 97% of them after 0.5s and all of them within 3.5s. So retry
-    # quickly (and let the backoff escalate) instead of stalling playback for 15s.
+    # period=0.25 -> 4 req/s. Apple throttles per developer account, so these 429s come
+    # from the fleet-wide load on the bundled token rather than from this rate: measured
+    # against the catalog search endpoint, every 429 cleared on a retry, 97% of them
+    # after 0.5s and all within 3.5s. So retry quickly (and let the backoff escalate)
+    # instead of stalling playback for 15s.
     throttler = ThrottlerManager(rate_limit=1, period=0.25, initial_backoff=1)
 
     def __init__(self, provider: AppleMusicProvider) -> None:

--- a/music_assistant/providers/apple_music/api_client.py
+++ b/music_assistant/providers/apple_music/api_client.py
@@ -73,8 +73,11 @@ def _raise_on_auth_error(status: int, endpoint: str) -> None:
 class AppleMusicAPIClient:
     """Handles all HTTP communication with the Apple Music API."""
 
-    # period=0.25 -> 4 req/s. Raise it if Apple starts returning 429s.
-    throttler = ThrottlerManager(rate_limit=1, period=0.25, initial_backoff=15)
+    # period=0.25 -> 4 req/s. Apple's 429s are momentary edge throttling that is not
+    # governed by this rate: measured against the catalog search endpoint, every 429
+    # cleared on a retry, 97% of them after 0.5s and all of them within 3.5s. So retry
+    # quickly (and let the backoff escalate) instead of stalling playback for 15s.
+    throttler = ThrottlerManager(rate_limit=1, period=0.25, initial_backoff=1)
 
     def __init__(self, provider: AppleMusicProvider) -> None:
         """Initialize the API client."""

--- a/music_assistant/providers/apple_music/setup_flow.py
+++ b/music_assistant/providers/apple_music/setup_flow.py
@@ -49,7 +49,9 @@ async def run_setup(session: SetupSession) -> None:
     # prefer the bundled developer token; only prompt for (and store) a manual one when
     # the bundle ships an empty/expired token, e.g. on development builds
     app_token = MUSIC_APP_TOKEN
-    if not await _app_token_valid(mass, app_token):
+    # only prompt when Apple actually rejected the bundled token: /v1/test also answers
+    # 429 while the (shared) token is being throttled, which says nothing about validity
+    if await _app_token_accepted(mass, app_token) is False:
         app_token_errors: dict[str, str] | None = None
         while True:
             values = await session.form(
@@ -64,7 +66,8 @@ async def run_setup(session: SetupSession) -> None:
                 errors=app_token_errors,
             )
             app_token = str(values.get(CONF_MUSIC_APP_TOKEN) or "")
-            if await _app_token_valid(mass, app_token):
+            # a token the user just typed must be positively accepted before we store it
+            if await _app_token_accepted(mass, app_token):
                 break
             app_token_errors = {CONF_MUSIC_APP_TOKEN: "invalid_value"}
         collected[CONF_MUSIC_APP_TOKEN] = app_token
@@ -110,9 +113,12 @@ async def run_setup(session: SetupSession) -> None:
             errors = {"base": err.translation_key or str(err)}
 
 
-async def _app_token_valid(mass: MusicAssistant, app_token: str) -> bool:
+async def _app_token_accepted(mass: MusicAssistant, app_token: str) -> bool | None:
     """
-    Return whether the given Apple Music developer (app) token is accepted by the API.
+    Return whether the API accepted the given Apple Music developer (app) token.
+
+    True when Apple accepted it, False when Apple rejected it and None when the check was
+    inconclusive (throttled, server error or unreachable).
 
     :param mass: The MusicAssistant instance.
     :param app_token: The developer (app) token to validate.
@@ -126,11 +132,12 @@ async def _app_token_valid(mass: MusicAssistant, app_token: str) -> bool:
             ssl=True,
             timeout=ClientTimeout(total=10),
         ) as response:
-            return response.status == 200
+            if response.status == 200:
+                return True
+            return False if response.status in (401, 403) else None
     except ClientError, TimeoutError:
-        # a transient network error must not abort the flow; treat the token as
-        # invalid so the user lands on the manual app-token form and can retry
-        return False
+        # a transient network error tells us nothing about the token itself
+        return None
 
 
 def _validate_user_token(token: ConfigValueType) -> bool:

--- a/music_assistant/providers/apple_music/setup_flow.py
+++ b/music_assistant/providers/apple_music/setup_flow.py
@@ -49,8 +49,7 @@ async def run_setup(session: SetupSession) -> None:
     # prefer the bundled developer token; only prompt for (and store) a manual one when
     # the bundle ships an empty/expired token, e.g. on development builds
     app_token = MUSIC_APP_TOKEN
-    # only prompt when Apple actually rejected the bundled token: /v1/test also answers
-    # 429 while the (shared) token is being throttled, which says nothing about validity
+    # a throttled /v1/test says nothing about validity, so only an explicit rejection counts
     if await _app_token_accepted(mass, app_token) is False:
         app_token_errors: dict[str, str] | None = None
         while True:
@@ -66,7 +65,7 @@ async def run_setup(session: SetupSession) -> None:
                 errors=app_token_errors,
             )
             app_token = str(values.get(CONF_MUSIC_APP_TOKEN) or "")
-            # a token the user just typed must be positively accepted before we store it
+            # a typed token must be positively accepted, not merely un-rejected
             if await _app_token_accepted(mass, app_token):
                 break
             app_token_errors = {CONF_MUSIC_APP_TOKEN: "invalid_value"}
@@ -117,8 +116,7 @@ async def _app_token_accepted(mass: MusicAssistant, app_token: str) -> bool | No
     """
     Return whether the API accepted the given Apple Music developer (app) token.
 
-    True when Apple accepted it, False when Apple rejected it and None when the check was
-    inconclusive (throttled, server error or unreachable).
+    True when accepted, False when rejected, None when inconclusive (throttled/unreachable).
 
     :param mass: The MusicAssistant instance.
     :param app_token: The developer (app) token to validate.
@@ -136,7 +134,6 @@ async def _app_token_accepted(mass: MusicAssistant, app_token: str) -> bool | No
                 return True
             return False if response.status in (401, 403) else None
     except ClientError, TimeoutError:
-        # a transient network error tells us nothing about the token itself
         return None
 
 

--- a/tests/providers/apple_music/test_api_client.py
+++ b/tests/providers/apple_music/test_api_client.py
@@ -326,3 +326,17 @@ async def test_get_data_429_retries_within_a_second() -> None:
     assert sleeps, "expected the 429 to be retried after a backoff"
     # jitter adds at most 10% on top of the initial backoff
     assert max(sleeps) <= 1.1
+
+
+@pytest.mark.asyncio
+async def test_get_data_sustained_429_is_ridden_out_for_minutes() -> None:
+    """Throttling that outlasts the first retries is waited out, not failed within seconds."""
+    client, provider = _make_client()
+    provider.mass.http_session.get = MagicMock(
+        return_value=_FakeRequestCtx(_make_response(status=429))
+    )
+    sleep_mock = AsyncMock()
+    with patch(_SLEEP_TARGET, new=sleep_mock), pytest.raises(RetriesExhausted):
+        await client.get_data("me/library/songs", limit=50, offset=0)
+    sleeps = [call.args[0] for call in sleep_mock.await_args_list]
+    assert sum(sleeps) > 100

--- a/tests/providers/apple_music/test_api_client.py
+++ b/tests/providers/apple_music/test_api_client.py
@@ -300,3 +300,29 @@ async def test_write_requests_auth_error_raises_login_failed(status: int) -> Non
             await client.post_data("me/library")
         with pytest.raises(LoginFailed):
             await client.delete_data("me/library/playlists/p.1")
+
+
+# ---------------------------------------------------------------------------
+# P5: a momentary 429 recovers quickly instead of stalling playback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_data_429_retries_within_a_second() -> None:
+    """A 429 is retried after ~1s, so a throttled boundary fetch does not stall playback."""
+    client, provider = _make_client()
+    payload = {"data": [{"id": "1"}]}
+    provider.mass.http_session.get = MagicMock(
+        side_effect=[
+            _FakeRequestCtx(_make_response(status=429)),
+            _FakeRequestCtx(_make_response(status=200, json_data=payload)),
+        ]
+    )
+    sleep_mock = AsyncMock()
+    with patch(_SLEEP_TARGET, new=sleep_mock):
+        result = await client.get_data("me/library/songs", limit=50, offset=0)
+    assert result == payload
+    sleeps = [call.args[0] for call in sleep_mock.await_args_list]
+    assert sleeps, "expected the 429 to be retried after a backoff"
+    # jitter adds at most 10% on top of the initial backoff
+    assert max(sleeps) <= 1.1

--- a/tests/providers/apple_music/test_setup_flow.py
+++ b/tests/providers/apple_music/test_setup_flow.py
@@ -1,0 +1,61 @@
+"""Unit tests for the Apple Music setup flow helpers."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import ClientError
+
+from music_assistant.providers.apple_music.setup_flow import _app_token_accepted
+
+
+class _FakeRequestCtx:
+    """Minimal async context manager mimicking aiohttp's request context."""
+
+    def __init__(self, status: int) -> None:
+        self._response = MagicMock(status=status)
+
+    async def __aenter__(self) -> MagicMock:
+        return self._response
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+
+def _make_mass(status: int) -> MagicMock:
+    mass = MagicMock()
+    mass.http_session.get = MagicMock(return_value=_FakeRequestCtx(status))
+    return mass
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (200, True),
+        (401, False),
+        (403, False),
+        # a throttled or broken /v1/test says nothing about the token itself
+        (429, None),
+        (500, None),
+        (503, None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_app_token_accepted_per_status(status: int, expected: bool | None) -> None:
+    """Only an explicit rejection by Apple marks the developer token as invalid."""
+    assert await _app_token_accepted(_make_mass(status), "app-token") is expected
+
+
+@pytest.mark.asyncio
+async def test_app_token_accepted_empty_token_is_rejected() -> None:
+    """An empty (e.g. not provisioned) token is rejected without calling the API."""
+    mass = _make_mass(200)
+    assert await _app_token_accepted(mass, "") is False
+    mass.http_session.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_app_token_accepted_network_error_is_inconclusive() -> None:
+    """An unreachable API does not make a valid token look invalid."""
+    mass = MagicMock()
+    mass.http_session.get = MagicMock(side_effect=ClientError("boom"))
+    assert await _app_token_accepted(mass, "app-token") is None


### PR DESCRIPTION
# What does this implement/fix?

Apple Music playback stalls for 15+ seconds whenever a request is throttled, even though
Apple's throttling clears almost immediately.

**Why we get throttled at all:** Apple rate-limits per *developer account*, and the
bundled developer token carries the request load of every Music Assistant installation.
Measured with both tokens interleaved on identical URLs from one host, alternating order,
360 pairs against `/v1/catalog/us/search`:

| arm | 429 rate |
| --- | --- |
| bundled token (fleet-wide load) | 67/360 (18.6%) |
| token from a different Apple Developer team, no load | 0/360 (0.0%) |

All 67 discordant pairs favoured the same arm across six consecutive windows
(exact McNemar p ≈ 2⁻⁶⁷). This PR does not address that account-level saturation — it
fixes how badly we react to it.

**Why it hurts so much today:** the 429s are momentary. Retrying each one at
0.5s/1s/2s/4s/8s, **all 70 observed 429s recovered — 68 after 0.5s, the rest within
3.5s** (median 0.5s, no `Retry-After` header is sent). The provider waited 15s before its
first retry, then 30/60/120s. On a queue boundary fetch that turns a sub-second hiccup
into an audible gap, a skipped track, or a repeated track.

Our own pacing is not the driver: in 10-minute-idled trials of 120 requests each, 1 req/s
gave 54% 429s while 2 req/s gave 2%, with no monotonic relationship — so the rate limit is
left at 4 req/s. Cached endpoints such as `/catalog/{sf}/songs/{id}` were clean at that
rate throughout (0/80).

The same `/v1/test` endpoint also answers 429 while the bundled token is being throttled,
which the setup flow read as "this token is invalid" and used to ask the user for a manual
developer token they do not have.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5955

## Changes

- Apple Music API client: initial retry backoff 15s → 1s (still escalating 1/2/4/8/16s
  over the existing 5 attempts, so a genuine outage backs off as before).
- Setup flow: only treat an explicit 401/403 as a rejected developer token; a throttled,
  failing or unreachable `/v1/test` is inconclusive and no longer prompts for a manual
  token.
- Regression tests for both.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
