### PR TITLE
Publish the address the streamserver is actually bound to

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -200,6 +200,7 @@ class StreamsController(CoreController):
         self.manifest.icon = "cast-audio"
         self.announcement_renderer = AnnouncementRenderer()
         self._bind_ip: str = "0.0.0.0"
+        self._base_url: str = ""
         self._configured_publish_ip: str | None = None
         # every address players may reach this host on, best candidate first - for mDNS
         # records, which can carry them all, unlike the single-valued publish_ip
@@ -237,7 +238,7 @@ class StreamsController(CoreController):
     @property
     def base_url(self) -> str:
         """Return the base_url for the streamserver."""
-        return self._server.base_url
+        return self._base_url
 
     @property
     def bind_ip(self) -> str:
@@ -449,14 +450,13 @@ class StreamsController(CoreController):
         self._configured_publish_ip = (
             None if configured_publish_ip == CONF_VALUE_AUTO else configured_publish_ip
         )
-        # resolve the "auto" default (or an unset value) to this server's primary IP
         all_ip_addresses = await get_ip_addresses(include_ipv6=True)
-        self.publish_ip = self._configured_publish_ip or all_ip_addresses[0]
         bind_ip = str(config.get_value(CONF_BIND_IP))
+        self._resolve_publish_state(bind_ip, all_ip_addresses)
         await self._server.setup(
             bind_ip=bind_ip,
             bind_port=cast("int", self.publish_port),
-            base_url=f"http://{format_ip_for_url(str(self.publish_ip))}:{self.publish_port}",
+            base_url=self._base_url,
             static_routes=[
                 (
                     "*",
@@ -475,10 +475,7 @@ class StreamsController(CoreController):
         # adopt what the server actually bound to: a configured port of 0 is only resolved
         # by the OS at bind time and an unavailable bind IP falls back to all interfaces
         self.publish_port = cast("int", self._server.port)
-        self._bind_ip = self._server.bind_ip or DEFAULT_HOST
-        self.publish_addresses = _get_publish_addresses(
-            self._bind_ip, self._configured_publish_ip, all_ip_addresses
-        )
+        self._resolve_publish_state(self._server.bind_ip or DEFAULT_HOST, all_ip_addresses)
         # print a big fat message in the log where the streamserver is running
         # because this is a common source of issues for people with more complex setups
         self.logger.log(
@@ -555,7 +552,9 @@ class StreamsController(CoreController):
             and media.media_type not in (MediaType.RADIO, MediaType.AUDIO_SOURCE)
         )
         base_path = "flow" if flow_mode else "single"
-        return f"{self._server.base_url}/{base_path}/{session_id}/{queue_id}/{queue_item_id}/{player_id}.{fmt}"
+        return (
+            f"{self.base_url}/{base_path}/{session_id}/{queue_id}/{queue_item_id}/{player_id}.{fmt}"
+        )
 
     def update_stream_metadata(
         self,
@@ -1694,6 +1693,28 @@ class StreamsController(CoreController):
             self.audio.smart_fades_mixer.logger.setLevel(self.logger.level)
         else:
             self.audio.smart_fades_mixer.logger.setLevel(log_level)
+
+    def _resolve_publish_state(self, bind_ip: str, all_ip_addresses: tuple[str, ...]) -> None:
+        """
+        Resolve the addresses and base URL to advertise for the given bind address.
+
+        Reads ``self.publish_port``, so set that first.
+
+        :param bind_ip: Address the streamserver binds to (a wildcard means all interfaces).
+        :param all_ip_addresses: All detected host IP addresses, in ranked order.
+        """
+        self._bind_ip = bind_ip
+        if self._configured_publish_ip:
+            self.publish_ip = self._configured_publish_ip
+        elif bind_ip and bind_ip not in WILDCARD_BIND_IPS:
+            # only this interface serves the stream, so no other address can reach it
+            self.publish_ip = bind_ip
+        else:
+            self.publish_ip = all_ip_addresses[0]
+        self.publish_addresses = _get_publish_addresses(
+            bind_ip, self._configured_publish_ip, all_ip_addresses
+        )
+        self._base_url = f"http://{format_ip_for_url(self.publish_ip)}:{self.publish_port}"
 
 
 def _same_ip_family(ip: str, other_ip: str) -> bool:

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1704,16 +1704,11 @@ class StreamsController(CoreController):
         :param all_ip_addresses: All detected host IP addresses, in ranked order.
         """
         self._bind_ip = bind_ip
-        if self._configured_publish_ip:
-            self.publish_ip = self._configured_publish_ip
-        elif bind_ip and bind_ip not in WILDCARD_BIND_IPS:
-            # only this interface serves the stream, so no other address can reach it
-            self.publish_ip = bind_ip
-        else:
-            self.publish_ip = all_ip_addresses[0]
         self.publish_addresses = _get_publish_addresses(
             bind_ip, self._configured_publish_ip, all_ip_addresses
         )
+        # players that can only be handed one address get the highest ranked one
+        self.publish_ip = self.publish_addresses[0]
         self._base_url = f"http://{format_ip_for_url(self.publish_ip)}:{self.publish_port}"
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -106,8 +106,7 @@ def use_ephemeral_server_ports() -> Iterator[None]:
         patch("music_assistant.controllers.streams.controller.DEFAULT_PORT", 0),
         patch("music_assistant.controllers.webserver.controller.DEFAULT_HOST", LOOPBACK_IP),
         patch("music_assistant.controllers.streams.controller.DEFAULT_HOST", LOOPBACK_IP),
-        # the streamserver advertises its publish IP independently of the bind IP, so
-        # pin that too to keep the URLs it hands out pointing at the socket it listens on
+        # keep address detection off the host's real interfaces
         patch(
             "music_assistant.controllers.streams.controller.get_ip_addresses",
             AsyncMock(return_value=(LOOPBACK_IP,)),

--- a/tests/controllers/streams/test_publish_ip.py
+++ b/tests/controllers/streams/test_publish_ip.py
@@ -51,6 +51,7 @@ async def _setup_streams(
     bind_ip: str,
     publish_ip: str = CONF_VALUE_AUTO,
     all_ip_addresses: tuple[str, ...] = ALL_ADDRESSES,
+    bind_port: int | None = None,
 ) -> None:
     """
     Run the streamserver's setup against the given bind and publish configuration.
@@ -60,10 +61,15 @@ async def _setup_streams(
     :param bind_ip: Address to configure as bind IP.
     :param publish_ip: Address to configure as publish IP ("auto" to have it resolved).
     :param all_ip_addresses: Host addresses the setup detects, in ranked order.
+    :param bind_port: Port to configure as bind port (0 to have the OS assign one).
     """
     config = await mass.config.get_core_config(controller.domain)
     config.update(
-        {CONF_BIND_IP: bind_ip, CONF_PUBLISH_IP: publish_ip, CONF_BIND_PORT: unused_port()}
+        {
+            CONF_BIND_IP: bind_ip,
+            CONF_PUBLISH_IP: publish_ip,
+            CONF_BIND_PORT: unused_port() if bind_port is None else bind_port,
+        }
     )
     with (
         patch(
@@ -118,6 +124,16 @@ async def test_unavailable_bind_ip_publishes_dialable_address(
 
     assert controller.publish_ip == ALL_ADDRESSES[0]
     assert controller.base_url == f"http://{ALL_ADDRESSES[0]}:{controller.publish_port}"
+
+
+async def test_os_assigned_port_lands_in_base_url(
+    controller: StreamsController, mass_minimal: MusicAssistant
+) -> None:
+    """A port the OS only assigns at bind time ends up in the URLs handed to players."""
+    await _setup_streams(controller, mass_minimal, bind_ip=LOOPBACK_IP, bind_port=0)
+
+    assert controller.publish_port != 0
+    assert controller.base_url == f"http://{LOOPBACK_IP}:{controller.publish_port}"
 
 
 async def test_ipv6_publish_ip_is_bracketed_in_base_url(

--- a/tests/controllers/streams/test_publish_ip.py
+++ b/tests/controllers/streams/test_publish_ip.py
@@ -1,0 +1,130 @@
+"""Tests for the streamserver publish IP resolution."""
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aiohttp.test_utils import unused_port
+
+from music_assistant.constants import (
+    CONF_BIND_IP,
+    CONF_BIND_PORT,
+    CONF_PUBLISH_IP,
+    CONF_VALUE_AUTO,
+)
+from music_assistant.controllers.streams.controller import StreamsController
+from music_assistant.controllers.tasks import TasksController
+from music_assistant.mass import MusicAssistant
+
+# TEST-NET-3 (RFC 5737) is never assigned to a host, so binding it always fails
+UNBINDABLE_IP = "203.0.113.7"
+# a publish IP does not have to exist on this host at all (NAT/port forward setups)
+EXTERNAL_PUBLISH_IP = "203.0.113.9"
+LOOPBACK_IP = "127.0.0.1"
+# the address the tests bind is deliberately absent here, so a publish IP that follows
+# the bind address can never be mistaken for the one auto-detection would have picked
+ALL_ADDRESSES = ("192.168.1.10", "10.0.0.5", "fd00::10")
+
+
+@pytest.fixture
+async def controller(mass_minimal: MusicAssistant) -> AsyncGenerator[StreamsController]:
+    """
+    Yield a StreamsController attached to a minimal server, closed afterwards.
+
+    :param mass_minimal: Minimal MusicAssistant instance.
+    """
+    mass_minimal.tasks = TasksController(mass_minimal)
+    await mass_minimal.tasks.setup(await mass_minimal.config.get_core_config("tasks"))
+    streams = StreamsController(mass_minimal)
+    mass_minimal.streams = streams
+    try:
+        yield streams
+    finally:
+        # close unconditionally: a failed assertion must not leave the socket bound
+        await streams.close()
+        await mass_minimal.tasks.close()
+
+
+async def _setup_streams(
+    controller: StreamsController,
+    mass: MusicAssistant,
+    bind_ip: str,
+    publish_ip: str = CONF_VALUE_AUTO,
+    all_ip_addresses: tuple[str, ...] = ALL_ADDRESSES,
+) -> None:
+    """
+    Run the streamserver's setup against the given bind and publish configuration.
+
+    :param controller: The StreamsController to set up.
+    :param mass: The MusicAssistant instance owning the controller.
+    :param bind_ip: Address to configure as bind IP.
+    :param publish_ip: Address to configure as publish IP ("auto" to have it resolved).
+    :param all_ip_addresses: Host addresses the setup detects, in ranked order.
+    """
+    config = await mass.config.get_core_config(controller.domain)
+    config.update(
+        {CONF_BIND_IP: bind_ip, CONF_PUBLISH_IP: publish_ip, CONF_BIND_PORT: unused_port()}
+    )
+    with (
+        patch(
+            "music_assistant.controllers.streams.controller.get_ip_addresses",
+            AsyncMock(return_value=all_ip_addresses),
+        ),
+        patch(
+            "music_assistant.controllers.streams.controller.check_ffmpeg_version",
+            AsyncMock(),
+        ),
+    ):
+        await controller.setup(config)
+
+
+async def test_specific_bind_ip_is_published(
+    controller: StreamsController, mass_minimal: MusicAssistant
+) -> None:
+    """A streamserver pinned to one interface hands players that same address."""
+    await _setup_streams(controller, mass_minimal, bind_ip=LOOPBACK_IP)
+
+    assert controller.publish_ip == LOOPBACK_IP
+    assert controller.base_url == f"http://{LOOPBACK_IP}:{controller.publish_port}"
+
+
+async def test_wildcard_bind_publishes_primary_address(
+    controller: StreamsController, mass_minimal: MusicAssistant
+) -> None:
+    """A streamserver on all interfaces advertises the primary detected address."""
+    await _setup_streams(controller, mass_minimal, bind_ip="0.0.0.0")
+
+    assert controller.publish_ip == ALL_ADDRESSES[0]
+    assert controller.base_url == f"http://{ALL_ADDRESSES[0]}:{controller.publish_port}"
+
+
+async def test_configured_publish_ip_outranks_bind_ip(
+    controller: StreamsController, mass_minimal: MusicAssistant
+) -> None:
+    """An explicitly configured publish IP stays authoritative over the bind address."""
+    await _setup_streams(
+        controller, mass_minimal, bind_ip=LOOPBACK_IP, publish_ip=EXTERNAL_PUBLISH_IP
+    )
+
+    assert controller.publish_ip == EXTERNAL_PUBLISH_IP
+    assert controller.base_url == f"http://{EXTERNAL_PUBLISH_IP}:{controller.publish_port}"
+
+
+async def test_unavailable_bind_ip_publishes_dialable_address(
+    controller: StreamsController, mass_minimal: MusicAssistant
+) -> None:
+    """A bind that fell back to all interfaces advertises a reachable address, not the failed one."""
+    await _setup_streams(controller, mass_minimal, bind_ip=UNBINDABLE_IP)
+
+    assert controller.publish_ip == ALL_ADDRESSES[0]
+    assert controller.base_url == f"http://{ALL_ADDRESSES[0]}:{controller.publish_port}"
+
+
+async def test_ipv6_publish_ip_is_bracketed_in_base_url(
+    controller: StreamsController, mass_minimal: MusicAssistant
+) -> None:
+    """An IPv6 publish IP is bracketed in the stream URLs handed to players."""
+    await _setup_streams(controller, mass_minimal, bind_ip="::", all_ip_addresses=("fd00::10",))
+
+    assert controller.publish_ip == "fd00::10"
+    assert controller.base_url == f"http://[fd00::10]:{controller.publish_port}"


### PR DESCRIPTION
# What does this implement/fix?

When the streamserver is pinned to a specific network interface (Settings → System → Streams → bind IP) and the publish IP is left on `auto`, the address handed to players was picked independently of that bind IP: it always resolved to the host's primary address. On a machine with more than one network (a VPN, a docker bridge, a second NIC) that is regularly a different address than the one the streamserver actually listens on, so players got stream URLs pointing at an address where nothing is listening.

The addresses advertised over mDNS already followed the bind IP, so the two could disagree with each other. The webserver already resolves its publish address this way; the streamserver now does the same.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- The streamserver's publish IP now follows the interface it is bound to, falling back to the primary detected address on a wildcard bind. An explicitly configured publish IP still wins over everything.
- The publish IP is now taken from the addresses already being advertised, so the single address handed to players can no longer disagree with them — including when an unavailable bind IP falls back to all interfaces.
- Tests covering a specific bind, a wildcard bind, a configured publish IP, a failed bind, an OS-assigned port and an IPv6 address.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
