### PR TITLE
Keep the Character index intact when the server stops during a refresh

### DIFF
--- a/music_assistant/providers/sonic_similarity/clap_index.py
+++ b/music_assistant/providers/sonic_similarity/clap_index.py
@@ -171,7 +171,8 @@ class ClapIndex:
         :param embedding: 1024-dim query embedding (from CLAP text encoder).
         :param k: Max number of neighbors to return.
         """
-        if self._index is None or len(self._index) == 0:
+        # pinned in a local: teardown runs on a worker thread and can land between reads
+        if (index := self._index) is None or len(index) == 0:
             return []
         vec = np.asarray(embedding, dtype=np.float32).reshape(-1)
         matches = await asyncio.to_thread(self._search_sync, vec, k)

--- a/music_assistant/providers/sonic_similarity/clap_index.py
+++ b/music_assistant/providers/sonic_similarity/clap_index.py
@@ -157,7 +157,9 @@ class ClapIndex:
         """
         if self._index is None:
             return None
-        for label, (prov, iid) in self._reverse.items():
+        # snapshot: a rebuild inserts into the map from its worker thread, which
+        # would otherwise break this scan mid-iteration
+        for label, (prov, iid) in list(self._reverse.items()):
             if iid != item_id:
                 continue
             arr = self._embedding_for_label(label)

--- a/music_assistant/providers/sonic_similarity/clap_index.py
+++ b/music_assistant/providers/sonic_similarity/clap_index.py
@@ -123,9 +123,8 @@ class ClapIndex:
             return
 
         vec = np.asarray(embedding, dtype=np.float32)
-        if not await asyncio.to_thread(self._add_sync, label, vec):
+        if not await asyncio.to_thread(self._add_sync, label, vec, provider, item_id):
             return
-        self._reverse[label] = (provider, item_id)
         self._dirty_adds += 1
         await self._maybe_flush()
 
@@ -256,14 +255,17 @@ class ClapIndex:
                     self._reverse = {}
                     self._keys_path.unlink(missing_ok=True)
 
-    def _add_sync(self, label: int, vec: np.ndarray) -> bool:
-        """Insert the vector, or return False if the index was released meanwhile."""
+    def _add_sync(self, label: int, vec: np.ndarray, provider: str, item_id: str) -> bool:
+        """Insert the vector with its reverse entry, or return False if the index was released."""
+        # both halves under one lock: a reverse entry without its vector makes
+        # contains() lie and blocks a later rebuild from re-adding the embedding
         with self._lock:
             if self._index is None:
                 return False
             if label in self._index:
                 self._index.remove(label)
             self._index.add(label, vec)
+            self._reverse[label] = (provider, item_id)
             return True
 
     def _embedding_for_label(self, label: int) -> np.ndarray | None:

--- a/music_assistant/providers/sonic_similarity/clap_index.py
+++ b/music_assistant/providers/sonic_similarity/clap_index.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -79,7 +80,10 @@ class ClapIndex:
         self._reverse: dict[int, tuple[str, str]] = {}
         self._dirty_adds: int = 0
         self._last_save: float = time.monotonic()
-        self._save_lock = asyncio.Lock()
+        # Serialises every worker-thread touch of _index/_reverse, teardown included.
+        # Deliberately a threading.Lock: an asyncio.Lock is released the moment the
+        # awaiting task is cancelled, which leaves the worker running unprotected.
+        self._lock = threading.Lock()
 
     async def load(self) -> None:
         """Create a fresh index or restore from disk."""
@@ -87,9 +91,7 @@ class ClapIndex:
 
     async def close(self) -> None:
         """Flush to disk and release the index."""
-        await self.save()
-        self._index = None
-        self._reverse.clear()
+        await asyncio.to_thread(self._close_sync)
 
     def contains(self, provider: str, item_id: str) -> bool:
         """Check if a track is present in the index (cheap, in-memory)."""
@@ -121,7 +123,8 @@ class ClapIndex:
             return
 
         vec = np.asarray(embedding, dtype=np.float32)
-        await asyncio.to_thread(self._add_sync, label, vec)
+        if not await asyncio.to_thread(self._add_sync, label, vec):
+            return
         self._reverse[label] = (provider, item_id)
         self._dirty_adds += 1
         await self._maybe_flush()
@@ -186,10 +189,9 @@ class ClapIndex:
 
     async def save(self) -> None:
         """Force an unconditional flush."""
-        async with self._save_lock:
-            await asyncio.to_thread(self._save_sync)
-            self._dirty_adds = 0
-            self._last_save = time.monotonic()
+        await asyncio.to_thread(self._save_sync)
+        self._dirty_adds = 0
+        self._last_save = time.monotonic()
 
     def __len__(self) -> int:
         """Return the number of tracks currently in the index."""
@@ -210,53 +212,59 @@ class ClapIndex:
             ScalarKind,
         )
 
-        self._index = Index(
-            ndim=CLAP_EMBEDDING_DIM,
-            metric=MetricKind.Cos,
-            dtype=ScalarKind.F16,
-        )
-        self._reverse = {}
+        with self._lock:
+            self._index = Index(
+                ndim=CLAP_EMBEDDING_DIM,
+                metric=MetricKind.Cos,
+                dtype=ScalarKind.F16,
+            )
+            self._reverse = {}
 
-        # Index + keys are paired: a populated reverse map without a backing
-        # index makes contains() lie and permanently blocks rebuilds from
-        # re-adding embeddings. Drop the keys file whenever the index is
-        # missing or unreadable so the next rebuild starts consistent.
-        index_loaded = False
-        if self._index_path.exists():
-            try:
-                self._index.load(str(self._index_path))
-                index_loaded = True
-                self._logger.debug(
-                    "Loaded CLAP index from %s (%d vectors)",
-                    self._index_path,
-                    len(self._index),
-                )
-            except Exception:
-                self._logger.exception("Failed to load CLAP index file, starting fresh")
-                self._index_path.unlink(missing_ok=True)
-                self._index = Index(
-                    ndim=CLAP_EMBEDDING_DIM,
-                    metric=MetricKind.Cos,
-                    dtype=ScalarKind.F16,
-                )
+            # Index + keys are paired: a populated reverse map without a backing
+            # index makes contains() lie and permanently blocks rebuilds from
+            # re-adding embeddings. Drop the keys file whenever the index is
+            # missing or unreadable so the next rebuild starts consistent.
+            index_loaded = False
+            if self._index_path.exists():
+                try:
+                    self._index.load(str(self._index_path))
+                    index_loaded = True
+                    self._logger.debug(
+                        "Loaded CLAP index from %s (%d vectors)",
+                        self._index_path,
+                        len(self._index),
+                    )
+                except Exception:
+                    self._logger.exception("Failed to load CLAP index file, starting fresh")
+                    self._index_path.unlink(missing_ok=True)
+                    self._index = Index(
+                        ndim=CLAP_EMBEDDING_DIM,
+                        metric=MetricKind.Cos,
+                        dtype=ScalarKind.F16,
+                    )
 
-        if not index_loaded:
-            self._keys_path.unlink(missing_ok=True)
-            return
-
-        if self._keys_path.exists():
-            try:
-                raw = json.loads(self._keys_path.read_text(encoding="utf-8"))
-                self._reverse = {int(k): (v[0], v[1]) for k, v in raw.items()}
-            except Exception:
-                self._logger.exception("Failed to load CLAP keys file, starting fresh")
-                self._reverse = {}
+            if not index_loaded:
                 self._keys_path.unlink(missing_ok=True)
+                return
 
-    def _add_sync(self, label: int, vec: np.ndarray) -> None:
-        if label in self._index:
-            self._index.remove(label)
-        self._index.add(label, vec)
+            if self._keys_path.exists():
+                try:
+                    raw = json.loads(self._keys_path.read_text(encoding="utf-8"))
+                    self._reverse = {int(k): (v[0], v[1]) for k, v in raw.items()}
+                except Exception:
+                    self._logger.exception("Failed to load CLAP keys file, starting fresh")
+                    self._reverse = {}
+                    self._keys_path.unlink(missing_ok=True)
+
+    def _add_sync(self, label: int, vec: np.ndarray) -> bool:
+        """Insert the vector, or return False if the index was released meanwhile."""
+        with self._lock:
+            if self._index is None:
+                return False
+            if label in self._index:
+                self._index.remove(label)
+            self._index.add(label, vec)
+            return True
 
     def _embedding_for_label(self, label: int) -> np.ndarray | None:
         """Fetch and validate the stored 1024-dim vector for a label, or None."""
@@ -272,10 +280,28 @@ class ClapIndex:
         return arr
 
     def _search_sync(self, vec: np.ndarray, k: int) -> list[tuple[int, float]]:
-        res = self._index.search(vec, k)
-        return list(zip(res.keys, res.distances, strict=False))
+        with self._lock:
+            if self._index is None:
+                return []
+            res = self._index.search(vec, k)
+            return list(zip(res.keys, res.distances, strict=False))
 
     def _save_sync(self) -> None:
+        with self._lock:
+            self._save_locked()
+
+    def _close_sync(self) -> None:
+        # Releasing under the same lock keeps a still-running save (its awaiting
+        # task cancelled on shutdown) from writing out state torn down beneath it.
+        with self._lock:
+            self._save_locked()
+            self._index = None
+            # rebind rather than clear(): a reader iterating the map on the event
+            # loop keeps the old one alive instead of failing mid-iteration
+            self._reverse = {}
+
+    def _save_locked(self) -> None:
+        """Write index and keys to disk. Caller must hold self._lock."""
         if self._index is None:
             return
         # Keys first (atomic rename): a crash leaves phantom labels (silently

--- a/tests/providers/sonic_similarity/test_clap_index.py
+++ b/tests/providers/sonic_similarity/test_clap_index.py
@@ -8,7 +8,11 @@ the configured storage_path.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import threading
+import time
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -147,6 +151,48 @@ async def test_save_writes_keys_before_index_so_a_crash_doesnt_orphan_labels(
     assert keys_path.exists()
     assert "track1" in keys_path.read_text(encoding="utf-8")
     assert not (tmp_path / "sonic_similarity_clap_keys.json.tmp").exists()
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_a_save_whose_task_was_cancelled(
+    tmp_path: Path,
+    logger: logging.Logger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Server shutdown cancels the save task; its worker keeps writing and must finish alone."""
+    idx = ClapIndex(_make_mass(tmp_path), logger)  # type: ignore[arg-type]
+    await idx.load()
+    await idx.add("spotify", "track1", _unit_vec(1))
+
+    real_save = idx._index.save
+    in_save = threading.Event()
+    active = 0
+    max_active = 0
+
+    def _slow_save(path: str) -> None:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        in_save.set()
+        time.sleep(0.2)
+        real_save(path)
+        active -= 1
+
+    monkeypatch.setattr(idx._index, "save", _slow_save)
+
+    save_task = asyncio.create_task(idx.save())
+    await asyncio.to_thread(in_save.wait)
+    save_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await save_task
+
+    # the unload that follows task cancellation on shutdown
+    await idx.close()
+
+    assert max_active == 1
+    keys_path = tmp_path / "sonic_similarity_clap_keys.json"
+    assert "track1" in keys_path.read_text(encoding="utf-8")
+    assert idx._index is None
 
 
 @pytest.mark.asyncio

--- a/tests/providers/sonic_similarity/test_clap_index.py
+++ b/tests/providers/sonic_similarity/test_clap_index.py
@@ -207,6 +207,44 @@ async def test_close_waits_for_a_save_whose_task_was_cancelled(
 
 
 @pytest.mark.asyncio
+async def test_lookup_survives_inserts_from_the_rebuild_worker(
+    tmp_path: Path, logger: logging.Logger
+) -> None:
+    """A lookup on the event loop must not break while a rebuild inserts from its thread."""
+
+    class _StubIndex:
+        """Stand-in so the insert loop costs the map, not usearch."""
+
+        def __contains__(self, label: int) -> bool:
+            return False
+
+        def add(self, label: int, vec: np.ndarray) -> None:
+            """Accept the vector and discard it."""
+
+    idx = ClapIndex(_make_mass(tmp_path), logger)  # type: ignore[arg-type]
+    idx._index = _StubIndex()
+    idx._reverse = {label: ("spotify", f"track{label}") for label in range(40_000)}
+
+    stop = threading.Event()
+    vec = _unit_vec(1)
+
+    def _insert_until_stopped() -> None:
+        for label in range(10_000_000, 10_050_000):
+            if stop.is_set():
+                return
+            idx._add_sync(label, vec, "spotify", f"new{label}")
+
+    worker = threading.Thread(target=_insert_until_stopped, daemon=True)
+    worker.start()
+    try:
+        for _ in range(20):
+            assert idx.get_embedding_by_item_id("absent_track") is None
+    finally:
+        stop.set()
+        worker.join(timeout=5)
+
+
+@pytest.mark.asyncio
 async def test_add_landing_after_release_leaves_no_phantom_entry(
     tmp_path: Path, logger: logging.Logger
 ) -> None:

--- a/tests/providers/sonic_similarity/test_clap_index.py
+++ b/tests/providers/sonic_similarity/test_clap_index.py
@@ -196,6 +196,23 @@ async def test_close_waits_for_a_save_whose_task_was_cancelled(
 
 
 @pytest.mark.asyncio
+async def test_add_landing_after_release_leaves_no_phantom_entry(
+    tmp_path: Path, logger: logging.Logger
+) -> None:
+    """An insert that reaches the worker after teardown must not record a key without a vector."""
+    idx = ClapIndex(_make_mass(tmp_path), logger)  # type: ignore[arg-type]
+    await idx.load()
+    await idx.close()
+
+    # the worker an in-flight add() would have reached once the index was released
+    applied = idx._add_sync(derive_label("spotify", "late"), _unit_vec(1), "spotify", "late")
+
+    assert applied is False
+    assert len(idx) == 0
+    assert not idx.contains("spotify", "late")
+
+
+@pytest.mark.asyncio
 async def test_corrupt_index_with_valid_keys_drops_keys_to_avoid_phantom_contains(
     tmp_path: Path, logger: logging.Logger
 ) -> None:

--- a/tests/providers/sonic_similarity/test_clap_index.py
+++ b/tests/providers/sonic_similarity/test_clap_index.py
@@ -166,30 +166,41 @@ async def test_close_waits_for_a_save_whose_task_was_cancelled(
 
     real_save = idx._index.save
     in_save = threading.Event()
-    active = 0
-    max_active = 0
+    release = threading.Event()
+    writers_lock = threading.Lock()
+    writers = 0
 
     def _slow_save(path: str) -> None:
-        nonlocal active, max_active
-        active += 1
-        max_active = max(max_active, active)
+        nonlocal writers
+        with writers_lock:
+            writers += 1
         in_save.set()
-        time.sleep(0.2)
+        # parked here rather than sleeping, so the assertion below can never
+        # be decided by how fast the machine happens to be
+        assert release.wait(10), "close() never let the save finish"
         real_save(path)
-        active -= 1
 
     monkeypatch.setattr(idx._index, "save", _slow_save)
 
     save_task = asyncio.create_task(idx.save())
-    await asyncio.to_thread(in_save.wait)
+    assert await asyncio.to_thread(in_save.wait, 10)
     save_task.cancel()
     with suppress(asyncio.CancelledError):
         await save_task
 
     # the unload that follows task cancellation on shutdown
-    await idx.close()
+    close_task = asyncio.create_task(idx.close())
 
-    assert max_active == 1
+    # an unguarded close would start writing here; the lock keeps it queued
+    # behind the worker still parked above
+    deadline = time.monotonic() + 0.25
+    while time.monotonic() < deadline and writers < 2:
+        await asyncio.sleep(0.01)
+    assert writers == 1
+
+    release.set()
+    await close_task
+
     keys_path = tmp_path / "sonic_similarity_clap_keys.json"
     assert "track1" in keys_path.read_text(encoding="utf-8")
     assert idx._index is None


### PR DESCRIPTION
# What does this implement/fix?

The Character (CLAP) index writes itself to disk on a background thread, guarded by a lock that is dropped the moment the surrounding task is cancelled — while the thread carries on writing.

Server shutdown hits exactly that order: the hourly index refresh is cancelled first, and the provider unload that follows starts a second save and releases the index underneath the one still running. That leaves two writers on the same files, and in the worst case the key map is written out empty, which silently leaves Character similarity returning no results until the index is rebuilt.

Changes:

- Serialise the index saves in the worker threads themselves, so a save always runs alone
- Let shutdown wait for an in-flight save to finish before releasing the index, instead of overtaking it
- Skip the bookkeeping for an embedding that arrives after the index was released
- Added a regression test covering the cancelled-save-then-unload order

**Related issue (if applicable):**

- n/a — spotted while reviewing #5326

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
