### PR TITLE
Don't start an AirPlay session that is already outdated

### DIFF
--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -647,6 +647,11 @@ class SendspinAirPlayBridge:
             if cleanup and not cleanup.done():
                 await cleanup
 
+            if asyncio.current_task() is not self._airplay_stream_start_task:
+                # A newer stream start owns the bridge and everything it holds:
+                # neither the kept stream nor the receiver is this task's to touch.
+                return
+
             # A kept, still-connected stream (see _stream_is_warm_eligible,
             # checked by the stream-start callbacks) absorbs the new media via a
             # flush-refill on the SAME cli stdin instead of a cold reconnect.
@@ -693,6 +698,12 @@ class SendspinAirPlayBridge:
         :param stream: New AirPlay stream to start.
         :return: True when the stream is anchored, False when superseded.
         """
+        if asyncio.current_task() is not self._airplay_stream_start_task:
+            # A newer stream start owns the bridge. The stream handed in is not
+            # connected yet, so there is nothing to tear down: returning here
+            # keeps a second session off the receiver and leaves the timing
+            # decision the newer start recorded alone.
+            return False
         try:
             # Resolving and recording the decision never awaits, so two bridges
             # starting together cannot both find their group still undecided.
@@ -1124,8 +1135,12 @@ class SendspinAirPlayBridge:
             #     group's current playback position, so the joiner lands in sync.
             # _anchor_stream re-bases this onto the instant the binary acks.
             self._drop_until_us = chunk.timestamp_us
+            # Started on the next loop iteration so the handle below is published
+            # first: the start path compares itself against that handle to tell
+            # whether it still owns the bridge, and an eager start would run its
+            # first checks while the handle is still unset.
             self._airplay_stream_start_task = self.mass.create_task(
-                self._start_protocol_from_chunk()
+                self._start_protocol_from_chunk(), eager_start=False
             )
 
         if not self._anchor_settled:

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -291,6 +291,9 @@ class SendspinAirPlayBridge:
         self._start_unix_ms: int = 0
         self._write_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
         self._writer_task: asyncio.Task[None] | None = None
+        # The start that currently owns the bridge. Every step of the start path
+        # compares itself against this to tell whether it may still touch the
+        # bridge, so it is published before that task runs (see _on_audio_chunk).
         self._airplay_stream_start_task: asyncio.Task[None] | None = None
         self._airplay_stream_ready = asyncio.Event()
         # Whether the current stream has been anchored with its first START.

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -625,7 +625,6 @@ async def test_cold_start_superseded_while_connecting_stops_its_transport() -> N
 
     stream.start.assert_not_awaited()
     stream.stop.assert_awaited_once_with(force=True)
-    assert bridge._airplay_stream is None
 
 
 async def test_cold_start_superseded_during_the_anchor_stops_its_transport() -> None:

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -24,7 +24,7 @@ tests are deterministic and independent of the host wall-clock:
   a new Sendspin stream and rides the persistent-stdin flush-refill (FLUSH +
   re-anchoring START) instead of a cold reconnect -- with flush-timeout and
   superseded-task fallback, and the supersession handling that keeps a stale
-  start from tearing down the stream a newer one owns;
+  start from spawning a process or touching the stream a newer one owns;
 * the recovery from a transport lost mid-stream: the dead CLI is released and
   re-anchored on the group's live timeline. Every give-up then takes the speaker
   out of the Sendspin session, so the player stops reporting playback nobody can
@@ -521,10 +521,19 @@ async def test_cold_start_connects_then_anchors_first_start() -> None:
     assert bridge._airplay_stream_ready.is_set()
 
 
-async def test_cold_start_superseded_before_start_stops_transport() -> None:
-    """A cold bridge start that is superseded after connect stops its transport."""
+async def test_a_superseded_cold_start_never_reaches_the_receiver() -> None:
+    """
+    A cold start that already lost the race bails out before it spawns anything.
+
+    Connecting first would pay a full process spawn and session setup only to
+    kill it again, put a second session on a receiver the newer start is about
+    to claim, and overwrite the shared-clock decision of the process that start
+    is really running.
+    """
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    # the decision the newer start recorded for the process it is spawning
+    bridge._use_shared_ptp = True
     # a different task owns the bridge: this cold start is stale
     bridge._airplay_stream_start_task = MagicMock()
     stream = _make_anchor_stream()
@@ -541,8 +550,82 @@ async def test_cold_start_superseded_before_start_stops_transport() -> None:
     ):
         await bridge._start_protocol_from_chunk()
 
+    stream.connect.assert_not_awaited()
+    stream.stop.assert_not_awaited()
+    assert bridge._use_shared_ptp is True
+
+
+async def test_a_superseded_start_leaves_the_kept_stream_untouched() -> None:
+    """
+    A start that lost the race never flushes the stream the newer one kept.
+
+    Arming the bridge keeps a warm-eligible stream alive, so the stale and the
+    newer start find the same instance; flushing it here would cut into the
+    audio the newer start is anchoring on it.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    kept_stream = _make_anchor_stream()
+    bridge._airplay_stream = kept_stream
+    # a different task owns the bridge: this start is stale
+    bridge._airplay_stream_start_task = MagicMock()
+
+    await bridge._start_protocol_from_chunk()
+
+    kept_stream.flush.assert_not_awaited()
+    kept_stream.stop.assert_not_awaited()
+    assert bridge._airplay_stream is kept_stream
+
+
+async def test_a_start_superseded_during_the_warm_fallback_spawns_nothing() -> None:
+    """
+    Losing the race while releasing the kept stream still stops short of the receiver.
+
+    A failed warm handover tears the kept stream down before it falls back to a
+    cold start, and that teardown is long enough for a newer start to claim the
+    bridge in the meantime.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    kept_stream = _make_anchor_stream()
+    kept_stream.flush = AsyncMock(return_value=False)
+    bridge._airplay_stream = kept_stream
+    cold_stream = _make_anchor_stream()
+
+    async def stop(**_kwargs: object) -> None:
+        # a newer stream start claimed the bridge while the kept stream went down
+        bridge._airplay_stream_start_task = MagicMock()
+
+    kept_stream.stop = AsyncMock(side_effect=stop)
+
+    with patch(
+        "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+        return_value=cold_stream,
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    cold_stream.connect.assert_not_awaited()
+    cold_stream.stop.assert_not_awaited()
+
+
+async def test_cold_start_superseded_while_connecting_stops_its_transport() -> None:
+    """A cold stream superseded while its process comes up is torn down again."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    stream = _make_anchor_stream()
+
+    async def wait_for_connection() -> None:
+        # a newer stream start claimed the bridge while the process came up
+        bridge._airplay_stream_start_task = MagicMock()
+
+    stream.wait_for_connection = AsyncMock(side_effect=wait_for_connection)
+
+    assert await bridge._start_cold_stream(stream) is False
+
     stream.start.assert_not_awaited()
     stream.stop.assert_awaited_once_with(force=True)
+    assert bridge._airplay_stream is None
 
 
 async def test_cold_start_superseded_during_the_anchor_stops_its_transport() -> None:
@@ -2514,10 +2597,10 @@ async def test_the_real_chunk_path_records_the_decision_it_spawns_with() -> None
     """
     Driving the bridge the way Sendspin does still records what the CLI got.
 
-    The start task is created eagerly, so it runs to its first await before the
-    caller has published the task handle. Anything in the start path that reads
-    that handle before then sees None, and a decision gated on it would be lost
-    while the process it describes is already running.
+    The start path tells whether it still owns the bridge by comparing itself
+    against the task handle the chunk handler publishes, so the start task must
+    not run before that handle is set. Started eagerly it would read None on its
+    very first check and give up as if a newer start had claimed the bridge.
     """
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     _group_bridges(bridge, daemon_ready=True)
@@ -2525,18 +2608,19 @@ async def test_the_real_chunk_path_records_the_decision_it_spawns_with() -> None
     started: list[asyncio.Task[None]] = []
 
     async def connect(_use_shared_ptp: bool | None) -> None:
-        # a real connect does I/O, so the eagerly started task suspends here and
-        # its caller gets to publish the task handle
+        # a real connect does I/O, so the task suspends here
         await asyncio.sleep(0)
 
     stream.connect = AsyncMock(side_effect=connect)
 
     loop = asyncio.get_running_loop()
 
-    def create_task(coro: Coroutine[None, None, None], **_kwargs: object) -> asyncio.Task[None]:
-        # mirrors mass.create_task, whose eager start runs the coroutine to its
-        # first await before this returns
-        task = asyncio.Task(coro, loop=loop, eager_start=True)
+    def create_task(
+        coro: Coroutine[None, None, None], *, eager_start: bool = True, **_kwargs: object
+    ) -> asyncio.Task[None]:
+        # mirrors mass.create_task, whose default eager start would run the
+        # coroutine to its first await before this returns
+        task = asyncio.Task(coro, loop=loop, eager_start=eager_start)
         started.append(task)
         return task
 


### PR DESCRIPTION
# What does this implement/fix?

When a bridged AirPlay speaker gets a rapid skip, the stream start that lost the race kept going: it spawned a cliairplay process and set up a full session against the speaker (measured at 1.7-1.8s) before noticing it no longer owned the bridge, then killed it again. On the way there it also overwrote the record of which clock the *newer* start's process is running on, which can hand a wrong answer to another speaker joining the same group.

The ownership check could not be moved earlier before, because the task handle it compares against is only published after the start task has already begun running. Creating that task lazily publishes the handle first, so the check is valid from the very first line.

## Changes

- Create the bridge stream-start task lazily so its task handle is published before it runs.
- Bail out at the top of the start path when a newer stream start already owns the bridge: nothing is spawned, the kept stream is left alone and the newer start's clock decision stays intact.
- Bail out again at the top of the cold start, which is reached after releasing a kept stream that failed its warm handover.
- Tests for each bail-out point, plus the existing end-to-end chunk-path test now guards that the handle really is published first.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a)
