### PR TITLE
Run the test suite in parallel

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -69,6 +69,4 @@ jobs:
           # instruction counts are reproducible under simulation. Server-level / async
           # scenarios are non-deterministic under instruction counting and are covered by
           # the scripts/perf/ deep-dive suite instead.
-          # -o addopts="" clears the default "--cov music_assistant" so coverage
-          # instrumentation does not interfere with the CodSpeed measurements.
-          run: pytest tests/benchmarks/ --codspeed -o addopts=""
+          run: pytest tests/benchmarks/ --codspeed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,8 +168,8 @@ jobs:
       - name: Pytest
         # mode=partial runs only the changed providers' tests with coverage scoped to
         # those provider packages; mode=full runs everything with full coverage.
-        # --dist loadfile keeps each test file on one xdist worker so syrupy
-        # snapshot handling works correctly.
+        # --dist loadfile keeps each test file on one xdist worker: snapshot updates
+        # never race on an .ambr file and module-scoped fixtures are reused.
         env:
           MODE: ${{ needs.changes.outputs.mode }}
           TEST_PATHS: ${{ needs.changes.outputs.test_paths }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,8 @@ jobs:
       - name: Pytest
         # mode=partial runs only the changed providers' tests with coverage scoped to
         # those provider packages; mode=full runs everything with full coverage.
-        # `-o addopts=` clears the default "--cov music_assistant" so the scope applies.
+        # --dist loadfile keeps each test file on one xdist worker so syrupy
+        # snapshot handling works correctly.
         env:
           MODE: ${{ needs.changes.outputs.mode }}
           TEST_PATHS: ${{ needs.changes.outputs.test_paths }}
@@ -198,7 +199,7 @@ jobs:
           # it in the saved snapshot so it is never evicted.
           setpriv --reuid=tester --regid=tester --init-groups \
             env HOME=/home/tester \
-            pytest -p numpy -o addopts="" --durations 10 $cov --cov-report=term-missing --cov-report=xml $targets
+            pytest -p numpy -n auto --dist loadfile --durations 10 $cov --cov-report=term-missing --cov-report=xml $targets
       - name: Upload coverage to Codecov
         if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: codecov/codecov-action@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Music Assistant is an async Python music library manager that connects to stream
 ## Development Commands
 
 - `scripts/setup.sh` - Initial setup (venv, dependencies, pre-commit hooks). Re-run after pulling latest code.
-- `pytest` - Run all tests
+- `pytest` - Run all tests (add `-n auto --dist loadfile` to run in parallel)
 - `pytest tests/specific_test.py` - Run a specific test file
 - `pre-commit run --all-files` - Run all pre-commit hooks
 - `python -m music_assistant --log-level debug` - Run server locally (localhost:8095)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Music Assistant is an async Python music library manager that connects to stream
 
 - `scripts/setup.sh` - Initial setup (venv, dependencies, pre-commit hooks). Re-run after pulling latest code.
 - `pytest` - Run all tests (add `-n auto --dist loadfile` to run in parallel)
+- `pytest --cov music_assistant` - Run all tests with coverage
 - `pytest tests/specific_test.py` - Run a specific test file
 - `pre-commit run --all-files` - Run all pre-commit hooks
 - `python -m music_assistant --log-level debug` - Run server locally (localhost:8095)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ test = [
   "pytest-codspeed==5.0.3",
   "pytest-cov==7.0.0",
   "pytest-timeout==2.4.0",
+  "pytest-xdist==3.8.0",
   "syrupy==5.5.3",
   "tomli==2.4.1",
   "ruff==0.15.22",
@@ -183,7 +184,6 @@ module = ["plexapi", "plexapi.*"]
 line-ending = "lf"
 
 [tool.pytest.ini_options]
-addopts = "--cov music_assistant"
 asyncio_mode = "auto"
 timeout = 120
 filterwarnings = [

--- a/tests/common.py
+++ b/tests/common.py
@@ -20,6 +20,28 @@ if TYPE_CHECKING:
     from music_assistant_models.event import MassEvent
 
 
+def utf8_safe(value: object) -> object:
+    """
+    Return ``value`` with any non-UTF-8-encodable strings made encodable.
+
+    Lone surrogates (e.g. from undecodable filesystem paths) are replaced with
+    their backslash escapes so the value survives strict-UTF-8 serialization.
+    """
+    if isinstance(value, str):
+        try:
+            value.encode()
+        except UnicodeEncodeError:
+            return value.encode("utf-8", "backslashreplace").decode()
+        return value
+    if isinstance(value, list):
+        return [utf8_safe(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(utf8_safe(item) for item in value)
+    if isinstance(value, dict):
+        return {utf8_safe(key): utf8_safe(item) for key, item in value.items()}
+    return value
+
+
 def _get_fixture_folder(provider: str | None = None) -> pathlib.Path:
     tests_base = pathlib.Path(__file__).parent
     if provider:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,20 @@ from music_assistant.controllers.discovery import DiscoveryController
 from music_assistant.controllers.music import MusicController
 from music_assistant.controllers.tasks import TasksController
 from music_assistant.mass import MusicAssistant
-from tests.common import suppress_auto_loaded_providers, use_ephemeral_server_ports
+from tests.common import suppress_auto_loaded_providers, use_ephemeral_server_ports, utf8_safe
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_report_to_serializable() -> Generator[None, object, object]:
+    """
+    Make serialized test reports strict-UTF-8 safe for pytest-xdist.
+
+    Tests that exercise undecodable filesystem paths leak lone surrogates into
+    the captured report; execnet's channel serializer rejects those and kills
+    the whole worker.
+    """
+    data = yield
+    return utf8_safe(data)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,9 +26,9 @@ def pytest_report_to_serializable() -> Generator[None, object, object]:
     """
     Make serialized test reports strict-UTF-8 safe for pytest-xdist.
 
-    Tests that exercise undecodable filesystem paths leak lone surrogates into
-    the captured report; execnet's channel serializer rejects those and kills
-    the whole worker.
+    Lone surrogates in a captured report (e.g. undecodable filesystem paths) kill
+    the execnet worker channel. Covers test reports only; other xdist payloads
+    (warnings, log-start nodeids) are serialized outside this hook.
     """
     data = yield
     return utf8_safe(data)


### PR DESCRIPTION
# What does this implement/fix?

The CI test job ran the full suite serially on one core, so every full run took far longer than needed — locally the suite drops from ~117s to ~33s with parallel execution, and the CI job should see a similar cut in wall time and billed minutes.

- Add `pytest-xdist` and run CI tests with `-n auto --dist loadfile` (loadfile keeps each test file on one worker, so snapshot updates never race and module-scoped fixtures are reused)
- Remove the always-on `--cov music_assistant` from the default pytest addopts: bare `pytest` now runs without coverage (use `pytest --cov music_assistant` when needed); CI passes its coverage flags explicitly, so the `-o addopts=""` workarounds in the test and codspeed workflows are gone
- Make serialized test reports UTF-8 safe: a test that exercises undecodable (lone-surrogate) filesystem paths killed the xdist worker channel and aborted the whole run

Coverage output was verified identical between serial and parallel runs. Note: in parallel mode the run log shows a harmless controller-side `CoverageWarning: No data was collected`; the combined coverage report is complete.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.