### PR TITLE
Remove an unused internal URL from the webserver helper

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -456,7 +456,6 @@ class StreamsController(CoreController):
         await self._server.setup(
             bind_ip=bind_ip,
             bind_port=cast("int", self.publish_port),
-            base_url=self._base_url,
             static_routes=[
                 (
                     "*",

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -315,7 +315,6 @@ class WebserverController(CoreController):
         await self._server.setup(
             bind_ip=bind_ip,
             bind_port=self.publish_port,
-            base_url=self._auto_base_url,
             static_routes=routes,
             # add assets subdir as static_content
             static_content=("/assets", os.path.join(frontend_dir, "assets"), "assets"),

--- a/music_assistant/helpers/webserver.py
+++ b/music_assistant/helpers/webserver.py
@@ -6,7 +6,6 @@ from collections.abc import Callable, Coroutine, Mapping
 from typing import TYPE_CHECKING, Any, Final
 
 from aiohttp import web
-from yarl import URL
 
 from music_assistant.constants import WILDCARD_BIND_IPS
 
@@ -68,7 +67,6 @@ class Webserver:
         self,
         bind_ip: str | None,
         bind_port: int,
-        base_url: str,
         static_routes: list[tuple[str, str, Handler]] | None = None,
         static_content: tuple[str, str, str] | None = None,
         ingress_tcp_site_params: tuple[str, int] | None = None,
@@ -82,15 +80,13 @@ class Webserver:
             interfaces. The effective address is available as the ``bind_ip`` property.
         :param bind_port: Port to bind to, or 0 to let the OS assign a free one, which
             requires a specific ``bind_ip``. The assigned port is available as the
-            ``port`` property and replaces the port in ``base_url``.
-        :param base_url: Base URL for the server.
+            ``port`` property.
         :param static_routes: List of static routes to register.
         :param static_content: Tuple of (path, directory, name) for static content.
         :param ingress_tcp_site_params: Tuple of (host, port) for ingress TCP site.
         :param app_state: Optional dict of key-value pairs to set on app before starting.
         :param ssl_context: Optional SSL context for HTTPS support.
         """
-        self._base_url = base_url.removesuffix("/")
         self._bind_port = bind_port
         self._static_routes = static_routes
         self._webapp = web.Application(
@@ -149,7 +145,6 @@ class Webserver:
         # port 0 asks the OS for a free port, which it only picks at bind time
         if bind_port == 0:
             self._bind_port = self._apprunner.addresses[0][1]
-            self._base_url = str(URL(self._base_url).with_port(self._bind_port))
         # start additional ingress TCP site if configured
         # this is only used if we're running in the context of an HA add-on
         # which proxies our frontend and api through ingress
@@ -175,11 +170,6 @@ class Webserver:
         if self._webapp:
             await self._webapp.shutdown()
             await self._webapp.cleanup()
-
-    @property
-    def base_url(self) -> str:
-        """Return the base URL of this webserver."""
-        return self._base_url
 
     @property
     def port(self) -> int | None:

--- a/music_assistant/providers/siriusxm/__init__.py
+++ b/music_assistant/providers/siriusxm/__init__.py
@@ -133,7 +133,6 @@ class SiriusXMProvider(MusicProvider):
         await self._sxm_server.setup(
             bind_ip=bind_ip,
             bind_port=bind_port,
-            base_url=self._base_url,
             static_routes=[
                 ("*", "/{tail:.*}", http_handler),
             ],

--- a/tests/controllers/webserver/test_bind_fallback.py
+++ b/tests/controllers/webserver/test_bind_fallback.py
@@ -65,9 +65,7 @@ async def test_unavailable_bind_ip_falls_back_to_all_interfaces(server: Webserve
     """An address that cannot be bound starts the server on all interfaces instead."""
     port = unused_port()
 
-    await server.setup(
-        bind_ip=UNBINDABLE_IP, bind_port=port, base_url=f"http://{UNBINDABLE_IP}:{port}"
-    )
+    await server.setup(bind_ip=UNBINDABLE_IP, bind_port=port)
 
     assert server.bind_ip is None
     assert server.port == port
@@ -83,7 +81,7 @@ async def test_available_bind_ip_is_reported(server: Webserver) -> None:
     """A bind that succeeded reports the address it is pinned to."""
     port = unused_port()
 
-    await server.setup(bind_ip="127.0.0.1", bind_port=port, base_url=f"http://127.0.0.1:{port}")
+    await server.setup(bind_ip="127.0.0.1", bind_port=port)
 
     assert server.bind_ip == "127.0.0.1"
     assert server.port == port
@@ -93,7 +91,7 @@ async def test_wildcard_bind_ip_is_reported_as_all_interfaces(server: Webserver)
     """A configured wildcard is reported the same way as a fallback: no pinned address."""
     port = unused_port()
 
-    await server.setup(bind_ip="0.0.0.0", bind_port=port, base_url=f"http://0.0.0.0:{port}")
+    await server.setup(bind_ip="0.0.0.0", bind_port=port)
 
     assert server.bind_ip is None
 

--- a/tests/controllers/webserver/test_ssl_base_url.py
+++ b/tests/controllers/webserver/test_ssl_base_url.py
@@ -100,7 +100,6 @@ def _make_server_mock() -> MagicMock:
     server = MagicMock()
 
     async def _adopt_setup_args(**kwargs: Any) -> None:
-        server.base_url = kwargs["base_url"]
         server.port = kwargs["bind_port"]
         bind_ip = kwargs["bind_ip"]
         server.bind_ip = None if bind_ip in WILDCARD_BIND_IPS else bind_ip


### PR DESCRIPTION
# What does this implement/fix?

The internal `Webserver` helper kept its own copy of the base URL, but nothing reads it anymore: both the webserver and the streams controller now resolve and publish their own address. That left the helper rewriting and storing a URL that no caller ever asked for.

This removes that dead surface, so the helper only deals with binding and serving.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Dropped the `base_url` argument from `Webserver.setup()` and the `base_url` property.
- Dropped the port rewrite that patched the OS-assigned port into that URL.
- Updated the three callers (webserver controller, streams controller, SiriusXM) to no longer pass it.

The port the OS assigns for a `bind_port` of 0 is still reported through the `port` property, which is what the controllers actually use to build their address.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
