### PR TITLE
Make the discovery tests independent of the host platform

### DIFF
--- a/tests/controllers/discovery/test_discovery.py
+++ b/tests/controllers/discovery/test_discovery.py
@@ -118,6 +118,7 @@ async def test_discovery_controller_owns_async_zeroconf(mass_minimal: MusicAssis
         ),
         patch(
             "music_assistant.controllers.discovery.controller.get_zeroconf_args",
+            autospec=True,
             return_value=zc_args,
         ) as mock_get_zeroconf_args,
     ):

--- a/tests/controllers/discovery/test_discovery.py
+++ b/tests/controllers/discovery/test_discovery.py
@@ -103,16 +103,9 @@ async def test_discovery_controller_owns_async_zeroconf(mass_minimal: MusicAssis
     mock_zc.async_unregister_service = AsyncMock()
     mock_zc.async_close = AsyncMock()
 
-    # Mock a dual-stack adapter so get_zeroconf_args returns predictable results
-    mock_adapter = MagicMock()
-    mock_adapter.nice_name = "eth0"
-    mock_ipv4 = MagicMock()
-    mock_ipv4.is_IPv6 = False
-    mock_ipv4.ip = "192.168.1.10"
-    mock_ipv6 = MagicMock()
-    mock_ipv6.is_IPv6 = True
-    mock_ipv6.ip = ("fd00::1", 0, 2)
-    mock_adapter.ips = [mock_ipv4, mock_ipv6]
+    # Stub the resolved zeroconf args so the assertion below does not depend on
+    # the host's network adapters or platform (both are covered by the util tests)
+    zc_args = {"ip_version": IPVersion.All, "interfaces": ["192.168.1.10", "fd00::1%2"]}
 
     with (
         patch(
@@ -124,18 +117,19 @@ async def test_discovery_controller_owns_async_zeroconf(mass_minimal: MusicAssis
             new=AsyncMock(return_value=b"\x7f\x00\x00\x01"),
         ),
         patch(
-            "music_assistant.helpers.util.ifaddr.get_adapters",
-            return_value=[mock_adapter],
-        ),
+            "music_assistant.controllers.discovery.controller.get_zeroconf_args",
+            return_value=zc_args,
+        ) as mock_get_zeroconf_args,
     ):
         await mass_minimal.discovery.setup(await mass_minimal.config.get_core_config("discovery"))
         assert mass_minimal.discovery.aiozc is mock_zc
 
     await mass_minimal.discovery.close()
 
+    mock_get_zeroconf_args.assert_called_once_with(True)
     mock_async_zeroconf.assert_called_once_with(
-        ip_version=IPVersion.All,
-        interfaces=["192.168.1.10", "fd00::1%2"],
+        ip_version=zc_args["ip_version"],
+        interfaces=zc_args["interfaces"],
     )
 
 

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -398,11 +398,29 @@ def test_get_zeroconf_args_dual_stack() -> None:
     adapters = [
         _make_mock_adapter("eth0", ["192.168.1.10"], [("fd00::1", 0, 2)]),
     ]
-    with patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters):
+    with (
+        patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters),
+        patch("music_assistant.helpers.util.sys.platform", "linux"),
+    ):
         result = util.get_zeroconf_args(use_all_interfaces=False)
     assert result["ip_version"] == IPVersion.All
     assert isinstance(result["interfaces"], list)
     assert "192.168.1.10" in result["interfaces"]
+
+
+@pytest.mark.parametrize("platform", ["darwin", "freebsd14"])
+def test_get_zeroconf_args_dual_stack_ipv4_fallback(platform: str) -> None:
+    """Test that a dual-stack host falls back to IPv4-only on macOS/FreeBSD."""
+    adapters = [
+        _make_mock_adapter("eth0", ["192.168.1.10"], [("fd00::1", 0, 2)]),
+    ]
+    with (
+        patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters),
+        patch("music_assistant.helpers.util.sys.platform", platform),
+    ):
+        result = util.get_zeroconf_args(use_all_interfaces=False)
+    assert result["ip_version"] == IPVersion.V4Only
+    assert result["interfaces"] == InterfaceChoice.Default
 
 
 def test_get_zeroconf_args_ipv4_only() -> None:
@@ -444,7 +462,10 @@ def test_get_zeroconf_args_all_interfaces() -> None:
     adapters = [
         _make_mock_adapter("eth0", ["192.168.1.10"], [("fd00::1", 0, 2)]),
     ]
-    with patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters):
+    with (
+        patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters),
+        patch("music_assistant.helpers.util.sys.platform", "linux"),
+    ):
         result = util.get_zeroconf_args(use_all_interfaces=True)
     assert result["ip_version"] == IPVersion.All
     assert isinstance(result["interfaces"], list)


### PR DESCRIPTION
# What does this implement/fix?

Three discovery/zeroconf tests failed on macOS (and would on FreeBSD) while passing on Linux CI, so every local test run produced noise that had to be re-verified as pre-existing before any change could be trusted. The tests asserted the dual-stack outcome without controlling the platform they ran on: `get_zeroconf_args()` deliberately falls back to IPv4-only on macOS/FreeBSD, where an IPv6 listen socket cannot join IPv4 multicast groups. The production behaviour is correct — only the tests were missing a stub.

**Related issue (if applicable):**

- n/a

## Changes

- Pin the platform in the two dual-stack `get_zeroconf_args` tests so their result no longer depends on the host.
- Add coverage for the macOS/FreeBSD IPv4-only fallback, which previously had none.
- Stub the zeroconf arguments at the controller boundary in the discovery test, so it verifies what it is about — that the discovery controller creates and owns the shared `AsyncZeroconf` — instead of re-deriving the helper's platform logic.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a — tests only)
