### PR TITLE
Only rewrite the settings file on shutdown when something changed

### DIFF
--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -129,11 +129,14 @@ class ConfigController(
     async def close(self) -> None:
         """Handle logic on server stop."""
         if self._timer_handle is not None:
+            # a change that is still waiting out the debounce delay counts as pending on
+            # its own: a save that was already writing may have cleared the marker for it
             self._timer_handle.cancel()
             self._timer_handle = None
+            self._save_pending = True
         if self._save_pending:
-            # a scheduled save did not make it to disk: it is either still waiting out
-            # the debounce delay or its task was cancelled on stop, so write it here
+            # the save never made it to disk: its task was either cancelled on stop or
+            # never started, so write the data here
             await self._async_save()
         LOGGER.debug("Stopped.")
 

--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -68,6 +68,7 @@ class ConfigController(
         self._data: dict[str, Any] = {}
         self.filename = os.path.join(self.mass.storage_path, "settings.json")
         self._timer_handle: asyncio.TimerHandle | None = None
+        self._save_pending = False
         self._save_lock = asyncio.Lock()
 
     async def setup(self) -> None:
@@ -127,10 +128,13 @@ class ConfigController(
 
     async def close(self) -> None:
         """Handle logic on server stop."""
-        if not self._timer_handle:
-            # no point in forcing a save when there are no changes pending
-            return
-        await self._async_save()
+        if self._timer_handle is not None:
+            self._timer_handle.cancel()
+            self._timer_handle = None
+        if self._save_pending:
+            # a scheduled save did not make it to disk: it is either still waiting out
+            # the debounce delay or its task was cancelled on stop, so write it here
+            await self._async_save()
         LOGGER.debug("Stopped.")
 
     def get(self, key: str, default: Any = None) -> Any:
@@ -200,13 +204,12 @@ class ConfigController(
             self._timer_handle.cancel()
             self._timer_handle = None
 
+        self._save_pending = True
         if immediate:
             self.mass.loop.create_task(self._async_save())
         else:
             # schedule the save for later
-            self._timer_handle = self.mass.loop.call_later(
-                DEFAULT_SAVE_DELAY, self.mass.create_task, self._async_save
-            )
+            self._timer_handle = self.mass.loop.call_later(DEFAULT_SAVE_DELAY, self._start_save)
 
     def encrypt_string(self, str_value: str) -> str:
         """Encrypt a (password)string with Fernet."""
@@ -294,11 +297,19 @@ class ConfigController(
                 LOGGER.exception("Error while reading persistent storage file %s", filename)
         LOGGER.debug("Started with empty storage: No persistent storage file found.")
 
+    def _start_save(self) -> None:
+        """Start the save task, called by the save timer."""
+        self._timer_handle = None
+        self.mass.create_task(self._async_save)
+
     async def _async_save(self) -> None:
         """Save persistent data to disk."""
         async with self._save_lock:
             json_data = await async_json_dumps(self._data, indent=True)
             await asyncio.to_thread(self._save_to_disk, json_data)
+            # only clear the marker once the data is actually on disk, so a save that
+            # fails or gets cancelled is still flushed on stop
+            self._save_pending = False
         LOGGER.debug("Saved data to persistent storage")
 
     def _save_to_disk(self, json_data: str) -> None:

--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -303,6 +303,9 @@ class ConfigController(
     def _start_save(self) -> None:
         """Start the save task, called by the save timer."""
         self._timer_handle = None
+        # re-assert the marker: a save that finished while this timer was armed may have
+        # cleared it for a change that was not part of that write
+        self._save_pending = True
         self.mass.create_task(self._async_save)
 
     async def _async_save(self) -> None:

--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -68,7 +68,8 @@ class ConfigController(
         self._data: dict[str, Any] = {}
         self.filename = os.path.join(self.mass.storage_path, "settings.json")
         self._timer_handle: asyncio.TimerHandle | None = None
-        self._save_pending = False
+        self._save_requested = 0
+        self._save_written = 0
         self._save_lock = asyncio.Lock()
 
     async def setup(self) -> None:
@@ -129,14 +130,11 @@ class ConfigController(
     async def close(self) -> None:
         """Handle logic on server stop."""
         if self._timer_handle is not None:
-            # a change that is still waiting out the debounce delay counts as pending on
-            # its own: a save that was already writing may have cleared the marker for it
             self._timer_handle.cancel()
             self._timer_handle = None
-            self._save_pending = True
-        if self._save_pending:
-            # the save never made it to disk: its task was either cancelled on stop or
-            # never started, so write the data here
+        if self._save_written != self._save_requested:
+            # the latest change never made it to disk: its save is either still waiting
+            # out the debounce delay or was cancelled on stop, so write it here
             await self._async_save()
         LOGGER.debug("Stopped.")
 
@@ -207,7 +205,7 @@ class ConfigController(
             self._timer_handle.cancel()
             self._timer_handle = None
 
-        self._save_pending = True
+        self._save_requested += 1
         if immediate:
             self.mass.loop.create_task(self._async_save())
         else:
@@ -303,19 +301,17 @@ class ConfigController(
     def _start_save(self) -> None:
         """Start the save task, called by the save timer."""
         self._timer_handle = None
-        # re-assert the marker: a save that finished while this timer was armed may have
-        # cleared it for a change that was not part of that write
-        self._save_pending = True
         self.mass.create_task(self._async_save)
 
     async def _async_save(self) -> None:
         """Save persistent data to disk."""
         async with self._save_lock:
+            # remember which change we are about to write: anything requested after this
+            # point is not part of it, and must leave the settings marked as unsaved
+            requested = self._save_requested
             json_data = await async_json_dumps(self._data, indent=True)
             await asyncio.to_thread(self._save_to_disk, json_data)
-            # only clear the marker once the data is actually on disk, so a save that
-            # fails or gets cancelled is still flushed on stop
-            self._save_pending = False
+            self._save_written = requested
         LOGGER.debug("Saved data to persistent storage")
 
     def _save_to_disk(self, json_data: str) -> None:

--- a/tests/controllers/config/test_save_on_shutdown.py
+++ b/tests/controllers/config/test_save_on_shutdown.py
@@ -1,0 +1,57 @@
+"""
+Tests that config changes survive a real server shutdown.
+
+These run against an actual MusicAssistant instance rather than a stub, because
+the ordering that matters here is the server's own: ``stop()`` cancels the
+tracked tasks - the save task among them - before it closes the controllers.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+    from music_assistant.mass import MusicAssistant
+
+
+async def test_immediate_save_survives_a_shutdown(
+    mass_minimal: MusicAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A change saved immediately must be on disk after a stop, without errors."""
+    mass_minimal.config.set("test/immediate", "value", immediate=True)
+
+    await mass_minimal.stop()
+
+    settings = json.loads(Path(mass_minimal.config.filename).read_text())
+    assert settings["test"]["immediate"] == "value"
+    assert not [record for record in caplog.records if record.levelname == "ERROR"]
+
+
+async def test_debounced_save_survives_a_shutdown(
+    mass_minimal: MusicAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A change still waiting out the debounce delay must be on disk after a stop."""
+    mass_minimal.config.set("test/debounced", "value")
+
+    await mass_minimal.stop()
+
+    settings = json.loads(Path(mass_minimal.config.filename).read_text())
+    assert settings["test"]["debounced"] == "value"
+    assert not [record for record in caplog.records if record.levelname == "ERROR"]
+
+
+async def test_shutdown_does_not_rewrite_unchanged_settings(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A stop without config changes must leave the settings file alone."""
+    mass_minimal.config.set("test/change", "value")
+    await mass_minimal.config._async_save()
+    written_at = Path(mass_minimal.config.filename).stat().st_mtime_ns
+
+    await mass_minimal.stop()
+
+    assert Path(mass_minimal.config.filename).stat().st_mtime_ns == written_at

--- a/tests/controllers/config/test_save_scheduling.py
+++ b/tests/controllers/config/test_save_scheduling.py
@@ -93,12 +93,12 @@ async def _change_made_while_saving(
 
     def blocking_save_to_disk(json_data: str) -> None:
         writing.set()
-        release.wait(5)
+        assert release.wait(5), "the test never released the save"
         save_to_disk(json_data)
 
     with patch.object(controller, "_save_to_disk", new=blocking_save_to_disk):
         controller.set("first", 1, immediate=True)
-        await asyncio.to_thread(writing.wait, 5)
+        assert await asyncio.to_thread(writing.wait, 5), "the save never reached the write"
         controller.set("second", 2)
         release.set()
         await asyncio.gather(*mass.tasks)
@@ -250,6 +250,41 @@ async def test_close_saves_change_made_while_a_save_was_writing(tmp_path: Path) 
     assert json.loads(Path(controller.filename).read_text()) == {"first": 1, "second": 2}
 
 
+async def test_close_saves_change_whose_save_waited_for_a_running_one(tmp_path: Path) -> None:
+    """
+    A change whose save queued up behind a running save must survive a stop.
+
+    The running save finishes first and marks the settings saved, but its write was
+    prepared before the change, so the queued save is the one that still owes a write.
+    """
+    controller, mass = _make_controller(tmp_path)
+    save_to_disk = controller._save_to_disk
+    writing = threading.Event()
+    release = threading.Event()
+
+    def blocking_save_to_disk(json_data: str) -> None:
+        writing.set()
+        assert release.wait(5), "the test never released the save"
+        save_to_disk(json_data)
+
+    with patch.object(controller, "_save_to_disk", new=blocking_save_to_disk):
+        controller.set("first", 1, immediate=True)
+        assert await asyncio.to_thread(writing.wait, 5), "the save never reached the write"
+        running = mass.tasks.pop()
+        with patch(
+            "music_assistant.controllers.config.controller.async_json_dumps",
+            new=_stalled_json_dumps,
+        ):
+            controller.set("second", 2, immediate=True)
+            release.set()
+            await running
+            await _cancel_save_tasks(mass)
+
+    await controller.close()
+
+    assert json.loads(Path(controller.filename).read_text()) == {"first": 1, "second": 2}
+
+
 async def test_close_saves_that_change_once_its_timer_has_fired(tmp_path: Path) -> None:
     """
     The same change must also survive once its debounce timer has already fired.
@@ -260,7 +295,7 @@ async def test_close_saves_that_change_once_its_timer_has_fired(tmp_path: Path) 
     controller, mass = _make_controller(tmp_path)
 
     async with _change_made_while_saving(controller, mass):
-        assert controller._save_pending is False
+        assert controller._save_written == controller._save_requested - 1
         assert controller._timer_handle is not None
 
     with patch(

--- a/tests/controllers/config/test_save_scheduling.py
+++ b/tests/controllers/config/test_save_scheduling.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
-from collections.abc import Callable, Coroutine
+from collections.abc import AsyncIterator, Callable, Coroutine
+from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -74,6 +75,35 @@ async def _stalled_json_dumps(*_args: Any, **_kwargs: Any) -> str:
     """Stand in for the serialization step of a save that is still busy when the server stops."""
     await asyncio.Event().wait()
     return ""
+
+
+@asynccontextmanager
+async def _change_made_while_saving(
+    controller: ConfigController, mass: _FakeMass
+) -> AsyncIterator[None]:
+    """
+    Change a setting while a save is writing, and leave that save finished.
+
+    The change lands after the running save took its snapshot, so it is not part of
+    that write, and the save clears the pending marker on its way out.
+    """
+    save_to_disk = controller._save_to_disk
+    writing = threading.Event()
+    release = threading.Event()
+
+    def blocking_save_to_disk(json_data: str) -> None:
+        writing.set()
+        release.wait(5)
+        save_to_disk(json_data)
+
+    with patch.object(controller, "_save_to_disk", new=blocking_save_to_disk):
+        controller.set("first", 1, immediate=True)
+        await asyncio.to_thread(writing.wait, 5)
+        controller.set("second", 2)
+        release.set()
+        await asyncio.gather(*mass.tasks)
+        mass.tasks.clear()
+    yield
 
 
 async def _cancel_save_tasks(mass: _FakeMass) -> None:
@@ -211,22 +241,34 @@ async def test_close_cancels_the_pending_save_timer(tmp_path: Path) -> None:
 async def test_close_saves_change_made_while_a_save_was_writing(tmp_path: Path) -> None:
     """A change made after a save took its snapshot is not in that write, so the stop must do it."""
     controller, mass = _make_controller(tmp_path)
-    save_to_disk = controller._save_to_disk
-    writing = threading.Event()
-    release = threading.Event()
 
-    def blocking_save_to_disk(json_data: str) -> None:
-        writing.set()
-        release.wait(5)
-        save_to_disk(json_data)
+    async with _change_made_while_saving(controller, mass):
+        pass
 
-    with patch.object(controller, "_save_to_disk", new=blocking_save_to_disk):
-        controller.set("first", 1, immediate=True)
-        await asyncio.to_thread(writing.wait, 5)
-        controller.set("second", 2)
-        release.set()
-        await asyncio.gather(*mass.tasks)
-        mass.tasks.clear()
+    await controller.close()
+
+    assert json.loads(Path(controller.filename).read_text()) == {"first": 1, "second": 2}
+
+
+async def test_close_saves_that_change_once_its_timer_has_fired(tmp_path: Path) -> None:
+    """
+    The same change must also survive once its debounce timer has already fired.
+
+    From that point the timer handle is gone too, so the save it started is the only
+    remaining record that the change is not on disk - and the stop cancels it.
+    """
+    controller, mass = _make_controller(tmp_path)
+
+    async with _change_made_while_saving(controller, mass):
+        assert controller._save_pending is False
+        assert controller._timer_handle is not None
+
+    with patch(
+        "music_assistant.controllers.config.controller.async_json_dumps", new=_stalled_json_dumps
+    ):
+        controller._timer_handle.cancel()
+        controller._start_save()
+        await _cancel_save_tasks(mass)
 
     await controller.close()
 

--- a/tests/controllers/config/test_save_scheduling.py
+++ b/tests/controllers/config/test_save_scheduling.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from collections.abc import Callable, Coroutine
 from pathlib import Path
 from types import SimpleNamespace
@@ -35,7 +36,9 @@ class _FakeMass:
         return self._track(target(*args, **kwargs))
 
     def _track(self, coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any]:
-        task = self._loop.create_task(coro)
+        # eager start, like the real server: the save already runs up to its first
+        # suspension before the caller gets the task back
+        task = asyncio.Task(coro, loop=self._loop, eager_start=True)
         self.tasks.append(task)
         return task
 
@@ -67,6 +70,20 @@ async def _await_save_task(mass: _FakeMass) -> None:
     mass.tasks.clear()
 
 
+async def _stalled_json_dumps(*_args: Any, **_kwargs: Any) -> str:
+    """Stand in for the serialization step of a save that is still busy when the server stops."""
+    await asyncio.Event().wait()
+    return ""
+
+
+async def _cancel_save_tasks(mass: _FakeMass) -> None:
+    """Cancel the running save tasks, as the server does on stop."""
+    for task in mass.tasks:
+        task.cancel()
+    await asyncio.gather(*mass.tasks, return_exceptions=True)
+    mass.tasks.clear()
+
+
 async def test_close_skips_save_when_nothing_changed(tmp_path: Path) -> None:
     """A stop without config changes may not rewrite the settings file."""
     controller, mass = _make_controller(tmp_path)
@@ -78,6 +95,15 @@ async def test_close_skips_save_when_nothing_changed(tmp_path: Path) -> None:
 
     save_to_disk.assert_not_called()
     assert json.loads(Path(controller.filename).read_text()) == {"generation": 1}
+
+
+async def test_save_timer_handle_is_cleared_when_it_fires(tmp_path: Path) -> None:
+    """The timer handle may not outlive the timer it belongs to."""
+    controller, mass = _make_controller(tmp_path)
+    _set_without_delay(controller, "generation", 1)
+    await _await_save_task(mass)
+
+    assert controller._timer_handle is None
 
 
 async def test_close_skips_save_after_immediate_save(tmp_path: Path) -> None:
@@ -127,13 +153,81 @@ async def test_close_saves_change_whose_save_task_was_cancelled(tmp_path: Path) 
     save that was already scheduled is cancelled and can only complete here.
     """
     controller, mass = _make_controller(tmp_path)
-    _set_without_delay(controller, "generation", 1)
-    await _wait_for_save_task(mass)
-    for task in mass.tasks:
-        task.cancel()
-    await asyncio.gather(*mass.tasks, return_exceptions=True)
+    with patch(
+        "music_assistant.controllers.config.controller.async_json_dumps", new=_stalled_json_dumps
+    ):
+        _set_without_delay(controller, "generation", 1)
+        await _wait_for_save_task(mass)
+        await _cancel_save_tasks(mass)
     assert not Path(controller.filename).exists()
 
     await controller.close()
 
     assert json.loads(Path(controller.filename).read_text()) == {"generation": 1}
+
+
+async def test_close_saves_immediate_save_that_was_cancelled(tmp_path: Path) -> None:
+    """An immediate save that did not finish before the stop must still be written."""
+    controller, mass = _make_controller(tmp_path)
+    with patch(
+        "music_assistant.controllers.config.controller.async_json_dumps", new=_stalled_json_dumps
+    ):
+        controller.set("generation", 1, immediate=True)
+        await _cancel_save_tasks(mass)
+    assert not Path(controller.filename).exists()
+
+    await controller.close()
+
+    assert json.loads(Path(controller.filename).read_text()) == {"generation": 1}
+
+
+async def test_close_saves_change_whose_save_failed(tmp_path: Path) -> None:
+    """A save that could not be written must be retried on stop."""
+    controller, mass = _make_controller(tmp_path)
+    with patch.object(controller, "_save_to_disk", side_effect=OSError("no space left on device")):
+        _set_without_delay(controller, "generation", 1)
+        await _wait_for_save_task(mass)
+        await asyncio.gather(*mass.tasks, return_exceptions=True)
+        mass.tasks.clear()
+    assert not Path(controller.filename).exists()
+
+    await controller.close()
+
+    assert json.loads(Path(controller.filename).read_text()) == {"generation": 1}
+
+
+async def test_close_cancels_the_pending_save_timer(tmp_path: Path) -> None:
+    """The stop may not leave a timer behind that still fires a save afterwards."""
+    controller, mass = _make_controller(tmp_path)
+    _set_without_delay(controller, "generation", 1)
+
+    await controller.close()
+    await asyncio.sleep(0)
+
+    assert controller._timer_handle is None
+    assert not mass.tasks
+
+
+async def test_close_saves_change_made_while_a_save_was_writing(tmp_path: Path) -> None:
+    """A change made after a save took its snapshot is not in that write, so the stop must do it."""
+    controller, mass = _make_controller(tmp_path)
+    save_to_disk = controller._save_to_disk
+    writing = threading.Event()
+    release = threading.Event()
+
+    def blocking_save_to_disk(json_data: str) -> None:
+        writing.set()
+        release.wait(5)
+        save_to_disk(json_data)
+
+    with patch.object(controller, "_save_to_disk", new=blocking_save_to_disk):
+        controller.set("first", 1, immediate=True)
+        await asyncio.to_thread(writing.wait, 5)
+        controller.set("second", 2)
+        release.set()
+        await asyncio.gather(*mass.tasks)
+        mass.tasks.clear()
+
+    await controller.close()
+
+    assert json.loads(Path(controller.filename).read_text()) == {"first": 1, "second": 2}

--- a/tests/controllers/config/test_save_scheduling.py
+++ b/tests/controllers/config/test_save_scheduling.py
@@ -1,0 +1,139 @@
+"""
+Tests for the debounced save of the persistent settings storage.
+
+Saves are debounced by a timer, so on server stop the controller has to decide
+whether anything still needs writing: skip the write when the data on disk is
+already up to date, but never skip one that is genuinely still pending.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable, Coroutine
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from music_assistant.controllers.config.controller import ConfigController
+
+
+class _FakeMass:
+    """Minimal MusicAssistant stub that tracks every task the controller creates."""
+
+    def __init__(self, storage_path: Path) -> None:
+        self.storage_path = str(storage_path)
+        self.tasks: list[asyncio.Task[Any]] = []
+        self._loop = asyncio.get_running_loop()
+        self.loop = SimpleNamespace(call_later=self._loop.call_later, create_task=self._track)
+
+    def create_task(
+        self, target: Callable[..., Coroutine[Any, Any, Any]], *args: Any, **kwargs: Any
+    ) -> asyncio.Task[Any]:
+        """Create a task from a coroutine function, as the real server does."""
+        return self._track(target(*args, **kwargs))
+
+    def _track(self, coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any]:
+        task = self._loop.create_task(coro)
+        self.tasks.append(task)
+        return task
+
+
+def _make_controller(tmp_path: Path) -> tuple[ConfigController, _FakeMass]:
+    mass = _FakeMass(tmp_path)
+    controller = ConfigController(mass)  # type: ignore[arg-type]
+    controller.initialized = True
+    return controller, mass
+
+
+def _set_without_delay(controller: ConfigController, key: str, value: Any) -> None:
+    """Change a setting with the debounce delay reduced to zero."""
+    with patch("music_assistant.controllers.config.controller.DEFAULT_SAVE_DELAY", 0):
+        controller.set(key, value)
+
+
+async def _wait_for_save_task(mass: _FakeMass) -> None:
+    """Wait until the save timer has fired and started its task."""
+    async with asyncio.timeout(5):
+        while not mass.tasks:
+            await asyncio.sleep(0)
+
+
+async def _await_save_task(mass: _FakeMass) -> None:
+    """Wait for the scheduled save to run to completion."""
+    await _wait_for_save_task(mass)
+    await asyncio.gather(*mass.tasks)
+    mass.tasks.clear()
+
+
+async def test_close_skips_save_when_nothing_changed(tmp_path: Path) -> None:
+    """A stop without config changes may not rewrite the settings file."""
+    controller, mass = _make_controller(tmp_path)
+    _set_without_delay(controller, "generation", 1)
+    await _await_save_task(mass)
+
+    with patch.object(controller, "_save_to_disk") as save_to_disk:
+        await controller.close()
+
+    save_to_disk.assert_not_called()
+    assert json.loads(Path(controller.filename).read_text()) == {"generation": 1}
+
+
+async def test_close_skips_save_after_immediate_save(tmp_path: Path) -> None:
+    """An immediate save leaves nothing behind for the stop to write."""
+    controller, mass = _make_controller(tmp_path)
+    controller.set("generation", 1, immediate=True)
+    await _await_save_task(mass)
+
+    with patch.object(controller, "_save_to_disk") as save_to_disk:
+        await controller.close()
+
+    save_to_disk.assert_not_called()
+    assert json.loads(Path(controller.filename).read_text()) == {"generation": 1}
+
+
+async def test_close_skips_save_after_startup_migration(tmp_path: Path) -> None:
+    """A migration during load writes the settings file, so the stop must not repeat it."""
+    controller, _ = _make_controller(tmp_path)
+    Path(controller.filename).write_text(json.dumps({"generation": 1}))
+    with patch(
+        "music_assistant.controllers.config.controller.migrate", new=AsyncMock(return_value=True)
+    ):
+        await controller._load()
+
+    with patch.object(controller, "_save_to_disk") as save_to_disk:
+        await controller.close()
+
+    save_to_disk.assert_not_called()
+
+
+async def test_close_saves_change_that_is_still_debounced(tmp_path: Path) -> None:
+    """A change made within the debounce delay must survive a stop."""
+    controller, mass = _make_controller(tmp_path)
+    controller.set("generation", 1)
+
+    await controller.close()
+
+    assert not mass.tasks
+    assert json.loads(Path(controller.filename).read_text()) == {"generation": 1}
+
+
+async def test_close_saves_change_whose_save_task_was_cancelled(tmp_path: Path) -> None:
+    """
+    A change must survive a stop that cancels the save task before closing.
+
+    The server cancels all tracked tasks before it closes the controllers, so a
+    save that was already scheduled is cancelled and can only complete here.
+    """
+    controller, mass = _make_controller(tmp_path)
+    _set_without_delay(controller, "generation", 1)
+    await _wait_for_save_task(mass)
+    for task in mass.tasks:
+        task.cancel()
+    await asyncio.gather(*mass.tasks, return_exceptions=True)
+    assert not Path(controller.filename).exists()
+
+    await controller.close()
+
+    assert json.loads(Path(controller.filename).read_text()) == {"generation": 1}


### PR DESCRIPTION
# What does this implement/fix?

Music Assistant rewrote `settings.json` on every single shutdown, even when nothing had changed since the last save.

Saves are debounced by a timer, and the check that skips the write on stop looked at that timer's handle. The handle was never cleared once the timer fired, so from the first delayed save onwards it always looked like a save was still pending and the skip never happened.

The fix tracks whether there is actually unsaved data instead. That marker is only cleared once the data has really been written, so a save that is still waiting out the debounce delay - or one whose task was cancelled while the server was shutting down - is still flushed on stop.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Clear the debounce timer handle when the timer fires
- Track a pending marker, cleared only once the settings have actually been written
- Skip the save on stop based on that marker, and cancel a still-armed timer there
- Tests for both sides: no write when nothing changed, and a write for a save that is still debounced, was cancelled on stop, or came from an immediate save

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.