### PR TITLE
Only fail the dependency security check on vulnerabilities a PR introduces

### DIFF
--- a/.github/workflows/dependency-security-report.yml
+++ b/.github/workflows/dependency-security-report.yml
@@ -22,7 +22,10 @@
 #   success — no dependency changes, or changes reviewed/auto-approved
 #   pending — dependency changes detected, analysis in progress (set by init job)
 #   failure — awaiting maintainer review (overridable via /approve-dependencies)
-#   error   — analysis failed, high-risk packages or known vulnerabilities
+#   error   — analysis failed, or high-risk packages / known vulnerabilities in the
+#             dependencies the PR changes. The analysis scans the whole installed
+#             environment and only direct requirements are compared, so findings
+#             elsewhere are reported but never gate the PR
 #             (NOT overridable via /approve-dependencies; requires a re-run or fix)
 #
 # The `init` job runs on `pull_request_target` for EVERY PR (the analysis
@@ -113,7 +116,8 @@ jobs:
             });
 
   report:
-    # Only report for runs triggered by pull requests
+    # Only report for runs triggered by pull requests, so a workflow_run whose
+    # originating event was a push/merge can never post a status.
     if: github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
@@ -125,6 +129,9 @@ jobs:
     steps:
       # Resolve the PR(s) and all trusted facts from the head commit. head_sha is
       # set by GitHub from the workflow_run event and cannot be forged by the PR.
+      # It comes from the payload, not from `github.sha`/`github.ref`: a
+      # workflow_run job is stamped with the default branch tip, which is
+      # unrelated to the PR being reported on.
       # Commit statuses are per-SHA, so if several open PRs share this head
       # commit the gate must consider ALL of them (strictest result wins).
       - name: Resolve pull request (trusted)
@@ -316,9 +323,13 @@ jobs:
             echo "" >> security_report.md
 
             if [ "$PIP_AUDIT" == "fail" ]; then
-              echo "- ❌ **Vulnerability Scan**: Failed - Known vulnerabilities detected" >> security_report.md
-            else
+              echo "- ❌ **Vulnerability Scan**: Known vulnerabilities in the dependencies this PR changes" >> security_report.md
+            elif [ "$PIP_AUDIT" == "preexisting" ]; then
+              echo "- ⚠️  **Vulnerability Scan**: Known vulnerabilities found, but none in the dependencies this PR changes" >> security_report.md
+            elif [ "$PIP_AUDIT" == "pass" ]; then
               echo "- ✅ **Vulnerability Scan**: Passed - No known vulnerabilities" >> security_report.md
+            else
+              echo "- ❌ **Vulnerability Scan**: The scan could not be completed" >> security_report.md
             fi
 
             if [ "$TRUSTED_SOURCES" == "fail" ]; then
@@ -434,22 +445,31 @@ jobs:
             const resultsPresent = process.env.RESULTS_PRESENT === 'true';
             const isHighRisk = process.env.SAFETY_STATUS === 'high_risk';
             const hasVulns = process.env.PIP_AUDIT === 'fail';
+            const scanFailed = process.env.PIP_AUDIT === 'scan_failed';
 
             let state = 'success';
             let description = 'No dependency changes to review';
 
-            if (!analysisOk) {
+            if (!prs.some(p => p.deps_changed)) {
+              // The analysis also runs for PRs that only touch a manifest's
+              // metadata. With no dependency to review there is nothing to gate,
+              // and its findings cover the whole environment, not these PRs.
+              core.info(`No dependency changes in ${prs.map(p => `#${p.number}`).join(', ')}; reporting success.`);
+            } else if (!analysisOk) {
               state = 'error';
               description = 'Dependency security analysis failed - re-run the Dependency Security Check workflow';
             } else if (!resultsPresent) {
               state = 'error';
               description = 'Dependency security scan results missing - re-run the Dependency Security Check workflow';
+            } else if (scanFailed) {
+              state = 'error';
+              description = 'Dependency security scan could not be completed - re-run the Dependency Security Check workflow';
             } else if (isHighRisk) {
               state = 'error';
               description = 'High-risk packages detected - security review required';
             } else if (hasVulns) {
               state = 'error';
-              description = 'Known vulnerabilities detected';
+              description = 'Known vulnerabilities in the dependencies this PR changes';
             } else {
               // Every open PR sharing this head commit must pass the gate
               const blocked = prs.find(p =>
@@ -459,7 +479,7 @@ jobs:
                 description = prs.length > 1
                   ? `Awaiting maintainer review on PR #${blocked.number} (add "dependencies-reviewed" label)`
                   : 'Awaiting maintainer review (add "dependencies-reviewed" label)';
-              } else if (prs.some(p => p.deps_changed)) {
+              } else {
                 state = 'success';
                 description = prs.every(p => !p.deps_changed || p.is_automated)
                   ? 'Automated dependency update - approved'
@@ -472,7 +492,7 @@ jobs:
               context: 'Dependency Security Review', description,
             });
 
-            if (analysisOk && resultsPresent && !isHighRisk && !hasVulns) {
+            if (analysisOk && resultsPresent && !scanFailed && !isHighRisk && !hasVulns) {
               for (const pr of prs) {
                 if (pr.deps_changed && pr.is_automated && !pr.has_review_label) {
                   await github.rest.issues.addLabels({

--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -81,25 +81,6 @@ jobs:
             rm requirements_all.txt.original
           fi
 
-      # Step 2: Run pip-audit for known vulnerabilities
-      - name: Run pip-audit on installed environment
-        id: pip_audit
-        continue-on-error: true
-        run: |
-          echo "## 🔍 Vulnerability Scan Results" > audit_report.md
-          echo "" >> audit_report.md
-
-          if .venv/bin/pip-audit --desc --format=markdown >> audit_report.md 2>&1; then
-            echo "status=pass" >> $GITHUB_OUTPUT
-            echo "✅ No known vulnerabilities found" >> audit_report.md
-          else
-            echo "status=fail" >> $GITHUB_OUTPUT
-            echo "" >> audit_report.md
-            echo "⚠️  **Vulnerabilities detected! Please review the findings above.**" >> audit_report.md
-          fi
-
-          cat audit_report.md
-
       # Step 2: Detect new or changed dependencies
       - name: Detect dependency changes
         id: deps_check
@@ -148,7 +129,41 @@ jobs:
 
           cat deps_report.md
 
-      # Step 3: Check manifest.json changes
+      # Step 3: Run pip-audit for known vulnerabilities. The audit covers the whole
+      # installed environment, so only findings in the packages this PR adds or
+      # changes gate it; the rest are reported for information.
+      - name: Run pip-audit on installed environment
+        id: pip_audit
+        run: |
+          echo "## 🔍 Vulnerability Scan Results" > audit_report.md
+          echo "" >> audit_report.md
+
+          .venv/bin/pip-audit --desc --format=markdown >> audit_report.md 2>&1 || true
+          .venv/bin/pip-audit --format=json --output=audit.json || true
+
+          # Gate when the scan itself could not be completed, rather than pass silently
+          STATUS=$(python3 scripts/audit_changed_packages.py audit.json new_deps.txt) || STATUS=scan_failed
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
+
+          echo "" >> audit_report.md
+          case "$STATUS" in
+            fail)
+              echo "⚠️  **Vulnerabilities detected in the dependencies this PR changes!**" >> audit_report.md
+              ;;
+            preexisting)
+              echo "ℹ️  The findings above are in packages this PR does not change. Only direct requirements are compared, so review them if this PR adds a package that pulls them in." >> audit_report.md
+              ;;
+            scan_failed)
+              echo "❌ The vulnerability scan could not be completed." >> audit_report.md
+              ;;
+            *)
+              echo "✅ No known vulnerabilities found" >> audit_report.md
+              ;;
+          esac
+
+          cat audit_report.md
+
+      # Step 4: Check manifest.json changes
       - name: Check provider manifest changes
         id: manifest_check
         run: |
@@ -196,7 +211,7 @@ jobs:
 
           cat manifest_report.md
 
-      # Step 4: Run package safety check on new dependencies
+      # Step 5: Run package safety check on new dependencies
       - name: Check new package safety
         id: safety_check
         if: steps.deps_check.outputs.has_changes == 'true'
@@ -255,7 +270,7 @@ jobs:
 
           cat safety_report.md
 
-      # Step 5: Persist analysis results for the reporting workflow.
+      # Step 6: Persist analysis results for the reporting workflow.
       # The report runs via workflow_run and cannot see this job's outputs, so
       # the result strings are passed via the artifact. This data is UNTRUSTED
       # (produced by fork code); the reporting workflow validates it and derives
@@ -274,7 +289,7 @@ jobs:
             echo "LICENSE=${{ steps.safety_check.outputs.license }}"
           } > status.env
 
-      # Step 6: Hand off report fragments and results to the reporting workflow
+      # Step 7: Hand off report fragments and results to the reporting workflow
       - name: Upload security reports
         if: always()
         uses: actions/upload-artifact@v7.0.1

--- a/scripts/audit_changed_packages.py
+++ b/scripts/audit_changed_packages.py
@@ -1,0 +1,100 @@
+"""
+CI check: decide whether pip-audit findings affect the dependencies a pull request changes.
+
+pip-audit scans the whole installed environment, so on any pull request it also reports
+vulnerabilities in packages the pull request never touched. Those must not gate it: the
+author cannot act on them, and the resulting status is not overridable by a maintainer.
+
+Only direct requirements are compared, so a vulnerability reaching the environment through
+a transitive dependency is reported without gating.
+
+Prints the status the reporting workflow gates on:
+    pass         no known vulnerabilities at all
+    preexisting  vulnerabilities exist, but none in the changed dependencies
+    fail         vulnerabilities in dependencies this pull request adds or changes
+
+Usage:
+    python3 scripts/audit_changed_packages.py audit.json new_deps.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+# ruff: noqa: T201
+
+# Leading package name of a requirement line, before any extras, version or marker.
+REQUIREMENT_NAME = re.compile(r"^([A-Za-z0-9._-]+)")
+
+
+def normalize(name: str) -> str:
+    """
+    Return the PEP 503 normalized form of a package name.
+
+    :param name: Package name as written in a requirement line or an audit report.
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def changed_packages(requirements: str) -> set[str]:
+    """
+    Return the normalized names of the packages in the given requirement lines.
+
+    :param requirements: Requirement lines a pull request adds or changes, one per line.
+    """
+    names = set()
+    for raw in requirements.splitlines():
+        line = raw.strip()
+        # Skip comments and pip options such as --index-url
+        if not line or line.startswith(("#", "-")):
+            continue
+        if match := REQUIREMENT_NAME.match(line):
+            names.add(normalize(match.group(1)))
+    return names
+
+
+def vulnerable_packages(audit: str) -> set[str]:
+    """
+    Return the normalized names of the packages pip-audit reported vulnerabilities for.
+
+    :param audit: A pip-audit report in JSON format.
+    """
+    # Indexed rather than fetched with a default: pip-audit is installed unpinned, so a
+    # schema change has to surface as an error instead of an empty, passing result set
+    report = json.loads(audit)
+    return {normalize(dep["name"]) for dep in report["dependencies"] if dep.get("vulns")}
+
+
+def audit_status(audit: str, requirements: str) -> str:
+    """
+    Return `pass`, `preexisting` or `fail` for the given audit report and changed requirements.
+
+    :param audit: A pip-audit report in JSON format.
+    :param requirements: Requirement lines a pull request adds or changes, one per line.
+    """
+    vulnerable = vulnerable_packages(audit)
+    if not vulnerable:
+        return "pass"
+    return "fail" if vulnerable & changed_packages(requirements) else "preexisting"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print the audit status for the given report and changed requirements."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("audit", type=Path, help="pip-audit report in JSON format.")
+    parser.add_argument(
+        "requirements", type=Path, help="Requirement lines the pull request adds or changes."
+    )
+    args = parser.parse_args(argv)
+
+    # The requirements file is only written when the pull request changes dependencies
+    requirements = args.requirements.read_text() if args.requirements.is_file() else ""
+    print(audit_status(args.audit.read_text(), requirements))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_audit_changed_packages.py
+++ b/tests/scripts/test_audit_changed_packages.py
@@ -1,0 +1,143 @@
+"""Tests for scoping pip-audit findings to the dependencies a pull request changes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.audit_changed_packages import (
+    audit_status,
+    changed_packages,
+    main,
+    normalize,
+    vulnerable_packages,
+)
+
+
+def audit_report(*vulnerable: str, skipped: str | None = None) -> str:
+    """
+    Return a pip-audit JSON report where the given packages carry a vulnerability.
+
+    :param vulnerable: Package names to report a vulnerability for.
+    :param skipped: Package name pip-audit could not audit, if any.
+    """
+    dependencies = [
+        {"name": name, "version": "1.0.0", "vulns": [{"id": "GHSA-test", "fix_versions": []}]}
+        for name in vulnerable
+    ]
+    dependencies.append({"name": "clean-package", "version": "1.0.0", "vulns": []})
+    if skipped:
+        dependencies.append({"name": skipped, "skip_reason": "not found on PyPI"})
+    return json.dumps({"dependencies": dependencies, "fixes": []})
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("aiohttp", "aiohttp"),
+        ("Zeroconf", "zeroconf"),
+        ("aiohttp_fast_zlib", "aiohttp-fast-zlib"),
+        ("zope.interface", "zope-interface"),
+        ("a__b", "a-b"),
+    ],
+)
+def test_normalize(name: str, expected: str) -> None:
+    """Package names are compared in their PEP 503 normalized form."""
+    assert normalize(name) == expected
+
+
+def test_changed_packages_reads_requirement_lines() -> None:
+    """Package names are extracted regardless of the version specifier used."""
+    requirements = """
+        aiohttp==3.14.1
+        music-assistant-models>=1.2
+        some_pkg[extra]~=2.0 ; python_version >= '3.14'
+        aiolibdatachannel @ git+https://github.com/example/aiolibdatachannel@v1
+
+        # a comment
+        --index-url https://example.org/simple
+    """
+    assert changed_packages(requirements) == {
+        "aiohttp",
+        "music-assistant-models",
+        "some-pkg",
+        "aiolibdatachannel",
+    }
+
+
+def test_vulnerable_packages_ignores_clean_and_skipped() -> None:
+    """Only packages with findings count; skipped ones carry no vulns key."""
+    report = audit_report("aiohttp", skipped="torch")
+    assert vulnerable_packages(report) == {"aiohttp"}
+
+
+def test_no_findings_passes() -> None:
+    """A clean audit passes even when the pull request changes dependencies."""
+    assert audit_status(audit_report(), "aiohttp==3.14.1") == "pass"
+
+
+def test_findings_outside_the_changed_packages_are_preexisting() -> None:
+    """Vulnerabilities in untouched packages describe the base branch, not the pull request."""
+    assert audit_status(audit_report("aiohttp"), "some-pkg==1.0") == "preexisting"
+
+
+def test_findings_without_dependency_changes_are_preexisting() -> None:
+    """A pull request that changes no dependency can never introduce a vulnerability."""
+    assert audit_status(audit_report("aiohttp"), "") == "preexisting"
+
+
+def test_findings_in_a_changed_package_fail() -> None:
+    """A vulnerability in a package the pull request touches blocks it."""
+    assert audit_status(audit_report("aiohttp"), "aiohttp==3.14.1") == "fail"
+
+
+def test_findings_match_across_name_spellings() -> None:
+    """The comparison survives the underscore/dash spellings both sides use."""
+    assert audit_status(audit_report("aiohttp_fast_zlib"), "aiohttp-fast-zlib==0.3.0") == "fail"
+
+
+def test_main_prints_status(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The status is printed for the reporting workflow to pick up."""
+    audit = tmp_path / "audit.json"
+    audit.write_text(audit_report("aiohttp"))
+    requirements = tmp_path / "new_deps.txt"
+    requirements.write_text("aiohttp==3.14.1\n")
+
+    assert main([str(audit), str(requirements)]) == 0
+    assert capsys.readouterr().out.strip() == "fail"
+
+
+def test_main_without_a_requirements_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The requirements file is absent when the analysis found no dependency changes."""
+    audit = tmp_path / "audit.json"
+    audit.write_text(audit_report("aiohttp"))
+
+    assert main([str(audit), str(tmp_path / "missing.txt")]) == 0
+    assert capsys.readouterr().out.strip() == "preexisting"
+
+
+@pytest.mark.parametrize(
+    ("report", "expected"),
+    [
+        ("not json at all", json.JSONDecodeError),
+        # A pip-audit release that renames the key must not read as "no findings"
+        ('{"deps": [], "fixes": []}', KeyError),
+    ],
+)
+def test_an_unusable_report_raises(tmp_path: Path, report: str, expected: type[Exception]) -> None:
+    """An unreadable audit must fail loudly; the workflow gates on a non-zero exit."""
+    audit = tmp_path / "audit.json"
+    audit.write_text(report)
+
+    with pytest.raises(expected):
+        main([str(audit), str(tmp_path / "missing.txt")])
+
+
+def test_a_missing_report_raises(tmp_path: Path) -> None:
+    """pip-audit writing no report at all must fail loudly rather than pass."""
+    with pytest.raises(FileNotFoundError):
+        main([str(tmp_path / "missing.json"), str(tmp_path / "missing.txt")])


### PR DESCRIPTION
# What does this implement/fix?

The `Dependency Security Review` check could fail on pull requests that
introduce no vulnerability at all, with a state that `/approve-dependencies`
cannot clear.

The check scans the whole installed environment, so it reports vulnerabilities
that already exist on the target branch. Every pull request that touched a
`manifest.json`, `pyproject.toml` or `requirements_all.txt` inherited them and
got blocked with nothing the author could fix, in a state `/approve-dependencies`
refuses to clear. Seen on #5261, where three `aiohttp` advisories against `dev`
blocked a provider that changes no dependency at all, and re-running the seeding
job was the only way out. Those advisories are since fixed, so nothing is stuck
right now — the next one against any pinned package brings it straight back.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Only block a pull request on vulnerabilities in the packages it actually adds
  or changes. The others are still listed in the report, marked as not coming
  from this pull request.
- Report success straight away when a pull request changes no dependency at all,
  instead of letting scan results decide.
- Say so clearly, and keep blocking, when the scan itself cannot complete.
- Add `scripts/audit_changed_packages.py` with tests for the scoping.

Only direct requirements are compared, so a vulnerability that arrives through a
transitive dependency is reported but does not block. Comparing those properly
would mean building and scanning the target branch's environment as well, which
roughly doubles the job — left for later.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
