### PR TITLE
Don't remember a mute that never happened

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -931,59 +931,19 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
 
         # Set mute lock for players in a group
         # This prevents auto-unmute when group volume changes
+        had_mute_lock = ATTR_MUTE_LOCK in player.extra_data
         is_in_group = bool(player.state.synced_to or player.state.active_group)
         if muted and is_in_group:
             player.extra_data[ATTR_MUTE_LOCK] = True
 
-        if mute_control == PLAYER_CONTROL_NATIVE:
-            # player supports mute command natively: forward to player
-            await player.volume_mute(muted)
-            return
-        if mute_control == PLAYER_CONTROL_FAKE:
-            # user wants to use fake mute control - so we use volume instead
-            self.logger.debug(
-                "Using volume for muting for player %s",
-                player.state.name,
-            )
-            if muted:
-                already_muted = bool(player.extra_data.get(ATTR_FAKE_MUTE))
-                if not already_muted:
-                    # on a repeated mute command the volume is already 0
-                    player.extra_data[ATTR_PREVIOUS_VOLUME] = player.state.volume_level
-                await self._handle_cmd_volume_set(player_id, 0)
-                # set the flag after the volume command, as that clears it
-                player.extra_data[ATTR_FAKE_MUTE] = True
-                player.update_state()
-            else:
-                prev_volume = player.extra_data.get(ATTR_PREVIOUS_VOLUME, 1)
-                player.extra_data[ATTR_FAKE_MUTE] = False
-                player.update_state()
-                await self._handle_cmd_volume_set(player_id, prev_volume)
-            return
-
-        # handle external player control
-        if player_control := self._controls.get(mute_control):
-            control_name = player_control.name
-            self.logger.debug("Redirecting mute command to PlayerControl %s", control_name)
-            if not player_control.supports_mute:
-                raise UnsupportedFeaturedException(
-                    f"Player control {control_name} is not available"
-                )
-            assert player_control.mute_set is not None
-            await player_control.mute_set(muted)
-            return
-
-        # handle to protocol player as volume_mute control
-        if protocol_player := self.get_player(mute_control):
-            self.logger.debug(
-                "Redirecting mute command to protocol player %s",
-                protocol_player.provider.manifest.name,
-            )
-            await protocol_player.volume_mute(muted)
-            return
-
-        # the configured control disappeared after the mute control was resolved
-        raise UnsupportedFeaturedException(f"Player {player.state.name} does not support muting")
+        try:
+            await self._handle_cmd_volume_mute(player, mute_control, muted)
+        except Exception:
+            # a mute that did not happen may not leave a lock behind, but a lock
+            # earned by an earlier successful mute must survive
+            if not had_mute_lock:
+                player.extra_data.pop(ATTR_MUTE_LOCK, None)
+            raise
 
     @handle_player_command
     async def play_media(self, player_id: str, media: PlayerMedia) -> None:
@@ -3537,6 +3497,66 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             )
             await self._handle_cmd_volume_set(protocol_player.player_id, device_volume)
             return
+
+    async def _handle_cmd_volume_mute(self, player: Player, mute_control: str, muted: bool) -> None:
+        """
+        Send the mute command to the given player's mute control.
+
+        Skips permission checks, locking and mute lock bookkeeping (internal use only).
+
+        :param player: the player to handle the command.
+        :param mute_control: the already resolved mute control of the player.
+        :param muted: bool if player should be muted.
+        """
+        if mute_control == PLAYER_CONTROL_NATIVE:
+            # player supports mute command natively: forward to player
+            await player.volume_mute(muted)
+            return
+        if mute_control == PLAYER_CONTROL_FAKE:
+            # user wants to use fake mute control - so we use volume instead
+            self.logger.debug(
+                "Using volume for muting for player %s",
+                player.state.name,
+            )
+            if muted:
+                already_muted = bool(player.extra_data.get(ATTR_FAKE_MUTE))
+                if not already_muted:
+                    # on a repeated mute command the volume is already 0
+                    player.extra_data[ATTR_PREVIOUS_VOLUME] = player.state.volume_level
+                await self._handle_cmd_volume_set(player.player_id, 0)
+                # set the flag after the volume command, as that clears it
+                player.extra_data[ATTR_FAKE_MUTE] = True
+                player.update_state()
+            else:
+                prev_volume = player.extra_data.get(ATTR_PREVIOUS_VOLUME, 1)
+                player.extra_data[ATTR_FAKE_MUTE] = False
+                player.update_state()
+                await self._handle_cmd_volume_set(player.player_id, prev_volume)
+            return
+
+        # handle external player control
+        if player_control := self._controls.get(mute_control):
+            control_name = player_control.name
+            self.logger.debug("Redirecting mute command to PlayerControl %s", control_name)
+            if not player_control.supports_mute:
+                raise UnsupportedFeaturedException(
+                    f"Player control {control_name} is not available"
+                )
+            assert player_control.mute_set is not None
+            await player_control.mute_set(muted)
+            return
+
+        # handle to protocol player as volume_mute control
+        if protocol_player := self.get_player(mute_control):
+            self.logger.debug(
+                "Redirecting mute command to protocol player %s",
+                protocol_player.provider.manifest.name,
+            )
+            await protocol_player.volume_mute(muted)
+            return
+
+        # the configured control disappeared after the mute control was resolved
+        raise UnsupportedFeaturedException(f"Player {player.state.name} does not support muting")
 
     async def _handle_play_media(self, player_id: str, media: PlayerMedia) -> None:
         """

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1627,6 +1627,47 @@ class TestMuteControlGuard:
             await controller.cmd_volume_mute("player_1", False)
         assert ATTR_MUTE_LOCK not in player.extra_data
 
+    async def test_failed_mute_sets_no_mute_lock(self, mock_mass: MagicMock) -> None:
+        """A grouped player whose mute command failed is not left holding a mute lock."""
+        control = PlayerControl(
+            id="ext_mute",
+            provider="test",
+            name="External Mute",
+            supports_mute=False,
+        )
+        controller, player = self._make_player(
+            mock_mass,
+            mute_control="ext_mute",
+            volume_control=PLAYER_CONTROL_NONE,
+            controls={"ext_mute": control},
+        )
+        player.state.synced_to = "leader"
+
+        with pytest.raises(UnsupportedFeaturedException):
+            await controller.cmd_volume_mute("player_1", True)
+        assert ATTR_MUTE_LOCK not in player.extra_data
+
+    async def test_failed_mute_keeps_existing_mute_lock(self, mock_mass: MagicMock) -> None:
+        """A failed mute leaves the lock of an earlier successful mute in place."""
+        control = PlayerControl(
+            id="ext_mute",
+            provider="test",
+            name="External Mute",
+            supports_mute=False,
+        )
+        controller, player = self._make_player(
+            mock_mass,
+            mute_control="ext_mute",
+            volume_control=PLAYER_CONTROL_NONE,
+            controls={"ext_mute": control},
+        )
+        player.state.synced_to = "leader"
+        player.extra_data[ATTR_MUTE_LOCK] = True
+
+        with pytest.raises(UnsupportedFeaturedException):
+            await controller.cmd_volume_mute("player_1", True)
+        assert player.extra_data[ATTR_MUTE_LOCK] is True
+
 
 class TestGroupMuteMemberFilter:
     """Group mute skips members that have no mute control of their own."""


### PR DESCRIPTION
# What does this implement/fix?

When a player that is part of a group is muted, Music Assistant remembers that it was muted on purpose, so a group volume change does not silently unmute it again. That marker was kept even when the mute command itself failed (for example because the linked mute control does not support muting), leaving it behind on a player that was never muted.

Changes:

- A failed mute command no longer leaves the marker behind, while a marker from an earlier successful mute is kept.
- Moved the sending of the mute command into a private helper, matching how the volume command is already structured.
- Added tests for a grouped player whose mute command fails.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
