### PR TITLE
Protect the cached Home Assistant entity list and reduce its memory use

### DIFF
--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -14,6 +14,8 @@ import logging
 import os
 from functools import partial
 from itertools import batched
+from sys import intern
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict, cast
 
 from hass_client import HomeAssistantClient
@@ -46,7 +48,7 @@ from music_assistant.models.plugin import AIEngine, PluginProvider, TTSEngine
 from .constants import OFF_STATES, MediaPlayerEntityFeature, parse_supported_features
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Collection
+    from collections.abc import Callable, Collection, Mapping
 
     from aiohttp import ClientSession
     from hass_client.models import (
@@ -187,7 +189,7 @@ class HomeAssistantProvider(PluginProvider):
     _ai_engines: list[AIEngine]
     _tts_engines: list[TTSEngine]
     _startup_complete: bool = False
-    _entity_registry: dict[str, HassRegistryEntity] | None = None
+    _entity_registry: Mapping[str, HassRegistryEntity] | None = None
     _entity_registry_generation: int = 0
     _entity_registry_lock: asyncio.Lock
     _wanted_controls: dict[str, _ControlCapabilities] | None = None
@@ -380,12 +382,16 @@ class HomeAssistantProvider(PluginProvider):
             "player_controls": len(self._player_controls) if self._player_controls else 0,
         }
 
-    async def get_entity_registry(self) -> dict[str, HassRegistryEntity]:
+    async def get_entity_registry(self) -> Mapping[str, HassRegistryEntity]:
         """
         Return the Home Assistant entity registry, keyed by entity ID.
 
         Entities that are disabled in Home Assistant are absent from the result, and so are
         entities without a unique ID: those are not part of Home Assistant's registry at all.
+
+        The result is shared between all callers and must be treated as read-only: the
+        mapping itself rejects writes, but the entries are plain dicts, so copy an entry
+        before changing it.
         """
         if (registry := self._entity_registry) is not None:
             return registry
@@ -1045,7 +1051,11 @@ class HomeAssistantProvider(PluginProvider):
         except Exception as err:
             self.logger.warning("Failed to refresh Home Assistant engines: %s", err)
 
-    async def _fetch_entity_registry(self) -> dict[str, HassRegistryEntity]:
+    # unlike the device registry below, this listing is mirrored for the lifetime of the
+    # connection rather than kept behind a TTL: it runs to several megabytes on a large
+    # setup, and Home Assistant announces every change, so the mirror is both the cheaper
+    # and the more accurate option
+    async def _fetch_entity_registry(self) -> Mapping[str, HassRegistryEntity]:
         """Fetch the entity registry from Home Assistant, keyed by entity ID."""
         # the display variant of the registry listing carries abbreviated keys and only the
         # fields the Home Assistant frontend needs, making it several times smaller
@@ -1053,14 +1063,19 @@ class HomeAssistantProvider(PluginProvider):
             "dict[str, Any]",
             await self.hass.send_command("config/entity_registry/list_for_display"),
         )
-        return {
-            entry["ei"]: HassRegistryEntity(
+        # the listing repeats a handful of platform names and one device id per device over
+        # all of its entities, so hold on to a single string object per distinct value
+        device_ids: dict[str, str] = {}
+        registry: dict[str, HassRegistryEntity] = {}
+        for entry in result["entities"]:
+            if (device_id := entry.get("di")) is not None:
+                device_id = device_ids.setdefault(device_id, device_id)
+            registry[entry["ei"]] = HassRegistryEntity(
                 entity_id=entry["ei"],
-                platform=entry["pl"],
-                device_id=entry.get("di"),
+                platform=intern(entry["pl"]),
+                device_id=device_id,
             )
-            for entry in result["entities"]
-        }
+        return MappingProxyType(registry)
 
     # the lock sits outside the cache to keep a burst of lookups from fetching once per
     # caller. use_cache stores in the background, so the callers that reach a still-cold

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -1051,7 +1051,7 @@ class HomeAssistantProvider(PluginProvider):
         except Exception as err:
             self.logger.warning("Failed to refresh Home Assistant engines: %s", err)
 
-    # unlike the device registry below, this listing is mirrored for the lifetime of the
+    # unlike _fetch_device_registry, this listing is mirrored for the lifetime of the
     # connection rather than kept behind a TTL: it runs to several megabytes on a large
     # setup, and Home Assistant announces every change, so the mirror is both the cheaper
     # and the more accurate option

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -808,6 +808,11 @@ async def test_registry_reuses_repeated_strings() -> None:
             registry = await provider._fetch_entity_registry()
 
         assert len(registry) == 3
+        assert registry["light.lamp_0"] == {
+            "entity_id": "light.lamp_0",
+            "platform": "esphome",
+            "device_id": "device",
+        }
         assert len({id(entry["platform"]) for entry in registry.values()}) == 1
         assert len({id(entry["device_id"]) for entry in registry.values()}) == 1
 

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from math import ceil
@@ -23,6 +24,7 @@ from music_assistant.providers.hass import (
     CONF_VERIFY_SSL,
     CONF_VOLUME_CONTROLS,
     STATE_FETCH_BATCH_SIZE,
+    HassRegistryEntity,
     HomeAssistantProvider,
     setup,
 )
@@ -774,6 +776,40 @@ async def test_registry_changed_during_the_fetch_is_not_cached() -> None:
         registry_fetches = hass.calls.count(REGISTRY_LIST_COMMAND)
         await provider.get_states(domains=("tts",))
         assert hass.calls.count(REGISTRY_LIST_COMMAND) == registry_fetches + 1
+
+
+async def test_shared_registry_rejects_writes() -> None:
+    """Reject writes to the registry that is shared between all callers."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, _):
+        registry = await provider.get_entity_registry()
+
+        with pytest.raises(TypeError):
+            registry["light.kitchen"] = HassRegistryEntity(  # type: ignore[index]
+                entity_id="light.kitchen", platform="test", device_id=None
+            )
+
+
+async def test_registry_reuses_repeated_strings() -> None:
+    """Hold on to a single string object per distinct platform and device id."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, _):
+        # decode the listing like a real response, so the repeated platform and device id
+        # arrive as distinct string objects instead of shared literals
+        entities = json.loads(
+            json.dumps(
+                [
+                    {"ei": f"light.lamp_{index}", "pl": "esphome", "di": "device"}
+                    for index in range(3)
+                ]
+            )
+        )
+        with patch.object(
+            provider.hass, "send_command", AsyncMock(return_value={"entities": entities})
+        ):
+            registry = await provider._fetch_entity_registry()
+
+        assert len(registry) == 3
+        assert len({id(entry["platform"]) for entry in registry.values()}) == 1
+        assert len({id(entry["device_id"]) for entry in registry.values()}) == 1
 
 
 async def test_device_registry_is_reused_within_the_cache_window() -> None:


### PR DESCRIPTION
# What does this implement/fix?

The Home Assistant entity registry is fetched once and then kept in memory for as long as the connection lasts. Every part of Music Assistant that needs it gets handed the exact same object, so a future change that writes to it would quietly corrupt the copy everyone else is reading. It is now handed out as read-only, so such a write fails immediately instead of causing hard to trace problems later.

The listing also repeats the same integration name and device id over and over — once per entity — and each repeat was stored separately. Keeping one copy of each distinct value cuts the memory it occupies by about a quarter (roughly 16 MB down to 12 MB on a setup with 41k entities).

A short comment now records why this registry is kept in memory while the device registry is refreshed on a timer, so the difference reads as deliberate.

**Related issue (if applicable):**

- follow-up on https://github.com/music-assistant/server/pull/5270 and https://github.com/music-assistant/server/pull/5273

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
