### PR TITLE
Show the real SSL status in the webserver settings

### DIFF
--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -158,6 +158,8 @@ class WebserverController(CoreController):
         self.clients: set[WebsocketClientHandler] = set()
         # the URL that the "auto" base_url setting resolves to, detected at setup
         self._auto_base_url: str = ""
+        # whether SSL is switched on in the config, resolved at setup
+        self._ssl_configured: bool = False
         # whether the webserver actually serves TLS, resolved at setup
         self._ssl_active: bool = False
         self.bind_ip: str | None = None
@@ -300,7 +302,8 @@ class WebserverController(CoreController):
         bind_ip = cast("str | None", config.get_value(CONF_BIND_IP))
         # Create SSL context if SSL is enabled
         ssl_context = None
-        if config.get_value(CONF_ENABLE_SSL, False):
+        self._ssl_configured = bool(config.get_value(CONF_ENABLE_SSL, False))
+        if self._ssl_configured:
             ssl_context = await create_server_ssl_context(
                 str(config.get_value(CONF_SSL_CERTIFICATE) or ""),
                 str(config.get_value(CONF_SSL_PRIVATE_KEY) or ""),
@@ -511,12 +514,23 @@ class WebserverController(CoreController):
                 default_value=DEFAULT_SERVER_PORT,
                 requires_reload=True,
             ),
+            # the two alerts are mutually exclusive: the generic one while SSL is switched off,
+            # and the SSL specific one when a certificate failed to load and left the webserver
+            # on plain HTTP
             ConfigEntry(
                 key="webserver_warn",
                 type=ConfigEntryType.ALERT,
                 required=False,
+                hidden=self._ssl_configured,
                 depends_on=CONF_ENABLE_SSL,
                 depends_on_value=False,
+            ),
+            ConfigEntry(
+                key="ssl_inactive_warn",
+                type=ConfigEntryType.ALERT,
+                required=False,
+                hidden=not self._ssl_configured or self._ssl_active,
+                depends_on=CONF_ENABLE_SSL,
             ),
             ConfigEntry(
                 key=CONF_ENABLE_SSL,

--- a/music_assistant/controllers/webserver/strings.json
+++ b/music_assistant/controllers/webserver/strings.json
@@ -15,6 +15,9 @@
     "webserver_warn": {
       "label": "Please note that the webserver is by default unencrypted. Never ever expose the webserver directly to the internet! \n\nEnable SSL below or use a reverse proxy or VPN to secure access. \n\nAs an alternative, consider using the Remote Access feature which secures access to your Music Assistant instance without the need to expose your webserver directly."
     },
+    "ssl_inactive_warn": {
+      "label": "SSL/TLS is enabled, but the certificate could not be loaded, so the webserver is still running unencrypted. \n\nCheck the certificate and private key below and use the Verify button to test them. The webserver switches to HTTPS as soon as a valid certificate is saved."
+    },
     "enable_ssl": {
       "label": "Enable SSL/TLS",
       "description": "Enable HTTPS by providing an SSL certificate and private key. \nThis encrypts all communication with the webserver."

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -803,6 +803,7 @@
   "core.webserver.config_entries.enable_ssl.label": "Enable SSL/TLS",
   "core.webserver.config_entries.ssl_certificate.description": "Provide your SSL certificate in PEM format. You can either:\n- Paste the full contents of your certificate file, or\n- Enter an absolute file path (e.g., /ssl/fullchain.pem)\n\nThis should include the full certificate chain if applicable.\nBoth RSA and ECDSA certificates are supported.",
   "core.webserver.config_entries.ssl_certificate.label": "SSL Certificate",
+  "core.webserver.config_entries.ssl_inactive_warn.label": "SSL/TLS is enabled, but the certificate could not be loaded, so the webserver is still running unencrypted. \n\nCheck the certificate and private key below and use the Verify button to test them. The webserver switches to HTTPS as soon as a valid certificate is saved.",
   "core.webserver.config_entries.ssl_private_key.description": "Provide your SSL private key in PEM format. You can either:\n- Paste the full contents of your private key file, or\n- Enter an absolute file path (e.g., /ssl/privkey.pem)\n\nBoth RSA and ECDSA keys are supported. The key must be unencrypted.\nThis is securely encrypted and stored.",
   "core.webserver.config_entries.ssl_private_key.label": "SSL Private Key",
   "core.webserver.config_entries.verify_ssl.action_label": "Verify",

--- a/tests/controllers/webserver/test_ssl_base_url.py
+++ b/tests/controllers/webserver/test_ssl_base_url.py
@@ -131,6 +131,20 @@ async def test_ssl_disabled_alerts_the_webserver_is_unencrypted(
     assert await _visible_alerts(webserver) == {"webserver_warn"}
 
 
+async def test_switching_ssl_off_drops_the_certificate_alert(
+    mock_mass: MagicMock, tmp_path: Path
+) -> None:
+    """Verify a reload onto the same controller reports the SSL state it was reloaded with."""
+    webserver, _ = await _setup_webserver(
+        mock_mass, tmp_path, certificate="not a certificate", private_key="not a private key"
+    )
+    assert await _visible_alerts(webserver) == {"ssl_inactive_warn"}
+
+    await _run_setup(webserver, tmp_path, certificate="", private_key="", enable_ssl=False)
+
+    assert await _visible_alerts(webserver) == {"webserver_warn"}
+
+
 def _make_server_mock() -> MagicMock:
     """Create a Webserver double that adopts the address it is set up with."""
     server = MagicMock()
@@ -183,7 +197,33 @@ async def _setup_webserver(
     webserver._server = server
     webserver.auth = MagicMock(setup=AsyncMock())
     webserver.remote_access = MagicMock(setup=AsyncMock())
+    await _run_setup(
+        webserver,
+        tmp_path,
+        certificate=certificate,
+        private_key=private_key,
+        enable_ssl=enable_ssl,
+    )
+    return webserver, server
 
+
+async def _run_setup(
+    webserver: WebserverController,
+    tmp_path: Path,
+    *,
+    certificate: str,
+    private_key: str,
+    enable_ssl: bool,
+) -> None:
+    """
+    Set up a prepared controller against the given SSL config, as a (re)load does.
+
+    :param webserver: The prepared controller to set up.
+    :param tmp_path: Directory to serve as the frontend, in place of the bundled one.
+    :param certificate: Value for the ssl_certificate config option.
+    :param private_key: Value for the ssl_private_key config option.
+    :param enable_ssl: Value for the enable_ssl config option.
+    """
     config_values: dict[str, Any] = {
         "bind_port": 8095,
         "bind_ip": None,
@@ -205,4 +245,3 @@ async def _setup_webserver(
         ),
     ):
         await webserver.setup(cast("CoreConfig", config))
-    return webserver, server

--- a/tests/controllers/webserver/test_ssl_base_url.py
+++ b/tests/controllers/webserver/test_ssl_base_url.py
@@ -1,4 +1,4 @@
-"""Tests for the URL scheme the webserver advertises when SSL is enabled."""
+"""Tests for the URL scheme and settings alerts that follow the webserver's SSL state."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.x509.oid import NameOID
+from music_assistant_models.enums import ConfigEntryType
 
 from music_assistant.constants import WILDCARD_BIND_IPS
 from music_assistant.controllers.webserver.controller import WebserverController
@@ -54,6 +55,7 @@ def mock_mass() -> MagicMock:
     mass = MagicMock()
     mass.config.get_raw_core_config_value.return_value = "GLOBAL"
     mass.running_as_hass_addon = False
+    mass.providers = []
     return mass
 
 
@@ -95,6 +97,40 @@ async def test_invalid_certificate_advertises_plain_http(
     assert server.setup.await_args.kwargs["ssl_context"] is None
 
 
+async def test_valid_certificate_shows_no_alert(
+    mock_mass: MagicMock, tmp_path: Path, self_signed_cert: tuple[str, str]
+) -> None:
+    """Verify a served HTTPS webserver is not flagged as unencrypted."""
+    certificate, private_key = self_signed_cert
+    webserver, _ = await _setup_webserver(
+        mock_mass, tmp_path, certificate=certificate, private_key=private_key
+    )
+
+    assert await _visible_alerts(webserver) == set()
+
+
+async def test_invalid_certificate_alerts_ssl_did_not_take_effect(
+    mock_mass: MagicMock, tmp_path: Path
+) -> None:
+    """Verify enabling SSL with an unusable certificate is reported as such."""
+    webserver, _ = await _setup_webserver(
+        mock_mass, tmp_path, certificate="not a certificate", private_key="not a private key"
+    )
+
+    assert await _visible_alerts(webserver) == {"ssl_inactive_warn"}
+
+
+async def test_ssl_disabled_alerts_the_webserver_is_unencrypted(
+    mock_mass: MagicMock, tmp_path: Path
+) -> None:
+    """Verify the generic warning is the only alert when SSL was never switched on."""
+    webserver, _ = await _setup_webserver(
+        mock_mass, tmp_path, certificate="", private_key="", enable_ssl=False
+    )
+
+    assert await _visible_alerts(webserver) == {"webserver_warn"}
+
+
 def _make_server_mock() -> MagicMock:
     """Create a Webserver double that adopts the address it is set up with."""
     server = MagicMock()
@@ -108,20 +144,38 @@ def _make_server_mock() -> MagicMock:
     return server
 
 
+async def _visible_alerts(webserver: WebserverController) -> set[str]:
+    """
+    Return the keys of the alert entries the settings UI renders for a controller.
+
+    :param webserver: The controller to read the config entries from.
+    """
+    with patch(
+        "music_assistant.controllers.webserver.controller.get_ip_addresses",
+        AsyncMock(return_value=("192.168.1.5",)),
+    ):
+        entries = await webserver._build_config_entries()
+    return {
+        entry.key for entry in entries if entry.type == ConfigEntryType.ALERT and not entry.hidden
+    }
+
+
 async def _setup_webserver(
     mock_mass: MagicMock,
     tmp_path: Path,
     *,
     certificate: str,
     private_key: str,
+    enable_ssl: bool = True,
 ) -> tuple[WebserverController, MagicMock]:
     """
-    Run the real setup of a WebserverController with SSL enabled.
+    Run the real setup of a WebserverController.
 
     :param mock_mass: Mocked Music Assistant instance to build the controller on.
     :param tmp_path: Directory to serve as the frontend, in place of the bundled one.
     :param certificate: Value for the ssl_certificate config option.
     :param private_key: Value for the ssl_private_key config option.
+    :param enable_ssl: Value for the enable_ssl config option.
     :return: The controller and the Webserver double it was set up against.
     """
     webserver = WebserverController(mock_mass)
@@ -133,7 +187,7 @@ async def _setup_webserver(
     config_values: dict[str, Any] = {
         "bind_port": 8095,
         "bind_ip": None,
-        "enable_ssl": True,
+        "enable_ssl": enable_ssl,
         "ssl_certificate": certificate,
         "ssl_private_key": private_key,
     }


### PR DESCRIPTION
# What does this implement/fix?

The SSL warning on the Webserver settings page did not follow what the server is actually doing.

When SSL is switched on but the certificate or private key is missing or invalid, the server quietly falls back to plain HTTP (fixed server-side in #5330), yet the settings page kept presenting SSL as on and said nothing. The other way around, the generic "your webserver is unencrypted" alert kept showing even when HTTPS was working fine, because that alert was hidden with `depends_on`, which the frontend does not apply to alert entries.

Both alerts are now decided server-side from the state the webserver actually resolved at startup, so exactly one of them shows and it matches reality.

**Related issue (if applicable):**

- follow-up on #5330

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Remember at startup whether SSL was switched on, next to the existing "is TLS actually served" state.
- Show a new alert when SSL is on but the certificate could not be loaded, pointing at the certificate fields and the Verify button.
- Hide the generic "webserver is unencrypted" alert once SSL is switched on, so the two alerts never both show.
- Added tests covering all three cases.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
