### PR TITLE
Use original release years for Trivia questions

### DIFF
--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Iterable
+from contextlib import suppress
+from dataclasses import replace
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, ClassVar, Final, cast
 
-from music_assistant_models.enums import AlbumType, MediaType
+from music_assistant_models.enums import AlbumType, ExternalID, MediaType
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import (
     Album,
@@ -42,6 +46,7 @@ if TYPE_CHECKING:
         MusicQuizGame,
         MusicQuizRound,
     )
+    from music_assistant.providers.musicbrainz import MusicbrainzProvider
     from music_assistant.providers.radio_playlist import RadioPlaylistProvider
 
 LOGGER = logging.getLogger(__name__)
@@ -55,6 +60,7 @@ MAX_SUGGESTION_COUNT = 12
 PLAYBACK_REPLACEMENT_RESERVE = 4
 QUIZ_TRACK_RECENCY_SECONDS = 24 * 60 * 60
 MIN_RELEASE_YEAR = 1000
+RELEASE_YEAR_LOOKUP_BUDGET_SECONDS = 2.0
 SUPPORTED_SOURCE_MEDIA_TYPES: Final = frozenset(
     {
         MediaType.TRACK,
@@ -429,6 +435,43 @@ class QuizType(ABC):
             return True
         return self._recency_snapshot is not None and self._recency_snapshot.track_recent(
             track, QUIZ_TRACK_RECENCY_SECONDS
+        )
+
+    async def _musicbrainz_dated_track(self, track: Track) -> Track:
+        """
+        Return the track dated with the first release year MusicBrainz knows for its recording.
+
+        The track itself is returned unchanged when MusicBrainz has nothing better to offer.
+
+        :param track: Track to date by its ISRC.
+        """
+        musicbrainz = self.mass.get_provider("musicbrainz")
+        isrc = track.get_external_id(ExternalID.ISRC)
+        if musicbrainz is None or not isrc:
+            return track
+        release_year: int | None = None
+        # callers wait for this and MusicBrainz throttles to 10 requests per 10 seconds, so a
+        # lookup that does not resolve within the budget leaves the track on its library year
+        with suppress(TimeoutError):
+            async with asyncio.timeout(RELEASE_YEAR_LOOKUP_BUDGET_SECONDS):
+                try:
+                    release_year = await cast(
+                        "MusicbrainzProvider", musicbrainz
+                    ).get_release_year_by_isrc(isrc)
+                except Exception as err:
+                    LOGGER.debug("Could not date Music Quiz track %s: %s", track.uri, err)
+        # a year outside this range is rejected by get_track_release_year anyway, and a year
+        # below 1 cannot be expressed as a datetime at all
+        if release_year is None or not MIN_RELEASE_YEAR <= release_year <= utc().year:
+            return track
+        release_date = track.metadata.release_date
+        if release_date is not None and release_date.year <= release_year:
+            return track
+        # the track controller hands out objects that are shared with the library cache,
+        # so the release date is written to a copy instead of the track itself
+        return replace(
+            track,
+            metadata=replace(track.metadata, release_date=datetime(release_year, 1, 1, tzinfo=UTC)),
         )
 
 

--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -8,15 +8,13 @@ import secrets
 from collections.abc import Sequence
 from contextlib import suppress
 from dataclasses import replace
-from datetime import UTC, datetime
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
-from music_assistant_models.enums import ExternalID, MediaType
+from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import Artist, ItemMapping, Track
 
 from music_assistant.helpers.compare import compare_artist
-from music_assistant.helpers.datetime import utc
 from music_assistant.helpers.json import json_dumps
 from music_assistant.providers.music_quiz.ai_distractors import (
     AI_QUERY_TIMEOUT_SECONDS,
@@ -42,8 +40,8 @@ from music_assistant.providers.music_quiz.models import (
     TimelineRoundState,
 )
 from music_assistant.providers.music_quiz.quiz_types.base import (
-    MIN_RELEASE_YEAR,
     PLAYBACK_REPLACEMENT_RESERVE,
+    RELEASE_YEAR_LOOKUP_BUDGET_SECONDS,
     QuizType,
     get_track_release_year,
 )
@@ -60,7 +58,6 @@ from music_assistant.providers.music_quiz.suggestions import (
 if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
     from music_assistant.providers.music_quiz.models import MusicQuizConfig
-    from music_assistant.providers.musicbrainz import MusicbrainzProvider
 
 LOGGER = logging.getLogger(__name__)
 SYSTEM_RANDOM = secrets.SystemRandom()
@@ -68,7 +65,6 @@ SYSTEM_RANDOM = secrets.SystemRandom()
 DEFAULT_BONUS_OPTION_COUNT = 4
 COMPLETED_REVEAL_AUTO_ADVANCE_SECONDS = 30.0
 TRACK_ENRICHMENT_CONCURRENCY = 10
-RELEASE_YEAR_LOOKUP_BUDGET_SECONDS = 2.0
 BONUS_CANDIDATE_LIMIT = 24
 
 
@@ -308,43 +304,6 @@ class MusicTimelineQuizType(QuizType):
         with suppress(TimeoutError):
             async with asyncio.timeout(RELEASE_YEAR_LOOKUP_BUDGET_SECONDS):
                 await asyncio.gather(*(_rescue_track(track) for track in candidates))
-
-    async def _musicbrainz_dated_track(self, track: Track) -> Track:
-        """
-        Return the track dated with the first release year MusicBrainz knows for its recording.
-
-        The track itself is returned unchanged when MusicBrainz has nothing better to offer.
-
-        :param track: Track to date by its ISRC.
-        """
-        musicbrainz = self.mass.get_provider("musicbrainz")
-        isrc = track.get_external_id(ExternalID.ISRC)
-        if musicbrainz is None or not isrc:
-            return track
-        release_year: int | None = None
-        # callers wait for this and MusicBrainz throttles to 10 requests per 10 seconds, so a
-        # lookup that does not resolve within the budget leaves the track on its library year
-        with suppress(TimeoutError):
-            async with asyncio.timeout(RELEASE_YEAR_LOOKUP_BUDGET_SECONDS):
-                try:
-                    release_year = await cast(
-                        "MusicbrainzProvider", musicbrainz
-                    ).get_release_year_by_isrc(isrc)
-                except Exception as err:
-                    LOGGER.debug("Could not date Music Quiz track %s: %s", track.uri, err)
-        # a year outside this range is rejected by get_track_release_year anyway, and a year
-        # below 1 cannot be expressed as a datetime at all
-        if release_year is None or not MIN_RELEASE_YEAR <= release_year <= utc().year:
-            return track
-        release_date = track.metadata.release_date
-        if release_date is not None and release_date.year <= release_year:
-            return track
-        # the track controller hands out objects that are shared with the library cache,
-        # so the release date is written to a copy instead of the track itself
-        return replace(
-            track,
-            metadata=replace(track.metadata, release_date=datetime(release_year, 1, 1, tzinfo=UTC)),
-        )
 
     async def _create_entry(
         self,

--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -267,6 +267,11 @@ class TriviaQuizType(QuizType):
         track_facts = SYSTEM_RANDOM.choice(
             [facts for facts in available_tracks if facts.source_uri in preferred_uris]
         )
+        # an album can carry a reissue year, which would be scored as the correct answer to a
+        # release year question; dating only the track that becomes this round's question keeps
+        # the lookups bounded where dating the eligible pool would not
+        dated_track = await self._musicbrainz_dated_track(source_pool[track_facts.source_uri])
+        track_facts = self._track_facts(dated_track) or track_facts
         fact = self._select_fact(track_facts, round_index)
         generation = await self._generate_question(fact)
         correct = SuggestionCandidate(

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -882,8 +882,7 @@ async def test_stalled_musicbrainz_lookups_keep_the_library_year() -> None:
 
     await quiz.initialize()
     with patch(
-        "music_assistant.providers.music_quiz.quiz_types."
-        "music_timeline.RELEASE_YEAR_LOOKUP_BUDGET_SECONDS",
+        "music_assistant.providers.music_quiz.quiz_types.base.RELEASE_YEAR_LOOKUP_BUDGET_SECONDS",
         0.01,
     ):
         game_round = await _prepare_round_with_tracks(quiz, tracks)

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -304,6 +304,32 @@ def _correct_source_uri(state: MultipleChoiceRoundState) -> str:
     return correct[0].uri
 
 
+def _with_isrc(track: Track, isrc: str) -> Track:
+    """Return the given track carrying an ISRC."""
+    track.add_external_id(ExternalID.ISRC, isrc)
+    return track
+
+
+def _with_musicbrainz(mass: MagicMock, years: dict[str, int]) -> MagicMock:
+    """Attach a MusicBrainz provider that dates the given ISRCs to the mock MusicAssistant."""
+    provider = MagicMock()
+    provider.get_release_year_by_isrc = AsyncMock(side_effect=lambda isrc: years.get(isrc))
+    mass.get_provider = MagicMock(
+        side_effect=lambda domain: provider if domain == "musicbrainz" else None
+    )
+    return provider
+
+
+def _year_question_provider() -> MagicMock:
+    """Return a mock AI provider that words one release year question."""
+    return _ai_provider(
+        _valid_response(
+            "In which year was this song first released?",
+            ["2011", "1994", "1987"],
+        )
+    )
+
+
 def test_registry_identity_and_config_are_trivia_specific() -> None:
     """Register stable Trivia identity and normalize unrelated settings."""
     assert get_quiz_type("trivia") is TriviaQuizType
@@ -718,6 +744,146 @@ def test_album_mapping_retains_release_grounding_without_compilation_evidence() 
     assert facts.album == VARIOUS_ARTISTS_NAME
     assert facts.release_year == 2000
     assert TriviaQuizType._available_targets(facts) == tuple(TriviaTarget)
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_dates_a_reissue_album_mapping() -> None:
+    """Prefer the MusicBrainz recording year over a reissue year on an album mapping."""
+    track = _with_isrc(
+        _track("reissue", "Teardrop", "Massive Attack", album="Mezzanine", album_year=2007),
+        "ISRC-REISSUE",
+    )
+    quiz, mass = _quiz([track])
+    _with_musicbrainz(mass, {"ISRC-REISSUE": 1998})
+
+    facts = quiz._track_facts(await quiz._musicbrainz_dated_track(track))
+
+    assert facts is not None
+    assert facts.release_year == 1998
+
+
+@pytest.mark.asyncio
+async def test_library_release_year_survives_a_later_musicbrainz_year() -> None:
+    """Keep the earliest known year when MusicBrainz only knows a later remaster."""
+    dated_album = _with_isrc(
+        _track("album-dated", "Penny Lane", "The Beatles", album="Past Masters", album_year=1967),
+        "ISRC-ALBUM-DATED",
+    )
+    dated_track = _with_isrc(
+        _track("track-dated", "Penny Lane", "The Beatles", release_year=1967),
+        "ISRC-TRACK-DATED",
+    )
+    quiz, mass = _quiz([dated_album, dated_track])
+    _with_musicbrainz(mass, {"ISRC-ALBUM-DATED": 2017, "ISRC-TRACK-DATED": 2017})
+
+    album_facts = quiz._track_facts(await quiz._musicbrainz_dated_track(dated_album))
+    track_facts = quiz._track_facts(await quiz._musicbrainz_dated_track(dated_track))
+
+    assert album_facts is not None
+    assert album_facts.release_year == 1967
+    assert track_facts is not None
+    assert track_facts.release_year == 1967
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_adds_a_year_target_to_an_undated_track() -> None:
+    """Offer a release year target once MusicBrainz dates a track the library left undated."""
+    track = _with_isrc(
+        _track("undated", "Teardrop", "Massive Attack", album="Mezzanine"),
+        "ISRC-UNDATED",
+    )
+    quiz, mass = _quiz([track])
+    _with_musicbrainz(mass, {"ISRC-UNDATED": 1998})
+
+    undated_facts = quiz._track_facts(track)
+    dated_facts = quiz._track_facts(await quiz._musicbrainz_dated_track(track))
+
+    assert undated_facts is not None
+    assert undated_facts.release_year is None
+    assert quiz._available_targets(undated_facts) == (
+        TriviaTarget.ARTIST,
+        TriviaTarget.TITLE,
+        TriviaTarget.ALBUM,
+    )
+    assert dated_facts is not None
+    assert dated_facts.release_year == 1998
+    assert quiz._available_targets(dated_facts) == tuple(TriviaTarget)
+
+
+@pytest.mark.asyncio
+async def test_compilation_release_year_stays_suppressed_after_dating() -> None:
+    """Keep compilation year facts suppressed even when MusicBrainz can date the recording."""
+    track = _with_isrc(_track("compilation", "Africa", "Toto", release_year=1998), "ISRC-COMP")
+    track.album = _full_album(
+        "party-hits",
+        "Party Hits",
+        album_type=AlbumType.COMPILATION,
+        year=1998,
+    )
+    quiz, mass = _quiz([track])
+    _with_musicbrainz(mass, {"ISRC-COMP": 1982})
+
+    facts = quiz._track_facts(await quiz._musicbrainz_dated_track(track))
+
+    assert facts is not None
+    assert facts.release_year is None
+    assert TriviaTarget.YEAR not in quiz._available_targets(facts)
+
+
+@pytest.mark.asyncio
+async def test_prepare_round_scores_and_grounds_the_musicbrainz_release_year() -> None:
+    """Score and ground a release year question on the MusicBrainz recording year."""
+    track = _with_isrc(_track("reissue", "Teardrop", release_year=2007), "ISRC-REISSUE")
+    provider = _year_question_provider()
+    quiz, mass = _quiz([track], providers=[provider])
+    _with_musicbrainz(mass, {"ISRC-REISSUE": 1998})
+
+    game_round = await quiz.prepare_round(0, [])
+
+    assert game_round.answer_label == "1998"
+    assert isinstance(game_round.answer_state, MultipleChoiceRoundState)
+    assert _correct_source_uri(game_round.answer_state) == track.uri
+    payload = _prompt_payload(provider.ai_query.await_args.args[0])
+    assert payload["question_target"] == TriviaTarget.YEAR
+    assert payload["correct_answer"] == "1998"
+    assert payload["track_metadata"]["release_year"] == 1998
+
+
+@pytest.mark.asyncio
+async def test_prepare_round_keeps_library_years_without_musicbrainz() -> None:
+    """Ground a release year question on library metadata when MusicBrainz is unavailable."""
+    track = _with_isrc(_track("library", "Teardrop", release_year=1998), "ISRC-LIBRARY")
+    quiz, mass = _quiz([track], providers=[_year_question_provider()])
+    mass.get_provider = MagicMock(return_value=None)
+
+    game_round = await quiz.prepare_round(0, [])
+
+    assert game_round.answer_label == "1998"
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_lookups_do_not_scale_with_the_source_pool() -> None:
+    """Date only the track that becomes the question, never the complete eligible pool."""
+    tracks = [
+        _with_isrc(
+            _track(
+                f"track-{index}",
+                f"Song {index}",
+                f"Artist {index}",
+                album=f"Album {index}",
+                album_year=2007,
+            ),
+            f"ISRC-{index}",
+        )
+        for index in range(60)
+    ]
+    quiz, mass = _quiz(tracks, providers=[_ai_provider(_valid_response())])
+    musicbrainz = _with_musicbrainz(mass, {f"ISRC-{index}": 1998 for index in range(60)})
+
+    await quiz.initialize()
+    await quiz.prepare_round(0, [])
+
+    assert musicbrainz.get_release_year_by_isrc.await_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Music Timeline was recently fixed to use the original release year of a song instead of the year of the album it happens to sit on (#5250). Trivia asks release year questions too, but never got that fix, so it could mark a player wrong for giving the actual right answer.

A song picked from a reissue, a compilation or an album without a proper type would be scored against that album's year - on a real library those years were off by around 15 years on average. The wrong year also ended up in the question text itself.

Trivia now looks up the original release year the same way Music Timeline does, for the one song each question is built from.

- Moved the MusicBrainz release year lookup to the shared quiz base so Trivia and Music Timeline use the same one
- Trivia now dates the song it builds a question from, so both the scored answer and the question text use the original release year
- Kept the existing behaviour of never picking a later year than the one already known, so remasters don't push a song forward in time
- Added tests, including one that keeps the lookups limited to the songs actually asked about

**Related issue (if applicable):**

- follow-up to #5250

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
