### PR TITLE
Prevent short server freezes when similarity indexes are saved

### DIFF
--- a/music_assistant/providers/sonic_similarity/clap_index.py
+++ b/music_assistant/providers/sonic_similarity/clap_index.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .index_io import save_index
 from .similarity import ScoredCandidate
 
 if TYPE_CHECKING:
@@ -317,7 +318,7 @@ class ClapIndex:
             encoding="utf-8",
         )
         tmp_keys_path.replace(self._keys_path)
-        self._index.save(str(self._index_path))
+        save_index(self._index, self._index_path)
         self._logger.debug(
             "Saved CLAP index to %s (%d vectors)",
             self._index_path,

--- a/music_assistant/providers/sonic_similarity/index_io.py
+++ b/music_assistant/providers/sonic_similarity/index_io.py
@@ -1,0 +1,29 @@
+"""Shared on-disk writing for the plugin's usearch indexes."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Keeps any single write syscall short enough not to park the worker for long.
+WRITE_CHUNK_BYTES = 4 * 1024 * 1024
+
+
+def save_index(index: Any, path: Path) -> None:
+    """
+    Write a usearch index to disk. Must be called from a worker thread.
+
+    :param index: The usearch index to serialize.
+    :param path: Destination file, overwritten in place.
+    """
+    # usearch's own save(path) holds the GIL for the entire write, so handing it to
+    # asyncio.to_thread still freezes the event loop for the duration. Passing no
+    # path returns the serialized bytes instead of writing them, which costs a
+    # fraction of that; the bytes then go out through plain file I/O, which does
+    # release the GIL.
+    blob = memoryview(index.save())
+    with path.open("wb") as index_file:
+        for offset in range(0, len(blob), WRITE_CHUNK_BYTES):
+            index_file.write(blob[offset : offset + WRITE_CHUNK_BYTES])

--- a/music_assistant/providers/sonic_similarity/index_io.py
+++ b/music_assistant/providers/sonic_similarity/index_io.py
@@ -7,9 +7,6 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from pathlib import Path
 
-# Keeps any single write syscall short enough not to park the worker for long.
-WRITE_CHUNK_BYTES = 4 * 1024 * 1024
-
 
 def save_index(index: Any, path: Path) -> None:
     """
@@ -23,7 +20,4 @@ def save_index(index: Any, path: Path) -> None:
     # path returns the serialized bytes instead of writing them, which costs a
     # fraction of that; the bytes then go out through plain file I/O, which does
     # release the GIL.
-    blob = memoryview(index.save())
-    with path.open("wb") as index_file:
-        for offset in range(0, len(blob), WRITE_CHUNK_BYTES):
-            index_file.write(blob[offset : offset + WRITE_CHUNK_BYTES])
+    path.write_bytes(index.save())

--- a/music_assistant/providers/sonic_similarity/provider.py
+++ b/music_assistant/providers/sonic_similarity/provider.py
@@ -73,6 +73,7 @@ from music_assistant.providers.sonic_similarity.helpers import (
     apply_filters,
     format_text_query,
 )
+from music_assistant.providers.sonic_similarity.index_io import save_index
 from music_assistant.providers.sonic_similarity.models import SimilarParams, _SearchContext
 from music_assistant.providers.sonic_similarity.similarity import (
     Candidate,
@@ -1340,7 +1341,7 @@ class SonicSimilarityPlugin(PluginProvider):
             for label, features in row_entries:
                 normalized = normalize_features(features, new_corpus_means, new_corpus_stds)
                 builder.add(label, np.array(normalized, dtype=np.float32))
-            builder.save(str(new_index_path))
+            save_index(builder, new_index_path)
             viewer = self._make_empty_index()
             viewer.view(str(new_index_path))
             return viewer

--- a/tests/providers/sonic_similarity/test_clap_index.py
+++ b/tests/providers/sonic_similarity/test_clap_index.py
@@ -14,11 +14,12 @@ import threading
 import time
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
 
+from music_assistant.providers.sonic_similarity import index_io
 from music_assistant.providers.sonic_similarity.clap_index import (
     CLAP_EMBEDDING_DIM,
     ClapIndex,
@@ -84,6 +85,31 @@ async def test_round_trip_persists_under_sonic_similarity_stem(
 
 
 @pytest.mark.asyncio
+async def test_saved_index_reloads_with_its_embeddings(
+    tmp_path: Path, logger: logging.Logger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A saved index comes back intact through a fresh instance, chunk boundaries included."""
+    # well under the payload, so the write loop runs many times over
+    monkeypatch.setattr(index_io, "WRITE_CHUNK_BYTES", 4096)
+
+    idx = ClapIndex(_make_mass(tmp_path), logger)  # type: ignore[arg-type]
+    await idx.load()
+    vectors = {f"track{n}": _unit_vec(n) for n in range(20)}
+    for item_id, vec in vectors.items():
+        await idx.add("spotify", item_id, vec)
+    await idx.save()
+
+    reloaded = ClapIndex(_make_mass(tmp_path), logger)  # type: ignore[arg-type]
+    await reloaded.load()
+
+    assert len(reloaded) == len(vectors)
+    for item_id, vec in vectors.items():
+        stored = reloaded.get_embedding("spotify", item_id)
+        assert stored is not None
+        np.testing.assert_allclose(stored, vec, atol=1e-3)
+
+
+@pytest.mark.asyncio
 async def test_get_embedding_by_item_id_missing_returns_none(
     tmp_path: Path, logger: logging.Logger
 ) -> None:
@@ -138,7 +164,7 @@ async def test_save_writes_keys_before_index_so_a_crash_doesnt_orphan_labels(
     await idx.add("spotify", "track1", _unit_vec(1))
 
     # Force the index save to fail after the keys file has already been written.
-    def _boom(_path: str) -> None:
+    def _boom() -> Any:
         raise RuntimeError("disk full mid-save")
 
     monkeypatch.setattr(idx._index, "save", _boom)
@@ -170,7 +196,7 @@ async def test_close_waits_for_a_save_whose_task_was_cancelled(
     writers_lock = threading.Lock()
     writers = 0
 
-    def _slow_save(path: str) -> None:
+    def _slow_save() -> Any:
         nonlocal writers
         with writers_lock:
             writers += 1
@@ -178,7 +204,7 @@ async def test_close_waits_for_a_save_whose_task_was_cancelled(
         # parked here rather than sleeping, so the assertion below can never
         # be decided by how fast the machine happens to be
         assert release.wait(10), "close() never let the save finish"
-        real_save(path)
+        return real_save()
 
     monkeypatch.setattr(idx._index, "save", _slow_save)
 

--- a/tests/providers/sonic_similarity/test_clap_index.py
+++ b/tests/providers/sonic_similarity/test_clap_index.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import pytest
 
-from music_assistant.providers.sonic_similarity import index_io
 from music_assistant.providers.sonic_similarity.clap_index import (
     CLAP_EMBEDDING_DIM,
     ClapIndex,
@@ -86,12 +85,9 @@ async def test_round_trip_persists_under_sonic_similarity_stem(
 
 @pytest.mark.asyncio
 async def test_saved_index_reloads_with_its_embeddings(
-    tmp_path: Path, logger: logging.Logger, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, logger: logging.Logger
 ) -> None:
-    """A saved index comes back intact through a fresh instance, chunk boundaries included."""
-    # well under the payload, so the write loop runs many times over
-    monkeypatch.setattr(index_io, "WRITE_CHUNK_BYTES", 4096)
-
+    """A saved index comes back intact through a fresh instance."""
     idx = ClapIndex(_make_mass(tmp_path), logger)  # type: ignore[arg-type]
     await idx.load()
     vectors = {f"track{n}": _unit_vec(n) for n in range(20)}


### PR DESCRIPTION
# What does this implement/fix?

Writing the sonic similarity index files briefly froze the whole server. The `usearch` library holds Python's global lock for the entire duration of its own file write, so even though the save already ran on a background thread, nothing else could run until it finished — including audio streaming.

Measured on a 50k-track library (110 MB Character index), the freeze was ~170 ms per save on a fast desktop. The cost turns out to be CPU-bound rather than disk-bound (usearch does two small writes per track and never syncs to disk), so it scales with processor speed — on a Raspberry Pi it lands in the half-second range. Saves repeat while analysis is backfilling and again on shutdown.

The fix asks usearch for the index bytes and writes them out with normal file I/O, which does not block the rest of the server. The file produced is byte-for-byte identical to before.

**Related issue (if applicable):**

- n/a — spotted while reviewing #5337

## Changes

- New `index_io.save_index()` helper shared by both similarity indexes.
- Character (CLAP) index save: the freeze drops roughly 6-8x, ~170 ms → ~21 ms at 50k tracks.
- The 18-dim index rebuild: ~22 ms → ~3 ms.
- Added a save/reload round-trip test, which nothing covered before.

Trade-off: serialising to memory first means each save briefly allocates a buffer the size of the index (~110 MB at 50k tracks) that the old path did not. The index is already resident at that size and this engine needs torch loaded anyway, so it is the cheaper side of the trade.

Loading is left alone deliberately. It has the same limitation, but costs ~70 ms once at provider startup instead of repeatedly during a backfill, so paying that same full-size buffer there does not earn its keep.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
