### PR TITLE
Fail unconfirmed AirPlay starts and wait for every speaker's clock

### DIFF
--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -232,8 +232,9 @@ The `AirPlayStreamSession` class in [stream_session.py](stream_session.py) manag
    - Connects every member before anchoring playback
    - Wires each member's ffmpeg into its persistent CLI stdin and starts feeding audio
    - Waits until every member's binary confirms the feed flowing (`[STATUS] audio`),
-     then sends one shared audible start instant with a short anchor lead
-     (400 ms solo / 500 ms group); readiness is fully event-driven, so no
+     then sends one shared audible start instant with an anchor lead
+     (400 ms solo / 500 ms warm group / 2500 ms cold group, see
+     `AIRPLAY_COLD_GROUP_START_LEAD_MS`); readiness is fully event-driven, so no
      setup time is guessed and the binary bursts the receiver pre-fill after START
 
 2. **Client Setup** (per player, `_start_client()` method)
@@ -247,7 +248,7 @@ The `AirPlayStreamSession` class in [stream_session.py](stream_session.py) manag
    - Receives PCM audio chunks from Music Assistant core
    - Distributes chunks to all players via FFmpeg
    - Tracks elapsed time based on bytes sent
-   - Handles silence padding if audio source is slow (watchdog mechanism)
+   - Handles silence padding if audio source is slow
 
 4. **Connection Monitoring**
    - Waits for all devices to connect and confirm audio flowing before anchoring playback
@@ -286,16 +287,9 @@ The provider supports synchronized multi-room audio by:
 When adding a player to an already-playing session (`add_client()` in [stream_session.py](stream_session.py)):
 
 1. **Ring buffer**: Session maintains a few seconds of recent audio chunks in memory
-2. **Compensated start time**: The joiner's start instant accounts for the buffer duration: `start_time + (seconds_streamed - buffer_duration)`, shifted forward (with the buffer head trimmed) when it would land in the past
+2. **Anchored past receiver readiness**: The joiner's START is commanded just past the instant its binary projects the receiver's clock becomes usable, and the binary acks the instant it can truly honour
 3. **Anchor first, then prime**: The joiner's START is sent before the buffered chunks; pre-START the binary only buffers its bounded ring and sends nothing, so anchoring first lets it drain the prime as it streams in
-4. **Fast catch-up**: Device processes buffered audio and catches up to real-time position
-5. **Seamless sync**: Joins live stream perfectly synchronized with other players
-
-This approach significantly reduces the delay when adding players to an active session, as the late joiner receives audio data immediately instead of waiting for new chunks.
-
-**Config option**: `enable_late_join` (default: `True`)
-- If disabled: Session restarts with all players when members change
-- If enabled: New players join seamlessly without interrupting others
+4. **Content mapped onto the acked instant**: The stream position due at that instant is primed from the ring tail (when it is at or behind the write head) or skipped off the head of the live feed (when it is ahead). There is no catch-up: the binary makes the first post-START stdin byte audible exactly at the acked instant and freezes the anchor there
 
 ## DACP (Digital Audio Control Protocol)
 
@@ -426,9 +420,10 @@ protocol path (RAOP, AirPlay 2 RAOP-compat and native).
 1. Start every CLI and wait until every group member reports connected
 2. Wire each member's ffmpeg into its persistent stdin, begin feeding PCM and
    wait until every member confirms the feed flowing (`[STATUS] audio`)
-3. Send one shared `START` (now + 400 ms solo / 500 ms group) to every member;
-   readiness is event-confirmed so the anchor covers only the receiver re-anchor,
-   and the binary bursts the receiver pre-fill from START
+3. Send one shared `START` (now + 400 ms solo / 500 ms warm group / 2500 ms cold
+   group, see `AIRPLAY_COLD_GROUP_START_LEAD_MS`) to every member; readiness is
+   event-confirmed so a warm anchor covers only the receiver re-anchor, and the
+   binary bursts the receiver pre-fill from START
 4. **Warm seek / next-track / grouped resume** reuse the live connections: MA
    stops feeding old audio, kills the per-seek ffmpeg (never the persistent
    stdin), sends `ACTION=FLUSH` to every member and awaits `[STATUS] flushed`,
@@ -466,9 +461,9 @@ grant the binary `CAP_NET_BIND_SERVICE` (for example,
 in the container's bounding set. UDP 319/320 must also be free on the container's
 network namespace.
 
-If the daemon cannot bind, the binary exits with code 2. The provider logs a
-warning and native AirPlay 2 streams fall back to NTP timing. Playback keeps
-working, but native AirPlay 2 multi-room sync may be degraded.
+If the daemon cannot bind, the provider logs a warning and native AirPlay 2
+streams fall back to NTP timing. Playback keeps working, but native AirPlay 2
+multi-room sync may be degraded.
 
 After connect, the binary reports the effective lead and the device's
 buffering window on stdout (`[STATUS] latency lead_ms=... device_min_frames=...
@@ -555,12 +550,6 @@ keeps their exposed player id stable and their Universal Player merging intact.
 - **`native_mrp_credentials`**: Stored native MRP credentials (hidden)
 
 ## Known Issues
-
-### Broken AirPlay Models
-
-Some devices have known broken AirPlay implementations (see `BROKEN_AIRPLAY_MODELS` in [constants.py](constants.py)):
-- **Samsung devices**: Known issues with both RAOP and AirPlay 2
-- These players are disabled by default
 
 ### Limitations
 

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -46,8 +46,8 @@ class ClockReadiness(StrEnum):
     NOT_APPLICABLE = "not_applicable"
     # The receiver never answered our PTP clock and will render silence.
     STALLED = "stalled"
-    # Nothing arrived within the wait: a slow device (retryable) or a binary
-    # too old to report readiness at all.
+    # Nothing arrived within the wait: a slow device (retryable) or a receiver
+    # whose readiness went unreported.
     UNREPORTED = "unreported"
 
 

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -105,6 +105,14 @@ AIRPLAY_CLOCK_READY_TIMEOUT_MS: Final[int] = 2500
 # for the command reaching the binary and for the convergence error of a
 # projection made from the receiver's very first probe.
 AIRPLAY_CLOCK_READY_LEAD_MS: Final[int] = 500
+# Firmware families that advertise SupportsPTP but never render a PTP-timed
+# stream: the receiver runs the full PTP delay exchange yet stays silent at any
+# anchor (verified on the Edifier MS50A), while NTP timing plays fine - Apple
+# senders end up on non-PTP timing with these devices too. Matched as a prefix
+# of the _airplay fv record; a firmware update changes that string, so a fixed
+# generation gets PTP again automatically (the newer LinkPlay platform, e.g.
+# WiiM Pro on p20.4.x, renders PTP correctly and must not match).
+AIRPLAY_BROKEN_PTP_FIRMWARE_PREFIXES: Final[tuple[str, ...]] = ("p20.Linkplay.",)
 # How long a plain (non-join) START waits for the binary's [STATUS] started ack.
 # Nothing holds that ack back, so the window only has to cover the command's trip
 # down the pipe and the answer coming back - unlike a join's ack below, which is

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -476,8 +476,6 @@ class AirPlayPlayer(Player):
                 media,
             )
             await stream_session.start(audio_source)
-            self._attr_elapsed_time = time.time() - stream_session.start_time
-            self._attr_elapsed_time_last_updated = time.time()
             self._transitioning = False
 
     async def volume_set(self, volume_level: int) -> None:

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -826,7 +826,7 @@ class SendspinAirPlayBridge:
         # Always a join: the Sendspin timeline is the group's, never the bridge's
         # to set, so the binary must hold its ack until the receiver clock
         # verification resolves and report the instant it really scheduled.
-        actual = await stream.start(commanded_ms, join=True)
+        acked_adjusted = await stream.start(commanded_ms, join=True)
 
         # The ack can be held for seconds, so re-check ownership before touching
         # any state a newer stream start may already own.
@@ -835,14 +835,6 @@ class SendspinAirPlayBridge:
             or self._airplay_stream is not stream
         ):
             return False
-        if actual is None:
-            self.logger.warning(
-                "AirPlay start for %s was not acknowledged, trusting the commanded "
-                "instant %d - playback may start slightly late",
-                self.airplay_player.display_name,
-                commanded_ms,
-            )
-        acked_adjusted = actual if actual is not None else commanded_ms
         # The command carries the device's sync_adjust; the group timeline does not.
         acked_timeline_ms = acked_adjusted - adjust_ms
         sendspin_now_us = self.sendspin_server.clock.now_us()

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -27,6 +27,7 @@ from music_assistant.helpers.named_pipe import AsyncNamedPipeWriter
 from music_assistant.helpers.process import AsyncProcess
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_ARTWORK_SIZE,
+    AIRPLAY_BROKEN_PTP_FIRMWARE_PREFIXES,
     AIRPLAY_CONTENT_CUT_TOLERANCE_MS,
     AIRPLAY_JOIN_START_ACK_TIMEOUT_MS,
     AIRPLAY_PCM_FORMAT,
@@ -827,9 +828,24 @@ class AirPlayStream:
         # the daemon publishing its clock there is nothing to attach to, and a
         # stream that asks anyway silently takes its own timing instead.
         if target_protocol == StreamingProtocol.AIRPLAY2:
-            shared_ptp = prov.ptp_daemon_ready if use_shared_ptp is None else use_shared_ptp
-            if shared_ptp:
-                args += ["--ptp-shared"]
+            device_fv = str(
+                (airplay_info.decoded_properties.get("fv") if airplay_info else None) or ""
+            )
+            if device_fv.startswith(AIRPLAY_BROKEN_PTP_FIRMWARE_PREFIXES):
+                # This receiver would render silence at any PTP anchor; NTP
+                # timing keeps it audible and still anchored to our clock. A
+                # mixed group is coherent: this member follows the session
+                # timeline over NTP while the others follow it over PTP.
+                args += ["--no-ptp"]
+                self.player.logger.debug(
+                    "Using NTP timing for %s: firmware %s never renders a PTP-timed stream",
+                    self.player.display_name,
+                    device_fv,
+                )
+            else:
+                shared_ptp = prov.ptp_daemon_ready if use_shared_ptp is None else use_shared_ptp
+                if shared_ptp:
+                    args += ["--ptp-shared"]
 
         # Local interface binding
         target_ip = str(self.player.device_info.ip_address)

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -1204,7 +1204,11 @@ class AirPlayStream:
                 # the ack timeout.
                 pass
             else:
-                self._start_ack = (requested, actual)
+                # A line missing at_unix_ms parses as 0, which is never a real
+                # instant: treat it like the malformed ack above rather than
+                # handing the caller 0 as the scheduled instant.
+                if actual:
+                    self._start_ack = (requested, actual)
                 if requested and actual and abs(actual - requested) > 2:
                     # A correction on its own is self-healed: a join lands on it
                     # by design, and a solo start simply adopts it as the anchor.

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -121,7 +121,7 @@ class AirPlayStream:
         # password) fails right away instead of running out its timeout.
         self._process_ended = asyncio.Event()
         # Structured fatal failure the binary reported before exiting; stays
-        # None with an older binary that does not emit the line.
+        # None when it exited without reporting one.
         self._connect_error: CliError | None = None
         # Set when the binary answers an in-place FLUSH, either acknowledging it
         # ([STATUS] flushed) or reporting that it rejected the command, which
@@ -138,8 +138,8 @@ class AirPlayStream:
         self._start_ack: tuple[int, int] | None = None
         self._start_error: CliError | None = None
         # Whether the last commanded START was a late-join start: routes the
-        # correction log levels (a corrected join is the routine landing path,
-        # a corrected origin start is a loud signal).
+        # post-commit correction log level (a corrected join is the routine
+        # landing path, a corrected origin start is a loud signal).
         self._start_was_join = False
         # Receiver storm guard state: last-honored monotonic time per remote
         # transport command, plus a counter of suppressed repeats.
@@ -203,10 +203,6 @@ class AirPlayStream:
         # timeline. Reset per process (and on every re-anchoring START/resume);
         # a new cliairplay re-anchors from scratch.
         self.cumulative_shift_seconds: float = 0.0
-        # Set once the machine-readable [STATUS] REANCHOR line is seen: newer
-        # binaries emit it alongside the legacy warn for the same event, so the
-        # warn line is then ignored to avoid double counting.
-        self._reanchor_status_seen: bool = False
         # Set once a stalled receiver clock has been reported, so the warning
         # stays a single support signal instead of repeating with every
         # clock_ready update of this stream session.
@@ -245,7 +241,7 @@ class AirPlayStream:
         """
         self._check_password_preflight()
         # A fresh cliairplay process re-anchors from scratch, so drop any shift
-        # (and its status-line supersession flag) carried on this stream object.
+        # carried on this stream object.
         self.reset_reanchor_shift()
         args = await self._build_cli_args(use_shared_ptp)
         self.player.logger.debug("Starting cliairplay for player %s", self.player.player_id)
@@ -266,28 +262,29 @@ class AirPlayStream:
         """
         Wait for device connection to be established.
 
-        Also gives the binary's command pipe a moment to open, so the first
-        commands are not dropped. A pipe that never opens is reported but does
-        not fail the wait.
+        Also waits for the binary's command pipe to open, so the first commands
+        are not dropped.
 
         :raises PlayerCommandFailed: If the binary reported that the device needs
-            a password, or rejected the configured one.
+            a password, rejected the configured one, or never opened the command
+            pipe that carries playback commands.
         :raises TimeoutError: If the connection was not established for any other
-            reason (including a binary too old to report one).
+            reason (including an unreported one).
         """
         if not self._cli_proc:
             raise RuntimeError("cliairplay process is not running")
         await self._await_connected()
         # The binary attaches to its command pipe only once it is connected, so
         # the first command waits for that reader instead of being dropped. A
-        # stream torn down while connecting takes its pipe along, which is not a
-        # fault worth reporting.
+        # pipe that never opens leaves the stream unable to be anchored at all,
+        # so it fails the connection rather than letting the caller command a
+        # START nothing can receive. A stream torn down while connecting takes
+        # its pipe along, which is not a fault worth reporting.
         if not await self.commands_pipe.wait_for_reader(_COMMAND_PIPE_READER_TIMEOUT):
             if self.running:
-                self.player.logger.warning(
-                    "cliairplay did not open its command pipe for %s; "
-                    "playback commands cannot be delivered",
-                    self.player.display_name,
+                raise PlayerCommandFailed(
+                    f"cliairplay did not open its command pipe for "
+                    f"{self.player.display_name}; playback commands cannot be delivered"
                 )
         # Nothing has reached this binary yet, so clear the delivery state to
         # make sure the pushes below are really sent.
@@ -459,7 +456,7 @@ class AirPlayStream:
 
     async def start(
         self, start_unix_ms: int = 0, position_ms: int = 0, *, join: bool = False
-    ) -> int | None:
+    ) -> int:
         """
         Anchor playback so the first pending stdin sample is audible at an instant.
 
@@ -478,11 +475,10 @@ class AirPlayStream:
             starts leave it False.
         :return: The true scheduled audible instant (unix ms) from the binary's
             started ack — the commanded instant when it was feasible, the
-            corrected-forward one otherwise; None when no ack arrived (older
-            binary), in which case the commanded instant was applied under the
-            legacy clamp semantics.
+            corrected-forward one otherwise.
         :raises PlayerCommandFailed: If the START command cannot be delivered,
-            or the binary reports that it scheduled no instant.
+            the binary reports that it scheduled no instant, or it never
+            acknowledged the start.
         """
         if not self.running or not self.connected:
             raise RuntimeError("Cannot start playback without a connected cliairplay process")
@@ -533,26 +529,20 @@ class AirPlayStream:
         # re-align a group. A join's ack is held back until the receiver clock
         # verification resolves and therefore gets a much wider window than a
         # plain start, which acks within the command round-trip. A reported
-        # failure answers the wait immediately; no ack within the timeout means
-        # an older binary, so fall back to trusting the commanded instant
-        # (legacy clamp semantics).
+        # failure answers the wait immediately.
         ack_timeout = (
             AIRPLAY_JOIN_START_ACK_TIMEOUT_MS if join else AIRPLAY_START_ACK_TIMEOUT_MS
         ) / 1000
         try:
             await asyncio.wait_for(self._started.wait(), ack_timeout)
-        except TimeoutError:
-            # Only an older binary reaches this now, and the caller treats it as
-            # "the commanded instant stands". Say so: it is the one case where
-            # content is mapped onto an instant nothing confirmed.
-            self.player.logger.warning(
-                "AirPlay player %s did not acknowledge its start within %.1fs; "
-                "assuming the commanded instant %d was applied",
-                self.player.display_name,
-                ack_timeout,
-                start_unix_ms,
-            )
-            return None
+        except TimeoutError as err:
+            # Nothing confirmed the instant, so nothing may be mapped onto it:
+            # an anchor the caller records but the receiver never played is a
+            # timeline every later joiner then aligns itself against.
+            raise PlayerCommandFailed(
+                f"AirPlay player {self.player.display_name} did not acknowledge its "
+                f"start within {ack_timeout:.1f}s (commanded instant {start_unix_ms})"
+            ) from err
         if (error := self._start_error) is not None:
             # Nothing was anchored, so there is no instant to map content onto.
             # Failing here costs the caller the round-trip instead of the whole
@@ -561,7 +551,9 @@ class AirPlayStream:
                 f"cliairplay could not start playback on {self.player.display_name}"
                 + (f": {error.detail}" if error.detail else "")
             )
-        return self._start_ack[1] if self._start_ack else None
+        # A malformed ack still answered the START, so the commanded instant is
+        # what the binary applied (see the parse fallback in _handle_status_line).
+        return self._start_ack[1] if self._start_ack else start_unix_ms
 
     def rebase_position(self, position_ms: int) -> None:
         """
@@ -579,9 +571,8 @@ class AirPlayStream:
         self.player.set_state_from_stream(elapsed_time=self._start_position, stream=self)
 
     def reset_reanchor_shift(self) -> None:
-        """Clear the accumulated re-anchor shift and its status-line supersession flag."""
+        """Clear the accumulated re-anchor shift."""
         self.cumulative_shift_seconds = 0.0
-        self._reanchor_status_seen = False
 
     async def send_metadata(
         self,
@@ -1215,14 +1206,12 @@ class AirPlayStream:
             else:
                 self._start_ack = (requested, actual)
                 if requested and actual and abs(actual - requested) > 2:
-                    # The session re-aligns the group from these acks. A
-                    # corrected join is the routine landing path (the low join
-                    # headroom defers to the binary's readiness correction);
-                    # for origin starts and group convergence rounds a
-                    # correction stays loud — there repeated corrections are
-                    # the support signal that leads/readiness need attention.
-                    player.logger.log(
-                        logging.INFO if self._start_was_join else logging.WARNING,
+                    # A correction on its own is self-healed: a join lands on it
+                    # by design, and a solo start simply adopts it as the anchor.
+                    # Only the session knows when one costs something - a group
+                    # that has to be re-anchored to converge - and it raises that
+                    # to a warning itself.
+                    player.logger.info(
                         "AirPlay start corrected by %+d ms on %s (requested %d, scheduled %d)",
                         actual - requested,
                         player.display_name,
@@ -1275,8 +1264,6 @@ class AirPlayStream:
             return True
         elif "[STATUS] REANCHOR" in line:
             self._parse_reanchor_status(line)
-        elif "Re-anchored" in line and "shifted_frames=" in line:
-            self._parse_reanchor_shift(line)
         elif "[STATUS] error " in line:
             self._parse_error_status(line)
         elif "[ERROR]" in line:
@@ -1295,13 +1282,11 @@ class AirPlayStream:
 
     def _parse_reanchor_status(self, line: str) -> None:
         """
-        Parse the machine-readable [STATUS] REANCHOR line from newer binaries.
+        Parse the machine-readable [STATUS] REANCHOR line.
 
-        Newer cliairplay builds report the shift cumulative since the last
-        start/resume directly, so this SETS the tracked shift (using the sample
-        rate carried on the line when present) and marks the legacy warn line as
-        superseded, since both fire for the same event and would otherwise be
-        double counted.
+        The binary reports the shift cumulative since the last start/resume
+        directly, so this SETS the tracked shift, using the sample rate carried
+        on the line when present.
 
         :param line: The status line, e.g. ``[STATUS] REANCHOR shifted_frames=67870
             total_shifted_frames=135740 sample_rate=44100``.
@@ -1311,34 +1296,9 @@ class AirPlayStream:
             total_frames = int(fields["total_shifted_frames"])
         except KeyError, ValueError:
             return
-        self._reanchor_status_seen = True
         self.cumulative_shift_seconds = total_frames / self._reanchor_sample_rate(
             fields.get("sample_rate")
         )
-        self.player.logger.debug(
-            "cliairplay re-anchored %s after PCM starvation: cumulative shift %.3fs",
-            self.player.display_name,
-            self.cumulative_shift_seconds,
-        )
-
-    def _parse_reanchor_shift(self, line: str) -> None:
-        """
-        Track a legacy cliairplay PCM-starvation re-anchor warning on stderr.
-
-        The warn line reports the per-event shift in frames, so it is accumulated
-        at the session PCM rate. Ignored once the machine-readable [STATUS]
-        REANCHOR line has been seen: newer binaries emit both for the same event
-        and the status line carries the authoritative cumulative total.
-
-        :param line: The raw stderr line, e.g. ``[AP2] Re-anchored after PCM
-            starvation: shifted_frames=67870 lead_frames=77175 count=1``.
-        """
-        if self._reanchor_status_seen:
-            return
-        match = re.search(r"shifted_frames=(\d+)", line)
-        if not match:
-            return
-        self.cumulative_shift_seconds += int(match.group(1)) / self._reanchor_sample_rate(None)
         self.player.logger.debug(
             "cliairplay re-anchored %s after PCM starvation: cumulative shift %.3fs",
             self.player.display_name,
@@ -1507,8 +1467,8 @@ class AirPlayStream:
         Return the error for a connection that was never established.
 
         A binary that reported why it gave up produces a specific, actionable
-        error. Everything else - including an older binary that reports no reason
-        at all - keeps the plain timeout the callers already handle.
+        error. Everything else - including an unreported reason - keeps the plain
+        timeout the callers already handle.
         """
         error = self._connect_error
         if error and error.code == CLI_ERROR_AUTH_REQUIRED:

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -1093,7 +1093,7 @@ class AirPlayStreamSession:
         """
         Return the latest receiver-clock readiness any member reported.
 
-        Members that report nothing are not represented in the result; the
+        Members that report nothing contribute no instant to the maximum; the
         caller anchors those on its lead alone.
 
         :return: Unix epoch ms of the latest projection any member reported, or 0

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -49,7 +49,7 @@ _CLOCK_READINESS_NOTES: dict[ClockReadiness, str] = {
     ClockReadiness.NOT_APPLICABLE: "runs on NTP timing, so there is none to wait for; "
     "anchoring on the join floor",
     ClockReadiness.UNREPORTED: "was not reported within {timeout:.1f}s (a slow device, or a "
-    "binary too old to report it); anchoring on the join floor",
+    "receiver that never answered); anchoring on the join floor",
 }
 
 
@@ -640,11 +640,9 @@ class AirPlayStreamSession:
                     )
                     return
                 # Map the content onto the instant the binary acked — its
-                # verified truth — falling back to the commanded instant when no
-                # ack arrived (older binary). The ring is re-snapshotted here, so
-                # the mapping covers whatever the group was fed while the ack was
-                # outstanding.
-                acked_at = (actual - adjust_ms) / 1000 if actual is not None else requested_at
+                # verified truth. The ring is re-snapshotted here, so the mapping
+                # covers whatever the group was fed while the ack was outstanding.
+                acked_at = (actual - adjust_ms) / 1000
                 start_at, fed_pos_due, prime, skip_bytes = map_to(acked_at, committed=True)
                 self._client_skip_bytes[airplay_player.player_id] = skip_bytes
                 # An instant that moved carries the content mapped onto it
@@ -753,11 +751,17 @@ class AirPlayStreamSession:
         self._pcm_buffer_max = self._ring_bytes_for(lead)
 
     def _session_is_live(self) -> bool:
-        """Return whether the session still has a running reference member (call under the lock)."""
+        """Return whether the session still plays a joinable timeline (call under the lock)."""
         if not self.sync_clients:
             return False
-        reference_stream = self.sync_clients[0].stream
-        return reference_stream is not None and reference_stream.running
+        reference = self.sync_clients[0]
+        reference_stream = reference.stream
+        if reference_stream is None or not reference_stream.running:
+            return False
+        # A parked (standby) session keeps every member's stream running while
+        # its timeline is gone - the anchor is stale and nothing is being fed -
+        # so only a member that is actually playing can absorb a joiner.
+        return reference.playback_state == PlaybackState.PLAYING
 
     async def _resolve_shared_ptp(self, ap2_members: int | None = None) -> bool:
         """
@@ -1093,18 +1097,17 @@ class AirPlayStreamSession:
         caller anchors those on its lead alone.
 
         :return: Unix epoch ms of the latest projection any member reported, or 0
-            when there is nothing to wait for — a solo start, a receiver on NTP
-            timing, one that never answered, or a binary too old to report. The
-            caller then anchors on its lead alone.
+            when there is nothing to wait for — a receiver on NTP timing, or one
+            that never answered. The caller then anchors on its lead alone.
         """
-        if len(self.sync_clients) == 1:
-            # A lone receiver has no partner to be late against, so waiting only
-            # delays it; the instant matters once members have to agree on one.
-            # This assumes it seats a fresh session quickly, which holds for the
-            # receivers measured (Sonos, Apple, Samsung) but not for every one:
-            # a receiver that does need its clock up front - a multiroom master,
-            # say - is covered by a separate readiness decision, not this one.
-            return 0
+        # A solo start waits for the projection too: a receiver that has not
+        # seated its clock renders silence at an anchor it cannot honor, and
+        # enough of them need that time (WiiM, Edifier) that no start may assume
+        # otherwise. It costs a warm clock nothing - the binary reports it ready
+        # with a past instant right after connect - and a cold one anchors just
+        # past its own projection instead of being corrected there by the binary
+        # afterwards: the same instant, planned rather than repaired, with the
+        # readiness lead's slack on top.
         results = await asyncio.gather(
             *[
                 p.stream.wait_clock_ready(timeout=AIRPLAY_CLOCK_READY_TIMEOUT_MS / 1000)
@@ -1150,7 +1153,7 @@ class AirPlayStreamSession:
         target_ms = start_unix_ms
         corrected_ms = start_unix_ms
         for _ in range(4):
-            member_tasks: list[tuple[int, asyncio.Task[int | None]]] = []
+            member_tasks: list[tuple[int, asyncio.Task[int]]] = []
             async with asyncio.TaskGroup() as task_group:
                 for player in self.sync_clients:
                     stream = player.stream
@@ -1168,10 +1171,7 @@ class AirPlayStreamSession:
                     )
             corrected_ms = target_ms
             for adjust_ms, task in member_tasks:
-                actual = task.result()
-                if actual is None:
-                    continue  # older binary without a started ack
-                corrected_ms = max(corrected_ms, actual - adjust_ms)
+                corrected_ms = max(corrected_ms, task.result() - adjust_ms)
             if corrected_ms <= target_ms + 2:
                 break
             if len(member_tasks) == 1:

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -571,6 +571,11 @@ def _raop_player() -> MagicMock:
     return player
 
 
+async def _ack_commanded_instant(start_unix_ms: int = 0, *_args: object, **_kwargs: object) -> int:
+    """Ack a START at exactly the instant it was commanded, as a feasible one is."""
+    return start_unix_ms
+
+
 def _make_ptp_session(prov: MagicMock, sync_clients: list[MagicMock]) -> AirPlayStreamSession:
     """Build a stream session wired to a mock provider for PTP-decision tests."""
     pcm_format = MagicMock()
@@ -624,6 +629,7 @@ async def test_raop_session_resolves_ptp_for_first_ap2_late_joiner() -> None:
     prov = MagicMock()
     raop_player = _raop_player()
     raop_player.player_id = "raop"
+    raop_player.playback_state = PlaybackState.PLAYING
     raop_player.stream = MagicMock()
     raop_player.stream.running = True
     raop_player.stream.cumulative_shift_seconds = 0.0
@@ -648,10 +654,10 @@ async def test_raop_session_resolves_ptp_for_first_ap2_late_joiner() -> None:
         player.stream = MagicMock(running=True, connected=True)
         player.stream.wait_for_connection = AsyncMock()
         player.stream.flush = AsyncMock(return_value=True)
-        # Verified-start API defaults: no started ack, no warm-lead constraint
-        # and no receiver clock projection (an older binary), so the test
-        # asserts the commanded values directly.
-        player.stream.start = AsyncMock(return_value=None)
+        # Verified-start API defaults: every START is acked at the commanded
+        # instant, with no warm-lead constraint and no receiver clock
+        # projection, so the test asserts the commanded values directly.
+        player.stream.start = AsyncMock(side_effect=_ack_commanded_instant)
         player.stream.wait_clock_ready = AsyncMock(return_value=(ClockReadiness.UNREPORTED, 0))
         player.stream.warm_lead_ms = 0
         player.stream.flushed_head_unix_ms = 0
@@ -679,7 +685,7 @@ async def test_session_start_applies_uniform_ptp_decision_to_all_members() -> No
         player.stream.wait_for_connection = AsyncMock()
         player.stream.wait_audio_present = AsyncMock(return_value=True)
         player.stream.wait_clock_ready = AsyncMock(return_value=(ClockReadiness.UNREPORTED, 0))
-        player.stream.start = AsyncMock(return_value=None)
+        player.stream.start = AsyncMock(side_effect=_ack_commanded_instant)
     session = _make_ptp_session(prov, players)
 
     with (
@@ -704,7 +710,7 @@ async def test_session_start_calculates_anchor_after_ptp_resolution() -> None:
         player.stream.wait_for_connection = AsyncMock()
         player.stream.wait_audio_present = AsyncMock(return_value=True)
         player.stream.wait_clock_ready = AsyncMock(return_value=(ClockReadiness.UNREPORTED, 0))
-        player.stream.start = AsyncMock(return_value=None)
+        player.stream.start = AsyncMock(side_effect=_ack_commanded_instant)
         player.config.get_value = MagicMock(return_value=0)
     session = _make_ptp_session(prov, players)
     now = 100.0

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -478,7 +478,14 @@ def _make_anchor_stream(
     must be real numbers: the anchor compares ``warm_lead_ms`` /
     ``flushed_head_unix_ms`` with ``> 0`` and the shift fold subtracts
     ``cumulative_shift_seconds``, none of which a bare MagicMock can answer.
+
+    :param ack: Instant the binary acks the START at. None acks the commanded
+        instant, as a feasible one is.
     """
+
+    async def _ack_start(start_unix_ms: int = 0, **_kwargs: object) -> int:
+        return start_unix_ms if ack is None else ack
+
     stream = MagicMock()
     stream.cumulative_shift_seconds = 0.0
     stream.connect = AsyncMock()
@@ -486,7 +493,7 @@ def _make_anchor_stream(
     stream.stop = AsyncMock()
     stream.flush = AsyncMock(return_value=True)
     stream.wait_clock_ready = AsyncMock(return_value=(ClockReadiness.PROJECTED, ready_at_unix_ms))
-    stream.start = AsyncMock(return_value=ack)
+    stream.start = AsyncMock(side_effect=_ack_start)
     stream.warm_lead_ms = warm_lead_ms
     stream.flushed_head_unix_ms = flushed_head_unix_ms
     return stream
@@ -1205,21 +1212,6 @@ async def test_warm_anchor_clears_the_receivers_queued_audio(
     assert await _anchor(bridge, stream, warm=True) is True
 
     assert _commanded_instant(stream) == UNIX_NOW_MS + expected_anchor_offset_ms + adjust_ms
-
-
-async def test_missing_ack_falls_back_to_the_commanded_instant() -> None:
-    """An older binary that never acks must not wedge the writer."""
-    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-    stream = _make_anchor_stream(ack=None)
-    _prepare_anchor(bridge, stream, first_chunk_lead_ms=250)
-
-    assert await _anchor(bridge, stream) is True
-
-    commanded = UNIX_NOW_MS + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS
-    assert bridge._start_unix_ms == commanded
-    assert bridge._drop_until_us == SENDSPIN_EPOCH_US + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS * 1_000
-    assert bridge._anchor_settled is True
-    assert bridge._airplay_stream_ready.is_set()
 
 
 async def test_superseded_during_the_ack_mutates_nothing() -> None:

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -1498,6 +1498,20 @@ async def test_start_accepts_a_malformed_ack_as_the_commanded_instant() -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_treats_a_missing_scheduled_instant_as_malformed() -> None:
+    """An ack without at_unix_ms parses cleanly to 0, which must never be returned."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+
+    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True):
+        start_task = asyncio.create_task(stream.start(START_UNIX_MS, 0))
+        await asyncio.sleep(0)
+        stream._handle_status_line(f"[STATUS] started requested_unix_ms={START_UNIX_MS}")
+        assert await start_task == START_UNIX_MS
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("join", "expected_timeout"),
     [

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -292,6 +292,29 @@ async def test_cli_args_no_ptp_shared_when_daemon_alive_but_not_ready() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cli_args_broken_ptp_firmware_routes_to_ntp() -> None:
+    """
+    Old-LinkPlay platform firmware gets --no-ptp instead of the shared clock.
+
+    These receivers advertise SupportsPTP but render silence at any PTP anchor
+    (Edifier MS50A), so the stream routes them to NTP timing. The newer LinkPlay
+    platform (WiiM, fv without the Linkplay token) renders PTP fine and must
+    keep the shared clock.
+    """
+    player = _make_player()
+    player.airplay_discovery_info.decoded_properties["fv"] = "p20.Linkplay.4.6.430230"
+    args = await _build_args(player)
+    assert "--no-ptp" in args
+    assert "--ptp-shared" not in args
+
+    player = _make_player()
+    player.airplay_discovery_info.decoded_properties["fv"] = "p20.4.8.814756"
+    args = await _build_args(player)
+    assert "--no-ptp" not in args
+    assert "--ptp-shared" in args
+
+
+@pytest.mark.asyncio
 async def test_cli_args_no_latency_override() -> None:
     """The playback lead/buffer is binary-managed; MA never passes --latency."""
     player = _make_player()

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -1465,10 +1465,8 @@ async def test_start_returns_the_instant_the_binary_scheduled() -> None:
 
 
 @pytest.mark.asyncio
-async def test_start_reports_no_instant_when_the_ack_never_arrives(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """An unacknowledged START reports no instant and says the commanded one is assumed."""
+async def test_start_fails_when_the_ack_never_arrives() -> None:
+    """An unacknowledged START fails: nothing may be mapped onto an unconfirmed instant."""
     stream = AirPlayStream(_make_player())
     stream._cli_proc = MagicMock(closed=False)
     stream._connected.set()
@@ -1476,12 +1474,27 @@ async def test_start_reports_no_instant_when_the_ack_never_arrives(
     with (
         patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True),
         patch("music_assistant.providers.airplay.stream.AIRPLAY_START_ACK_TIMEOUT_MS", 10),
-        caplog.at_level(logging.WARNING),
+        pytest.raises(PlayerCommandFailed, match="did not acknowledge its start") as err,
     ):
-        assert await stream.start(START_UNIX_MS, 0) is None
+        await stream.start(START_UNIX_MS, 0)
 
-    assert "did not acknowledge its start" in caplog.text
-    assert str(START_UNIX_MS) in caplog.text
+    # the player and the instant nothing confirmed are the whole diagnostic
+    assert "Player A" in str(err.value)
+    assert str(START_UNIX_MS) in str(err.value)
+
+
+@pytest.mark.asyncio
+async def test_start_accepts_a_malformed_ack_as_the_commanded_instant() -> None:
+    """An ack that cannot be parsed still answered the START, so the commanded instant stands."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+
+    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True):
+        start_task = asyncio.create_task(stream.start(START_UNIX_MS, 0))
+        await asyncio.sleep(0)
+        stream._handle_status_line("[STATUS] started requested_unix_ms=nonsense at_unix_ms=")
+        assert await start_task == START_UNIX_MS
 
 
 @pytest.mark.asyncio
@@ -1511,8 +1524,9 @@ async def test_start_ack_window_matches_the_arm(join: bool, expected_timeout: fl
             "music_assistant.providers.airplay.stream.asyncio.wait_for",
             side_effect=record_timeout,
         ),
+        pytest.raises(PlayerCommandFailed),
     ):
-        assert await stream.start(START_UNIX_MS, 0, join=join) is None
+        await stream.start(START_UNIX_MS, 0, join=join)
 
     assert timeouts == [expected_timeout]
 
@@ -1675,52 +1689,36 @@ def test_elapsed_includes_start_position() -> None:
     )
 
 
-def test_legacy_reanchor_warns_accumulate_per_event() -> None:
-    """The legacy warn line reports a per-event shift, so successive events accumulate."""
+def test_reanchor_status_sets_the_cumulative_total() -> None:
+    """Each [STATUS] REANCHOR line carries the authoritative total, so it SETS the shift."""
     stream = AirPlayStream(_make_player())
     assert stream.cumulative_shift_seconds == 0.0
 
-    for _event in range(2):
-        assert (
-            stream._handle_status_line(
-                "[AP2] Re-anchored after PCM starvation: "
-                "shifted_frames=67870 lead_frames=77175 count=1"
-            )
-            is False
-        )
-
-    # two +1.539s events accumulate to ~3.078s
-    assert stream.cumulative_shift_seconds == pytest.approx(2 * 67870 / 44100)
-
-
-def test_reanchor_status_supersedes_legacy_warn() -> None:
-    """The [STATUS] REANCHOR total is authoritative and stops the legacy warn double count."""
-    stream = AirPlayStream(_make_player())
-
-    # a first legacy warn accumulates until the status line arrives
-    stream._handle_status_line(
-        "[AP2] Re-anchored after PCM starvation: shifted_frames=67870 lead_frames=77175 count=1"
-    )
-    # the machine-readable line SETS from the cumulative total and supersedes the warn
     assert (
         stream._handle_status_line(
             "[STATUS] REANCHOR shifted_frames=67870 total_shifted_frames=67870 sample_rate=44100"
         )
         is False
     )
-    assert stream._reanchor_status_seen is True
     assert stream.cumulative_shift_seconds == pytest.approx(67870 / 44100)
 
-    # both lines fire per event for new binaries: the warn that follows is ignored,
-    # only the status line's cumulative total is tracked (no double count)
-    stream._handle_status_line(
-        "[AP2] Re-anchored after PCM starvation: shifted_frames=67870 lead_frames=77175 count=2"
-    )
-    assert stream.cumulative_shift_seconds == pytest.approx(67870 / 44100)
+    # the second event reports the running total, never a delta to add
     stream._handle_status_line(
         "[STATUS] REANCHOR shifted_frames=67870 total_shifted_frames=135740 sample_rate=44100"
     )
     assert stream.cumulative_shift_seconds == pytest.approx(135740 / 44100)
+
+
+def test_human_readable_reanchor_warn_is_not_counted() -> None:
+    """The binary's warn line accompanies the status line; counting it would double it."""
+    stream = AirPlayStream(_make_player())
+
+    ended = stream._handle_status_line(
+        "[AP2] Re-anchored after PCM starvation: shifted_frames=67870 lead_frames=77175 count=1"
+    )
+
+    assert ended is False
+    assert stream.cumulative_shift_seconds == 0.0
 
 
 def test_reanchor_status_prefers_line_sample_rate() -> None:
@@ -1747,28 +1745,15 @@ def test_reanchor_status_ignores_line_without_total() -> None:
     stream._handle_status_line("[STATUS] REANCHOR shifted_frames=67870 sample_rate=44100")
 
     assert stream.cumulative_shift_seconds == 1.5
-    assert stream._reanchor_status_seen is False
-
-
-def test_reanchor_shift_ignores_line_without_frames() -> None:
-    """A malformed legacy re-anchor line leaves the tracked shift unchanged."""
-    stream = AirPlayStream(_make_player())
-    stream.cumulative_shift_seconds = 1.5
-
-    ended = stream._handle_status_line("[AP2] Re-anchored after PCM starvation: shifted_frames=")
-
-    assert ended is False
-    assert stream.cumulative_shift_seconds == 1.5
 
 
 @pytest.mark.asyncio
 async def test_start_resets_reanchor_shift() -> None:
-    """A START re-anchors from scratch, clearing the shift and the status flag."""
+    """A START re-anchors from scratch, clearing the accumulated shift."""
     stream = AirPlayStream(_make_player())
     stream._cli_proc = MagicMock(closed=False)
     stream._connected.set()
     stream.cumulative_shift_seconds = 3.078
-    stream._reanchor_status_seen = True
 
     with patch.object(
         stream,
@@ -1779,16 +1764,14 @@ async def test_start_resets_reanchor_shift() -> None:
         assert await stream.start(START_UNIX_MS, 0) == START_UNIX_MS
 
     assert stream.cumulative_shift_seconds == 0.0
-    assert stream._reanchor_status_seen is False
 
 
 @pytest.mark.asyncio
 async def test_connect_resets_accumulated_shift() -> None:
-    """A fresh cliairplay process starts from a zero playout shift and cleared flag."""
+    """A fresh cliairplay process starts from a zero playout shift."""
     player = _make_player()
     stream = AirPlayStream(player)
     stream.cumulative_shift_seconds = 5.0
-    stream._reanchor_status_seen = True
     process = MagicMock(closed=False)
     process.start = AsyncMock(return_value=None)
 
@@ -1807,7 +1790,6 @@ async def test_connect_resets_accumulated_shift() -> None:
         await stream.connect()
 
     assert stream.cumulative_shift_seconds == 0.0
-    assert stream._reanchor_status_seen is False
 
 
 @pytest.mark.asyncio
@@ -1919,8 +1901,8 @@ async def test_deferred_volume_resend_reads_the_state_when_it_fires() -> None:
 
 
 @pytest.mark.asyncio
-async def test_wait_for_connection_reports_an_unread_command_pipe() -> None:
-    """A binary that never attaches to the command pipe is reported for the player it serves."""
+async def test_wait_for_connection_fails_on_an_unread_command_pipe() -> None:
+    """A binary that never attaches to the command pipe can never be anchored: fail the connect."""
     player = _make_player()
     player.logger = MagicMock()
     player.volume_muted = False
@@ -1934,12 +1916,12 @@ async def test_wait_for_connection_reports_an_unread_command_pipe() -> None:
         ) as wait_for_reader,
         patch.object(stream, "_send_current_metadata", new_callable=AsyncMock),
         patch.object(stream, "send_cli_command", return_value=None),
+        pytest.raises(PlayerCommandFailed, match="command pipe") as err,
     ):
         await stream.wait_for_connection()
 
     wait_for_reader.assert_awaited_once()
-    player.logger.warning.assert_called_once()
-    assert player.display_name in player.logger.warning.call_args.args
+    assert player.display_name in str(err.value)
 
 
 @pytest.mark.asyncio
@@ -2759,7 +2741,7 @@ async def test_generic_connect_failure_keeps_the_timeout_semantics() -> None:
 @pytest.mark.asyncio
 async def test_dead_process_fails_the_connect_wait_immediately() -> None:
     """
-    An older binary reports no reason at all, so the wait keeps its timeout error.
+    A binary that reports no reason at all leaves the wait its plain timeout error.
 
     It must still end the moment the process is gone instead of running out the
     full connect timeout.

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -30,14 +30,20 @@ from music_assistant.providers.airplay.stream_session import AirPlayStreamSessio
 PCM_SAMPLE_SIZE = 176400  # 44.1kHz / 16-bit / 2ch
 
 
+async def _ack_commanded_instant(start_unix_ms: int = 0, *_args: Any, **_kwargs: Any) -> int:
+    """Ack a START at exactly the instant it was commanded, as a feasible one is."""
+    return start_unix_ms
+
+
 def _stream_defaults(stream: MagicMock) -> MagicMock:
     """
     Apply the verified-start API defaults to a mocked stream.
 
-    No started ack, no warm-lead constraint and no receiver clock projection,
-    matching an older binary, so the tests assert the commanded values directly.
+    Every START is acked at the commanded instant, with no warm-lead constraint
+    and no receiver clock projection, so the tests assert the commanded values
+    directly.
     """
-    stream.start = AsyncMock(return_value=None)
+    stream.start = AsyncMock(side_effect=_ack_commanded_instant)
     stream.wait_clock_ready = AsyncMock(return_value=(ClockReadiness.UNREPORTED, 0))
     stream.warm_lead_ms = 0
     stream.flushed_head_unix_ms = 0
@@ -65,6 +71,8 @@ def _make_session(
     leader = MagicMock()
     leader.player_id = "leader"
     leader.protocol = StreamingProtocol.RAOP
+    # a joinable session has a reference member that is actually playing
+    leader.playback_state = PlaybackState.PLAYING
     leader.stream = _stream_defaults(MagicMock())
     leader.stream.running = True
     leader.stream.connected = True
@@ -185,9 +193,10 @@ async def test_initial_group_waits_for_every_member_before_shared_start(
         async def wait_for_connection() -> None:
             operations.append(f"connected:{player.player_id}")
 
-        async def start(start_unix_ms: int, position_ms: int) -> None:
+        async def start(start_unix_ms: int, position_ms: int) -> int:
             assert position_ms == 12_000
             operations.append(f"started:{player.player_id}:{start_unix_ms}")
+            return start_unix_ms
 
         stream.wait_for_connection = AsyncMock(side_effect=wait_for_connection)
         stream.wait_audio_present = AsyncMock(return_value=True)
@@ -251,8 +260,40 @@ async def test_group_start_never_anchors_before_every_receiver_clock_is_usable()
 
 
 @pytest.mark.asyncio
-async def test_solo_start_does_not_wait_for_a_clock_projection() -> None:
-    """A lone receiver seats itself, so its start keeps the short lead."""
+async def test_solo_start_waits_for_the_receiver_clock_projection() -> None:
+    """A lone receiver on a cold clock renders silence, so its anchor waits for it too."""
+    now = 100.0
+    ready_at_unix_ms = int(now * 1000) + 5_000
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.protocol = StreamingProtocol.AIRPLAY2
+    player.config.get_value = MagicMock(return_value=0)
+
+    async def start_client(_player: MagicMock, _use_shared_ptp: bool) -> None:
+        stream = _stream_defaults(MagicMock(running=True))
+        stream.wait_for_connection = AsyncMock()
+        stream.wait_audio_present = AsyncMock(return_value=True)
+        stream.wait_clock_ready = AsyncMock(
+            return_value=(ClockReadiness.PROJECTED, ready_at_unix_ms)
+        )
+        player.stream = stream
+
+    with (
+        patch.object(session, "_start_client", side_effect=start_client),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch.object(session, "_resolve_shared_ptp", new_callable=AsyncMock, return_value=False),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
+    ):
+        await session.start(MagicMock())
+
+    player.stream.wait_clock_ready.assert_awaited_once()
+    # the projection is further out than the solo lead, so it carries the anchor
+    assert player.stream.start.await_args.args[0] == ready_at_unix_ms + AIRPLAY_CLOCK_READY_LEAD_MS
+
+
+@pytest.mark.asyncio
+async def test_solo_start_with_a_usable_clock_keeps_the_short_lead() -> None:
+    """A warm clock reports ready with a past instant, so waiting for it costs nothing."""
     now = 100.0
     session = _make_session(0, 0)
     player: Any = session.sync_clients[0]
@@ -263,9 +304,9 @@ async def test_solo_start_does_not_wait_for_a_clock_projection() -> None:
         stream = _stream_defaults(MagicMock(running=True))
         stream.wait_for_connection = AsyncMock()
         stream.wait_audio_present = AsyncMock(return_value=True)
-        # A projection far in the future must not delay a solo start.
+        # already usable: the projection sits a second in the past
         stream.wait_clock_ready = AsyncMock(
-            return_value=(ClockReadiness.PROJECTED, int(now * 1000) + 5_000)
+            return_value=(ClockReadiness.PROJECTED, int(now * 1000) - 1_000)
         )
         player.stream = stream
 
@@ -278,7 +319,6 @@ async def test_solo_start_does_not_wait_for_a_clock_projection() -> None:
         await session.start(MagicMock())
 
     assert player.stream.start.await_args.args[0] == int(now * 1000) + AIRPLAY_START_LEAD_MS
-    player.stream.wait_clock_ready.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -334,6 +374,43 @@ async def test_corrected_solo_start_adopts_the_instant_without_reanchoring() -> 
 
 
 @pytest.mark.asyncio
+async def test_group_start_fails_when_a_member_never_acknowledges() -> None:
+    """An unacknowledged member start fails the session instead of recording its instant."""
+    session = _make_session(0, 0)
+    first_player: Any = session.sync_clients[0]
+    first_player.protocol = StreamingProtocol.RAOP
+    second_player = MagicMock(player_id="silent", protocol=StreamingProtocol.RAOP)
+    second_player.config.get_value = MagicMock(return_value=0)
+    session.sync_clients.append(second_player)
+    anchor_before = (session.start_unix_ms, session.start_time)
+
+    async def start_client(player: MagicMock, _use_shared_ptp: bool) -> None:
+        stream = _stream_defaults(MagicMock(running=True))
+        stream.wait_for_connection = AsyncMock()
+        stream.wait_audio_present = AsyncMock(return_value=True)
+        if player is second_player:
+            stream.start = AsyncMock(
+                side_effect=PlayerCommandFailed(
+                    "AirPlay player Player B did not acknowledge its start within 2.0s"
+                )
+            )
+        player.stream = stream
+
+    with (
+        patch.object(session, "_start_client", side_effect=start_client),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch.object(session, "stop", new_callable=AsyncMock) as stop_session,
+        pytest.raises(PlayerCommandFailed, match="did not acknowledge its start"),
+    ):
+        await session.start(MagicMock())
+
+    # Nothing may be recorded from a round that had no verified answer: an
+    # anchor the group never played is what every later joiner aligns against.
+    assert (session.start_unix_ms, session.start_time) == anchor_before
+    stop_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "protocol",
     [StreamingProtocol.RAOP, StreamingProtocol.AIRPLAY2],
@@ -351,7 +428,6 @@ async def test_initial_single_player_starts_after_connect(
     stream.wait_for_connection = AsyncMock()
     stream.wait_audio_present = AsyncMock(return_value=True)
     stream.flush = AsyncMock(return_value=True)
-    stream.start = AsyncMock(return_value=None)
 
     async def start_client(_player: MagicMock, _use_shared_ptp: bool) -> None:
         player.stream = stream
@@ -384,7 +460,6 @@ async def test_initial_connection_failure_never_starts_partial_group() -> None:
             stream.wait_for_connection = AsyncMock(side_effect=TimeoutError("connect timeout"))
         else:
             stream.wait_for_connection = AsyncMock()
-        stream.start = AsyncMock(return_value=None)
         player.stream = stream
 
     with (
@@ -473,7 +548,6 @@ async def test_initial_connection_cancellation_never_starts_group() -> None:
         await asyncio.Event().wait()
 
     stream.wait_for_connection = AsyncMock(side_effect=wait_for_connection)
-    stream.start = AsyncMock(return_value=None)
 
     async def start_client(_player: MagicMock, _use_shared_ptp: bool) -> None:
         player.stream = stream
@@ -576,7 +650,6 @@ async def test_standby_resumes_warm_on_existing_streams(
         player.stream.send_cli_command = AsyncMock(return_value=True)
         player.stream.wait_audio_present = AsyncMock(return_value=True)
         player.stream.flush = AsyncMock(return_value=True)
-        player.stream.start = AsyncMock(return_value=None)
         players.append(player)
         original_streams[player.player_id] = player.stream
     session.sync_clients = players
@@ -624,7 +697,6 @@ async def test_warm_replace_flushes_all_before_starting_any() -> None:
 
         stream.flush = AsyncMock(side_effect=flush)
         stream.wait_audio_present = AsyncMock(return_value=True)
-        stream.start = AsyncMock(return_value=None)
         player.stream = stream
         players.append(player)
     session.sync_clients = players
@@ -664,7 +736,6 @@ async def test_warm_replace_stops_old_audio_and_ffmpeg_before_flush() -> None:
         return True
 
     stream.flush = AsyncMock(side_effect=flush)
-    stream.start = AsyncMock(return_value=None)
     old_ffmpeg = MagicMock(closed=False)
 
     async def kill_ffmpeg() -> None:
@@ -706,7 +777,6 @@ async def test_warm_replace_flush_failure_falls_back_to_cold() -> None:
         player.config.get_value = MagicMock(return_value=0)
         stream = _stream_defaults(MagicMock(running=True, connected=True))
         stream.flush = AsyncMock(return_value=acked)
-        stream.start = AsyncMock(return_value=None)
         player.stream = stream
         players.append(player)
     session.sync_clients = players
@@ -1014,6 +1084,58 @@ async def test_late_join_start_failure_stops_client() -> None:
 
 
 @pytest.mark.asyncio
+async def test_late_join_unacknowledged_start_stops_client() -> None:
+    """A joiner whose START is never acked is torn down, never mapped onto that instant."""
+    session = _make_session(time.time() - 10, 12.5)
+    player = _make_late_joiner()
+
+    def setup_unacknowledged_start(*_args: Any, **_kwargs: Any) -> None:
+        _setup_stream(player)()
+        player.stream.start = AsyncMock(
+            side_effect=PlayerCommandFailed(
+                "AirPlay player Player B did not acknowledge its start within 5.0s"
+            )
+        )
+
+    with (
+        patch.object(session, "_start_client", side_effect=setup_unacknowledged_start),
+        patch.object(session, "stop_client", new_callable=AsyncMock) as stop_client,
+    ):
+        await session.add_client(player)
+
+    assert player not in session.sync_clients
+    assert player.player_id not in session._client_skip_bytes
+    player.stream.rebase_position.assert_not_called()
+    stop_client.assert_awaited_once_with(player, reason="late joiner start/prime failed")
+
+
+@pytest.mark.asyncio
+async def test_late_join_refuses_a_parked_session() -> None:
+    """A parked (standby) session has no live timeline, so it cannot absorb a joiner."""
+    session = _make_session(time.time() - 10, 12.5)
+    reference: Any = session.sync_clients[0]
+    reference.stream.send_cli_command = AsyncMock(return_value=True)
+    reference.set_state_from_stream = MagicMock(
+        side_effect=lambda **kwargs: setattr(reference, "playback_state", kwargs["state"])
+    )
+    assert await session.standby()
+    assert reference.playback_state == PlaybackState.PAUSED
+    player = _make_late_joiner()
+
+    with (
+        patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start,
+        patch.object(session, "stop_client", new_callable=AsyncMock) as stop_client,
+    ):
+        await session.add_client(player)
+
+    # The parked session zeroed seconds_streamed while start_time stayed put, so
+    # anchoring here maps the joiner onto a timeline nothing is playing.
+    mock_start.assert_not_called()
+    stop_client.assert_not_awaited()
+    assert player not in session.sync_clients
+
+
+@pytest.mark.asyncio
 async def test_late_join_no_running_session() -> None:
     """Test that add_client is a no-op when no session is running."""
     now = time.time()
@@ -1208,7 +1330,7 @@ async def test_late_join_floor_wins_over_a_clock_that_is_already_ready() -> None
 
 @pytest.mark.asyncio
 async def test_late_join_falls_back_to_the_floor_without_a_clock_projection() -> None:
-    """No projection (older binary, NTP timing or a silent receiver) anchors on the floor."""
+    """No projection (NTP timing or a silent receiver) anchors on the floor."""
     # Freeze time so both the test and the code under test agree on `now`.
     now = 1_000_000.0
     session = _make_session(now - 5.0, 5.0)
@@ -1333,10 +1455,11 @@ async def test_late_join_feed_keeps_flowing_while_start_ack_is_outstanding() -> 
     def setup_deferred_ack(*_args: Any, **_kwargs: Any) -> None:
         _setup_stream(player)()
 
-        async def start(*_args: Any, **_kwargs: Any) -> None:
+        async def start(start_unix_ms: int, *_args: Any, **_kwargs: Any) -> int:
             # the binary holds its ack until the receiver clock is verified
             ack_outstanding.set()
             await ack_released.wait()
+            return start_unix_ms
 
         player.stream.start = AsyncMock(side_effect=start)
 
@@ -1516,7 +1639,6 @@ async def test_replace_clears_skip_and_shift_state() -> None:
     stream.connected = True
     stream.flush = AsyncMock(return_value=True)
     stream.wait_audio_present = AsyncMock(return_value=True)
-    stream.start = AsyncMock(return_value=None)
     session._client_skip_bytes[player.player_id] = 999
 
     with (
@@ -1577,11 +1699,12 @@ async def test_late_join_pads_with_silence_when_the_ring_ran_out_under_a_committ
     def setup_with_feed(*_args: Any, **_kwargs: Any) -> None:
         _setup_stream(player)()
 
-        async def start(_start_unix_ms: int, _position_ms: int, *, join: bool = False) -> None:
+        async def start(start_unix_ms: int, _position_ms: int, *, join: bool = False) -> int:
             assert join is True
             # The group keeps being fed while the START ack is outstanding: this
             # is what pushes the joiner's due position off the back of the ring.
             await session._write_chunk_to_all_players(b"\x02" * int(2.0 * PCM_SAMPLE_SIZE))
+            return start_unix_ms
 
         player.stream.start = AsyncMock(side_effect=start)
 
@@ -1631,9 +1754,10 @@ async def test_late_join_ring_shortfall_keeps_a_misaligned_ring_head_frame_align
     def setup_with_feed(*_args: Any, **_kwargs: Any) -> None:
         _setup_stream(player)()
 
-        async def start(_start_unix_ms: int, _position_ms: int, *, join: bool = False) -> None:
+        async def start(start_unix_ms: int, _position_ms: int, *, join: bool = False) -> int:
             assert join is True
             await session._write_chunk_to_all_players(b"\x02" * (int(2.0 * PCM_SAMPLE_SIZE) + 1))
+            return start_unix_ms
 
         player.stream.start = AsyncMock(side_effect=start)
 


### PR DESCRIPTION
# What does this implement/fix?

Pre-beta fixes from a full audit, plus the two field reports from today.

A start the speaker never acknowledged was assumed to have worked: the session
recorded a start instant nothing played on and reported PLAYING while the
speaker sat silent - reachable whenever the command pipe never gained a
reader. And a speaker playing on its own skipped the wait-for-clock step that
groups, joins and the bridge already perform, so a speaker with a cold clock
was anchored too early: some stay silent (WiiM, Edifier), others start with a
scary correction warning. Both behaviours were leftovers for binaries too old
to answer - which the version pin made impossible long ago.

- Fail a start whose acknowledgement never arrives instead of assuming it
  worked, and fail the connection when the command pipe never gains a reader
- Wait for every speaker's clock before anchoring, including solo starts
- Refuse to join a speaker onto a paused group session; it would be anchored
  against a timeline that is not advancing
- Remove a wrong (often negative) elapsed-time report on cold starts
- Log a self-healed start correction as information, not a warning
- Remove the obsolete fallbacks and the legacy re-anchor parser they carried
- Correct the worst of the README: two documented features that never existed,
  wrong timing numbers, and a replaced late-join description

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

**Update:** now also routes old-LinkPlay firmware (Edifier MS50A, `fv=p20.Linkplay.4.x`) to NTP timing. These receivers advertise SupportsPTP and run the full PTP delay exchange, yet render silence at any PTP anchor while NTP timing plays fine — this is the cause behind the "corrected by +1970 ms and stays silent" report; the intermittent audible sessions were the accidental NTP fallback winning a port-bind race. Requires the airplay-cli release with `--no-ptp` (music-assistant/airplay-cli#54), so the version pin must move past v0.4.9 before this merges.