### PR TITLE
Keep the settings file safe when a save is cancelled on shutdown

### DIFF
--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -209,7 +209,7 @@ class ConfigController(
 
         self._save_requested += 1
         if immediate:
-            self.mass.loop.create_task(self._async_save())
+            self.mass.create_task(self._async_save)
         else:
             # schedule the save for later
             self._timer_handle = self.mass.loop.call_later(DEFAULT_SAVE_DELAY, self._start_save)

--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -7,6 +7,7 @@ import base64
 import contextlib
 import logging
 import os
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
@@ -71,6 +72,7 @@ class ConfigController(
         self._save_requested = 0
         self._save_written = 0
         self._save_lock = asyncio.Lock()
+        self._disk_lock = threading.Lock()
 
     async def setup(self) -> None:
         """Async initialize of controller."""
@@ -316,24 +318,29 @@ class ConfigController(
 
     def _save_to_disk(self, json_data: str) -> None:
         """Atomically write the settings file to disk, rotating the previous one to backup."""
-        filename = Path(self.filename)
-        filename_temp = Path(f"{self.filename}.tmp")
-        with filename_temp.open("w", encoding="utf-8") as _file:
-            _file.write(json_data)
-            _file.flush()
-            # fsync so a power failure can not leave a zero-length file behind (#5716)
-            os.fsync(_file.fileno())
-        with contextlib.suppress(FileNotFoundError, *JSON_DECODE_EXCEPTIONS):
-            # only rotate a parseable file to the backup, so a corrupt
-            # (crash leftover) file can never clobber a possibly good backup
-            json_loads(filename.read_bytes())
-            filename.replace(f"{self.filename}.backup")
-        filename_temp.replace(filename)
-        # best effort: fsync the directory as well so the renames themselves
-        # survive a power failure (not supported on all platforms/filesystems)
-        with contextlib.suppress(OSError):
-            dir_fd = os.open(os.path.dirname(self.filename), os.O_RDONLY)
-            try:
-                os.fsync(dir_fd)
-            finally:
-                os.close(dir_fd)
+        # cancelling a save does not stop the worker thread it already handed the write
+        # to, so _save_lock is released while this is still running. guard the file
+        # itself here, in the thread that actually writes it, or a second writer would
+        # race this one over the same temp file and leave no settings at all
+        with self._disk_lock:
+            filename = Path(self.filename)
+            filename_temp = Path(f"{self.filename}.tmp")
+            with filename_temp.open("w", encoding="utf-8") as _file:
+                _file.write(json_data)
+                _file.flush()
+                # fsync so a power failure can not leave a zero-length file behind (#5716)
+                os.fsync(_file.fileno())
+            with contextlib.suppress(FileNotFoundError, *JSON_DECODE_EXCEPTIONS):
+                # only rotate a parseable file to the backup, so a corrupt
+                # (crash leftover) file can never clobber a possibly good backup
+                json_loads(filename.read_bytes())
+                filename.replace(f"{self.filename}.backup")
+            filename_temp.replace(filename)
+            # best effort: fsync the directory as well so the renames themselves
+            # survive a power failure (not supported on all platforms/filesystems)
+            with contextlib.suppress(OSError):
+                dir_fd = os.open(os.path.dirname(self.filename), os.O_RDONLY)
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)

--- a/tests/controllers/config/test_save_scheduling.py
+++ b/tests/controllers/config/test_save_scheduling.py
@@ -175,6 +175,24 @@ async def test_close_saves_change_that_is_still_debounced(tmp_path: Path) -> Non
     assert json.loads(Path(controller.filename).read_text()) == {"generation": 1}
 
 
+async def test_cancelled_save_does_not_race_the_next_writer(tmp_path: Path) -> None:
+    """
+    A save cancelled mid-write may not leave a second writer racing it.
+
+    Cancelling a save does not stop the worker thread it handed the write to, so the
+    save that follows writes the same file at the same time as one that is on its way
+    out - and between them they used to leave no settings file at all.
+    """
+    controller, mass = _make_controller(tmp_path)
+    controller.set("generation", 1, immediate=True)
+    await _cancel_save_tasks(mass)
+
+    await controller.close()
+
+    assert json.loads(Path(controller.filename).read_text()) == {"generation": 1}
+    assert not Path(f"{controller.filename}.tmp").exists()
+
+
 async def test_close_saves_change_whose_save_task_was_cancelled(tmp_path: Path) -> None:
     """
     A change must survive a stop that cancels the save task before closing.


### PR DESCRIPTION
# What does this implement/fix?

Stacked on #5345 - review that one first, this PR targets its branch and will retarget to `dev` once it merges.

Cancelling a save does not stop the worker thread it already handed the write to, and the lock around that save is released as it unwinds. The save that runs on shutdown then wrote the settings file at the same time as the one on its way out: one writer renamed `settings.json` to the backup while the other still expected it to be there. The result was no `settings.json` at all - the content survived only in `settings.json.backup`, so the next start fell back to it.

The write is now guarded in the thread that performs it, so a write already underway finishes before the next one starts.

That also makes it safe to hand the immediate save to the server's normal task helper, which is the last save that ran outside it - never cancelled on stop, and its failures never logged.

Found while auditing the save path rather than from a report, hence `maintenance`.

Worth knowing: `mass.create_task` refuses to run off the event loop thread, where `loop.create_task` only complained about that in debug mode. Every caller that reaches an immediate save today is already on the loop thread, so nothing changes in practice - it just means a future off-loop caller fails loudly instead of quietly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Guard the settings write in the thread that performs it, so two writers can no longer overlap
- Run the immediate save through the server's task helper like every other save
- Test that a save cancelled mid-write leaves a valid settings file behind

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
