### PR TITLE
Fix mono audio playing too quietly and stalling some players

### DIFF
--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -607,8 +607,7 @@ def get_ffmpeg_args(
         "mono" if output_format.channels == 1 else "stereo",
     ]
     if output_path.upper() == "NULL":
-        # devnull stream. the channel args are deliberately dropped here: this sink
-        # feeds the loudness analysis, which must measure the source as it is.
+        # devnull stream: nothing is encoded here, so there is no channel count to declare
         output_path = "-"
         output_args = ["-f", "null"]
     elif output_format.content_type.is_pcm():
@@ -623,8 +622,7 @@ def get_ffmpeg_args(
         ]
     elif output_format.content_type == ContentType.NUT:
         # passthrough-mode (for creating the cache) using NUT container.
-        # the channel args are deliberately dropped here: they carry no meaning
-        # next to an -acodec copy.
+        # -acodec copy leaves the source untouched, so there is no channel count to declare
         output_args = [
             "-vn",
             "-dn",
@@ -668,8 +666,8 @@ def get_ffmpeg_args(
     # append (final) output path at the end of the args
     output_args.append(output_path)
 
-    # runs ahead of the caller's own filters, so the channel-aware ones among them
-    # (per-channel preamp, left/right selection) are handed a real FL/FR pair
+    # runs ahead of the caller's own filters, so channel-aware ones such as the
+    # per-channel preamp see the conformed layout instead of the source layout
     if channel_filter := _get_channel_conform_filter(input_format.channels, output_format.channels):
         filter_params = [channel_filter, *filter_params]
 
@@ -741,6 +739,8 @@ def _get_channel_conform_filter(input_channels: int, output_channels: int) -> st
 
     :param input_channels: Channel count entering FFmpeg.
     :param output_channels: Channel count the output is encoded at.
+    :return: The filter to run before any caller supplied ones, or None when the
+        source already carries the requested channel count.
     """
     if input_channels > 2 and output_channels <= 2:
         # a single channel output needs this fold too, otherwise a mono/left/right pan

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -607,7 +607,8 @@ def get_ffmpeg_args(
         "mono" if output_format.channels == 1 else "stereo",
     ]
     if output_path.upper() == "NULL":
-        # devnull stream
+        # devnull stream. the channel args are deliberately dropped here: this sink
+        # feeds the loudness analysis, which must measure the source as it is.
         output_path = "-"
         output_args = ["-f", "null"]
     elif output_format.content_type.is_pcm():
@@ -621,7 +622,9 @@ def get_ffmpeg_args(
             output_format.content_type.value,
         ]
     elif output_format.content_type == ContentType.NUT:
-        # passthrough-mode (for creating the cache) using NUT container
+        # passthrough-mode (for creating the cache) using NUT container.
+        # the channel args are deliberately dropped here: they carry no meaning
+        # next to an -acodec copy.
         output_args = [
             "-vn",
             "-dn",
@@ -632,12 +635,12 @@ def get_ffmpeg_args(
             "nut",
         ]
     elif output_format.content_type == ContentType.AAC:
-        output_args = ["-f", "adts", "-c:a", "aac", "-b:a", "256k"]
+        output_args += ["-f", "adts", "-c:a", "aac", "-b:a", "256k"]
     elif output_format.content_type == ContentType.MP3:
-        output_args = ["-f", "mp3", "-b:a", f"{DEFAULT_MP3_BIT_RATE}k"]
+        output_args += ["-f", "mp3", "-b:a", f"{DEFAULT_MP3_BIT_RATE}k"]
     elif output_format.content_type == ContentType.WAV:
         pcm_format = ContentType.from_bit_depth(output_format.bit_depth)
-        output_args = [
+        output_args += [
             "-ar",
             str(output_format.sample_rate),
             "-acodec",
@@ -665,14 +668,10 @@ def get_ffmpeg_args(
     # append (final) output path at the end of the args
     output_args.append(output_path)
 
-    # edge case: source file is not stereo - downmix to stereo. a single channel
-    # output needs this too, otherwise a mono/left/right pan filter would only see
-    # the front channels and silently drop the center and surround content.
-    if input_format.channels > 2 and output_format.channels <= 2:
-        filter_params = [
-            "pan=stereo|FL=1.0*FL+0.707*FC+0.707*SL+0.707*LFE|FR=1.0*FR+0.707*FC+0.707*SR+0.707*LFE",
-            *filter_params,
-        ]
+    # runs ahead of the caller's own filters, so the channel-aware ones among them
+    # (per-channel preamp, left/right selection) are handed a real FL/FR pair
+    if channel_filter := _get_channel_conform_filter(input_format.channels, output_format.channels):
+        filter_params = [channel_filter, *filter_params]
 
     if resample_filter := get_ffmpeg_resample_filter(
         input_format,
@@ -734,6 +733,26 @@ async def check_ffmpeg_version() -> None:
         version,
         "with libsoxr support" if libsoxr_support else "",
     )
+
+
+def _get_channel_conform_filter(input_channels: int, output_channels: int) -> str | None:
+    """
+    Return the filter that maps the source onto the output channel count, if one is needed.
+
+    :param input_channels: Channel count entering FFmpeg.
+    :param output_channels: Channel count the output is encoded at.
+    """
+    if input_channels > 2 and output_channels <= 2:
+        # a single channel output needs this fold too, otherwise a mono/left/right pan
+        # would only see the front channels and silently drop the center and surround
+        return (
+            "pan=stereo|FL=1.0*FL+0.707*FC+0.707*SL+0.707*LFE|FR=1.0*FR+0.707*FC+0.707*SR+0.707*LFE"
+        )
+    if input_channels == 1 and output_channels > 1:
+        # duplicate rather than leaving the widening to ffmpeg, whose rematrix
+        # spreads the source at 1/sqrt(2) per channel and so costs 3 dB
+        return "pan=stereo|c0=c0|c1=c0"
+    return None
 
 
 def _build_filtergraph_args(

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -132,7 +132,7 @@ def test_get_ffmpeg_args_single_channel_output_declares_mono() -> None:
 def test_get_ffmpeg_args_passthrough_sinks_omit_channels(
     output_path: str, output_content_type: ContentType, expected: list[str]
 ) -> None:
-    """The analysis sink and the cache passthrough see mono content exactly as it is."""
+    """The analysis sink and the cache passthrough declare no channel count of their own."""
     input_format = AudioFormat(
         content_type=ContentType.PCM_S16LE, sample_rate=44100, bit_depth=16, channels=1
     )
@@ -142,7 +142,6 @@ def test_get_ffmpeg_args_passthrough_sinks_omit_channels(
 
     args = get_ffmpeg_args(input_format, output_format, [], output_path=output_path)
 
-    assert "-af" not in args
     assert _output_args(args) == expected
 
 

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -65,6 +65,115 @@ def test_get_ffmpeg_args_downmixes_multichannel_for_single_channel_output() -> N
     assert filter_graph.index("pan=stereo|FL=") < filter_graph.index("pan=mono|c0=0.5*FL+0.5*FR")
 
 
+def _output_args(args: list[str]) -> list[str]:
+    """Return the output section of an ffmpeg command line (everything past the input path)."""
+    return args[args.index("-i") + 2 :]
+
+
+@pytest.mark.parametrize(
+    ("content_type", "encoder_args"),
+    [
+        (ContentType.AAC, ["-f", "adts", "-c:a", "aac", "-b:a", "256k"]),
+        (ContentType.MP3, ["-f", "mp3", "-b:a", "320k"]),
+        (ContentType.WAV, ["-ar", "44100", "-acodec", "pcm_s16le", "-f", "wav"]),
+        (
+            ContentType.FLAC,
+            ["-sample_fmt", "s16", "-ar", "44100", "-f", "flac", "-compression_level", "0"],
+        ),
+    ],
+)
+def test_get_ffmpeg_args_encoded_output_declares_channels(
+    content_type: ContentType, encoder_args: list[str]
+) -> None:
+    """Every encoded output format is handed the requested channel count."""
+    input_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=44100, bit_depth=16, channels=2
+    )
+    output_format = AudioFormat(content_type=content_type, sample_rate=44100, bit_depth=16)
+
+    args = get_ffmpeg_args(input_format, output_format, [])
+
+    assert _output_args(args) == ["-ac", "2", "-channel_layout", "stereo", *encoder_args, "-"]
+
+
+def test_get_ffmpeg_args_single_channel_output_declares_mono() -> None:
+    """A one channel target is declared as mono rather than stereo."""
+    fmt = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=44100, bit_depth=16, channels=1
+    )
+    output_format = AudioFormat(
+        content_type=ContentType.WAV, sample_rate=44100, bit_depth=16, channels=1
+    )
+
+    args = get_ffmpeg_args(fmt, output_format, [])
+
+    assert _output_args(args) == [
+        "-ac",
+        "1",
+        "-channel_layout",
+        "mono",
+        "-ar",
+        "44100",
+        "-acodec",
+        "pcm_s16le",
+        "-f",
+        "wav",
+        "-",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("output_path", "output_content_type", "expected"),
+    [
+        ("NULL", ContentType.FLAC, ["-f", "null", "-"]),
+        ("-", ContentType.NUT, ["-vn", "-dn", "-sn", "-acodec", "copy", "-f", "nut", "-"]),
+    ],
+)
+def test_get_ffmpeg_args_passthrough_sinks_omit_channels(
+    output_path: str, output_content_type: ContentType, expected: list[str]
+) -> None:
+    """The analysis sink and the cache passthrough see mono content exactly as it is."""
+    input_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=44100, bit_depth=16, channels=1
+    )
+    output_format = AudioFormat(
+        content_type=output_content_type, sample_rate=44100, bit_depth=16, channels=1
+    )
+
+    args = get_ffmpeg_args(input_format, output_format, [], output_path=output_path)
+
+    assert "-af" not in args
+    assert _output_args(args) == expected
+
+
+def test_get_ffmpeg_args_duplicates_mono_source_for_stereo_output() -> None:
+    """A mono source is widened by duplication, ahead of the caller's own filters."""
+    input_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=44100, bit_depth=16, channels=1
+    )
+    output_format = AudioFormat(
+        content_type=ContentType.FLAC, sample_rate=44100, bit_depth=16, channels=2
+    )
+
+    args = get_ffmpeg_args(input_format, output_format, ["volume=-1dB"])
+
+    assert args[args.index("-af") + 1] == "pan=stereo|c0=c0|c1=c0,volume=-1dB"
+
+
+def test_get_ffmpeg_args_mono_source_to_mono_output_is_not_widened() -> None:
+    """A mono source kept at one channel needs no channel filter at all."""
+    fmt = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=44100, bit_depth=16, channels=1
+    )
+    output_format = AudioFormat(
+        content_type=ContentType.FLAC, sample_rate=44100, bit_depth=16, channels=1
+    )
+
+    args = get_ffmpeg_args(fmt, output_format, [])
+
+    assert "-af" not in args
+
+
 # -- parse_ffmpeg_stream_info --
 
 
@@ -672,4 +781,36 @@ def test_filtergraph_complex_runs_in_ffmpeg(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert out.exists()
     # identity IR => output level matches input level
+    assert abs(_wav_rms_db(out) - _wav_rms_db(main)) < 0.5
+
+
+def test_mono_source_keeps_its_level_when_widened_to_stereo(tmp_path: Path) -> None:
+    """Widening a mono source to stereo duplicates it, where a rematrix would cost 3 dB."""
+    main = tmp_path / "mono.wav"
+    out = tmp_path / "stereo.wav"
+    subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=1000:duration=1:sample_rate=44100",
+            "-ac",
+            "1",
+            str(main),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    args = get_ffmpeg_args(
+        AudioFormat(content_type=ContentType.WAV, sample_rate=44100, bit_depth=16, channels=1),
+        AudioFormat(content_type=ContentType.WAV, sample_rate=44100, bit_depth=16, channels=2),
+        [],
+        input_path=str(main),
+        output_path=str(out),
+    )
+    result = subprocess.run(args, capture_output=True, text=True, check=False)  # noqa: S603
+
+    assert result.returncode == 0, result.stderr
     assert abs(_wav_rms_db(out) - _wav_rms_db(main)) < 0.5


### PR DESCRIPTION
# What does this implement/fix?

Mono audio was handled inconsistently on the way out of MA. Mono content played about 3 dB quieter than it should on the FLAC and PCM paths, and for WAV, MP3 and AAC the requested channel count was dropped entirely — those branches replaced the output arguments instead of adding to them. A mono source was then streamed as mono while MA still announced stereo, so players on the "forced content length" profile were told to expect twice the audio that was actually coming and waited for the rest.

**Related issue (if applicable):**

- n/a

## Changes

- Keep the requested channel count on WAV, MP3 and AAC output instead of discarding it.
- Widen mono audio by duplicating the channel, so it no longer loses 3 dB to ffmpeg's own channel rematrix.
- Leave the analysis sink and the cache passthrough alone, and record in the code why they declare no channel count.
- Add tests for the output arguments of every encoder branch, plus an end-to-end check that the level survives.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a)
