### PR TITLE
Fix surround sound sources being misread as stereo

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1325,9 +1325,9 @@ class StreamsAudio:
         rate the player supports that is <= the source rate, so the source is never
         upsampled. The bit depth follows the source unless audio processing
         (crossfade, volume normalization, DSP) is active — those need F32 headroom
-        to avoid clipping/precision loss. Realtime AudioSource items skip all
-        processing and get a pure passthrough format (source rate/bit depth when
-        the player supports them).
+        to avoid clipping/precision loss. Surround sources are folded down to stereo.
+        Realtime AudioSource items skip all processing and get a pure passthrough
+        format (source rate/bit depth when the player supports them).
 
         :param player: The player requesting the stream.
         :param streamdetails: Stream details for the current item.
@@ -1355,7 +1355,10 @@ class StreamsAudio:
             sample_rate=output_sample_rate,
             content_type=content_type,
             bit_depth=bit_depth,
-            channels=streamdetails.audio_format.channels,
+            # fold surround sources down to stereo right at the decode step: no
+            # output format carries more than two channels, so a wider PCM format
+            # only makes every bytes-to-seconds sum on the stream come out short
+            channels=min(streamdetails.audio_format.channels, 2),
         )
         if crossfade_enabled or overlay_active:
             pcm_format.channels = 2

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -3161,8 +3161,9 @@ class StreamsAudio:
         The format matches the source's native sample rate, bit depth and
         channel count whenever the player can accept them; if the player does
         not support the source's sample rate, it is snapped down to the
-        closest supported rate. No F32 widening, no forced stereo — realtime
-        sources skip every processing stage that would otherwise need them.
+        closest supported rate. No F32 widening — realtime sources skip every
+        processing stage that would otherwise need it. Surround sources are
+        still folded down to stereo, which every output path requires anyway.
 
         :param player: The player requesting the stream.
         :param streamdetails: Stream details for the AudioSource item.
@@ -3186,7 +3187,10 @@ class StreamsAudio:
             content_type=ContentType.from_bit_depth(bit_depth),
             sample_rate=output_sample_rate,
             bit_depth=bit_depth,
-            channels=streamdetails.audio_format.channels,
+            # a realtime source may announce more channels than anything downstream can
+            # carry (a VBAN stream can be configured up to 8), and player handoff formats
+            # copy this count straight through, so fold it here
+            channels=min(streamdetails.audio_format.channels, 2),
         )
 
     def _flow_restart_context(

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -420,7 +420,9 @@ class AudioBuffer:
             content_type=ContentType.from_bit_depth(streamdetails.audio_format.bit_depth),
             sample_rate=streamdetails.audio_format.sample_rate,
             bit_depth=streamdetails.audio_format.bit_depth,
-            channels=streamdetails.audio_format.channels,
+            # buffer the stereo fold of a surround source, so audio analysis measures
+            # the same audio that is played back rather than the untouched surround mix
+            channels=min(streamdetails.audio_format.channels, 2),
         )
 
         # determine ready threshold: how many seconds of audio must be buffered

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -582,10 +582,7 @@ def get_ffmpeg_args(
                 input_args += ["-seekable", "0"]
         if input_format.content_type.is_pcm():
             input_args += [
-                "-ac",
-                str(input_format.channels),
-                "-channel_layout",
-                "mono" if input_format.channels == 1 else "stereo",
+                *_get_channel_args(input_format),
                 "-ar",
                 str(input_format.sample_rate),
                 "-acodec",
@@ -600,12 +597,7 @@ def get_ffmpeg_args(
         input_args += ["-i", input_path]
 
     # collect output args
-    output_args = [
-        "-ac",
-        str(output_format.channels),
-        "-channel_layout",
-        "mono" if output_format.channels == 1 else "stereo",
-    ]
+    output_args = _get_channel_args(output_format)
     if output_path.upper() == "NULL":
         # devnull stream: nothing is encoded here, so there is no channel count to declare
         output_path = "-"
@@ -733,6 +725,24 @@ async def check_ffmpeg_version() -> None:
     )
 
 
+def _get_channel_args(audio_format: AudioFormat) -> list[str]:
+    """
+    Return the FFmpeg channel count/layout arguments for the given audio format.
+
+    :param audio_format: Format to describe.
+    """
+    args = ["-ac", str(audio_format.channels)]
+    # only name the layout where the channel count leaves no doubt: a wider count
+    # maps to several possible layouts (5.1 vs 5.1(side), 7.1 vs 7.1(wide), ...)
+    # and naming the wrong one wins over -ac, so FFmpeg would then misread the
+    # stream as that layout instead. Left alone, it derives the default itself.
+    if audio_format.channels == 1:
+        args += ["-channel_layout", "mono"]
+    elif audio_format.channels == 2:
+        args += ["-channel_layout", "stereo"]
+    return args
+
+
 def _get_channel_conform_filter(input_channels: int, output_channels: int) -> str | None:
     """
     Return the filter that maps the source onto the output channel count, if one is needed.
@@ -744,10 +754,12 @@ def _get_channel_conform_filter(input_channels: int, output_channels: int) -> st
     """
     if input_channels > 2 and output_channels <= 2:
         # a single channel output needs this fold too, otherwise a mono/left/right pan
-        # would only see the front channels and silently drop the center and surround
-        return (
-            "pan=stereo|FL=1.0*FL+0.707*FC+0.707*SL+0.707*LFE|FR=1.0*FR+0.707*FC+0.707*SR+0.707*LFE"
-        )
+        # would only see the front channels and silently drop the center and surround.
+        # aformat leaves the rematrix to ffmpeg, which picks the correct coefficients
+        # for whatever layout the input turns out to have (and, for an integer output,
+        # scales them to stay clip-safe). A fixed pan expression, naming channels that
+        # a given layout may not even have, can do neither.
+        return "aformat=channel_layouts=stereo"
     if input_channels == 1 and output_channels > 1:
         # duplicate rather than leaving the widening to ffmpeg, whose rematrix
         # spreads the source at 1/sqrt(2) per channel and so costs 3 dB

--- a/tests/controllers/streams/test_flow_format.py
+++ b/tests/controllers/streams/test_flow_format.py
@@ -324,6 +324,36 @@ async def test_select_pcm_format_uses_stereo_f32_for_radio_overlay() -> None:
 
 
 @pytest.mark.asyncio
+async def test_select_pcm_format_folds_surround_source_to_stereo() -> None:
+    """A surround source is narrowed to stereo, since no output format carries more."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (48000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    streamdetails = _make_streamdetails(sample_rate=48000, bit_depth=24, channels=6)
+
+    fmt = await audio.select_pcm_format(player, streamdetails, crossfade_enabled=False)
+
+    assert fmt.channels == 2
+
+
+@pytest.mark.asyncio
+async def test_select_pcm_format_keeps_mono_source_mono() -> None:
+    """A mono source is not widened when no processing stage needs a stereo pivot."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (48000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    streamdetails = _make_streamdetails(sample_rate=48000, bit_depth=24, channels=1)
+
+    fmt = await audio.select_pcm_format(player, streamdetails, crossfade_enabled=False)
+
+    assert fmt.channels == 1
+
+
+@pytest.mark.asyncio
 async def test_select_flow_pcm_format_uses_f32_when_volume_normalization_active() -> None:
     """Active volume normalization on the start track triggers F32 headroom."""
     audio = _make_streams_audio()

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -109,10 +109,11 @@ def test_get_ffmpeg_args_omits_layout_above_stereo() -> None:
         assert "-channel_layout" not in part
 
 
-def test_multichannel_pcm_keeps_its_duration_in_ffmpeg(tmp_path: Path) -> None:
-    """Raw surround PCM is read at its real width, so it is not stretched out in time."""
+def test_multichannel_pcm_folds_down_without_stretching(tmp_path: Path) -> None:
+    """Raw surround PCM keeps its real width and length, and its rear channels survive."""
     source = tmp_path / "surround.pcm"
     out = tmp_path / "out.flac"
+    # only the rear channels carry a tone: a downmix that drops them yields silence
     subprocess.run(  # noqa: S603
         [  # noqa: S607
             "ffmpeg",
@@ -122,7 +123,7 @@ def test_multichannel_pcm_keeps_its_duration_in_ffmpeg(tmp_path: Path) -> None:
             "-i",
             "sine=frequency=1000:duration=1:sample_rate=48000",
             "-af",
-            "pan=5.1|FL=c0|FR=c0|FC=c0|LFE=c0|BL=c0|BR=c0",
+            "pan=5.1|BL=c0|BR=c0",
             "-f",
             "s16le",
             str(source),
@@ -165,6 +166,7 @@ def test_multichannel_pcm_keeps_its_duration_in_ffmpeg(tmp_path: Path) -> None:
         check=True,
     ).stdout
     assert float(duration) == pytest.approx(1.0, abs=0.05)
+    assert _rms_db(out) > -40
 
 
 def _output_args(args: list[str]) -> list[str]:
@@ -800,8 +802,8 @@ def test_get_ffmpeg_args_uses_filter_complex_with_complex_filter() -> None:
     assert args.index("/ir.wav") > args.index("-i")
 
 
-def _wav_rms_db(path: Path) -> float:
-    """Return the overall RMS level of a wav file in dB via ffmpeg astats."""
+def _rms_db(path: Path) -> float:
+    """Return the overall RMS level of an audio file in dB via ffmpeg astats."""
     output = subprocess.run(  # noqa: S603
         [  # noqa: S607
             "ffmpeg",
@@ -882,7 +884,7 @@ def test_filtergraph_complex_runs_in_ffmpeg(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert out.exists()
     # identity IR => output level matches input level
-    assert abs(_wav_rms_db(out) - _wav_rms_db(main)) < 0.5
+    assert abs(_rms_db(out) - _rms_db(main)) < 0.5
 
 
 def test_mono_source_keeps_its_level_when_widened_to_stereo(tmp_path: Path) -> None:
@@ -914,4 +916,4 @@ def test_mono_source_keeps_its_level_when_widened_to_stereo(tmp_path: Path) -> N
     result = subprocess.run(args, capture_output=True, text=True, check=False)  # noqa: S603
 
     assert result.returncode == 0, result.stderr
-    assert abs(_wav_rms_db(out) - _wav_rms_db(main)) < 0.5
+    assert abs(_rms_db(out) - _rms_db(main)) < 0.5

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -62,7 +62,109 @@ def test_get_ffmpeg_args_downmixes_multichannel_for_single_channel_output() -> N
     args = get_ffmpeg_args(input_format, output_format, ["pan=mono|c0=0.5*FL+0.5*FR"])
 
     filter_graph = args[args.index("-af") + 1]
-    assert filter_graph.index("pan=stereo|FL=") < filter_graph.index("pan=mono|c0=0.5*FL+0.5*FR")
+    assert filter_graph.index("aformat=channel_layouts=stereo") < filter_graph.index(
+        "pan=mono|c0=0.5*FL+0.5*FR"
+    )
+
+
+def _split_at_input(args: list[str]) -> tuple[list[str], list[str]]:
+    """Split generated ffmpeg args into the part describing the input and the output."""
+    idx = args.index("-i")
+    return args[:idx], args[idx + 2 :]
+
+
+@pytest.mark.parametrize(
+    ("channels", "expected_layout"),
+    [(1, "mono"), (2, "stereo")],
+)
+def test_get_ffmpeg_args_names_layout_up_to_stereo(channels: int, expected_layout: str) -> None:
+    """Mono and stereo PCM are described by both their channel count and their layout."""
+    fmt = AudioFormat(
+        content_type=ContentType.PCM_S24LE,
+        sample_rate=48000,
+        bit_depth=24,
+        channels=channels,
+    )
+
+    input_args, output_args = _split_at_input(get_ffmpeg_args(fmt, fmt, []))
+
+    for part in (input_args, output_args):
+        assert part[part.index("-ac") + 1] == str(channels)
+        assert part[part.index("-channel_layout") + 1] == expected_layout
+
+
+def test_get_ffmpeg_args_omits_layout_above_stereo() -> None:
+    """Surround PCM is described by its channel count alone, never as a stereo layout."""
+    fmt = AudioFormat(
+        content_type=ContentType.PCM_S24LE,
+        sample_rate=48000,
+        bit_depth=24,
+        channels=6,
+    )
+
+    input_args, output_args = _split_at_input(get_ffmpeg_args(fmt, fmt, []))
+
+    for part in (input_args, output_args):
+        assert part[part.index("-ac") + 1] == "6"
+        assert "-channel_layout" not in part
+
+
+def test_multichannel_pcm_keeps_its_duration_in_ffmpeg(tmp_path: Path) -> None:
+    """Raw surround PCM is read at its real width, so it is not stretched out in time."""
+    source = tmp_path / "surround.pcm"
+    out = tmp_path / "out.flac"
+    subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=1000:duration=1:sample_rate=48000",
+            "-af",
+            "pan=5.1|FL=c0|FR=c0|FC=c0|LFE=c0|BL=c0|BR=c0",
+            "-f",
+            "s16le",
+            str(source),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        sample_rate=48000,
+        bit_depth=16,
+        channels=6,
+    )
+    output_format = AudioFormat(
+        content_type=ContentType.FLAC,
+        sample_rate=48000,
+        bit_depth=16,
+        channels=2,
+    )
+    args = get_ffmpeg_args(
+        pcm_format, output_format, [], input_path=str(source), output_path=str(out)
+    )
+
+    result = subprocess.run([*args, "-y"], capture_output=True, text=True, check=False)  # noqa: S603
+    assert result.returncode == 0, result.stderr
+
+    duration = subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "csv=p=0",
+            str(out),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert float(duration) == pytest.approx(1.0, abs=0.05)
 
 
 def _output_args(args: list[str]) -> list[str]:


### PR DESCRIPTION
# What does this implement/fix?

Every PCM stream was announced to ffmpeg as stereo, whatever its real channel count. That layout wins over the channel count, so anything wider than stereo was read at the wrong width: a surround track had its length (and the play time reported to scrobbling services) come out three times too short, and a raw multichannel source such as a VBAN stream configured above 2 channels played back garbled.

Found by Copilot on #5329, left out of scope there.

## Changes

- Name the channel layout only for mono and stereo, where the channel count leaves no doubt, and let ffmpeg derive it for anything wider
- Fold surround down to stereo with ffmpeg's own rematrix instead of a fixed pan expression, which dropped the rear channels on a standard 5.1 layout, mixed in the LFE and could clip
- Pick a stereo internal stream format for surround sources everywhere they are chosen, since no output format carries more than two channels — this also keeps loudness analysis measuring the stereo fold that is actually played

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a)
