### PR TITLE
Fix mute command failing on group players

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -918,6 +918,11 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         player = self.get_player(player_id, True)
         assert player
 
+        if player.type == PlayerType.GROUP:
+            # redirect to special group mute control
+            await self.cmd_group_volume_mute(player_id, muted)
+            return
+
         # clearing the mute lock may not depend on mute support, otherwise a lock set
         # while the player still had a mute control would outlive a control change
         if not muted:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1694,6 +1694,64 @@ class TestGroupMuteMemberFilter:
         leader_mute.assert_awaited_once_with(True)
 
 
+class TestGroupPlayerMuteRedirect:
+    """A mute command on a group player is handled at group level."""
+
+    def _setup(self, mock_mass: MagicMock) -> tuple[PlayerController, MockPlayer, MockPlayer]:
+        """Build a controller with a group player holding a single mute capable member."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        group = MockPlayer(provider, "group", "Group", player_type=PlayerType.GROUP)
+        group._attr_supported_features = {PlayerFeature.VOLUME_SET, PlayerFeature.VOLUME_MUTE}
+        group._attr_group_members = ["member"]
+        member = MockPlayer(provider, "member", "Member")
+        member._attr_supported_features = {PlayerFeature.VOLUME_SET, PlayerFeature.VOLUME_MUTE}
+        controller._players = {"group": group, "member": member}
+        mock_mass.players = controller
+        mock_mass.player_queues.get = MagicMock(return_value=None)
+        for player in (group, member):
+            player.set_initialized()
+            player.update_state(signal_event=False)
+        return controller, group, member
+
+    async def test_mute_on_group_player_is_forwarded_to_members(self, mock_mass: MagicMock) -> None:
+        """A group player has no mute of its own, so the members must be muted instead."""
+        controller, _group, member = self._setup(mock_mass)
+        member_mute = AsyncMock()
+        member.volume_mute = member_mute  # type: ignore[method-assign]
+
+        await controller.cmd_volume_mute("group", True)
+
+        member_mute.assert_awaited_once_with(True)
+
+    async def test_mute_on_group_player_without_own_mute_control(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A group that has no mute control of its own must still mute its members."""
+        controller, group, member = self._setup(mock_mass)
+        group._attr_supported_features = {PlayerFeature.VOLUME_SET}
+        group._cache.clear()
+        group.update_state(signal_event=False)
+        assert group.mute_control == PLAYER_CONTROL_NONE
+        member_mute = AsyncMock()
+        member.volume_mute = member_mute  # type: ignore[method-assign]
+
+        await controller.cmd_volume_mute("group", True)
+
+        member_mute.assert_awaited_once_with(True)
+
+    async def test_mute_on_group_player_without_mute_capable_members(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A group whose members cannot mute must not raise, just like group mute itself."""
+        controller, _group, member = self._setup(mock_mass)
+        member._attr_supported_features = {PlayerFeature.VOLUME_SET}
+        member._cache.clear()
+        member.update_state(signal_event=False)
+
+        await controller.cmd_volume_mute("group", True)
+
+
 class TestCurrentMediaTimeUpdates:
     """Playback-position anchor semantics of timing-only state updates."""
 


### PR DESCRIPTION
# What does this implement/fix?

Muting a group player through the API failed with an error instead of muting the group. The web UI was never affected because it uses the dedicated group mute command, but Home Assistant, the MCP server and other API clients send the regular mute command and got a "command failed" back.

The regular volume commands already redirect group players to their group-level counterpart; mute was the only one missing that redirect.

- Mute on a group player is now applied to the group members, like the volume commands already do.
- Added tests for muting a group player.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
