### PR TITLE
Better crossfades on tracks with long outros, ambient blends and mastered fade-outs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,6 +170,10 @@ jobs:
         # those provider packages; mode=full runs everything with full coverage.
         # --dist loadfile keeps each test file on one xdist worker: snapshot updates
         # never race on an .ambr file and module-scoped fixtures are reused.
+        # --max-worker-restart=0: with loadfile, replacing a worker that died on a native
+        # crash leaves the controller blocked on its event queue forever, so the job only
+        # ends at its 30m cap with no summary. Shutting down instead fails in seconds and
+        # names the crashing test; a crashed worker invalidates the run either way.
         env:
           MODE: ${{ needs.changes.outputs.mode }}
           TEST_PATHS: ${{ needs.changes.outputs.test_paths }}
@@ -199,7 +203,7 @@ jobs:
           # it in the saved snapshot so it is never evicted.
           setpriv --reuid=tester --regid=tester --init-groups \
             env HOME=/home/tester \
-            pytest -p numpy -n auto --dist loadfile --durations 10 $cov --cov-report=term-missing --cov-report=xml $targets
+            pytest -p numpy -n auto --dist loadfile --max-worker-restart=0 --durations 10 $cov --cov-report=term-missing --cov-report=xml $targets
       - name: Upload coverage to Codecov
         if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: codecov/codecov-action@v7

--- a/music_assistant/controllers/streams/smart_fades/filters.py
+++ b/music_assistant/controllers/streams/smart_fades/filters.py
@@ -258,6 +258,9 @@ class CrossfadeFilter(Filter):
         logger: logging.Logger,
         crossfade_duration: float | None = None,
         crossfade_samples: int | None = None,
+        *,
+        fadeout_curve: str = "qsin",
+        fadein_curve: str = "qsin",
     ):
         """
         Initialize crossfade filter.
@@ -268,11 +271,15 @@ class CrossfadeFilter(Filter):
             acrossfade silently emits nothing when its requested length exceeds the
             buffer it is fed, and a fractional ``d`` can round just past a
             frame-aligned buffer. A sample count cannot.
+        :param fadeout_curve: acrossfade ``c1`` curve applied to the outgoing stream.
+        :param fadein_curve: acrossfade ``c2`` curve applied to the incoming stream.
         """
         if (crossfade_duration is None) == (crossfade_samples is None):
             raise ValueError("Provide exactly one of crossfade_duration or crossfade_samples")
         self.crossfade_duration = crossfade_duration
         self.crossfade_samples = crossfade_samples
+        self.fadeout_curve = fadeout_curve
+        self.fadein_curve = fadein_curve
         super().__init__(logger)
 
     def apply(self, input_fadein_label: str, input_fadeout_label: str) -> list[str]:
@@ -283,7 +290,10 @@ class CrossfadeFilter(Filter):
             else f"d={self.crossfade_duration}"
         )
         # equal-power qsin curves; the default tri/tri dips ~3dB mid-fade on uncorrelated material
-        return [f"{input_fadeout_label}{input_fadein_label}acrossfade={overlap}:c1=qsin:c2=qsin"]
+        return [
+            f"{input_fadeout_label}{input_fadein_label}acrossfade={overlap}:"
+            f"c1={self.fadeout_curve}:c2={self.fadein_curve}"
+        ]
 
     def __repr__(self) -> str:
         """Return string representation of CrossfadeFilter."""

--- a/music_assistant/controllers/streams/smart_fades/mixer.py
+++ b/music_assistant/controllers/streams/smart_fades/mixer.py
@@ -17,6 +17,7 @@ from music_assistant.controllers.streams.smart_fades.fades import (
 )
 from music_assistant.controllers.streams.smart_fades.helpers import detect_effective_audio_end
 from music_assistant.controllers.streams.smart_fades.vocal import (
+    PROTECTIVE_VOCAL_CONFIG,
     VocalMask,
     build_vocal_windows,
     parse_vocal_probabilities,
@@ -252,6 +253,7 @@ class SmartFadesMixer:
             buffer_offset,
             track_duration,
             beat_duration=60.0 / analysis.bpm if analysis.bpm and analysis.bpm > 0.0 else None,
+            config=PROTECTIVE_VOCAL_CONFIG,
         )
         if not vocal_mask.windows:
             return 0

--- a/music_assistant/controllers/streams/smart_fades/models.py
+++ b/music_assistant/controllers/streams/smart_fades/models.py
@@ -288,4 +288,5 @@ class TransitionPlan:
     fadeout_trim: FadeOutTrim | None = None
     # seconds trimmed off the incoming head for beat alignment
     fadein_trim_start: float | None = None
+    fadeout_curve: str = "qsin"
     metrics: PlanMetrics = field(default_factory=PlanMetrics)

--- a/music_assistant/controllers/streams/smart_fades/planner/assembly.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/assembly.py
@@ -126,6 +126,7 @@ class PlanAssembler:
         return replace(
             candidate.plan,
             eq_plan=self._choose_eq(candidate.plan),
+            fadeout_curve=self._choose_fadeout_curve(candidate.plan),
             metrics=candidate.metrics,
         )
 
@@ -530,6 +531,20 @@ class PlanAssembler:
             if running_max > 0.0 and power > 0.0:
                 max_drop_db = max(max_drop_db, 10.0 * float(np.log10(running_max / power)))
         return max_drop_db
+
+    def _choose_fadeout_curve(self, plan: TransitionPlan) -> str:
+        """Pick ``nofade`` when the overlap sits entirely inside a detected mastered fade."""
+        ctx = self._ctx
+        if ctx.fade_onset is None:
+            return "qsin"
+        crossfade_start = plan.fade_out_window - plan.crossfade_duration
+        if crossfade_start < ctx.fade_onset:
+            return "qsin"
+        bar_out = ctx.outgoing.beats_per_bar * 60.0 / ctx.outgoing.bpm
+        if plan.fade_out_window < ctx.audio_end - bar_out:
+            return "qsin"
+        # the record already fades itself here; don't double it with a second curve
+        return "nofade"
 
 
 class EmergencyHandoffFactory:

--- a/music_assistant/controllers/streams/smart_fades/planner/candidates.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/candidates.py
@@ -325,7 +325,7 @@ class RescueAnchorGenerator(CandidateGenerator):
 
 
 class TrimClosingAnchorGenerator(CandidateGenerator):
-    """Emits the tier ladder at the audible end when a large audible tail is stranded."""
+    """Emits the tier's ladder at that anchor, at the audible end, when a large tail is stranded."""
 
     name = "trim-closing-anchor"
 
@@ -334,10 +334,13 @@ class TrimClosingAnchorGenerator(CandidateGenerator):
         anchor = ctx.audio_end
         if anchor - ctx.default_anchor < _TRIM_CLOSING_MIN_GAP_S:
             return
-        ladder = bars_ladder(ctx, ctx.tier)
+        # the context tier is decided at the early anchor; these rungs sit at the audible
+        # end, where a grid the early window was too short for may be fully blendable
+        _, tier = choose_tier(ctx.outgoing, ctx.incoming, anchor)
+        ladder = bars_ladder(ctx, tier)
         for bars in ladder:
             yield CandidateSpec(
-                tier=ctx.tier,
+                tier=tier,
                 bars=bars,
                 anchor_s=anchor,
                 entry_s=None,

--- a/music_assistant/controllers/streams/smart_fades/planner/candidates.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/candidates.py
@@ -334,8 +334,7 @@ class TrimClosingAnchorGenerator(CandidateGenerator):
         anchor = ctx.audio_end
         if anchor - ctx.default_anchor < _TRIM_CLOSING_MIN_GAP_S:
             return
-        # the context tier is decided at the early anchor; these rungs sit at the audible
-        # end, where a grid the early window was too short for may be fully blendable
+        # ctx.tier is decided at the early anchor; the grid can be blendable at the audible end
         _, tier = choose_tier(ctx.outgoing, ctx.incoming, anchor)
         ladder = bars_ladder(ctx, tier)
         for bars in ladder:
@@ -360,7 +359,7 @@ class LazyOverlayGenerator(CandidateGenerator):
             return
         if ctx.bpm_diff_percent > TIME_STRETCH_BPM_PERCENTAGE_THRESHOLD:
             return
-        duties = _vocal_duties(ctx)
+        duties = _window_duties(ctx, _LAZY_OVERLAY_SECONDS)
         if duties is None or duties[0] > _LAZY_DUTY_MAX or duties[1] > _LAZY_DUTY_MAX:
             return
         yield CandidateSpec(
@@ -957,6 +956,33 @@ def _vocal_duties(ctx: TransitionContext) -> tuple[float, float] | None:
         SMART_CROSSFADE_DURATION
     )
     return out_duty, in_duty
+
+
+def _window_duties(ctx: TransitionContext, seconds: float) -> tuple[float, float] | None:
+    """
+    Vocal duty per deck over the window an unphrased overlay of ``seconds`` actually spans.
+
+    :param ctx: The transition context.
+    :param seconds: Requested overlay length; the outgoing window is the last
+        ``seconds`` before the audible end, the incoming window its first ``seconds``.
+    """
+    if ctx.vocal_out_scoring is None or ctx.vocal_in_scoring is None:
+        return None
+    # mirrors the anchored tail: a sub-half-second gap to the buffer end is not trimmed
+    effective_end = ctx.audio_end
+    if effective_end >= ctx.buffer_duration - 0.5:
+        effective_end = ctx.buffer_duration
+    span = min(seconds, effective_end)
+    if span <= 0.0:
+        return None
+    out_secs = sum(
+        max(0.0, min(right, effective_end) - max(left, effective_end - span))
+        for left, right in ctx.vocal_out_scoring.windows
+    )
+    in_secs = sum(
+        max(0.0, min(right, span) - max(left, 0.0)) for left, right in ctx.vocal_in_scoring.windows
+    )
+    return out_secs / span, in_secs / span
 
 
 def _fade_onset_pin(ctx: TransitionContext) -> float:

--- a/music_assistant/controllers/streams/smart_fades/renderer.py
+++ b/music_assistant/controllers/streams/smart_fades/renderer.py
@@ -103,7 +103,13 @@ class TransitionRenderer:
         self._append_shelf(filters, plan.eq_plan.low_in, "fadein")
         self._append_shelf(filters, plan.eq_plan.high_in, "fadein")
         self._append_shelf(filters, plan.eq_plan.mid_in, "fadein")
-        filters.append(CrossfadeFilter(logger=self.logger, crossfade_samples=crossfade_samples))
+        filters.append(
+            CrossfadeFilter(
+                logger=self.logger,
+                crossfade_samples=crossfade_samples,
+                fadeout_curve=plan.fadeout_curve,
+            )
+        )
         return filters
 
     def _append_shelf(

--- a/music_assistant/controllers/streams/smart_fades/vocal.py
+++ b/music_assistant/controllers/streams/smart_fades/vocal.py
@@ -108,6 +108,8 @@ class VocalHysteresisConfig:
 
 
 DEFAULT_VOCAL_CONFIG = VocalHysteresisConfig()
+# retention keeps audio, so it wants recall; only the planner's veto needs the gate
+PROTECTIVE_VOCAL_CONFIG = VocalHysteresisConfig(min_run_peak=0.0, min_run_mean=0.0)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/controllers/streams/smart_fades/test_assembly.py
+++ b/tests/controllers/streams/smart_fades/test_assembly.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 
 import numpy as np
 import pytest
@@ -73,6 +74,16 @@ def _bands_pair(f_low_out: float, f_low_in: float) -> tuple[AudioAnalysisData, A
 
     out = _analysis_with_bands(*_levels(f_low_out), duration=240.0)
     inc = _analysis_with_bands(*_levels(f_low_in), duration=240.0)
+    return out, inc
+
+
+def _mastered_fade_pair() -> tuple[AudioAnalysisData, AudioAnalysisData]:
+    """Build a -14dB frozen-spectrum ramp from media 210s, mirroring test_generators.py's fixture."""
+    t = np.linspace(0.0, 240.0, 1800)
+    gain_db = np.where(t < 210.0, 0.0, -(t - 210.0) / 30.0 * 14.0)
+    band = (0.3 * 10.0 ** (gain_db / 20.0)).astype(np.float32)
+    out = _analysis_with_bands(band, band, band, band, duration=240.0)
+    inc = _analysis(120.0, duration=240.0)
     return out, inc
 
 
@@ -174,6 +185,53 @@ class TestFinalizeCarriesMetrics:
         plan = PlanAssembler(ctx, LOGGER).finalize(candidate)
 
         assert plan.metrics == candidate.metrics
+
+
+class TestFinalizeChoosesFadeoutCurve:
+    """The crossfade degrades to ``nofade`` only when the overlap sits fully inside a mastered fade."""
+
+    def _candidate(self, ctx: TransitionContext) -> Candidate:
+        factory = CandidateFactory(ctx, LOGGER)
+        candidate = factory.build(CandidateSpec(tier=ctx.tier, bars=1, anchor_s=None, entry_s=None))
+        assert candidate is not None  # the 1-bar rung always yields a candidate
+        return candidate
+
+    def test_overlap_entirely_inside_the_fade_uses_nofade(self) -> None:
+        """A crossfade that starts after the fade onset and runs to the audible end gets nofade."""
+        out, inc = _mastered_fade_pair()
+        ctx = _ctx(out, inc)
+        assert ctx.fade_onset is not None
+        candidate = self._candidate(ctx)
+        plan = replace(candidate.plan, fade_out_window=44.0, crossfade_duration=20.0)
+        candidate = replace(candidate, plan=plan)
+
+        new_plan = PlanAssembler(ctx, LOGGER).finalize(candidate)
+
+        assert new_plan.fadeout_curve == "nofade"
+
+    def test_no_detected_fade_keeps_qsin(self) -> None:
+        """Without a detected mastered fade, the crossfade curve stays the qsin default."""
+        out, inc = _rich_pair()
+        ctx = _ctx(out, inc)
+        assert ctx.fade_onset is None
+        candidate = self._candidate(ctx)
+
+        new_plan = PlanAssembler(ctx, LOGGER).finalize(candidate)
+
+        assert new_plan.fadeout_curve == "qsin"
+
+    def test_overlap_straddling_the_fade_onset_keeps_qsin(self) -> None:
+        """A crossfade that starts before the fade onset (flat-then-fade) cannot use nofade."""
+        out, inc = _mastered_fade_pair()
+        ctx = _ctx(out, inc)
+        assert ctx.fade_onset is not None
+        candidate = self._candidate(ctx)
+        plan = replace(candidate.plan, fade_out_window=44.0, crossfade_duration=30.0)
+        candidate = replace(candidate, plan=plan)
+
+        new_plan = PlanAssembler(ctx, LOGGER).finalize(candidate)
+
+        assert new_plan.fadeout_curve == "qsin"
 
 
 class TestFinalizeDipGuardBehavior:

--- a/tests/controllers/streams/smart_fades/test_filters.py
+++ b/tests/controllers/streams/smart_fades/test_filters.py
@@ -42,6 +42,15 @@ def test_crossfade_uses_equal_power_curves() -> None:
     assert filter_strings == ["[fadeout][fadein]acrossfade=d=12.5:c1=qsin:c2=qsin"]
 
 
+def test_crossfade_emits_the_given_curves() -> None:
+    """Explicit fadeout/fadein curves override the default qsin:qsin pair."""
+    crossfade = CrossfadeFilter(
+        logger=LOGGER, crossfade_duration=12.5, fadeout_curve="nofade", fadein_curve="tri"
+    )
+    filter_strings = crossfade.apply("[fadein]", "[fadeout]")
+    assert filter_strings == ["[fadeout][fadein]acrossfade=d=12.5:c1=nofade:c2=tri"]
+
+
 def test_crossfade_sample_count_uses_ns() -> None:
     """
     A sample-count crossfade must emit ``acrossfade=ns=`` rather than ``d=``.

--- a/tests/controllers/streams/smart_fades/test_planner_rungs.py
+++ b/tests/controllers/streams/smart_fades/test_planner_rungs.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import logging
 
-from music_assistant.controllers.streams.smart_fades.models import TransitionStrategy
+from music_assistant.controllers.streams.smart_fades.models import (
+    TransitionStrategy,
+    TransitionTier,
+)
 from music_assistant.controllers.streams.smart_fades.planner.candidates import (
     EnergyLadderGenerator,
     LazyOverlayGenerator,
@@ -166,6 +169,60 @@ def test_trim_closing_not_emitted_for_small_gap() -> None:
     """A tail whose energy anchor already sits near the audible end emits nothing."""
     specs = list(TrimClosingAnchorGenerator().generate(_small_trim_gap_ctx()))
     assert specs == []
+
+
+def _late_blendable_only_ctx() -> TransitionContext:
+    """
+    Build a context whose early window is too sparse to blend but the late one qualifies.
+
+    A full 4/4 grid runs to the end of both 124 BPM decks with matching keys,
+    so the tier at the audible end is FULL_BLEND. The outgoing rms_energy
+    stays loud for only a few bars into the buffer before dropping to a
+    still-audible level and then real silence, so the early mix-out anchor
+    lands with too few downbeats behind it for the early window's tier check
+    to pass, while the audible tail runs on for many more bars past it.
+    """
+    beats = [i * 60 / 124 for i in range(int(240 * 124 / 60))]
+    downbeats = beats[::4]
+    rms_energy = [0.9] * 1550 + [0.25] * (1730 - 1550) + [0.0] * (1800 - 1730)
+    aa_out = AudioAnalysisData(
+        duration=240.0,
+        bpm=124.0,
+        beats=beats,
+        downbeats=downbeats,
+        beats_per_bar=4,
+        rms_energy=rms_energy,
+        key="A",
+        mode="minor",
+        extra_data={},
+    )
+    aa_in = AudioAnalysisData(
+        duration=240.0,
+        bpm=124.0,
+        beats=beats,
+        downbeats=downbeats,
+        beats_per_bar=4,
+        rms_energy=[0.8] * 1800,
+        key="A",
+        mode="minor",
+        extra_data={},
+    )
+    ctx = build_transition_context(aa_out, aa_in, 45.0, logging.getLogger("test"))
+    assert ctx.audio_end - ctx.default_anchor >= 8.0
+    early_downbeats = [d for d in ctx.outgoing.downbeats if d <= ctx.default_anchor]
+    assert len(early_downbeats) < 8
+    return ctx
+
+
+def test_trim_closing_ladder_uses_the_tier_at_its_own_anchor() -> None:
+    """A grid that only becomes blendable at the audible end still earns the long rungs."""
+    ctx = _late_blendable_only_ctx()
+    assert ctx.tier is TransitionTier.QUICK_FADE  # the early window has too few downbeats
+    specs = list(TrimClosingAnchorGenerator().generate(ctx))
+    assert specs
+    assert max(spec.bars for spec in specs) == 8
+    assert all(spec.tier is not TransitionTier.QUICK_FADE for spec in specs)
+    assert all(spec.ideal_bars == 8 for spec in specs)
 
 
 def _ctx_with_late_natural_entry() -> TransitionContext:

--- a/tests/controllers/streams/smart_fades/test_planner_rungs.py
+++ b/tests/controllers/streams/smart_fades/test_planner_rungs.py
@@ -9,10 +9,14 @@ from music_assistant.controllers.streams.smart_fades.models import (
     TransitionTier,
 )
 from music_assistant.controllers.streams.smart_fades.planner.candidates import (
+    _LAZY_OVERLAY_SECONDS,
     EnergyLadderGenerator,
     LazyOverlayGenerator,
     TrimClosingAnchorGenerator,
     _entry_options,
+    _vocal_duties,
+    _window_duties,
+    earns_instrumental_blend,
 )
 from music_assistant.controllers.streams.smart_fades.planner.context import (
     TransitionContext,
@@ -322,6 +326,117 @@ def test_lazy_overlay_beats_trim_closing_on_a_qualifying_pair() -> None:
 
     plan = SmartCrossFadePlanner(logging.getLogger("test")).plan(aa_out, aa_in, 45.0)
     assert plan.metrics.strategy is TransitionStrategy.LAZY_OVERLAY
+
+
+def _lazy_gate_outgoing() -> AudioAnalysisData:
+    """
+    Outgoing analysis shared by the lazy-gate vocal-window fixtures.
+
+    Same shape as ``_late_blendable_only_ctx``'s outgoing deck: a full 4/4
+    grid at 124 BPM, but the early mix-out anchor leaves fewer than 8
+    downbeats before it, so the pair reaches QUICK_FADE and the lazy gate.
+    The vocal timeline is all-zero, so the outgoing side never contributes duty.
+    """
+    beats = [i * 60 / 124 for i in range(int(240 * 124 / 60))]
+    downbeats = beats[::4]
+    rms_energy = [0.9] * 1550 + [0.25] * (1730 - 1550) + [0.0] * (1800 - 1730)
+    return AudioAnalysisData(
+        duration=240.0,
+        bpm=124.0,
+        beats=beats,
+        downbeats=downbeats,
+        beats_per_bar=4,
+        rms_energy=rms_energy,
+        key="A",
+        mode="minor",
+        extra_data={"vocal_activity": [0.0] * 1800},
+    )
+
+
+def _lazy_gate_incoming(vocal_run: tuple[float, float]) -> AudioAnalysisData:
+    """Incoming analysis for the lazy-gate fixtures: a 45s head with vocal only over ``vocal_run``."""
+    beats = [i * 60 / 124 for i in range(int(45 * 124 / 60))]
+    vocal_activity = [0.0] * 1800
+    frame_duration = 45.0 / 1800
+    start_bin = int(vocal_run[0] / frame_duration)
+    end_bin = int(vocal_run[1] / frame_duration)
+    for i in range(start_bin, end_bin):
+        vocal_activity[i] = 0.95
+    return AudioAnalysisData(
+        duration=45.0,
+        bpm=124.0,
+        beats=beats,
+        downbeats=beats[::4],
+        beats_per_bar=4,
+        rms_energy=[0.8] * 1800,
+        key="A",
+        mode="minor",
+        extra_data={"vocal_activity": vocal_activity},
+    )
+
+
+def _front_loaded_vocal_ctx() -> TransitionContext:
+    """
+    Build a lazy-gate context where B's vocal sits inside the overlay's first 16s.
+
+    B's vocal run covers media 4.0-7.2s: ~3.2s of a 16s overlay (~0.20 duty)
+    but only ~0.07 over the full 45s head, so the whole-window gate would
+    pass it while the windowed gate correctly blocks it.
+    """
+    ctx = build_transition_context(
+        _lazy_gate_outgoing(), _lazy_gate_incoming((4.0, 7.2)), 45.0, logging.getLogger("test")
+    )
+    assert ctx.tier is TransitionTier.QUICK_FADE
+    whole = _vocal_duties(ctx)
+    assert whole is not None
+    assert whole[1] <= 0.10
+    windowed = _window_duties(ctx, _LAZY_OVERLAY_SECONDS)
+    assert windowed is not None
+    assert windowed[1] > 0.10
+    return ctx
+
+
+def _late_vocal_ctx() -> TransitionContext:
+    """
+    Build a lazy-gate context where B's vocal sits entirely outside the overlay's first 16s.
+
+    B's vocal run covers media 20.0-30.0s: 0.0 duty inside a 16s overlay but
+    ~0.22 over the full 45s head, so the whole-window gate wrongly blocks it
+    while the windowed gate correctly allows it.
+    """
+    ctx = build_transition_context(
+        _lazy_gate_outgoing(), _lazy_gate_incoming((20.0, 30.0)), 45.0, logging.getLogger("test")
+    )
+    assert ctx.tier is TransitionTier.QUICK_FADE
+    whole = _vocal_duties(ctx)
+    assert whole is not None
+    assert whole[1] > 0.10
+    windowed = _window_duties(ctx, _LAZY_OVERLAY_SECONDS)
+    assert windowed is not None
+    assert windowed[1] <= 0.10
+    return ctx
+
+
+def test_lazy_overlay_denied_when_vocals_sit_inside_the_overlay() -> None:
+    """Vocals concentrated in B's first 16s block the overlay even when its 45s duty is low."""
+    ctx = _front_loaded_vocal_ctx()
+    assert list(LazyOverlayGenerator().generate(ctx)) == []
+
+
+def test_lazy_overlay_allowed_when_vocals_sit_outside_the_overlay() -> None:
+    """Vocals late in B's head leave the overlay window ambient, so the overlay still fires."""
+    ctx = _late_vocal_ctx()
+    specs = list(LazyOverlayGenerator().generate(ctx))
+    assert len(specs) == 1
+    assert specs[0].strategy is TransitionStrategy.LAZY_OVERLAY
+
+
+def test_instrumental_blend_gate_unchanged_by_window_duties() -> None:
+    """The both-instrumental 16-bar gate keeps reading whole-window duty."""
+    ctx = _front_loaded_vocal_ctx()
+    assert _vocal_duties(ctx) is not None
+    # the 16-bar gate's own verdict must not move when the lazy gate narrows its window
+    assert earns_instrumental_blend(ctx) is False
 
 
 def test_short_rungs_offer_intro_keeping_entry() -> None:

--- a/tests/controllers/streams/smart_fades/test_renderer.py
+++ b/tests/controllers/streams/smart_fades/test_renderer.py
@@ -156,6 +156,14 @@ class TestTransitionRenderer:
         assert crossfade.crossfade_samples == 10 * PCM.sample_rate
         assert timing.crossfade_duration == pytest.approx(10.0)
 
+    def test_fadeout_curve_flows_into_the_crossfade_filter(self) -> None:
+        """The plan's fadeout_curve becomes the acrossfade filter's c1 curve."""
+        plan = _plan(fadeout_curve="nofade")
+        filters, _ = TransitionRenderer(LOGGER).render(plan, PCM, _seconds(45))
+        crossfade = filters[-1]
+        assert isinstance(crossfade, CrossfadeFilter)
+        assert "c1=nofade" in crossfade.apply("[fadein]", "[fadeout]")[0]
+
     def test_stretch_savings_shorten_fadeout_accounting(self) -> None:
         """A speed-up ramp removes time from the rendered fade-out total."""
         plan = _plan(tempo_plan=TempoPlan(steps=[(30.0, 1.0), (35.0, 1.02)]))

--- a/tests/controllers/streams/smart_fades/test_vocal_aware.py
+++ b/tests/controllers/streams/smart_fades/test_vocal_aware.py
@@ -17,6 +17,7 @@ from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.controllers.streams.smart_fades.filters import CrossfadeFilter
+from music_assistant.controllers.streams.smart_fades.mixer import SmartFadesMixer
 from music_assistant.controllers.streams.smart_fades.models import (
     TransitionPlan,
     TransitionStrategy,
@@ -71,6 +72,7 @@ def _analysis(
 def _vocal_probabilities(
     duration: float,
     active_windows: list[tuple[float, float]],
+    level: float = 0.9,
 ) -> list[float]:
     """Build a probability timeline that is quiet except inside ``active_windows``."""
     n_frames = 1800
@@ -80,18 +82,19 @@ def _vocal_probabilities(
         start_index = max(0, int(start / frame_duration))
         end_index = min(n_frames, int(end / frame_duration) + 1)
         for i in range(start_index, end_index):
-            probabilities[i] = 0.9
+            probabilities[i] = level
     return probabilities
 
 
 def _with_vocal_activity(
     analysis: AudioAnalysisData,
     active_windows: list[tuple[float, float]],
+    level: float = 0.9,
 ) -> AudioAnalysisData:
     """Attach a valid vocal_activity list, active only inside ``active_windows``."""
     assert analysis.duration is not None
     analysis.extra_data = {
-        "vocal_activity": _vocal_probabilities(analysis.duration, active_windows)
+        "vocal_activity": _vocal_probabilities(analysis.duration, active_windows, level)
     }
     return analysis
 
@@ -269,6 +272,29 @@ class TestOutgoingVocalRetention:
 
         plan = _plan(out, inc, 45.0)
         assert plan.fade_out_window <= probe_ctx.audio_end + 1e-6
+
+    def test_retention_bytes_counts_a_weak_trailing_run(self) -> None:
+        """
+        A trailing run too weak for the planner's veto gate still protects retention.
+
+        The gate exists so a spurious window can't veto an entire blend; here a
+        window only decides how much outgoing audio survives silence removal, so
+        a weak-but-real run (peak and mean both below the planner's confidence
+        floors) must still count instead of yielding zero retention.
+        """
+        duration = 200.0
+        bpm = 100.0
+        buffer_seconds = 45.0
+        out = _analysis(bpm, duration, rms_energy=_rms_with_silence(duration, 190.3))
+        out = _with_vocal_activity(out, [(185.0, 187.0)], level=0.6)
+
+        pcm_format = AudioFormat(
+            content_type=ContentType.PCM_S16LE, sample_rate=44100, bit_depth=16, channels=2
+        )
+        fade_out_bytes_len = int(buffer_seconds * pcm_format.pcm_sample_size)
+
+        retention = SmartFadesMixer._get_vocal_retention_bytes(out, fade_out_bytes_len, pcm_format)
+        assert retention > 0
 
 
 class TestScheduleRecomputationAfterAnchorMovement:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5357. It fixes defects found in the review of that PR. Each change was measured
against a production analysis corpus of 7,349 analysed tracks and about 1,850 planned transitions.
Blind A/B listening then compared the change against the previous head.

- **A stale tier capped the trim-closing ladder.** `TransitionContext.tier` is decided at the early
  kick-folded anchor, but `TrimClosingAnchorGenerator` places its rungs at the audible end. A grid
  that the early window was too short for is often fully blendable there. The generator now derives
  its ladder from `choose_tier` at its own anchor. 503 tracks (6.8%) have this shape and strand a
  median of 23 s of audible tail. At pair level the change lifts 17% of affected transitions from
  4 bars or fewer to an 8-bar blend.
- **The lazy overlay measured vocal duty over the wrong window.** It renders a 16 s overlay. It
  gated on duty across the whole audible tail of the outgoing deck. On the incoming deck it gated
  across the full 45 s head. A deck that sings only at the very start or the very end could pass
  the gate and then sing through the overlay. A new `_window_duties` helper measures each deck over the window
  the overlay spans. `_vocal_duties` stays unchanged, because it also feeds
  `earns_instrumental_blend`, whose correct window is 16 bars of its own overlap.
- **A mastered fade-out was faded twice.** When the mastering engineer bakes a fade into the
  recording, that fade is already in the PCM. The `c1=qsin` curve of `acrossfade` then applied a
  second one, so the outgoing track disappeared early and the transition dipped mid-overlap. The
  crossfade curves are now configurable. The assembler picks `nofade` when the overlap sits fully
  inside a detected mastered fade and runs to the audible end. The record's own fade becomes the
  fade. This affects 9.4% of planned transitions. The other 90.6% render bit-identical.
- **The vocal gate reached the mixer's retention decision.** `build_vocal_windows` discards a run
  unless its peak or mean shows real confidence. That gate exists for the planner, where a false
  window vetoes blend length. `SmartFadesMixer._get_vocal_retention_bytes` used the same default to
  decide how much outgoing audio to keep from silence removal, where a missed window truncates
  audible singing. The mixer now passes a config with the gate lifted. The planner and every shared
  default stay exactly as they are, so blend selection cannot move.

**On the fourth item.** It is a correctness fix and it has no demonstrated audible effect. Of 1,794
tracks that carry a vocal timeline, 435 get a smaller retention value from the gate. The call site
keeps `max(len(stripped), vocal_bytes)`, so the change only reaches the audio where the vocal runs
past the point `strip_silence` would cut. 66 tracks have a vocal that reaches the audible end.
Decoding their real PCM leaves 10 such cases, and only 4 of them differ by 0.5 s or more. A blind
round over those 4 returned 2-2 with every verdict hedged. Preference did not track effect size. The fix ships on
the reasoning, not on the ear: the coupling between the two consumers was accidental, and their
error preferences are opposite.

**On the review's other two findings.** The mastered-fade anchor override (B1) was investigated at
length. Clamping the anchor of trim-closing to `fade_onset` halves the deepest overruns, but it
pushes 66% of affected tracks onto the rescue path. Blind listening showed that the audible defect
is the double fade, not the anchor, so the curve fixes it instead. Anchor snapping (S2) was
implemented and listened to, and it lost 3-0. It does not quantise the overlap. The median distance
from a whole bar stayed at 0.244, and near-exact overlaps fell from 6 to 3. It also aligns
`fade_out_window`, which is where the outgoing track reaches zero gain, so nothing audible sits
there to align. It shortened the blend for no audible gain and is not included.

Verification: 369 tests pass. A 42-pair contract sweep passes with 0 violations. Unchanged
transitions decode bit-identical (4 of 4) and changed ones differ (5 of 5). The blind round for the
curve change returned 3-0 with 0 regressions. The listener notes match the mechanism: "hear the
outgoing for longer", "more balanced volume mixing", "the other one fades out too quickly". The
single corpus transition where `nofade` meets a vocal collision (0.46 s of a 2.24 s overlap) was
rendered both ways and judged indistinguishable.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
