### PR TITLE
Name FFmpeg channel layouts in one place

### DIFF
--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -23,6 +23,7 @@ from music_assistant.controllers.streams.smart_fades.models import (
 from music_assistant.controllers.streams.smart_fades.planner import SmartCrossFadePlanner
 from music_assistant.controllers.streams.smart_fades.renderer import TransitionRenderer
 from music_assistant.helpers.audio import iter_pcm_slices
+from music_assistant.helpers.ffmpeg import get_ffmpeg_channel_args
 from music_assistant.helpers.process import AsyncProcess
 from music_assistant.helpers.util import remove_file
 
@@ -95,12 +96,9 @@ class SmartFade(ABC):
             # Input 1: fadeout part (as file)
             "-acodec",
             pcm_format.content_type.name.lower(),  # e.g., "pcm_f32le" not just "f32le"
-            "-ac",
-            str(pcm_format.channels),
+            *get_ffmpeg_channel_args(pcm_format),
             "-ar",
             str(pcm_format.sample_rate),
-            "-channel_layout",
-            "mono" if pcm_format.channels == 1 else "stereo",
             "-f",
             pcm_format.content_type.value,
             "-i",
@@ -108,12 +106,9 @@ class SmartFade(ABC):
             # Input 2: fade_in part (stdin)
             "-acodec",
             pcm_format.content_type.name.lower(),
-            "-ac",
-            str(pcm_format.channels),
+            *get_ffmpeg_channel_args(pcm_format),
             "-ar",
             str(pcm_format.sample_rate),
-            "-channel_layout",
-            "mono" if pcm_format.channels == 1 else "stereo",
             "-f",
             pcm_format.content_type.value,
             "-i",
@@ -131,12 +126,9 @@ class SmartFade(ABC):
                 # Output format specification - must match input codec format
                 "-acodec",
                 pcm_format.content_type.name.lower(),
-                "-ac",
-                str(pcm_format.channels),
+                *get_ffmpeg_channel_args(pcm_format),
                 "-ar",
                 str(pcm_format.sample_rate),
-                "-channel_layout",
-                "mono" if pcm_format.channels == 1 else "stereo",
                 "-f",
                 pcm_format.content_type.value,
                 "-",

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -446,7 +446,10 @@ async def get_ffmpeg_overlay_stream(
             "1",
         ]
     overlay_input_args += ["-stream_loop", "-1", "-i", overlay_input]
-    channel_layout = "mono" if pcm_format.channels == 1 else "stereo"
+    # conform the overlay to the main stream's layout so amix sees two matching inputs;
+    # an unnameable count is left to FFmpeg's own negotiation
+    layout = _get_channel_layout_name(pcm_format.channels)
+    conform_filter = f",aformat=channel_layouts={layout}" if layout else ""
     # silenceremove strips a near-silent intro from the overlay source (e.g. a soft
     # fade-in) so it becomes audible right away; it is a no-op for sources that
     # already start at full level. It runs before volume so detection is based on
@@ -454,8 +457,8 @@ async def get_ffmpeg_overlay_stream(
     filter_complex = (
         f"[0:a]silenceremove=start_periods=1:start_threshold=-40dB,"
         f"volume={overlay_volume / 100},"
-        f"aresample={pcm_format.sample_rate},"
-        f"aformat=channel_layouts={channel_layout}[overlay];"
+        f"aresample={pcm_format.sample_rate}"
+        f"{conform_filter}[overlay];"
         "[1:a][overlay]amix=inputs=2:duration=first:normalize=0[mixed]"
     )
     async with FFMpeg(
@@ -582,7 +585,7 @@ def get_ffmpeg_args(
                 input_args += ["-seekable", "0"]
         if input_format.content_type.is_pcm():
             input_args += [
-                *_get_channel_args(input_format),
+                *get_ffmpeg_channel_args(input_format),
                 "-ar",
                 str(input_format.sample_rate),
                 "-acodec",
@@ -597,7 +600,7 @@ def get_ffmpeg_args(
         input_args += ["-i", input_path]
 
     # collect output args
-    output_args = _get_channel_args(output_format)
+    output_args = get_ffmpeg_channel_args(output_format)
     if output_path.upper() == "NULL":
         # devnull stream: nothing is encoded here, so there is no channel count to declare
         output_path = "-"
@@ -680,6 +683,20 @@ def get_ffmpeg_args(
     return generic_args + input_args + extra_input_args + filter_args + extra_args + output_args
 
 
+def get_ffmpeg_channel_args(audio_format: AudioFormat) -> list[str]:
+    """
+    Return the FFmpeg channel count/layout arguments for the given audio format.
+
+    The layout is only named for channel counts that map to exactly one layout.
+
+    :param audio_format: Format to describe.
+    """
+    args = ["-ac", str(audio_format.channels)]
+    if layout := _get_channel_layout_name(audio_format.channels):
+        args += ["-channel_layout", layout]
+    return args
+
+
 async def check_ffmpeg_version() -> None:
     """Check if ffmpeg is present (with libsoxr support)."""
     # check for FFmpeg presence
@@ -725,22 +742,20 @@ async def check_ffmpeg_version() -> None:
     )
 
 
-def _get_channel_args(audio_format: AudioFormat) -> list[str]:
+def _get_channel_layout_name(channels: int) -> str | None:
     """
-    Return the FFmpeg channel count/layout arguments for the given audio format.
+    Return FFmpeg's layout name for a channel count, or None when it has no unambiguous one.
 
-    :param audio_format: Format to describe.
+    :param channels: Number of channels to name.
     """
-    args = ["-ac", str(audio_format.channels)]
-    # only name the layout where the channel count leaves no doubt: a wider count
-    # maps to several possible layouts (5.1 vs 5.1(side), 7.1 vs 7.1(wide), ...)
-    # and naming the wrong one wins over -ac, so FFmpeg would then misread the
-    # stream as that layout instead. Left alone, it derives the default itself.
-    if audio_format.channels == 1:
-        args += ["-channel_layout", "mono"]
-    elif audio_format.channels == 2:
-        args += ["-channel_layout", "stereo"]
-    return args
+    if channels == 1:
+        return "mono"
+    if channels == 2:
+        return "stereo"
+    # a wider count maps to several possible layouts (5.1 vs 5.1(side), 7.1 vs 7.1(wide), ...)
+    # and a named layout wins over -ac, so naming the wrong one would make FFmpeg misread the
+    # stream as that layout. Left unnamed, it derives the default for the count itself.
+    return None
 
 
 def _get_channel_conform_filter(input_channels: int, output_channels: int) -> str | None:


### PR DESCRIPTION
# What does this implement/fix?

FFmpeg picks its own channel layout from the channel count, and naming the wrong one silently wins over the count. We already learned that the hard way in #5363, but the same `"mono" if channels == 1 else "stereo"` guess was still written out by hand in four more places, so the rule lived in five spots at once.

This pulls the decision into one helper that every caller now shares. No behaviour change: for mono and stereo — the only widths these paths ever run at — every caller ends up asking ffmpeg for exactly the same thing as before. The smart fades calls list `-channel_layout` before `-ar` now instead of after; both are input options, so the order carries no meaning.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
