### PR TITLE
Look for a caller's own audio filter graph in every argument list

### DIFF
--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -673,10 +673,10 @@ def get_ffmpeg_args(
     ):
         filter_params.append(resample_filter)
 
-    # ffmpeg refuses a simple -af chain alongside a complex graph on the same stream, so a
-    # caller that declares its own graph (through either extra arg list) keeps sole ownership
-    caller_owns_filtergraph = (
-        "-filter_complex" in extra_args or "-filter_complex" in extra_output_args
+    # ffmpeg refuses a simple -af chain alongside a complex graph on the same stream, so we
+    # leave the graph to any caller that declares one in one of the passthrough arg lists
+    caller_owns_filtergraph = any(
+        "-filter_complex" in args for args in (extra_args, extra_input_args, extra_output_args)
     )
 
     # a complex fragment brings its own inputs, which must follow the main input

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -673,10 +673,16 @@ def get_ffmpeg_args(
     ):
         filter_params.append(resample_filter)
 
+    # ffmpeg refuses a simple -af chain alongside a complex graph on the same stream, so a
+    # caller that declares its own graph (through either extra arg list) keeps sole ownership
+    caller_owns_filtergraph = (
+        "-filter_complex" in extra_args or "-filter_complex" in extra_output_args
+    )
+
     # a complex fragment brings its own inputs, which must follow the main input
     extra_input_args, filter_args = (
         _build_filtergraph_args(filter_params)
-        if filter_params and "-filter_complex" not in extra_args
+        if filter_params and not caller_owns_filtergraph
         else ([], [])
     )
 

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -802,6 +802,41 @@ def test_get_ffmpeg_args_uses_filter_complex_with_complex_filter() -> None:
     assert args.index("/ir.wav") > args.index("-i")
 
 
+def test_get_ffmpeg_args_yields_filtergraph_to_caller_output_args() -> None:
+    """A caller-owned graph in the output args keeps the simple -af chain out of the command."""
+    fmt = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=48000, bit_depth=16, channels=2
+    )
+    args = get_ffmpeg_args(
+        fmt,
+        fmt,
+        ["volume=-1dB"],
+        extra_output_args=["-filter_complex", "[0:a][1:a]amix[mixed]", "-map", "[mixed]"],
+    )
+    assert "-af" not in args
+    assert args.count("-filter_complex") == 1
+    assert "volume=-1dB" not in args
+
+
+def test_get_ffmpeg_args_channel_conform_yields_to_caller_output_args() -> None:
+    """The auto-injected channel filter is dropped too when the caller owns the graph."""
+    input_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=48000, bit_depth=16, channels=1
+    )
+    output_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE, sample_rate=48000, bit_depth=16, channels=2
+    )
+    args = get_ffmpeg_args(
+        input_format,
+        output_format,
+        [],
+        extra_output_args=["-filter_complex", "[0:a][1:a]amix[mixed]", "-map", "[mixed]"],
+    )
+    assert "-af" not in args
+    assert args.count("-filter_complex") == 1
+    assert not any(arg.startswith("pan=") for arg in args)
+
+
 def _rms_db(path: Path) -> float:
     """Return the overall RMS level of an audio file in dB via ffmpeg astats."""
     output = subprocess.run(  # noqa: S603

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -802,23 +802,42 @@ def test_get_ffmpeg_args_uses_filter_complex_with_complex_filter() -> None:
     assert args.index("/ir.wav") > args.index("-i")
 
 
-def test_get_ffmpeg_args_yields_filtergraph_to_caller_output_args() -> None:
-    """A caller-owned graph in the output args keeps the simple -af chain out of the command."""
+PASSTHROUGH_ARG_LISTS = ["extra_args", "extra_input_args", "extra_output_args"]
+
+
+def _args_with_caller_filtergraph(
+    input_format: AudioFormat,
+    output_format: AudioFormat,
+    filter_params: list[str],
+    arg_list: str,
+) -> list[str]:
+    """Build ffmpeg args with a caller-owned filter graph in the named passthrough list."""
+    graph = ["-filter_complex", "[0:a][1:a]amix[mixed]"]
+    return get_ffmpeg_args(
+        input_format,
+        output_format,
+        filter_params,
+        extra_args=graph if arg_list == "extra_args" else [],
+        extra_input_args=graph if arg_list == "extra_input_args" else [],
+        extra_output_args=graph if arg_list == "extra_output_args" else [],
+    )
+
+
+@pytest.mark.parametrize("arg_list", PASSTHROUGH_ARG_LISTS)
+def test_get_ffmpeg_args_yields_filtergraph_to_caller(arg_list: str) -> None:
+    """A caller-owned graph keeps our simple -af chain out of the command."""
     fmt = AudioFormat(
         content_type=ContentType.PCM_S16LE, sample_rate=48000, bit_depth=16, channels=2
     )
-    args = get_ffmpeg_args(
-        fmt,
-        fmt,
-        ["volume=-1dB"],
-        extra_output_args=["-filter_complex", "[0:a][1:a]amix[mixed]", "-map", "[mixed]"],
-    )
+
+    args = _args_with_caller_filtergraph(fmt, fmt, ["volume=-1dB"], arg_list)
+
     assert "-af" not in args
-    assert args.count("-filter_complex") == 1
     assert "volume=-1dB" not in args
 
 
-def test_get_ffmpeg_args_channel_conform_yields_to_caller_output_args() -> None:
+@pytest.mark.parametrize("arg_list", PASSTHROUGH_ARG_LISTS)
+def test_get_ffmpeg_args_channel_conform_yields_to_caller(arg_list: str) -> None:
     """The auto-injected channel filter is dropped too when the caller owns the graph."""
     input_format = AudioFormat(
         content_type=ContentType.PCM_S16LE, sample_rate=48000, bit_depth=16, channels=1
@@ -826,14 +845,10 @@ def test_get_ffmpeg_args_channel_conform_yields_to_caller_output_args() -> None:
     output_format = AudioFormat(
         content_type=ContentType.PCM_S16LE, sample_rate=48000, bit_depth=16, channels=2
     )
-    args = get_ffmpeg_args(
-        input_format,
-        output_format,
-        [],
-        extra_output_args=["-filter_complex", "[0:a][1:a]amix[mixed]", "-map", "[mixed]"],
-    )
+
+    args = _args_with_caller_filtergraph(input_format, output_format, [], arg_list)
+
     assert "-af" not in args
-    assert args.count("-filter_complex") == 1
     assert not any(arg.startswith("pan=") for arg in args)
 
 


### PR DESCRIPTION
# What does this implement/fix?

When building the ffmpeg command we skip our own simple `-af` filter chain if the caller
already brings its own complex filter graph, because ffmpeg refuses the two together on the
same stream. That check only looked at one of the three argument lists a caller can pass
things through, and not the ones actually used for this: the audio overlay mixer declares its
graph via the output args, and providers can pass args through the input args. Nothing is
broken today, but the automatic channel conversion added in #5362 can now add a filter of our
own where there was none before, so the check should cover all three lists.

- Look for a caller-owned `-filter_complex` in all three passthrough argument lists
- Added tests covering each of the three, including the auto-injected channel filter

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
