### PR TITLE
Use less memory for the cached Home Assistant entity registry

### DIFF
--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -100,10 +100,9 @@ class DeviceMediaPlayerInfo(TypedDict):
     announce_entity_id: str | None
 
 
-class HassRegistryEntity(TypedDict):
+class HassRegistryEntity(NamedTuple):
     """Home Assistant entity registry entry, limited to the fields Music Assistant uses."""
 
-    entity_id: str
     platform: str
     device_id: str | None
 
@@ -389,9 +388,8 @@ class HomeAssistantProvider(PluginProvider):
         Entities that are disabled in Home Assistant are absent from the result, and so are
         entities without a unique ID: those are not part of Home Assistant's registry at all.
 
-        The result is shared between all callers and must be treated as read-only: the
-        mapping itself rejects writes, but the entries are plain dicts, so copy an entry
-        before changing it.
+        The result is shared between all callers and is read-only: both the mapping and
+        its entries reject writes.
         """
         if (registry := self._entity_registry) is not None:
             return registry
@@ -465,13 +463,13 @@ class HomeAssistantProvider(PluginProvider):
         if not device_by_mac:
             return {}
         media_players_by_device: dict[str, list[str]] = {}
-        for entry in (await self.get_entity_registry()).values():
+        for entity_id, entry in (await self.get_entity_registry()).items():
             if (
-                entry["platform"] == platform
-                and entry["entity_id"].startswith("media_player.")
-                and (device_id := entry["device_id"])
+                entry.platform == platform
+                and entity_id.startswith("media_player.")
+                and (device_id := entry.device_id)
             ):
-                media_players_by_device.setdefault(device_id, []).append(entry["entity_id"])
+                media_players_by_device.setdefault(device_id, []).append(entity_id)
         candidates_by_mac = {
             mac: media_players_by_device.get(device["id"], [])
             for mac, device in device_by_mac.items()
@@ -1071,7 +1069,6 @@ class HomeAssistantProvider(PluginProvider):
             if (device_id := entry.get("di")) is not None:
                 device_id = device_ids.setdefault(device_id, device_id)
             registry[entry["ei"]] = HassRegistryEntity(
-                entity_id=entry["ei"],
                 platform=intern(entry["pl"]),
                 device_id=device_id,
             )

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -101,7 +101,11 @@ class DeviceMediaPlayerInfo(TypedDict):
 
 
 class HassRegistryEntity(NamedTuple):
-    """Home Assistant entity registry entry, limited to the fields Music Assistant uses."""
+    """
+    Home Assistant entity registry entry, limited to the fields Music Assistant uses.
+
+    The entity ID is not a field: entries are always keyed by it.
+    """
 
     platform: str
     device_id: str | None

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -788,7 +788,7 @@ async def test_shared_registry_rejects_writes() -> None:
                 platform="test", device_id=None
             )
         with pytest.raises(AttributeError):
-            next(iter(registry.values())).platform = "test"  # type: ignore[misc]
+            registry["tts.only"].platform = "test"  # type: ignore[misc]
 
 
 async def test_registry_reuses_repeated_strings() -> None:

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -779,14 +779,16 @@ async def test_registry_changed_during_the_fetch_is_not_cached() -> None:
 
 
 async def test_shared_registry_rejects_writes() -> None:
-    """Reject writes to the registry that is shared between all callers."""
+    """Reject writes to the registry (and its entries) shared between all callers."""
     async with _start_provider([_state("tts.only", "Only")]) as (provider, _):
         registry = await provider.get_entity_registry()
 
         with pytest.raises(TypeError):
             registry["light.kitchen"] = HassRegistryEntity(  # type: ignore[index]
-                entity_id="light.kitchen", platform="test", device_id=None
+                platform="test", device_id=None
             )
+        with pytest.raises(AttributeError):
+            next(iter(registry.values())).platform = "test"  # type: ignore[misc]
 
 
 async def test_registry_reuses_repeated_strings() -> None:
@@ -808,13 +810,11 @@ async def test_registry_reuses_repeated_strings() -> None:
             registry = await provider._fetch_entity_registry()
 
         assert len(registry) == 3
-        assert registry["light.lamp_0"] == {
-            "entity_id": "light.lamp_0",
-            "platform": "esphome",
-            "device_id": "device",
-        }
-        assert len({id(entry["platform"]) for entry in registry.values()}) == 1
-        assert len({id(entry["device_id"]) for entry in registry.values()}) == 1
+        assert registry["light.lamp_0"] == HassRegistryEntity(
+            platform="esphome", device_id="device"
+        )
+        assert len({id(entry.platform) for entry in registry.values()}) == 1
+        assert len({id(entry.device_id) for entry in registry.values()}) == 1
 
 
 async def test_device_registry_is_reused_within_the_cache_window() -> None:


### PR DESCRIPTION
# What does this implement/fix?

The Home Assistant entity registry is cached in memory for as long as the connection lives, and on large setups it is big: a real-world 41k entity registry was the reason the listing was slimmed down earlier. Each entry was a small dict, which costs a lot more than the three values it holds, and the entries were still writable so anything could quietly modify the shared cache.

Storing the entries as a `NamedTuple` (the idiom already used elsewhere in this file) fixes both. Measured on a synthetic 41k entity registry: **11.73 MB → 7.35 MB**, a 37% reduction (184 bytes per entry → 64).

- Entity registry entries are now immutable tuples instead of dicts
- Dropped the `entity_id` field, which just repeated the key the entries are stored under
- Updated the two read sites and the tests accordingly

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
