### PR TITLE
Ask Music Quiz Trivia release year questions about compilation tracks

### DIFF
--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -437,18 +437,20 @@ class QuizType(ABC):
             track, QUIZ_TRACK_RECENCY_SECONDS
         )
 
-    async def _musicbrainz_dated_track(self, track: Track) -> Track:
+    async def _musicbrainz_dated_track(self, track: Track) -> tuple[Track, int | None]:
         """
         Return the track dated with the first release year MusicBrainz knows for its recording.
 
         The track itself is returned unchanged when MusicBrainz has nothing better to offer.
 
         :param track: Track to date by its ISRC.
+        :return: The dated track and the release year MusicBrainz knows for its recording, which
+            is also reported when the track already carries that year or an earlier one.
         """
         musicbrainz = self.mass.get_provider("musicbrainz")
         isrc = track.get_external_id(ExternalID.ISRC)
         if musicbrainz is None or not isrc:
-            return track
+            return track, None
         release_year: int | None = None
         # callers wait for this and MusicBrainz throttles to 10 requests per 10 seconds, so a
         # lookup that does not resolve within the budget leaves the track on its library year
@@ -463,16 +465,17 @@ class QuizType(ABC):
         # a year outside this range is rejected by get_track_release_year anyway, and a year
         # below 1 cannot be expressed as a datetime at all
         if release_year is None or not MIN_RELEASE_YEAR <= release_year <= utc().year:
-            return track
+            return track, None
         release_date = track.metadata.release_date
         if release_date is not None and release_date.year <= release_year:
-            return track
+            return track, release_year
         # the track controller hands out objects that are shared with the library cache,
         # so the release date is written to a copy instead of the track itself
-        return replace(
+        dated_track = replace(
             track,
             metadata=replace(track.metadata, release_date=datetime(release_year, 1, 1, tzinfo=UTC)),
         )
+        return dated_track, release_year
 
 
 def get_track_release_year(track: Track) -> int | None:

--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -444,8 +444,9 @@ class QuizType(ABC):
         The track itself is returned unchanged when MusicBrainz has nothing better to offer.
 
         :param track: Track to date by its ISRC.
-        :return: The dated track and the release year MusicBrainz knows for its recording, which
-            is also reported when the track already carries that year or an earlier one.
+        :return: The dated track and the usable release year MusicBrainz knows for its recording.
+            The year is reported even when the track already carries that year or an earlier one,
+            and is None when MusicBrainz knows no year or only an implausible one.
         """
         musicbrainz = self.mass.get_provider("musicbrainz")
         isrc = track.get_external_id(ExternalID.ISRC)

--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -295,7 +295,7 @@ class MusicTimelineQuizType(QuizType):
 
         async def _rescue_track(track: Track) -> None:
             async with semaphore:
-                dated_track = await self._musicbrainz_dated_track(track)
+                dated_track, _ = await self._musicbrainz_dated_track(track)
             if dated_track.uri is not None and self._track_is_eligible(dated_track):
                 eligible_tracks[dated_track.uri] = dated_track
 
@@ -313,7 +313,7 @@ class MusicTimelineQuizType(QuizType):
         existing_ids: set[str] | None = None,
     ) -> TimelineEntry:
         """Create a stable timeline entry from an eligible track."""
-        track = await self._musicbrainz_dated_track(track)
+        track, _ = await self._musicbrainz_dated_track(track)
         release_year = self._release_year(track)
         if release_year is None or not track.uri or not track.artist_str:
             raise InvalidDataError("Music Timeline track is missing required timeline metadata")

--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -270,10 +270,10 @@ class TriviaQuizType(QuizType):
         # an album can carry a reissue year, which would be scored as the correct answer to a
         # release year question; dating only the track that becomes this round's question keeps
         # the lookups bounded where dating the eligible pool would not
-        source_track = source_pool[track_facts.source_uri]
-        dated_track = await self._musicbrainz_dated_track(source_track)
-        musicbrainz_dated = dated_track.metadata.release_date != source_track.metadata.release_date
-        dated_facts = self._track_facts(dated_track, musicbrainz_dated=musicbrainz_dated)
+        dated_track, musicbrainz_year = await self._musicbrainz_dated_track(
+            source_pool[track_facts.source_uri]
+        )
+        dated_facts = self._track_facts(dated_track, musicbrainz_year=musicbrainz_year)
         track_facts = dated_facts or track_facts
         fact = self._select_fact(track_facts, round_index)
         generation = await self._generate_question(fact)
@@ -548,13 +548,15 @@ class TriviaQuizType(QuizType):
         return used_source_uris
 
     @staticmethod
-    def _track_facts(track: Track, *, musicbrainz_dated: bool = False) -> TriviaTrackFacts | None:
+    def _track_facts(
+        track: Track, *, musicbrainz_year: int | None = None
+    ) -> TriviaTrackFacts | None:
         """
         Return bounded factual metadata available on a selected track.
 
         :param track: Selected source track to read the facts from.
-        :param musicbrainz_dated: Whether the track carries a release date supplied by
-            MusicBrainz, which makes its year usable even on an untrusted compilation album.
+        :param musicbrainz_year: Release year MusicBrainz knows for the track's recording, which
+            is the only year usable when the track sits on an untrusted compilation album.
         """
         if not track.uri or not (title := _bounded_metadata_value(track.name)):
             return None
@@ -570,12 +572,11 @@ class TriviaQuizType(QuizType):
                 if untrusted_compilation
                 else _bounded_metadata_value(album.name if album else None)
             ),
-            # get_track_release_year already refuses an untrusted album's own year, so a dated
-            # compilation track is left with the recording year MusicBrainz supplied
+            # on an untrusted compilation both available years are unusable: the album carries
+            # the reissue year and the track its position on that reissue, so only the year
+            # MusicBrainz knows for the recording can answer a release year question
             release_year=(
-                None
-                if untrusted_compilation and not musicbrainz_dated
-                else get_track_release_year(track)
+                musicbrainz_year if untrusted_compilation else get_track_release_year(track)
             ),
         )
         return facts if TriviaQuizType._available_targets(facts) else None

--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -270,8 +270,11 @@ class TriviaQuizType(QuizType):
         # an album can carry a reissue year, which would be scored as the correct answer to a
         # release year question; dating only the track that becomes this round's question keeps
         # the lookups bounded where dating the eligible pool would not
-        dated_track = await self._musicbrainz_dated_track(source_pool[track_facts.source_uri])
-        track_facts = self._track_facts(dated_track) or track_facts
+        source_track = source_pool[track_facts.source_uri]
+        dated_track = await self._musicbrainz_dated_track(source_track)
+        musicbrainz_dated = dated_track.metadata.release_date != source_track.metadata.release_date
+        dated_facts = self._track_facts(dated_track, musicbrainz_dated=musicbrainz_dated)
+        track_facts = dated_facts or track_facts
         fact = self._select_fact(track_facts, round_index)
         generation = await self._generate_question(fact)
         correct = SuggestionCandidate(
@@ -545,8 +548,14 @@ class TriviaQuizType(QuizType):
         return used_source_uris
 
     @staticmethod
-    def _track_facts(track: Track) -> TriviaTrackFacts | None:
-        """Return bounded factual metadata available on a selected track."""
+    def _track_facts(track: Track, *, musicbrainz_dated: bool = False) -> TriviaTrackFacts | None:
+        """
+        Return bounded factual metadata available on a selected track.
+
+        :param track: Selected source track to read the facts from.
+        :param musicbrainz_dated: Whether the track carries a release date supplied by
+            MusicBrainz, which makes its year usable even on an untrusted compilation album.
+        """
         if not track.uri or not (title := _bounded_metadata_value(track.name)):
             return None
         artist = _bounded_metadata_value(track.artist_str or None)
@@ -561,7 +570,13 @@ class TriviaQuizType(QuizType):
                 if untrusted_compilation
                 else _bounded_metadata_value(album.name if album else None)
             ),
-            release_year=None if untrusted_compilation else get_track_release_year(track),
+            # get_track_release_year already refuses an untrusted album's own year, so a dated
+            # compilation track is left with the recording year MusicBrainz supplied
+            release_year=(
+                None
+                if untrusted_compilation and not musicbrainz_dated
+                else get_track_release_year(track)
+            ),
         )
         return facts if TriviaQuizType._available_targets(facts) else None
 

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -1016,8 +1016,8 @@ async def test_compilation_year_round_is_scored_on_the_musicbrainz_year() -> Non
 
 
 @pytest.mark.asyncio
-async def test_compilation_rounds_only_generate_artist_and_title_targets() -> None:
-    """Generate valid rounds without selecting compilation album or year targets."""
+async def test_undated_compilation_rounds_only_generate_artist_and_title_targets() -> None:
+    """Generate valid rounds without album or year targets while MusicBrainz cannot date them."""
     first_track = _track("one", "First Song", "Artist One", release_year=2012)
     first_track.album = _full_album(
         "first-album",

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -756,7 +756,8 @@ async def test_musicbrainz_dates_a_reissue_album_mapping() -> None:
     quiz, mass = _quiz([track])
     _with_musicbrainz(mass, {"ISRC-REISSUE": 1998})
 
-    facts = quiz._track_facts(await quiz._musicbrainz_dated_track(track))
+    dated_track, _ = await quiz._musicbrainz_dated_track(track)
+    facts = quiz._track_facts(dated_track)
 
     assert facts is not None
     assert facts.release_year == 1998
@@ -776,8 +777,10 @@ async def test_library_release_year_survives_a_later_musicbrainz_year() -> None:
     quiz, mass = _quiz([dated_album, dated_track])
     _with_musicbrainz(mass, {"ISRC-ALBUM-DATED": 2017, "ISRC-TRACK-DATED": 2017})
 
-    album_facts = quiz._track_facts(await quiz._musicbrainz_dated_track(dated_album))
-    track_facts = quiz._track_facts(await quiz._musicbrainz_dated_track(dated_track))
+    album_dated, _ = await quiz._musicbrainz_dated_track(dated_album)
+    track_dated, _ = await quiz._musicbrainz_dated_track(dated_track)
+    album_facts = quiz._track_facts(album_dated)
+    track_facts = quiz._track_facts(track_dated)
 
     assert album_facts is not None
     assert album_facts.release_year == 1967
@@ -796,7 +799,8 @@ async def test_musicbrainz_adds_a_year_target_to_an_undated_track() -> None:
     _with_musicbrainz(mass, {"ISRC-UNDATED": 1998})
 
     undated_facts = quiz._track_facts(track)
-    dated_facts = quiz._track_facts(await quiz._musicbrainz_dated_track(track))
+    dated_track, _ = await quiz._musicbrainz_dated_track(track)
+    dated_facts = quiz._track_facts(dated_track)
 
     assert undated_facts is not None
     assert undated_facts.release_year is None
@@ -810,10 +814,19 @@ async def test_musicbrainz_adds_a_year_target_to_an_undated_track() -> None:
     assert quiz._available_targets(dated_facts) == tuple(TriviaTarget)
 
 
+@pytest.mark.parametrize(
+    "library_year",
+    [1998, 1982, 1975, None],
+    ids=["reissue-year", "same-year", "earlier-year", "undated"],
+)
 @pytest.mark.asyncio
-async def test_compilation_release_year_uses_the_musicbrainz_recording_year() -> None:
-    """Offer a year target on a compilation track once MusicBrainz dates the recording."""
-    track = _with_isrc(_track("compilation", "Africa", "Toto", release_year=1998), "ISRC-COMP")
+async def test_compilation_release_year_uses_the_musicbrainz_recording_year(
+    library_year: int | None,
+) -> None:
+    """Answer a compilation year question with the MusicBrainz year whatever the library says."""
+    track = _with_isrc(
+        _track("compilation", "Africa", "Toto", release_year=library_year), "ISRC-COMP"
+    )
     track.album = _full_album(
         "party-hits",
         "Party Hits",
@@ -823,12 +836,20 @@ async def test_compilation_release_year_uses_the_musicbrainz_recording_year() ->
     quiz, mass = _quiz([track])
     _with_musicbrainz(mass, {"ISRC-COMP": 1982})
 
-    facts = quiz._track_facts(await quiz._musicbrainz_dated_track(track), musicbrainz_dated=True)
+    dated_track, musicbrainz_year = await quiz._musicbrainz_dated_track(track)
+    facts = quiz._track_facts(dated_track, musicbrainz_year=musicbrainz_year)
 
     assert facts is not None
     assert facts.album is None
     assert facts.release_year == 1982
-    assert TriviaTarget.YEAR in quiz._available_targets(facts)
+    assert quiz._available_targets(facts) == (
+        TriviaTarget.ARTIST,
+        TriviaTarget.TITLE,
+        TriviaTarget.YEAR,
+    )
+    fact = quiz._select_fact(facts, 2)
+    assert fact.target is TriviaTarget.YEAR
+    assert fact.correct_answer == "1982"
 
 
 def test_compilation_release_year_stays_suppressed_without_dating() -> None:

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -777,10 +777,10 @@ async def test_library_release_year_survives_a_later_musicbrainz_year() -> None:
     quiz, mass = _quiz([dated_album, dated_track])
     _with_musicbrainz(mass, {"ISRC-ALBUM-DATED": 2017, "ISRC-TRACK-DATED": 2017})
 
-    album_dated, _ = await quiz._musicbrainz_dated_track(dated_album)
-    track_dated, _ = await quiz._musicbrainz_dated_track(dated_track)
-    album_facts = quiz._track_facts(album_dated)
-    track_facts = quiz._track_facts(track_dated)
+    album_dated, album_year = await quiz._musicbrainz_dated_track(dated_album)
+    track_dated, track_year = await quiz._musicbrainz_dated_track(dated_track)
+    album_facts = quiz._track_facts(album_dated, musicbrainz_year=album_year)
+    track_facts = quiz._track_facts(track_dated, musicbrainz_year=track_year)
 
     assert album_facts is not None
     assert album_facts.release_year == 1967
@@ -850,6 +850,28 @@ async def test_compilation_release_year_uses_the_musicbrainz_recording_year(
     fact = quiz._select_fact(facts, 2)
     assert fact.target is TriviaTarget.YEAR
     assert fact.correct_answer == "1982"
+
+
+@pytest.mark.asyncio
+async def test_compilation_release_year_rejects_an_implausible_musicbrainz_year() -> None:
+    """Keep a compilation year suppressed when MusicBrainz answers with an unusable year."""
+    track = _with_isrc(_track("compilation", "Africa", "Toto", release_year=1998), "ISRC-COMP")
+    track.album = _full_album(
+        "party-hits",
+        "Party Hits",
+        album_type=AlbumType.COMPILATION,
+        year=1998,
+    )
+    quiz, mass = _quiz([track])
+    _with_musicbrainz(mass, {"ISRC-COMP": 9999})
+
+    dated_track, musicbrainz_year = await quiz._musicbrainz_dated_track(track)
+    facts = quiz._track_facts(dated_track, musicbrainz_year=musicbrainz_year)
+
+    assert musicbrainz_year is None
+    assert facts is not None
+    assert facts.release_year is None
+    assert TriviaTarget.YEAR not in quiz._available_targets(facts)
 
 
 def test_compilation_release_year_stays_suppressed_without_dating() -> None:
@@ -946,6 +968,51 @@ async def test_musicbrainz_lookups_do_not_scale_with_the_source_pool() -> None:
     await quiz.prepare_round(0, [])
 
     assert musicbrainz.get_release_year_by_isrc.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_compilation_year_round_is_scored_on_the_musicbrainz_year() -> None:
+    """Score a compilation release year round on the MusicBrainz recording year."""
+    tracks = [
+        _with_isrc(
+            _track(f"track-{index}", f"Song {index}", f"Artist {index}", release_year=2012),
+            f"ISRC-{index}",
+        )
+        for index in range(3)
+    ]
+    for index, track in enumerate(tracks):
+        track.album = _full_album(
+            f"album-{index}",
+            f"Compilation {index}",
+            album_type=AlbumType.COMPILATION,
+            year=2012,
+        )
+    provider = _ai_provider()
+    provider.ai_query.side_effect = [
+        _valid_response("Who performs the selected song?", ["Portishead", "Radiohead", "Air"]),
+        _valid_response("Which title is this?", ["Teardrop", "Genesis", "Midnight City"]),
+        _valid_response("In which year did this first appear?", ["1975", "1991", "2003"]),
+    ]
+    quiz, mass = _quiz(tracks, providers=[provider], round_count=3)
+    _with_musicbrainz(mass, {f"ISRC-{index}": 1982 for index in range(3)})
+
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types.trivia.SYSTEM_RANDOM.choice",
+        side_effect=lambda candidates: candidates[0],
+    ):
+        first_round = await quiz.prepare_round(0, [])
+        second_round = await quiz.prepare_round(1, [first_round])
+        year_round = await quiz.prepare_round(2, [first_round, second_round])
+
+    assert year_round.answer_label == "1982"
+    payload = _prompt_payload(provider.ai_query.await_args.args[0])
+    assert payload["question_target"] == TriviaTarget.YEAR
+    assert payload["correct_answer"] == "1982"
+    assert payload["track_metadata"] == {
+        "title": "Song 2",
+        "artist": "Artist 2",
+        "release_year": 1982,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -811,8 +811,8 @@ async def test_musicbrainz_adds_a_year_target_to_an_undated_track() -> None:
 
 
 @pytest.mark.asyncio
-async def test_compilation_release_year_stays_suppressed_after_dating() -> None:
-    """Keep compilation year facts suppressed even when MusicBrainz can date the recording."""
+async def test_compilation_release_year_uses_the_musicbrainz_recording_year() -> None:
+    """Offer a year target on a compilation track once MusicBrainz dates the recording."""
     track = _with_isrc(_track("compilation", "Africa", "Toto", release_year=1998), "ISRC-COMP")
     track.album = _full_album(
         "party-hits",
@@ -823,11 +823,52 @@ async def test_compilation_release_year_stays_suppressed_after_dating() -> None:
     quiz, mass = _quiz([track])
     _with_musicbrainz(mass, {"ISRC-COMP": 1982})
 
-    facts = quiz._track_facts(await quiz._musicbrainz_dated_track(track))
+    facts = quiz._track_facts(await quiz._musicbrainz_dated_track(track), musicbrainz_dated=True)
+
+    assert facts is not None
+    assert facts.album is None
+    assert facts.release_year == 1982
+    assert TriviaTarget.YEAR in quiz._available_targets(facts)
+
+
+def test_compilation_release_year_stays_suppressed_without_dating() -> None:
+    """Keep the compilation's own year suppressed while MusicBrainz has not dated the track."""
+    track = _track("compilation", "Africa", "Toto", release_year=1998)
+    track.album = _full_album(
+        "party-hits",
+        "Party Hits",
+        album_type=AlbumType.COMPILATION,
+        year=1998,
+    )
+
+    facts = TriviaQuizType._track_facts(track)
 
     assert facts is not None
     assert facts.release_year is None
-    assert TriviaTarget.YEAR not in quiz._available_targets(facts)
+    assert TriviaTarget.YEAR not in TriviaQuizType._available_targets(facts)
+
+
+@pytest.mark.asyncio
+async def test_prepare_round_grounds_a_dated_compilation_on_its_musicbrainz_year() -> None:
+    """Ground a compilation round on the MusicBrainz year while hiding the compilation album."""
+    track = _with_isrc(_track("compilation", "Africa", "Toto", release_year=1998), "ISRC-COMP")
+    track.album = _full_album(
+        "party-hits",
+        "Party Hits",
+        album_type=AlbumType.COMPILATION,
+        year=1998,
+    )
+    provider = _ai_provider(_valid_response())
+    quiz, mass = _quiz([track], providers=[provider])
+    _with_musicbrainz(mass, {"ISRC-COMP": 1982})
+
+    await quiz.prepare_round(0, [])
+
+    assert _prompt_payload(provider.ai_query.await_args.args[0])["track_metadata"] == {
+        "title": "Africa",
+        "artist": "Toto",
+        "release_year": 1982,
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Music Quiz Trivia refused to ask about the release year of any track that sits on a compilation, because a compilation's own year is usually the reissue year rather than the year the song came out. That refusal was applied even after MusicBrainz had already looked up the real recording year, so a perfectly good year — and a question opportunity — was thrown away.

Trivia now uses the MusicBrainz year for compilation tracks. The compilation's own year is still refused, and the compilation album name is still hidden, exactly as before.

- Trivia answers a release year question about a compilation track with the year MusicBrainz knows for the recording
- The compilation's own year, and any year the compilation stamped on the track, are still refused
- The year stays hidden when MusicBrainz cannot date the track
- Compilation album names remain hidden as an answer
- The shared dating helper now reports the year it found; Music Timeline is unaffected

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
