### PR TITLE
Make the group mute command work on any player

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -886,25 +886,23 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
     @handle_player_command
     async def cmd_group_volume_mute(self, player_id: str, muted: bool) -> None:
         """
-        Send VOLUME_MUTE command to all players in a group.
+        Handle muting a playergroup (or synced players) as a whole.
 
-        - player_id: player_id of the group player or sync leader.
-        - muted: bool if group should be muted.
+        :param player_id: Player ID of group player or syncleader to handle the command.
+        :param muted: bool if the group should be muted.
         """
         player = self.get_player(player_id, True)
         assert player is not None  # for type checker
         if player.state.type == PlayerType.GROUP or player.state.group_members:
             # dedicated group player or sync leader
-            coros = []
-            for child_player in self.iter_group_members(
-                player, only_powered=True, exclude_self=False
-            ):
-                if child_player.mute_control == PLAYER_CONTROL_NONE:
-                    # members without a mute control are left alone, just like the
-                    # group mute state itself is calculated from the capable members only
-                    continue
-                coros.append(self.cmd_volume_mute(child_player.player_id, muted))
-            await asyncio.gather(*coros)
+            await self._mute_group_members(player, muted)
+            return
+        if player.state.synced_to and (sync_leader := self.get_player(player.state.synced_to)):
+            # redirect to sync leader
+            await self._mute_group_members(sync_leader, muted)
+            return
+        # treat as normal player mute
+        await self.cmd_volume_mute(player_id, muted)
 
     @api_command("players/cmd/volume_mute", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command(lock=PlayerLockPurpose.VOLUME)
@@ -3502,6 +3500,24 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             )
             await self._handle_cmd_volume_set(protocol_player.player_id, device_volume)
             return
+
+    async def _mute_group_members(self, group_player: Player, muted: bool) -> None:
+        """
+        Mute or unmute all mute capable members of a player group or synced players.
+
+        :param group_player: The group player or sync leader.
+        :param muted: bool if the group should be muted.
+        """
+        coros = []
+        for child_player in self.iter_group_members(
+            group_player, only_powered=True, exclude_self=False
+        ):
+            if child_player.mute_control == PLAYER_CONTROL_NONE:
+                # members without a mute control are left alone, just like the
+                # group mute state itself is calculated from the capable members only
+                continue
+            coros.append(self.cmd_volume_mute(child_player.player_id, muted))
+        await asyncio.gather(*coros)
 
     async def _handle_cmd_volume_mute(self, player: Player, mute_control: str, muted: bool) -> None:
         """

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -888,7 +888,8 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         """
         Handle muting a playergroup (or synced players) as a whole.
 
-        :param player_id: Player ID of group player or syncleader to handle the command.
+        :param player_id: Player ID of the group player, syncleader or (grouped) player
+            to handle the command.
         :param muted: bool if the group should be muted.
         """
         player = self.get_player(player_id, True)

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -888,8 +888,10 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         """
         Handle muting a playergroup (or synced players) as a whole.
 
-        :param player_id: Player ID of the group player, syncleader or (grouped) player
-            to handle the command.
+        A group player or syncleader mutes all of its members, a synced player is
+        redirected to its syncleader and an ungrouped player is muted on its own.
+
+        :param player_id: Player ID of the player to handle the command.
         :param muted: bool if the group should be muted.
         """
         player = self.get_player(player_id, True)

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1770,7 +1770,9 @@ class TestGroupMuteOnNonGroupPlayer:
             }
             players[player_id] = player
         if members:
-            players["leader"]._attr_group_members = ["leader", *members]
+            # the leader is not listed as its own member here, so the tests also cover
+            # that a sync leader is injected into its own final group_members
+            players["leader"]._attr_group_members = list(members)
         controller._players = dict(players)
         mock_mass.players = controller
         mock_mass.player_queues.get = MagicMock(return_value=None)
@@ -1780,17 +1782,13 @@ class TestGroupMuteOnNonGroupPlayer:
             player.update_state(signal_event=False)
         return controller, players
 
-    def _spy_group_mute(self, controller: PlayerController) -> list[str]:
-        """Record every (re-)entry into cmd_group_volume_mute on the given controller."""
-        entries: list[str] = []
-        original = controller.cmd_group_volume_mute
-
-        async def _wrapper(player_id: str, muted: bool) -> None:
-            entries.append(player_id)
-            await original(player_id, muted)
-
-        controller.cmd_group_volume_mute = _wrapper  # type: ignore[method-assign]
-        return entries
+    def _stub_mutes(self, players: dict[str, MockPlayer]) -> dict[str, AsyncMock]:
+        """Replace the native mute command of every given player with a mock."""
+        mutes: dict[str, AsyncMock] = {}
+        for player_id, player in players.items():
+            mutes[player_id] = AsyncMock()
+            player.volume_mute = mutes[player_id]  # type: ignore[method-assign]
+        return mutes
 
     async def test_group_mute_on_synced_member_redirects_to_leader(
         self, mock_mass: MagicMock
@@ -1798,57 +1796,60 @@ class TestGroupMuteOnNonGroupPlayer:
         """A member of a sync group mutes the whole group through its sync leader."""
         controller, players = self._setup(mock_mass, "member")
         assert players["member"].state.synced_to == "leader"
-        mutes = {}
-        for player_id, player in players.items():
-            mutes[player_id] = AsyncMock()
-            player.volume_mute = mutes[player_id]  # type: ignore[method-assign]
-        entries = self._spy_group_mute(controller)
+        mutes = self._stub_mutes(players)
 
         await controller.cmd_group_volume_mute("member", True)
 
         mutes["leader"].assert_awaited_once_with(True)
         mutes["member"].assert_awaited_once_with(True)
-        # the leader may not bounce the command back to the group mute command
-        assert entries == ["member"]
+        assert ATTR_MUTE_LOCK in players["member"].extra_data
 
-    async def test_group_mute_on_sync_leader_does_not_recurse(self, mock_mass: MagicMock) -> None:
-        """A sync leader is part of its own member list, so it must mute itself only once."""
+    async def test_group_mute_on_sync_leader_mutes_the_leader_once(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A sync leader is part of its own member list, so it must be muted only once."""
         controller, players = self._setup(mock_mass, "member")
-        mutes = {}
-        for player_id, player in players.items():
-            mutes[player_id] = AsyncMock()
-            player.volume_mute = mutes[player_id]  # type: ignore[method-assign]
-        entries = self._spy_group_mute(controller)
+        mutes = self._stub_mutes(players)
 
         await controller.cmd_group_volume_mute("leader", True)
 
         mutes["leader"].assert_awaited_once_with(True)
-        assert entries == ["leader"]
+        mutes["member"].assert_awaited_once_with(True)
 
     async def test_group_mute_on_plain_player_mutes_that_player(self, mock_mass: MagicMock) -> None:
         """A player that is not grouped at all is muted as a normal player."""
         controller, players = self._setup(mock_mass)
-        player_mute = AsyncMock()
-        players["leader"].volume_mute = player_mute  # type: ignore[method-assign]
+        mutes = self._stub_mutes(players)
 
         await controller.cmd_group_volume_mute("leader", True)
 
-        player_mute.assert_awaited_once_with(True)
+        mutes["leader"].assert_awaited_once_with(True)
+
+    async def test_group_mute_on_plain_player_without_mute_control(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A plain player that cannot mute reports that, just like a normal mute command."""
+        controller, players = self._setup(mock_mass)
+        players["leader"]._attr_supported_features = {PlayerFeature.VOLUME_SET}
+        players["leader"]._cache.clear()
+        players["leader"].update_state(signal_event=False)
+
+        with pytest.raises(UnsupportedFeaturedException):
+            await controller.cmd_group_volume_mute("leader", True)
 
     async def test_group_unmute_on_synced_member_redirects_to_leader(
         self, mock_mass: MagicMock
     ) -> None:
-        """Unmuting through a member clears the mute of every group member."""
+        """Unmuting through a member clears the mute (and mute lock) of every group member."""
         controller, players = self._setup(mock_mass, "member")
-        for player in players.values():
-            player.extra_data[ATTR_MUTE_LOCK] = True
-            player.volume_mute = AsyncMock()  # type: ignore[method-assign]
+        mutes = self._stub_mutes(players)
+        players["member"].extra_data[ATTR_MUTE_LOCK] = True
 
         await controller.cmd_group_volume_mute("member", False)
 
-        for player in players.values():
-            player.volume_mute.assert_awaited_once_with(False)  # type: ignore[attr-defined]
-            assert ATTR_MUTE_LOCK not in player.extra_data
+        mutes["leader"].assert_awaited_once_with(False)
+        mutes["member"].assert_awaited_once_with(False)
+        assert ATTR_MUTE_LOCK not in players["member"].extra_data
 
 
 class TestCurrentMediaTimeUpdates:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1752,6 +1752,105 @@ class TestGroupPlayerMuteRedirect:
         await controller.cmd_volume_mute("group", True)
 
 
+class TestGroupMuteOnNonGroupPlayer:
+    """A group mute command works on any player, just like the group volume command."""
+
+    def _setup(
+        self, mock_mass: MagicMock, *members: str
+    ) -> tuple[PlayerController, dict[str, MockPlayer]]:
+        """Build a controller with a mute capable leader synced to the given members."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        players: dict[str, MockPlayer] = {}
+        for player_id in ("leader", *members):
+            player = MockPlayer(provider, player_id, player_id.title())
+            player._attr_supported_features = {
+                PlayerFeature.VOLUME_SET,
+                PlayerFeature.VOLUME_MUTE,
+            }
+            players[player_id] = player
+        if members:
+            players["leader"]._attr_group_members = ["leader", *members]
+        controller._players = dict(players)
+        mock_mass.players = controller
+        mock_mass.player_queues.get = MagicMock(return_value=None)
+        for player in players.values():
+            player.set_initialized()
+            player._cache.clear()
+            player.update_state(signal_event=False)
+        return controller, players
+
+    def _spy_group_mute(self, controller: PlayerController) -> list[str]:
+        """Record every (re-)entry into cmd_group_volume_mute on the given controller."""
+        entries: list[str] = []
+        original = controller.cmd_group_volume_mute
+
+        async def _wrapper(player_id: str, muted: bool) -> None:
+            entries.append(player_id)
+            await original(player_id, muted)
+
+        controller.cmd_group_volume_mute = _wrapper  # type: ignore[method-assign]
+        return entries
+
+    async def test_group_mute_on_synced_member_redirects_to_leader(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A member of a sync group mutes the whole group through its sync leader."""
+        controller, players = self._setup(mock_mass, "member")
+        assert players["member"].state.synced_to == "leader"
+        mutes = {}
+        for player_id, player in players.items():
+            mutes[player_id] = AsyncMock()
+            player.volume_mute = mutes[player_id]  # type: ignore[method-assign]
+        entries = self._spy_group_mute(controller)
+
+        await controller.cmd_group_volume_mute("member", True)
+
+        mutes["leader"].assert_awaited_once_with(True)
+        mutes["member"].assert_awaited_once_with(True)
+        # the leader may not bounce the command back to the group mute command
+        assert entries == ["member"]
+
+    async def test_group_mute_on_sync_leader_does_not_recurse(self, mock_mass: MagicMock) -> None:
+        """A sync leader is part of its own member list, so it must mute itself only once."""
+        controller, players = self._setup(mock_mass, "member")
+        mutes = {}
+        for player_id, player in players.items():
+            mutes[player_id] = AsyncMock()
+            player.volume_mute = mutes[player_id]  # type: ignore[method-assign]
+        entries = self._spy_group_mute(controller)
+
+        await controller.cmd_group_volume_mute("leader", True)
+
+        mutes["leader"].assert_awaited_once_with(True)
+        assert entries == ["leader"]
+
+    async def test_group_mute_on_plain_player_mutes_that_player(self, mock_mass: MagicMock) -> None:
+        """A player that is not grouped at all is muted as a normal player."""
+        controller, players = self._setup(mock_mass)
+        player_mute = AsyncMock()
+        players["leader"].volume_mute = player_mute  # type: ignore[method-assign]
+
+        await controller.cmd_group_volume_mute("leader", True)
+
+        player_mute.assert_awaited_once_with(True)
+
+    async def test_group_unmute_on_synced_member_redirects_to_leader(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Unmuting through a member clears the mute of every group member."""
+        controller, players = self._setup(mock_mass, "member")
+        for player in players.values():
+            player.extra_data[ATTR_MUTE_LOCK] = True
+            player.volume_mute = AsyncMock()  # type: ignore[method-assign]
+
+        await controller.cmd_group_volume_mute("member", False)
+
+        for player in players.values():
+            player.volume_mute.assert_awaited_once_with(False)  # type: ignore[attr-defined]
+            assert ATTR_MUTE_LOCK not in player.extra_data
+
+
 class TestCurrentMediaTimeUpdates:
     """Playback-position anchor semantics of timing-only state updates."""
 


### PR DESCRIPTION
# What does this implement/fix?

The `players/cmd/group_volume_mute` command only did something when it was aimed at a group player or a sync leader. Sent to any other player it was silently dropped, while its volume counterpart (`players/cmd/group_volume`) has always handled every player.

The group mute command now behaves the same way as the group volume command: it mutes a group player or sync leader, redirects a member of a sync group to its sync leader, and falls back to a normal mute for a player that is not grouped at all.

Our own clients only ever send this command for a real group, so no user visible behaviour changes here - this makes the command consistent for anyone using the API directly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Group mute on a member of a sync group now mutes the whole group through its sync leader.
- Group mute on a plain (ungrouped) player now mutes that player, and reports the same "not supported" error as a normal mute when it has no mute control.
- Moved the member fan-out into a small helper so both entry points share it.
- Added tests for the new paths.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
