### PR TITLE
Fix missing mute control for universal group players

### DIFF
--- a/music_assistant/providers/universal_group/constants.py
+++ b/music_assistant/providers/universal_group/constants.py
@@ -12,10 +12,12 @@ from music_assistant.helpers.ffmpeg import DEFAULT_MP3_BIT_RATE
 
 UGP_PREFIX: Final[str] = "ugp_"
 
-# Features the group has no hardware of its own for, but which the player manager
-# fans out to the members. They are advertised as soon as a single member can
-# handle them, matching how the group state for those features is derived.
+# Features the group has no hardware of its own for: the player manager fans these
+# commands out to the members. They are advertised only when a member can actually
+# carry them out, which is the same condition under which the group state for them
+# (group_volume / group_volume_muted) resolves to a value.
 EXTRA_FEATURES_FROM_MEMBERS: Final[set[PlayerFeature]] = {
+    PlayerFeature.VOLUME_SET,
     PlayerFeature.VOLUME_MUTE,
 }
 

--- a/music_assistant/providers/universal_group/constants.py
+++ b/music_assistant/providers/universal_group/constants.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 from typing import Final
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
-from music_assistant_models.enums import ConfigEntryType, ContentType
+from music_assistant_models.enums import ConfigEntryType, ContentType, PlayerFeature
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.helpers.ffmpeg import DEFAULT_MP3_BIT_RATE
 
 UGP_PREFIX: Final[str] = "ugp_"
+
+# Features the group has no hardware of its own for, but which the player manager
+# fans out to the members. They are advertised as soon as a single member can
+# handle them, matching how the group state for those features is derived.
+EXTRA_FEATURES_FROM_MEMBERS: Final[set[PlayerFeature]] = {
+    PlayerFeature.VOLUME_MUTE,
+}
 
 # Grace period (seconds) before a universal group releases its members after
 # the active stream naturally ends (playback_state transitions to IDLE without

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -40,6 +40,7 @@ from .constants import (
     CONF_ENTRY_UGP_OUTPUT_FORMAT,
     CONF_UGP_OUTPUT_FORMAT,
     CONFIG_ENTRY_UGP_NOTE,
+    EXTRA_FEATURES_FROM_MEMBERS,
     IDLE_GRACE_SECONDS,
     UGP_OUTPUT_MP3,
     resolve_ugp_output_format,
@@ -99,6 +100,22 @@ class UniversalGroupPlayer(Player):
             )
         )
         self._set_attributes()
+
+    @property
+    def supported_features(self) -> set[PlayerFeature]:
+        """Return the supported features of the player."""
+        features = {*self._attr_supported_features}
+        # derive the member-inherited features from all (configured) members, so a
+        # capability like muting is advertised whether or not the group is active.
+        # Resolved on read (not cached in _attr_supported_features) because member
+        # availability and controls change independently of the group's own state.
+        for member_id in self._attr_group_members:
+            member_player = self.mass.players.get_player(member_id)
+            if member_player and member_player.state.available:
+                for feature in EXTRA_FEATURES_FROM_MEMBERS:
+                    if feature in member_player.state.supported_features:
+                        features.add(feature)
+        return features
 
     @property
     def requires_flow_mode(self) -> bool:
@@ -275,6 +292,10 @@ class UniversalGroupPlayer(Player):
     async def volume_set(self, volume_level: int) -> None:
         """Send VOLUME_SET command to given player."""
         # group volume is already handled in the player manager
+
+    async def volume_mute(self, muted: bool) -> None:
+        """Send VOLUME_MUTE command to given player."""
+        # group mute is already handled in the player manager
 
     async def play_media(self, media: PlayerMedia) -> None:
         """Handle PLAY MEDIA on given player."""

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -284,14 +284,6 @@ class UniversalGroupPlayer(Player):
             self._attr_group_members = self._attr_static_group_members.copy()
         self.update_state()
 
-    async def volume_set(self, volume_level: int) -> None:
-        """Send VOLUME_SET command to given player."""
-        # group volume is already handled in the player manager
-
-    async def volume_mute(self, muted: bool) -> None:
-        """Send VOLUME_MUTE command to given player."""
-        # group mute is already handled in the player manager
-
     async def play_media(self, media: PlayerMedia) -> None:
         """Handle PLAY MEDIA on given player."""
         # form on play: cancel any pending idle-grace release, then capture the

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -50,13 +50,14 @@ from .ugp_stream import UGPStream
 if TYPE_CHECKING:
     from .provider import UniversalGroupProvider
 
-# PlayerFeature.POWER is intentionally not in the base feature set anymore:
-# the lifecycle (form on play, dissolve on stop, debounced idle deform) governs
-# whether the group captures its members. POWER is added dynamically when the
-# user assigns 'Fake power control' to the group.
+# The features the group carries on its own. Everything else is resolved per read in
+# the supported_features property: POWER when the user assigns 'Fake power control',
+# SET_MEMBERS for dynamic groups, and EXTRA_FEATURES_FROM_MEMBERS from the members.
+# PlayerFeature.POWER is intentionally not a base feature: the lifecycle (form on
+# play, dissolve on stop, debounced idle deform) governs whether the group captures
+# its members.
 BASE_FEATURES = {
     PlayerFeature.PLAY_MEDIA,
-    PlayerFeature.VOLUME_SET,
     PlayerFeature.MULTI_DEVICE_DSP,
 }
 
@@ -81,7 +82,6 @@ class UniversalGroupPlayer(Player):
         # opt-in mechanism for explicit on/off semantics.
         self._attr_powered = None
         self._attr_device_info = DeviceInfo(model="Universal Group", manufacturer=provider.name)
-        self._attr_supported_features = {*BASE_FEATURES}
         self._attr_needs_poll = True
         self._attr_poll_interval = 30
         # task that releases members after the idle grace window expires
@@ -104,11 +104,18 @@ class UniversalGroupPlayer(Player):
     @property
     def supported_features(self) -> set[PlayerFeature]:
         """Return the supported features of the player."""
-        features = {*self._attr_supported_features}
-        # derive the member-inherited features from all (configured) members, so a
-        # capability like muting is advertised whether or not the group is active.
-        # Resolved on read (not cached in _attr_supported_features) because member
-        # availability and controls change independently of the group's own state.
+        features = {*BASE_FEATURES}
+        # The raw config value is read here to avoid recursion via the power_control
+        # property (which itself may inspect supported features).
+        raw_power_conf = self.mass.config.get_raw_player_config_value(
+            self.player_id, CONF_POWER_CONTROL
+        )
+        if raw_power_conf == PLAYER_CONTROL_FAKE:
+            features.add(PlayerFeature.POWER)
+        if self.is_dynamic:
+            features.add(PlayerFeature.SET_MEMBERS)
+        # derive the fanned-out features from all (configured) members, so volume and
+        # mute are advertised whether or not the group currently has a live session.
         for member_id in self._attr_group_members:
             member_player = self.mass.players.get_player(member_id)
             if member_player and member_player.state.available:
@@ -176,18 +183,6 @@ class UniversalGroupPlayer(Player):
             # only realign members to the configured static set when the group
             # is dormant — otherwise we would lose any dynamic adds mid-session.
             self._attr_group_members = static_members.copy()
-        if self.is_dynamic:
-            self._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
-        elif PlayerFeature.SET_MEMBERS in self._attr_supported_features:
-            self._attr_supported_features.remove(PlayerFeature.SET_MEMBERS)
-        # advertise POWER feature only when the user has opted in via fake control
-        raw_power_conf = self.mass.config.get_raw_player_config_value(
-            self.player_id, CONF_POWER_CONTROL
-        )
-        if raw_power_conf == PLAYER_CONTROL_FAKE:
-            self._attr_supported_features.add(PlayerFeature.POWER)
-        else:
-            self._attr_supported_features.discard(PlayerFeature.POWER)
 
     @cached_property
     def is_dynamic(self) -> bool:
@@ -513,12 +508,6 @@ class UniversalGroupPlayer(Player):
 
     def _set_attributes(self) -> None:
         """Set attributes of the group player."""
-        if self.is_dynamic and PlayerFeature.SET_MEMBERS not in self.supported_features:
-            # dynamic group players should support SET_MEMBERS feature
-            self._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
-        elif not self.is_dynamic and PlayerFeature.SET_MEMBERS in self.supported_features:
-            # static group players should not support SET_MEMBERS feature
-            self._attr_supported_features.discard(PlayerFeature.SET_MEMBERS)
         prev_state = self._attr_playback_state
         # grab current media and state from one of the active players
         # use state properties (not raw attributes) to account for protocol player propagation

--- a/tests/providers/universal_group/test_universal_group.py
+++ b/tests/providers/universal_group/test_universal_group.py
@@ -371,3 +371,64 @@ class TestSupportedFeaturesPower:
         ugp = _make_ugp(mass)
         await ugp.on_config_updated()
         assert PlayerFeature.POWER in ugp.supported_features
+
+
+class TestSupportedFeaturesFromMembers:
+    """VOLUME_MUTE is inherited from the members the mute command is fanned out to."""
+
+    @staticmethod
+    def _attach_members(mass: MagicMock, *members: MagicMock) -> None:
+        """Register the given mock members on the mock player controller."""
+        by_id = {member.player_id: member for member in members}
+        mass.players.get_player = MagicMock(
+            side_effect=lambda pid, *_args, **_kwargs: by_id.get(pid)
+        )
+
+    def test_mute_not_advertised_without_capable_members(self) -> None:
+        """Members that can't be muted leave the group without a mute capability."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        member = _make_mock_player("m1")
+        self._attach_members(mass, member)
+        ugp._attr_group_members = ["m1"]
+
+        assert PlayerFeature.VOLUME_MUTE not in ugp.supported_features
+
+    def test_mute_advertised_when_a_member_supports_it(self) -> None:
+        """A single mute-capable member is enough to advertise mute on the group."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        plain_member = _make_mock_player("m1")
+        mute_member = _make_mock_player("m2")
+        mute_member.state.supported_features = {
+            PlayerFeature.PLAY_MEDIA,
+            PlayerFeature.VOLUME_MUTE,
+        }
+        self._attach_members(mass, plain_member, mute_member)
+        ugp._attr_group_members = ["m1", "m2"]
+
+        assert PlayerFeature.VOLUME_MUTE in ugp.supported_features
+
+    def test_unavailable_members_do_not_contribute(self) -> None:
+        """An offline member's capabilities are not advertised by the group."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        member = _make_mock_player("m1", available=False)
+        member.state.supported_features = {PlayerFeature.PLAY_MEDIA, PlayerFeature.VOLUME_MUTE}
+        self._attach_members(mass, member)
+        ugp._attr_group_members = ["m1"]
+
+        assert PlayerFeature.VOLUME_MUTE not in ugp.supported_features
+
+    def test_dormant_group_inherits_from_configured_members(self) -> None:
+        """Mute stays advertised while the group is idle, so HA keeps the control."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        member = _make_mock_player("m1")
+        member.state.supported_features = {PlayerFeature.PLAY_MEDIA, PlayerFeature.VOLUME_MUTE}
+        self._attach_members(mass, member)
+        ugp._attr_static_group_members = ["m1"]
+        ugp._attr_group_members = ["m1"]
+
+        assert not ugp.is_active_session
+        assert PlayerFeature.VOLUME_MUTE in ugp.supported_features

--- a/tests/providers/universal_group/test_universal_group.py
+++ b/tests/providers/universal_group/test_universal_group.py
@@ -14,7 +14,11 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.constants import PLAYER_CONTROL_FAKE
+from music_assistant_models.constants import (
+    PLAYER_CONTROL_FAKE,
+    PLAYER_CONTROL_NATIVE,
+    PLAYER_CONTROL_NONE,
+)
 from music_assistant_models.enums import PlaybackState, PlayerFeature
 
 from music_assistant.providers.universal_group.player import UniversalGroupPlayer
@@ -373,8 +377,39 @@ class TestSupportedFeaturesPower:
         assert PlayerFeature.POWER in ugp.supported_features
 
 
+class TestSupportedFeaturesSetMembers:
+    """SET_MEMBERS tracks the dynamic-members config option."""
+
+    @staticmethod
+    def _make_mass(dynamic: bool) -> MagicMock:
+        """Build a mock mass whose group is (or isn't) a dynamic group."""
+        mass = _make_mock_mass()
+
+        def _config_value(key: str, default: object = None) -> object:
+            if key == "group_members":
+                return []
+            if key == "dynamic_members":
+                return dynamic
+            return default
+
+        mass.config.get_base_player_config.return_value = MagicMock(
+            name=None, default_name="Test UGP", get_value=_config_value
+        )
+        return mass
+
+    def test_dynamic_group_advertises_set_members(self) -> None:
+        """A dynamic group lets the user change its members."""
+        ugp = _make_ugp(self._make_mass(dynamic=True))
+        assert PlayerFeature.SET_MEMBERS in ugp.supported_features
+
+    def test_static_group_does_not_advertise_set_members(self) -> None:
+        """A static group's members are fixed by its config."""
+        ugp = _make_ugp(self._make_mass(dynamic=False))
+        assert PlayerFeature.SET_MEMBERS not in ugp.supported_features
+
+
 class TestSupportedFeaturesFromMembers:
-    """VOLUME_MUTE is inherited from the members the mute command is fanned out to."""
+    """Volume and mute are inherited from the members those commands are fanned out to."""
 
     @staticmethod
     def _attach_members(mass: MagicMock, *members: MagicMock) -> None:
@@ -383,6 +418,25 @@ class TestSupportedFeaturesFromMembers:
         mass.players.get_player = MagicMock(
             side_effect=lambda pid, *_args, **_kwargs: by_id.get(pid)
         )
+
+    def test_volume_advertised_when_a_member_supports_it(self) -> None:
+        """A volume-capable member gives the group a volume capability."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        member = _make_mock_player("m1")
+        member.state.supported_features = {PlayerFeature.PLAY_MEDIA, PlayerFeature.VOLUME_SET}
+        self._attach_members(mass, member)
+        ugp._attr_group_members = ["m1"]
+
+        assert PlayerFeature.VOLUME_SET in ugp.supported_features
+
+    def test_volume_not_advertised_without_capable_members(self) -> None:
+        """An empty group has nothing to send a volume command to."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+
+        assert ugp._attr_group_members == []
+        assert PlayerFeature.VOLUME_SET not in ugp.supported_features
 
     def test_mute_not_advertised_without_capable_members(self) -> None:
         """Members that can't be muted leave the group without a mute capability."""
@@ -420,8 +474,13 @@ class TestSupportedFeaturesFromMembers:
 
         assert PlayerFeature.VOLUME_MUTE not in ugp.supported_features
 
-    def test_dormant_group_inherits_from_configured_members(self) -> None:
-        """Mute stays advertised while the group is idle, so HA keeps the control."""
+    def test_dormant_group_resolves_a_native_mute_control(self) -> None:
+        """
+        An idle group resolves a mute control, which is what HA gates its mute button on.
+
+        Without an inherited VOLUME_MUTE this lands on PLAYER_CONTROL_NONE and the
+        capability is dropped from the player state again.
+        """
         mass = _make_mock_mass()
         ugp = _make_ugp(mass)
         member = _make_mock_player("m1")
@@ -429,6 +488,20 @@ class TestSupportedFeaturesFromMembers:
         self._attach_members(mass, member)
         ugp._attr_static_group_members = ["m1"]
         ugp._attr_group_members = ["m1"]
+        # a member update reaches the group as trigger_player_update -> update_state,
+        # which is what drops the cached mute_control so it can be re-resolved
+        ugp.update_state()
 
         assert not ugp.is_active_session
-        assert PlayerFeature.VOLUME_MUTE in ugp.supported_features
+        assert ugp.mute_control == PLAYER_CONTROL_NATIVE
+
+    def test_mute_control_stays_none_without_capable_members(self) -> None:
+        """No member can be muted → no mute control to hand to HA."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        member = _make_mock_player("m1")
+        self._attach_members(mass, member)
+        ugp._attr_group_members = ["m1"]
+        ugp.update_state()
+
+        assert ugp.mute_control == PLAYER_CONTROL_NONE


### PR DESCRIPTION
# What does this implement/fix?

A universal group player never advertised mute support, so Home Assistant showed no mute button for it and rejected `media_player.volume_mute` calls — even though muting a universal group works fine, since the command is fanned out to the group members.

The group didn't declare the mute capability, which made its mute control resolve to "none", which in turn stripped mute from the player state. Sync groups already inherit mute from their members; universal groups now do the same.

While fixing this, volume got the same treatment. A universal group has no volume or mute hardware of its own — both commands are fanned out to the members — but volume was advertised unconditionally while mute was not. Both are now advertised only when a member can actually carry them out, which is the same condition under which the group's volume and mute state resolve to a value.

The Music Assistant web UI was unaffected by the mute bug — it derives the group mute button from the group mute state, not from the capability flag.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Universal groups inherit volume and mute from their available members, mirroring sync groups.
- Collapsed the group's capability handling into a single `supported_features` property, removing logic that was duplicated across two methods and could drift.
- Capabilities are resolved on read, so they follow members coming and going and stay available while the group is idle.
- Added tests for members with and without volume/mute support, offline members, an idle group, and the dynamic/static members option.

Note: a user who had explicitly set a universal group's mute control to "none" will get mute back, since that choice was indistinguishable from the old default and was never stored.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
