### PR TITLE
Keep a mono sound effect at the same volume as a stereo one

### DIFF
--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -32,6 +32,10 @@ CACHE_ATTR_LIBSOXR_PRESENT: Final[str] = "libsoxr_present"
 CACHE_ATTR_FFMPEG_VERSION: Final[str] = "ffmpeg_version"
 DEFAULT_MP3_BIT_RATE: Final[int] = 320
 
+# added to unity gain to cancel the 1/sqrt(2) per channel that FFmpeg's
+# mono->stereo rematrix applies, so a mono source keeps its original level
+_MONO_WIDEN_COMPENSATION: Final[float] = 2**0.5 - 1
+
 # Regex patterns to extract audio format details from ffmpeg's stderr output.
 # Examples of the lines we parse:
 #   Stream #0:0: Audio: mp3, 44100 Hz, stereo, fltp, 320 kb/s
@@ -422,8 +426,9 @@ async def get_ffmpeg_overlay_stream(
     Mix a looping audio overlay into a PCM audio stream.
 
     The overlay is looped for the full duration of the main stream and the mixed
-    output has the exact same PCM format and duration as the main input. If the
-    overlay input fails mid-stream, the main audio continues unaffected.
+    output has the exact same PCM format and duration as the main input. It mixes
+    in at the same level regardless of its own channel count. If the overlay input
+    fails mid-stream, the main audio continues unaffected.
 
     :param audio_input: The main audio stream (raw PCM in ``pcm_format``).
     :param overlay_input: File path or URL of the overlay audio.
@@ -453,10 +458,12 @@ async def get_ffmpeg_overlay_stream(
     # silenceremove strips a near-silent intro from the overlay source (e.g. a soft
     # fade-in) so it becomes audible right away; it is a no-op for sources that
     # already start at full level. It runs before volume so detection is based on
-    # the source's own levels rather than the scaled output.
+    # the source's own levels rather than the scaled output. volume in turn has to
+    # stay ahead of the resample and conform steps, which replace the source's own
+    # channel count with the output's.
     filter_complex = (
         f"[0:a]silenceremove=start_periods=1:start_threshold=-40dB,"
-        f"volume={overlay_volume / 100},"
+        f"{_get_overlay_volume_filter(overlay_volume, pcm_format.channels)},"
         f"aresample={pcm_format.sample_rate}"
         f"{conform_filter}[overlay];"
         "[1:a][overlay]amix=inputs=2:duration=first:normalize=0[mixed]"
@@ -786,6 +793,25 @@ def _get_channel_conform_filter(input_channels: int, output_channels: int) -> st
         # spreads the source at 1/sqrt(2) per channel and so costs 3 dB
         return "pan=stereo|c0=c0|c1=c0"
     return None
+
+
+def _get_overlay_volume_filter(overlay_volume: int, output_channels: int) -> str:
+    """
+    Return the filter that scales an overlay source to the requested loudness.
+
+    :param overlay_volume: Requested overlay loudness in percent.
+    :param output_channels: Channel count of the mixed output.
+    """
+    gain = overlay_volume / 100
+    if output_channels != 2:
+        return f"volume={gain}"
+    # widening a mono source to stereo is left to FFmpeg, whose rematrix spreads it at
+    # 1/sqrt(2) per channel and so drops it 3 dB below an equally loud stereo source.
+    # nb_channels is evaluated where this filter sits, ahead of any layout conversion,
+    # so it still reports the source's own count and only a mono source is compensated,
+    # leaving a stereo one (and its image) untouched. Kept free of commas, which would
+    # otherwise read as the end of this filter in the graph.
+    return f"volume={gain}*(1+{_MONO_WIDEN_COMPENSATION}*not(nb_channels-1))"
 
 
 def _build_filtergraph_args(

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -427,9 +427,9 @@ async def get_ffmpeg_overlay_stream(
     Mix a looping audio overlay into a PCM audio stream.
 
     The overlay is looped for the full duration of the main stream and the mixed
-    output has the exact same PCM format and duration as the main input. A mono
-    overlay mixes in at the same level as an equivalent stereo one. If the overlay
-    input fails mid-stream, the main audio continues unaffected.
+    output has the exact same PCM format and duration as the main input. For a stereo
+    output, a mono overlay mixes in at the same level as an equivalent stereo one. If
+    the overlay input fails mid-stream, the main audio continues unaffected.
 
     :param audio_input: The main audio stream (raw PCM in ``pcm_format``).
     :param overlay_input: File path or URL of the overlay audio.

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -32,9 +32,10 @@ CACHE_ATTR_LIBSOXR_PRESENT: Final[str] = "libsoxr_present"
 CACHE_ATTR_FFMPEG_VERSION: Final[str] = "ffmpeg_version"
 DEFAULT_MP3_BIT_RATE: Final[int] = 320
 
-# added to unity gain to cancel the 1/sqrt(2) per channel that FFmpeg's
-# mono->stereo rematrix applies, so a mono source keeps its original level
-_MONO_WIDEN_COMPENSATION: Final[float] = 2**0.5 - 1
+# FFmpeg's mono->stereo rematrix spreads a source at 1/sqrt(2) per channel; this factor
+# restores its original level. _get_channel_conform_filter avoids the same loss on the
+# main decode path by duplicating the channel instead.
+_MONO_WIDEN_COMPENSATION: Final[float] = 2**0.5
 
 # Regex patterns to extract audio format details from ffmpeg's stderr output.
 # Examples of the lines we parse:
@@ -426,9 +427,9 @@ async def get_ffmpeg_overlay_stream(
     Mix a looping audio overlay into a PCM audio stream.
 
     The overlay is looped for the full duration of the main stream and the mixed
-    output has the exact same PCM format and duration as the main input. It mixes
-    in at the same level regardless of its own channel count. If the overlay input
-    fails mid-stream, the main audio continues unaffected.
+    output has the exact same PCM format and duration as the main input. A mono
+    overlay mixes in at the same level as an equivalent stereo one. If the overlay
+    input fails mid-stream, the main audio continues unaffected.
 
     :param audio_input: The main audio stream (raw PCM in ``pcm_format``).
     :param overlay_input: File path or URL of the overlay audio.
@@ -804,14 +805,13 @@ def _get_overlay_volume_filter(overlay_volume: int, output_channels: int) -> str
     """
     gain = overlay_volume / 100
     if output_channels != 2:
+        # a mono source widened to more than two channels is routed to the centre at full
+        # level, so only a stereo output loses any. No overlay call site is non-stereo today.
         return f"volume={gain}"
-    # widening a mono source to stereo is left to FFmpeg, whose rematrix spreads it at
-    # 1/sqrt(2) per channel and so drops it 3 dB below an equally loud stereo source.
-    # nb_channels is evaluated where this filter sits, ahead of any layout conversion,
-    # so it still reports the source's own count and only a mono source is compensated,
-    # leaving a stereo one (and its image) untouched. Kept free of commas, which would
-    # otherwise read as the end of this filter in the graph.
-    return f"volume={gain}*(1+{_MONO_WIDEN_COMPENSATION}*not(nb_channels-1))"
+    # nb_channels is evaluated where this filter sits, ahead of any layout conversion, so it
+    # still reports the source's own count: only a mono source is scaled up, leaving a stereo
+    # one and its image untouched. Comma-free, as a comma would end this filter in the graph.
+    return f"volume={gain}*{_MONO_WIDEN_COMPENSATION}^not(nb_channels-1)"
 
 
 def _build_filtergraph_args(

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import subprocess
-from collections.abc import AsyncGenerator
+from array import array
+from collections.abc import AsyncGenerator, Sequence
+from math import sqrt
 from pathlib import Path
 
 import pytest
@@ -16,6 +18,7 @@ from music_assistant.helpers.ffmpeg import (
     FFMpeg,
     FFMpegStreamInfo,
     _build_filtergraph_args,
+    _get_overlay_volume_filter,
     get_ffmpeg_args,
     get_ffmpeg_overlay_stream,
     parse_ffmpeg_duration,
@@ -437,10 +440,60 @@ _BYTES_PER_SECOND = _PCM_FORMAT.pcm_sample_size  # 1 second of PCM audio
 
 @pytest.fixture
 def overlay_file(tmp_path: Path) -> Path:
-    """Generate a 1 second sine-tone wav file to use as overlay source."""
+    """Generate a 1 second mono sine-tone wav file to use as overlay source."""
     overlay_path = tmp_path / "overlay.wav"
     subprocess.run(  # noqa: S603
         ["ffmpeg", "-f", "lavfi", "-i", "sine=frequency=440:duration=1", str(overlay_path)],  # noqa: S607
+        check=True,
+        capture_output=True,
+    )
+    return overlay_path
+
+
+@pytest.fixture
+def overlay_file_stereo(tmp_path: Path) -> Path:
+    """Generate a stereo overlay wav carrying the same tone as ``overlay_file`` on both channels."""
+    overlay_path = tmp_path / "overlay_stereo.wav"
+    subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "ffmpeg",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=1",
+            "-af",
+            "pan=stereo|c0=c0|c1=c0",
+            str(overlay_path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return overlay_path
+
+
+@pytest.fixture
+def overlay_file_wide_stereo(tmp_path: Path) -> Path:
+    """Generate a 1 second stereo overlay wav with the tone on the left channel only."""
+    overlay_path = tmp_path / "overlay_wide.wav"
+    subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "ffmpeg",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=1",
+            "-f",
+            "lavfi",
+            "-i",
+            "anullsrc=cl=mono:d=1",
+            "-filter_complex",
+            "[0:a][1:a]amerge=inputs=2,aformat=channel_layouts=stereo[out]",
+            "-map",
+            "[out]",
+            "-t",
+            "1",
+            str(overlay_path),
+        ],
         check=True,
         capture_output=True,
     )
@@ -476,6 +529,31 @@ async def _silence(seconds: int) -> AsyncGenerator[bytes]:
 
 async def _collect_chunks(stream: AsyncGenerator[bytes]) -> list[bytes]:
     return [chunk async for chunk in stream]
+
+
+def _samples(pcm: bytes, channel: int | None = None) -> Sequence[int]:
+    """Return the samples of the given PCM audio, optionally for one channel only."""
+    samples = array("h")
+    samples.frombytes(pcm)
+    return samples if channel is None else samples[channel :: _PCM_FORMAT.channels]
+
+
+def _rms(samples: Sequence[int]) -> float:
+    """Return the RMS level of the given PCM samples."""
+    return sqrt(sum(sample * sample for sample in samples) / len(samples))
+
+
+async def _mix_overlay(overlay_input: Path) -> bytes:
+    """Mix the given overlay source into 1 second of silence and return the result."""
+    return b"".join(
+        await _collect_chunks(
+            get_ffmpeg_overlay_stream(
+                audio_input=_silence(1),
+                overlay_input=str(overlay_input),
+                pcm_format=_PCM_FORMAT,
+            )
+        )
+    )
 
 
 async def test_overlay_stream_mixes_loops_and_preserves_length(overlay_file: Path) -> None:
@@ -556,6 +634,39 @@ async def test_overlay_stream_trims_leading_silence(
     # without trimming, the first second would be the overlay's silent intro;
     # the trim makes the tone play from the start, so the first second has signal
     assert any(output)
+
+
+async def test_overlay_stream_level_is_independent_of_source_channel_count(
+    overlay_file: Path, overlay_file_stereo: Path
+) -> None:
+    """A mono overlay source mixes in at the same level as an identical stereo one."""
+    mono_level = _rms(_samples(await _mix_overlay(overlay_file)))
+    stereo_level = _rms(_samples(await _mix_overlay(overlay_file_stereo)))
+    assert mono_level > 0
+    # left to FFmpeg, the mono source would be spread at 1/sqrt(2) per channel
+    # and land a factor sqrt(2) (3 dB) below the stereo one
+    assert mono_level == pytest.approx(stereo_level, rel=0.02)
+
+
+async def test_overlay_stream_preserves_stereo_image(overlay_file_wide_stereo: Path) -> None:
+    """A stereo overlay keeps its channels apart instead of being folded to dual mono."""
+    output = await _mix_overlay(overlay_file_wide_stereo)
+    # the source carries the tone on the left only, so a fold would leak it into the right
+    assert _rms(_samples(output, channel=0)) > 0
+    assert not any(_samples(output, channel=1))
+
+
+# -- overlay volume filter --
+
+
+def test_overlay_volume_filter_compensates_only_where_widening_happens() -> None:
+    """Only a stereo output widens a mono source, so only there is the level compensated."""
+    stereo_output = _get_overlay_volume_filter(100, 2)
+    assert "nb_channels" in stereo_output
+    # a comma would read as the end of this filter in the graph
+    assert "," not in stereo_output
+    # nothing is widened towards a single channel, so nothing needs compensating
+    assert _get_overlay_volume_filter(100, 1) == "volume=1.0"
 
 
 # -- _log_reader_task (decode-error flood guard) --

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -482,16 +482,8 @@ def overlay_file_wide_stereo(tmp_path: Path) -> Path:
             "lavfi",
             "-i",
             "sine=frequency=440:duration=1",
-            "-f",
-            "lavfi",
-            "-i",
-            "anullsrc=cl=mono:d=1",
-            "-filter_complex",
-            "[0:a][1:a]amerge=inputs=2,aformat=channel_layouts=stereo[out]",
-            "-map",
-            "[out]",
-            "-t",
-            "1",
+            "-af",
+            "pan=stereo|c0=c0",
             str(overlay_path),
         ],
         check=True,
@@ -659,14 +651,15 @@ async def test_overlay_stream_preserves_stereo_image(overlay_file_wide_stereo: P
 # -- overlay volume filter --
 
 
-def test_overlay_volume_filter_compensates_only_where_widening_happens() -> None:
-    """Only a stereo output widens a mono source, so only there is the level compensated."""
+def test_overlay_volume_filter_compensates_only_for_a_stereo_output() -> None:
+    """Only the widening to stereo costs a mono source level, so only there is it scaled up."""
     stereo_output = _get_overlay_volume_filter(100, 2)
     assert "nb_channels" in stereo_output
     # a comma would read as the end of this filter in the graph
     assert "," not in stereo_output
-    # nothing is widened towards a single channel, so nothing needs compensating
+    # a mono source keeps its level when it is widened further, or not at all
     assert _get_overlay_volume_filter(100, 1) == "volume=1.0"
+    assert _get_overlay_volume_filter(60, 6) == "volume=0.6"
 
 
 # -- _log_reader_task (decode-error flood guard) --


### PR DESCRIPTION
# What does this implement/fix?

When the audio overlay (looping sound effect / ambience) came from a **mono** source file, it played back noticeably quieter than a stereo one — exactly 3 dB — so the overlay volume slider did not deliver the same loudness across sound effects.

The cause is in FFmpeg: when it widens a mono source to stereo it spreads it at 1/sqrt(2) per channel, which costs 3 dB. The overlay's channel count is only known once FFmpeg has opened the file, so it cannot be handled when the mixer is set up. Instead the overlay's own volume filter now compensates for the widening, because at that point in the chain it still sees the source's real channel count.

- Mono sound effects now mix in at the same level as stereo ones
- Stereo sound effects are untouched, keeping their left/right image
- Added tests covering both the level and the stereo image

**Related issue (if applicable):**

- n/a — found while working on #5367

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.