### PR TITLE
Reattach a player control after it comes back

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -81,11 +81,14 @@ from music_assistant.constants import (
     CONF_GROUP_MEMBERS,
     CONF_MAX_VOLUME,
     CONF_MIN_VOLUME,
+    CONF_MUTE_CONTROL,
     CONF_PLAY_MEDIA_OVERRIDES_GROUP,
     CONF_PLAYER_DSP,
     CONF_PLAYERS,
+    CONF_POWER_CONTROL,
     CONF_PROTOCOL_PARENT_ID,
     CONF_REPORTED_MAC,
+    CONF_VOLUME_CONTROL,
     VERBOSE_LOG_LEVEL,
 )
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
@@ -1825,7 +1828,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         )
 
         # always call update to update any attached players etc.
-        self.update_player_control(player_control.id)
+        self.update_player_control(player_control.id, include_configured=True)
 
     async def register_or_update_player_control(self, player_control: PlayerControl) -> None:
         """Register a new playercontrol on the controller or update existing one."""
@@ -1833,12 +1836,20 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             return
         if player_control.id in self._controls:
             self._controls[player_control.id] = player_control
-            self.update_player_control(player_control.id)
+            self.update_player_control(player_control.id, include_configured=True)
             return
         await self.register_player_control(player_control)
 
-    def update_player_control(self, control_id: str) -> None:
-        """Update playercontrol state."""
+    def update_player_control(self, control_id: str, include_configured: bool = False) -> None:
+        """
+        Refresh the players that use the given player control.
+
+        :param control_id: The control whose state or availability changed.
+        :param include_configured: Also refresh the players that select this control in their
+            config but do not currently resolve to it. Needed when a control (re)appears,
+            because such a player has already fallen back to another control and would
+            otherwise never pick this one back up.
+        """
         if self.mass.closing:
             return
         # update all players that are using this control
@@ -1847,6 +1858,8 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                 player.state.power_control,
                 player.state.volume_control,
                 player.state.mute_control,
+            ) or (
+                include_configured and control_id in self._configured_control_ids(player.player_id)
             ):
                 self.mass.loop.call_soon(player.refresh_state)
 
@@ -2347,6 +2360,14 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             next_item.image, size=512, prefer_stream_server=True
         )
         self._schedule_palette_fetch(player_id, next_url, trigger_update=False)
+
+    def _configured_control_ids(self, player_id: str) -> set[str]:
+        """Return the player control ids the given player's config selects."""
+        return {
+            str(value)
+            for conf_key in (CONF_POWER_CONTROL, CONF_VOLUME_CONTROL, CONF_MUTE_CONTROL)
+            if (value := self.mass.config.get_raw_player_config_value(player_id, conf_key))
+        }
 
     def _get_volume_limits(self, player_id: str) -> tuple[int, int]:
         """Get the configured min/max volume limits for a player."""

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -2367,6 +2367,32 @@ class TestRemovePlayerControl:
         assert controller.player_controls() == []
         mock_mass.loop.call_soon.assert_called_once_with(using_control.refresh_state)
 
+    async def test_a_returning_control_is_picked_back_up(self, mock_mass: MagicMock) -> None:
+        """Test that a control removed and registered again re-attaches to its player."""
+        # run the scheduled refresh straight away so each step is observable
+        mock_mass.loop = MagicMock()
+        mock_mass.loop.call_soon.side_effect = lambda callback, *args: callback(*args)
+        mock_mass.config.get_raw_player_config_value.side_effect = _player_config_stub(
+            {CONF_POWER_CONTROL: "switch.amp"}
+        )
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+        provider = MockProvider("test_provider", instance_id="test_prov", mass=mock_mass)
+        mock_mass.get_provider.return_value = provider
+        player = MockPlayer(provider, "player", "Player")
+        controller._players = {"player": player}
+        control = PlayerControl(id="switch.amp", provider="test_prov", name="Amp")
+
+        await controller.register_or_update_player_control(control)
+        assert player.state.power_control == "switch.amp"
+
+        # the Home Assistant plugin drops and re-registers its controls around a reload
+        controller.remove_player_control(control.id)
+        assert player.state.power_control == PLAYER_CONTROL_NONE
+
+        await controller.register_or_update_player_control(control)
+        assert player.state.power_control == "switch.amp"
+
     def test_removing_an_unknown_control_does_nothing(self, mock_mass: MagicMock) -> None:
         """Test that removing a control that was never registered is a no-op."""
         mock_mass.loop = MagicMock()


### PR DESCRIPTION
# What does this implement/fix?

A player control that disappeared and came back was never picked up again. That happens on every Home Assistant reconnect, because the plugin removes and re-registers all of its controls around a reload: the player had already fallen back to no control, so it no longer matched the returning one and stayed without power or volume control until something else happened to refresh it.

Visible as a power button that does nothing, no auto power on when playback starts, and the volume slider quietly driving the device itself instead of the chosen Home Assistant entity.

Follow-up to #5280, which added the fallback but only refreshed players that still resolved to the control.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- when a player control is registered, also refresh the players that select it in their config, not only the ones already using it
- test that a control survives a remove and register round trip

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.