### PR TITLE
Only refetch the Home Assistant entity registry when a change can affect it

### DIFF
--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -90,6 +90,13 @@ CONTROL_DOMAINS = ("media_player", "switch", "input_boolean", "number", "input_n
 FEATURE_DOMAINS = ("tts", "ai_task")
 FEATURE_DOMAIN_PREFIXES = tuple(f"{domain}." for domain in FEATURE_DOMAINS)
 
+# Entity registry fields a change to which can alter the mirrored registry. Beyond the
+# mirrored fields themselves, disabled_by decides whether an entity is listed at all, and
+# a move to another config entry can clear disabled_by without reporting that field.
+MIRRORED_REGISTRY_FIELDS = frozenset(
+    {"entity_id", "platform", "device_id", "disabled_by", "config_entry_id"}
+)
+
 
 class DeviceMediaPlayerInfo(TypedDict):
     """Home Assistant correlation info for a device that is natively connected elsewhere."""
@@ -1030,10 +1037,11 @@ class HomeAssistantProvider(PluginProvider):
 
     def _on_entity_registry_update(self, event: Event) -> None:
         """Handle an entity registry update event."""
-        # any registry change invalidates the cached registry, whatever domain it concerns
-        self._entity_registry = None
-        self._entity_registry_generation += 1
-        entity_id = event["data"].get("entity_id", "")
+        data = event["data"]
+        if _affects_mirrored_registry(data):
+            self._entity_registry = None
+            self._entity_registry_generation += 1
+        entity_id = data.get("entity_id", "")
         if not entity_id.startswith(FEATURE_DOMAIN_PREFIXES):
             return
         self._schedule_engine_refresh()
@@ -1136,6 +1144,24 @@ def _get_control_name(entity_id: str, state: State | None) -> str:
     if state and (friendly_name := state["attributes"].get("friendly_name")):
         return f"{friendly_name} ({entity_id})"
     return entity_id
+
+
+def _affects_mirrored_registry(data: Mapping[str, Any]) -> bool:
+    """
+    Return whether an entity registry update can change the mirrored entity registry.
+
+    :param data: The data of a Home Assistant entity_registry_updated event.
+    """
+    if data.get("action") != "update":
+        # a created or removed entity always enters or leaves the listing
+        return True
+    # an update reports the fields it touched, so a change that only concerns fields we do
+    # not mirror (a rename, an icon, an area, a label) leaves our listing accurate. an
+    # update can also report no fields at all, as a device rename re-derives a name field
+    # that Home Assistant strips from the report, so treat that as a change of unknown reach
+    if not (changes := data.get("changes")):
+        return True
+    return not MIRRORED_REGISTRY_FIELDS.isdisjoint(changes)
 
 
 def _decompress_state(entity_id: str, compressed_state: CompressedState) -> State:

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -92,8 +92,9 @@ FEATURE_DOMAIN_PREFIXES = tuple(f"{domain}." for domain in FEATURE_DOMAINS)
 
 # Entity registry fields a change to which can alter the mirrored registry. Beyond the
 # mirrored fields themselves, disabled_by decides whether an entity is listed at all, and
-# a move to another config entry can clear disabled_by without reporting that field.
-MIRRORED_REGISTRY_FIELDS = frozenset(
+# config_entry_id joins them because Home Assistant can clear disabled_by while reporting
+# only the move to the other config entry.
+REGISTRY_FIELDS_AFFECTING_MIRROR = frozenset(
     {"entity_id", "platform", "device_id", "disabled_by", "config_entry_id"}
 )
 
@@ -1041,6 +1042,15 @@ class HomeAssistantProvider(PluginProvider):
         if _affects_mirrored_registry(data):
             self._entity_registry = None
             self._entity_registry_generation += 1
+        elif self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+            # the kept mirror rests on which fields Home Assistant reports, so leave a
+            # trail that tells a stale entity listing apart from a lookup that never ran
+            self.logger.log(
+                VERBOSE_LOG_LEVEL,
+                "Keeping the mirrored entity registry, %s changed on %s",
+                ", ".join(data["changes"]),
+                data.get("entity_id", "?"),
+            )
         entity_id = data.get("entity_id", "")
         if not entity_id.startswith(FEATURE_DOMAIN_PREFIXES):
             return
@@ -1161,7 +1171,7 @@ def _affects_mirrored_registry(data: Mapping[str, Any]) -> bool:
     # that Home Assistant strips from the report, so treat that as a change of unknown reach
     if not (changes := data.get("changes")):
         return True
-    return not MIRRORED_REGISTRY_FIELDS.isdisjoint(changes)
+    return not REGISTRY_FIELDS_AFFECTING_MIRROR.isdisjoint(changes)
 
 
 def _decompress_state(entity_id: str, compressed_state: CompressedState) -> State:

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -330,12 +330,26 @@ async def _wait_for_stored(provider: HomeAssistantProvider) -> None:
             await asyncio.sleep(0)
 
 
+def _registry_event(
+    entity_id: str, action: str = "update", changes: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Return the data Home Assistant sends in an entity_registry_updated event."""
+    data: dict[str, Any] = {"action": action, "entity_id": entity_id}
+    if action == "update":
+        # an update carries the old value of every field it touched
+        data["changes"] = changes or {}
+    return data
+
+
 async def _fire_registry_update(
-    provider: HomeAssistantProvider, hass: _HomeAssistantClient, entity_id: str
+    provider: HomeAssistantProvider,
+    hass: _HomeAssistantClient,
+    entity_id: str,
+    action: str,
 ) -> None:
     """Deliver an entity registry update and wait for the engine rebuild it schedules."""
     with patch("music_assistant.providers.hass.ENGINE_REFRESH_DEBOUNCE", 0):
-        hass.fire_event("entity_registry_updated", {"action": "update", "entity_id": entity_id})
+        hass.fire_event("entity_registry_updated", _registry_event(entity_id, action))
         assert provider._engine_refresh_task is not None
         async with asyncio.timeout(1):
             await provider._engine_refresh_task
@@ -644,7 +658,7 @@ async def test_registry_update_refreshes_the_engines() -> None:
         assert ProviderFeature.TTS not in provider.supported_features
 
         hass.compressed_states["tts.new"] = _compressed(_state("tts.new", "New"))
-        await _fire_registry_update(provider, hass, "tts.new")
+        await _fire_registry_update(provider, hass, "tts.new", "create")
 
         assert [engine.id for engine in await provider.get_tts_engines()] == ["tts.new"]
         assert ProviderFeature.TTS in provider.supported_features
@@ -659,7 +673,7 @@ async def test_registry_update_discards_the_feature_of_a_removed_engine() -> Non
         assert ProviderFeature.TTS in provider.supported_features
 
         del hass.compressed_states["tts.only"]
-        await _fire_registry_update(provider, hass, "tts.only")
+        await _fire_registry_update(provider, hass, "tts.only", "remove")
 
         assert await provider.get_tts_engines() == []
         assert ProviderFeature.TTS not in provider.supported_features
@@ -672,11 +686,29 @@ async def test_registry_update_of_another_domain_is_ignored() -> None:
     async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
         await provider.loaded_in_mass()
 
-        hass.fire_event(
-            "entity_registry_updated", {"action": "create", "entity_id": "light.kitchen"}
-        )
+        hass.fire_event("entity_registry_updated", _registry_event("light.kitchen", "create"))
 
         assert provider._engine_refresh_task is None
+
+
+async def test_registry_update_of_a_feature_entity_refreshes_without_a_refetch() -> None:
+    """Rebuild the engine lists for a renamed feature entity without refetching the registry."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        await provider.loaded_in_mass()
+        registry = await provider.get_entity_registry()
+        hass.compressed_states["tts.only"] = _compressed(_state("tts.only", "Renamed"))
+
+        with patch("music_assistant.providers.hass.ENGINE_REFRESH_DEBOUNCE", 0):
+            hass.fire_event(
+                "entity_registry_updated", _registry_event("tts.only", changes={"name": "Only"})
+            )
+            assert provider._engine_refresh_task is not None
+            async with asyncio.timeout(1):
+                await provider._engine_refresh_task
+
+        engines = await provider.get_tts_engines()
+        assert [engine.name for engine in engines] == ["Renamed (tts.only)"]
+        assert provider._entity_registry is registry
 
 
 async def test_burst_of_registry_updates_triggers_a_single_refresh() -> None:
@@ -688,8 +720,7 @@ async def test_burst_of_registry_updates_triggers_a_single_refresh() -> None:
         with patch("music_assistant.providers.hass.ENGINE_REFRESH_DEBOUNCE", 0.05):
             for index in range(3):
                 hass.fire_event(
-                    "entity_registry_updated",
-                    {"action": "create", "entity_id": f"tts.new_{index}"},
+                    "entity_registry_updated", _registry_event(f"tts.new_{index}", "create")
                 )
             assert provider._engine_refresh_task is not None
             async with asyncio.timeout(1):
@@ -699,20 +730,95 @@ async def test_burst_of_registry_updates_triggers_a_single_refresh() -> None:
 
 
 async def test_registry_update_of_another_domain_invalidates_the_registry() -> None:
-    """Refresh the cached registry for a registry update of any domain."""
+    """Refresh the cached registry for an entity that appeared in any domain."""
     async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
         registry_fetches = hass.calls.count(REGISTRY_LIST_COMMAND)
         hass.compressed_states["light.kitchen"] = _compressed(_state("light.kitchen", "Kitchen"))
 
-        hass.fire_event(
-            "entity_registry_updated", {"action": "create", "entity_id": "light.kitchen"}
-        )
+        hass.fire_event("entity_registry_updated", _registry_event("light.kitchen", "create"))
 
         # an entity that can not back a feature must not trigger an engine rebuild
         assert provider._engine_refresh_task is None
         result = await provider.get_states(domains=("light",))
         assert [state["entity_id"] for state in result] == ["light.kitchen"]
         assert hass.calls.count(REGISTRY_LIST_COMMAND) == registry_fetches + 1
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        pytest.param({"name": "Old name"}, id="rename"),
+        pytest.param({"icon": None}, id="icon"),
+        pytest.param({"area_id": None, "labels": []}, id="area_and_labels"),
+        pytest.param({"hidden_by": None}, id="hidden"),
+        # an integration reload re-registers its entities, which touches these
+        pytest.param({"capabilities": None, "supported_features": 0}, id="reload"),
+    ],
+)
+async def test_registry_update_of_unmirrored_fields_keeps_the_registry(
+    changes: dict[str, Any],
+) -> None:
+    """Keep the mirrored registry for an update that cannot change what it holds."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        registry = await provider.get_entity_registry()
+        registry_fetches = hass.calls.count(REGISTRY_LIST_COMMAND)
+
+        hass.fire_event(
+            "entity_registry_updated", _registry_event("light.kitchen", changes=changes)
+        )
+
+        assert await provider.get_entity_registry() is registry
+        assert hass.calls.count(REGISTRY_LIST_COMMAND) == registry_fetches
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        pytest.param({"entity_id": "light.old"}, id="entity_id"),
+        pytest.param({"platform": "old_platform"}, id="platform"),
+        pytest.param({"device_id": None}, id="device_id"),
+        # the listing omits disabled entities, so this one enters or leaves it
+        pytest.param({"disabled_by": None}, id="disabled_by"),
+        # a device rename reports no changed fields at all
+        pytest.param({}, id="changes_empty"),
+        # a move to another config entry can silently re-enable the entity
+        pytest.param({"config_entry_id": "other"}, id="config_entry_id"),
+    ],
+)
+async def test_registry_update_of_mirrored_fields_invalidates_the_registry(
+    changes: dict[str, Any],
+) -> None:
+    """Refetch the mirrored registry for an update that can change what it holds."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        await provider.get_entity_registry()
+        registry_fetches = hass.calls.count(REGISTRY_LIST_COMMAND)
+
+        hass.fire_event(
+            "entity_registry_updated", _registry_event("light.kitchen", changes=changes)
+        )
+
+        assert provider._entity_registry is None
+        await provider.get_entity_registry()
+        assert hass.calls.count(REGISTRY_LIST_COMMAND) == registry_fetches + 1
+
+
+async def test_unmirrored_change_during_the_fetch_is_still_cached() -> None:
+    """Cache a registry listing that only an irrelevant registry update raced."""
+    async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
+        provider._entity_registry = None
+        # hold back the registry response until the update has been delivered
+        hass._registry_result = asyncio.get_running_loop().create_future()
+        lookup = asyncio.ensure_future(provider.get_states(domains=("tts",)))
+        await asyncio.sleep(0)
+
+        hass.fire_event(
+            "entity_registry_updated", _registry_event("light.kitchen", changes={"name": "Old"})
+        )
+        hass._registry_result.set_result(None)
+        async with asyncio.timeout(1):
+            await lookup
+
+        assert provider._entity_registry is not None
 
 
 async def test_domains_are_resolved_through_the_display_registry() -> None:
@@ -765,9 +871,7 @@ async def test_registry_changed_during_the_fetch_is_not_cached() -> None:
         lookup = asyncio.ensure_future(provider.get_states(domains=("tts",)))
         await asyncio.sleep(0)
 
-        hass.fire_event(
-            "entity_registry_updated", {"action": "create", "entity_id": "light.kitchen"}
-        )
+        hass.fire_event("entity_registry_updated", _registry_event("light.kitchen", "create"))
         hass._registry_result.set_result(None)
         async with asyncio.timeout(1):
             await lookup
@@ -887,7 +991,8 @@ async def test_disabled_entity_is_never_requested() -> None:
         # Home Assistant omits disabled entities from the registry, their state remains
         hass.disabled_entities.add("media_player.spare")
         hass.fire_event(
-            "entity_registry_updated", {"action": "update", "entity_id": "media_player.spare"}
+            "entity_registry_updated",
+            _registry_event("media_player.spare", changes={"disabled_by": None}),
         )
         hass.subscriptions.clear()
 


### PR DESCRIPTION
# What does this implement/fix?

Music Assistant keeps a copy of the Home Assistant entity registry for as long as a connection to Home Assistant lasts (it is fetched again from scratch whenever that connection is re-established). Until now *any* registry change threw that whole copy away, so the next lookup downloaded it again — several megabytes on a large setup. Home Assistant fires those change notifications for every entity in the house, and for changes as small as a rename, a new icon or an area assignment.

That copy only holds three details per entity, so Music Assistant now checks which fields actually changed and keeps the copy when the change cannot possibly affect it. New and removed entities still refresh it, as do changes that add or remove an entity from the listing.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Only discard the cached registry listing when the reported change concerns the entity ID, platform or device it belongs to, whether it is disabled, or which config entry it belongs to.
- Always discard it for created and removed entities, and for a change that reports no fields at all.
- Leave the debounced text-to-speech and AI engine refresh untouched: it still runs for every change to a `tts.` or `ai_task.` entity.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
