### PR TITLE
Start audio overlays without a delay

### DIFF
--- a/music_assistant/helpers/dsp.py
+++ b/music_assistant/helpers/dsp.py
@@ -39,10 +39,13 @@ class ComplexFilterInput:
     :param path: Audio file to read.
     :param filters: Optional chain applied to the input before the body consumes
         it (e.g. "aresample=48000").
+    :param input_args: Optional FFmpeg options for reading this input, placed
+        before its ``-i`` (e.g. ["-stream_loop", "-1"]).
     """
 
     path: str
     filters: str = ""
+    input_args: list[str] = field(default_factory=list)
 
 
 @dataclass(slots=True)

--- a/music_assistant/helpers/dsp.py
+++ b/music_assistant/helpers/dsp.py
@@ -34,13 +34,14 @@ if TYPE_CHECKING:
 @dataclass(slots=True)
 class ComplexFilterInput:
     """
-    An extra audio file feeding a ComplexFilter.
+    An extra audio source feeding a ComplexFilter.
 
-    :param path: Audio file to read.
+    :param path: Audio source to read, either a file path or a URL.
     :param filters: Optional chain applied to the input before the body consumes
         it (e.g. "aresample=48000").
     :param input_args: Optional FFmpeg options for reading this input, placed
-        before its ``-i`` (e.g. ["-stream_loop", "-1"]).
+        before its ``-i`` on top of the ones every input already gets
+        (e.g. ["-stream_loop", "-1"]).
     """
 
     path: str
@@ -59,7 +60,7 @@ class ComplexFilter:
 
     :param body: The filter consuming the main input followed by each extra
         input in order (e.g. "afir=irnorm=1").
-    :param inputs: Extra audio files for ``body``, in the order it consumes them.
+    :param inputs: Extra audio sources for ``body``, in the order it consumes them.
     """
 
     body: str

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -19,7 +19,7 @@ from music_assistant_models.helpers import get_global_cache_value, set_global_ca
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 
-from .dsp import ComplexFilter
+from .dsp import ComplexFilter, ComplexFilterInput
 from .process import AsyncProcess, check_output
 from .util import close_async_generator
 
@@ -438,9 +438,9 @@ async def get_ffmpeg_overlay_stream(
     :param pcm_format: PCM format of both the main input and the mixed output.
     :param chunk_size: Optional exact chunk size for the yielded audio.
     """
-    # the overlay is passed as an extra (first) ffmpeg input, infinitely looped;
-    # the main audio arrives on stdin. amix with duration=first follows the main
-    # input's length, normalize=0 keeps the original levels (no averaging).
+    # the overlay is an extra ffmpeg input, infinitely looped, while the main audio
+    # arrives on stdin. amix takes the main input first so duration=first follows its
+    # length, and normalize=0 keeps the original levels (no averaging).
     overlay_input_args = []
     if overlay_input.startswith("http"):
         overlay_input_args += [
@@ -451,7 +451,7 @@ async def get_ffmpeg_overlay_stream(
             "-reconnect_streamed",
             "1",
         ]
-    overlay_input_args += ["-stream_loop", "-1", "-i", overlay_input]
+    overlay_input_args += ["-stream_loop", "-1"]
     # conform the overlay to the main stream's layout so amix sees two matching inputs;
     # an unnameable count is left to FFmpeg's own negotiation
     layout = _get_channel_layout_name(pcm_format.channels)
@@ -462,21 +462,28 @@ async def get_ffmpeg_overlay_stream(
     # the source's own levels rather than the scaled output. volume in turn has to
     # stay ahead of the resample and conform steps, which replace the source's own
     # channel count with the output's.
-    filter_complex = (
-        f"[0:a]silenceremove=start_periods=1:start_threshold=-40dB,"
-        f"{_get_overlay_volume_filter(overlay_volume, pcm_format.channels)},"
-        f"aresample={pcm_format.sample_rate}"
-        f"{conform_filter}[overlay];"
-        "[1:a][overlay]amix=inputs=2:duration=first:normalize=0[mixed]"
+    overlay_mixer = ComplexFilter(
+        body="amix=inputs=2:duration=first:normalize=0",
+        inputs=[
+            ComplexFilterInput(
+                path=overlay_input,
+                filters=(
+                    f"silenceremove=start_periods=1:start_threshold=-40dB,"
+                    f"{_get_overlay_volume_filter(overlay_volume, pcm_format.channels)},"
+                    f"aresample={pcm_format.sample_rate}"
+                    f"{conform_filter}"
+                ),
+                input_args=overlay_input_args,
+            )
+        ],
     )
     async with FFMpeg(
         audio_input=audio_input,
-        # The overlay is input 0, so ffmpeg probes it before the PCM input and
-        # mutates input_format with its metadata. Keep that mutation local.
+        # ffmpeg mirrors the metadata it probes from the input onto input_format,
+        # so hand it a copy to keep that mutation off the caller's format.
         input_format=copy(pcm_format),
         output_format=pcm_format,
-        extra_input_args=overlay_input_args,
-        extra_output_args=["-filter_complex", filter_complex, "-map", "[mixed]"],
+        filter_params=[overlay_mixer],
         collect_log_history=True,
     ) as ffmpeg_proc:
         iterator = ffmpeg_proc.iter_chunked(chunk_size) if chunk_size else ffmpeg_proc.iter_any()
@@ -681,17 +688,9 @@ def get_ffmpeg_args(
     ):
         filter_params.append(resample_filter)
 
-    # ffmpeg refuses a simple -af chain alongside a complex graph on the same stream, so we
-    # leave the graph to any caller that declares one in one of the passthrough arg lists
-    caller_owns_filtergraph = any(
-        "-filter_complex" in args for args in (extra_args, extra_input_args, extra_output_args)
-    )
-
     # a complex fragment brings its own inputs, which must follow the main input
     extra_input_args, filter_args = (
-        _build_filtergraph_args(filter_params)
-        if filter_params and not caller_owns_filtergraph
-        else ([], [])
+        _build_filtergraph_args(filter_params) if filter_params else ([], [])
     )
 
     return generic_args + input_args + extra_input_args + filter_args + extra_args + output_args
@@ -861,7 +860,7 @@ def _build_filtergraph_args(
         flush_pending()
         source_labels: list[str] = []
         for extra_input in item.inputs:
-            input_args += ["-i", extra_input.path]
+            input_args += [*extra_input.input_args, "-i", extra_input.path]
             source = f"{next_input}:a"
             next_input += 1
             if extra_input.filters:

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -37,6 +37,17 @@ DEFAULT_MP3_BIT_RATE: Final[int] = 320
 # main decode path by duplicating the channel instead.
 _MONO_WIDEN_COMPENSATION: Final[float] = 2**0.5
 
+# FFmpeg applies these to the single input they precede, not to the command as a whole,
+# so every input we open has to bring its own copy.
+_INPUT_READ_ARGS: Final[list[str]] = [
+    "-protocol_whitelist",
+    "file,hls,http,https,tcp,tls,crypto,pipe,data,fd,rtp,udp,concat",
+    "-probesize",
+    "8096",
+    "-analyzeduration",
+    "500000",  # 0.5 seconds should be enough to detect the format
+]
+
 # Regex patterns to extract audio format details from ffmpeg's stderr output.
 # Examples of the lines we parse:
 #   Stream #0:0: Audio: mp3, 44100 Hz, stereo, fltp, 320 kb/s
@@ -438,52 +449,13 @@ async def get_ffmpeg_overlay_stream(
     :param pcm_format: PCM format of both the main input and the mixed output.
     :param chunk_size: Optional exact chunk size for the yielded audio.
     """
-    # the overlay is an extra ffmpeg input, infinitely looped, while the main audio
-    # arrives on stdin. amix takes the main input first so duration=first follows its
-    # length, and normalize=0 keeps the original levels (no averaging).
-    overlay_input_args = []
-    if overlay_input.startswith("http"):
-        overlay_input_args += [
-            "-reconnect",
-            "1",
-            "-reconnect_delay_max",
-            "10",
-            "-reconnect_streamed",
-            "1",
-        ]
-    overlay_input_args += ["-stream_loop", "-1"]
-    # conform the overlay to the main stream's layout so amix sees two matching inputs;
-    # an unnameable count is left to FFmpeg's own negotiation
-    layout = _get_channel_layout_name(pcm_format.channels)
-    conform_filter = f",aformat=channel_layouts={layout}" if layout else ""
-    # silenceremove strips a near-silent intro from the overlay source (e.g. a soft
-    # fade-in) so it becomes audible right away; it is a no-op for sources that
-    # already start at full level. It runs before volume so detection is based on
-    # the source's own levels rather than the scaled output. volume in turn has to
-    # stay ahead of the resample and conform steps, which replace the source's own
-    # channel count with the output's.
-    overlay_mixer = ComplexFilter(
-        body="amix=inputs=2:duration=first:normalize=0",
-        inputs=[
-            ComplexFilterInput(
-                path=overlay_input,
-                filters=(
-                    f"silenceremove=start_periods=1:start_threshold=-40dB,"
-                    f"{_get_overlay_volume_filter(overlay_volume, pcm_format.channels)},"
-                    f"aresample={pcm_format.sample_rate}"
-                    f"{conform_filter}"
-                ),
-                input_args=overlay_input_args,
-            )
-        ],
-    )
     async with FFMpeg(
         audio_input=audio_input,
         # ffmpeg mirrors the metadata it probes from the input onto input_format,
         # so hand it a copy to keep that mutation off the caller's format.
         input_format=copy(pcm_format),
         output_format=pcm_format,
-        filter_params=[overlay_mixer],
+        filter_params=[_build_overlay_mixer(overlay_input, pcm_format, overlay_volume)],
         collect_log_history=True,
     ) as ffmpeg_proc:
         iterator = ffmpeg_proc.iter_chunked(chunk_size) if chunk_size else ffmpeg_proc.iter_any()
@@ -558,12 +530,7 @@ def get_ffmpeg_args(
         loglevel,
         "-nostats",
         "-ignore_unknown",
-        "-protocol_whitelist",
-        "file,hls,http,https,tcp,tls,crypto,pipe,data,fd,rtp,udp,concat",
-        "-probesize",
-        "8096",
-        "-analyzeduration",
-        "500000",  # 0.5 seconds should be enough to detect the format
+        *_INPUT_READ_ARGS,
     ]
     # collect input args
     if "-f" in extra_input_args:
@@ -813,6 +780,56 @@ def _get_overlay_volume_filter(overlay_volume: int, output_channels: int) -> str
     return f"volume={gain}*{_MONO_WIDEN_COMPENSATION}^not(nb_channels-1)"
 
 
+def _build_overlay_mixer(
+    overlay_input: str, pcm_format: AudioFormat, overlay_volume: int
+) -> ComplexFilter:
+    """
+    Build the filter that mixes a looping audio overlay into the main audio.
+
+    :param overlay_input: File path or URL of the overlay audio.
+    :param pcm_format: PCM format of the main input and the mixed output.
+    :param overlay_volume: Overlay loudness relative to the main audio in percent.
+    """
+    input_args = []
+    if overlay_input.startswith("http"):
+        input_args += [
+            "-reconnect",
+            "1",
+            "-reconnect_delay_max",
+            "10",
+            "-reconnect_streamed",
+            "1",
+        ]
+    input_args += ["-stream_loop", "-1"]
+    # conform the overlay to the main stream's layout so amix sees two matching inputs;
+    # an unnameable count is left to FFmpeg's own negotiation
+    layout = _get_channel_layout_name(pcm_format.channels)
+    conform_filter = f",aformat=channel_layouts={layout}" if layout else ""
+    return ComplexFilter(
+        # the main audio is amix's first input, so duration=first follows its length;
+        # normalize=0 keeps the original levels (no averaging)
+        body="amix=inputs=2:duration=first:normalize=0",
+        inputs=[
+            ComplexFilterInput(
+                path=overlay_input,
+                # silenceremove strips a near-silent intro from the overlay source (e.g. a
+                # soft fade-in) so it becomes audible right away; it is a no-op for sources
+                # that already start at full level. It runs before volume so detection is
+                # based on the source's own levels rather than the scaled output. volume
+                # in turn has to stay ahead of the resample and conform steps, which
+                # replace the source's own channel count with the output's.
+                filters=(
+                    f"silenceremove=start_periods=1:start_threshold=-40dB,"
+                    f"{_get_overlay_volume_filter(overlay_volume, pcm_format.channels)},"
+                    f"aresample={pcm_format.sample_rate}"
+                    f"{conform_filter}"
+                ),
+                input_args=input_args,
+            )
+        ],
+    )
+
+
 def _build_filtergraph_args(
     filter_params: list[str | ComplexFilter],
 ) -> tuple[list[str], list[str]]:
@@ -860,7 +877,7 @@ def _build_filtergraph_args(
         flush_pending()
         source_labels: list[str] = []
         for extra_input in item.inputs:
-            input_args += [*extra_input.input_args, "-i", extra_input.path]
+            input_args += [*_INPUT_READ_ARGS, *extra_input.input_args, "-i", extra_input.path]
             source = f"{next_input}:a"
             next_input += 1
             if extra_input.filters:

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -880,6 +880,22 @@ def test_build_filtergraph_multiple_inputs() -> None:
     )
 
 
+def test_build_filtergraph_input_args_precede_the_input() -> None:
+    """An input's own ffmpeg options are emitted directly before its -i."""
+    result = _build_filtergraph_args(
+        [
+            ComplexFilter(
+                "amix=inputs=2",
+                [ComplexFilterInput("/loop.wav", input_args=["-stream_loop", "-1"])],
+            )
+        ]
+    )
+    assert result == (
+        ["-stream_loop", "-1", "-i", "/loop.wav"],
+        ["-filter_complex", "[0:a][1:a]amix=inputs=2[dsp1]", "-map", "[dsp1]"],
+    )
+
+
 def test_get_ffmpeg_args_uses_af_without_complex_filter() -> None:
     """Plain filter chains keep the -af path (no -filter_complex/-map)."""
     fmt = AudioFormat(
@@ -904,56 +920,6 @@ def test_get_ffmpeg_args_uses_filter_complex_with_complex_filter() -> None:
     # the impulse response is a real input, so it never passes through graph quoting
     assert args.count("-i") == 2
     assert args.index("/ir.wav") > args.index("-i")
-
-
-PASSTHROUGH_ARG_LISTS = ["extra_args", "extra_input_args", "extra_output_args"]
-
-
-def _args_with_caller_filtergraph(
-    input_format: AudioFormat,
-    output_format: AudioFormat,
-    filter_params: list[str],
-    arg_list: str,
-) -> list[str]:
-    """Build ffmpeg args with a caller-owned filter graph in the named passthrough list."""
-    graph = ["-filter_complex", "[0:a][1:a]amix[mixed]"]
-    return get_ffmpeg_args(
-        input_format,
-        output_format,
-        filter_params,
-        extra_args=graph if arg_list == "extra_args" else [],
-        extra_input_args=graph if arg_list == "extra_input_args" else [],
-        extra_output_args=graph if arg_list == "extra_output_args" else [],
-    )
-
-
-@pytest.mark.parametrize("arg_list", PASSTHROUGH_ARG_LISTS)
-def test_get_ffmpeg_args_yields_filtergraph_to_caller(arg_list: str) -> None:
-    """A caller-owned graph keeps our simple -af chain out of the command."""
-    fmt = AudioFormat(
-        content_type=ContentType.PCM_S16LE, sample_rate=48000, bit_depth=16, channels=2
-    )
-
-    args = _args_with_caller_filtergraph(fmt, fmt, ["volume=-1dB"], arg_list)
-
-    assert "-af" not in args
-    assert "volume=-1dB" not in args
-
-
-@pytest.mark.parametrize("arg_list", PASSTHROUGH_ARG_LISTS)
-def test_get_ffmpeg_args_channel_conform_yields_to_caller(arg_list: str) -> None:
-    """The auto-injected channel filter is dropped too when the caller owns the graph."""
-    input_format = AudioFormat(
-        content_type=ContentType.PCM_S16LE, sample_rate=48000, bit_depth=16, channels=1
-    )
-    output_format = AudioFormat(
-        content_type=ContentType.PCM_S16LE, sample_rate=48000, bit_depth=16, channels=2
-    )
-
-    args = _args_with_caller_filtergraph(input_format, output_format, [], arg_list)
-
-    assert "-af" not in args
-    assert not any(arg.startswith("pan=") for arg in args)
 
 
 def _rms_db(path: Path) -> float:

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -15,9 +15,11 @@ from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.helpers.dsp import ComplexFilter, ComplexFilterInput
 from music_assistant.helpers.ffmpeg import (
+    _INPUT_READ_ARGS,
     FFMpeg,
     FFMpegStreamInfo,
     _build_filtergraph_args,
+    _build_overlay_mixer,
     _get_overlay_volume_filter,
     get_ffmpeg_args,
     get_ffmpeg_overlay_stream,
@@ -662,6 +664,36 @@ def test_overlay_volume_filter_compensates_only_for_a_stereo_output() -> None:
     assert _get_overlay_volume_filter(60, 6) == "volume=0.6"
 
 
+def test_overlay_mixer_loops_its_source() -> None:
+    """The overlay source is looped for as long as the main stream runs."""
+    (overlay,) = _build_overlay_mixer("/sound.wav", _PCM_FORMAT, 100).inputs
+    # a local file has nothing to reconnect to
+    assert overlay.input_args == ["-stream_loop", "-1"]
+
+
+def test_overlay_mixer_reconnects_for_http_sources() -> None:
+    """An http overlay source additionally gets the reconnect options."""
+    (overlay,) = _build_overlay_mixer("http://host/sound.mp3", _PCM_FORMAT, 100).inputs
+    assert "-reconnect" in overlay.input_args
+    assert overlay.input_args[-2:] == ["-stream_loop", "-1"]
+
+
+def test_overlay_args_probe_the_main_input_and_add_no_filters() -> None:
+    """Both inputs are read under our own limits and no filter is injected on top."""
+    args = get_ffmpeg_args(
+        _PCM_FORMAT, _PCM_FORMAT, [_build_overlay_mixer("/sound.wav", _PCM_FORMAT, 100)]
+    )
+    main_input = args.index("-i")
+    # the limits must reach the main input, which is the first one, and the overlay
+    assert args.index("-probesize") < main_input
+    assert args.count("-probesize") == 2
+    assert args.index("-stream_loop") > main_input
+    # the overlay format matches the output, so nothing gets resampled or reconformed
+    assert "-af" not in args
+    assert args.count("-filter_complex") == 1
+    assert not any(arg.startswith(("pan=", "aresample=resampler=")) for arg in args)
+
+
 # -- _log_reader_task (decode-error flood guard) --
 
 
@@ -838,7 +870,7 @@ def test_build_filtergraph_single_complex_fragment() -> None:
         [ComplexFilter("afir=irnorm=1", [ComplexFilterInput("/ir.wav", "aresample=48000")])]
     )
     assert result == (
-        ["-i", "/ir.wav"],
+        [*_INPUT_READ_ARGS, "-i", "/ir.wav"],
         [
             "-filter_complex",
             "[1:a]aresample=48000[dsp1];[0:a][dsp1]afir=irnorm=1[dsp2]",
@@ -858,7 +890,7 @@ def test_build_filtergraph_complex_between_simple_runs() -> None:
         ]
     )
     assert result == (
-        ["-i", "/ir.wav"],
+        [*_INPUT_READ_ARGS, "-i", "/ir.wav"],
         [
             "-filter_complex",
             "[0:a]equalizer=x[dsp1];[1:a]aresample=48000[dsp2];"
@@ -875,7 +907,7 @@ def test_build_filtergraph_multiple_inputs() -> None:
         [ComplexFilter("amerge", [ComplexFilterInput("/a.wav"), ComplexFilterInput("/b.wav")])]
     )
     assert result == (
-        ["-i", "/a.wav", "-i", "/b.wav"],
+        [*_INPUT_READ_ARGS, "-i", "/a.wav", *_INPUT_READ_ARGS, "-i", "/b.wav"],
         ["-filter_complex", "[0:a][1:a][2:a]amerge[dsp1]", "-map", "[dsp1]"],
     )
 
@@ -891,7 +923,7 @@ def test_build_filtergraph_input_args_precede_the_input() -> None:
         ]
     )
     assert result == (
-        ["-stream_loop", "-1", "-i", "/loop.wav"],
+        [*_INPUT_READ_ARGS, "-stream_loop", "-1", "-i", "/loop.wav"],
         ["-filter_complex", "[0:a][1:a]amix=inputs=2[dsp1]", "-map", "[dsp1]"],
     )
 


### PR DESCRIPTION
# What does this implement/fix?

When an audio overlay (a looping sound effect mixed under the music) was active, playback
took about five seconds to start. FFmpeg's stream detection limits are set per input, not
once for the whole command, and they were landing on the overlay instead of on the music.
The music stream was therefore analysed with ffmpeg's five second default, and nothing came
out until that had passed.

The cause was that the overlay mixer hand-built its own ffmpeg filter graph and smuggled it
in through the output arguments, while the rest of the audio pipeline builds such graphs in
one shared place. Moving the overlay onto that shared path required being able to say "read
this input with these options", which also fixes the detection limits, and lets the graph
builder be the only thing putting these graphs together.

- Audio overlays no longer delay the start of playback
- Every ffmpeg input is now read under our own detection limits and protocol whitelist
- Overlay mixing reuses the shared filter graph builder instead of a hand-built graph
- Dropped the now-unused guard for callers bringing their own graph

The mixed audio itself is unchanged: the generated command produces byte-identical output,
verified against both a local file and an http overlay source.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
