### PR TITLE
Fix guests keeping access after party guest access is switched off

### DIFF
--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -463,9 +463,11 @@ class PartyPlugin(PluginProvider):
         # 1. The plugin is being removed entirely (is_removed=True)
         # 2. Guest access is disabled in config (provider reload with disabled setting)
         # This ensures guests are immediately disconnected when access is revoked
-        # Note: We read the LIVE config value since self.config is a snapshot from init
+        # Note: We read the LIVE config value since self.config is a snapshot from init.
+        # The default must match the config entry's default_value: only values that differ
+        # from their default are persisted, so switching guest access off drops the key.
         guest_access_enabled = self.mass.config.get_raw_provider_config_value(
-            self.instance_id, CONF_ENABLE_GUEST_ACCESS, default=True
+            self.instance_id, CONF_ENABLE_GUEST_ACCESS, default=False
         )
         if is_removed or not guest_access_enabled:
             self.logger.debug("Revoking guest tokens...")

--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -463,9 +463,10 @@ class PartyPlugin(PluginProvider):
         # 1. The plugin is being removed entirely (is_removed=True)
         # 2. Guest access is disabled in config (provider reload with disabled setting)
         # This ensures guests are immediately disconnected when access is revoked
-        # Note: We read the LIVE config value since self.config is a snapshot from init.
-        # The default must match the config entry's default_value: only values that differ
-        # from their default are persisted, so switching guest access off drops the key.
+        # Note: We read the LIVE stored value, which also covers reloads that are triggered
+        # outside of a config save. The default must match the config entry's default_value:
+        # only values that differ from their default are persisted, so switching guest access
+        # off drops the key entirely.
         guest_access_enabled = self.mass.config.get_raw_provider_config_value(
             self.instance_id, CONF_ENABLE_GUEST_ACCESS, default=False
         )

--- a/tests/providers/party/test_party_plugin.py
+++ b/tests/providers/party/test_party_plugin.py
@@ -8,9 +8,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.auth import Scope
-from music_assistant_models.enums import ConfigEntryType, MediaType, PlaybackState
+from music_assistant_models.config_entries import ProviderConfig
+from music_assistant_models.enums import ConfigEntryType, MediaType, PlaybackState, ProviderType
 from music_assistant_models.errors import ActionUnavailable, InvalidDataError
 
+from music_assistant.controllers.config.controller import ConfigController
 from music_assistant.helpers.shared_playback import SharedPlaybackMode
 from music_assistant.providers.party import (
     CONF_ENABLE_ADD_QUEUE,
@@ -278,9 +280,10 @@ async def test_unload_revokes_guest_tokens_when_guest_access_is_off() -> None:
     await plugin.unload()
 
     cast("AsyncMock", plugin._revoke_guest_tokens).assert_awaited_once()
-    # the live stored value is what decides, not the config snapshot taken at init
+    # the live stored value is what decides, not the config snapshot taken at init, and an
+    # absent key must read as disabled (matching the config entry's default_value)
     cast("MagicMock", plugin.mass.config.get_raw_provider_config_value).assert_called_once_with(
-        "party--test", CONF_ENABLE_GUEST_ACCESS, default=True
+        "party--test", CONF_ENABLE_GUEST_ACCESS, default=False
     )
 
 
@@ -300,5 +303,53 @@ async def test_unload_revokes_guest_tokens_on_removal() -> None:
     plugin = _create_unload_plugin(guest_access_enabled=True)
 
     await plugin.unload(is_removed=True)
+
+    cast("AsyncMock", plugin._revoke_guest_tokens).assert_awaited_once()
+
+
+async def _create_stored_config_controller(*, guest_access_enabled: bool) -> ConfigController:
+    """Store the party config the way a real save does and return a controller holding it."""
+    entries = await _create_config_entries_plugin(
+        guest_access_enabled=guest_access_enabled
+    ).get_config_entries()
+    config = ProviderConfig.parse(
+        entries,
+        {"type": ProviderType.PLUGIN, "domain": "party", "instance_id": "party--test"},
+    )
+    config.update({CONF_ENABLE_GUEST_ACCESS: guest_access_enabled})
+
+    controller = ConfigController.__new__(ConfigController)
+    controller._data = {"providers": {"party--test": config.to_raw()}}
+    controller.initialized = True
+    return controller
+
+
+@pytest.mark.parametrize("guest_access_enabled", [True, False])
+@pytest.mark.asyncio
+async def test_stored_guest_access_value_survives_a_save(guest_access_enabled: bool) -> None:
+    """
+    Only non-default values are persisted, so a disabled toggle is stored as an absent key.
+
+    unload() must still read that absent key back as disabled.
+    """
+    controller = await _create_stored_config_controller(guest_access_enabled=guest_access_enabled)
+
+    stored_values = controller._data["providers"]["party--test"]["values"]
+    assert (CONF_ENABLE_GUEST_ACCESS in stored_values) is guest_access_enabled
+    assert (
+        controller.get_raw_provider_config_value(
+            "party--test", CONF_ENABLE_GUEST_ACCESS, default=False
+        )
+        is guest_access_enabled
+    )
+
+
+@pytest.mark.asyncio
+async def test_unload_revokes_guest_tokens_after_a_real_save_of_guest_access_off() -> None:
+    """Switching guest access off and reloading revokes the tokens against real stored config."""
+    plugin = _create_unload_plugin(guest_access_enabled=False)
+    plugin.mass.config = await _create_stored_config_controller(guest_access_enabled=False)
+
+    await plugin.unload()
 
     cast("AsyncMock", plugin._revoke_guest_tokens).assert_awaited_once()

--- a/tests/providers/party/test_party_plugin.py
+++ b/tests/providers/party/test_party_plugin.py
@@ -12,7 +12,7 @@ from music_assistant_models.config_entries import ProviderConfig
 from music_assistant_models.enums import ConfigEntryType, MediaType, PlaybackState, ProviderType
 from music_assistant_models.errors import ActionUnavailable, InvalidDataError
 
-from music_assistant.controllers.config.controller import ConfigController
+from music_assistant.controllers.config import ConfigController
 from music_assistant.helpers.shared_playback import SharedPlaybackMode
 from music_assistant.providers.party import (
     CONF_ENABLE_ADD_QUEUE,
@@ -347,7 +347,8 @@ async def test_stored_guest_access_value_survives_a_save(guest_access_enabled: b
 @pytest.mark.asyncio
 async def test_unload_revokes_guest_tokens_after_a_real_save_of_guest_access_off() -> None:
     """Switching guest access off and reloading revokes the tokens against real stored config."""
-    plugin = _create_unload_plugin(guest_access_enabled=False)
+    plugin = _create_unload_plugin(guest_access_enabled=True)
+    # the real stored config replaces the stub, so the absent key is what drives the outcome
     plugin.mass.config = await _create_stored_config_controller(guest_access_enabled=False)
 
     await plugin.unload()


### PR DESCRIPTION
# What does this implement/fix?

Switching guest access off in the Party plugin did not actually kick the guests out. Their tokens stayed valid, their connections stayed open and pending join codes kept working, so anyone who joined the party still had access after the host ended it.

The stored setting is only written when it differs from its default, so switching the toggle off removed the setting entirely. The code that revokes guest access read that missing setting as "still enabled" and skipped the revoke.

- Read the stored guest access setting with the same default as the setting itself, so an absent value means disabled
- Guest tokens, connections and pending join codes are now revoked as soon as guest access is switched off
- Added test coverage that goes through the real save/reload path instead of a mocked config read

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
