### PR TITLE
Fix mismatched default when reading the preferred output protocol setting

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1735,9 +1735,9 @@ class ProtocolLinkingMixin:
                     return protocol_player, linked
 
         # 2. Check for user's preferred output protocol.
-        # The value is only stored while it differs from the entry's default, which is
-        # computed per player ("native" when a native output is available, otherwise "auto").
-        # An absent value therefore means "no explicit preference" and falls through below.
+        # The value is only stored while it differs from the entry's default, which is computed
+        # per player: "native" when a native output is available, otherwise "auto". Both of those
+        # are handled identically by the steps below, so an absent value can safely fall through.
         preferred = self.mass.config.get_raw_player_config_value(
             player.player_id, CONF_PREFERRED_OUTPUT_PROTOCOL
         )

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1734,9 +1734,12 @@ class ProtocolLinkingMixin:
                     )
                     return protocol_player, linked
 
-        # 2. Check for user's preferred output protocol
+        # 2. Check for user's preferred output protocol.
+        # The value is only stored while it differs from the entry's default, which is
+        # computed per player ("native" when a native output is available, otherwise "auto").
+        # An absent value therefore means "no explicit preference" and falls through below.
         preferred = self.mass.config.get_raw_player_config_value(
-            player.player_id, CONF_PREFERRED_OUTPUT_PROTOCOL, "auto"
+            player.player_id, CONF_PREFERRED_OUTPUT_PROTOCOL
         )
         if preferred and preferred != "auto":
             if preferred == "native":
@@ -1950,7 +1953,7 @@ class ProtocolLinkingMixin:
         Returns tuple of (child_protocol_id, protocol_domain) or (None, None).
         """
         child_preferred = self.mass.config.get_raw_player_config_value(
-            child_player.player_id, CONF_PREFERRED_OUTPUT_PROTOCOL, "auto"
+            child_player.player_id, CONF_PREFERRED_OUTPUT_PROTOCOL
         )
         if not child_preferred or child_preferred in {"auto", "native"}:
             return None, None

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -175,7 +175,7 @@ def mock_mass() -> MagicMock:
             return 0
         if key == "max_volume":
             return 100
-        return default if default is not None else "auto"
+        return default
 
     mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw_player_config_value)
     # Return "GLOBAL" for log level config (standard default)
@@ -1935,7 +1935,7 @@ class TestJoinActiveNativeSession:
                 return 0
             if key == "max_volume":
                 return 100
-            return default if default is not None else "auto"
+            return default
 
         mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw)
 
@@ -1966,7 +1966,7 @@ class TestJoinActiveNativeSession:
                 return 0
             if key == "max_volume":
                 return 100
-            return default if default is not None else "auto"
+            return default
 
         mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw)
 
@@ -2002,7 +2002,7 @@ class TestJoinActiveNativeSession:
                 return 0
             if key == "max_volume":
                 return 100
-            return default if default is not None else "auto"
+            return default
 
         mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw)
 
@@ -2039,7 +2039,7 @@ class TestJoinActiveNativeSession:
                 return 0
             if key == "max_volume":
                 return 100
-            return default if default is not None else "auto"
+            return default
 
         mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw)
 


### PR DESCRIPTION
# What does this implement/fix?

The "preferred output protocol" player setting is declared with a default that depends on the player: `native` when the player has an available native output, `auto` otherwise. Two places read that setting back with a hardcoded `auto` fallback, so for a native-capable player the code read `auto` while the setting actually defaults to `native`.

No user-visible effect today (both code paths already treat `auto` and `native` the same), but the two defaults shouldn't silently disagree - a later change to either branch would turn this into a real bug. Same pattern as the party guest access fix in #5380.

- Read the setting without a fallback in both places, so nothing claims a default that contradicts the setting itself. An unset value falls through to the same protocol selection that `auto` and `native` already share.
- Matches how the same setting is already read elsewhere in the player model.
- Test mocks for player settings now return the same value the real code does, so these paths are actually covered.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
