### PR TITLE
Fix playback stopping after the first track on grouped Sonos speakers

### DIFF
--- a/music_assistant/controllers/player_queues/stream_feeder.py
+++ b/music_assistant/controllers/player_queues/stream_feeder.py
@@ -117,10 +117,14 @@ class StreamFeederMixin(_PlayerQueuesBase):
                 # nothing re-attempts this handover, so a skip here means the player runs out
                 # of audio when the current track ends - leave a trace of why it was skipped
                 self.logger.debug(
-                    "Not enqueuing next track %s on queue %s (player state: %s)",
+                    "Not enqueuing next track %s on queue %s "
+                    "(state: %s, source: %s, same session: %s, flow mode: %s)",
                     next_item.name,
                     queue.display_name,
-                    player.state.playback_state if player else "unavailable",
+                    player.state.playback_state if player else "player unavailable",
+                    player.state.active_source if player else None,
+                    queue_data.session_id == session_id,
+                    queue.flow_mode,
                 )
                 return
 

--- a/music_assistant/controllers/player_queues/stream_feeder.py
+++ b/music_assistant/controllers/player_queues/stream_feeder.py
@@ -114,6 +114,14 @@ class StreamFeederMixin(_PlayerQueuesBase):
                 or queue_data.session_id != session_id
                 or queue.flow_mode
             ):
+                # nothing re-attempts this handover, so a skip here means the player runs out
+                # of audio when the current track ends - leave a trace of why it was skipped
+                self.logger.debug(
+                    "Not enqueuing next track %s on queue %s (player state: %s)",
+                    next_item.name,
+                    queue.display_name,
+                    player.state.playback_state if player else "unavailable",
+                )
                 return
 
             current_item = queue.current_item

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2397,10 +2397,11 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                     child_player.on_group_updated(player, changed_values)
                 else:
                     child_player.on_sync_parent_updated(player, changed_values)
-        # update/signal group player(s) when child updates
-        else:
-            for group_player in self._get_player_groups(player, powered_only=False):
-                group_player.on_group_member_updated(player, changed_values)
+        # update/signal group player(s) when a member updates. A sync leader is a member of the
+        # group player that formed the sync group and gaining members of its own does not change
+        # that: a group player mirrors its leader, so it depends on exactly these updates.
+        for group_player in self._get_player_groups(player, powered_only=False):
+            group_player.on_group_member_updated(player, changed_values)
 
         # update/signal manually sync-parent player when child updates
         if (_sync_parent_id := player.state.synced_to) and (

--- a/music_assistant/providers/sonos_s1/constants.py
+++ b/music_assistant/providers/sonos_s1/constants.py
@@ -99,6 +99,12 @@ PLAYBACK_STATE_MAP = {
 SONOS_STATE_PLAYING = "PLAYING"
 SONOS_STATE_TRANSITIONING = "TRANSITIONING"
 
+# A speaker that reports TRANSITIONING carries no usable transport state (the coordinator of a
+# group that is still forming reports it for several seconds), so that report is discarded. One
+# follow-up poll this many seconds later picks up the settled state instead of leaving the player
+# stale until the regular poll interval comes round again.
+TRANSITION_POLL_DELAY = 1.0
+
 # Subscription Settings
 SUBSCRIPTION_TIMEOUT = 1200
 SUBSCRIPTION_SERVICES = {

--- a/music_assistant/providers/sonos_s1/constants.py
+++ b/music_assistant/providers/sonos_s1/constants.py
@@ -99,11 +99,12 @@ PLAYBACK_STATE_MAP = {
 SONOS_STATE_PLAYING = "PLAYING"
 SONOS_STATE_TRANSITIONING = "TRANSITIONING"
 
+POLL_INTERVAL = 5
 # A speaker that reports TRANSITIONING carries no usable transport state (the coordinator of a
-# group that is still forming reports it for several seconds), so that report is discarded. One
-# follow-up poll this many seconds later picks up the settled state instead of leaving the player
-# stale until the regular poll interval comes round again.
-TRANSITION_POLL_DELAY = 1.0
+# group that is still forming reports it for several seconds), so that report is discarded. It is
+# watched closely until it reports a usable state again, instead of leaving the player stale for a
+# full poll interval.
+TRANSITION_POLL_INTERVAL = 1
 
 # Subscription Settings
 SUBSCRIPTION_TIMEOUT = 1200

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -12,6 +12,7 @@ import contextlib
 import logging
 import time
 from collections.abc import Callable, Coroutine
+from functools import partial
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.enums import IdentifierType, MediaType, PlaybackState, PlayerState
@@ -39,6 +40,7 @@ from .constants import (
     SOURCE_TV,
     SUBSCRIPTION_SERVICES,
     SUBSCRIPTION_TIMEOUT,
+    TRANSITION_POLL_DELAY,
 )
 from .helpers import SonosUpdateError, soco_error
 
@@ -94,6 +96,7 @@ class SonosPlayer(Player):
         self._subscription_lock: asyncio.Lock | None = None
         self._last_activity: float = NEVER_TIME
         self._resub_cooldown_expires_at: float | None = None
+        self._awaiting_settled_state: bool = False
 
     @property
     def missing_subscriptions(self) -> set[str]:
@@ -309,7 +312,9 @@ class SonosPlayer(Player):
         new_status = transport_info["current_transport_state"]
 
         if new_status == SONOS_STATE_TRANSITIONING:
+            self._schedule_settled_state_poll()
             return
+        self._awaiting_settled_state = False
 
         new_status = _convert_state(new_status)
         update_position = new_status != self._attr_playback_state
@@ -636,7 +641,9 @@ class SonosPlayer(Player):
 
         # Ignore transitions, we should get the target state soon
         if new_status == SONOS_STATE_TRANSITIONING:
+            self._schedule_settled_state_poll()
             return
+        self._awaiting_settled_state = False
 
         evars = event.variables
         new_status = _convert_state(evars["transport_state"])
@@ -685,6 +692,23 @@ class SonosPlayer(Player):
         if "zone_player_uui_ds_in_group" not in event.variables:
             return
         asyncio.run_coroutine_threadsafe(self.create_update_groups_coro(event), self.mass.loop)
+
+    def _schedule_settled_state_poll(self) -> None:
+        """Schedule a single follow-up poll to pick up the speaker's settled transport state."""
+        # only one poll per transition: a speaker that is still transitioning when it runs falls
+        # back to the regular poll interval instead of polling on repeat
+        if self._awaiting_settled_state:
+            return
+        self._awaiting_settled_state = True
+        # reached from both the event callback and the (threaded) poll, so hop to the event loop
+        self.mass.loop.call_soon_threadsafe(
+            partial(
+                self.mass.call_later,
+                TRANSITION_POLL_DELAY,
+                self.poll,
+                task_id=f"sonos_settled_state_poll_{self.player_id}",
+            )
+        )
 
     def _update_attributes(self) -> None:
         """Update attributes of the MA Player from SoCo state."""

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -705,10 +705,16 @@ class SonosPlayer(Player):
             partial(
                 self.mass.call_later,
                 TRANSITION_POLL_DELAY,
-                self.poll,
+                self._settled_state_poll,
                 task_id=f"sonos_settled_state_poll_{self.player_id}",
             )
         )
+
+    async def _settled_state_poll(self) -> None:
+        """Poll for the settled transport state, unless an event already delivered it."""
+        if not self._awaiting_settled_state:
+            return
+        await self.poll()
 
     def _update_attributes(self) -> None:
         """Update attributes of the MA Player from SoCo state."""

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -12,7 +12,6 @@ import contextlib
 import logging
 import time
 from collections.abc import Callable, Coroutine
-from functools import partial
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.enums import IdentifierType, MediaType, PlaybackState, PlayerState
@@ -32,6 +31,7 @@ from .constants import (
     NEVER_TIME,
     PLAYER_FEATURES,
     PLAYER_SOURCE_MAP,
+    POLL_INTERVAL,
     POSITION_SECONDS,
     RESUB_COOLDOWN_SECONDS,
     SONOS_STATE_TRANSITIONING,
@@ -40,7 +40,7 @@ from .constants import (
     SOURCE_TV,
     SUBSCRIPTION_SERVICES,
     SUBSCRIPTION_TIMEOUT,
-    TRANSITION_POLL_DELAY,
+    TRANSITION_POLL_INTERVAL,
 )
 from .helpers import SonosUpdateError, soco_error
 
@@ -87,7 +87,7 @@ class SonosPlayer(Player):
         if mac_address:
             self._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, mac_address)
         self._attr_needs_poll = True
-        self._attr_poll_interval = 5
+        self._attr_poll_interval = POLL_INTERVAL
         self._attr_available = True
         self._attr_can_group_with = {provider.instance_id}
 
@@ -96,7 +96,6 @@ class SonosPlayer(Player):
         self._subscription_lock: asyncio.Lock | None = None
         self._last_activity: float = NEVER_TIME
         self._resub_cooldown_expires_at: float | None = None
-        self._awaiting_settled_state: bool = False
 
     @property
     def missing_subscriptions(self) -> set[str]:
@@ -312,9 +311,9 @@ class SonosPlayer(Player):
         new_status = transport_info["current_transport_state"]
 
         if new_status == SONOS_STATE_TRANSITIONING:
-            self._schedule_settled_state_poll()
+            self._attr_poll_interval = TRANSITION_POLL_INTERVAL
             return
-        self._awaiting_settled_state = False
+        self._attr_poll_interval = POLL_INTERVAL
 
         new_status = _convert_state(new_status)
         update_position = new_status != self._attr_playback_state
@@ -641,9 +640,9 @@ class SonosPlayer(Player):
 
         # Ignore transitions, we should get the target state soon
         if new_status == SONOS_STATE_TRANSITIONING:
-            self._schedule_settled_state_poll()
+            self._attr_poll_interval = TRANSITION_POLL_INTERVAL
             return
-        self._awaiting_settled_state = False
+        self._attr_poll_interval = POLL_INTERVAL
 
         evars = event.variables
         new_status = _convert_state(evars["transport_state"])
@@ -692,29 +691,6 @@ class SonosPlayer(Player):
         if "zone_player_uui_ds_in_group" not in event.variables:
             return
         asyncio.run_coroutine_threadsafe(self.create_update_groups_coro(event), self.mass.loop)
-
-    def _schedule_settled_state_poll(self) -> None:
-        """Schedule a single follow-up poll to pick up the speaker's settled transport state."""
-        # only one poll per transition: a speaker that is still transitioning when it runs falls
-        # back to the regular poll interval instead of polling on repeat
-        if self._awaiting_settled_state:
-            return
-        self._awaiting_settled_state = True
-        # reached from both the event callback and the (threaded) poll, so hop to the event loop
-        self.mass.loop.call_soon_threadsafe(
-            partial(
-                self.mass.call_later,
-                TRANSITION_POLL_DELAY,
-                self._settled_state_poll,
-                task_id=f"sonos_settled_state_poll_{self.player_id}",
-            )
-        )
-
-    async def _settled_state_poll(self) -> None:
-        """Poll for the settled transport state, unless an event already delivered it."""
-        if not self._awaiting_settled_state:
-            return
-        await self.poll()
 
     def _update_attributes(self) -> None:
         """Update attributes of the MA Player from SoCo state."""

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -367,6 +367,35 @@ class TestStateForwarding:
         )
         on_sync_parent_updated.assert_not_called()
 
+    def test_sync_leader_updates_also_reach_its_group_player(self, mock_mass: MagicMock) -> None:
+        """A sync leader must notify its group player as well as its own sync children."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        group_player = MockPlayer(provider, "group", "Group", player_type=PlayerType.GROUP)
+        leader = MockPlayer(provider, "leader", "Leader")
+        follower = MockPlayer(provider, "follower", "Follower")
+
+        controller._players = {"group": group_player, "leader": leader, "follower": follower}
+        mock_mass.players = controller
+
+        group_player._attr_group_members = ["leader", "follower"]
+        leader._attr_group_members = ["leader", "follower"]
+        for player in (group_player, leader, follower):
+            # _get_player_groups only considers players the controller finished registering
+            player.initialized.set()
+            player.update_state(signal_event=False)
+
+        with (
+            patch.object(group_player, "on_group_member_updated") as on_group_member_updated,
+            patch.object(follower, "on_sync_parent_updated") as on_sync_parent_updated,
+        ):
+            changed_values = {"playback_state": (PlaybackState.IDLE, PlaybackState.PLAYING)}
+            controller._forward_state_update(leader, changed_values)
+
+        on_group_member_updated.assert_called_once_with(leader, changed_values)
+        on_sync_parent_updated.assert_called_once_with(leader, changed_values)
+
 
 class TestSleepTimer:
     """Test native sleep timer handling."""

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import MediaType, PlaybackState
 
 from music_assistant.models.player import PlayerMedia
-from music_assistant.providers.sonos_s1.constants import TRANSITION_POLL_DELAY
+from music_assistant.providers.sonos_s1.constants import POLL_INTERVAL, TRANSITION_POLL_INTERVAL
 from music_assistant.providers.sonos_s1.player import SonosPlayer
 
 STREAM_URL = "http://192.168.1.2:8097/single/sessionabc/queue1/item1/player1.flac"
@@ -27,13 +26,6 @@ def sonos_player() -> SonosPlayer:
     provider = MagicMock()
     provider.mass.streams.resolve_stream_url = AsyncMock(return_value=STREAM_URL)
     return SonosPlayer(provider=provider, soco=soco)
-
-
-def _mock_mass(sonos_player: SonosPlayer) -> MagicMock:
-    """Return the player's mocked mass, running the threadsafe hop inline so it stays assertable."""
-    mass = cast("MagicMock", sonos_player.mass)
-    mass.loop.call_soon_threadsafe = MagicMock(side_effect=lambda callback: callback())
-    return mass
 
 
 def _make_media() -> PlayerMedia:
@@ -71,71 +63,41 @@ async def test_play_media_builds_didl_from_stream_url(sonos_player: SonosPlayer)
     assert "library://track/123" not in call_args.kwargs["meta"]
 
 
-def test_transitional_state_schedules_a_single_settle_poll(sonos_player: SonosPlayer) -> None:
-    """A transitional transport state keeps the last known state and polls again shortly."""
-    mass = _mock_mass(sonos_player)
-    sonos_player._attr_playback_state = PlaybackState.IDLE
-    sonos_player.soco.get_current_transport_info.return_value = {
-        "current_transport_state": "TRANSITIONING"
-    }
+def _set_transport_state(sonos_player: SonosPlayer, state: str) -> None:
+    """Make the mocked speaker report the given transport state."""
+    sonos_player.soco.get_current_transport_info.return_value = {"current_transport_state": state}
 
-    sonos_player.poll_media()
+
+def test_transitional_state_shortens_the_poll_interval(sonos_player: SonosPlayer) -> None:
+    """A transitional transport state keeps the last known state and is watched closely."""
+    sonos_player._attr_playback_state = PlaybackState.IDLE
+    _set_transport_state(sonos_player, "TRANSITIONING")
+
     sonos_player.poll_media()
 
     assert sonos_player._attr_playback_state == PlaybackState.IDLE
-    assert mass.call_later.call_count == 1
-    assert mass.call_later.call_args.args[0] == TRANSITION_POLL_DELAY
-    assert mass.call_later.call_args.args[1] == sonos_player._settled_state_poll
-    # poll_media runs in a worker thread, so scheduling must hop to the event loop
-    assert mass.loop.call_soon_threadsafe.called
+    assert sonos_player.poll_interval == TRANSITION_POLL_INTERVAL
 
 
-def test_settled_state_re_arms_the_settle_poll(sonos_player: SonosPlayer) -> None:
-    """Once a usable state is reported again, a later transition may schedule a new poll."""
-    mass = _mock_mass(sonos_player)
-    sonos_player.soco.get_current_transport_info.return_value = {
-        "current_transport_state": "TRANSITIONING"
-    }
-    sonos_player.poll_media()
+def test_settled_state_restores_the_poll_interval(sonos_player: SonosPlayer) -> None:
+    """A usable transport state returns the speaker to the regular poll interval."""
+    sonos_player._attr_poll_interval = TRANSITION_POLL_INTERVAL
 
-    sonos_player.soco.get_current_transport_info.return_value = {
-        "current_transport_state": "PLAYING"
-    }
+    _set_transport_state(sonos_player, "PLAYING")
     with (
         patch.object(sonos_player, "_set_basic_track_info"),
         patch.object(sonos_player, "update_player"),
     ):
         sonos_player.poll_media()
 
-    sonos_player.soco.get_current_transport_info.return_value = {
-        "current_transport_state": "TRANSITIONING"
-    }
-    sonos_player.poll_media()
-
-    assert mass.call_later.call_count == 2
+    assert sonos_player.poll_interval == POLL_INTERVAL
 
 
-def test_transitional_event_schedules_a_settle_poll(sonos_player: SonosPlayer) -> None:
-    """A transitional state delivered by subscription event also triggers a follow-up poll."""
-    mass = _mock_mass(sonos_player)
+def test_transitional_event_shortens_the_poll_interval(sonos_player: SonosPlayer) -> None:
+    """A transitional state delivered by subscription event is watched closely too."""
     event = MagicMock()
     event.variables = {"transport_state": "TRANSITIONING"}
 
     sonos_player._handle_avtransport_event(event)
 
-    assert mass.call_later.call_count == 1
-    assert mass.call_later.call_args.args[1] == sonos_player._settled_state_poll
-
-
-async def test_settle_poll_is_skipped_when_the_state_already_arrived(
-    sonos_player: SonosPlayer,
-) -> None:
-    """A settled state reported before the follow-up poll runs makes that poll a no-op."""
-    with patch.object(sonos_player, "poll", new=AsyncMock()) as poll:
-        sonos_player._awaiting_settled_state = False
-        await sonos_player._settled_state_poll()
-        poll.assert_not_awaited()
-
-        sonos_player._awaiting_settled_state = True
-        await sonos_player._settled_state_poll()
-        poll.assert_awaited_once()
+    assert sonos_player.poll_interval == TRANSITION_POLL_INTERVAL

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -30,9 +30,9 @@ def sonos_player() -> SonosPlayer:
 
 
 def _mock_mass(sonos_player: SonosPlayer) -> MagicMock:
-    """Return the player's mocked mass with the threadsafe hop running inline."""
+    """Return the player's mocked mass, running the threadsafe hop inline so it stays assertable."""
     mass = cast("MagicMock", sonos_player.mass)
-    mass.loop.call_soon_threadsafe = lambda callback: callback()
+    mass.loop.call_soon_threadsafe = MagicMock(side_effect=lambda callback: callback())
     return mass
 
 
@@ -85,6 +85,9 @@ def test_transitional_state_schedules_a_single_settle_poll(sonos_player: SonosPl
     assert sonos_player._attr_playback_state == PlaybackState.IDLE
     assert mass.call_later.call_count == 1
     assert mass.call_later.call_args.args[0] == TRANSITION_POLL_DELAY
+    assert mass.call_later.call_args.args[1] == sonos_player._settled_state_poll
+    # poll_media runs in a worker thread, so scheduling must hop to the event loop
+    assert mass.loop.call_soon_threadsafe.called
 
 
 def test_settled_state_re_arms_the_settle_poll(sonos_player: SonosPlayer) -> None:
@@ -110,3 +113,29 @@ def test_settled_state_re_arms_the_settle_poll(sonos_player: SonosPlayer) -> Non
     sonos_player.poll_media()
 
     assert mass.call_later.call_count == 2
+
+
+def test_transitional_event_schedules_a_settle_poll(sonos_player: SonosPlayer) -> None:
+    """A transitional state delivered by subscription event also triggers a follow-up poll."""
+    mass = _mock_mass(sonos_player)
+    event = MagicMock()
+    event.variables = {"transport_state": "TRANSITIONING"}
+
+    sonos_player._handle_avtransport_event(event)
+
+    assert mass.call_later.call_count == 1
+    assert mass.call_later.call_args.args[1] == sonos_player._settled_state_poll
+
+
+async def test_settle_poll_is_skipped_when_the_state_already_arrived(
+    sonos_player: SonosPlayer,
+) -> None:
+    """A settled state reported before the follow-up poll runs makes that poll a no-op."""
+    with patch.object(sonos_player, "poll", new=AsyncMock()) as poll:
+        sonos_player._awaiting_settled_state = False
+        await sonos_player._settled_state_poll()
+        poll.assert_not_awaited()
+
+        sonos_player._awaiting_settled_state = True
+        await sonos_player._settled_state_poll()
+        poll.assert_awaited_once()

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import MediaType, PlaybackState
 
 from music_assistant.models.player import PlayerMedia
+from music_assistant.providers.sonos_s1.constants import TRANSITION_POLL_DELAY
 from music_assistant.providers.sonos_s1.player import SonosPlayer
 
 STREAM_URL = "http://192.168.1.2:8097/single/sessionabc/queue1/item1/player1.flac"
@@ -25,6 +27,13 @@ def sonos_player() -> SonosPlayer:
     provider = MagicMock()
     provider.mass.streams.resolve_stream_url = AsyncMock(return_value=STREAM_URL)
     return SonosPlayer(provider=provider, soco=soco)
+
+
+def _mock_mass(sonos_player: SonosPlayer) -> MagicMock:
+    """Return the player's mocked mass with the threadsafe hop running inline."""
+    mass = cast("MagicMock", sonos_player.mass)
+    mass.loop.call_soon_threadsafe = lambda callback: callback()
+    return mass
 
 
 def _make_media() -> PlayerMedia:
@@ -60,3 +69,44 @@ async def test_play_media_builds_didl_from_stream_url(sonos_player: SonosPlayer)
     assert call_args.args[0] == STREAM_URL
     assert STREAM_URL in call_args.kwargs["meta"]
     assert "library://track/123" not in call_args.kwargs["meta"]
+
+
+def test_transitional_state_schedules_a_single_settle_poll(sonos_player: SonosPlayer) -> None:
+    """A transitional transport state keeps the last known state and polls again shortly."""
+    mass = _mock_mass(sonos_player)
+    sonos_player._attr_playback_state = PlaybackState.IDLE
+    sonos_player.soco.get_current_transport_info.return_value = {
+        "current_transport_state": "TRANSITIONING"
+    }
+
+    sonos_player.poll_media()
+    sonos_player.poll_media()
+
+    assert sonos_player._attr_playback_state == PlaybackState.IDLE
+    assert mass.call_later.call_count == 1
+    assert mass.call_later.call_args.args[0] == TRANSITION_POLL_DELAY
+
+
+def test_settled_state_re_arms_the_settle_poll(sonos_player: SonosPlayer) -> None:
+    """Once a usable state is reported again, a later transition may schedule a new poll."""
+    mass = _mock_mass(sonos_player)
+    sonos_player.soco.get_current_transport_info.return_value = {
+        "current_transport_state": "TRANSITIONING"
+    }
+    sonos_player.poll_media()
+
+    sonos_player.soco.get_current_transport_info.return_value = {
+        "current_transport_state": "PLAYING"
+    }
+    with (
+        patch.object(sonos_player, "_set_basic_track_info"),
+        patch.object(sonos_player, "update_player"),
+    ):
+        sonos_player.poll_media()
+
+    sonos_player.soco.get_current_transport_info.return_value = {
+        "current_transport_state": "TRANSITIONING"
+    }
+    sonos_player.poll_media()
+
+    assert mass.call_later.call_count == 2


### PR DESCRIPTION
# What does this implement/fix?

Playing a playlist on a group of Sonos speakers could stop after the first track: the track played to the end and everything went quiet instead of moving on.

A group player mirrors the playback state of its group leader, but the leader was the one player that never told the group anything. A player that has sync members of its own took the "notify my sync children" branch of the state fan-out and skipped notifying the group entirely, so the group only found out it was playing second-hand via one of the followers, or from its own 30 second idle poll.

Because the group still looked idle just after playback started, the queue skipped handing the next track to the speakers, and there was nothing to play when the first track ended.

Worth being explicit about the limit: the queue only tries this handover once, and gives up for good if the player is not reported as playing within five seconds. This PR makes the group learn its leader's state immediately rather than second-hand, which covers the normal case, but a speaker group that takes longer than that to settle can still miss the window. Making that handover retry is a separate change.

**Related issue (if applicable):**

- reported on Discord, no issue link

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Forward a member's state update to its group player(s) even when that member is a sync leader with members of its own
- Poll a Sonos S1 speaker again shortly after it reports a transitional state, rather than leaving it stale until the next regular poll
- Log why a next-track handover was skipped, so a silent stop is traceable

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
