### PR TITLE
Date quiz songs without an ISRC by artist and title

### DIFF
--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -439,12 +439,12 @@ class QuizType(ABC):
 
     async def _musicbrainz_dated_track(self, track: Track) -> tuple[Track, int | None]:
         """
-        Return the track dated with the first release year MusicBrainz knows for its recording.
+        Return the track dated with the first release year MusicBrainz knows for the song.
 
         The track itself is returned unchanged when MusicBrainz has nothing better to offer.
 
         :param track: Track to date.
-        :return: The dated track and the usable release year MusicBrainz knows for its recording.
+        :return: The dated track and the usable release year MusicBrainz knows for the song.
             The year is reported even when the track already carries that year or an earlier one,
             and is None when MusicBrainz knows no year or only an implausible one.
         """
@@ -482,15 +482,16 @@ class QuizType(ABC):
         musicbrainz: MusicbrainzProvider, track: Track
     ) -> int | None:
         """
-        Return the first release year MusicBrainz knows for a track's recording.
+        Return the first release year MusicBrainz knows for a track.
 
         :param musicbrainz: The loaded MusicBrainz provider.
         :param track: Track to date.
         """
+        # an ISRC identifies the exact recording, so it is always the better evidence and
+        # the search below is only reached when it is absent or MusicBrainz does not know it
         if isrc := track.get_external_id(ExternalID.ISRC):
-            return await musicbrainz.get_release_year_by_isrc(isrc)
-        # YouTube Music, Plex, Jellyfin and Subsonic never hand out an ISRC, so their tracks
-        # can only be dated by name; that costs the single request the ISRC lookup skipped
+            if (release_year := await musicbrainz.get_release_year_by_isrc(isrc)) is not None:
+                return release_year
         artist_name = track.artists[0].name if track.artists else None
         if not artist_name or not track.name:
             return None

--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -443,14 +443,13 @@ class QuizType(ABC):
 
         The track itself is returned unchanged when MusicBrainz has nothing better to offer.
 
-        :param track: Track to date by its ISRC.
+        :param track: Track to date.
         :return: The dated track and the usable release year MusicBrainz knows for its recording.
             The year is reported even when the track already carries that year or an earlier one,
             and is None when MusicBrainz knows no year or only an implausible one.
         """
         musicbrainz = self.mass.get_provider("musicbrainz")
-        isrc = track.get_external_id(ExternalID.ISRC)
-        if musicbrainz is None or not isrc:
+        if musicbrainz is None:
             return track, None
         release_year: int | None = None
         # callers wait for this and MusicBrainz throttles to 10 requests per 10 seconds, so a
@@ -458,9 +457,9 @@ class QuizType(ABC):
         with suppress(TimeoutError):
             async with asyncio.timeout(RELEASE_YEAR_LOOKUP_BUDGET_SECONDS):
                 try:
-                    release_year = await cast(
-                        "MusicbrainzProvider", musicbrainz
-                    ).get_release_year_by_isrc(isrc)
+                    release_year = await self._musicbrainz_release_year(
+                        cast("MusicbrainzProvider", musicbrainz), track
+                    )
                 except Exception as err:
                     LOGGER.debug("Could not date Music Quiz track %s: %s", track.uri, err)
         # a year outside this range is rejected by get_track_release_year anyway, and a year
@@ -477,6 +476,25 @@ class QuizType(ABC):
             metadata=replace(track.metadata, release_date=datetime(release_year, 1, 1, tzinfo=UTC)),
         )
         return dated_track, release_year
+
+    @staticmethod
+    async def _musicbrainz_release_year(
+        musicbrainz: MusicbrainzProvider, track: Track
+    ) -> int | None:
+        """
+        Return the first release year MusicBrainz knows for a track's recording.
+
+        :param musicbrainz: The loaded MusicBrainz provider.
+        :param track: Track to date.
+        """
+        if isrc := track.get_external_id(ExternalID.ISRC):
+            return await musicbrainz.get_release_year_by_isrc(isrc)
+        # YouTube Music, Plex, Jellyfin and Subsonic never hand out an ISRC, so their tracks
+        # can only be dated by name; that costs the single request the ISRC lookup skipped
+        artist_name = track.artists[0].name if track.artists else None
+        if not artist_name or not track.name:
+            return None
+        return await musicbrainz.get_release_year_by_track_name(artist_name, track.name)
 
 
 def get_track_release_year(track: Track) -> int | None:

--- a/music_assistant/providers/musicbrainz/provider.py
+++ b/music_assistant/providers/musicbrainz/provider.py
@@ -428,6 +428,53 @@ class MusicbrainzProvider(MetadataProvider):
         :param track_name: Track name to search for.
         :returns: Tuple of (artist, release_groups) or None.
         """
+        if not (result := await self._search_release_groups_by_track_name(artist_name, track_name)):
+            return None
+        artist, release_groups = result
+        return (MusicBrainzArtist.from_raw(artist), [rg for rg, _ in release_groups])
+
+    async def get_release_year_by_track_name(self, artist_name: str, track_name: str) -> int | None:
+        """
+        Get the year a song was first released, by artist and track name.
+
+        Weaker evidence than :meth:`get_release_year_by_isrc`, which identifies the exact
+        recording: this matches on name and only counts studio albums and singles named
+        after the song, so an ambiguous or unknown name yields no year rather than a guess.
+
+        :param artist_name: Name of the track's primary artist.
+        :param track_name: Name of the track.
+        :return: The earliest known release year, or None if MusicBrainz does not know it.
+        """
+        result = await self._search_release_groups_by_track_name(artist_name, track_name)
+        if not result or not (release_groups := result[1]):
+            return None
+        # the release groups are sorted oldest first, and undated ones sort last
+        release_date = release_groups[0][1]
+        return int(release_date[:4]) if release_date[:4].isdigit() else None
+
+    @staticmethod
+    def _link_type_for_relation(relation: MusicBrainzRelation) -> LinkType | None:
+        if link_type := URL_RELATION_TYPE_MAPPING.get(relation.type):
+            return link_type
+        if relation.type == "social network" and relation.url:
+            url_lower = relation.url.resource.lower()
+            for host, link_type in SOCIAL_HOST_MAPPING:
+                if host in url_lower:
+                    return link_type
+        return None
+
+    async def _search_release_groups_by_track_name(
+        self, artist_name: str, track_name: str
+    ) -> tuple[dict[str, Any], list[tuple[MusicBrainzReleaseGroup, str]]] | None:
+        """
+        Search recordings by artist and track name and aggregate their release groups.
+
+        :param artist_name: Artist name to search for.
+        :param track_name: Track name to search for.
+        :return: Tuple of (raw artist, release groups with their earliest release date sorted
+            oldest first), or None when no recording matched. The release groups are empty
+            when the matched recordings carry no studio album or same-named single.
+        """
         search_artist = re.sub(LUCENE_SPECIAL, r"\\\1", artist_name)
         search_track = re.sub(LUCENE_SPECIAL, r"\\\1", track_name)
         result = await self._api_client.get_data(
@@ -468,10 +515,7 @@ class MusicbrainzProvider(MetadataProvider):
         # Aggregate release groups from ALL matching recordings
         # This ensures we find albums even if the first recording only has singles
         all_release_groups: dict[str, tuple[MusicBrainzReleaseGroup, str]] = {}
-        first_artist = None
-        for recording, artist, first_release_date in matches:
-            if first_artist is None:
-                first_artist = artist
+        for recording, _, _ in matches:
             for rg, release_date in self._get_release_groups_with_dates(recording, track_name):
                 rg_id = rg.id
                 if rg_id in all_release_groups:
@@ -485,27 +529,12 @@ class MusicbrainzProvider(MetadataProvider):
                 else:
                     all_release_groups[rg_id] = (rg, release_date)
 
-        if all_release_groups:
-            # Sort by release date
-            sorted_groups = sorted(
-                all_release_groups.values(), key=lambda x: x[1] if x[1] else "9999"
-            )
-            return (MusicBrainzArtist.from_raw(first_artist), [rg for rg, _ in sorted_groups])
-
-        # Fall back to the earliest recording (for artist lookup at least)
-        recording, artist, _ = matches[0]
-        return (MusicBrainzArtist.from_raw(artist), [])
-
-    @staticmethod
-    def _link_type_for_relation(relation: MusicBrainzRelation) -> LinkType | None:
-        if link_type := URL_RELATION_TYPE_MAPPING.get(relation.type):
-            return link_type
-        if relation.type == "social network" and relation.url:
-            url_lower = relation.url.resource.lower()
-            for host, link_type in SOCIAL_HOST_MAPPING:
-                if host in url_lower:
-                    return link_type
-        return None
+        if not all_release_groups:
+            # Fall back to the earliest recording (for artist lookup at least)
+            return (matches[0][1], [])
+        # Sort by release date
+        sorted_groups = sorted(all_release_groups.values(), key=lambda x: x[1] if x[1] else "9999")
+        return (matches[0][1], sorted_groups)
 
     def _get_release_groups_with_dates(
         self, recording: dict[str, Any], track_name: str

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -797,23 +797,22 @@ async def test_musicbrainz_dates_a_track_without_an_isrc_by_name() -> None:
 
 
 @pytest.mark.asyncio
-async def test_musicbrainz_name_lookup_only_wins_when_it_predates_the_library_year() -> None:
-    """Never let a name lookup push a track to a later year than the library knows."""
-    later = _track("later", "Africa", "Toto", album_year=1982)
-    other = _track("other", "Genesis", "Justice", album_year=2007)
-    quiz, mass = _quiz([later, other])
+async def test_musicbrainz_name_lookup_never_pushes_a_track_to_a_later_year() -> None:
+    """Never let a name lookup overwrite a release date the track already carries."""
+    # the track carries the year itself, so only the "already earlier" guard can keep it
+    dated = _track("dated", "Africa", "Toto", release_year=1982)
+    quiz, mass = _quiz([dated])
     _with_musicbrainz(mass, {}, name_years={("Toto", "Africa"): 2005})
 
-    await quiz.initialize()
-    game_round = await _prepare_round_with_tracks(quiz, [later, other])
+    dated_track, release_year = await quiz._musicbrainz_dated_track(dated)
 
-    assert isinstance(game_round.answer_state, TimelineRoundState)
-    assert game_round.answer_state.placement_snapshot[0].release_year == 1982
+    assert release_year == 2005
+    assert MusicTimelineQuizType._release_year(dated_track) == 1982
 
 
 @pytest.mark.asyncio
-async def test_musicbrainz_does_not_look_up_by_name_when_the_track_has_an_isrc() -> None:
-    """Spend one MusicBrainz request per track: the ISRC identifies the recording exactly."""
+async def test_musicbrainz_does_not_look_up_by_name_when_the_isrc_dates_the_track() -> None:
+    """Spend one MusicBrainz request per track while the ISRC identifies the recording."""
     dated = _with_isrc(_track("dated", "Africa", "Toto", album_year=1998), "ISRC-DATED")
     quiz, mass = _quiz([dated])
     musicbrainz = _with_musicbrainz(
@@ -826,6 +825,20 @@ async def test_musicbrainz_does_not_look_up_by_name_when_the_track_has_an_isrc()
 
     assert release_year == 1982
     musicbrainz.get_release_year_by_track_name.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_falls_back_to_the_name_when_it_does_not_know_the_isrc() -> None:
+    """Date a track by name when MusicBrainz has no recording for its ISRC."""
+    unknown = _with_isrc(_track("unknown", "Africa", "Toto", album_year=1998), "ISRC-UNKNOWN")
+    quiz, mass = _quiz([unknown])
+    musicbrainz = _with_musicbrainz(mass, {}, name_years={("Toto", "Africa"): 1982})
+
+    _, release_year = await quiz._musicbrainz_dated_track(unknown)
+
+    assert release_year == 1982
+    musicbrainz.get_release_year_by_isrc.assert_awaited_once_with("ISRC-UNKNOWN")
+    musicbrainz.get_release_year_by_track_name.assert_awaited_once_with("Toto", "Africa")
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -234,11 +234,24 @@ def _with_musicbrainz(
     mass: MagicMock,
     years: dict[str, int] | None = None,
     error: Exception | None = None,
+    name_years: dict[tuple[str, str], int] | None = None,
 ) -> MagicMock:
-    """Attach a MusicBrainz provider that dates the given ISRCs to the mock MusicAssistant."""
+    """
+    Attach a MusicBrainz provider to the mock MusicAssistant.
+
+    :param mass: Mock MusicAssistant to attach the provider to.
+    :param years: Release year per ISRC.
+    :param error: Raised by both lookups instead of answering.
+    :param name_years: Release year per (artist name, track name), for tracks without an ISRC.
+    """
     provider = MagicMock()
     provider.get_release_year_by_isrc = AsyncMock(
         side_effect=error if error is not None else lambda isrc: (years or {}).get(isrc)
+    )
+    provider.get_release_year_by_track_name = AsyncMock(
+        side_effect=error
+        if error is not None
+        else lambda artist, track: (name_years or {}).get((artist, track))
     )
     mass.get_provider = MagicMock(
         side_effect=lambda domain: provider if domain == "musicbrainz" else None
@@ -765,6 +778,68 @@ async def test_musicbrainz_lookups_do_not_scale_with_the_source_pool() -> None:
     assert isinstance(game_round.answer_state, TimelineRoundState)
     assert game_round.answer_state.candidate.entry.release_year == 1970
     assert musicbrainz.get_release_year_by_isrc.await_count <= quiz.config.round_count + 1
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_dates_a_track_without_an_isrc_by_name() -> None:
+    """Date tracks from providers that never hand out an ISRC by artist and title."""
+    # a greatest hits set typed as a regular album keeps its (wrong) year without this
+    hits = _track("hits", "Radio Ga Ga", "Queen", album_year=1991)
+    other = _track("other", "Genesis", "Justice", album_year=2007)
+    quiz, mass = _quiz([hits, other])
+    _with_musicbrainz(mass, {}, name_years={("Queen", "Radio Ga Ga"): 1984})
+
+    await quiz.initialize()
+    game_round = await _prepare_round_with_tracks(quiz, [hits, other])
+
+    assert isinstance(game_round.answer_state, TimelineRoundState)
+    assert game_round.answer_state.placement_snapshot[0].release_year == 1984
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_name_lookup_only_wins_when_it_predates_the_library_year() -> None:
+    """Never let a name lookup push a track to a later year than the library knows."""
+    later = _track("later", "Africa", "Toto", album_year=1982)
+    other = _track("other", "Genesis", "Justice", album_year=2007)
+    quiz, mass = _quiz([later, other])
+    _with_musicbrainz(mass, {}, name_years={("Toto", "Africa"): 2005})
+
+    await quiz.initialize()
+    game_round = await _prepare_round_with_tracks(quiz, [later, other])
+
+    assert isinstance(game_round.answer_state, TimelineRoundState)
+    assert game_round.answer_state.placement_snapshot[0].release_year == 1982
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_does_not_look_up_by_name_when_the_track_has_an_isrc() -> None:
+    """Spend one MusicBrainz request per track: the ISRC identifies the recording exactly."""
+    dated = _with_isrc(_track("dated", "Africa", "Toto", album_year=1998), "ISRC-DATED")
+    quiz, mass = _quiz([dated])
+    musicbrainz = _with_musicbrainz(
+        mass,
+        {"ISRC-DATED": 1982},
+        name_years={("Toto", "Africa"): 1955},
+    )
+
+    _, release_year = await quiz._musicbrainz_dated_track(dated)
+
+    assert release_year == 1982
+    musicbrainz.get_release_year_by_track_name.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_skips_the_name_lookup_without_an_artist() -> None:
+    """Never search MusicBrainz for a track that carries no artist to search on."""
+    anonymous = _track("anonymous", "Untitled", "Nobody", album_year=1990)
+    anonymous.artists = UniqueList([])
+    quiz, mass = _quiz([anonymous])
+    musicbrainz = _with_musicbrainz(mass, {})
+
+    _, release_year = await quiz._musicbrainz_dated_track(anonymous)
+
+    assert release_year is None
+    musicbrainz.get_release_year_by_track_name.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -905,6 +905,31 @@ def test_compilation_release_year_stays_suppressed_without_dating() -> None:
 
 
 @pytest.mark.asyncio
+async def test_prepare_round_grounds_a_compilation_without_an_isrc_on_its_name_lookup() -> None:
+    """Ground a compilation round on the name lookup when the track carries no ISRC."""
+    # a compilation has no usable year of its own, so the name lookup is the only thing
+    # that can answer a release year question about tracks from an ISRC-less provider
+    track = _track("compilation", "Africa", "Toto", release_year=1998)
+    track.album = _full_album(
+        "party-hits",
+        "Party Hits",
+        album_type=AlbumType.COMPILATION,
+        year=1998,
+    )
+    provider = _ai_provider(_valid_response())
+    quiz, mass = _quiz([track], providers=[provider])
+    _with_musicbrainz(mass, {}, name_years={("Toto", "Africa"): 1982})
+
+    await quiz.prepare_round(0, [])
+
+    assert _prompt_payload(provider.ai_query.await_args.args[0])["track_metadata"] == {
+        "title": "Africa",
+        "artist": "Toto",
+        "release_year": 1982,
+    }
+
+
+@pytest.mark.asyncio
 async def test_prepare_round_grounds_a_dated_compilation_on_its_musicbrainz_year() -> None:
     """Ground a compilation round on the MusicBrainz year while hiding the compilation album."""
     track = _with_isrc(_track("compilation", "Africa", "Toto", release_year=1998), "ISRC-COMP")

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -310,10 +310,23 @@ def _with_isrc(track: Track, isrc: str) -> Track:
     return track
 
 
-def _with_musicbrainz(mass: MagicMock, years: dict[str, int]) -> MagicMock:
-    """Attach a MusicBrainz provider that dates the given ISRCs to the mock MusicAssistant."""
+def _with_musicbrainz(
+    mass: MagicMock,
+    years: dict[str, int],
+    name_years: dict[tuple[str, str], int] | None = None,
+) -> MagicMock:
+    """
+    Attach a MusicBrainz provider to the mock MusicAssistant.
+
+    :param mass: Mock MusicAssistant to attach the provider to.
+    :param years: Release year per ISRC.
+    :param name_years: Release year per (artist name, track name), for tracks without an ISRC.
+    """
     provider = MagicMock()
     provider.get_release_year_by_isrc = AsyncMock(side_effect=lambda isrc: years.get(isrc))
+    provider.get_release_year_by_track_name = AsyncMock(
+        side_effect=lambda artist, track: (name_years or {}).get((artist, track))
+    )
     mass.get_provider = MagicMock(
         side_effect=lambda domain: provider if domain == "musicbrainz" else None
     )

--- a/tests/providers/musicbrainz/test_provider.py
+++ b/tests/providers/musicbrainz/test_provider.py
@@ -202,14 +202,19 @@ def _recording(
     *releases: dict[str, Any],
     title: str = "Bohemian Rhapsody",
     artist: str = "Queen",
+    artist_id: str = "artist-1",
+    first_release: str | None = None,
 ) -> dict[str, Any]:
     """Return one searched recording credited to the given artist."""
-    return {
+    recording: dict[str, Any] = {
         "id": f"recording-{title}-{releases[0]['date'] if releases else 'none'}",
         "title": title,
-        "artist-credit": [{"artist": {"id": "artist-1", "name": artist, "sort-name": artist}}],
+        "artist-credit": [{"artist": {"id": artist_id, "name": artist, "sort-name": artist}}],
         "releases": list(releases),
     }
+    if first_release is not None:
+        recording["first-release-date"] = first_release
+    return recording
 
 
 async def test_release_year_by_track_name_returns_the_earliest_studio_release() -> None:
@@ -250,6 +255,18 @@ async def test_release_year_by_track_name_ignores_untrustworthy_releases() -> No
     assert await provider.get_release_year_by_track_name("Queen", "Bohemian Rhapsody") == 1975
 
 
+async def test_release_year_by_track_name_ignores_an_undated_release_group() -> None:
+    """Date a song by the oldest release group that has a date, not by an undated one."""
+    provider, _ = _provider(
+        _search_result(
+            _recording(_release("", title="Unknown Pressing")),
+            _recording(_release("1975-11-21")),
+        )
+    )
+
+    assert await provider.get_release_year_by_track_name("Queen", "Bohemian Rhapsody") == 1975
+
+
 async def test_release_year_by_track_name_accepts_a_single_named_after_the_song() -> None:
     """Date a song by its own single when no studio album carries it."""
     provider, _ = _provider(
@@ -276,11 +293,19 @@ async def test_release_year_by_track_name_is_none_without_a_confident_match() ->
 
 
 async def test_release_group_by_track_name_returns_the_artist_and_oldest_groups_first() -> None:
-    """Hand out the matched artist and their release groups, oldest release first."""
+    """Hand out the artist of the oldest recording, and their release groups oldest first."""
     provider, _ = _provider(
         _search_result(
-            _recording(_release("2011-05-16", title="The Platinum Collection")),
-            _recording(_release("1975-11-21")),
+            _recording(
+                _release("2011-05-16", title="The Platinum Collection"),
+                first_release="2011-05-16",
+                artist_id="artist-reissue",
+            ),
+            _recording(
+                _release("1975-11-21"),
+                first_release="1975-11-21",
+                artist_id="artist-original",
+            ),
         )
     )
 
@@ -288,7 +313,9 @@ async def test_release_group_by_track_name_returns_the_artist_and_oldest_groups_
 
     assert result is not None
     artist, release_groups = result
-    assert artist.name == "Queen"
+    # MusicBrainz can hold several artist entries under one name, and the oldest recording
+    # is the one that identifies the original
+    assert artist.id == "artist-original"
     assert [group.title for group in release_groups] == [
         "A Night at the Opera",
         "The Platinum Collection",

--- a/tests/providers/musicbrainz/test_provider.py
+++ b/tests/providers/musicbrainz/test_provider.py
@@ -161,3 +161,162 @@ async def test_recordings_by_isrc_rejects_a_malformed_isrc() -> None:
 
     assert await provider.get_recordings_by_isrc("../artist/1") == []
     get_data.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# get_release_year_by_track_name
+# ---------------------------------------------------------------------------
+
+
+def _release(
+    date: str,
+    *,
+    title: str = "A Night at the Opera",
+    primary_type: str = "Album",
+    secondary_types: list[str] | None = None,
+    status: str = "Official",
+) -> dict[str, Any]:
+    """Return one release of a searched recording."""
+    release: dict[str, Any] = {
+        "id": f"release-{date}",
+        "title": title,
+        "date": date,
+        "status": status,
+        "release-group": {
+            "id": f"rg-{title}-{primary_type}",
+            "title": title,
+            "primary-type": primary_type,
+        },
+    }
+    if secondary_types:
+        release["release-group"]["secondary-types"] = secondary_types
+    return release
+
+
+def _search_result(*recordings: dict[str, Any]) -> dict[str, Any]:
+    """Return a recording search response holding the given recordings."""
+    return {"count": len(recordings), "recordings": list(recordings)}
+
+
+def _recording(
+    *releases: dict[str, Any],
+    title: str = "Bohemian Rhapsody",
+    artist: str = "Queen",
+) -> dict[str, Any]:
+    """Return one searched recording credited to the given artist."""
+    return {
+        "id": f"recording-{title}-{releases[0]['date'] if releases else 'none'}",
+        "title": title,
+        "artist-credit": [{"artist": {"id": "artist-1", "name": artist, "sort-name": artist}}],
+        "releases": list(releases),
+    }
+
+
+async def test_release_year_by_track_name_returns_the_earliest_studio_release() -> None:
+    """Date a song by the oldest studio album any matching recording appeared on."""
+    provider, get_data = _provider(
+        _search_result(
+            _recording(_release("2011-05-16", title="The Platinum Collection")),
+            _recording(_release("1992-08-25", title="Classic Queen")),
+            _recording(_release("1975-11-21")),
+        )
+    )
+
+    assert await provider.get_release_year_by_track_name("Queen", "Bohemian Rhapsody") == 1975
+    get_data.assert_awaited_once_with(
+        "recording",
+        query='"Bohemian Rhapsody" AND artist:"Queen"',
+        limit="100",
+    )
+
+
+async def test_release_year_by_track_name_ignores_untrustworthy_releases() -> None:
+    """Never date a song by a compilation, a live album, a bootleg or an unrelated single."""
+    provider, _ = _provider(
+        _search_result(
+            _recording(
+                # every untrusted release predates the studio album, so each filter has to
+                # hold on its own for the studio year to win
+                _release("1968-10-26", title="Greatest Hits", secondary_types=["Compilation"]),
+                _release("1969-06-22", title="Live Killers", secondary_types=["Live"]),
+                _release("1970-01-01", title="Some Other Song", primary_type="Single"),
+                _release("1971-03-01", title="Bootleg Tape", status="Bootleg"),
+                _release("1972-05-05", title="A Tribute", primary_type="Other"),
+                _release("1975-11-21"),
+            )
+        )
+    )
+
+    assert await provider.get_release_year_by_track_name("Queen", "Bohemian Rhapsody") == 1975
+
+
+async def test_release_year_by_track_name_accepts_a_single_named_after_the_song() -> None:
+    """Date a song by its own single when no studio album carries it."""
+    provider, _ = _provider(
+        _search_result(
+            _recording(_release("1975-10-31", title="Bohemian Rhapsody", primary_type="Single"))
+        )
+    )
+
+    assert await provider.get_release_year_by_track_name("Queen", "Bohemian Rhapsody") == 1975
+
+
+async def test_release_year_by_track_name_is_none_without_a_confident_match() -> None:
+    """Return no year at all rather than guessing from a name that does not match."""
+    for response in (
+        None,
+        {"count": 0, "recordings": []},
+        _search_result(_recording(_release("1975-11-21"), artist="Not Queen")),
+        _search_result(_recording(_release("1975-11-21"), title="Another Song")),
+        _search_result(_recording()),
+        _search_result(_recording(_release(""))),
+    ):
+        provider, _ = _provider(response)
+        assert await provider.get_release_year_by_track_name("Queen", "Bohemian Rhapsody") is None
+
+
+async def test_release_group_by_track_name_returns_the_artist_and_oldest_groups_first() -> None:
+    """Hand out the matched artist and their release groups, oldest release first."""
+    provider, _ = _provider(
+        _search_result(
+            _recording(_release("2011-05-16", title="The Platinum Collection")),
+            _recording(_release("1975-11-21")),
+        )
+    )
+
+    result = await provider.get_release_group_by_track_name("Queen", "Bohemian Rhapsody")
+
+    assert result is not None
+    artist, release_groups = result
+    assert artist.name == "Queen"
+    assert [group.title for group in release_groups] == [
+        "A Night at the Opera",
+        "The Platinum Collection",
+    ]
+
+
+async def test_release_group_by_track_name_returns_the_artist_without_release_groups() -> None:
+    """Still identify the artist when no matched recording carries a usable release group."""
+    provider, _ = _provider(
+        _search_result(_recording(_release("1981-10-26", secondary_types=["Compilation"])))
+    )
+
+    result = await provider.get_release_group_by_track_name("Queen", "Bohemian Rhapsody")
+
+    assert result is not None
+    artist, release_groups = result
+    assert artist.name == "Queen"
+    assert release_groups == []
+
+
+async def test_release_year_by_track_name_escapes_lucene_specials() -> None:
+    """Escape characters that would otherwise change the meaning of the search query."""
+    provider, get_data = _provider(_search_result())
+
+    await provider.get_release_year_by_track_name("AC/DC", "T.N.T. (live!)")
+
+    get_data.assert_awaited_once_with(
+        "recording",
+        query='"T.N.T. \\(live\\!\\)" AND artist:"AC\\/DC"',
+        limit="100",
+    )


### PR DESCRIPTION
# What does this implement/fix?

Music Timeline and Trivia date songs by asking MusicBrainz when a recording was first
released, which is looked up by the track's ISRC. YouTube Music, Plex, Jellyfin and
Subsonic never set an ISRC, so their songs skipped that lookup entirely and kept the
year of the album they happen to sit on — usually wrong for a greatest hits set.

Those tracks now fall back to a lookup by artist and song title, which also covers the
songs whose ISRC MusicBrainz simply has no recording for. Nothing changes for a song
whose ISRC does resolve, so the common case costs the same single request as before.

Measured against 45 hand-dated songs: the year shown goes from 73% exact to 88% exact,
and songs dated more than two years wrong drop from 15% to 8%. On a real ISRC-less
library it dates 59% of the songs it is asked about; the rest keep the year they have
today rather than being guessed at. Only studio albums and singles named after the song
count, so an ambiguous title yields no year rather than a wrong one.

**Related issue (if applicable):**

- follow-up to #5250

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
