### PR TITLE
Show the real buffer depth default per device

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -106,16 +106,19 @@ AIRPLAY_CLOCK_READY_TIMEOUT_MS: Final[int] = 2500
 # projection made from the receiver's very first probe.
 AIRPLAY_CLOCK_READY_LEAD_MS: Final[int] = 500
 # Default receiver buffer depth per device family: (manufacturer wildcard,
-# model wildcard) -> depth in ms, matched case-insensitively in order, first
-# match wins; unmatched devices stay on Automatic (the binary's stock depth).
-# Devices whose fv record marks the old LinkPlay platform match as
-# manufacturer "Linkplay" whatever brand they carry (Edifier and other OEMs).
-# LinkPlay pipelines starve at the stock depth - silent renderer behind a
-# perfectly healthy session - and need the full 1750 ms once the device is
-# also master of a native multiroom group, at the cost of slower warm seeks.
-# Extend the table as field reports identify more starving devices.
-AIRPLAY_LINKPLAY_FV_PREFIX: Final[str] = "p20.Linkplay."
-AIRPLAY_BUFFER_DEPTH_DEFAULTS: Final[tuple[tuple[str, str, int], ...]] = (("linkplay*", "*", 1750),)
+# model wildcard, firmware wildcard) -> depth in ms, matched case-insensitively
+# in order, first match wins; unmatched devices stay on Automatic (the binary's
+# stock depth). LinkPlay pipelines starve at the stock depth - silent renderer
+# behind a perfectly healthy session - and need the full 1750 ms once the
+# device is also master of a native multiroom group, at the cost of slower
+# warm seeks. Extend the table as field reports identify more starving devices.
+AIRPLAY_BUFFER_DEPTH_DEFAULTS: Final[tuple[tuple[str, str, str, int], ...]] = (
+    # The newer LinkPlay platform names Linkplay as the manufacturer (WiiM, ...).
+    ("linkplay*", "*", "*", 1750),
+    # The older LinkPlay platform ships under OEM brands (Edifier, ...) but
+    # marks the platform in its firmware string.
+    ("*", "*", "p20.linkplay.*", 1750),
+)
 # Per-player override of the splice receiver-queue depth in ms (0 = automatic).
 CONF_BUFFER_DEPTH: Final[str] = "buffer_depth"
 # How long a plain (non-join) START waits for the binary's [STATUS] started ack.

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -105,17 +105,17 @@ AIRPLAY_CLOCK_READY_TIMEOUT_MS: Final[int] = 2500
 # for the command reaching the binary and for the convergence error of a
 # projection made from the receiver's very first probe.
 AIRPLAY_CLOCK_READY_LEAD_MS: Final[int] = 500
-# LinkPlay-based receivers route playback through an internal pipeline that
-# starves below ~1 s of queued audio: at the stock 600 ms splice depth the
-# renderer stays silent (Edifier MS50A even solo; a WiiM acting as native
-# multiroom master) while the sender sees a perfectly healthy session. A
-# deeper receiver queue feeds the pipeline - verified live at 1000 ms on the
-# worst known device - at the cost of slower warm seeks on these players.
-# Detected via the _airplay TXT: the old platform embeds "Linkplay" in fv,
-# the newer one names Linkplay as manufacturer.
+# Default receiver buffer depth per device family: (manufacturer wildcard,
+# model wildcard) -> depth in ms, matched case-insensitively in order, first
+# match wins; unmatched devices stay on Automatic (the binary's stock depth).
+# Devices whose fv record marks the old LinkPlay platform match as
+# manufacturer "Linkplay" whatever brand they carry (Edifier and other OEMs).
+# LinkPlay pipelines starve at the stock depth - silent renderer behind a
+# perfectly healthy session - and need the full 1750 ms once the device is
+# also master of a native multiroom group, at the cost of slower warm seeks.
+# Extend the table as field reports identify more starving devices.
 AIRPLAY_LINKPLAY_FV_PREFIX: Final[str] = "p20.Linkplay."
-AIRPLAY_LINKPLAY_MANUFACTURER: Final[str] = "linkplay"
-AIRPLAY_LINKPLAY_BUFFER_DEPTH_MS: Final[int] = 1000
+AIRPLAY_BUFFER_DEPTH_DEFAULTS: Final[tuple[tuple[str, str, int], ...]] = (("linkplay*", "*", 1750),)
 # Per-player override of the splice receiver-queue depth in ms (0 = automatic).
 CONF_BUFFER_DEPTH: Final[str] = "buffer_depth"
 # How long a plain (non-join) START waits for the binary's [STATUS] started ack.

--- a/music_assistant/providers/airplay/helpers.py
+++ b/music_assistant/providers/airplay/helpers.py
@@ -7,6 +7,7 @@ import os
 import platform
 import plistlib
 import re
+from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import ClientError, ClientTimeout
@@ -15,6 +16,8 @@ from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.helpers.process import check_output
 from music_assistant.helpers.util import format_ip_for_url
+
+from .constants import AIRPLAY_BUFFER_DEPTH_DEFAULTS, AIRPLAY_LINKPLAY_FV_PREFIX
 
 if TYPE_CHECKING:
     from zeroconf.asyncio import AsyncServiceInfo
@@ -165,6 +168,25 @@ def is_apple_tv(manufacturer: str, model: str) -> bool:
     (e.g. "Apple TV 4K", "Apple TV Gen4").
     """
     return manufacturer.lower().startswith("apple") and "apple tv" in model.lower()
+
+
+def default_buffer_depth(manufacturer: str, model: str, fv: str | None) -> int:
+    """
+    Return the default receiver buffer depth in ms for a device, 0 for automatic.
+
+    :param manufacturer: Device manufacturer from discovery.
+    :param model: Device model from discovery.
+    :param fv: The device's _airplay fv (firmware) TXT record, when known.
+    """
+    # The old LinkPlay platform carries OEM brands but identifies itself in fv.
+    if fv and fv.startswith(AIRPLAY_LINKPLAY_FV_PREFIX):
+        manufacturer = "Linkplay"
+    for manufacturer_match, model_match, depth_ms in AIRPLAY_BUFFER_DEPTH_DEFAULTS:
+        if fnmatch(manufacturer.lower(), manufacturer_match) and fnmatch(
+            model.lower(), model_match
+        ):
+            return depth_ms
+    return 0
 
 
 def get_decoded_property(discovery_info: AsyncServiceInfo, key: str) -> str | None:

--- a/music_assistant/providers/airplay/helpers.py
+++ b/music_assistant/providers/airplay/helpers.py
@@ -17,7 +17,7 @@ from music_assistant_models.media_items import AudioFormat
 from music_assistant.helpers.process import check_output
 from music_assistant.helpers.util import format_ip_for_url
 
-from .constants import AIRPLAY_BUFFER_DEPTH_DEFAULTS, AIRPLAY_LINKPLAY_FV_PREFIX
+from .constants import AIRPLAY_BUFFER_DEPTH_DEFAULTS
 
 if TYPE_CHECKING:
     from zeroconf.asyncio import AsyncServiceInfo
@@ -178,12 +178,11 @@ def default_buffer_depth(manufacturer: str, model: str, fv: str | None) -> int:
     :param model: Device model from discovery.
     :param fv: The device's _airplay fv (firmware) TXT record, when known.
     """
-    # The old LinkPlay platform carries OEM brands but identifies itself in fv.
-    if fv and fv.startswith(AIRPLAY_LINKPLAY_FV_PREFIX):
-        manufacturer = "Linkplay"
-    for manufacturer_match, model_match, depth_ms in AIRPLAY_BUFFER_DEPTH_DEFAULTS:
-        if fnmatch(manufacturer.lower(), manufacturer_match) and fnmatch(
-            model.lower(), model_match
+    for manufacturer_match, model_match, fv_match, depth_ms in AIRPLAY_BUFFER_DEPTH_DEFAULTS:
+        if (
+            fnmatch(manufacturer.lower(), manufacturer_match)
+            and fnmatch(model.lower(), model_match)
+            and fnmatch((fv or "").lower(), fv_match)
         ):
             return depth_ms
     return 0

--- a/music_assistant/providers/airplay/helpers.py
+++ b/music_assistant/providers/airplay/helpers.py
@@ -7,7 +7,7 @@ import os
 import platform
 import plistlib
 import re
-from fnmatch import fnmatch
+from fnmatch import fnmatchcase
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import ClientError, ClientTimeout
@@ -179,10 +179,13 @@ def default_buffer_depth(manufacturer: str, model: str, fv: str | None) -> int:
     :param fv: The device's _airplay fv (firmware) TXT record, when known.
     """
     for manufacturer_match, model_match, fv_match, depth_ms in AIRPLAY_BUFFER_DEPTH_DEFAULTS:
+        # fnmatchcase with both sides lowered: plain fnmatch only normalizes
+        # case on case-insensitive platforms, so a capitalized table row would
+        # match on macOS and silently fail on Linux.
         if (
-            fnmatch(manufacturer.lower(), manufacturer_match)
-            and fnmatch(model.lower(), model_match)
-            and fnmatch((fv or "").lower(), fv_match)
+            fnmatchcase(manufacturer.lower(), manufacturer_match.lower())
+            and fnmatchcase(model.lower(), model_match.lower())
+            and fnmatchcase((fv or "").lower(), fv_match.lower())
         ):
             return depth_ms
     return 0

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -57,6 +57,8 @@ from .constants import (
     StreamingProtocol,
 )
 from .helpers import (
+    default_buffer_depth,
+    get_decoded_property,
     is_apple_device,
     is_macos_device,
     player_id_to_mac_address,
@@ -330,10 +332,11 @@ class AirPlayPlayer(Player):
                 category="protocol_generic",
                 advanced=True,
             ),
-            # Receiver-queue depth presets: 0 = automatic (600 ms stock, 1000 ms
-            # for LinkPlay-based devices whose pipeline starves below ~1 s).
-            # Capped at 1750 - the receiver's standard 2 s buffer minus margin;
-            # deeper values would overflow it.
+            # Receiver-queue depth presets, capped at 1750 - the receiver's
+            # standard 2 s buffer minus the delivery margin; deeper would
+            # overflow it. The default comes from the device-family table, and
+            # Automatic resolves through that same table at stream time, so
+            # selecting it never downgrades an affected device.
             ConfigEntry(
                 key=CONF_BUFFER_DEPTH,
                 type=ConfigEntryType.INTEGER,
@@ -345,7 +348,13 @@ class AirPlayPlayer(Player):
                     ConfigValueOption(1500),
                     ConfigValueOption(1750),
                 ],
-                default_value=0,
+                default_value=default_buffer_depth(
+                    self.device_info.manufacturer or "",
+                    self.device_info.model or "",
+                    get_decoded_property(self.airplay_discovery_info, "fv")
+                    if self.airplay_discovery_info
+                    else None,
+                ),
                 category="protocol_generic",
                 advanced=True,
                 requires_reload=True,

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -29,9 +29,6 @@ from music_assistant.providers.airplay.constants import (
     AIRPLAY_ARTWORK_SIZE,
     AIRPLAY_CONTENT_CUT_TOLERANCE_MS,
     AIRPLAY_JOIN_START_ACK_TIMEOUT_MS,
-    AIRPLAY_LINKPLAY_BUFFER_DEPTH_MS,
-    AIRPLAY_LINKPLAY_FV_PREFIX,
-    AIRPLAY_LINKPLAY_MANUFACTURER,
     AIRPLAY_PCM_FORMAT,
     AIRPLAY_START_ACK_TIMEOUT_MS,
     CLI_PROBLEM_MARKERS,
@@ -45,8 +42,10 @@ from music_assistant.providers.airplay.constants import (
     StreamingProtocol,
 )
 from music_assistant.providers.airplay.helpers import (
+    default_buffer_depth,
     generate_active_remote_id,
     get_cli_binary,
+    get_decoded_property,
     serialize_txt_records,
 )
 
@@ -835,17 +834,17 @@ class AirPlayStream:
         # the daemon publishing its clock there is nothing to attach to, and a
         # stream that asks anyway silently takes its own timing instead.
         if target_protocol == StreamingProtocol.AIRPLAY2:
-            # LinkPlay-based receivers starve below ~1 s of queued audio (see
-            # the constants); give them a deeper receiver queue. A configured
-            # per-player depth always wins, for other starving devices too.
-            props = airplay_info.decoded_properties if airplay_info else {}
-            is_linkplay = (
-                str(props.get("fv") or "").startswith(AIRPLAY_LINKPLAY_FV_PREFIX)
-                or AIRPLAY_LINKPLAY_MANUFACTURER in str(props.get("manufacturer") or "").lower()
-            )
-            depth_ms = cast("int", self.player.config.get_value(CONF_BUFFER_DEPTH, 0) or 0)
-            if not depth_ms and is_linkplay:
-                depth_ms = AIRPLAY_LINKPLAY_BUFFER_DEPTH_MS
+            # Deeper receiver queue for devices whose pipeline starves at the
+            # stock depth. The stored value wins; Automatic (0) resolves
+            # through the same device-family table that seeds the config
+            # entry default, so selecting it never downgrades a device.
+            depth_ms = cast("int", self.player.config.get_value(CONF_BUFFER_DEPTH) or 0)
+            if not depth_ms:
+                depth_ms = default_buffer_depth(
+                    self.player.device_info.manufacturer or "",
+                    self.player.device_info.model or "",
+                    get_decoded_property(airplay_info, "fv") if airplay_info else None,
+                )
             if depth_ms:
                 args += ["--latency", str(depth_ms)]
             shared_ptp = prov.ptp_daemon_ready if use_shared_ptp is None else use_shared_ptp

--- a/music_assistant/providers/airplay/strings.json
+++ b/music_assistant/providers/airplay/strings.json
@@ -18,7 +18,7 @@
     },
     "buffer_depth": {
       "label": "Audio buffer depth",
-      "description": "How much audio the speaker keeps queued ahead of playback. Automatic uses 600 ms, or 1000 ms for LinkPlay-based devices (WiiM, Edifier and others), whose audio pipeline needs a deeper buffer - especially when the speaker is also part of the vendor's own multiroom group. Pick a deeper value if this speaker stays silent while Music Assistant shows it playing; deeper buffers make track skips respond slower.",
+      "description": "How much audio the speaker keeps queued ahead of playback. Deeper values help speakers that stay silent or drop out while Music Assistant shows them playing - especially when the speaker also plays in a multiroom group of its own brand - at the cost of slower track skips. Automatic picks a default suited to the device.",
       "options": {
         "0": "Automatic",
         "500": "500 ms",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -834,7 +834,7 @@
   "provider.ai_radio.setup_flow.abort.no_tts_engine": "AI Radio needs a text-to-speech engine. Set up a plugin that provides text-to-speech first, for example the Home Assistant plugin with a TTS entity.",
   "provider.ai_radio.setup_flow.user.description": "Pick the AI engine that writes the moderator sections and the text-to-speech engine that voices them.",
   "provider.ai_radio.setup_flow.user.title": "Choose the AI Radio engines",
-  "provider.airplay.config_entries.buffer_depth.description": "How much audio the speaker keeps queued ahead of playback. Automatic uses 600 ms, or 1000 ms for LinkPlay-based devices (WiiM, Edifier and others), whose audio pipeline needs a deeper buffer - especially when the speaker is also part of the vendor's own multiroom group. Pick a deeper value if this speaker stays silent while Music Assistant shows it playing; deeper buffers make track skips respond slower.",
+  "provider.airplay.config_entries.buffer_depth.description": "How much audio the speaker keeps queued ahead of playback. Deeper values help speakers that stay silent or drop out while Music Assistant shows them playing - especially when the speaker also plays in a multiroom group of its own brand - at the cost of slower track skips. Automatic picks a default suited to the device.",
   "provider.airplay.config_entries.buffer_depth.label": "Audio buffer depth",
   "provider.airplay.config_entries.buffer_depth.options.0": "Automatic",
   "provider.airplay.config_entries.buffer_depth.options.1000": "1000 ms",

--- a/tests/providers/airplay/test_helpers.py
+++ b/tests/providers/airplay/test_helpers.py
@@ -9,6 +9,7 @@ from aiohttp import ClientError
 
 from music_assistant.providers.airplay.helpers import (
     _CLI_BINARY_CHECK_TIMEOUT,
+    default_buffer_depth,
     get_cli_binary,
     get_decoded_property,
     probe_audio_formats,
@@ -239,3 +240,16 @@ def _mass_serving_info(info: dict[str, Any], status: int = 200) -> MagicMock:
     mass = MagicMock()
     mass.http_session.get = MagicMock(return_value=context)
     return mass
+
+
+def test_default_buffer_depth_family_table() -> None:
+    """The family table maps both LinkPlay generations to the deep queue."""
+    # Newer platform: Linkplay named as manufacturer.
+    assert (
+        default_buffer_depth("Linkplay Technology Inc.", "WiiM Pro Receiver", "p20.4.8.814756")
+        == 1750
+    )
+    # Older platform: OEM brand, the platform only marked in fv.
+    assert default_buffer_depth("Edifier Inc", "Edifier MS50A", "p20.Linkplay.4.6.430230") == 1750
+    assert default_buffer_depth("Sonos", "Era 100", "p20.96.0-79160") == 0
+    assert default_buffer_depth("Apple Inc.", "AppleTV11,1", None) == 0

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -755,6 +755,8 @@ def _stream_player(*, ptp_daemon_ready: bool) -> MagicMock:
     player.volume_level = 40
     player.device_info.mac_address = "AA:BB:CC:DD:EE:FF"
     player.device_info.ip_address = "192.168.1.50"
+    player.device_info.manufacturer = "Acme, Inc."
+    player.device_info.model = "Test1,1"
     player.logger = logging.getLogger("test.airplay.player")
     player.config.get_value = MagicMock(return_value=None)
     # Keep the arg build on its shortest path: no discovery records to expand.

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -47,6 +47,8 @@ def _make_player() -> MagicMock:
     player.volume_level = 40
     player.device_info.mac_address = "AA:BB:CC:DD:EE:FF"
     player.device_info.ip_address = "192.168.1.50"
+    player.device_info.manufacturer = "Acme, Inc."
+    player.device_info.model = "Test1,1"
     player.logger = logging.getLogger("test.airplay.player")
     player.config.get_value = MagicMock(side_effect=lambda _key, default=None: default)
     player.state.active_group = None
@@ -295,25 +297,25 @@ async def test_cli_args_no_ptp_shared_when_daemon_alive_but_not_ready() -> None:
 @pytest.mark.asyncio
 async def test_cli_args_linkplay_gets_deeper_buffer() -> None:
     """
-    LinkPlay-based receivers get a deeper splice queue, on the normal PTP path.
+    LinkPlay-family devices get the deep receiver queue from the family table.
 
-    Their pipeline starves below ~1 s of queued audio and renders silence at
-    the stock 600 ms depth (Edifier MS50A even solo, WiiM as multiroom master).
-    Both platform generations must match: the old one embeds Linkplay in fv,
-    the newer one only names Linkplay as manufacturer.
+    Their pipeline starves at the stock depth - fully once the device is also
+    master of a native multiroom group - so the table maps them to 1750 ms.
+    Both platform generations must match: the newer names Linkplay as
+    manufacturer, the older only marks the platform in fv under OEM brands.
     """
     player = _make_player()
-    player.airplay_discovery_info.decoded_properties["fv"] = "p20.Linkplay.4.6.430230"
+    player.device_info.manufacturer = "Linkplay Technology Inc."
     args = await _build_args(player)
-    assert _arg_value(args, "--latency") == "1000"
-    assert "--no-ptp" not in args
+    assert _arg_value(args, "--latency") == "1750"
     assert "--ptp-shared" in args
 
+    # Old platform: OEM brand, the Linkplay token only in fv.
     player = _make_player()
-    player.airplay_discovery_info.decoded_properties["fv"] = "p20.4.8.814756"
-    player.airplay_discovery_info.decoded_properties["manufacturer"] = "Linkplay Technology Inc."
+    player.device_info.manufacturer = "Edifier Inc"
+    player.airplay_discovery_info.decoded_properties["fv"] = "p20.Linkplay.4.6.430230"
     args = await _build_args(player)
-    assert _arg_value(args, "--latency") == "1000"
+    assert _arg_value(args, "--latency") == "1750"
 
     # Non-LinkPlay devices stay on the binary's stock depth.
     player = _make_player()
@@ -323,8 +325,9 @@ async def test_cli_args_linkplay_gets_deeper_buffer() -> None:
 
 @pytest.mark.asyncio
 async def test_cli_args_buffer_depth_config_overrides_auto() -> None:
-    """A configured buffer depth wins over the automatic value, on any device."""
+    """A configured buffer depth wins over the device-family default."""
     player = _make_player()
+    player.device_info.manufacturer = "Linkplay Technology Inc."
     player.config.get_value = MagicMock(
         side_effect=lambda key, default=None: 1500 if key == CONF_BUFFER_DEPTH else default
     )


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5369 on the *Audio buffer depth* setting. The entry showed **Automatic** on LinkPlay devices even though they effectively run a deeper queue (the default was applied at stream time only), and its description leaked internal vendor details.

- A `(manufacturer, model)` wildcard table now seeds the entry default, so the UI shows the real value per device (`Linkplay, * = 1750`; everything else Automatic). Old-platform OEM brands (Edifier and others) match through a firmware wildcard column (`p20.linkplay.*`), so they need no per-brand rows and nothing is relabeled. Extend the table as field reports come in.
- The LinkPlay default moves from 1000 to **1750 ms** - field-tested by Marvin as the depth a WiiM needs once it is also master of a native multiroom group.
- *Automatic* resolves through the same table at stream time, so explicitly selecting it never downgrades an affected device.
- The entry description is now vendor-neutral.

## Types of changes

- [ ] Enhancement to an existing feature — `enhancement`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.