### PR TITLE
Apple Music: batch library sync requests to cut API usage

### DIFF
--- a/music_assistant/providers/apple_music/api_client.py
+++ b/music_assistant/providers/apple_music/api_client.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 _APPLE_API_BASE = "https://api.music.apple.com/v1"
 
-_LIBRARY_PAGE_SIZE = 50
+_LIBRARY_PAGE_SIZE = 100
 
 _PAGE_TRUNCATION_RETRIES = 3
 

--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -377,7 +377,11 @@ class AppleMusicLibraryManager:
             for item in library_only_items
         ]
         details = await self._fetch_library_song_details(
-            [item["id"] for item, track in parsed_tracks if self._track_has_weak_album_mapping(track)]
+            [
+                item["id"]
+                for item, track in parsed_tracks
+                if self._track_has_weak_album_mapping(track)
+            ]
         )
         for item, parsed_track in parsed_tracks:
             if (detail := details.get(item["id"])) is None:
@@ -387,7 +391,9 @@ class AppleMusicLibraryManager:
                 item, parsed_track, detail, rating_response.get(item["id"])
             )
 
-    async def _fetch_library_song_details(self, library_ids: list[str]) -> dict[str, dict[str, Any]]:
+    async def _fetch_library_song_details(
+        self, library_ids: list[str]
+    ) -> dict[str, dict[str, Any]]:
         """Return the detailed library-song items for the given ids, keyed by id."""
         details: dict[str, dict[str, Any]] = {}
         for offset in range(0, len(library_ids), _DETAIL_BATCH_SIZE):
@@ -400,5 +406,7 @@ class AppleMusicLibraryManager:
                 # the listing parse stays usable, so a failed batch only costs album detail
                 self.logger.debug("Unable to fetch library song details: %s", err)
                 continue
-            details.update({item["id"]: item for item in response.get("data", []) if item.get("id")})
+            details.update(
+                {item["id"]: item for item in response.get("data", []) if item.get("id")}
+            )
         return details

--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -180,7 +180,7 @@ class AppleMusicLibraryManager:
 
     async def library_remove(self, prov_item_id: str, media_type: MediaType) -> None:
         """Remove item from library."""
-        self.logger.warning(
+        self.logger.debug(
             "Deleting items from your library is not yet supported by the Apple Music API. "
             f"Skipping deletion of {media_type} - {prov_item_id}."
         )
@@ -404,7 +404,9 @@ class AppleMusicLibraryManager:
                 )
             except MusicAssistantError as err:
                 # the listing parse stays usable, so a failed batch only costs album detail
-                self.logger.debug("Unable to fetch library song details: %s", err)
+                self.logger.warning(
+                    "Unable to fetch library song details for %s tracks: %s", len(batch), err
+                )
                 continue
             details.update(
                 {item["id"]: item for item in response.get("data", []) if item.get("id")}

--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -18,8 +18,11 @@ if TYPE_CHECKING:
 
     from .provider import AppleMusicProvider
 
-# Tracks carry heavy includes, so they page smaller than the library default.
-_TRACK_PAGE_SIZE = 30
+# 100 is the maximum Apple accepts; the heavy includes only cost ~20% latency per page.
+_TRACK_PAGE_SIZE = 100
+
+# Detail lookups for weak-mapped library tracks go out in batches of this many ids.
+_DETAIL_BATCH_SIZE = 100
 
 # Catalog enrichment batch size: 300 (the documented max) returns a 504, so cap at 150. This also
 # bounds the in-flight window, keeping a ~100k library from being materialized at once.
@@ -115,24 +118,15 @@ class AppleMusicLibraryManager:
             and not is_catalog_id(album_item_id)
         )
 
-    async def _parse_library_track_with_detail_fallback(
-        self, item: dict[str, Any], is_favourite: bool | None
+    def _apply_album_detail(
+        self,
+        item: dict[str, Any],
+        parsed_track: Track,
+        detail: dict[str, Any],
+        is_favourite: bool | None,
     ) -> Track:
-        """Parse library track and fetch detail when album mapping is weak."""
-        parsed_track = parse_track(self.provider, item, is_favourite)
-        initial_is_weak = self._track_has_weak_album_mapping(parsed_track)
-        if not initial_is_weak:
-            return parsed_track
-        try:
-            detail_response = await self.api.get_data(
-                f"me/library/songs/{item['id']}", include="catalog,albums,artists"
-            )
-        except MusicAssistantError as err:
-            self.logger.debug("Unable to fetch library song details for %s: %s", item["id"], err)
-            return parsed_track
-        if not detail_response.get("data"):
-            return parsed_track
-        detailed_track = parse_track(self.provider, detail_response["data"][0], is_favourite)
+        """Return the detail-based track when it resolves the album the listing lacked."""
+        detailed_track = parse_track(self.provider, detail, is_favourite)
         if self._track_has_weak_album_mapping(detailed_track):
             # Keep detail album fallback if list had no album.
             if not parsed_track.album and detailed_track.album:
@@ -378,6 +372,33 @@ class AppleMusicLibraryManager:
             return
         library_ids = [item["id"] for item in library_only_items if item and item["id"]]
         rating_response = await self.api.get_ratings(library_ids, MediaType.TRACK)
-        for item in library_only_items:
-            is_favourite = rating_response.get(item["id"])
-            yield await self._parse_library_track_with_detail_fallback(item, is_favourite)
+        parsed_tracks = [
+            (item, parse_track(self.provider, item, rating_response.get(item["id"])))
+            for item in library_only_items
+        ]
+        details = await self._fetch_library_song_details(
+            [item["id"] for item, track in parsed_tracks if self._track_has_weak_album_mapping(track)]
+        )
+        for item, parsed_track in parsed_tracks:
+            if (detail := details.get(item["id"])) is None:
+                yield parsed_track
+                continue
+            yield self._apply_album_detail(
+                item, parsed_track, detail, rating_response.get(item["id"])
+            )
+
+    async def _fetch_library_song_details(self, library_ids: list[str]) -> dict[str, dict[str, Any]]:
+        """Return the detailed library-song items for the given ids, keyed by id."""
+        details: dict[str, dict[str, Any]] = {}
+        for offset in range(0, len(library_ids), _DETAIL_BATCH_SIZE):
+            batch = library_ids[offset : offset + _DETAIL_BATCH_SIZE]
+            try:
+                response = await self.api.get_data(
+                    "me/library/songs", ids=",".join(batch), include="catalog,albums,artists"
+                )
+            except MusicAssistantError as err:
+                # the listing parse stays usable, so a failed batch only costs album detail
+                self.logger.debug("Unable to fetch library song details: %s", err)
+                continue
+            details.update({item["id"]: item for item in response.get("data", []) if item.get("id")})
+        return details

--- a/tests/providers/apple_music/test_library.py
+++ b/tests/providers/apple_music/test_library.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import MusicAssistantError
 from music_assistant_models.media_items import (
     Album,
     Artist,
@@ -549,3 +550,19 @@ async def test_library_only_detail_fetches_are_batched() -> None:
     assert all(len(kwargs["ids"].split(",")) <= _DETAIL_BATCH_SIZE for _endpoint, kwargs in calls)
     # the batched detail response still resolves the album that the listing lacked
     assert all(track.album is not None for track in tracks)
+
+
+@pytest.mark.asyncio
+async def test_library_only_detail_batch_failure_reports_how_many_lost_detail() -> None:
+    """A failed detail batch keeps the listing tracks and warns with the number affected."""
+    count = 20
+    items = [_library_song(idx, catalog_id=None) for idx in range(count)]
+    manager, _calls = _make_library_only_manager(items)
+    manager.api.get_data = AsyncMock(side_effect=MusicAssistantError("boom"))
+
+    tracks = [track async for track in manager.get_library_tracks()]
+
+    assert len(tracks) == count
+    assert all(track.album is None for track in tracks)
+    manager.logger.warning.assert_called_once()
+    assert count in manager.logger.warning.call_args.args

--- a/tests/providers/apple_music/test_library.py
+++ b/tests/providers/apple_music/test_library.py
@@ -15,6 +15,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.providers.apple_music.library import (
+    _DETAIL_BATCH_SIZE,
     _MAX_SEARCH_FALLBACK_PER_WINDOW,
     _TRACK_SYNC_WINDOW,
     AppleMusicLibraryManager,
@@ -498,3 +499,53 @@ async def test_search_replacement_skips_item_mappings() -> None:
 
     # Should return None since ItemMapping should be skipped
     assert result is None
+
+
+def _make_library_only_manager(
+    items: list[dict[str, Any]],
+) -> tuple[AppleMusicLibraryManager, list[tuple[str, dict[str, Any]]]]:
+    """Build a manager streaming library-only songs, recording every api call it makes."""
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+    provider._storefront = "us"
+    api = provider.api_client
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def _iter(*_args: Any, **_kwargs: Any) -> Any:
+        for item in items:
+            yield item
+
+    async def _get_data(endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        calls.append((endpoint, kwargs))
+        requested = kwargs.get("ids", "").split(",") if kwargs.get("ids") else []
+        return {
+            "data": [
+                _library_song_with_metadata(
+                    int(item_id.split(".")[1]), catalog_id=None, album_name=f"Album {item_id}"
+                )
+                for item_id in requested
+            ]
+        }
+
+    api.iter_all_items = _iter
+    api.get_data = AsyncMock(side_effect=_get_data)
+    api.get_ratings = AsyncMock(return_value={})
+    return AppleMusicLibraryManager(provider), calls
+
+
+@pytest.mark.asyncio
+async def test_library_only_detail_fetches_are_batched() -> None:
+    """Weak-mapped library-only tracks are enriched in batches, not one request per track."""
+    count = 250
+    items = [_library_song(idx, catalog_id=None) for idx in range(count)]
+    manager, calls = _make_library_only_manager(items)
+
+    tracks = [track async for track in manager.get_library_tracks()]
+
+    assert len(tracks) == count
+    # two windows (150 + 100), each batching its weak-mapped tracks at _DETAIL_BATCH_SIZE
+    assert len(calls) == 3
+    assert all(len(kwargs["ids"].split(",")) <= _DETAIL_BATCH_SIZE for _endpoint, kwargs in calls)
+    # the batched detail response still resolves the album that the listing lacked
+    assert all(track.album is not None for track in tracks)

--- a/tests/providers/apple_music/test_library.py
+++ b/tests/providers/apple_music/test_library.py
@@ -504,7 +504,7 @@ async def test_search_replacement_skips_item_mappings() -> None:
 
 def _make_library_only_manager(
     items: list[dict[str, Any]],
-) -> tuple[AppleMusicLibraryManager, list[tuple[str, dict[str, Any]]]]:
+) -> tuple[AppleMusicLibraryManager, MagicMock, list[tuple[str, dict[str, Any]]]]:
     """Build a manager streaming library-only songs, recording every api call it makes."""
     provider = MagicMock()
     provider.domain = "apple_music"
@@ -532,7 +532,7 @@ def _make_library_only_manager(
     api.iter_all_items = _iter
     api.get_data = AsyncMock(side_effect=_get_data)
     api.get_ratings = AsyncMock(return_value={})
-    return AppleMusicLibraryManager(provider), calls
+    return AppleMusicLibraryManager(provider), provider, calls
 
 
 @pytest.mark.asyncio
@@ -540,7 +540,7 @@ async def test_library_only_detail_fetches_are_batched() -> None:
     """Weak-mapped library-only tracks are enriched in batches, not one request per track."""
     count = 250
     items = [_library_song(idx, catalog_id=None) for idx in range(count)]
-    manager, calls = _make_library_only_manager(items)
+    manager, _provider, calls = _make_library_only_manager(items)
 
     tracks = [track async for track in manager.get_library_tracks()]
 
@@ -557,12 +557,12 @@ async def test_library_only_detail_batch_failure_reports_how_many_lost_detail() 
     """A failed detail batch keeps the listing tracks and warns with the number affected."""
     count = 20
     items = [_library_song(idx, catalog_id=None) for idx in range(count)]
-    manager, _calls = _make_library_only_manager(items)
-    manager.api.get_data = AsyncMock(side_effect=MusicAssistantError("boom"))
+    manager, provider, _calls = _make_library_only_manager(items)
+    provider.api_client.get_data = AsyncMock(side_effect=MusicAssistantError("boom"))
 
     tracks = [track async for track in manager.get_library_tracks()]
 
     assert len(tracks) == count
     assert all(track.album is None for track in tracks)
-    manager.logger.warning.assert_called_once()
-    assert count in manager.logger.warning.call_args.args
+    provider.logger.warning.assert_called_once()
+    assert count in provider.logger.warning.call_args.args

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -548,7 +548,7 @@ async def test_library_tracks_fetches_detail_when_list_item_has_no_album() -> No
     assert isinstance(tracks[0].album, ItemMapping)
     assert tracks[0].album.name == "Album From Detail"
     provider.api_client.get_data.assert_called_once_with(
-        "me/library/songs/i.librarytrack3", include="catalog,albums,artists"
+        "me/library/songs", ids="i.librarytrack3", include="catalog,albums,artists"
     )
 
 
@@ -614,7 +614,7 @@ async def test_library_tracks_fetches_detail_for_album_name_only_mapping() -> No
     assert tracks[0].album.item_id == "l.album4"
     assert tracks[0].album.name == "Resolved Album"
     provider.api_client.get_data.assert_called_once_with(
-        "me/library/songs/i.librarytrack4", include="catalog,albums,artists"
+        "me/library/songs", ids="i.librarytrack4", include="catalog,albums,artists"
     )
 
 


### PR DESCRIPTION
# What does this implement/fix?

Apple rate limits per *developer account*, and the bundled developer token carries the
request load of every Music Assistant installation — so every request one install saves
is headroom for all the others. (Measured in #5333: the bundled token drew 67/360 429s on
catalog search where a token from a different Apple Developer team, run interleaved from
the same host, drew 0/360.)

Library sync was the heaviest offender:

- it fired **one `me/library/songs/{id}` detail request per track** whose listing entry had
  a weak album mapping — thousands of extra requests on a large library;
- it paged listings at 30 (tracks) and 50 (everything else) where Apple accepts 100.

## Changes

- Fetch weak-mapped track details via `me/library/songs?ids=` in batches of 100. A failed
  batch degrades exactly as the old per-item failure did — the listing-parsed track is kept,
  just without album detail.
- Track listing page size 30 → 100. Measured against a real library: `limit=100` with
  `include=catalog,albums,artists` returns cleanly at 1733ms, versus 1449ms at `limit=30`.
- Default library page size 50 → 100 (Apple's documented maximum; 200 returns HTTP 400).

The catalog enrichment window stays at 150 — the existing comment records that 300 returns
a 504, and that still holds.

## Measured effect

Same library, same account, full sync run against `dev` and against this branch:

| | before | after |
| --- | --- | --- |
| total API calls | **57** | **40** |
| `me/library/songs` listing | 23 pages | 7 |
| `me/library/albums` listing | 2 pages | 1 |
| wall clock | 65s | 45s |
| synced rows (tracks/albums/artists/playlists) | 641 / 97 / 319 / 28 | identical |

Every other call in the breakdown is unchanged, so for that library the saving is the
pagination alone. It has no weak-mapped library-only tracks, so the detail batching
contributed nothing there — its effect scales with how many such tracks a library has,
one request each before this change, and is covered by the unit tests rather than by
this measurement.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
