### PR TITLE
Keep group players up to date regardless of who triggers the update

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2595,7 +2595,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         # the user context of whichever command happens to trigger the lookup. A group
         # player mirrors its members, so it is also included while unavailable -
         # skipping it there is exactly how its state goes stale. Disabled players take
-        # no part at all and players still registering have no config yet.
+        # no part at all and players still registering are not fully set up yet.
         player_id = player.player_id
         for _player in list(self._players.values()):
             if _player.player_id == player_id:

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2420,7 +2420,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         # update/signal group player(s) when a member updates. A sync leader is a member of the
         # group player that formed the sync group and gaining members of its own does not change
         # that: a group player mirrors its leader, so it depends on exactly these updates.
-        for group_player in self._get_player_groups(player, powered_only=False):
+        for group_player in self._get_player_groups(player):
             group_player.on_group_member_updated(player, changed_values)
 
         # update/signal manually sync-parent player when child updates
@@ -2449,7 +2449,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             return
         if player.state.group_members:
             player.extra_data.pop(ATTR_GROUP_VOLUME_SNAPSHOT, None)
-        for group_player in self._get_player_groups(player, powered_only=False):
+        for group_player in self._get_player_groups(player):
             group_player.extra_data.pop(ATTR_GROUP_VOLUME_SNAPSHOT, None)
         if player.state.synced_to and (leader := self.get_player(player.state.synced_to)):
             leader.extra_data.pop(ATTR_GROUP_VOLUME_SNAPSHOT, None)
@@ -2584,18 +2584,27 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             return None
         return media_item, provider
 
-    def _get_player_groups(
-        self, player: Player, available_only: bool = True, powered_only: bool = False
-    ) -> Iterator[Player]:
-        """Return all groupplayers the given player belongs to."""
-        for _player in self.all_players(return_unavailable=not available_only):
-            if _player.player_id == player.player_id:
+    def _get_player_groups(self, player: Player) -> Iterator[Player]:
+        """
+        Return all group players the given player is a member of.
+
+        :param player: The player to look up the group memberships for.
+        """
+        # Deliberately walks the registry instead of all_players(): this is internal
+        # topology used to keep derived state consistent, so it must not be narrowed by
+        # the user context of whichever command happens to trigger the lookup. A group
+        # player mirrors its members, so it is also included while unavailable -
+        # skipping it there is exactly how its state goes stale. Disabled players take
+        # no part at all and players still registering have no config yet.
+        player_id = player.player_id
+        for _player in list(self._players.values()):
+            if _player.player_id == player_id:
                 continue
             if _player.state.type != PlayerType.GROUP:
                 continue
-            if powered_only and _player.state.powered is False:
+            if not _player.state.enabled or not _player.initialized.is_set():
                 continue
-            if player.player_id in _player.state.group_members:
+            if player_id in _player.state.group_members:
                 yield _player
 
     # Protocol linking methods are provided by ProtocolLinkingMixin (protocol_linking.py)

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -19,6 +19,7 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
+from music_assistant_models.auth import User, UserRole
 from music_assistant_models.constants import (
     PLAYER_CONTROL_FAKE,
     PLAYER_CONTROL_NATIVE,
@@ -51,6 +52,7 @@ from music_assistant.constants import (
     CONF_VOLUME_CONTROL,
 )
 from music_assistant.controllers.players import PlayerController
+from music_assistant.controllers.webserver.helpers.auth_middleware import current_user
 from tests.common import MockPlayer, MockProvider
 
 
@@ -389,6 +391,117 @@ class TestStateForwarding:
 
         on_group_member_updated.assert_called_once_with(leader, changed_values)
         on_sync_parent_updated.assert_called_once_with(leader, changed_values)
+
+    def test_group_player_is_notified_under_restricted_user_context(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """The fan-out must not be narrowed by the user that triggered the update."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        group_player = MockPlayer(provider, "group", "Group", player_type=PlayerType.GROUP)
+        member = MockPlayer(provider, "member", "Member")
+
+        controller._players = {"group": group_player, "member": member}
+        mock_mass.players = controller
+
+        group_player._attr_group_members = ["member"]
+        for player in (group_player, member):
+            player.initialized.set()
+            player.update_state(signal_event=False)
+
+        # a non-admin user that may only see the member; the contextvar is copied into
+        # the task an API command runs in, so it is live during the state fan-out
+        restricted_user = User(
+            user_id="user_1",
+            username="restricted",
+            role=UserRole.USER,
+            player_filter=["member"],
+        )
+        token = current_user.set(restricted_user)
+        try:
+            assert group_player not in controller.all_players()
+            with patch.object(group_player, "on_group_member_updated") as on_group_member_updated:
+                changed_values = {"playback_state": (PlaybackState.IDLE, PlaybackState.PLAYING)}
+                controller._forward_state_update(member, changed_values)
+        finally:
+            current_user.reset(token)
+
+        on_group_member_updated.assert_called_once_with(member, changed_values)
+
+    def test_unavailable_group_player_is_still_notified(self, mock_mass: MagicMock) -> None:
+        """A group player mirrors its members, so it must update while unavailable too."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        group_player = MockPlayer(provider, "group", "Group", player_type=PlayerType.GROUP)
+        member = MockPlayer(provider, "member", "Member")
+
+        controller._players = {"group": group_player, "member": member}
+        mock_mass.players = controller
+
+        group_player._attr_group_members = ["member"]
+        for player in (group_player, member):
+            player.initialized.set()
+            player.update_state(signal_event=False)
+        group_player._attr_available = False
+        group_player.update_state(signal_event=False)
+        assert group_player.state.available is False
+
+        with patch.object(group_player, "on_group_member_updated") as on_group_member_updated:
+            changed_values = {"playback_state": (PlaybackState.IDLE, PlaybackState.PLAYING)}
+            controller._forward_state_update(member, changed_values)
+
+        on_group_member_updated.assert_called_once_with(member, changed_values)
+
+    def test_disabled_group_player_is_not_notified(self, mock_mass: MagicMock) -> None:
+        """A disabled player takes no part, unlike one that is merely unavailable."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        group_player = MockPlayer(provider, "group", "Group", player_type=PlayerType.GROUP)
+        member = MockPlayer(provider, "member", "Member")
+
+        controller._players = {"group": group_player, "member": member}
+        mock_mass.players = controller
+
+        group_player._attr_group_members = ["member"]
+        for player in (group_player, member):
+            player.initialized.set()
+            player.update_state(signal_event=False)
+        group_player._config.enabled = False
+        group_player.update_state(signal_event=False, force_update=True)
+        assert group_player.state.enabled is False
+
+        with patch.object(group_player, "on_group_member_updated") as on_group_member_updated:
+            controller._forward_state_update(
+                member, {"playback_state": (PlaybackState.IDLE, PlaybackState.PLAYING)}
+            )
+
+        on_group_member_updated.assert_not_called()
+
+    def test_uninitialized_group_player_is_not_notified(self, mock_mass: MagicMock) -> None:
+        """A player the controller is still registering has no config to derive state from."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        group_player = MockPlayer(provider, "group", "Group", player_type=PlayerType.GROUP)
+        member = MockPlayer(provider, "member", "Member")
+
+        controller._players = {"group": group_player, "member": member}
+        mock_mass.players = controller
+
+        group_player._attr_group_members = ["member"]
+        member.initialized.set()
+        for player in (group_player, member):
+            player.update_state(signal_event=False)
+
+        with patch.object(group_player, "on_group_member_updated") as on_group_member_updated:
+            controller._forward_state_update(
+                member, {"playback_state": (PlaybackState.IDLE, PlaybackState.PLAYING)}
+            )
+
+        on_group_member_updated.assert_not_called()
 
 
 class TestSleepTimer:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -305,6 +305,35 @@ class TestPlayerAvailability:
             asyncio.run(controller.cmd_set_members("leader", player_ids_to_add=["member"]))
 
 
+def _group_with_member(
+    mock_mass: MagicMock, *, initialize_group: bool = True
+) -> tuple[PlayerController, MockPlayer, MockPlayer]:
+    """
+    Build a controller holding one group player with a single member.
+
+    :param mock_mass: The mocked MusicAssistant instance to attach the controller to.
+    :param initialize_group: Whether the group player is marked as fully registered.
+
+    :return: The controller, the group player and its member.
+    """
+    controller = PlayerController(mock_mass)
+    provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+    group_player = MockPlayer(provider, "group", "Group", player_type=PlayerType.GROUP)
+    member = MockPlayer(provider, "member", "Member")
+
+    controller._players = {"group": group_player, "member": member}
+    mock_mass.players = controller
+
+    group_player._attr_group_members = ["member"]
+    member.initialized.set()
+    if initialize_group:
+        group_player.initialized.set()
+    for player in (group_player, member):
+        player.update_state(signal_event=False)
+    return controller, group_player, member
+
+
 class TestStateForwarding:
     """Test forwarding of player state changes to related players."""
 
@@ -396,19 +425,7 @@ class TestStateForwarding:
         self, mock_mass: MagicMock
     ) -> None:
         """The fan-out must not be narrowed by the user that triggered the update."""
-        controller = PlayerController(mock_mass)
-        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
-
-        group_player = MockPlayer(provider, "group", "Group", player_type=PlayerType.GROUP)
-        member = MockPlayer(provider, "member", "Member")
-
-        controller._players = {"group": group_player, "member": member}
-        mock_mass.players = controller
-
-        group_player._attr_group_members = ["member"]
-        for player in (group_player, member):
-            player.initialized.set()
-            player.update_state(signal_event=False)
+        controller, group_player, member = _group_with_member(mock_mass)
 
         # a non-admin user that may only see the member; the contextvar is copied into
         # the task an API command runs in, so it is live during the state fan-out
@@ -431,19 +448,7 @@ class TestStateForwarding:
 
     def test_unavailable_group_player_is_still_notified(self, mock_mass: MagicMock) -> None:
         """A group player mirrors its members, so it must update while unavailable too."""
-        controller = PlayerController(mock_mass)
-        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
-
-        group_player = MockPlayer(provider, "group", "Group", player_type=PlayerType.GROUP)
-        member = MockPlayer(provider, "member", "Member")
-
-        controller._players = {"group": group_player, "member": member}
-        mock_mass.players = controller
-
-        group_player._attr_group_members = ["member"]
-        for player in (group_player, member):
-            player.initialized.set()
-            player.update_state(signal_event=False)
+        controller, group_player, member = _group_with_member(mock_mass)
         group_player._attr_available = False
         group_player.update_state(signal_event=False)
         assert group_player.state.available is False
@@ -456,19 +461,7 @@ class TestStateForwarding:
 
     def test_disabled_group_player_is_not_notified(self, mock_mass: MagicMock) -> None:
         """A disabled player takes no part, unlike one that is merely unavailable."""
-        controller = PlayerController(mock_mass)
-        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
-
-        group_player = MockPlayer(provider, "group", "Group", player_type=PlayerType.GROUP)
-        member = MockPlayer(provider, "member", "Member")
-
-        controller._players = {"group": group_player, "member": member}
-        mock_mass.players = controller
-
-        group_player._attr_group_members = ["member"]
-        for player in (group_player, member):
-            player.initialized.set()
-            player.update_state(signal_event=False)
+        controller, group_player, member = _group_with_member(mock_mass)
         group_player._config.enabled = False
         group_player.update_state(signal_event=False, force_update=True)
         assert group_player.state.enabled is False
@@ -481,20 +474,8 @@ class TestStateForwarding:
         on_group_member_updated.assert_not_called()
 
     def test_uninitialized_group_player_is_not_notified(self, mock_mass: MagicMock) -> None:
-        """A player the controller is still registering has no config to derive state from."""
-        controller = PlayerController(mock_mass)
-        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
-
-        group_player = MockPlayer(provider, "group", "Group", player_type=PlayerType.GROUP)
-        member = MockPlayer(provider, "member", "Member")
-
-        controller._players = {"group": group_player, "member": member}
-        mock_mass.players = controller
-
-        group_player._attr_group_members = ["member"]
-        member.initialized.set()
-        for player in (group_player, member):
-            player.update_state(signal_event=False)
+        """A player the controller is still registering is not fully set up yet."""
+        controller, group_player, member = _group_with_member(mock_mass, initialize_group=False)
 
         with patch.object(group_player, "on_group_member_updated") as on_group_member_updated:
             controller._forward_state_update(


### PR DESCRIPTION
# What does this implement/fix?

When a player's state changes, Music Assistant notifies the group players it belongs to so the group can mirror it. That lookup went through the regular "list players" helper, which hides players the current user is not allowed to see and players that are momentarily unavailable.

Because the user context of an API command carries into the internal state handling, a state change triggered by a non-admin user (or by an automation impersonating one) could skip the group player entirely, leaving the group showing stale playback state. This became easier to hit after #5385 routed the sync leader mirroring through the same path.

The lookup is internal bookkeeping and now reads the player registry directly.

**Related issue (if applicable):**

- n/a (found while reviewing #5385)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Look up a player's group players directly in the player registry instead of through the user-facing player list, so the internal state fan-out is never narrowed by whoever triggered it.
- Also notify group players that are currently unavailable — a group mirrors its members, so skipping it there is exactly when its state goes stale. Disabled players and players still being registered are still skipped.
- Dropped two parameters that no caller ever set.
- Added regression tests covering the restricted-user case, the unavailable case, and the two remaining guards.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
