### PR TITLE
Avoid redundant Sonos S1 speaker polls after commands

### DIFF
--- a/music_assistant/providers/sonos_s1/constants.py
+++ b/music_assistant/providers/sonos_s1/constants.py
@@ -118,6 +118,9 @@ SUBSCRIPTION_SERVICES = {
 # Timing Constants
 NEVER_TIME = 0
 RESUB_COOLDOWN_SECONDS = 10.0
+# S1 speakers apply a command a moment after acknowledging it, so the resulting state is
+# read back with a short delay instead of trusting the response to the command itself.
+COMMAND_POLL_DELAY = 2
 
 # Position/Duration Keys
 DURATION_SECONDS = "duration_in_s"

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -25,6 +25,7 @@ from music_assistant.helpers.upnp import create_didl_metadata
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
 
 from .constants import (
+    COMMAND_POLL_DELAY,
     DURATION_SECONDS,
     LINEIN_SOURCE_IDS,
     LINEIN_SOURCES,
@@ -96,6 +97,7 @@ class SonosPlayer(Player):
         self._subscription_lock: asyncio.Lock | None = None
         self._last_activity: float = NEVER_TIME
         self._resub_cooldown_expires_at: float | None = None
+        self._poll_task_id = f"sonos_poll_{soco.uid}"
 
     @property
     def missing_subscriptions(self) -> set[str]:
@@ -128,6 +130,14 @@ class SonosPlayer(Player):
         self.update_state()
         await self.unsubscribe()
 
+    async def on_unload(self) -> None:
+        """Handle logic when the player is unloaded from the Player controller."""
+        await super().on_unload()
+        # cancel_timer only reaches a poll that is still pending: once the timer fired,
+        # the poll runs as a task under the same id and cancel_task is what stops it
+        self.mass.cancel_timer(self._poll_task_id)
+        self.mass.cancel_task(self._poll_task_id)
+
     async def stop(self) -> None:
         """Send STOP command to the player."""
         if self.synced_to:
@@ -142,7 +152,7 @@ class SonosPlayer(Player):
                 await asyncio.to_thread(self.soco.play_uri, "")
         else:
             await asyncio.to_thread(self.soco.stop)
-        self.mass.call_later(2, self.poll)
+        self.schedule_poll()
         self.update_state()
 
     async def play(self) -> None:
@@ -154,7 +164,7 @@ class SonosPlayer(Player):
             )
             return
         await asyncio.to_thread(self.soco.play)
-        self.mass.call_later(2, self.poll)
+        self.schedule_poll()
 
     async def pause(self) -> None:
         """Send PAUSE command to the player."""
@@ -169,7 +179,7 @@ class SonosPlayer(Player):
             await self.stop()
             return
         await asyncio.to_thread(self.soco.pause)
-        self.mass.call_later(2, self.poll)
+        self.schedule_poll()
 
     async def volume_set(self, volume_level: int) -> None:
         """Send VOLUME_SET command to the player."""
@@ -178,7 +188,7 @@ class SonosPlayer(Player):
             self.soco.volume = volume_level
 
         await asyncio.to_thread(set_volume_level, volume_level)
-        self.mass.call_later(2, self.poll)
+        self.schedule_poll()
 
     async def volume_mute(self, muted: bool) -> None:
         """Send VOLUME MUTE command to the player."""
@@ -187,7 +197,7 @@ class SonosPlayer(Player):
             self.soco.mute = muted
 
         await asyncio.to_thread(set_volume_mute, muted)
-        self.mass.call_later(2, self.poll)
+        self.schedule_poll()
 
     async def play_media(self, media: PlayerMedia) -> None:
         """Handle PLAY MEDIA on the player."""
@@ -216,7 +226,7 @@ class SonosPlayer(Player):
         await asyncio.to_thread(
             self.soco.play_uri, stream_url, meta=didl_metadata, force_radio=force_radio
         )
-        self.mass.call_later(2, self.poll)
+        self.schedule_poll()
 
     async def enqueue_next_media(self, media: PlayerMedia) -> None:
         """Handle enqueuing next media item."""
@@ -246,7 +256,7 @@ class SonosPlayer(Player):
             )
 
         await asyncio.to_thread(add_to_queue)
-        self.mass.call_later(2, self.poll)
+        self.schedule_poll()
 
     async def select_source(self, source: str) -> None:
         """Handle SELECT SOURCE command on the player."""
@@ -259,7 +269,7 @@ class SonosPlayer(Player):
                     self.soco.switch_to_line_in()
 
             await asyncio.to_thread(_switch_to_linein)
-            self.mass.call_later(2, self.poll)
+            self.schedule_poll()
         else:
             await self.stop()
 
@@ -282,13 +292,17 @@ class SonosPlayer(Player):
             for player_id in player_ids_to_remove:
                 if player_to_remove := cast("SonosPlayer", self.mass.players.get_player(player_id)):
                     await asyncio.to_thread(player_to_remove.soco.unjoin)
-                    self.mass.call_later(2, player_to_remove.poll)
+                    player_to_remove.schedule_poll()
 
         if player_ids_to_add:
             for player_id in player_ids_to_add:
                 if player_to_add := cast("SonosPlayer", self.mass.players.get_player(player_id)):
                     await asyncio.to_thread(player_to_add.soco.join, self.soco)
-                    self.mass.call_later(2, player_to_add.poll)
+                    player_to_add.schedule_poll()
+
+    def schedule_poll(self) -> None:
+        """Read the speaker state back shortly after a command was sent to it."""
+        self.mass.call_later(COMMAND_POLL_DELAY, self.poll, task_id=self._poll_task_id)
 
     async def poll(self) -> None:
         """Poll player for state updates."""

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -97,7 +97,8 @@ class SonosPlayer(Player):
         self._subscription_lock: asyncio.Lock | None = None
         self._last_activity: float = NEVER_TIME
         self._resub_cooldown_expires_at: float | None = None
-        self._poll_task_id = f"sonos_poll_{soco.uid}"
+        self._poll_task_id: str = f"sonos_poll_{self.player_id}"
+        self._unloaded: bool = False
 
     @property
     def missing_subscriptions(self) -> set[str]:
@@ -133,6 +134,9 @@ class SonosPlayer(Player):
     async def on_unload(self) -> None:
         """Handle logic when the player is unloaded from the Player controller."""
         await super().on_unload()
+        # a poll already running in its worker thread cannot be interrupted, so the flag
+        # is what keeps its results from reaching a player the controller no longer has
+        self._unloaded = True
         # cancel_timer only reaches a poll that is still pending: once the timer fired,
         # the poll runs as a task under the same id and cancel_task is what stops it
         self.mass.cancel_timer(self._poll_task_id)
@@ -366,6 +370,8 @@ class SonosPlayer(Player):
 
     def update_player(self, signal_update: bool = True) -> None:
         """Update Sonos Player."""
+        if self._unloaded:
+            return
         self._update_attributes()
         if signal_update:
             # send update to the player manager right away only if we are triggered from an event
@@ -427,13 +433,16 @@ class SonosPlayer(Player):
         if not self._subscriptions:
             return
         self.logger.log(VERBOSE_LOG_LEVEL, "Unsubscribing from events for %s", self.display_name)
+        # drop the subscriptions before awaiting: if the unsubscribe is cancelled midway
+        # they would stay behind as stale entries, and subscribe() skips the services it
+        # believes are still subscribed, leaving the speaker without events entirely
+        subscriptions, self._subscriptions = self._subscriptions, []
         results = await asyncio.gather(
-            *(subscription.unsubscribe() for subscription in self._subscriptions),
+            *(subscription.unsubscribe() for subscription in subscriptions),
             return_exceptions=True,
         )
         for result in results:
             self.log_subscription_result(result, "Unsubscribe")
-        self._subscriptions = []
 
     def update_groups(self) -> None:
         """Update group topology when polling."""
@@ -500,6 +509,8 @@ class SonosPlayer(Player):
 
         async def _handle_group_event(event: SonosEvent | None) -> None:
             """Get async lock and handle event."""
+            if self._unloaded:
+                return
             _provider = cast("SonosPlayerProvider", self._provider)
             async with _provider.topology_condition:
                 group = await _extract_group(event)

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -2,30 +2,78 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
+from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import MediaType, PlaybackState
 
+from music_assistant.mass import MusicAssistant
 from music_assistant.models.player import PlayerMedia
+from music_assistant.providers.sonos_s1 import player as player_module
 from music_assistant.providers.sonos_s1.constants import POLL_INTERVAL, TRANSITION_POLL_INTERVAL
 from music_assistant.providers.sonos_s1.player import SonosPlayer
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
 STREAM_URL = "http://192.168.1.2:8097/single/sessionabc/queue1/item1/player1.flac"
+
+
+def _make_soco(uid: str = "RINCON_000E58AAAAAA01400", name: str = "Test Sonos") -> MagicMock:
+    """Create a mocked soco device."""
+    soco = MagicMock()
+    soco.uid = uid
+    soco.household_id = "Sonos_household"
+    soco.player_name = name
+    soco.ip_address = "127.0.0.1"
+    soco.speaker_info = {"model_name": "Sonos Play:1"}
+    return soco
 
 
 @pytest.fixture
 def sonos_player() -> SonosPlayer:
     """Create a SonosPlayer with a mocked soco device and provider."""
-    soco = MagicMock()
-    soco.uid = "RINCON_000E58AAAAAA01400"
-    soco.household_id = "Sonos_household"
-    soco.player_name = "Test Sonos"
-    soco.ip_address = "127.0.0.1"
-    soco.speaker_info = {"model_name": "Sonos Play:1"}
     provider = MagicMock()
     provider.mass.streams.resolve_stream_url = AsyncMock(return_value=STREAM_URL)
-    return SonosPlayer(provider=provider, soco=soco)
+    return SonosPlayer(provider=provider, soco=_make_soco())
+
+
+@pytest.fixture
+async def timer_mass() -> AsyncGenerator[MusicAssistant]:
+    """Create a bare MusicAssistant exposing the real call_later/cancel_timer machinery."""
+    mass = object.__new__(MusicAssistant)
+    mass.loop = asyncio.get_running_loop()
+    mass.loop_thread_id = threading.get_ident()
+    mass._tracked_timers = {}
+    mass._tracked_tasks = {}
+    mass.config = MagicMock()
+    mass.players = MagicMock()
+    mass.players.all_players.return_value = []
+    yield mass
+    for handle in mass._tracked_timers.values():
+        handle.cancel()
+    for task in mass._tracked_tasks.values():
+        task.cancel()
+
+
+def _make_player(mass: MusicAssistant, uid: str, name: str) -> SonosPlayer:
+    """Create a SonosPlayer bound to the given MusicAssistant."""
+    provider = MagicMock()
+    provider.mass = mass
+    return SonosPlayer(provider=provider, soco=_make_soco(uid, name))
+
+
+def _poll_id(player: SonosPlayer) -> str:
+    """Return the task id that debounces the follow-up poll of the given speaker."""
+    return f"sonos_poll_{player.player_id}"
+
+
+def _pending_polls(mass: MusicAssistant) -> list[str]:
+    """Return the task ids of all pending speaker polls."""
+    return sorted(task_id for task_id in mass._tracked_timers if task_id.startswith("sonos_poll_"))
 
 
 def _make_media() -> PlayerMedia:
@@ -101,3 +149,80 @@ def test_transitional_event_shortens_the_poll_interval(sonos_player: SonosPlayer
     sonos_player._handle_avtransport_event(event)
 
     assert sonos_player.poll_interval == TRANSITION_POLL_INTERVAL
+
+
+async def test_repeated_commands_collapse_to_one_pending_poll(
+    timer_mass: MusicAssistant,
+) -> None:
+    """A burst of commands leaves a single pending poll instead of one poll per command."""
+    player = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+
+    await player.volume_set(30)
+    first_handle = timer_mass._tracked_timers[_poll_id(player)]
+    await player.volume_set(40)
+    await player.volume_mute(True)
+    await player.play()
+
+    assert _pending_polls(timer_mass) == [_poll_id(player)]
+    assert first_handle.cancelled()
+
+
+async def test_each_speaker_keeps_its_own_pending_poll(timer_mass: MusicAssistant) -> None:
+    """Commands to different speakers are polled independently."""
+    kitchen = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+    study = _make_player(timer_mass, "RINCON_000E58BBBBBB01400", "Study")
+
+    await kitchen.volume_set(30)
+    await study.volume_set(40)
+
+    assert _pending_polls(timer_mass) == sorted([_poll_id(kitchen), _poll_id(study)])
+
+
+async def test_set_members_polls_the_speakers_it_regrouped(timer_mass: MusicAssistant) -> None:
+    """Grouping polls each speaker that was joined or unjoined, not the coordinator."""
+    kitchen = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+    study = _make_player(timer_mass, "RINCON_000E58BBBBBB01400", "Study")
+    hallway = _make_player(timer_mass, "RINCON_000E58CCCCCC01400", "Hallway")
+    cast("MagicMock", timer_mass.players).get_player.side_effect = {
+        study.player_id: study,
+        hallway.player_id: hallway,
+    }.get
+
+    await kitchen.set_members(player_ids_to_add=[study.player_id, hallway.player_id])
+
+    assert _pending_polls(timer_mass) == sorted([_poll_id(study), _poll_id(hallway)])
+
+
+async def test_unload_cancels_the_pending_poll(timer_mass: MusicAssistant) -> None:
+    """An unloaded speaker is not polled by a command that was still in flight."""
+    player = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+    await player.volume_set(30)
+    handle = timer_mass._tracked_timers[_poll_id(player)]
+
+    await player.on_unload()
+
+    assert _pending_polls(timer_mass) == []
+    assert handle.cancelled()
+
+
+async def test_unload_cancels_a_poll_that_already_started(
+    timer_mass: MusicAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A poll that started just before the speaker was unloaded is aborted."""
+    monkeypatch.setattr(player_module, "COMMAND_POLL_DELAY", 0)
+    player = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+    polling = asyncio.Event()
+
+    async def _slow_poll() -> None:
+        polling.set()
+        await asyncio.sleep(5)
+
+    monkeypatch.setattr(player, "poll", _slow_poll)
+    player.schedule_poll()
+    await polling.wait()
+    task = timer_mass._tracked_tasks[_poll_id(player)]
+
+    await player.on_unload()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from functools import partial
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -13,7 +14,11 @@ from music_assistant_models.enums import MediaType, PlaybackState
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.player import PlayerMedia
 from music_assistant.providers.sonos_s1 import player as player_module
-from music_assistant.providers.sonos_s1.constants import POLL_INTERVAL, TRANSITION_POLL_INTERVAL
+from music_assistant.providers.sonos_s1.constants import (
+    POLL_INTERVAL,
+    SUBSCRIPTION_SERVICES,
+    TRANSITION_POLL_INTERVAL,
+)
 from music_assistant.providers.sonos_s1.player import SonosPlayer
 
 if TYPE_CHECKING:
@@ -63,6 +68,7 @@ def _make_player(mass: MusicAssistant, uid: str, name: str) -> SonosPlayer:
     """Create a SonosPlayer bound to the given MusicAssistant."""
     provider = MagicMock()
     provider.mass = mass
+    provider.topology_condition = asyncio.Condition()
     return SonosPlayer(provider=provider, soco=_make_soco(uid, name))
 
 
@@ -226,3 +232,54 @@ async def test_unload_cancels_a_poll_that_already_started(
 
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+async def test_unloaded_player_ignores_results_from_a_running_poll(
+    timer_mass: MusicAssistant,
+) -> None:
+    """A poll left running in its worker thread cannot update an unloaded speaker."""
+    player = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+    await player.on_unload()
+
+    with patch.object(player, "_update_attributes") as update_attributes:
+        player.update_player()
+
+    update_attributes.assert_not_called()
+
+
+async def test_unloaded_player_ignores_group_topology_updates(
+    timer_mass: MusicAssistant,
+) -> None:
+    """A group update raised by a running poll cannot update an unloaded speaker."""
+    player = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+    # let the speaker report itself as coordinator of a two-speaker group, so a
+    # topology update would regroup and signal the change if it were not unloaded
+    member = MagicMock(uid="RINCON_000E58BBBBBB01400", is_visible=True)
+    player.soco.group.coordinator.uid = player.player_id
+    player.soco.group.members = [player.soco.group.coordinator, member]
+    await player.on_unload()
+
+    with patch.object(player, "update_state") as update_state:
+        await player.create_update_groups_coro()
+        await asyncio.sleep(0)
+
+    assert player.group_members == []
+    update_state.assert_not_called()
+
+
+async def test_unsubscribe_drops_subscriptions_even_when_cancelled() -> None:
+    """A cancelled unsubscribe must not leave stale entries that block resubscribing."""
+    provider = MagicMock()
+    player = SonosPlayer(provider=provider, soco=_make_soco())
+    subscription = MagicMock()
+    subscription.unsubscribe = AsyncMock(side_effect=partial(asyncio.sleep, 5))
+    player._subscriptions = [subscription]
+
+    task = asyncio.create_task(player.unsubscribe())
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert player._subscriptions == []
+    assert player.missing_subscriptions == SUBSCRIPTION_SERVICES


### PR DESCRIPTION
# What does this implement/fix?

After every command (play, pause, volume, grouping, ...) the Sonos S1 provider schedules a follow-up poll to read the speaker state back a couple of seconds later. Those polls were untracked, so each one was scheduled independently: a burst of commands queued a redundant poll per command, and regrouping a five-speaker group queued five more on top of whatever was already pending.

They also outlived the player. Nothing cancelled a pending poll when a speaker was unloaded, so it could still fire afterwards and update a player that no longer exists.

Changes:

- Follow-up polls now use a stable per-speaker task id, so repeat scheduling collapses to a single pending poll per speaker.
- Grouping keys the poll on each speaker it regrouped, so those still debounce per speaker.
- Unloading a speaker cancels its pending poll and an already-started one. A poll already running in its worker thread can't be interrupted, so the speaker is also marked as unloaded and its late results are dropped rather than applied.
- Event subscriptions are now cleared before the unsubscribe is awaited. A cancelled unsubscribe used to leave stale entries behind, after which `subscribe()` skipped the services it believed were still subscribed and the speaker was left without events.
- Tests covering each of the above.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
