### PR TITLE
Accept AI quiz answers that arrive wrapped in a code fence

### DIFF
--- a/music_assistant/helpers/json.py
+++ b/music_assistant/helpers/json.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import re
 from _collections_abc import dict_keys, dict_values
 from types import MethodType
 from typing import Any, TypeVar
@@ -14,6 +15,16 @@ JSON_ENCODE_EXCEPTIONS = (TypeError, ValueError)
 JSON_DECODE_EXCEPTIONS = (orjson.JSONDecodeError,)
 
 DO_NOT_SERIALIZE_TYPES = (MethodType, asyncio.Task)
+
+# A markdown code fence wrapping the entire text, with an optional language tag on the
+# opening line. The fence length is backreferenced so the closing fence must match.
+_CODE_FENCE_PATTERN = re.compile(
+    r"(?P<fence>`{3,})[^\S\n]*"
+    r"(?:[A-Za-z0-9+#._-]*[^\S\n]*\n)?"
+    r"(?P<body>.*?)\n?"
+    r"(?P=fence)",
+    re.DOTALL,
+)
 
 # Type alias for plain, JSON-serializable data.
 # Note: tuples are accepted but will be returned as lists after a JSON round-trip.
@@ -73,6 +84,22 @@ json_loads = orjson.loads
 async def async_json_loads(data: str) -> Any:
     """Load json string async."""
     return await asyncio.to_thread(json_loads, data)
+
+
+def strip_code_fence(text: str) -> str:
+    """
+    Remove a markdown code fence that wraps an entire text, plus surrounding whitespace.
+
+    Only a fence around the complete text is removed, so text that merely contains a
+    fenced block, or JSON embedded in prose, is returned with its whitespace trimmed
+    and remains as invalid to a strict parser as it was before.
+
+    :param text: Text that may be wrapped in a markdown code fence.
+    """
+    stripped = text.strip()
+    if (match := _CODE_FENCE_PATTERN.fullmatch(stripped)) is None:
+        return stripped
+    return match["body"].strip()
 
 
 TargetT = TypeVar("TargetT", bound=DataClassORJSONMixin)

--- a/music_assistant/helpers/json.py
+++ b/music_assistant/helpers/json.py
@@ -16,15 +16,10 @@ JSON_DECODE_EXCEPTIONS = (orjson.JSONDecodeError,)
 
 DO_NOT_SERIALIZE_TYPES = (MethodType, asyncio.Task)
 
-# A markdown code fence wrapping the entire text, with an optional language tag on the
-# opening line. The fence length is backreferenced so the closing fence must match.
-_CODE_FENCE_PATTERN = re.compile(
-    r"(?P<fence>`{3,})[^\S\n]*"
-    r"(?:[A-Za-z0-9+#._-]*[^\S\n]*\n)?"
-    r"(?P<body>.*?)\n?"
-    r"(?P=fence)",
-    re.DOTALL,
-)
+_MIN_CODE_FENCE_LENGTH = 3
+# Applied to the opening line only, so a fence that carries anything other than a bare
+# language tag is left alone instead of having that line silently discarded.
+_CODE_FENCE_TAG_PATTERN = re.compile(r"[A-Za-z0-9+#._-]*")
 
 # Type alias for plain, JSON-serializable data.
 # Note: tuples are accepted but will be returned as lists after a JSON round-trip.
@@ -90,16 +85,32 @@ def strip_code_fence(text: str) -> str:
     """
     Remove a markdown code fence that wraps an entire text, plus surrounding whitespace.
 
-    Only a fence around the complete text is removed, so text that merely contains a
-    fenced block, or JSON embedded in prose, is returned with its whitespace trimmed
-    and remains as invalid to a strict parser as it was before.
+    Anything else is returned with only its whitespace trimmed: a fence around part of
+    the text, more than one fenced block, an unterminated fence, or a fence whose opening
+    line carries more than a language tag. Text that is not exactly one fenced block
+    therefore stays as invalid to a strict parser as it was before.
 
     :param text: Text that may be wrapped in a markdown code fence.
+    :return: The fenced content, or the trimmed text when it is not a single fenced block.
     """
     stripped = text.strip()
-    if (match := _CODE_FENCE_PATTERN.fullmatch(stripped)) is None:
+    fence_length = len(stripped) - len(stripped.lstrip("`"))
+    if fence_length < _MIN_CODE_FENCE_LENGTH:
         return stripped
-    return match["body"].strip()
+    fence = "`" * fence_length
+    inner = stripped[fence_length:]
+    if not inner.endswith(fence):
+        return stripped
+    # A closing fence must be the final run of backticks, matching the opening length.
+    inner = inner[:-fence_length]
+    if inner.endswith("`"):
+        return stripped
+    tag, separator, body = inner.partition("\n")
+    if not separator or not _CODE_FENCE_TAG_PATTERN.fullmatch(tag.strip()):
+        return stripped
+    if fence in body:
+        return stripped
+    return body.strip()
 
 
 TargetT = TypeVar("TargetT", bound=DataClassORJSONMixin)

--- a/music_assistant/helpers/json.py
+++ b/music_assistant/helpers/json.py
@@ -86,9 +86,10 @@ def strip_code_fence(text: str) -> str:
     Remove a markdown code fence that wraps an entire text, plus surrounding whitespace.
 
     Anything else is returned with only its whitespace trimmed: a fence around part of
-    the text, more than one fenced block, an unterminated fence, or a fence whose opening
-    line carries more than a language tag. Text that is not exactly one fenced block
-    therefore stays as invalid to a strict parser as it was before.
+    the text, more than one fenced block, an unterminated fence, a fence whose opening
+    line carries more than a language tag, or a body containing the fence itself. Text
+    that is not exactly one fenced block therefore stays as invalid to a strict parser
+    as it was before.
 
     :param text: Text that may be wrapped in a markdown code fence.
     :return: The fenced content, or the trimmed text when it is not a single fenced block.
@@ -101,8 +102,8 @@ def strip_code_fence(text: str) -> str:
     inner = stripped[fence_length:]
     if not inner.endswith(fence):
         return stripped
-    # A closing fence must be the final run of backticks, matching the opening length.
     inner = inner[:-fence_length]
+    # A closing fence must be the final run of backticks, matching the opening length.
     if inner.endswith("`"):
         return stripped
     tag, separator, body = inner.partition("\n")

--- a/music_assistant/providers/music_quiz/ai_distractors.py
+++ b/music_assistant/providers/music_quiz/ai_distractors.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from music_assistant.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads
+from music_assistant.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads, strip_code_fence
 from music_assistant.helpers.plugin_engines import resolve_ai_engine
 from music_assistant.providers.music_quiz.suggestions import answer_labels_are_too_close
 
@@ -100,7 +100,7 @@ def parse_ai_distractor_response(
     if len(set(candidate_ids)) != len(candidate_ids):
         raise ValueError("candidate IDs must be unique")
     try:
-        payload = json_loads(response)
+        payload = json_loads(strip_code_fence(response))
     except JSON_DECODE_EXCEPTIONS as err:
         raise ValueError("response is not valid JSON") from err
     if not isinstance(payload, dict) or payload.keys() != {"ranked_ids", "synthetic"}:

--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -22,6 +22,7 @@ from music_assistant.helpers.json import (
     SerializableType,
     json_dumps,
     json_loads,
+    strip_code_fence,
 )
 from music_assistant.helpers.plugin_engines import get_ai_engines, resolve_ai_engine
 from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
@@ -398,7 +399,7 @@ class TriviaQuizType(QuizType):
         if len(response.encode("utf-8")) > MAX_AI_RESPONSE_BYTES:
             raise ValueError("response exceeds the size limit")
         try:
-            payload = json_loads(response)
+            payload = json_loads(strip_code_fence(response))
         except JSON_DECODE_EXCEPTIONS as err:
             raise ValueError("response is not valid JSON") from err
         if not isinstance(payload, dict) or payload.keys() != {"question", "wrong_answers"}:

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -50,10 +50,10 @@ def test_strip_code_fence_only_trims_whitespace_of_other_text(text: str) -> None
 
 def test_strip_code_fence_handles_long_backtick_runs() -> None:
     """
-    Return a long run of backticks unchanged, without scanning for a fence body.
+    Return long runs of backticks unchanged instead of scanning them for a fence body.
 
-    Guards the linear scan: matching a fence with a backtracking pattern made such input
-    take seconds, which would block the event loop for a caller parsing an AI response.
+    Matching a fence with a backtracking pattern took seconds on these, which would block
+    the event loop of a caller parsing an AI response.
     """
     assert strip_code_fence("`" * 4096) == "`" * 4096
     assert strip_code_fence("`" * 4087 + "jsonjson") == "`" * 4087 + "jsonjson"

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -1,0 +1,59 @@
+"""Tests for the JSON helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from music_assistant.helpers.json import strip_code_fence
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ('```json\n{"a": 1}\n```', '{"a": 1}'),
+        ('```JSON\n{"a": 1}\n```', '{"a": 1}'),
+        ('```\n{"a": 1}\n```', '{"a": 1}'),
+        ('````json\n{"a": 1}\n````', '{"a": 1}'),
+        ('  ```json\r\n{"a": 1}\r\n```  ', '{"a": 1}'),
+        ('```json\n\n{"a": 1}\n\n```', '{"a": 1}'),
+    ],
+)
+def test_strip_code_fence_unwraps_a_single_fenced_block(text: str, expected: str) -> None:
+    """Return the content of one code fence wrapping the complete text."""
+    assert strip_code_fence(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        '{"a": 1}',
+        "not fenced at all",
+        # A fence around only part of the text must not be unwrapped.
+        'Here you go:\n```json\n{"a": 1}\n```',
+        '```json\n{"a": 1}\n```\nHope that helps!',
+        '```json\nnot json\n```\n```json\n{"a": 1}\n```',
+        # An unterminated or mismatched fence is not a fenced block.
+        '```json\n{"a": 1}',
+        '````json\n{"a": 1}\n```',
+        '```json\n{"a": 1}\n````',
+        "```",
+        "``````",
+        # The opening line must carry nothing but a language tag.
+        '```json {"a": 1}\n```',
+        '```{"a": 1}\n```',
+    ],
+)
+def test_strip_code_fence_only_trims_whitespace_of_other_text(text: str) -> None:
+    """Leave text that is not exactly one fenced block untouched apart from whitespace."""
+    assert strip_code_fence(f"  {text}  ") == text
+
+
+def test_strip_code_fence_handles_long_backtick_runs() -> None:
+    """
+    Return a long run of backticks unchanged, without scanning for a fence body.
+
+    Guards the linear scan: matching a fence with a backtracking pattern made such input
+    take seconds, which would block the event loop for a caller parsing an AI response.
+    """
+    assert strip_code_fence("`" * 4096) == "`" * 4096
+    assert strip_code_fence("`" * 4087 + "jsonjson") == "`" * 4087 + "jsonjson"

--- a/tests/providers/music_quiz/test_suggestions.py
+++ b/tests/providers/music_quiz/test_suggestions.py
@@ -298,9 +298,41 @@ def test_parse_ai_distractor_response_accepts_exact_schema() -> None:
 
 
 @pytest.mark.parametrize(
+    "fence",
+    ["```json", "```"],
+)
+def test_parse_ai_distractor_response_accepts_fenced_payload(fence: str) -> None:
+    """Accept an exact payload wrapped in a code fence with or without a language tag."""
+    payload = json.dumps(
+        {
+            "ranked_ids": ["candidate_0"],
+            "synthetic": [{"kind": "artist", "label": "Fake Artist"}],
+        }
+    )
+
+    parsed = parse_ai_distractor_response(
+        f"{fence}\n{payload}\n```\n",
+        ["candidate_0"],
+        ["artist"],
+    )
+
+    assert parsed.ranked_ids == ("candidate_0",)
+    assert [(item.kind, item.label) for item in parsed.synthetic] == [("artist", "Fake Artist")]
+
+
+@pytest.mark.parametrize(
     "response",
     [
         "not json",
+        "```json\nnot json\n```",
+        "Here is the JSON you asked for:\n```json\n"
+        + json.dumps(
+            {
+                "ranked_ids": ["candidate_0"],
+                "synthetic": [{"kind": "artist", "label": "Fake Artist"}],
+            }
+        )
+        + "\n```",
         json.dumps(
             {
                 "ranked_ids": ["candidate_0"],
@@ -402,6 +434,17 @@ def test_parse_ai_distractor_response_enforces_size_line_and_label_limits() -> N
         parse_ai_distractor_response(too_many_lines, [], [])
     with pytest.raises(ValueError, match="length"):
         parse_ai_distractor_response(oversized_label, [], ["artist"])
+
+
+def test_parse_ai_distractor_response_limits_the_original_response() -> None:
+    """Enforce the size and line limits before a code fence is stripped."""
+    oversized_response = f"```json\n{'x' * MAX_AI_RESPONSE_BYTES}\n```"
+    too_many_lines = "```json\n" + "\n".join("{}" for _ in range(MAX_AI_RESPONSE_LINES)) + "\n```"
+
+    with pytest.raises(ValueError, match="size"):
+        parse_ai_distractor_response(oversized_response, [], [])
+    with pytest.raises(ValueError, match="line"):
+        parse_ai_distractor_response(too_many_lines, [], [])
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -1354,6 +1354,27 @@ def test_strict_generation_parser_accepts_exact_valid_shape() -> None:
     )
 
 
+@pytest.mark.parametrize("fence", ["```json", "```"])
+def test_strict_generation_parser_accepts_fenced_response(fence: str) -> None:
+    """Parse a valid response wrapped in a code fence with or without a language tag."""
+    quiz, _ = _quiz([])
+
+    result = quiz._parse_generation(f"{fence}\n{_valid_response()}\n```\n", _artist_fact())
+
+    assert result == TriviaGeneration(
+        question="Which artist recorded this selected track?",
+        wrong_answers=("Portishead", "Radiohead", "Air"),
+    )
+
+
+def test_strict_generation_parser_limits_the_original_response() -> None:
+    """Enforce the response size limit before a code fence is stripped."""
+    quiz, _ = _quiz([])
+
+    with pytest.raises(ValueError, match="size"):
+        quiz._parse_generation(f"```json\n{'x' * MAX_AI_RESPONSE_BYTES}\n```", _artist_fact())
+
+
 @pytest.mark.asyncio
 async def test_generation_repairs_duplicate_answers_from_cached_grounding() -> None:
     """Keep valid AI answers and fill duplicate slots without another AI or source call."""
@@ -1770,6 +1791,8 @@ def test_answer_leak_detection_supports_non_space_scripts(
             }
         ),
         "x" * (MAX_AI_RESPONSE_BYTES + 1),
+        "```json\nnot json\n```",
+        "Here is the JSON you asked for:\n```json\n" + _valid_response() + "\n```",
         42,
     ],
 )


### PR DESCRIPTION
# What does this implement/fix?

The Music Quiz asks the AI engine to reply with bare JSON, but models regularly wrap that JSON in a markdown code fence anyway. Both quiz response parsers used a strict JSON parse, so a perfectly good answer was thrown away: Trivia burned one of its two attempts and could fail to start a game, and distractor generation quietly fell back to catalog answers.

Both parsers now strip a surrounding code fence before parsing. Nothing else is relaxed — JSON buried in prose is still rejected, and all schema and limit checks are unchanged.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Added a shared `strip_code_fence` helper in `helpers/json.py` that removes a code fence wrapping an entire text, with or without a language tag.
- Used it in the Music Quiz distractor parser and the Trivia response parser.
- Response size and line limits are still applied to the original reply, so a fence cannot be used to slip past them.
- Added tests for fenced, unfenced, fenced-garbage, and prose-wrapped responses.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
