### PR TITLE
Keep the chosen metadata language when other settings are saved

### DIFF
--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -117,11 +117,14 @@ class MetaDataController(
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return all Config Entries for this core module (if any)."""
         return (
+            # deliberately without a default_value: only values that differ from the entry
+            # default are persisted, so declaring one would make a chosen DEFAULT_LANGUAGE
+            # indistinguishable from "never chosen" for set_default_preferred_language.
+            # DEFAULT_LANGUAGE is applied when reading instead, see the locale property.
             ConfigEntry(
                 key=CONF_LANGUAGE,
                 type=ConfigEntryType.STRING,
                 required=False,
-                default_value=DEFAULT_LANGUAGE,
                 options=[ConfigValueOption(key, title=value) for key, value in LOCALES.items()],
             ),
             ConfigEntry(

--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -117,10 +117,9 @@ class MetaDataController(
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return all Config Entries for this core module (if any)."""
         return (
-            # deliberately without a default_value: only values that differ from the entry
-            # default are persisted, so declaring one would make a chosen DEFAULT_LANGUAGE
-            # indistinguishable from "never chosen" for set_default_preferred_language.
-            # DEFAULT_LANGUAGE is applied when reading instead, see the locale property.
+            # deliberately without a default_value: only values differing from the entry default
+            # are persisted, so declaring one would make a chosen DEFAULT_LANGUAGE
+            # indistinguishable from "never chosen". The locale property applies it on read.
             ConfigEntry(
                 key=CONF_LANGUAGE,
                 type=ConfigEntryType.STRING,

--- a/tests/controllers/metadata/test_preferred_language.py
+++ b/tests/controllers/metadata/test_preferred_language.py
@@ -25,11 +25,6 @@ async def metadata_controller(mass_minimal: MusicAssistant) -> MetaDataControlle
     return controller
 
 
-async def _save_unrelated_metadata_setting(mass: MusicAssistant) -> None:
-    """Save the metadata core config the way the settings UI does."""
-    await mass.config.save_core_config("metadata", {CONF_THUMB_CACHE_MAX_SIZE: 1000})
-
-
 async def test_locale_falls_back_to_the_default_language(
     metadata_controller: MetaDataController,
 ) -> None:
@@ -78,3 +73,8 @@ async def test_set_default_preferred_language_never_overrides_a_chosen_language(
     metadata_controller.set_default_preferred_language("de-DE")
 
     assert metadata_controller.locale == language
+
+
+async def _save_unrelated_metadata_setting(mass: MusicAssistant) -> None:
+    """Save the metadata core config the way the settings UI does."""
+    await mass.config.save_core_config("metadata", {CONF_THUMB_CACHE_MAX_SIZE: 1000})

--- a/tests/controllers/metadata/test_preferred_language.py
+++ b/tests/controllers/metadata/test_preferred_language.py
@@ -1,0 +1,80 @@
+"""Tests for the preferred language handling of the MetaDataController."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from music_assistant.constants import CONF_CORE, CONF_LANGUAGE
+from music_assistant.controllers.metadata import MetaDataController
+from music_assistant.controllers.metadata.constants import (
+    CONF_THUMB_CACHE_MAX_SIZE,
+    DEFAULT_LANGUAGE,
+)
+
+if TYPE_CHECKING:
+    from music_assistant.mass import MusicAssistant
+
+
+@pytest.fixture
+async def metadata_controller(mass_minimal: MusicAssistant) -> MetaDataController:
+    """Construct a MetaDataController with the minimal MA fixture."""
+    controller = MetaDataController(mass_minimal)
+    mass_minimal.metadata = controller
+    return controller
+
+
+async def _save_unrelated_metadata_setting(mass: MusicAssistant) -> None:
+    """Save the metadata core config the way the settings UI does."""
+    await mass.config.save_core_config("metadata", {CONF_THUMB_CACHE_MAX_SIZE: 1000})
+
+
+async def test_locale_falls_back_to_the_default_language(
+    metadata_controller: MetaDataController,
+) -> None:
+    """With nothing stored the locale reads as the default language."""
+    assert metadata_controller.locale == DEFAULT_LANGUAGE
+    assert metadata_controller.preferred_language == "en"
+
+
+async def test_set_default_preferred_language_seeds_an_unset_language(
+    metadata_controller: MetaDataController,
+) -> None:
+    """An external source can still seed the language while none has been chosen."""
+    metadata_controller.set_default_preferred_language("nl-NL")
+
+    assert metadata_controller.locale == "nl_NL"
+
+
+@pytest.mark.parametrize("language", [DEFAULT_LANGUAGE, "nl_NL"])
+async def test_chosen_language_survives_a_config_save(
+    metadata_controller: MetaDataController, language: str
+) -> None:
+    """
+    A chosen language stays stored when another metadata setting is saved.
+
+    Only values differing from their config entry default are persisted, so a language
+    equal to the default must not be dropped from storage by an unrelated save.
+    """
+    mass = metadata_controller.mass
+    metadata_controller.set_preferred_language(language)
+
+    await _save_unrelated_metadata_setting(mass)
+
+    assert mass.config.get(f"{CONF_CORE}/metadata/values/{CONF_LANGUAGE}") == language
+    assert metadata_controller.locale == language
+
+
+@pytest.mark.parametrize("language", [DEFAULT_LANGUAGE, "nl_NL"])
+async def test_set_default_preferred_language_never_overrides_a_chosen_language(
+    metadata_controller: MetaDataController, language: str
+) -> None:
+    """A chosen language is not overwritten by a seeded default after a config save."""
+    mass = metadata_controller.mass
+    metadata_controller.set_preferred_language(language)
+    await _save_unrelated_metadata_setting(mass)
+
+    metadata_controller.set_default_preferred_language("de-DE")
+
+    assert metadata_controller.locale == language


### PR DESCRIPTION
# What does this implement/fix?

If your metadata language was set to English (US), it could get silently replaced by the language of whatever browser or app connected next.

The language setting declared English (US) as its default value, and Music Assistant only stores settings that differ from their default. So choosing English (US) and then saving anything else on the Metadata settings page dropped the language from storage — after which it looked like no language had ever been chosen, and the next client to connect (or a Spotify/Qobuz login) would set its own.

The language setting no longer declares a default, so an explicit choice is always stored. English (US) is still what's used when nothing has been chosen yet.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Removed the default value from the metadata language config entry so a chosen language is always persisted.
- Added tests covering a real save/reload round-trip for both a default and a non-default language.
- Side effect: the Language dropdown no longer tags English (US) as `[Default]`, and shows no selection until a language has been picked or detected. The language actually used is still English (US) in that case.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

