### PR TITLE
De-duplicate the metadata controller test fixture

### DIFF
--- a/tests/controllers/metadata/conftest.py
+++ b/tests/controllers/metadata/conftest.py
@@ -1,0 +1,26 @@
+"""Shared fixtures for the metadata controller tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from music_assistant.controllers.metadata import MetaDataController
+
+if TYPE_CHECKING:
+    from music_assistant.mass import MusicAssistant
+
+
+@pytest.fixture
+async def cache_database(mass_minimal: MusicAssistant) -> None:
+    """Set up the cache database, for tests that read or write cached metadata."""
+    await mass_minimal.cache._setup_database()
+
+
+@pytest.fixture
+async def metadata_controller(mass_minimal: MusicAssistant) -> MetaDataController:
+    """Construct a MetaDataController with the minimal MA fixture."""
+    controller = MetaDataController(mass_minimal)
+    mass_minimal.metadata = controller
+    return controller

--- a/tests/controllers/metadata/test_image_proxy.py
+++ b/tests/controllers/metadata/test_image_proxy.py
@@ -42,16 +42,20 @@ from music_assistant.helpers.images import (
     is_svg_data,
     player_image_url,
 )
-from music_assistant.mass import MusicAssistant
 
 
 @pytest.fixture
-async def metadata_controller(mass_minimal: MusicAssistant) -> MetaDataController:
-    """Construct a MetaDataController with the minimal MA fixture."""
-    await mass_minimal.cache._setup_database()
-    controller = MetaDataController(mass_minimal)
-    mass_minimal.metadata = controller
-    return controller
+async def metadata_controller(
+    cache_database: None,  # noqa: ARG001
+    metadata_controller: MetaDataController,
+) -> MetaDataController:
+    """
+    Construct a MetaDataController backed by the cache database.
+
+    The controller tests in this module all persist and resolve image ids, unlike the
+    pure helper tests here, which need neither a controller nor a cache database.
+    """
+    return metadata_controller
 
 
 async def _wait_for_persisted_image_id(

--- a/tests/controllers/metadata/test_metadata.py
+++ b/tests/controllers/metadata/test_metadata.py
@@ -7,19 +7,11 @@ from typing import TYPE_CHECKING
 import pytest
 from music_assistant_models.media_items import MediaItemPalette
 
-from music_assistant.controllers.metadata import MetaDataController
-
 if TYPE_CHECKING:
-    from music_assistant.mass import MusicAssistant
+    from music_assistant.controllers.metadata import MetaDataController
 
-
-@pytest.fixture
-async def metadata_controller(mass_minimal: MusicAssistant) -> MetaDataController:
-    """Construct a MetaDataController with the minimal MA fixture."""
-    await mass_minimal.cache._setup_database()
-    controller = MetaDataController(mass_minimal)
-    mass_minimal.metadata = controller
-    return controller
+# every test here registers image ids, which are persisted to the cache database
+pytestmark = pytest.mark.usefixtures("cache_database")
 
 
 async def test_get_image_palette_resolves_registered_id(

--- a/tests/controllers/metadata/test_preferred_language.py
+++ b/tests/controllers/metadata/test_preferred_language.py
@@ -7,22 +7,14 @@ from typing import TYPE_CHECKING
 import pytest
 
 from music_assistant.constants import CONF_CORE, CONF_LANGUAGE
-from music_assistant.controllers.metadata import MetaDataController
 from music_assistant.controllers.metadata.constants import (
     CONF_THUMB_CACHE_MAX_SIZE,
     DEFAULT_LANGUAGE,
 )
 
 if TYPE_CHECKING:
+    from music_assistant.controllers.metadata import MetaDataController
     from music_assistant.mass import MusicAssistant
-
-
-@pytest.fixture
-async def metadata_controller(mass_minimal: MusicAssistant) -> MetaDataController:
-    """Construct a MetaDataController with the minimal MA fixture."""
-    controller = MetaDataController(mass_minimal)
-    mass_minimal.metadata = controller
-    return controller
 
 
 async def test_locale_falls_back_to_the_default_language(


### PR DESCRIPTION
# What does this implement/fix?

The `metadata_controller` pytest fixture was copy-pasted into three test files under `tests/controllers/metadata/`. Moved it into a package-level `conftest.py` so there is one definition.

Two of the three copies also set up the cache database; the third did not. That setup is now a separate opt-in `cache_database` fixture, so tests that don't touch the cache don't pay for it.

- Added `tests/controllers/metadata/conftest.py` with the shared `metadata_controller` and `cache_database` fixtures
- Dropped the duplicated fixture from `test_metadata.py`, `test_image_proxy.py` and `test_preferred_language.py`
- The nine pure helper tests in `test_image_proxy.py` no longer spin up a server instance or a cache database

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
