### PR TITLE
Make the Home Assistant registry-race tests wait for the actual fetch

### DIFF
--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -931,8 +931,10 @@ async def test_unmirrored_change_during_the_fetch_is_still_cached() -> None:
         provider._entity_registry = None
         # hold back the registry response until the update has been delivered
         hass._registry_result = asyncio.get_running_loop().create_future()
+        # the startup fetch left the event set, so re-arm it for the fetch under test
+        hass.registry_started.clear()
         lookup = asyncio.ensure_future(provider.get_states(domains=("tts",)))
-        await asyncio.sleep(0)
+        await hass.registry_started.wait()
 
         hass.fire_event(
             "entity_registry_updated", _registry_event("light.kitchen", changes={"name": "Old"})
@@ -991,8 +993,10 @@ async def test_registry_changed_during_the_fetch_is_not_cached() -> None:
         provider._entity_registry = None
         # hold back the registry response until the update has been delivered
         hass._registry_result = asyncio.get_running_loop().create_future()
+        # the startup fetch left the event set, so re-arm it for the fetch under test
+        hass.registry_started.clear()
         lookup = asyncio.ensure_future(provider.get_states(domains=("tts",)))
-        await asyncio.sleep(0)
+        await hass.registry_started.wait()
 
         hass.fire_event("entity_registry_updated", _registry_event("light.kitchen", "create"))
         hass._registry_result.set_result(None)

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -331,6 +331,21 @@ async def _wait_for_stored(provider: HomeAssistantProvider) -> None:
             await asyncio.sleep(0)
 
 
+def _hold_back_registry_fetch(hass: _HomeAssistantClient) -> asyncio.Future[None]:
+    """Hold back the next registry listing and return the future that releases it."""
+    registry_response: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    hass._registry_result = registry_response
+    # the startup fetch left the event set, so re-arm it for the fetch under test
+    hass.registry_started.clear()
+    return registry_response
+
+
+async def _wait_for_registry_fetch(hass: _HomeAssistantClient) -> None:
+    """Wait until the held back registry listing is in flight."""
+    async with asyncio.timeout(1):
+        await hass.registry_started.wait()
+
+
 def _registry_event(
     entity_id: str, action: str = "update", changes: dict[str, Any] | None = None
 ) -> dict[str, Any]:
@@ -930,16 +945,14 @@ async def test_unmirrored_change_during_the_fetch_is_still_cached() -> None:
     async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
         provider._entity_registry = None
         # hold back the registry response until the update has been delivered
-        hass._registry_result = asyncio.get_running_loop().create_future()
-        # the startup fetch left the event set, so re-arm it for the fetch under test
-        hass.registry_started.clear()
+        registry_response = _hold_back_registry_fetch(hass)
         lookup = asyncio.ensure_future(provider.get_states(domains=("tts",)))
-        await hass.registry_started.wait()
+        await _wait_for_registry_fetch(hass)
 
         hass.fire_event(
             "entity_registry_updated", _registry_event("light.kitchen", changes={"name": "Old"})
         )
-        hass._registry_result.set_result(None)
+        registry_response.set_result(None)
         async with asyncio.timeout(1):
             await lookup
 
@@ -973,13 +986,13 @@ async def test_concurrent_domain_lookups_share_one_registry_fetch() -> None:
         registry_fetches = hass.calls.count(REGISTRY_LIST_COMMAND)
         provider._entity_registry = None
         # hold back the registry response until both lookups are waiting for it
-        hass._registry_result = asyncio.get_running_loop().create_future()
+        registry_response = _hold_back_registry_fetch(hass)
 
         lookups = asyncio.gather(
             provider.get_states(domains=("tts",)), provider.get_states(domains=("tts",))
         )
-        await asyncio.sleep(0)
-        hass._registry_result.set_result(None)
+        await _wait_for_registry_fetch(hass)
+        registry_response.set_result(None)
         async with asyncio.timeout(1):
             results = await lookups
 
@@ -992,14 +1005,12 @@ async def test_registry_changed_during_the_fetch_is_not_cached() -> None:
     async with _start_provider([_state("tts.only", "Only")]) as (provider, hass):
         provider._entity_registry = None
         # hold back the registry response until the update has been delivered
-        hass._registry_result = asyncio.get_running_loop().create_future()
-        # the startup fetch left the event set, so re-arm it for the fetch under test
-        hass.registry_started.clear()
+        registry_response = _hold_back_registry_fetch(hass)
         lookup = asyncio.ensure_future(provider.get_states(domains=("tts",)))
-        await hass.registry_started.wait()
+        await _wait_for_registry_fetch(hass)
 
         hass.fire_event("entity_registry_updated", _registry_event("light.kitchen", "create"))
-        hass._registry_result.set_result(None)
+        registry_response.set_result(None)
         async with asyncio.timeout(1):
             await lookup
 


### PR DESCRIPTION
# What does this implement/fix?

Three tests in `tests/providers/hass/test_provider.py` cover what happens when an entity registry update, or a second lookup, arrives while the registry listing is still being fetched. They all delivered that by doing `await asyncio.sleep(0)` and assuming one event-loop tick was enough to reach the blocked fetch.

That holds today, but only by accident. Add one more `await` anywhere before the fetch and the tests stop testing the race: depending on where it lands you either lose the coverage silently (the test stays green while the update now arrives before the fetch ever starts) or get a phantom failure that points at the wrong thing. Both were reproduced.

They now wait for the fake client's "registry fetch is in flight" signal, so the ordering is explicit. Each test was re-checked to still fail when the behaviour it pins is broken.

**Related issue (if applicable):**

- follow-up on https://github.com/music-assistant/server/pull/5378

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
