### PR TITLE
Bound the Trivia quiz AI response the same way as the distractor parser

### DIFF
--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -25,6 +25,12 @@ from music_assistant.helpers.json import (
     strip_code_fence,
 )
 from music_assistant.helpers.plugin_engines import get_ai_engines, resolve_ai_engine
+from music_assistant.providers.music_quiz.ai_distractors import (
+    AI_QUERY_TIMEOUT_SECONDS,
+    MAX_AI_PROMPT_BYTES,
+    MAX_AI_RESPONSE_BYTES,
+    MAX_AI_RESPONSE_LINES,
+)
 from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
 from music_assistant.providers.music_quiz.models import (
     MultipleChoiceRoundState,
@@ -55,9 +61,6 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 AI_GENERATION_ATTEMPTS = 2
-AI_QUERY_TIMEOUT_SECONDS = 30.0
-MAX_AI_PROMPT_BYTES = 8192
-MAX_AI_RESPONSE_BYTES = 4096
 MAX_METADATA_VALUE_LENGTH = 500
 MAX_ANSWER_LENGTH = 200
 MAX_QUESTION_LENGTH = 300
@@ -398,6 +401,8 @@ class TriviaQuizType(QuizType):
             raise TypeError("response must be a string")
         if len(response.encode("utf-8")) > MAX_AI_RESPONSE_BYTES:
             raise ValueError("response exceeds the size limit")
+        if len(response.splitlines()) > MAX_AI_RESPONSE_LINES:
+            raise ValueError("response exceeds the line limit")
         try:
             payload = json_loads(strip_code_fence(response))
         except JSON_DECODE_EXCEPTIONS as err:

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -26,6 +26,12 @@ from music_assistant.constants import VARIOUS_ARTISTS_MBID, VARIOUS_ARTISTS_NAME
 from music_assistant.controllers.music.recency import RecencySnapshot
 from music_assistant.helpers.json import json_dumps, json_loads
 from music_assistant.models.plugin import AIEngine, PluginProvider
+from music_assistant.providers.music_quiz.ai_distractors import (
+    AI_QUERY_TIMEOUT_SECONDS,
+    MAX_AI_PROMPT_BYTES,
+    MAX_AI_RESPONSE_BYTES,
+    MAX_AI_RESPONSE_LINES,
+)
 from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
 from music_assistant.providers.music_quiz.models import (
     DEFAULT_TRIVIA_LANGUAGE,
@@ -39,9 +45,6 @@ from music_assistant.providers.music_quiz.quiz_types import get_quiz_type
 from music_assistant.providers.music_quiz.quiz_types.base import MAX_SUGGESTION_COUNT
 from music_assistant.providers.music_quiz.quiz_types.trivia import (
     AI_GENERATION_ATTEMPTS,
-    AI_QUERY_TIMEOUT_SECONDS,
-    MAX_AI_PROMPT_BYTES,
-    MAX_AI_RESPONSE_BYTES,
     MAX_ANSWER_LENGTH,
     MAX_METADATA_VALUE_LENGTH,
     MAX_QUESTION_LENGTH,
@@ -1405,12 +1408,28 @@ def test_strict_generation_parser_accepts_fenced_response(fence: str) -> None:
     )
 
 
-def test_strict_generation_parser_limits_the_original_response() -> None:
-    """Enforce the response size limit before a code fence is stripped."""
+def test_strict_generation_parser_enforces_size_and_line_limits() -> None:
+    """Reject responses outside their explicit resource limits."""
     quiz, _ = _quiz([])
+    oversized_response = "x" * (MAX_AI_RESPONSE_BYTES + 1)
+    too_many_lines = "\n".join("{}" for _ in range(MAX_AI_RESPONSE_LINES + 1))
 
     with pytest.raises(ValueError, match="size"):
-        quiz._parse_generation(f"```json\n{'x' * MAX_AI_RESPONSE_BYTES}\n```", _artist_fact())
+        quiz._parse_generation(oversized_response, _artist_fact())
+    with pytest.raises(ValueError, match="line"):
+        quiz._parse_generation(too_many_lines, _artist_fact())
+
+
+def test_strict_generation_parser_limits_the_original_response() -> None:
+    """Enforce the size and line limits before a code fence is stripped."""
+    quiz, _ = _quiz([])
+    oversized_response = f"```json\n{'x' * MAX_AI_RESPONSE_BYTES}\n```"
+    too_many_lines = "```json\n" + "\n".join("{}" for _ in range(MAX_AI_RESPONSE_LINES)) + "\n```"
+
+    with pytest.raises(ValueError, match="size"):
+        quiz._parse_generation(oversized_response, _artist_fact())
+    with pytest.raises(ValueError, match="line"):
+        quiz._parse_generation(too_many_lines, _artist_fact())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

The two Music Quiz AI response parsers bounded an untrusted AI reply differently: the distractor parser limits both the response size and its line count, while the Trivia parser only checked the size. Trivia now applies the same line limit, so both parsers bound a reply the same way.

Also drops Trivia's own copies of the shared AI request/response limits — they are now taken from `ai_distractors`, the module that owns them, like the other quiz types already do.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Trivia rejects an AI reply with too many lines, matching the distractor parser.
- The limit is checked on the original reply, so a markdown code fence cannot be used to get past it.
- Trivia reuses the shared timeout and prompt/response size limits instead of defining duplicates.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
