### PR TITLE
Use one shared rule for trusting album release info in Music Quiz

### DIFF
--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -98,6 +98,15 @@ def has_untrusted_release_year(album: Album | ItemMapping) -> bool:
         return False
     if album.album_type in UNTRUSTED_RELEASE_ALBUM_TYPES:
         return True
+    return has_various_artists_credit(album)
+
+
+def has_various_artists_credit(album: Album) -> bool:
+    """
+    Return whether an album is credited to Various Artists.
+
+    :param album: Album whose artist credits should be inspected.
+    """
     return any(
         artist.mbid == VARIOUS_ARTISTS_MBID
         or compare_strings(artist.name, VARIOUS_ARTISTS_NAME, strict=False)

--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -9,14 +9,12 @@ import re
 from collections.abc import Collection, Iterator, Sequence
 from dataclasses import dataclass, replace
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from music_assistant_models.enums import AlbumType
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import Album
 
-from music_assistant.constants import VARIOUS_ARTISTS_MBID, VARIOUS_ARTISTS_NAME
-from music_assistant.helpers.compare import compare_strings
 from music_assistant.helpers.json import (
     JSON_DECODE_EXCEPTIONS,
     SerializableType,
@@ -43,6 +41,8 @@ from music_assistant.providers.music_quiz.quiz_types.base import (
     MAX_SUGGESTION_COUNT,
     QuizType,
     get_track_release_year,
+    has_untrusted_release_year,
+    has_various_artists_credit,
 )
 from music_assistant.providers.music_quiz.suggestions import (
     SuggestionCandidate,
@@ -66,6 +66,8 @@ MAX_ANSWER_LENGTH = 200
 MAX_QUESTION_LENGTH = 300
 MAX_TRIVIA_LANGUAGE_TAG_LENGTH = 16
 TRIVIA_REVEAL_AUTO_ADVANCE_SECONDS = 15.0
+# album types whose release year is untrusted while their name remains a usable Trivia answer
+TRUSTED_ALBUM_NAME_TYPES: Final = frozenset({AlbumType.LIVE, AlbumType.SOUNDTRACK})
 SYSTEM_RANDOM = random.SystemRandom()
 _LANGUAGE_TAG_PATTERN = re.compile(
     r"(?P<language>[A-Za-z]{2,3})"
@@ -562,28 +564,24 @@ class TriviaQuizType(QuizType):
 
         :param track: Selected source track to read the facts from.
         :param musicbrainz_year: Release year MusicBrainz knows for the track's recording, which
-            is the only year usable when the track sits on an untrusted compilation album.
+            is the only year usable when the track's album carries untrusted release facts.
         """
         if not track.uri or not (title := _bounded_metadata_value(track.name)):
             return None
         artist = _bounded_metadata_value(track.artist_str or None)
         album = track.album
-        untrusted_compilation = isinstance(album, Album) and _is_untrusted_compilation_album(album)
+        untrusted_album = isinstance(album, Album) and _has_untrusted_release_facts(album)
         facts = TriviaTrackFacts(
             source_uri=track.uri,
             title=title,
             artist=artist,
             album=(
-                None
-                if untrusted_compilation
-                else _bounded_metadata_value(album.name if album else None)
+                None if untrusted_album else _bounded_metadata_value(album.name if album else None)
             ),
-            # on an untrusted compilation both available years are unusable: the album carries
-            # the reissue year and the track its position on that reissue, so only the year
-            # MusicBrainz knows for the recording can answer a release year question
-            release_year=(
-                musicbrainz_year if untrusted_compilation else get_track_release_year(track)
-            ),
+            # on such an album both available years are unusable: the album carries the reissue
+            # year and the track its position on that reissue, so only the year MusicBrainz knows
+            # for the recording can answer a release year question
+            release_year=(musicbrainz_year if untrusted_album else get_track_release_year(track)),
         )
         return facts if TriviaQuizType._available_targets(facts) else None
 
@@ -627,19 +625,21 @@ def _bounded_metadata_value(value: str | None) -> str | None:
     return cleaned if len(cleaned) <= MAX_METADATA_VALUE_LENGTH else None
 
 
-def _is_untrusted_compilation_album(album: Album) -> bool:
+def _has_untrusted_release_facts(album: Album) -> bool:
     """
-    Return whether Trivia must omit release facts supplied with an album.
+    Return whether Trivia must omit the release facts supplied with an album.
 
     :param album: Full album metadata attached to a selected Trivia track.
     """
-    if album.album_type == AlbumType.COMPILATION:
-        return True
-    return any(
-        artist.mbid == VARIOUS_ARTISTS_MBID
-        or compare_strings(artist.name, VARIOUS_ARTISTS_NAME, strict=False)
-        for artist in album.artists
-    )
+    if not has_untrusted_release_year(album):
+        return False
+    # the name of a live album or soundtrack still answers "which album is this from?", so such
+    # an album is only untrusted here when it also carries a Various Artists credit. Remaining a
+    # strict subset of has_untrusted_release_year is what keeps an album's own untrusted year out
+    # of the trusted release year branch in _track_facts.
+    if album.album_type in TRUSTED_ALBUM_NAME_TYPES:
+        return has_various_artists_credit(album)
+    return True
 
 
 def _normalize_trivia_language(language: str) -> str:

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -42,7 +42,10 @@ from music_assistant.providers.music_quiz.models import (
     TimelineBonusMode,
 )
 from music_assistant.providers.music_quiz.quiz_types import get_quiz_type
-from music_assistant.providers.music_quiz.quiz_types.base import MAX_SUGGESTION_COUNT
+from music_assistant.providers.music_quiz.quiz_types.base import (
+    MAX_SUGGESTION_COUNT,
+    has_untrusted_release_year,
+)
 from music_assistant.providers.music_quiz.quiz_types.trivia import (
     AI_GENERATION_ATTEMPTS,
     MAX_ANSWER_LENGTH,
@@ -54,6 +57,7 @@ from music_assistant.providers.music_quiz.quiz_types.trivia import (
     TriviaQuizType,
     TriviaTarget,
     TriviaTrackFacts,
+    _has_untrusted_release_facts,
 )
 
 
@@ -714,6 +718,70 @@ def test_various_artists_album_omits_album_and_year(
         TriviaTarget.ARTIST,
         TriviaTarget.TITLE,
     )
+
+
+@pytest.mark.parametrize(
+    ("album_type", "album_artists", "expected_album"),
+    [
+        (AlbumType.LIVE, [], "The Long Night"),
+        (AlbumType.SOUNDTRACK, [], "The Long Night"),
+        (
+            AlbumType.LIVE,
+            [_album_artist("primary", "Primary Artist"), _album_artist("va", VARIOUS_ARTISTS_NAME)],
+            None,
+        ),
+        (AlbumType.SOUNDTRACK, [_album_artist("va", VARIOUS_ARTISTS_NAME)], None),
+    ],
+    ids=["live", "soundtrack", "live-various-artists", "soundtrack-various-artists"],
+)
+def test_live_and_soundtrack_album_names_stay_usable_answers(
+    album_type: AlbumType,
+    album_artists: list[Artist],
+    expected_album: str | None,
+) -> None:
+    """Keep a live or soundtrack album name as an answer while distrusting its own year."""
+    # the track carries no year of its own, so the album's year is the only one that could
+    # surface and a trusted album type would leak it into the grounding
+    track = _track("live", "Teardrop", "Massive Attack")
+    track.album = _full_album(
+        "the-long-night",
+        "The Long Night",
+        album_type=album_type,
+        artists=album_artists,
+        year=2015,
+    )
+
+    facts = TriviaQuizType._track_facts(track)
+
+    assert facts is not None
+    assert facts.album == expected_album
+    assert facts.release_year is None
+
+
+def test_trivia_album_distrust_stays_a_subset_of_untrusted_release_years() -> None:
+    """Pin Trivia's album distrust as a subset of the shared untrusted release year rule."""
+    artist_credits: dict[str, list[Artist]] = {
+        "own": [_album_artist("own", "Album Artist")],
+        "various": [_album_artist("va", VARIOUS_ARTISTS_NAME)],
+    }
+    distrusted = set()
+    for album_type in AlbumType:
+        for credit, album_artists in artist_credits.items():
+            album = _full_album(
+                "album", "Album", album_type=album_type, artists=album_artists, year=2015
+            )
+            if _has_untrusted_release_facts(album):
+                distrusted.add((album_type, credit))
+                # _track_facts only bypasses get_track_release_year for albums Trivia distrusts,
+                # so every such album must also be one whose own year is never trusted
+                assert has_untrusted_release_year(album)
+
+    assert (AlbumType.COMPILATION, "own") in distrusted
+    assert (AlbumType.ALBUM, "various") in distrusted
+    assert (AlbumType.LIVE, "various") in distrusted
+    assert (AlbumType.SOUNDTRACK, "various") in distrusted
+    assert (AlbumType.LIVE, "own") not in distrusted
+    assert (AlbumType.SOUNDTRACK, "own") not in distrusted
 
 
 def test_normal_full_album_retains_release_grounding() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Music Quiz had two near-identical rules for judging whether an album's release info can be trusted: a shared one used for release years, and a Trivia-only one that also decides whether the album name may be used as an answer. The Various Artists check was copied between them, and the Trivia rule silently had to stay narrower than the shared one — Trivia only uses an album's own year when the shared rule says that is safe. Nothing enforced that, so a later tweak to the Trivia rule could have started grounding year questions on a reissue year.

- Moved the Various Artists check into a single shared helper
- Expressed the Trivia rule in terms of the shared rule plus an explicit exception for live albums and soundtracks, whose name is still a fine answer to "which album is this from?"
- Renamed the Trivia rule to match what it actually covers, which is more than compilations
- Added tests pinning that exception and the narrower-than-shared relationship

No behaviour change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
