### PR TITLE
Don't demand a setup setting the user cannot fill in

### DIFF
--- a/music_assistant/models/setup_flow.py
+++ b/music_assistant/models/setup_flow.py
@@ -385,6 +385,11 @@ class SetupSession:
         self.last_activity = time.monotonic()
         errors: dict[str, str] = {}
         parsed: dict[str, ConfigValueType] = {}
+        # gates resolve against the submitted values, so flipping one takes effect on the
+        # same submit regardless of where it sits on the form
+        submitted_entries = [
+            replace(entry, value=values.get(entry.key, entry.value)) for entry in step.entries
+        ]
         for entry in step.entries:
             if entry.type in UI_ONLY:
                 continue
@@ -392,7 +397,11 @@ class SetupSession:
             try:
                 # parse_value also runs the entry's optional validate callback and
                 # stores the parsed value on the entry (echoed on a re-render)
-                parsed[entry.key] = entry.parse_value(raw_value, allow_none=False)
+                # an entry behind an unmet dependency renders disabled, so demanding a
+                # value the user has no way to supply would wedge the flow
+                parsed[entry.key] = entry.parse_value(
+                    raw_value, allow_none=not entry.dependency_met(submitted_entries)
+                )
             except TypeError, ValueError:
                 errors[entry.key] = "required" if raw_value in (None, "") else "invalid_value"
                 if not isinstance(raw_value, list):

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncGenerator, Awaitable, Callable
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -13,7 +14,7 @@ from urllib.parse import parse_qs, urlsplit
 import pytest
 from aiohttp.test_utils import make_mocked_request
 from music_assistant_models.auth import Scope
-from music_assistant_models.config_entries import ConfigEntry, PlayerConfig
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, PlayerConfig
 from music_assistant_models.enums import (
     ConfigEntryType,
     EventType,
@@ -53,6 +54,11 @@ PORT_ENTRY = ConfigEntry(key="port", type=ConfigEntryType.INTEGER, required=Fals
 PASSWORD_ENTRY = ConfigEntry(key="password", type=ConfigEntryType.SECURE_STRING, required=True)
 REGION_ENTRY = ConfigEntry(
     key="region", type=ConfigEntryType.STRING, required=True, default_value="eu"
+)
+USE_PROXY_ENTRY = ConfigEntry(key="use_proxy", type=ConfigEntryType.BOOLEAN, default_value=False)
+# required with no default to fall back on, so only the gate keeps it satisfiable
+PROXY_HOST_ENTRY = ConfigEntry(
+    key="proxy_host", type=ConfigEntryType.STRING, required=True, depends_on=USE_PROXY_ENTRY.key
 )
 
 
@@ -341,6 +347,64 @@ async def test_form_validation_errors(flow_mass: MusicAssistant) -> None:
     assert finish_step.type == FlowStepType.FINISH
     raw_conf = flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}")
     assert raw_conf["setup_data"]["port"] == 8095
+
+
+async def test_gated_required_entry_does_not_block_submit(flow_mass: MusicAssistant) -> None:
+    """A required entry behind an unmet dependency renders disabled, so it may stay empty."""
+    submitted: dict[str, ConfigValueType] = {}
+
+    async def run_setup(session: SetupSession) -> None:
+        submitted.update(await session.form([USE_PROXY_ENTRY, PROXY_HOST_ENTRY]))
+        await session.finish(submitted)
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        finish_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"use_proxy": False})
+    assert finish_step.type == FlowStepType.FINISH
+    assert submitted == {"use_proxy": False, "proxy_host": None}
+
+
+async def test_gated_required_entry_is_demanded_once_its_gate_opens(
+    flow_mass: MusicAssistant,
+) -> None:
+    """Opening the gate in the same submit makes the entry required again."""
+
+    async def run_setup(session: SetupSession) -> None:
+        await session.finish(await session.form([USE_PROXY_ENTRY, PROXY_HOST_ENTRY]))
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        error_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"use_proxy": True})
+        assert error_step.type == FlowStepType.FORM
+        assert error_step.errors == {"proxy_host": "required"}
+        await flow_mass.config.abort_setup_flow(step.flow_id)
+
+
+async def test_gate_is_read_from_the_submitted_values(flow_mass: MusicAssistant) -> None:
+    """Closing a prefilled gate takes effect wherever the gate sits on the form."""
+    submitted: dict[str, ConfigValueType] = {}
+
+    async def run_setup(session: SetupSession) -> None:
+        # gate listed behind what it gates, and prefilled as a reconfigure run would
+        submitted.update(
+            await session.form([PROXY_HOST_ENTRY, replace(USE_PROXY_ENTRY, value=True)])
+        )
+        await session.finish(submitted)
+
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        finish_step = await flow_mass.config.submit_setup_flow(step.flow_id, {"use_proxy": False})
+    assert finish_step.type == FlowStepType.FINISH
+    assert submitted == {"use_proxy": False, "proxy_host": None}
 
 
 async def test_submit_returns_next_form_step(flow_mass: MusicAssistant) -> None:


### PR DESCRIPTION
# What does this implement/fix?

A setting in a setup wizard step can be greyed out because the option it depends on is
switched off. The wizard still demanded a value for it and answered with a "required"
error on a field the user has no way to fill in, leaving the step impossible to finish.

The settings page and the wizard's Next button already skip these settings; this brings
the server side of the wizard in line with them. No provider ships this combination
today, so nothing is broken right now - this closes the last of the three places that
had to agree.

**Related issue (if applicable):**

- companion: music-assistant/models#348
- companion: music-assistant/frontend#2284

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- A setup step no longer demands a value for a setting whose dependency is unmet
- The dependency is judged on the values just submitted, so switching a gate off takes
  effect on that same submit, wherever the gate sits on the form
- Tests covering a closed gate, a gate opened in the same submit, and a gate closed in
  the same submit

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
