### PR TITLE
Keep manually set radio name and artwork in playlists

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -958,6 +958,10 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 # a radio station must stay a radio station, also when the stream
                 # reports a duration or carries no ICY name
                 return await builtin_prov.get_radio(item_id)
+            if media_type == MediaType.TRACK:
+                # and a track must stay a track, also when the stream carries an
+                # ICY name or reports no duration
+                return await builtin_prov.get_track(item_id)
             return await builtin_prov.parse_item(item_id, requested_media_type=media_type)
         if media_type == MediaType.PODCAST_EPISODE:
             # special case for podcast episodes

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -954,6 +954,10 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         ):
             # handle special case of 'builtin' MusicProvider which allows us to play regular url's
             builtin_prov = cast("BuiltinProvider", provider or self.mass.get_provider("builtin"))
+            if media_type == MediaType.RADIO:
+                # a radio station must stay a radio station, also when the stream
+                # reports a duration or carries no ICY name
+                return await builtin_prov.get_radio(item_id)
             return await builtin_prov.parse_item(item_id, requested_media_type=media_type)
         if media_type == MediaType.PODCAST_EPISODE:
             # special case for podcast episodes

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -393,8 +393,10 @@ def generate_m3u(
             remotely = "true" if img.remotely_accessible else "false"
             fields = [img.type, img.path, img.provider, remotely]
             lines.append(f"#EXTIMG:{sep.join(fields)}")
-        if item.title is not None and item.length is not None:
-            lines.append(f"#EXTINF:{item.length},{item.title}")
+        if item.title is not None:
+            # -1 is the M3U convention for unknown length; without it an entry without
+            # duration (such as a radio station) loses its title on every rewrite
+            lines.append(f"#EXTINF:{item.length if item.length is not None else -1},{item.title}")
         lines.append(item.path)
     return "\n".join(lines) + "\n"
 
@@ -797,9 +799,7 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
     return PlaylistItem(
         path=primary_uri,
         title=title,
-        # generate_m3u only writes #EXTINF when length is set, and -1 is the M3U
-        # convention for unknown length, which parse_m3u maps back to None
-        length=str(duration) if duration else "-1",
+        length=str(duration) if duration else None,
         metadata=metadata,
         providers=prov_infos,
         images=images,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -190,39 +190,12 @@ class BuiltinProvider(MusicProvider):
 
     async def get_track(self, prov_track_id: str) -> Track:
         """Get full track details by id."""
-        parsed_item = cast("Track", await self.parse_item(prov_track_id))
-        stored_items: list[StoredItem] = self.mass.config.get(CONF_KEY_TRACKS, [])
-        if stored_item := next((x for x in stored_items if x["item_id"] == prov_track_id), None):
-            # always prefer the stored info, such as the name
-            parsed_item.name = stored_item["name"]
-            if image_url := stored_item.get("image_url"):
-                parsed_item.metadata.add_image(
-                    MediaItemImage(
-                        type=ImageType.THUMB,
-                        path=image_url,
-                        provider=self.domain,
-                        remotely_accessible=image_url.startswith("http"),
-                    )
-                )
-        return parsed_item
+        return cast("Track", await self.parse_item(prov_track_id))
 
     async def get_radio(self, prov_radio_id: str) -> Radio:
         """Get full radio details by id."""
         parsed_item = await self.parse_item(prov_radio_id, force_radio=True)
         assert isinstance(parsed_item, Radio)
-        stored_items: list[StoredItem] = self.mass.config.get(CONF_KEY_RADIOS, [])
-        if stored_item := next((x for x in stored_items if x["item_id"] == prov_radio_id), None):
-            # always prefer the stored info, such as the name
-            parsed_item.name = stored_item["name"]
-            if image_url := stored_item.get("image_url"):
-                parsed_item.metadata.add_image(
-                    MediaItemImage(
-                        type=ImageType.THUMB,
-                        path=image_url,
-                        provider=self.domain,
-                        remotely_accessible=image_url.startswith("http"),
-                    )
-                )
         return parsed_item
 
     async def get_artist(self, prov_artist_id: str) -> Artist:
@@ -746,6 +719,8 @@ class BuiltinProvider(MusicProvider):
                     )
                 ]
             )
+        if isinstance(media_item, Track | Radio):
+            self._apply_stored_details(media_item)
         return media_item
 
     async def resolve_image(self, path: str) -> str | bytes:
@@ -1001,6 +976,31 @@ class BuiltinProvider(MusicProvider):
         if diff <= 5:
             return 1
         return 0
+
+    def _apply_stored_details(self, media_item: Track | Radio) -> None:
+        """Apply the name and image stored for a manually added track or radio station."""
+        key = CONF_KEY_RADIOS if isinstance(media_item, Radio) else CONF_KEY_TRACKS
+        stored_items: list[StoredItem] = self.mass.config.get(key, [])
+        stored_item = next(
+            (x for x in stored_items if x["item_id"] == media_item.item_id),
+            None,
+        )
+        if stored_item is None:
+            return
+        media_item.name = stored_item["name"]
+        if image_url := stored_item.get("image_url"):
+            # the stored image goes first so it wins over any cover art on the stream
+            media_item.metadata.images = UniqueList(
+                [
+                    MediaItemImage(
+                        type=ImageType.THUMB,
+                        path=image_url,
+                        provider=self.domain,
+                        remotely_accessible=image_url.startswith("http"),
+                    ),
+                    *(media_item.metadata.images or []),
+                ]
+            )
 
     async def _resolve_url(self, url: str) -> str:
         """

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1060,7 +1060,8 @@ class BuiltinProvider(MusicProvider):
             return
         media_item.name = stored_item["name"]
         if image_url := stored_item.get("image_url"):
-            # the stored image goes first so it wins over any cover art on the stream
+            # the stored image replaces any cover art on the stream, so exactly one
+            # thumbnail is left to serialise into a playlist entry
             media_item.metadata.images = UniqueList(
                 [
                     MediaItemImage(
@@ -1069,7 +1070,7 @@ class BuiltinProvider(MusicProvider):
                         provider=self.domain,
                         remotely_accessible=image_url.startswith("http"),
                     ),
-                    *(media_item.metadata.images or []),
+                    *(x for x in (media_item.metadata.images or []) if x.type != ImageType.THUMB),
                 ]
             )
 

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import re
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping
 from typing import TYPE_CHECKING, Final, cast
 from urllib.parse import urlparse
 
@@ -59,6 +59,7 @@ from music_assistant.controllers.tasks.context import (
 )
 from music_assistant.helpers.compare import compare_strings
 from music_assistant.helpers.playlists import (
+    ImageInfo,
     IsHLSPlaylist,
     PlaylistItem,
     ProviderMappingInfo,
@@ -162,8 +163,10 @@ class BuiltinProvider(MusicProvider):
         if not await asyncio.to_thread(os.path.exists, self._playlists_dir):
             await asyncio.to_thread(os.mkdir, self._playlists_dir)
         await super().loaded_in_mass()
-        # migrate old-style playlists in the background to avoid blocking startup
-        # TODO: remove after MA 2.9
+        # run in the background to avoid blocking startup. besides migrating old-style
+        # playlists, this repairs entries whose manually set name or artwork no longer
+        # matches the builtin config, which is not a one-off.
+        # TODO: drop the config->M3U migration after MA 2.9, keep the repair pass
         self.mass.tasks.register_scheduled_task(
             task_id="migrate_builtin_playlists",
             name="Builtin provider playlist migration",
@@ -980,6 +983,71 @@ class BuiltinProvider(MusicProvider):
             return 1
         return 0
 
+    def _get_stored_item(
+        self, item: PlaylistItem, stored_by_media_type: Mapping[str, Mapping[str, StoredItem]]
+    ) -> StoredItem | None:
+        """
+        Return the stored details of a manually added playlist entry, if it is one.
+
+        :param item: The playlist entry as parsed from an M3U file.
+        :param stored_by_media_type: Stored items per media type, each keyed on item_id.
+        """
+        prov_mapping = next((x for x in item.providers if x.domain == self.domain), None)
+        if prov_mapping is None:
+            return None
+        media_type = (item.metadata or {}).get("media_type", "")
+        return stored_by_media_type.get(media_type, {}).get(prov_mapping.item_id)
+
+    def _stored_details_differ(
+        self, item: PlaylistItem, stored_by_media_type: Mapping[str, Mapping[str, StoredItem]]
+    ) -> bool:
+        """
+        Return True when a playlist entry no longer carries its manually set name or image.
+
+        :param item: The playlist entry as parsed from an M3U file.
+        :param stored_by_media_type: Stored items per media type, each keyed on item_id.
+        """
+        stored_item = self._get_stored_item(item, stored_by_media_type)
+        if stored_item is None:
+            return False
+        # an M3U file cannot hold the surrounding whitespace of a name, so comparing
+        # against the raw stored name would report a difference that no rewrite can settle
+        if stored_item["name"].strip() != (item.metadata or {}).get("name"):
+            return True
+        # a stored item without an image is not a difference: cover art from the stream
+        # is a valid fallback for as long as the user has set no image of their own
+        if image_url := stored_item.get("image_url"):
+            return not any(image.path == image_url for image in item.images)
+        return False
+
+    def _restore_stored_details(
+        self, item: PlaylistItem, stored_by_media_type: Mapping[str, Mapping[str, StoredItem]]
+    ) -> None:
+        """
+        Write the manually set name and image of a playlist entry back into it.
+
+        :param item: The playlist entry to update in place.
+        :param stored_by_media_type: Stored items per media type, each keyed on item_id.
+        """
+        stored_item = self._get_stored_item(item, stored_by_media_type)
+        if stored_item is None:
+            return
+        name = stored_item["name"]
+        item.metadata = {**(item.metadata or {}), "name": name}
+        # #EXTINF holds "<artists> - <name>" for a track and the plain name for a radio
+        # station, which has no artists; mirror how the entry would have been written
+        item.title = f"{', '.join(x.name for x in item.artists)} - {name}" if item.artists else name
+        if image_url := stored_item.get("image_url"):
+            item.images = [
+                ImageInfo(
+                    type=ImageType.THUMB.value,
+                    path=image_url,
+                    provider=self.domain,
+                    remotely_accessible=image_url.startswith("http"),
+                ),
+                *(x for x in item.images if x.type != ImageType.THUMB.value),
+            ]
+
     def _apply_stored_details(self, media_item: Track | Radio) -> None:
         """Apply the name and image stored for a manually added track or radio station."""
         key = CONF_KEY_RADIOS if isinstance(media_item, Radio) else CONF_KEY_TRACKS
@@ -1353,7 +1421,12 @@ class BuiltinProvider(MusicProvider):
         return sanitized or "untitled"
 
     async def _migrate_playlists(self) -> None:  # noqa: PLR0915
-        """Migrate old-style playlists (config + plain URI files) to M3U files."""
+        """
+        Migrate old-style playlists to M3U files and repair incomplete or stale entries.
+
+        Raises RuntimeError when too many entries could not be resolved to keep a broken
+        install from rewriting every playlist.
+        """
         # migrate playlists stored in config to M3U files on disk with enriched metadata
         stored_items: list[StoredItem] = self.mass.config.get(CONF_KEY_PLAYLISTS, [])
         for stored_item in stored_items:
@@ -1396,9 +1469,18 @@ class BuiltinProvider(MusicProvider):
             self.logger.debug("Migrated playlist '%s' -> %s.m3u", playlist_name, playlist_id)
         # clear old config entries
         self.mass.config.remove(CONF_KEY_PLAYLISTS)
-        # fix (already migrated) user playlists that have unresolved URIs
-        # by re-saving them with enriched metadata
+        # fix (already migrated) user playlists that have unresolved URIs, or entries whose
+        # manually set name or artwork was lost, by re-saving them with enriched metadata
         errors = 0
+        # built once: a lookup per entry would rescan the entire config list each time
+        stored_by_media_type = {
+            MediaType.RADIO.value: {
+                x["item_id"]: x for x in self.mass.config.get(CONF_KEY_RADIOS, [])
+            },
+            MediaType.TRACK.value: {
+                x["item_id"]: x for x in self.mass.config.get(CONF_KEY_TRACKS, [])
+            },
+        }
         for filename in await asyncio.to_thread(os.listdir, self._playlists_dir):
             if not filename.endswith(".m3u"):
                 continue
@@ -1411,10 +1493,16 @@ class BuiltinProvider(MusicProvider):
             has_changes = False
             for item in all_items:
                 force_migration = item.metadata and item.metadata.get("album") and not item.album
-                if item.title and item.providers and item.metadata and not force_migration:
+                unresolved = bool(force_migration) or not (
+                    item.title and item.providers and item.metadata
+                )
+                if not unresolved and not self._stored_details_differ(item, stored_by_media_type):
                     continue
                 self.logger.debug(
-                    "Found unresolved entry in playlist '%s': %s", playlist_id, item.path
+                    "Found %s entry in playlist '%s': %s",
+                    "unresolved" if unresolved else "outdated",
+                    playlist_id,
+                    item.path,
                 )
                 try:
                     enriched = await self._build_m3u_entry_from_uri(item.path)
@@ -1427,17 +1515,31 @@ class BuiltinProvider(MusicProvider):
                     item.artists = enriched.artists
                     item.podcast = enriched.podcast
                 except (MediaNotFoundError, InvalidDataError, ProviderUnavailableError) as err:
-                    self.logger.warning(
-                        "Could not enrich playlist entry %s during migration: %s", item.path, err
-                    )
-                    report_current_task_failure(f"Could not enrich playlist entry: {item.path}")
-                    errors += 1
-                else:
-                    has_changes = True
+                    if unresolved:
+                        self.logger.warning(
+                            "Could not enrich playlist entry %s during migration: %s",
+                            item.path,
+                            err,
+                        )
+                        report_current_task_failure(f"Could not enrich playlist entry: {item.path}")
+                        errors += 1
+                        continue
+                    # an outdated entry is still playable, so failing to reach the stream is
+                    # no migration error; restore the stored details without any IO so a
+                    # permanently unreachable stream keeps its name and image
                     self.logger.debug(
-                        "Enriched playlist entry %s",
+                        "Could not refresh playlist entry %s, restoring stored details: %s",
                         item.path,
+                        err,
                     )
+                    self._restore_stored_details(item, stored_by_media_type)
+                else:
+                    # writing an entry the refresh did not bring back in step would leave
+                    # it outdated, and every later run would rewrite the file again
+                    if self._stored_details_differ(item, stored_by_media_type):
+                        self._restore_stored_details(item, stored_by_media_type)
+                    self.logger.debug("Enriched playlist entry %s", item.path)
+                has_changes = True
             if has_changes:
                 await self._write_m3u_file(
                     playlist_id,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -190,7 +190,9 @@ class BuiltinProvider(MusicProvider):
 
     async def get_track(self, prov_track_id: str) -> Track:
         """Get full track details by id."""
-        return cast("Track", await self.parse_item(prov_track_id))
+        parsed_item = await self.parse_item(prov_track_id, requested_media_type=MediaType.TRACK)
+        assert isinstance(parsed_item, Track)
+        return parsed_item
 
     async def get_radio(self, prov_radio_id: str) -> Radio:
         """Get full radio details by id."""
@@ -685,8 +687,9 @@ class BuiltinProvider(MusicProvider):
             )
             if media_info.duration:
                 media_item.duration = int(media_info.duration or 0)
-        elif is_radio or force_radio:
-            # treat as radio
+        elif (is_radio or force_radio) and requested_media_type != MediaType.TRACK:
+            # treat as radio, unless a track was explicitly requested: such a track
+            # stays a track, also when its stream carries an ICY name or no duration
             media_item = Radio(
                 item_id=url,
                 provider=self.domain,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1017,7 +1017,12 @@ class BuiltinProvider(MusicProvider):
         # a stored item without an image is not a difference: cover art from the stream
         # is a valid fallback for as long as the user has set no image of their own
         if image_url := stored_item.get("image_url"):
-            return not any(image.path == image_url for image in item.images)
+            # only the thumbnail counts: the same url as another image type still leaves
+            # the stream's cover art as the one that shows
+            return not any(
+                image.type == ImageType.THUMB.value and image.path == image_url
+                for image in item.images
+            )
         return False
 
     def _restore_stored_details(

--- a/tests/controllers/music/test_music_controller.py
+++ b/tests/controllers/music/test_music_controller.py
@@ -12,7 +12,7 @@ from music_assistant_models.errors import (
     MusicAssistantError,
     UnsupportedFeaturedException,
 )
-from music_assistant_models.media_items import SoundEffect
+from music_assistant_models.media_items import Radio, SoundEffect
 
 from music_assistant.constants import VACUUM_MIN_RECLAIM_RATIO
 from music_assistant.controllers.music import MusicController
@@ -174,6 +174,67 @@ async def test_get_item_passes_sound_effect_type_to_builtin_provider() -> None:
         "http://example.com/intro.mp3",
         requested_media_type=MediaType.SOUND_EFFECT,
     )
+
+
+async def test_get_item_builtin_radio_keeps_user_supplied_details() -> None:
+    """A builtin radio URI resolves through get_radio so it stays a radio station."""
+    controller = MusicController.__new__(MusicController)
+    radio = Radio(
+        item_id="http://stream.example.com",
+        provider="builtin",
+        name="My Station",
+        provider_mappings=set(),
+    )
+    builtin_provider = MagicMock()
+    builtin_provider.domain = "builtin"
+    builtin_provider.parse_item = AsyncMock()
+    builtin_provider.get_radio = AsyncMock(return_value=radio)
+    controller.mass = MagicMock()
+    controller.mass.get_provider.side_effect = lambda provider_id: (
+        builtin_provider if provider_id in {"builtin", "builtin_1"} else None
+    )
+
+    result = await controller.get_item(
+        MediaType.RADIO,
+        "http://stream.example.com",
+        "builtin_1",
+    )
+
+    assert result is radio
+    builtin_provider.get_radio.assert_awaited_once_with("http://stream.example.com")
+    builtin_provider.parse_item.assert_not_awaited()
+
+
+async def test_get_item_builtin_unknown_type_still_parses_url() -> None:
+    """A plain URL of unknown media type is probed by the builtin provider."""
+    controller = MusicController.__new__(MusicController)
+    radio = Radio(
+        item_id="http://stream.example.com",
+        provider="builtin",
+        name="My Station",
+        provider_mappings=set(),
+    )
+    builtin_provider = MagicMock()
+    builtin_provider.domain = "builtin"
+    builtin_provider.parse_item = AsyncMock(return_value=radio)
+    builtin_provider.get_radio = AsyncMock()
+    controller.mass = MagicMock()
+    controller.mass.get_provider.side_effect = lambda provider_id: (
+        builtin_provider if provider_id in {"builtin", "builtin_1"} else None
+    )
+
+    result = await controller.get_item(
+        MediaType.UNKNOWN,
+        "http://stream.example.com",
+        "builtin_1",
+    )
+
+    assert result is radio
+    builtin_provider.parse_item.assert_awaited_once_with(
+        "http://stream.example.com",
+        requested_media_type=MediaType.UNKNOWN,
+    )
+    builtin_provider.get_radio.assert_not_awaited()
 
 
 async def test_get_item_builtin_playlist_instance_uses_playlist_controller() -> None:

--- a/tests/controllers/music/test_music_controller.py
+++ b/tests/controllers/music/test_music_controller.py
@@ -12,7 +12,7 @@ from music_assistant_models.errors import (
     MusicAssistantError,
     UnsupportedFeaturedException,
 )
-from music_assistant_models.media_items import Radio, SoundEffect
+from music_assistant_models.media_items import Radio, SoundEffect, Track
 
 from music_assistant.constants import VACUUM_MIN_RECLAIM_RATIO
 from music_assistant.controllers.music import MusicController
@@ -202,6 +202,35 @@ async def test_get_item_builtin_radio_keeps_user_supplied_details() -> None:
 
     assert result is radio
     builtin_provider.get_radio.assert_awaited_once_with("http://stream.example.com")
+    builtin_provider.parse_item.assert_not_awaited()
+
+
+async def test_get_item_builtin_track_keeps_user_supplied_details() -> None:
+    """A builtin track URI resolves through get_track so it stays a track."""
+    controller = MusicController.__new__(MusicController)
+    track = Track(
+        item_id="http://media.example.com/song.mp3",
+        provider="builtin",
+        name="My Song",
+        provider_mappings=set(),
+    )
+    builtin_provider = MagicMock()
+    builtin_provider.domain = "builtin"
+    builtin_provider.parse_item = AsyncMock()
+    builtin_provider.get_track = AsyncMock(return_value=track)
+    controller.mass = MagicMock()
+    controller.mass.get_provider.side_effect = lambda provider_id: (
+        builtin_provider if provider_id in {"builtin", "builtin_1"} else None
+    )
+
+    result = await controller.get_item(
+        MediaType.TRACK,
+        "http://media.example.com/song.mp3",
+        "builtin_1",
+    )
+
+    assert result is track
+    builtin_provider.get_track.assert_awaited_once_with("http://media.example.com/song.mp3")
     builtin_provider.parse_item.assert_not_awaited()
 
 

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -457,6 +457,32 @@ def test_round_trip_multiple_entries() -> None:
     assert parsed[2].length is None
 
 
+def test_round_trip_unknown_length_keeps_title() -> None:
+    """Test that an entry with unknown length survives repeated rewrites."""
+    original = PlaylistItem(
+        path="builtin://radio/http://stream.example.com",
+        title="My Custom Station Name",
+        metadata={"media_type": "radio", "name": "My Custom Station Name"},
+        images=[
+            ImageInfo(
+                type="thumb",
+                path="https://img.example.com/station.jpg",
+                provider="builtin",
+                remotely_accessible=True,
+            ),
+        ],
+    )
+    # playlist files are rewritten on every edit, so parse -> generate must be lossless
+    parsed = parse_m3u(generate_m3u("Radio", [original]))
+    reparsed = parse_m3u(generate_m3u("Radio", parsed))
+
+    assert len(reparsed) == 1
+    assert reparsed[0].title == "My Custom Station Name"
+    assert reparsed[0].length is None
+    assert reparsed[0].metadata == original.metadata
+    assert reparsed[0].images[0].path == "https://img.example.com/station.jpg"
+
+
 def test_round_trip_bare_uris() -> None:
     """Test round-trip with bare URIs (no metadata) - migrated playlists."""
     items = [
@@ -690,7 +716,7 @@ def test_media_item_to_playlist_item_radio() -> None:
     assert result.album is None
     assert len(result.artists) == 0
     # a radio has no duration, which must still yield an #EXTINF line carrying the name
-    assert result.length == "-1"
+    assert result.length is None
     assert "#EXTINF:-1,Test FM" in generate_m3u("Radio Stations", [result])
 
 

--- a/tests/providers/builtin/test_parse_item_media_type.py
+++ b/tests/providers/builtin/test_parse_item_media_type.py
@@ -1,0 +1,64 @@
+"""Tests for how the builtin provider decides between a track and a radio station."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import Radio, Track
+
+from music_assistant.helpers.tags import AudioTags
+from music_assistant.providers.builtin import BuiltinProvider
+
+STREAM_URL = "http://stream.example.com/live"
+
+
+def _make_provider(icyname: str | None, duration: float | None) -> BuiltinProvider:
+    """Create a provider whose stream probe reports the given ICY name and duration."""
+    tags = AudioTags(
+        raw={},
+        sample_rate=44100,
+        channels=2,
+        bits_per_sample=16,
+        format="mp3",
+        bit_rate=320,
+        duration=duration,
+        tags={"icyname": icyname} if icyname else {},
+        has_cover_image=False,
+        filename=STREAM_URL,
+    )
+    prov = object.__new__(BuiltinProvider)
+    prov.mass = MagicMock()
+    prov.mass.config.get.side_effect = lambda _key, default=None: default
+    prov.logger = MagicMock()
+    prov.manifest = MagicMock()
+    prov.manifest.domain = "builtin"
+    prov.config = MagicMock()
+    prov.config.instance_id = "builtin_1"
+    prov._get_media_info = AsyncMock(return_value=tags)  # type: ignore[method-assign]
+    return prov
+
+
+async def test_requested_track_stays_a_track_with_an_icy_name() -> None:
+    """A track added by URL is not turned into a radio station by its stream."""
+    prov = _make_provider(icyname="SOME RADIO", duration=None)
+
+    result = await prov.parse_item(STREAM_URL, requested_media_type=MediaType.TRACK)
+
+    assert isinstance(result, Track)
+
+
+async def test_unknown_media_type_still_probes_and_decides() -> None:
+    """A plain URL of unknown media type is classified from what the stream reports."""
+    prov = _make_provider(icyname="SOME RADIO", duration=None)
+
+    result = await prov.parse_item(STREAM_URL, requested_media_type=MediaType.UNKNOWN)
+
+    assert isinstance(result, Radio)
+
+
+async def test_get_track_returns_a_track_for_a_stream_without_duration() -> None:
+    """get_track never hands back a radio station for a stream that reports no duration."""
+    prov = _make_provider(icyname=None, duration=None)
+
+    assert isinstance(await prov.get_track(STREAM_URL), Track)

--- a/tests/providers/builtin/test_playlist_entry_repair.py
+++ b/tests/providers/builtin/test_playlist_entry_repair.py
@@ -1,0 +1,197 @@
+"""Tests for detecting playlist entries that lost their manually set name or artwork."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from music_assistant_models.enums import ImageType, MediaType
+
+from music_assistant.helpers.playlists import (
+    ArtistInfo,
+    ImageInfo,
+    PlaylistItem,
+    ProviderMappingInfo,
+)
+from music_assistant.providers.builtin import BuiltinProvider
+from music_assistant.providers.builtin.constants import StoredItem
+
+STREAM_URL = "http://stream.example.com/live"
+
+
+def _make_provider() -> BuiltinProvider:
+    """Create a minimal BuiltinProvider with a mocked manifest and mass."""
+    prov = object.__new__(BuiltinProvider)
+    prov.mass = MagicMock()
+    prov.logger = MagicMock()
+    prov.manifest = MagicMock()
+    prov.manifest.domain = "builtin"
+    return prov
+
+
+def _make_entry(
+    name: str | None = "My Station",
+    image_path: str | None = None,
+    domain: str = "builtin",
+    media_type: str = MediaType.RADIO.value,
+) -> PlaylistItem:
+    """Create a playlist entry as parsed from an M3U file."""
+    metadata = {"media_type": media_type}
+    if name is not None:
+        metadata["name"] = name
+    return PlaylistItem(
+        path=f"builtin://radio/{STREAM_URL}",
+        title=name,
+        metadata=metadata,
+        providers=[ProviderMappingInfo(domain=domain, item_id=STREAM_URL)],
+        images=[ImageInfo(type=ImageType.THUMB.value, path=image_path, provider="builtin")]
+        if image_path
+        else [],
+    )
+
+
+def _stored(
+    name: str = "My Station", image_url: str | None = None
+) -> dict[str, dict[str, StoredItem]]:
+    """Create the per-media-type lookup of stored items keyed on item_id."""
+    stored_item = StoredItem(item_id=STREAM_URL, name=name)
+    if image_url:
+        stored_item["image_url"] = image_url
+    return {
+        MediaType.RADIO.value: {STREAM_URL: stored_item},
+        MediaType.TRACK.value: {},
+    }
+
+
+def test_no_builtin_mapping_is_never_stale() -> None:
+    """An entry without a builtin #EXTPROV is not ours to repair."""
+    prov = _make_provider()
+
+    assert prov._stored_details_differ(_make_entry(domain="spotify"), _stored()) is False
+
+
+def test_no_stored_item_is_never_stale() -> None:
+    """An entry that was not added manually has no stored details to compare against."""
+    prov = _make_provider()
+    lookup: dict[str, dict[str, StoredItem]] = {
+        MediaType.RADIO.value: {},
+        MediaType.TRACK.value: {},
+    }
+
+    assert prov._stored_details_differ(_make_entry(), lookup) is False
+
+
+def test_other_media_type_is_never_stale() -> None:
+    """Only manually added tracks and radio stations carry stored details."""
+    prov = _make_provider()
+
+    entry = _make_entry(media_type=MediaType.PODCAST_EPISODE.value)
+    assert prov._stored_details_differ(entry, _stored()) is False
+
+
+def test_matching_details_are_not_stale() -> None:
+    """An entry that already carries the stored name and image is left alone."""
+    prov = _make_provider()
+
+    entry = _make_entry(name="My Station", image_path="http://img.example.com/logo.png")
+    lookup = _stored(name="My Station", image_url="http://img.example.com/logo.png")
+    assert prov._stored_details_differ(entry, lookup) is False
+
+
+def test_differing_name_is_stale() -> None:
+    """An entry holding the name broadcast by the stream needs repair."""
+    prov = _make_provider()
+
+    entry = _make_entry(name="ICY BROADCAST NAME")
+    assert prov._stored_details_differ(entry, _stored(name="My Station")) is True
+
+
+def test_missing_stored_image_is_stale() -> None:
+    """An entry that lost the manually set artwork needs repair."""
+    prov = _make_provider()
+
+    entry = _make_entry(image_path=STREAM_URL)
+    lookup = _stored(image_url="http://img.example.com/logo.png")
+    assert prov._stored_details_differ(entry, lookup) is True
+
+
+def test_stored_item_without_image_is_not_stale() -> None:
+    """Cover art from the stream stays as long as the user set no image of their own."""
+    prov = _make_provider()
+
+    entry = _make_entry(image_path=STREAM_URL)
+    assert prov._stored_details_differ(entry, _stored()) is False
+
+
+def test_restore_writes_stored_name_and_image() -> None:
+    """Restoring a radio entry puts the stored name in both #EXTMA and #EXTINF."""
+    prov = _make_provider()
+    entry = _make_entry(name="ICY BROADCAST NAME", image_path=STREAM_URL)
+    lookup = _stored(image_url="http://img.example.com/logo.png")
+
+    prov._restore_stored_details(entry, lookup)
+
+    assert entry.metadata is not None
+    assert entry.metadata["name"] == "My Station"
+    assert entry.title == "My Station"
+    assert [(x.path, x.remotely_accessible) for x in entry.images] == [
+        ("http://img.example.com/logo.png", True)
+    ]
+    # a repaired entry must not be picked up again, or every run rewrites the file
+    assert prov._stored_details_differ(entry, lookup) is False
+
+
+def test_a_padded_stored_name_settles() -> None:
+    """An M3U file cannot hold surrounding whitespace, so it must not count as a difference."""
+    prov = _make_provider()
+    entry = _make_entry(name="My Station")
+
+    assert prov._stored_details_differ(entry, _stored(name="  My Station  ")) is False
+
+
+def test_restore_keeps_non_thumb_images() -> None:
+    """Restoring the artwork replaces the thumbnail but keeps other image types."""
+    prov = _make_provider()
+    entry = _make_entry(image_path=STREAM_URL)
+    entry.images.append(
+        ImageInfo(type=ImageType.FANART.value, path="http://img.example.com/art.png", provider="x")
+    )
+
+    prov._restore_stored_details(entry, _stored(image_url="http://img.example.com/logo.png"))
+
+    assert [x.type for x in entry.images] == [ImageType.THUMB.value, ImageType.FANART.value]
+
+
+def test_restore_rebuilds_a_track_title_from_its_artists() -> None:
+    """A track's #EXTINF holds "<artists> - <name>", the way the entry was written."""
+    prov = _make_provider()
+    entry = _make_entry(name="Some Artist - Old Name", media_type=MediaType.TRACK.value)
+    entry.artists = [
+        ArtistInfo(
+            name="Some Artist", provider_domain="builtin", item_id="x", provider_instance="builtin"
+        )
+    ]
+    stored_item = StoredItem(item_id=STREAM_URL, name="My Song")
+    lookup = {MediaType.RADIO.value: {}, MediaType.TRACK.value: {STREAM_URL: stored_item}}
+
+    prov._restore_stored_details(entry, lookup)
+
+    assert entry.metadata is not None
+    assert entry.metadata["name"] == "My Song"
+    assert entry.title == "Some Artist - My Song"
+    assert prov._stored_details_differ(entry, lookup) is False
+
+
+def test_restore_without_stored_item_changes_nothing() -> None:
+    """An entry that was not added manually is left untouched."""
+    prov = _make_provider()
+    entry = _make_entry(name="Broadcast Name")
+    lookup: dict[str, dict[str, StoredItem]] = {
+        MediaType.RADIO.value: {},
+        MediaType.TRACK.value: {},
+    }
+
+    prov._restore_stored_details(entry, lookup)
+
+    assert entry.metadata is not None
+    assert entry.metadata["name"] == "Broadcast Name"
+    assert entry.title == "Broadcast Name"

--- a/tests/providers/builtin/test_playlist_entry_repair.py
+++ b/tests/providers/builtin/test_playlist_entry_repair.py
@@ -114,6 +114,20 @@ def test_missing_stored_image_is_stale() -> None:
     assert prov._stored_details_differ(entry, lookup) is True
 
 
+def test_stored_image_as_another_type_is_stale() -> None:
+    """The stored image only counts as present when it is the thumbnail that shows."""
+    prov = _make_provider()
+    entry = _make_entry(image_path=STREAM_URL)
+    entry.images.append(
+        ImageInfo(
+            type=ImageType.FANART.value, path="http://img.example.com/logo.png", provider="builtin"
+        )
+    )
+
+    lookup = _stored(image_url="http://img.example.com/logo.png")
+    assert prov._stored_details_differ(entry, lookup) is True
+
+
 def test_stored_item_without_image_is_not_stale() -> None:
     """Cover art from the stream stays as long as the user set no image of their own."""
     prov = _make_provider()


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

A radio station added by URL stores its user supplied name and image in the builtin provider config, but two things conspired to throw that away for stations sitting in a playlist:

- `MusicController.get_item()` resolved builtin radio/track URIs straight through `parse_item()`, which names the item after the stream's ICY name and has no image. It now goes through `get_radio()`/`get_track()`, which apply the stored details. Plain URLs of an unknown media type still use parse_item().
- generate_m3u() only wrote #EXTINF when a length was set, so a radio (which has none) lost its title on every playlist rewrite. The entry then looked unresolved to the playlist migration task, which re-fetched it from the provider and persisted the default name with no artwork.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5999

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
