### PR TITLE
Fix Sonos S1 speakers hanging after a failed subscription

### DIFF
--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -424,9 +424,8 @@ class SonosPlayer(Player):
                     raise SonosSubscriptionsFailed
             except SonosSubscriptionsFailed:
                 self.logger.warning("Creating subscriptions failed for %s", self.display_name)
-                assert self._subscription_lock is not None
-                async with self._subscription_lock:
-                    await self.offline()
+                # the subscription lock is already held here and is not reentrant
+                await self.offline()
 
     async def unsubscribe(self) -> None:
         """Cancel all subscriptions."""

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -285,25 +285,23 @@ async def test_unsubscribe_drops_subscriptions_even_when_cancelled() -> None:
     assert player.missing_subscriptions == SUBSCRIPTION_SERVICES
 
 
-async def _subscribe_with_failing_speaker(player: SonosPlayer) -> AsyncMock:
+async def _subscribe_with_failing_speaker(player: SonosPlayer) -> None:
     """Let the given player attempt to subscribe to a speaker that cannot be reached."""
-    offline = AsyncMock()
     with (
         patch.object(player, "_subscribe_target", AsyncMock(side_effect=OSError("unreachable"))),
-        patch.object(player, "offline", offline),
+        patch.object(player, "update_state"),
     ):
         async with asyncio.timeout(5):
             await player.subscribe()
-    return offline
 
 
 async def test_failed_subscribe_marks_the_speaker_offline() -> None:
     """A failed subscription must take the speaker offline and release the lock."""
     player = SonosPlayer(provider=MagicMock(), soco=_make_soco())
 
-    offline = await _subscribe_with_failing_speaker(player)
+    await _subscribe_with_failing_speaker(player)
 
-    offline.assert_awaited_once()
+    assert player.available is False
     assert player._subscription_lock is not None
     assert not player._subscription_lock.locked()
 

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -283,3 +283,38 @@ async def test_unsubscribe_drops_subscriptions_even_when_cancelled() -> None:
 
     assert player._subscriptions == []
     assert player.missing_subscriptions == SUBSCRIPTION_SERVICES
+
+
+async def _subscribe_with_failing_speaker(player: SonosPlayer) -> AsyncMock:
+    """Let the given player attempt to subscribe to a speaker that cannot be reached."""
+    offline = AsyncMock()
+    with (
+        patch.object(player, "_subscribe_target", AsyncMock(side_effect=OSError("unreachable"))),
+        patch.object(player, "offline", offline),
+    ):
+        async with asyncio.timeout(5):
+            await player.subscribe()
+    return offline
+
+
+async def test_failed_subscribe_marks_the_speaker_offline() -> None:
+    """A failed subscription must take the speaker offline and release the lock."""
+    player = SonosPlayer(provider=MagicMock(), soco=_make_soco())
+
+    offline = await _subscribe_with_failing_speaker(player)
+
+    offline.assert_awaited_once()
+    assert player._subscription_lock is not None
+    assert not player._subscription_lock.locked()
+
+
+async def test_speaker_can_resubscribe_after_a_failed_subscribe() -> None:
+    """A speaker that failed to subscribe must still be able to subscribe later."""
+    player = SonosPlayer(provider=MagicMock(), soco=_make_soco())
+    await _subscribe_with_failing_speaker(player)
+
+    with patch.object(player, "_subscribe_target", AsyncMock()) as subscribe_target:
+        async with asyncio.timeout(5):
+            await player.subscribe()
+
+    assert subscribe_target.await_count == len(SUBSCRIPTION_SERVICES)


### PR DESCRIPTION
# What does this implement/fix?

When a Sonos S1 speaker fails to create its event subscriptions — a flaky speaker, a network hiccup, a speaker rebooting — the error handler tried to take the subscription lock that the surrounding block was already holding. That lock is not reentrant, so the speaker got stuck there permanently, still holding the lock. It was never marked offline, never retried, and every later attempt to subscribe got stuck behind it too.

If that happened while the speaker was being set up during discovery, it took the whole provider down with it: discovery waits on each speaker's setup without a timeout, so the discovery run never finished, no further discovery was ever started, the provider never finished loading, and reloading it hung as well. One flaky speaker was enough.

The speaker is now taken offline directly, since the lock is already held.

Changes:

- Don't re-take the subscription lock in the failure path.
- Tests covering that a failed subscription takes the speaker offline and that it can subscribe again afterwards.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
