### PR TITLE
Keep ffmpeg's per-input read options with the input they belong to

### DIFF
--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -522,7 +522,7 @@ def get_ffmpeg_args(
         extra_input_args = []
     if extra_output_args is None:
         extra_output_args = []
-    # args that apply to the command as a whole
+    # the binary plus the options that apply to the command as a whole
     global_args = [
         "ffmpeg",
         "-hide_banner",
@@ -654,11 +654,11 @@ def get_ffmpeg_args(
         filter_params.append(resample_filter)
 
     # a complex fragment brings its own inputs, which must follow the main input
-    extra_input_args, filter_args = (
+    filter_input_args, filter_args = (
         _build_filtergraph_args(filter_params) if filter_params else ([], [])
     )
 
-    return global_args + input_args + extra_input_args + filter_args + extra_args + output_args
+    return global_args + input_args + filter_input_args + filter_args + extra_args + output_args
 
 
 def get_ffmpeg_channel_args(audio_format: AudioFormat) -> list[str]:

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -522,22 +522,20 @@ def get_ffmpeg_args(
         extra_input_args = []
     if extra_output_args is None:
         extra_output_args = []
-    # generic args
-    generic_args = [
+    # args that apply to the command as a whole
+    global_args = [
         "ffmpeg",
         "-hide_banner",
         "-loglevel",
         loglevel,
         "-nostats",
         "-ignore_unknown",
-        *_INPUT_READ_ARGS,
     ]
-    # collect input args
-    if "-f" in extra_input_args:
-        # input format is already specified in the extra input args
-        input_args = extra_input_args
-    else:
-        input_args = [*extra_input_args]
+    # collect args for the main input, mirroring how _build_filtergraph_args opens the
+    # extra inputs: the read args lead the group so the caller can still override them
+    input_args = [*_INPUT_READ_ARGS, *extra_input_args]
+    if "-f" not in extra_input_args:
+        # without an input format of their own, the caller leaves the input spec to us
         if input_path.startswith("http"):
             # append reconnect options for direct stream from http
             input_args += [
@@ -660,7 +658,7 @@ def get_ffmpeg_args(
         _build_filtergraph_args(filter_params) if filter_params else ([], [])
     )
 
-    return generic_args + input_args + extra_input_args + filter_args + extra_args + output_args
+    return global_args + input_args + extra_input_args + filter_args + extra_args + output_args
 
 
 def get_ffmpeg_channel_args(audio_format: AudioFormat) -> list[str]:

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -694,13 +694,25 @@ def test_overlay_args_probe_the_main_input_and_add_no_filters() -> None:
     assert not any(arg.startswith(("pan=", "aresample=resampler=")) for arg in args)
 
 
-def test_caller_supplied_input_format_still_gets_the_read_args() -> None:
-    """An input the caller specifies in full is still opened under our read limits."""
-    # the concat demuxer needs the protocol whitelist to open the files it lists
-    extra_input_args = ["-safe", "0", "-f", "concat", "-i", "/list.txt"]
+@pytest.mark.parametrize(
+    "extra_input_args",
+    [
+        # the concat demuxer brings its own -f, and needs the whitelist for the listed files
+        ["-safe", "0", "-f", "concat", "-i", "/list.txt"],
+        # a caller raising the probe limits relies on its own values landing last
+        ["-probesize", "65536", "-analyzeduration", "5000000"],
+    ],
+    ids=["caller-supplied-input-format", "caller-raised-probe-limits"],
+)
+def test_read_args_lead_the_main_input(extra_input_args: list[str]) -> None:
+    """Every main input is opened under our read limits, which the caller may override."""
     args = get_ffmpeg_args(_PCM_FORMAT, _PCM_FORMAT, [], extra_input_args=extra_input_args)
-    assert args[args.index("-protocol_whitelist") : args.index("-safe")] == _INPUT_READ_ARGS
-    # the caller's own input spec is used as-is, so we add no second input
+    start = args.index("-protocol_whitelist")
+    end = start + len(_INPUT_READ_ARGS)
+    assert args[start:end] == _INPUT_READ_ARGS
+    # the caller's args follow ours within the same input group, so theirs win on a conflict
+    assert args[end : end + len(extra_input_args)] == extra_input_args
+    # exactly one input either way: we add ours only when the caller brings none
     assert args.count("-i") == 1
 
 

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -694,6 +694,16 @@ def test_overlay_args_probe_the_main_input_and_add_no_filters() -> None:
     assert not any(arg.startswith(("pan=", "aresample=resampler=")) for arg in args)
 
 
+def test_caller_supplied_input_format_still_gets_the_read_args() -> None:
+    """An input the caller specifies in full is still opened under our read limits."""
+    # the concat demuxer needs the protocol whitelist to open the files it lists
+    extra_input_args = ["-safe", "0", "-f", "concat", "-i", "/list.txt"]
+    args = get_ffmpeg_args(_PCM_FORMAT, _PCM_FORMAT, [], extra_input_args=extra_input_args)
+    assert args[args.index("-protocol_whitelist") : args.index("-safe")] == _INPUT_READ_ARGS
+    # the caller's own input spec is used as-is, so we add no second input
+    assert args.count("-i") == 1
+
+
 # -- _log_reader_task (decode-error flood guard) --
 
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up cleanup on #5379. FFmpeg's `-protocol_whitelist`, `-probesize` and `-analyzeduration` only apply to the input they precede, but we kept them in a list called "generic args" together with the options that really are global (`-hide_banner`, `-loglevel`, `-nostats`, `-ignore_unknown`). That mix-up is what let the audio overlay swallow the main stream's read limits and stall playback startup by ~4.7s.

The generated command is unchanged — this only makes the distinction visible in the code so the same mistake is harder to make again.

**Related issue (if applicable):**

- follow-up on #5379

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- `generic_args` renamed to `global_args` and now holds only genuinely global options.
- The read args are emitted as the head of the main input's own argument group, the same way `_build_filtergraph_args` already opens every extra input.
- Both input branches are covered, including the one where the caller supplies its own `-f` (the concat demuxer, which needs the protocol whitelist to open the files it lists). Keeping the read args ahead of `extra_input_args` also preserves the existing behaviour that a caller can override them.
- Added a regression test for that caller-supplied-format branch.

Verified by diffing `get_ffmpeg_args()` output across 32 cases (PCM/FLAC/MP3/AAC/WAV/NUT/null outputs, mono/stereo/5.1, http and file inputs, the overlay and convolution paths, and the concat branch): byte-for-byte identical before and after.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
