### PR TITLE
Fix Bluesound players cutting off the end of a track

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -652,6 +652,13 @@ CONF_ENTRY_HTTP_PROFILE_FORCED_2 = ConfigEntry.from_dict(
         "hidden": True,
     }
 )
+CONF_ENTRY_HTTP_PROFILE_FORCED_3 = ConfigEntry.from_dict(
+    {
+        **CONF_ENTRY_HTTP_PROFILE.to_dict(),
+        "default_value": "forced_content_length",
+        "hidden": True,
+    }
+)
 CONF_ENTRY_HTTP_PROFILE_HIDDEN = ConfigEntry.from_dict(
     {**CONF_ENTRY_HTTP_PROFILE.to_dict(), "hidden": True}
 )

--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -1376,13 +1376,17 @@ def _migrate_output_limiter(data: dict[str, Any]) -> bool:
     return changed
 
 
+# the only HTTP profile BluOS devices play back correctly on
+FORCED_HTTP_PROFILE = "forced_content_length"
+
+
 def _migrate_bluesound_http_profile(data: dict[str, Any]) -> bool:
     """
     Drop the stored HTTP profile of Bluesound players.
 
-    BluOS devices keep looping the audio on any profile other than the forced content
-    length one, so the setting is no longer offered. Stored picks are removed rather than
-    kept, otherwise a player left on another profile would stay broken with no way back.
+    BluOS keeps looping the audio on any profile other than the forced content length one,
+    so the setting is no longer offered. Stored picks are removed rather than kept,
+    otherwise a player left on another profile would stay broken with no way back.
     """
     all_player_configs = data.get(CONF_PLAYERS, {})
     if not isinstance(all_player_configs, dict):
@@ -1394,7 +1398,9 @@ def _migrate_bluesound_http_profile(data: dict[str, Any]) -> bool:
         if not str(player_cfg.get("provider", "")).startswith("bluesound"):
             continue
         player_values = player_cfg.get("values")
-        if isinstance(player_values, dict) and CONF_HTTP_PROFILE in player_values:
+        if not isinstance(player_values, dict):
+            continue
+        if player_values.get(CONF_HTTP_PROFILE, FORCED_HTTP_PROFILE) != FORCED_HTTP_PROFILE:
             del player_values[CONF_HTTP_PROFILE]
             changed = True
     if changed:

--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -1382,11 +1382,11 @@ FORCED_HTTP_PROFILE = "forced_content_length"
 
 def _migrate_bluesound_http_profile(data: dict[str, Any]) -> bool:
     """
-    Drop the stored HTTP profile of Bluesound players.
+    Drop a stored HTTP profile that Bluesound players can no longer select.
 
     BluOS keeps looping the audio on any profile other than the forced content length one,
-    so the setting is no longer offered. Stored picks are removed rather than kept,
-    otherwise a player left on another profile would stay broken with no way back.
+    so the setting is no longer offered. A player left on another profile would stay broken
+    with no way back, so that pick is removed.
     """
     all_player_configs = data.get(CONF_PLAYERS, {})
     if not isinstance(all_player_configs, dict):

--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -14,6 +14,7 @@ from music_assistant.constants import (
     CONF_CORE,
     CONF_CROSSFADE_DURATION,
     CONF_CROSSFADE_MODE,
+    CONF_HTTP_PROFILE,
     CONF_ICON,
     CONF_LINKED_PROTOCOL_IDS,
     CONF_NFS_SUBFOLDER_MIGRATED,
@@ -606,6 +607,12 @@ async def migrate(data: dict[str, Any]) -> bool:  # noqa: PLR0915
     # back to the player-type default.
     # TODO: remove after 2.12 release
     if _migrate_player_icons(data):
+        changed = True
+
+    # Drop the stored HTTP profile of Bluesound players; the setting is no longer offered
+    # because BluOS only plays back correctly on the forced content length profile.
+    # TODO: remove after 2.12 release
+    if _migrate_bluesound_http_profile(data):
         changed = True
 
     return changed
@@ -1366,6 +1373,32 @@ def _migrate_output_limiter(data: dict[str, Any]) -> bool:
             changed = True
     if changed:
         LOGGER.info("Removed the obsolete output limiter setting from the player configuration(s)")
+    return changed
+
+
+def _migrate_bluesound_http_profile(data: dict[str, Any]) -> bool:
+    """
+    Drop the stored HTTP profile of Bluesound players.
+
+    BluOS devices keep looping the audio on any profile other than the forced content
+    length one, so the setting is no longer offered. Stored picks are removed rather than
+    kept, otherwise a player left on another profile would stay broken with no way back.
+    """
+    all_player_configs = data.get(CONF_PLAYERS, {})
+    if not isinstance(all_player_configs, dict):
+        return False
+    changed = False
+    for player_cfg in all_player_configs.values():
+        if not isinstance(player_cfg, dict):
+            continue
+        if not str(player_cfg.get("provider", "")).startswith("bluesound"):
+            continue
+        player_values = player_cfg.get("values")
+        if isinstance(player_values, dict) and CONF_HTTP_PROFILE in player_values:
+            del player_values[CONF_HTTP_PROFILE]
+            changed = True
+    if changed:
+        LOGGER.info("Restored the required HTTP profile on the Bluesound player configuration(s)")
     return changed
 
 

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -955,6 +955,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             queue.index_in_buffer = index
             queue_data.flow_mode_stream_log = []
             queue_data.flow_buffer_completed = None
+            queue_data.flow_queue_exhausted = None
             target_player = self.mass.players.get_player(queue_id)
             if target_player is None:
                 raise PlayerUnavailableError(f"Player {queue_id} is not available")
@@ -1384,7 +1385,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         if current_index is not None:
             self.mass.create_task(self._cleanup_stale_queue_buffers(queue_id, current_index))
 
-    def queue_buffer_completed(self, queue_id: str) -> None:
+    def queue_buffer_completed(self, queue_id: str, queue_exhausted: bool) -> None:
         """
         Call when the flow stream has finished generating all audio data for a queue.
 
@@ -1395,6 +1396,8 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         items have been added to the queue in the meantime, resuming playback if so.
 
         :param queue_id: The queue ID.
+        :param queue_exhausted: Whether the flow ended because the queue ran out of items,
+            as opposed to ending early to restart on a format change or a live item.
         """
         queue = self.get(queue_id)
         if not queue:
@@ -1407,6 +1410,8 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         # record so player providers can detect flow EOF without an idle report
         if original_session_id is not None:
             queue_data.flow_buffer_completed = original_session_id
+            if queue_exhausted:
+                queue_data.flow_queue_exhausted = original_session_id
 
         async def _resume_on_idle() -> None:
             # wait for the player to finish playing the buffered audio and go idle
@@ -1452,6 +1457,22 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         if queue_data is None or queue_data.session_id is None:
             return False
         return queue_data.flow_buffer_completed == queue_data.session_id
+
+    def flow_queue_exhausted(self, queue_id: str, session_id: str) -> bool:
+        """
+        Return whether the given flow stream session played the queue to its end.
+
+        False while a session is still streaming, and for a flow stream that ended early
+        to be restarted (a format change or a live item), where the player is expected to
+        pick up the next stream right away.
+
+        :param queue_id: The queue ID.
+        :param session_id: The stream session to check.
+        """
+        queue_data = self.queue_data_or_none(queue_id)
+        if queue_data is None or queue_data.session_id != session_id:
+            return False
+        return queue_data.flow_queue_exhausted == session_id
 
     # Main queue manipulation methods
 

--- a/music_assistant/controllers/player_queues/state.py
+++ b/music_assistant/controllers/player_queues/state.py
@@ -58,6 +58,9 @@ class PlayerQueueData:
     last_counted_play: str | None = None
     # session_id whose flow stream was fully generated
     flow_buffer_completed: str | None = None
+    # session_id whose flow stream ended because the queue ran out of items, as opposed
+    # to ending early to restart on a format change or a live item
+    flow_queue_exhausted: str | None = None
     # the current stream session id (set when a stream starts, cleared between sessions)
     session_id: str | None = None
     # per-item play log for the active flow-mode stream

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2194,6 +2194,7 @@ class StreamsAudio:
             """Return True if a newer stream session has taken over this queue."""
             return pq_data.session_id != flow_session_id
 
+        queue_exhausted = False
         while True:
             # bail out early if a newer producer has taken over this queue,
             # so we don't append another entry to a stream log we no longer own
@@ -2215,6 +2216,7 @@ class StreamsAudio:
                         queue.queue_id, queue_track.queue_item_id
                     )
                 except QueueEmpty:
+                    queue_exhausted = True
                     break
 
             if self._flow_stream_needs_restart(
@@ -2556,7 +2558,7 @@ class StreamsAudio:
         if not _superseded():
             # inform the queue controller that all audio data has been generated
             # so it can handle the case where new items were added after the flow stream ended
-            self.mass.player_queues.queue_buffer_completed(queue.queue_id)
+            self.mass.player_queues.queue_buffer_completed(queue.queue_id, queue_exhausted)
 
     async def get_overlay_mixed_stream(
         self,

--- a/music_assistant/controllers/streams/constants.py
+++ b/music_assistant/controllers/streams/constants.py
@@ -43,11 +43,12 @@ BUFFER_SIZE_MAP: Final[dict[str, int]] = {
 # Buffer size for radio streams (short rolling buffer)
 RADIO_BUFFER_SIZE: Final[int] = 15
 
-# Time to keep the flow stream response open after the last audio byte was written.
+# Time to keep the flow stream response open after the last audio byte of a queue.
 # Players buffer a few seconds ahead of what they actually render; some of them drop
 # that buffer the moment the connection is closed, cutting off the end of the queue.
-# Holding the (idle) connection open gives them time to play it out first.
-FLOW_STREAM_LEAD_OUT_SECONDS: Final[int] = 12
+# Holding the (idle) connection open gives them time to play it out first. Kept below
+# the webserver shutdown timeout so a lead-out never stalls a restart of the server.
+FLOW_STREAM_LEAD_OUT_SECONDS: Final[int] = 8
 
 
 # Configuration keys

--- a/music_assistant/controllers/streams/constants.py
+++ b/music_assistant/controllers/streams/constants.py
@@ -43,6 +43,12 @@ BUFFER_SIZE_MAP: Final[dict[str, int]] = {
 # Buffer size for radio streams (short rolling buffer)
 RADIO_BUFFER_SIZE: Final[int] = 15
 
+# Time to keep the flow stream response open after the last audio byte was written.
+# Players buffer a few seconds ahead of what they actually render; some of them drop
+# that buffer the moment the connection is closed, cutting off the end of the queue.
+# Holding the (idle) connection open gives them time to play it out first.
+FLOW_STREAM_LEAD_OUT_SECONDS: Final[int] = 12
+
 
 # Configuration keys
 CONF_BUFFER_SIZE: Final[str] = "buffer_size"

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1111,7 +1111,9 @@ class StreamsController(CoreController):
             # restarting (or completely failing) the audio stream by keeping the buffer short.
             # this is reported to be an issue especially with Chromecast players.
             # see for example: https://github.com/music-assistant/support/issues/3717
-            # allow buffer ahead of a few seconds and read rest in (near) realtime
+            # allow buffer ahead of a few seconds and read rest in (near) realtime.
+            # staying close to realtime also keeps the amount a player has buffered but not
+            # yet rendered predictable, which is what the lead-out below has to cover.
             extra_input_args=["-readrate", "1.05", "-readrate_initial_burst", "5"],
             chunk_size=icy_meta_interval if enable_icy else calculate_content_length(output_format),
         )
@@ -1651,15 +1653,21 @@ class StreamsController(CoreController):
             # either a newer stream session took over, or this flow ended early to be
             # restarted right away - in both cases there is no tail to play out
             return
-        # keep_alive tells us whether the player will actually see the connection close:
-        # aiohttp derives that from the request, so our own 'Connection: close' header is
-        # relayed to the player but never applied to the response itself.
+        if keep_alive:
+            # aiohttp decides this from the request, so our own 'Connection: close' header
+            # is relayed to the player but never applied to the response: the connection
+            # outlives the handler anyway and there is nothing to postpone.
+            self.logger.debug(
+                "Flow stream for queue %s exhausted - connection is kept alive, "
+                "so the player is not waiting on us to close it",
+                queue_id,
+            )
+            return
         self.logger.debug(
             "Flow stream for queue %s exhausted - holding the connection open for %ss "
-            "so the player can play out its buffer (keep_alive: %s)",
+            "so the player can play out its buffer",
             queue_id,
             FLOW_STREAM_LEAD_OUT_SECONDS,
-            keep_alive,
         )
         await asyncio.sleep(FLOW_STREAM_LEAD_OUT_SECONDS)
 

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1160,7 +1160,7 @@ class StreamsController(CoreController):
             self._active_output_streams -= 1
 
         if not client_disconnected and http_profile == "forced_content_length":
-            await self._flow_stream_lead_out(queue_id, session_id, keep_alive=resp.keep_alive)
+            await self._flow_stream_lead_out(resp, queue_id, session_id)
 
         return resp
 
@@ -1640,28 +1640,18 @@ class StreamsController(CoreController):
         return announce_player.get_output_config_value(CONF_HTTP_PROFILE, "default")
 
     async def _flow_stream_lead_out(
-        self, queue_id: str, session_id: str, keep_alive: bool | None
+        self, resp: web.StreamResponse, queue_id: str, session_id: str
     ) -> None:
         """
         Keep an exhausted flow stream response open so the player can play out its buffer.
 
+        :param resp: The flow stream response, already fully written.
         :param queue_id: Id of the queue the flow stream belongs to.
         :param session_id: Stream session this response was opened for.
-        :param keep_alive: Whether the connection will be reused instead of closed.
         """
         if not self.mass.player_queues.flow_queue_exhausted(queue_id, session_id):
             # either a newer stream session took over, or this flow ended early to be
             # restarted right away - in both cases there is no tail to play out
-            return
-        if keep_alive:
-            # aiohttp decides this from the request, so our own 'Connection: close' header
-            # is relayed to the player but never applied to the response: the connection
-            # outlives the handler anyway and there is nothing to postpone.
-            self.logger.debug(
-                "Flow stream for queue %s exhausted - connection is kept alive, "
-                "so the player is not waiting on us to close it",
-                queue_id,
-            )
             return
         self.logger.debug(
             "Flow stream for queue %s exhausted - holding the connection open for %ss "
@@ -1670,6 +1660,10 @@ class StreamsController(CoreController):
             FLOW_STREAM_LEAD_OUT_SECONDS,
         )
         await asyncio.sleep(FLOW_STREAM_LEAD_OUT_SECONDS)
+        # aiohttp derives keep-alive from the request, so the 'Connection: close' we
+        # advertise is relayed to the player but never applied to the response itself.
+        # Without this the player is left waiting on a stream that already ended.
+        resp.force_close()
 
     def _log_request(self, request: web.Request) -> None:
         """Log request."""

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -7,6 +7,7 @@ purely to stream audio packets to players.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import struct
@@ -83,6 +84,7 @@ from music_assistant.controllers.streams.constants import (
     CONF_BUFFER_SIZE_DEFAULT,
     CONF_SMART_FADES_LOG_LEVEL,
     DEFAULT_PORT,
+    FLOW_STREAM_LEAD_OUT_SECONDS,
     BufferSize,
     get_available_buffer_sizes,
 )
@@ -1110,9 +1112,10 @@ class StreamsController(CoreController):
             # this is reported to be an issue especially with Chromecast players.
             # see for example: https://github.com/music-assistant/support/issues/3717
             # allow buffer ahead of a few seconds and read rest in (near) realtime
-            extra_input_args=["-readrate", "1.1", "-readrate_initial_burst", "5"],
+            extra_input_args=["-readrate", "1.05", "-readrate_initial_burst", "5"],
             chunk_size=icy_meta_interval if enable_icy else calculate_content_length(output_format),
         )
+        client_disconnected = False
         try:
             # aclosing guarantees the flow stream (and thus the ffmpeg process chain
             # behind it) is torn down immediately when the player disconnects
@@ -1124,6 +1127,7 @@ class StreamsController(CoreController):
                         await resp.write(chunk)
                     except BrokenPipeError, ConnectionResetError, ConnectionError:
                         # race condition
+                        client_disconnected = True
                         break
 
                     if not enable_icy:
@@ -1152,6 +1156,9 @@ class StreamsController(CoreController):
                     await resp.write(length_b + metadata)
         finally:
             self._active_output_streams -= 1
+
+        if not client_disconnected and http_profile == "forced_content_length":
+            await self._flow_stream_lead_out(queue_id, session_id, keep_alive=resp.keep_alive)
 
         return resp
 
@@ -1630,6 +1637,32 @@ class StreamsController(CoreController):
             return "default"
         return announce_player.get_output_config_value(CONF_HTTP_PROFILE, "default")
 
+    async def _flow_stream_lead_out(
+        self, queue_id: str, session_id: str, keep_alive: bool | None
+    ) -> None:
+        """
+        Keep an exhausted flow stream response open so the player can play out its buffer.
+
+        :param queue_id: Id of the queue the flow stream belongs to.
+        :param session_id: Stream session this response was opened for.
+        :param keep_alive: Whether the connection will be reused instead of closed.
+        """
+        queue_data = self.mass.player_queues.queue_data_or_none(queue_id)
+        if queue_data is None or queue_data.session_id != session_id:
+            # a newer stream session took over: this response's audio is stale
+            return
+        # keep_alive tells us whether the player will actually see the connection close:
+        # aiohttp derives that from the request, so our own 'Connection: close' header is
+        # relayed to the player but never applied to the response itself.
+        self.logger.debug(
+            "Flow stream for queue %s exhausted - holding the connection open for %ss "
+            "so the player can play out its buffer (keep_alive: %s)",
+            queue_id,
+            FLOW_STREAM_LEAD_OUT_SECONDS,
+            keep_alive,
+        )
+        await asyncio.sleep(FLOW_STREAM_LEAD_OUT_SECONDS)
+
     def _log_request(self, request: web.Request) -> None:
         """Log request."""
         if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
@@ -1643,7 +1676,13 @@ class StreamsController(CoreController):
             )
         else:
             self.logger.debug(
-                "Got %s request to %s from %s", request.method, request.path, request.remote
+                "Got %s request to %s from %s (HTTP/%s.%s, connection: %s)",
+                request.method,
+                request.path,
+                request.remote,
+                request.version.major,
+                request.version.minor,
+                request.headers.get("Connection", "-"),
             )
 
     async def _reload_network_dependent_providers(self) -> None:

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1111,9 +1111,7 @@ class StreamsController(CoreController):
             # restarting (or completely failing) the audio stream by keeping the buffer short.
             # this is reported to be an issue especially with Chromecast players.
             # see for example: https://github.com/music-assistant/support/issues/3717
-            # allow buffer ahead of a few seconds and read rest in (near) realtime.
-            # staying close to realtime also keeps the amount a player has buffered but not
-            # yet rendered predictable, which is what the lead-out below has to cover.
+            # allow buffer ahead of a few seconds and read rest in (near) realtime
             extra_input_args=["-readrate", "1.05", "-readrate_initial_burst", "5"],
             chunk_size=icy_meta_interval if enable_icy else calculate_content_length(output_format),
         )
@@ -1160,7 +1158,7 @@ class StreamsController(CoreController):
             self._active_output_streams -= 1
 
         if not client_disconnected and http_profile == "forced_content_length":
-            await self._flow_stream_lead_out(resp, queue_id, session_id)
+            await self._finish_flow_stream(resp, queue_id, session_id)
 
         return resp
 
@@ -1639,27 +1637,28 @@ class StreamsController(CoreController):
             return "default"
         return announce_player.get_output_config_value(CONF_HTTP_PROFILE, "default")
 
-    async def _flow_stream_lead_out(
+    async def _finish_flow_stream(
         self, resp: web.StreamResponse, queue_id: str, session_id: str
     ) -> None:
         """
-        Keep an exhausted flow stream response open so the player can play out its buffer.
+        Close a fully served flow stream, giving the player time to drain when it ends the queue.
 
         :param resp: The flow stream response, already fully written.
         :param queue_id: Id of the queue the flow stream belongs to.
         :param session_id: Stream session this response was opened for.
         """
-        if not self.mass.player_queues.flow_queue_exhausted(queue_id, session_id):
-            # either a newer stream session took over, or this flow ended early to be
-            # restarted right away - in both cases there is no tail to play out
-            return
-        self.logger.debug(
-            "Flow stream for queue %s exhausted - holding the connection open for %ss "
-            "so the player can play out its buffer",
-            queue_id,
-            FLOW_STREAM_LEAD_OUT_SECONDS,
-        )
-        await asyncio.sleep(FLOW_STREAM_LEAD_OUT_SECONDS)
+        if self.mass.player_queues.flow_queue_exhausted(queue_id, session_id):
+            # the player is still holding a few seconds of audio it has not rendered yet
+            # and drops that as soon as the stream ends, so let it play out first.
+            # a flow that ends to be restarted right away gets no such grace: there the
+            # player should go idle as soon as possible so the next stream can start.
+            self.logger.debug(
+                "Flow stream for queue %s reached the end of the queue - holding the "
+                "connection open for %ss so the player can play out its buffer",
+                queue_id,
+                FLOW_STREAM_LEAD_OUT_SECONDS,
+            )
+            await asyncio.sleep(FLOW_STREAM_LEAD_OUT_SECONDS)
         # aiohttp derives keep-alive from the request, so the 'Connection: close' we
         # advertise is relayed to the player but never applied to the response itself.
         # Without this the player is left waiting on a stream that already ended.

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1647,9 +1647,9 @@ class StreamsController(CoreController):
         :param session_id: Stream session this response was opened for.
         :param keep_alive: Whether the connection will be reused instead of closed.
         """
-        queue_data = self.mass.player_queues.queue_data_or_none(queue_id)
-        if queue_data is None or queue_data.session_id != session_id:
-            # a newer stream session took over: this response's audio is stale
+        if not self.mass.player_queues.flow_queue_exhausted(queue_id, session_id):
+            # either a newer stream session took over, or this flow ended early to be
+            # restarted right away - in both cases there is no tail to play out
             return
         # keep_alive tells us whether the player will actually see the connection close:
         # aiohttp derives that from the request, so our own 'Connection: close' header is

--- a/music_assistant/helpers/webserver.py
+++ b/music_assistant/helpers/webserver.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
 MAX_CLIENT_SIZE: Final = 1024**2 * 16
 MAX_LINE_SIZE: Final = 24570
 
+# grace period handlers get to finish before they are cancelled on shutdown
+DEFAULT_SHUTDOWN_TIMEOUT: Final = 10
+
 # Type alias for dynamic route handlers
 DynamicRouteHandler = Callable[
     [web.Request], Coroutine[Any, Any, web.Response | web.StreamResponse]
@@ -101,7 +104,9 @@ class Webserver:
         if app_state:
             for key, value in app_state.items():
                 self._webapp[key] = value
-        self._apprunner = web.AppRunner(self._webapp, access_log=None, shutdown_timeout=10)
+        self._apprunner = web.AppRunner(
+            self._webapp, access_log=None, shutdown_timeout=DEFAULT_SHUTDOWN_TIMEOUT
+        )
         # add static routes
         if self._static_routes:
             for method, path, handler in self._static_routes:

--- a/music_assistant/providers/bluesound/const.py
+++ b/music_assistant/providers/bluesound/const.py
@@ -28,14 +28,6 @@ PLAYBACK_STATE_MAP = {
     "connecting": PlaybackState.IDLE,
 }
 
-PLAYBACK_STATE_POLL_MAP = {
-    "play": PlaybackState.PLAYING,
-    "stream": PlaybackState.PLAYING,
-    "stop": PlaybackState.IDLE,
-    "pause": PlaybackState.PAUSED,
-    "connecting": "CONNECTING",
-}
-
 SOURCE_TIDAL = "Tidal"
 SOURCE_AIRPLAY = "AirPlay"
 SOURCE_SPOTIFY = "Spotify"

--- a/music_assistant/providers/bluesound/const.py
+++ b/music_assistant/providers/bluesound/const.py
@@ -9,6 +9,10 @@ from music_assistant.models.player import PlayerSource
 IDLE_POLL_INTERVAL = 30
 PLAYBACK_POLL_INTERVAL = 10
 
+# how many polls a playing player may report 'connecting' before it counts as stopped.
+# spans the grace period the streams controller gives a player to empty its buffer.
+MAX_CONNECTING_POLLS = 2
+
 PLAYER_FEATURES_BASE = {
     PlayerFeature.PLAY_MEDIA,
     PlayerFeature.SET_MEMBERS,

--- a/music_assistant/providers/bluesound/player.py
+++ b/music_assistant/providers/bluesound/player.py
@@ -15,7 +15,7 @@ from pyblu.entities import Input, PairedPlayer, Preset
 from pyblu.errors import PlayerUnexpectedResponseError, PlayerUnreachableError
 
 from music_assistant.constants import (
-    CONF_ENTRY_HTTP_PROFILE_DEFAULT_3,
+    CONF_ENTRY_HTTP_PROFILE_FORCED_3,
     CONF_ENTRY_ICY_METADATA_DEFAULT_FULL,
     create_sample_rates_config_entry,
 )
@@ -92,7 +92,9 @@ class BluesoundPlayer(Player):
     async def get_config_entries(self) -> list[ConfigEntry]:
         """Return all (provider/player specific) Config Entries for the player."""
         return [
-            CONF_ENTRY_HTTP_PROFILE_DEFAULT_3,
+            # BluOS devices loop the audio forever on the other HTTP profiles,
+            # so this is not a choice we can leave to the user.
+            CONF_ENTRY_HTTP_PROFILE_FORCED_3,
             create_sample_rates_config_entry(
                 max_sample_rate=192000,
                 safe_max_sample_rate=192000,
@@ -327,6 +329,16 @@ class BluesoundPlayer(Player):
             duration=cast("int | None", self.status.total_seconds or None),
         )
 
+    def _resolve_playback_state(self) -> PlaybackState:
+        """Resolve the playback state from the reported BluOS transport state."""
+        # BluOS reports 'connecting' whenever it is (re)filling its buffer, including
+        # while it plays out the tail of a stream that stopped sending. Taking that as
+        # idle would end the queue while the player is still making sound, so we hold on
+        # to the playing state until BluOS reports a real stop.
+        if self.status.state == "connecting" and self._attr_playback_state == PlaybackState.PLAYING:
+            return PlaybackState.PLAYING
+        return PLAYBACK_STATE_MAP[self.status.state]
+
     async def update_attributes(self) -> None:
         """Update the BluOS player attributes."""
         self.logger.debug(f"updating {self.player_id} attributes")
@@ -347,7 +359,7 @@ class BluesoundPlayer(Player):
             self.logger.debug(f"Changing bluos poll state from {self.poll_state} to static")
             self.poll_state = POLL_STATE_STATIC
 
-        self._attr_playback_state = PLAYBACK_STATE_MAP[self.status.state]
+        self._attr_playback_state = self._resolve_playback_state()
 
         # Update polling interval
         if self.poll_state != POLL_STATE_DYNAMIC:

--- a/music_assistant/providers/bluesound/player.py
+++ b/music_assistant/providers/bluesound/player.py
@@ -23,6 +23,7 @@ from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia, PlayerSource
 from music_assistant.providers.bluesound.const import (
     IDLE_POLL_INTERVAL,
+    MAX_CONNECTING_POLLS,
     PLAYBACK_POLL_INTERVAL,
     PLAYBACK_STATE_MAP,
     PLAYER_FEATURES_BASE,
@@ -60,6 +61,7 @@ class BluesoundPlayer(Player):
         self.status: Status
         self.poll_state = POLL_STATE_STATIC
         self.dynamic_poll_count: int = 0
+        self._connecting_polls: int = 0
         self._listen_task: asyncio.Task[None] | None = None
         # Set base player attributes
         self._attr_supported_features = PLAYER_FEATURES_BASE.copy()
@@ -334,9 +336,14 @@ class BluesoundPlayer(Player):
         # BluOS reports 'connecting' whenever it is (re)filling its buffer, including
         # while it plays out the tail of a stream that stopped sending. Taking that as
         # idle would end the queue while the player is still making sound, so we hold on
-        # to the playing state until BluOS reports a real stop.
+        # to the playing state for a few polls. Beyond that the player is not buffering
+        # but stuck, and reporting it idle is what lets playback recover.
         if self.status.state == "connecting" and self._attr_playback_state == PlaybackState.PLAYING:
-            return PlaybackState.PLAYING
+            self._connecting_polls += 1
+            if self._connecting_polls <= MAX_CONNECTING_POLLS:
+                return PlaybackState.PLAYING
+        else:
+            self._connecting_polls = 0
         return PLAYBACK_STATE_MAP[self.status.state]
 
     async def update_attributes(self) -> None:

--- a/music_assistant/providers/bluesound/player.py
+++ b/music_assistant/providers/bluesound/player.py
@@ -92,7 +92,7 @@ class BluesoundPlayer(Player):
     async def get_config_entries(self) -> list[ConfigEntry]:
         """Return all (provider/player specific) Config Entries for the player."""
         return [
-            # BluOS devices loop the audio forever on the other HTTP profiles,
+            # BluOS keeps looping the audio on the other HTTP profiles,
             # so this is not a choice we can leave to the user.
             CONF_ENTRY_HTTP_PROFILE_FORCED_3,
             create_sample_rates_config_entry(

--- a/tests/controllers/config/test_migrations.py
+++ b/tests/controllers/config/test_migrations.py
@@ -91,6 +91,16 @@ def test_migrate_bluesound_http_profile_noop_when_absent() -> None:
     assert _migrate_bluesound_http_profile(data) is False
 
 
+def test_migrate_bluesound_http_profile_noop_when_already_required() -> None:
+    """A player already on the required profile needs no rewrite of the settings."""
+    data: dict[str, Any] = {
+        "players": {
+            "b1": {"provider": "bluesound", "values": {"http_profile": "forced_content_length"}}
+        }
+    }
+    assert _migrate_bluesound_http_profile(data) is False
+
+
 def _airplay_receiver_ghost_data() -> dict[str, Any]:
     """Build a config store with AirPlay Receiver ghost players next to real players."""
     return {

--- a/tests/controllers/config/test_migrations.py
+++ b/tests/controllers/config/test_migrations.py
@@ -19,6 +19,7 @@ from music_assistant.controllers.config.migrations import (
     PROVIDER_SETUP_FLOW_KEYS,
     _migrate_airplay_apple_power_control,
     _migrate_airplay_receiver_ghost_players,
+    _migrate_bluesound_http_profile,
     _migrate_bose_soundtouch_presets,
     _migrate_output_limiter,
     _migrate_player_icons,
@@ -63,6 +64,31 @@ def test_migrate_output_limiter_noop_when_absent() -> None:
     """Migration reports no change when no player stored the setting."""
     data: dict[str, Any] = {"players": {"p1": {"player_id": "p1", "values": {"flow_mode": True}}}}
     assert _migrate_output_limiter(data) is False
+
+
+def test_migrate_bluesound_http_profile_drops_stored_pick() -> None:
+    """A Bluesound player left on another HTTP profile is returned to the required one."""
+    data: dict[str, Any] = {
+        "players": {
+            "b1": {
+                "provider": "bluesound",
+                "values": {"http_profile": "chunked", "flow_mode": True},
+            },
+            "b2": {"provider": "bluesound--abc1", "values": {"http_profile": "no_content_length"}},
+            "c1": {"provider": "chromecast", "values": {"http_profile": "chunked"}},
+        }
+    }
+    assert _migrate_bluesound_http_profile(data) is True
+    assert data["players"]["b1"]["values"] == {"flow_mode": True}
+    assert data["players"]["b2"]["values"] == {}
+    # other providers still offer the setting, so their pick is left alone
+    assert data["players"]["c1"]["values"] == {"http_profile": "chunked"}
+
+
+def test_migrate_bluesound_http_profile_noop_when_absent() -> None:
+    """Migration reports no change when no Bluesound player stored a profile."""
+    data: dict[str, Any] = {"players": {"b1": {"provider": "bluesound", "values": {}}}}
+    assert _migrate_bluesound_http_profile(data) is False
 
 
 def _airplay_receiver_ghost_data() -> dict[str, Any]:

--- a/tests/controllers/player_queues/test_flow_stream_finished.py
+++ b/tests/controllers/player_queues/test_flow_stream_finished.py
@@ -57,7 +57,9 @@ def test_queue_buffer_completed_marks_session_finished() -> None:
     queue = MagicMock(queue_id="q", session_id="sess-1")
     fake = _fake_controller(queue)
 
-    PlayerQueuesController.queue_buffer_completed(cast("PlayerQueuesController", fake), "q")
+    PlayerQueuesController.queue_buffer_completed(
+        cast("PlayerQueuesController", fake), "q", queue_exhausted=True
+    )
 
     assert fake._queue_data["q"].flow_buffer_completed == "sess-1"
     assert _finished(fake, "q") is True
@@ -67,7 +69,9 @@ def test_flow_stream_finished_invalidated_by_new_session() -> None:
     """A completion from a previous session must not count for a fresh session."""
     queue = MagicMock(queue_id="q", session_id="sess-1")
     fake = _fake_controller(queue)
-    PlayerQueuesController.queue_buffer_completed(cast("PlayerQueuesController", fake), "q")
+    PlayerQueuesController.queue_buffer_completed(
+        cast("PlayerQueuesController", fake), "q", queue_exhausted=True
+    )
 
     # a new playback session starts (play_index assigns a fresh session_id)
     fake._queue_data["q"].session_id = "sess-2"
@@ -81,3 +85,56 @@ def test_flow_stream_finished_false_for_unknown_queue() -> None:
     fake = _fake_controller(queue)
 
     assert _finished(fake, "other") is False
+
+
+def _exhausted(fake: MagicMock, queue_id: str, session_id: str) -> bool:
+    return PlayerQueuesController.flow_queue_exhausted(
+        cast("PlayerQueuesController", fake), queue_id, session_id
+    )
+
+
+def test_flow_queue_exhausted_set_when_queue_ran_out() -> None:
+    """Playing the queue to its end marks the session as exhausted."""
+    queue = MagicMock(queue_id="q", session_id="sess-1")
+    fake = _fake_controller(queue)
+
+    PlayerQueuesController.queue_buffer_completed(
+        cast("PlayerQueuesController", fake), "q", queue_exhausted=True
+    )
+
+    assert _exhausted(fake, "q", "sess-1") is True
+
+
+def test_flow_queue_not_exhausted_on_early_restart() -> None:
+    """A flow that ended early to be restarted has no tail left to play out."""
+    queue = MagicMock(queue_id="q", session_id="sess-1")
+    fake = _fake_controller(queue)
+
+    PlayerQueuesController.queue_buffer_completed(
+        cast("PlayerQueuesController", fake), "q", queue_exhausted=False
+    )
+
+    assert fake._queue_data["q"].flow_buffer_completed == "sess-1"
+    assert _exhausted(fake, "q", "sess-1") is False
+
+
+def test_flow_queue_exhausted_invalidated_by_new_session() -> None:
+    """A previous session's end of queue must not count for a fresh session."""
+    queue = MagicMock(queue_id="q", session_id="sess-1")
+    fake = _fake_controller(queue)
+    PlayerQueuesController.queue_buffer_completed(
+        cast("PlayerQueuesController", fake), "q", queue_exhausted=True
+    )
+
+    fake._queue_data["q"].session_id = "sess-2"
+
+    assert _exhausted(fake, "q", "sess-1") is False
+    assert _exhausted(fake, "q", "sess-2") is False
+
+
+def test_flow_queue_exhausted_false_for_unknown_queue() -> None:
+    """An unknown queue id never reports an exhausted flow stream."""
+    queue = MagicMock(queue_id="q", session_id="sess-1")
+    fake = _fake_controller(queue)
+
+    assert _exhausted(fake, "other", "sess-1") is False

--- a/tests/controllers/streams/test_flow_stream_lead_out.py
+++ b/tests/controllers/streams/test_flow_stream_lead_out.py
@@ -46,6 +46,17 @@ async def test_skips_lead_out_when_flow_restarts() -> None:
 
 
 @pytest.mark.asyncio
+async def test_skips_lead_out_on_a_kept_alive_connection() -> None:
+    """A connection that outlives the response is not something the player waits on."""
+    controller = _controller(exhausted=True)
+    with patch(
+        "music_assistant.controllers.streams.controller.asyncio.sleep", new=AsyncMock()
+    ) as sleep:
+        await controller._flow_stream_lead_out(QUEUE_ID, SESSION_ID, keep_alive=True)
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_skips_lead_out_when_superseded() -> None:
     """A newer stream session owns playback, so the stale response must not linger."""
     controller = _controller(exhausted=True)

--- a/tests/controllers/streams/test_flow_stream_lead_out.py
+++ b/tests/controllers/streams/test_flow_stream_lead_out.py
@@ -23,45 +23,43 @@ def _controller(*, exhausted: bool) -> StreamsController:
     return StreamsController(mass)
 
 
-@pytest.mark.asyncio
-async def test_holds_connection_open_after_the_last_queue_item() -> None:
-    """A flow stream that played the queue to its end lets the player drain first."""
-    controller = _controller(exhausted=True)
+async def _lead_out(
+    controller: StreamsController, session_id: str = SESSION_ID
+) -> tuple[AsyncMock, MagicMock]:
+    """Run the lead-out against a stub response, returning the sleep and the response."""
+    resp = MagicMock()
     with patch(
         "music_assistant.controllers.streams.controller.asyncio.sleep", new=AsyncMock()
     ) as sleep:
-        await controller._flow_stream_lead_out(QUEUE_ID, SESSION_ID, keep_alive=False)
+        await controller._flow_stream_lead_out(resp, QUEUE_ID, session_id)
+    return sleep, resp
+
+
+@pytest.mark.asyncio
+async def test_holds_connection_open_after_the_last_queue_item() -> None:
+    """A flow stream that played the queue to its end lets the player drain first."""
+    sleep, _ = await _lead_out(_controller(exhausted=True))
     sleep.assert_awaited_once_with(FLOW_STREAM_LEAD_OUT_SECONDS)
+
+
+@pytest.mark.asyncio
+async def test_closes_the_connection_after_the_lead_out() -> None:
+    """The player only learns the stream ended once the connection is really closed."""
+    _, resp = await _lead_out(_controller(exhausted=True))
+    resp.force_close.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_skips_lead_out_when_flow_restarts() -> None:
     """A flow that ended early to be restarted must not delay the next stream."""
-    controller = _controller(exhausted=False)
-    with patch(
-        "music_assistant.controllers.streams.controller.asyncio.sleep", new=AsyncMock()
-    ) as sleep:
-        await controller._flow_stream_lead_out(QUEUE_ID, SESSION_ID, keep_alive=False)
+    sleep, resp = await _lead_out(_controller(exhausted=False))
     sleep.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_skips_lead_out_on_a_kept_alive_connection() -> None:
-    """A connection that outlives the response is not something the player waits on."""
-    controller = _controller(exhausted=True)
-    with patch(
-        "music_assistant.controllers.streams.controller.asyncio.sleep", new=AsyncMock()
-    ) as sleep:
-        await controller._flow_stream_lead_out(QUEUE_ID, SESSION_ID, keep_alive=True)
-    sleep.assert_not_awaited()
+    resp.force_close.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_skips_lead_out_when_superseded() -> None:
     """A newer stream session owns playback, so the stale response must not linger."""
-    controller = _controller(exhausted=True)
-    with patch(
-        "music_assistant.controllers.streams.controller.asyncio.sleep", new=AsyncMock()
-    ) as sleep:
-        await controller._flow_stream_lead_out(QUEUE_ID, "session-2", keep_alive=False)
+    sleep, resp = await _lead_out(_controller(exhausted=True), session_id="session-2")
     sleep.assert_not_awaited()
+    resp.force_close.assert_not_called()

--- a/tests/controllers/streams/test_flow_stream_lead_out.py
+++ b/tests/controllers/streams/test_flow_stream_lead_out.py
@@ -1,4 +1,4 @@
-"""Tests for the flow stream lead-out that lets players play out their buffer."""
+"""Tests for how a fully served flow stream is closed off."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ import pytest
 
 from music_assistant.controllers.streams.constants import FLOW_STREAM_LEAD_OUT_SECONDS
 from music_assistant.controllers.streams.controller import StreamsController
+from music_assistant.helpers.webserver import DEFAULT_SHUTDOWN_TIMEOUT
 
 SESSION_ID = "session-1"
 QUEUE_ID = "queue-1"
@@ -23,43 +24,48 @@ def _controller(*, exhausted: bool) -> StreamsController:
     return StreamsController(mass)
 
 
-async def _lead_out(
+async def _finish(
     controller: StreamsController, session_id: str = SESSION_ID
 ) -> tuple[AsyncMock, MagicMock]:
-    """Run the lead-out against a stub response, returning the sleep and the response."""
+    """Finish a flow stream against a stub response, returning the sleep and the response."""
     resp = MagicMock()
     with patch(
         "music_assistant.controllers.streams.controller.asyncio.sleep", new=AsyncMock()
     ) as sleep:
-        await controller._flow_stream_lead_out(resp, QUEUE_ID, session_id)
+        await controller._finish_flow_stream(resp, QUEUE_ID, session_id)
     return sleep, resp
 
 
 @pytest.mark.asyncio
 async def test_holds_connection_open_after_the_last_queue_item() -> None:
     """A flow stream that played the queue to its end lets the player drain first."""
-    sleep, _ = await _lead_out(_controller(exhausted=True))
+    sleep, _ = await _finish(_controller(exhausted=True))
     sleep.assert_awaited_once_with(FLOW_STREAM_LEAD_OUT_SECONDS)
 
 
 @pytest.mark.asyncio
 async def test_closes_the_connection_after_the_lead_out() -> None:
     """The player only learns the stream ended once the connection is really closed."""
-    _, resp = await _lead_out(_controller(exhausted=True))
+    _, resp = await _finish(_controller(exhausted=True))
     resp.force_close.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_skips_lead_out_when_flow_restarts() -> None:
-    """A flow that ended early to be restarted must not delay the next stream."""
-    sleep, resp = await _lead_out(_controller(exhausted=False))
+async def test_closes_without_delay_when_the_flow_restarts() -> None:
+    """A flow that ended early must free the player at once so the next stream can start."""
+    sleep, resp = await _finish(_controller(exhausted=False))
     sleep.assert_not_awaited()
-    resp.force_close.assert_not_called()
+    resp.force_close.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_skips_lead_out_when_superseded() -> None:
+async def test_closes_without_delay_when_superseded() -> None:
     """A newer stream session owns playback, so the stale response must not linger."""
-    sleep, resp = await _lead_out(_controller(exhausted=True), session_id="session-2")
+    sleep, resp = await _finish(_controller(exhausted=True), session_id="session-2")
     sleep.assert_not_awaited()
-    resp.force_close.assert_not_called()
+    resp.force_close.assert_called_once()
+
+
+def test_lead_out_fits_within_the_webserver_shutdown_budget() -> None:
+    """A lead-out in flight must not outlive the shutdown grace period."""
+    assert FLOW_STREAM_LEAD_OUT_SECONDS < DEFAULT_SHUTDOWN_TIMEOUT

--- a/tests/controllers/streams/test_flow_stream_lead_out.py
+++ b/tests/controllers/streams/test_flow_stream_lead_out.py
@@ -13,21 +13,20 @@ SESSION_ID = "session-1"
 QUEUE_ID = "queue-1"
 
 
-def _controller(session_id: str | None) -> StreamsController:
-    """Build a streams controller whose queue reports the given active stream session."""
+def _controller(*, exhausted: bool) -> StreamsController:
+    """Build a streams controller whose queue reports the given end-of-queue state."""
     mass = MagicMock()
     mass.config.get_raw_core_config_value.return_value = "GLOBAL"
-    if session_id is None:
-        mass.player_queues.queue_data_or_none.return_value = None
-    else:
-        mass.player_queues.queue_data_or_none.return_value = MagicMock(session_id=session_id)
+    mass.player_queues.flow_queue_exhausted = MagicMock(
+        side_effect=lambda qid, sid: exhausted and (qid, sid) == (QUEUE_ID, SESSION_ID)
+    )
     return StreamsController(mass)
 
 
 @pytest.mark.asyncio
-async def test_holds_connection_open_for_the_lead_out() -> None:
-    """A finished flow stream keeps its connection open so the player can drain."""
-    controller = _controller(SESSION_ID)
+async def test_holds_connection_open_after_the_last_queue_item() -> None:
+    """A flow stream that played the queue to its end lets the player drain first."""
+    controller = _controller(exhausted=True)
     with patch(
         "music_assistant.controllers.streams.controller.asyncio.sleep", new=AsyncMock()
     ) as sleep:
@@ -36,9 +35,9 @@ async def test_holds_connection_open_for_the_lead_out() -> None:
 
 
 @pytest.mark.asyncio
-async def test_skips_lead_out_when_superseded() -> None:
-    """A newer stream session owns playback, so the stale response must not linger."""
-    controller = _controller("session-2")
+async def test_skips_lead_out_when_flow_restarts() -> None:
+    """A flow that ended early to be restarted must not delay the next stream."""
+    controller = _controller(exhausted=False)
     with patch(
         "music_assistant.controllers.streams.controller.asyncio.sleep", new=AsyncMock()
     ) as sleep:
@@ -47,11 +46,11 @@ async def test_skips_lead_out_when_superseded() -> None:
 
 
 @pytest.mark.asyncio
-async def test_skips_lead_out_when_queue_is_gone() -> None:
-    """There is nothing left to play out once the queue itself disappeared."""
-    controller = _controller(None)
+async def test_skips_lead_out_when_superseded() -> None:
+    """A newer stream session owns playback, so the stale response must not linger."""
+    controller = _controller(exhausted=True)
     with patch(
         "music_assistant.controllers.streams.controller.asyncio.sleep", new=AsyncMock()
     ) as sleep:
-        await controller._flow_stream_lead_out(QUEUE_ID, SESSION_ID, keep_alive=False)
+        await controller._flow_stream_lead_out(QUEUE_ID, "session-2", keep_alive=False)
     sleep.assert_not_awaited()

--- a/tests/controllers/streams/test_flow_stream_lead_out.py
+++ b/tests/controllers/streams/test_flow_stream_lead_out.py
@@ -1,0 +1,57 @@
+"""Tests for the flow stream lead-out that lets players play out their buffer."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from music_assistant.controllers.streams.constants import FLOW_STREAM_LEAD_OUT_SECONDS
+from music_assistant.controllers.streams.controller import StreamsController
+
+SESSION_ID = "session-1"
+QUEUE_ID = "queue-1"
+
+
+def _controller(session_id: str | None) -> StreamsController:
+    """Build a streams controller whose queue reports the given active stream session."""
+    mass = MagicMock()
+    mass.config.get_raw_core_config_value.return_value = "GLOBAL"
+    if session_id is None:
+        mass.player_queues.queue_data_or_none.return_value = None
+    else:
+        mass.player_queues.queue_data_or_none.return_value = MagicMock(session_id=session_id)
+    return StreamsController(mass)
+
+
+@pytest.mark.asyncio
+async def test_holds_connection_open_for_the_lead_out() -> None:
+    """A finished flow stream keeps its connection open so the player can drain."""
+    controller = _controller(SESSION_ID)
+    with patch(
+        "music_assistant.controllers.streams.controller.asyncio.sleep", new=AsyncMock()
+    ) as sleep:
+        await controller._flow_stream_lead_out(QUEUE_ID, SESSION_ID, keep_alive=False)
+    sleep.assert_awaited_once_with(FLOW_STREAM_LEAD_OUT_SECONDS)
+
+
+@pytest.mark.asyncio
+async def test_skips_lead_out_when_superseded() -> None:
+    """A newer stream session owns playback, so the stale response must not linger."""
+    controller = _controller("session-2")
+    with patch(
+        "music_assistant.controllers.streams.controller.asyncio.sleep", new=AsyncMock()
+    ) as sleep:
+        await controller._flow_stream_lead_out(QUEUE_ID, SESSION_ID, keep_alive=False)
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_lead_out_when_queue_is_gone() -> None:
+    """There is nothing left to play out once the queue itself disappeared."""
+    controller = _controller(None)
+    with patch(
+        "music_assistant.controllers.streams.controller.asyncio.sleep", new=AsyncMock()
+    ) as sleep:
+        await controller._flow_stream_lead_out(QUEUE_ID, SESSION_ID, keep_alive=False)
+    sleep.assert_not_awaited()

--- a/tests/providers/bluesound/__init__.py
+++ b/tests/providers/bluesound/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Bluesound provider."""

--- a/tests/providers/bluesound/test_playback_state.py
+++ b/tests/providers/bluesound/test_playback_state.py
@@ -1,0 +1,51 @@
+"""
+Tests for how BluOS transport states map onto playback states.
+
+BluOS reports 'connecting' while it (re)fills its buffer, which includes the stretch where
+it plays out the tail of a stream that stopped sending. Reporting that as idle ends the
+queue while the player is still making sound, so a running stream stays 'playing' until
+BluOS reports a real stop.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import PlaybackState
+
+from music_assistant.providers.bluesound.player import BluesoundPlayer
+
+
+def _resolve(bluos_state: str, current_state: PlaybackState) -> PlaybackState:
+    """Resolve the playback state for a BluOS state reported on top of a current state."""
+    fake = MagicMock()
+    fake.status.state = bluos_state
+    fake._attr_playback_state = current_state
+    return BluesoundPlayer._resolve_playback_state(cast("BluesoundPlayer", fake))
+
+
+def test_connecting_while_playing_stays_playing() -> None:
+    """A buffering stream must not be mistaken for the end of the queue."""
+    assert _resolve("connecting", PlaybackState.PLAYING) == PlaybackState.PLAYING
+
+
+@pytest.mark.parametrize("current", [PlaybackState.IDLE, PlaybackState.PAUSED])
+def test_connecting_outside_playback_is_idle(current: PlaybackState) -> None:
+    """Connecting from a standstill is the device starting up, not playback."""
+    assert _resolve("connecting", current) == PlaybackState.IDLE
+
+
+@pytest.mark.parametrize(
+    ("bluos_state", "expected"),
+    [
+        ("play", PlaybackState.PLAYING),
+        ("stream", PlaybackState.PLAYING),
+        ("stop", PlaybackState.IDLE),
+        ("pause", PlaybackState.PAUSED),
+    ],
+)
+def test_reported_states_are_mapped(bluos_state: str, expected: PlaybackState) -> None:
+    """Every other BluOS state maps straight through, including a stop while playing."""
+    assert _resolve(bluos_state, PlaybackState.PLAYING) == expected

--- a/tests/providers/bluesound/test_playback_state.py
+++ b/tests/providers/bluesound/test_playback_state.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 import pytest
 from music_assistant_models.enums import PlaybackState
 
+from music_assistant.providers.bluesound.const import MAX_CONNECTING_POLLS
 from music_assistant.providers.bluesound.player import BluesoundPlayer
 
 
@@ -23,7 +24,16 @@ def _resolve(bluos_state: str, current_state: PlaybackState) -> PlaybackState:
     fake = MagicMock()
     fake.status.state = bluos_state
     fake._attr_playback_state = current_state
+    fake._connecting_polls = 0
     return BluesoundPlayer._resolve_playback_state(cast("BluesoundPlayer", fake))
+
+
+def _poll(fake: MagicMock, bluos_state: str) -> PlaybackState:
+    """Report one poll of the given BluOS state and feed the result back as current state."""
+    fake.status.state = bluos_state
+    state = BluesoundPlayer._resolve_playback_state(cast("BluesoundPlayer", fake))
+    fake._attr_playback_state = state
+    return state
 
 
 def test_connecting_while_playing_stays_playing() -> None:
@@ -49,3 +59,29 @@ def test_connecting_outside_playback_is_idle(current: PlaybackState) -> None:
 def test_reported_states_are_mapped(bluos_state: str, expected: PlaybackState) -> None:
     """Every other BluOS state maps straight through, including a stop while playing."""
     assert _resolve(bluos_state, PlaybackState.PLAYING) == expected
+
+
+def test_a_player_stuck_connecting_ends_up_idle() -> None:
+    """A player that never resumes must be reported idle so playback can recover."""
+    fake = MagicMock()
+    fake._attr_playback_state = PlaybackState.PLAYING
+    fake._connecting_polls = 0
+
+    states = [_poll(fake, "connecting") for _ in range(MAX_CONNECTING_POLLS + 1)]
+
+    assert states[:-1] == [PlaybackState.PLAYING] * MAX_CONNECTING_POLLS
+    assert states[-1] == PlaybackState.IDLE
+
+
+def test_resumed_playback_clears_the_connecting_grace() -> None:
+    """Buffering that resolves must not spend the grace of a later interruption."""
+    fake = MagicMock()
+    fake._attr_playback_state = PlaybackState.PLAYING
+    fake._connecting_polls = 0
+
+    assert _poll(fake, "connecting") == PlaybackState.PLAYING
+    assert _poll(fake, "stream") == PlaybackState.PLAYING
+    assert fake._connecting_polls == 0
+    # the full grace is available again
+    for _ in range(MAX_CONNECTING_POLLS):
+        assert _poll(fake, "connecting") == PlaybackState.PLAYING


### PR DESCRIPTION
# What does this implement/fix?

Bluesound (BluOS) players stop a few seconds before the end of a track. The player buffers ahead of what it is actually playing, and it throws that buffer away the moment our audio stream ends, so the tail of the last track is never heard. Most noticeable when playing a single track.

While looking into it: BluOS keeps looping the audio on any HTTP profile other than "forced content length", so that setting is no longer offered as a choice.

- Keep the connection open for a short while after the last audio byte and only then close it, so the player can play out what it still has buffered before it learns the queue ended
- Don't treat the BluOS "connecting" state as idle while a stream is playing, which ended the queue too early
- Pin Bluesound players to the only HTTP profile that works, and reset players that were left on another one
- Feed the audio slightly closer to real time so the player's buffer stays more predictable

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/5644

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
