### PR TITLE
Fix playback from Home Assistant failing with an admin permission error

### DIFF
--- a/music_assistant/controllers/webserver/helpers/auth_middleware.py
+++ b/music_assistant/controllers/webserver/helpers/auth_middleware.py
@@ -25,7 +25,7 @@ USER_CONTEXT_KEY = "authenticated_user"
 # TEMPORARY workaround for the 2.9 stable branch until the scope based authorization
 # from 2.10 lands: admin-only commands the Home Assistant system user may execute,
 # so add-on users are not blocked by the insufficient rights error.
-SYSTEM_USER_ALLOWED_ADMIN_COMMANDS = ("players/remove", "config/players/remove")
+SYSTEM_USER_ALLOWED_ADMIN_COMMANDS = ("players/remove", "config/players/remove", "auth/users")
 
 # ContextVar for tracking current user and token across async calls
 current_user: ContextVar[User | None] = ContextVar("current_user", default=None)

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -1474,9 +1474,12 @@ async def test_system_user_allowed_admin_commands(auth_manager: AuthenticationMa
 
     assert is_system_user_allowed_admin_command(system_user, "players/remove")
     assert is_system_user_allowed_admin_command(system_user, "config/players/remove")
+    # the integration lists users to resolve the calling Home Assistant user
+    assert is_system_user_allowed_admin_command(system_user, "auth/users")
     # other admin commands remain off limits for the system user
     assert not is_system_user_allowed_admin_command(system_user, "config/core/save")
     # regular users are not exempt
+    assert not is_system_user_allowed_admin_command(standard_user, "auth/users")
     assert not is_system_user_allowed_admin_command(standard_user, "players/remove")
 
 


### PR DESCRIPTION
# What does this implement/fix?

Since Home Assistant 2026.8.0 the play media action of the Music Assistant integration resolves the calling Home Assistant user to a Music Assistant user. It calls `auth/users` for that on every call, also when no username is given ([core#175257](https://github.com/home-assistant/core/pull/175257)). That command is admin only, and the add-on connects as the `homeassistant_system` user, so every playback command started from Home Assistant fails with `Admin access required`.

This adds `auth/users` to the admin-only commands the Home Assistant system user may run. Listing users exposes no secrets, and the system user already acts on behalf of other users on listing commands.

Ran locally: `ruff check`, `ruff format --check` and `mypy` on the changed files, plus the auth tests. The full `pre-commit` run needs native deps this environment lacks.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5997

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
