### PR TITLE
Fix playback from Home Assistant failing with a permission error

### DIFF
--- a/music_assistant/controllers/webserver/README.md
+++ b/music_assistant/controllers/webserver/README.md
@@ -72,6 +72,9 @@ Handles all authentication and user management:
 **User Roles:**
 - `ADMIN` - Full access to all commands and settings
 - `USER` - Standard access (configurable via player/provider filters)
+- `GUEST` - Read-only library access plus player/queue control
+- `SERVICE` - Standard access plus player config, reading user accounts and impersonation
+  (used by the Home Assistant integration)
 
 ### 3. RemoteAccessManager ([remote_access/](remote_access/))
 

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -272,10 +272,10 @@ class AuthenticationManager:
             return None
         return str(token_row["token_id"])
 
-    @api_command("auth/user", required_scope=Scope.USERS_MANAGE)
+    @api_command("auth/user", required_scope=Scope.USERS_READ)
     async def get_user(self, user_id: str) -> User | None:
         """
-        Get user by ID (admin only).
+        Get user by ID (requires the users.read scope).
 
         :param user_id: The user ID.
         :return: User object or None if not found.
@@ -767,12 +767,10 @@ class AuthenticationManager:
         )
         return [AuthToken.from_dict(dict(row)) for row in token_rows]
 
-    # a caller that may impersonate any user must be able to see which users exist,
-    # so the (read-only) listing is gated on the impersonation scope
-    @api_command("auth/users", required_scope=Scope.USERS_IMPERSONATE)
+    @api_command("auth/users", required_scope=Scope.USERS_READ)
     async def list_users(self) -> list[User]:
         """
-        Get all users.
+        Get all users (requires the users.read scope).
 
         System users are excluded from the list.
 

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -767,10 +767,12 @@ class AuthenticationManager:
         )
         return [AuthToken.from_dict(dict(row)) for row in token_rows]
 
-    @api_command("auth/users", required_scope=Scope.USERS_MANAGE)
+    # a caller that may impersonate any user must be able to see which users exist,
+    # so the (read-only) listing is gated on the impersonation scope
+    @api_command("auth/users", required_scope=Scope.USERS_IMPERSONATE)
     async def list_users(self) -> list[User]:
         """
-        Get all users (admin only).
+        Get all users.
 
         System users are excluded from the list.
 

--- a/music_assistant/controllers/webserver/helpers/auth_middleware.py
+++ b/music_assistant/controllers/webserver/helpers/auth_middleware.py
@@ -53,8 +53,9 @@ ROLE_SCOPES: Final[Mapping[str, frozenset[Scope]]] = {
     UserRole.GUEST: _GUEST_SCOPES,
     # service accounts (such as the Home Assistant integration) get
     # slightly elevated rights over a regular user
-    UserRole.SERVICE: _USER_SCOPES
-    | {Scope.CONFIG_PLAYERS_WRITE, Scope.USERS_READ, Scope.USERS_IMPERSONATE},
+    UserRole.SERVICE: (
+        _USER_SCOPES | {Scope.CONFIG_PLAYERS_WRITE, Scope.USERS_READ, Scope.USERS_IMPERSONATE}
+    ),
 }
 
 # ContextVar for tracking current user and token across async calls

--- a/music_assistant/controllers/webserver/helpers/auth_middleware.py
+++ b/music_assistant/controllers/webserver/helpers/auth_middleware.py
@@ -53,7 +53,8 @@ ROLE_SCOPES: Final[Mapping[str, frozenset[Scope]]] = {
     UserRole.GUEST: _GUEST_SCOPES,
     # service accounts (such as the Home Assistant integration) get
     # slightly elevated rights over a regular user
-    UserRole.SERVICE: _USER_SCOPES | {Scope.CONFIG_PLAYERS_WRITE, Scope.USERS_IMPERSONATE},
+    UserRole.SERVICE: _USER_SCOPES
+    | {Scope.CONFIG_PLAYERS_WRITE, Scope.USERS_READ, Scope.USERS_IMPERSONATE},
 }
 
 # ContextVar for tracking current user and token across async calls

--- a/music_assistant/helpers/resources/api_docs.html
+++ b/music_assistant/helpers/resources/api_docs.html
@@ -794,7 +794,7 @@ curl -X POST {BASE_URL}/api \
                 <h3>User Management Commands</h3>
                 <p>The following WebSocket commands are available for authentication management:</p>
                 <ul>
-                    <li><code>auth/users</code> - List all users (admin only)</li>
+                    <li><code>auth/users</code> - List all users (requires the users.impersonate scope)</li>
                     <li><code>auth/user</code> - Get user by ID (admin only)</li>
                     <li><code>auth/user/create</code> - Create a new user (admin only)</li>
                     <li><code>auth/user/update</code> - Update user profile, password, or role (admin for other users)</li>

--- a/music_assistant/helpers/resources/api_docs.html
+++ b/music_assistant/helpers/resources/api_docs.html
@@ -794,8 +794,8 @@ curl -X POST {BASE_URL}/api \
                 <h3>User Management Commands</h3>
                 <p>The following WebSocket commands are available for authentication management:</p>
                 <ul>
-                    <li><code>auth/users</code> - List all users (requires the users.impersonate scope)</li>
-                    <li><code>auth/user</code> - Get user by ID (admin only)</li>
+                    <li><code>auth/users</code> - List all users (requires the users.read scope)</li>
+                    <li><code>auth/user</code> - Get user by ID (requires the users.read scope)</li>
                     <li><code>auth/user/create</code> - Create a new user (admin only)</li>
                     <li><code>auth/user/update</code> - Update user profile, password, or role (admin for other users)</li>
                     <li><code>auth/user/enable</code> - Enable user (admin only)</li>

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -390,7 +390,7 @@ async def test_revoke_token(auth_manager: AuthenticationManager) -> None:
 
 async def test_list_users(auth_manager: AuthenticationManager) -> None:
     """
-    Test listing all users (admin only).
+    Test listing all users (requires the users.read scope).
 
     :param auth_manager: AuthenticationManager instance.
     """
@@ -2256,12 +2256,11 @@ async def test_homeassistant_system_user_may_read_users(
     standard_user = await auth_manager.create_user(username="user_a", role=UserRole.USER)
     guest_user = await auth_manager.create_user(username="guest_a", role=UserRole.GUEST)
     for command in (AuthenticationManager.list_users, AuthenticationManager.get_user):
-        required_scope = getattr(command, "api_required_scope", None)
-        assert required_scope is not None
-        assert has_scope(system_user, required_scope)
-        # reading user accounts remains off limits for regular users and guests
-        assert not has_scope(standard_user, required_scope)
-        assert not has_scope(guest_user, required_scope)
+        assert getattr(command, "api_required_scope", None) is Scope.USERS_READ
+    assert has_scope(system_user, Scope.USERS_READ)
+    # reading user accounts remains off limits for regular users and guests
+    assert not has_scope(standard_user, Scope.USERS_READ)
+    assert not has_scope(guest_user, Scope.USERS_READ)
 
 
 async def test_homeassistant_system_user_has_service_role(

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -2241,6 +2241,25 @@ def test_has_scope() -> None:
     assert not has_scope(_user("some_future_role"), Scope.LIBRARY_READ)
 
 
+async def test_homeassistant_system_user_may_list_users(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """
+    Test that the Home Assistant integration may list users to resolve the calling user.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    required_scope = getattr(AuthenticationManager.list_users, "api_required_scope", None)
+    assert required_scope is not None
+    system_user = await auth_manager.get_homeassistant_system_user()
+    assert has_scope(system_user, required_scope)
+    # listing users remains off limits for regular users and guests
+    standard_user = await auth_manager.create_user(username="user_a", role=UserRole.USER)
+    assert not has_scope(standard_user, required_scope)
+    guest_user = await auth_manager.create_user(username="guest_a", role=UserRole.GUEST)
+    assert not has_scope(guest_user, required_scope)
+
+
 async def test_homeassistant_system_user_has_service_role(
     auth_manager: AuthenticationManager,
 ) -> None:

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -2235,13 +2235,16 @@ def test_has_scope() -> None:
     assert not has_scope(_user(UserRole.GUEST), Scope.CONFIG_CORE_READ)
     # service
     assert has_scope(_user(UserRole.SERVICE), Scope.USERS_IMPERSONATE)
+    assert has_scope(_user(UserRole.SERVICE), Scope.USERS_READ)
     assert has_scope(_user(UserRole.SERVICE), Scope.CONFIG_PLAYERS_WRITE)
     assert not has_scope(_user(UserRole.SERVICE), Scope.CONFIG_CORE_WRITE)
+    # reading user accounts does not imply managing them
+    assert not has_scope(_user(UserRole.SERVICE), Scope.USERS_MANAGE)
     # an unknown (custom) role id is fail-closed and grants no scopes at all
     assert not has_scope(_user("some_future_role"), Scope.LIBRARY_READ)
 
 
-async def test_homeassistant_system_user_may_list_users(
+async def test_homeassistant_system_user_may_read_users(
     auth_manager: AuthenticationManager,
 ) -> None:
     """
@@ -2249,15 +2252,16 @@ async def test_homeassistant_system_user_may_list_users(
 
     :param auth_manager: AuthenticationManager instance.
     """
-    required_scope = getattr(AuthenticationManager.list_users, "api_required_scope", None)
-    assert required_scope is not None
     system_user = await auth_manager.get_homeassistant_system_user()
-    assert has_scope(system_user, required_scope)
-    # listing users remains off limits for regular users and guests
     standard_user = await auth_manager.create_user(username="user_a", role=UserRole.USER)
-    assert not has_scope(standard_user, required_scope)
     guest_user = await auth_manager.create_user(username="guest_a", role=UserRole.GUEST)
-    assert not has_scope(guest_user, required_scope)
+    for command in (AuthenticationManager.list_users, AuthenticationManager.get_user):
+        required_scope = getattr(command, "api_required_scope", None)
+        assert required_scope is not None
+        assert has_scope(system_user, required_scope)
+        # reading user accounts remains off limits for regular users and guests
+        assert not has_scope(standard_user, required_scope)
+        assert not has_scope(guest_user, required_scope)
 
 
 async def test_homeassistant_system_user_has_service_role(

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -105,6 +105,30 @@ async def test_admin_scoped_command_rejects_non_admin(role: UserRole) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("role", [UserRole.USER, UserRole.GUEST])
+async def test_users_read_command_rejects_non_service(role: UserRole) -> None:
+    """Reading user accounts is off limits for regular users and guests."""
+    client = _create_client(role, _command_handler(required_scope=Scope.USERS_READ))
+
+    await client._handle_command(CommandMessage(message_id="1", command="test/protected"))
+
+    assert _sent_error_code(client) == PERMISSION_DENIED
+    client.mass.create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", [UserRole.SERVICE, UserRole.ADMIN])
+async def test_users_read_command_allows_service_and_admin(role: UserRole) -> None:
+    """The Home Assistant integration runs as a service account and may read user accounts."""
+    client = _create_client(role, _command_handler(required_scope=Scope.USERS_READ))
+
+    await client._handle_command(CommandMessage(message_id="1", command="test/protected"))
+
+    assert _sent_error_code(client) is None
+    client.mass.create_task.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_authenticated_command_without_scope_allows_guest() -> None:
     """Guests may invoke authenticated commands that require no specific scope."""
     client = _create_client(UserRole.GUEST, _command_handler(required_scope=None))


### PR DESCRIPTION
# What does this implement/fix?

Since Home Assistant 2026.8.0, starting playback from Home Assistant fails with `This command requires the users.manage scope`. The play media action now resolves the calling Home Assistant user to a Music Assistant user and calls `auth/users` for that on every call, also when no username is given ([core#175257](https://github.com/home-assistant/core/pull/175257)). That command was admin-only, and the Home Assistant integration does not run as an admin.

Reading which users exist is not user management, but until now there was no scope that said so: the `users.*` family only had `manage`, `impersonate` and `invite`. This adds a `users.read` scope for read-only access to user accounts, grants it to the service role that the Home Assistant integration uses, and moves the two read commands onto it. Every other `users.*` command stays admin-only.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5997
- companion models PR https://github.com/music-assistant/models/pull/350
- docs PR https://github.com/music-assistant/music-assistant.io/pull/903

This covers installs where Music Assistant runs as a Home Assistant App, which is how the integration connects as the service account. When MA runs elsewhere, the integration keeps using the account you signed in with during setup, so that one has to be an admin - the docs PR above spells that out. Letting people create a service account for that is a nice follow up.

## Changes

- Add a `users.read` scope for read-only access to user accounts.
- Grant `users.read` to the service role (used by the Home Assistant integration).
- Move `auth/users` and `auth/user` from `users.manage` to `users.read`.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
