### PR TITLE
Only announce the publish IP for network discovery

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -103,6 +103,7 @@ from music_assistant.helpers.ffmpeg import LOGGER as FFMPEG_LOGGER
 from music_assistant.helpers.util import (
     format_ip_for_url,
     get_ip_addresses,
+    get_publish_ip_candidates,
     get_source_ip_for_target,
     sanitize_http_header_value,
 )
@@ -159,14 +160,14 @@ async def _wav_passthrough_stream(
 
 
 def _get_publish_addresses(
-    bind_ip: str, configured_publish_ip: str | None, all_ip_addresses: tuple[str, ...]
+    bind_ip: str, configured_publish_ip: str | None, publish_candidates: tuple[str, ...]
 ) -> list[str]:
     """
     Return the addresses this host should advertise to players on the local network.
 
     :param bind_ip: The configured bind IP (a wildcard means all interfaces).
     :param configured_publish_ip: The explicitly configured publish IP, or None when auto.
-    :param all_ip_addresses: All detected host IP addresses, in ranked order.
+    :param publish_candidates: Host addresses reachable from the local network, ranked.
     """
     if configured_publish_ip:
         # an explicitly configured address is the authoritative answer
@@ -175,10 +176,10 @@ def _get_publish_addresses(
         # only one interface is served, so no other address can be reached
         return [bind_ip]
     # Auto-detected: the primary address is only a guess at which interface the players
-    # live on, so advertise every address (highest ranked first) and let the device pick
-    # one it can reach. On a multi-homed host - a VPN or docker interface alongside the
-    # LAN - the primary-route address is regularly not the one on the players' network.
-    return list(all_ip_addresses)
+    # live on, so keep every candidate (highest ranked first) for the callers that can
+    # carry more than one. On a multi-homed host the primary-route address is regularly
+    # not the one on the players' network.
+    return list(publish_candidates)
 
 
 class StreamsController(CoreController):
@@ -202,8 +203,8 @@ class StreamsController(CoreController):
         self._bind_ip: str = "0.0.0.0"
         self._base_url: str = ""
         self._configured_publish_ip: str | None = None
-        # every address players may reach this host on, best candidate first - for mDNS
-        # records, which can carry them all, unlike the single-valued publish_ip
+        # every address players may reach this host on, best candidate first; publish_ip is
+        # the first of them and the network fingerprint watches the whole list for changes
         self.publish_addresses: list[str] = []
         # the network as it was at the previous setup, to spot a runtime change
         self._network_fingerprint: tuple[str, str, int, tuple[str, ...]] | None = None
@@ -450,9 +451,9 @@ class StreamsController(CoreController):
         self._configured_publish_ip = (
             None if configured_publish_ip == CONF_VALUE_AUTO else configured_publish_ip
         )
-        all_ip_addresses = await get_ip_addresses(include_ipv6=True)
+        publish_candidates = await get_publish_ip_candidates(include_ipv6=True)
         bind_ip = str(config.get_value(CONF_BIND_IP))
-        self._resolve_publish_state(bind_ip, all_ip_addresses)
+        self._resolve_publish_state(bind_ip, publish_candidates)
         await self._server.setup(
             bind_ip=bind_ip,
             bind_port=cast("int", self.publish_port),
@@ -474,7 +475,7 @@ class StreamsController(CoreController):
         # adopt what the server actually bound to: a configured port of 0 is only resolved
         # by the OS at bind time and an unavailable bind IP falls back to all interfaces
         self.publish_port = cast("int", self._server.port)
-        self._resolve_publish_state(self._server.bind_ip or DEFAULT_HOST, all_ip_addresses)
+        self._resolve_publish_state(self._server.bind_ip or DEFAULT_HOST, publish_candidates)
         # print a big fat message in the log where the streamserver is running
         # because this is a common source of issues for people with more complex setups
         self.logger.log(
@@ -1693,18 +1694,18 @@ class StreamsController(CoreController):
         else:
             self.audio.smart_fades_mixer.logger.setLevel(log_level)
 
-    def _resolve_publish_state(self, bind_ip: str, all_ip_addresses: tuple[str, ...]) -> None:
+    def _resolve_publish_state(self, bind_ip: str, publish_candidates: tuple[str, ...]) -> None:
         """
         Resolve the addresses and base URL to advertise for the given bind address.
 
         Reads ``self.publish_port``, so set that first.
 
         :param bind_ip: Address the streamserver binds to (a wildcard means all interfaces).
-        :param all_ip_addresses: All detected host IP addresses, in ranked order.
+        :param publish_candidates: Host addresses reachable from the local network, ranked.
         """
         self._bind_ip = bind_ip
         self.publish_addresses = _get_publish_addresses(
-            bind_ip, self._configured_publish_ip, all_ip_addresses
+            bind_ip, self._configured_publish_ip, publish_candidates
         )
         # players that can only be handed one address get the highest ranked one
         self.publish_ip = self.publish_addresses[0]

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -163,7 +163,7 @@ def _get_publish_addresses(
     bind_ip: str, configured_publish_ip: str | None, publish_candidates: tuple[str, ...]
 ) -> list[str]:
     """
-    Return the addresses this host should advertise to players on the local network.
+    Return the addresses this host publishes on, best candidate first.
 
     :param bind_ip: The configured bind IP (a wildcard means all interfaces).
     :param configured_publish_ip: The explicitly configured publish IP, or None when auto.
@@ -175,10 +175,8 @@ def _get_publish_addresses(
     if bind_ip and bind_ip not in WILDCARD_BIND_IPS:
         # only one interface is served, so no other address can be reached
         return [bind_ip]
-    # Auto-detected: the primary address is only a guess at which interface the players
-    # live on, so keep every candidate (highest ranked first) for the callers that can
-    # carry more than one. On a multi-homed host the primary-route address is regularly
-    # not the one on the players' network.
+    # auto-detected: keep the whole ranked list - publish_ip takes the best of them and
+    # the network fingerprint watches all of them to spot an interface change
     return list(publish_candidates)
 
 

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -292,7 +292,7 @@ class WebserverController(CoreController):
         # start the webserver
         if self.mass.running_as_hass_addon:
             # if we're running on the HA supervisor we start an additional TCP site
-            # on the internal ("172.30.32.) IP for the HA ingress proxy - that address
+            # on the internal ("172.30.32.") IP for the HA ingress proxy - that address
             # lives on a docker bridge, so it needs the unfiltered adapter list
             all_ip_addresses = await get_ip_addresses(include_ipv6=True)
             ingress_host = next(

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -54,7 +54,11 @@ from music_assistant.helpers.redirect_validation import (
     build_code_redirect_url,
     is_allowed_redirect_url,
 )
-from music_assistant.helpers.util import format_ip_for_url, get_ip_addresses
+from music_assistant.helpers.util import (
+    format_ip_for_url,
+    get_ip_addresses,
+    get_publish_ip_candidates,
+)
 from music_assistant.helpers.webserver import Webserver
 from music_assistant.models.core_controller import CoreController
 
@@ -92,14 +96,14 @@ CANCELLATION_ERRORS: Final = (asyncio.CancelledError, futures.CancelledError)
 
 
 def _get_publish_addresses(
-    bind_ip: str | None, publish_ip: str, all_ip_addresses: tuple[str, ...]
+    bind_ip: str | None, publish_ip: str, publish_candidates: tuple[str, ...]
 ) -> list[str]:
     """
     Return the IP addresses the webserver should publish/advertise.
 
     :param bind_ip: The configured bind IP (None or a wildcard means all interfaces).
     :param publish_ip: The resolved primary publish IP.
-    :param all_ip_addresses: All detected host IP addresses, in ranked order.
+    :param publish_candidates: Host addresses reachable from the local network, ranked.
     """
     addresses = [publish_ip]
     if bind_ip and bind_ip not in WILDCARD_BIND_IPS:
@@ -107,7 +111,7 @@ def _get_publish_addresses(
     # bound to all interfaces: also publish the primary address of the other
     # IP family (if any) so both IPv4-only and IPv6-only clients can connect
     publish_is_ipv6 = ":" in publish_ip
-    for ip in all_ip_addresses:
+    for ip in publish_candidates:
         if (":" in ip) != publish_is_ipv6:
             addresses.append(ip)
             break
@@ -286,10 +290,11 @@ class WebserverController(CoreController):
         routes.append(("GET", "/sendspin", self._sendspin_proxy.handle_sendspin_proxy))
         await self.auth.setup()
         # start the webserver
-        all_ip_addresses = await get_ip_addresses(include_ipv6=True)
         if self.mass.running_as_hass_addon:
             # if we're running on the HA supervisor we start an additional TCP site
-            # on the internal ("172.30.32.) IP for the HA ingress proxy
+            # on the internal ("172.30.32.) IP for the HA ingress proxy - that address
+            # lives on a docker bridge, so it needs the unfiltered adapter list
+            all_ip_addresses = await get_ip_addresses(include_ipv6=True)
             ingress_host = next(
                 (x for x in all_ip_addresses if x.startswith("172.30.32.")), all_ip_addresses[0]
             )
@@ -313,7 +318,8 @@ class WebserverController(CoreController):
         # out must follow the context that was actually created, not the configured value
         self._ssl_active = ssl_context is not None
         protocol = "https" if self._ssl_active else "http"
-        self._resolve_publish_state(bind_ip, all_ip_addresses, protocol)
+        publish_candidates = await get_publish_ip_candidates(include_ipv6=True)
+        self._resolve_publish_state(bind_ip, publish_candidates, protocol)
 
         await self._server.setup(
             bind_ip=bind_ip,
@@ -329,7 +335,7 @@ class WebserverController(CoreController):
         # adopt what the server actually bound to: a configured port of 0 is only resolved
         # by the OS at bind time and an unavailable bind IP falls back to all interfaces
         self.publish_port = cast("int", self._server.port)
-        self._resolve_publish_state(self._server.bind_ip, all_ip_addresses, protocol)
+        self._resolve_publish_state(self._server.bind_ip, publish_candidates, protocol)
         base_url = self.base_url
         # print a big fat message in the log where the webserver is running
         # because this is a common source of issues for people with more complex setups
@@ -470,7 +476,7 @@ class WebserverController(CoreController):
         return resp
 
     def _resolve_publish_state(
-        self, bind_ip: str | None, all_ip_addresses: tuple[str, ...], protocol: str
+        self, bind_ip: str | None, publish_candidates: tuple[str, ...], protocol: str
     ) -> None:
         """
         Resolve the addresses and base URL to advertise for the given bind address.
@@ -478,15 +484,17 @@ class WebserverController(CoreController):
         Reads ``self.publish_port``, so set that first.
 
         :param bind_ip: Address the webserver binds to (None or a wildcard means all interfaces).
-        :param all_ip_addresses: All detected host IP addresses, in ranked order.
+        :param publish_candidates: Host addresses reachable from the local network, ranked.
         :param protocol: URL scheme the webserver serves.
         """
         self.bind_ip = bind_ip
         if bind_ip and bind_ip not in WILDCARD_BIND_IPS:
             self.publish_ip = bind_ip
         else:
-            self.publish_ip = all_ip_addresses[0]
-        self.publish_addresses = _get_publish_addresses(bind_ip, self.publish_ip, all_ip_addresses)
+            self.publish_ip = publish_candidates[0]
+        self.publish_addresses = _get_publish_addresses(
+            bind_ip, self.publish_ip, publish_candidates
+        )
         self._auto_base_url = (
             f"{protocol}://{format_ip_for_url(self.publish_ip)}:{self.publish_port}"
         )

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -929,30 +929,35 @@ _ip_addresses_cache: dict[tuple[bool, bool], tuple[float, tuple[str, ...]]] = {}
 _ip_addresses_pending: dict[tuple[bool, bool], asyncio.Task[tuple[str, ...]]] = {}
 
 # Interfaces that only ever carry container, VM or VPN traffic, so a device on the local
-# network can never reach us on their addresses. Real LAN bridges (br0, vmbr0, bond0) are
-# deliberately not matched - only the hyphenated form docker gives its user-defined
-# networks. "veth" doubles as the match for the Windows "vEthernet (...)" adapters.
+# network can never reach us on their addresses.
 _VIRTUAL_INTERFACE_PREFIXES = (
-    "br-",
     "cali",
     "cni",
     "docker",
     "flannel",
     "hassio",
+    "incusbr",
+    "lxcbr",
+    "lxdbr",
+    "nordlynx",
     "podman",
     "ppp",
     "tailscale",
     "tap",
     "tun",
     "utun",
+    "vboxnet",
     "veth",
     "virbr",
     "vmnet",
     "wg",
     "zt",
-    # macOS host-only bridges for Docker Desktop, Parallels and VMware start at bridge100
-    "bridge1",
 )
+# Docker names its user-defined bridges br-<12 hex> and the macOS host-only bridges of
+# Docker Desktop, Parallels and VMware start at bridge100. Both are matched in full, so a
+# hand-named LAN bridge (br-lan on OpenWrt, a second macOS bridge1) is left alone - as are
+# the regular LAN bridge names br0, vmbr0 and bond0.
+_VIRTUAL_INTERFACE_NAMES = re.compile(r"br-[0-9a-f]{12}|bridge\d{3}")
 
 
 async def get_ip_addresses(include_ipv6: bool = False) -> tuple[str, ...]:
@@ -1100,7 +1105,10 @@ def _enumerate_ip_addresses(include_ipv6: bool, publish_candidates_only: bool) -
 
 def _is_virtual_interface(name: str) -> bool:
     """Return whether the named interface belongs to a container, VM or VPN network."""
-    return name.lower().startswith(_VIRTUAL_INTERFACE_PREFIXES)
+    name = name.lower()
+    return name.startswith(_VIRTUAL_INTERFACE_PREFIXES) or bool(
+        _VIRTUAL_INTERFACE_NAMES.fullmatch(name)
+    )
 
 
 def interface_name_for_ip(ip: str) -> str | None:

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -925,8 +925,34 @@ def clean_stream_title(line: str) -> str:
 # cache for get_ip_addresses: enumerating the network adapters involves a thread hop,
 # socket probes and a full adapter walk, while the result rarely (if ever) changes
 IP_ADDRESSES_CACHE_TTL = 30
-_ip_addresses_cache: dict[bool, tuple[float, tuple[str, ...]]] = {}
-_ip_addresses_pending: dict[bool, asyncio.Task[tuple[str, ...]]] = {}
+_ip_addresses_cache: dict[tuple[bool, bool], tuple[float, tuple[str, ...]]] = {}
+_ip_addresses_pending: dict[tuple[bool, bool], asyncio.Task[tuple[str, ...]]] = {}
+
+# Interfaces that only ever carry container, VM or VPN traffic, so a device on the local
+# network can never reach us on their addresses. Real LAN bridges (br0, vmbr0, bond0) are
+# deliberately not matched - only the hyphenated form docker gives its user-defined
+# networks. "veth" doubles as the match for the Windows "vEthernet (...)" adapters.
+_VIRTUAL_INTERFACE_PREFIXES = (
+    "br-",
+    "cali",
+    "cni",
+    "docker",
+    "flannel",
+    "hassio",
+    "podman",
+    "ppp",
+    "tailscale",
+    "tap",
+    "tun",
+    "utun",
+    "veth",
+    "virbr",
+    "vmnet",
+    "wg",
+    "zt",
+    # macOS host-only bridges for Docker Desktop, Parallels and VMware start at bridge100
+    "bridge1",
+)
 
 
 async def get_ip_addresses(include_ipv6: bool = False) -> tuple[str, ...]:
@@ -940,25 +966,45 @@ async def get_ip_addresses(include_ipv6: bool = False) -> tuple[str, ...]:
 
     :param include_ipv6: Whether to include IPv6 addresses in the result.
     """
-    if cached := _ip_addresses_cache.get(include_ipv6):
+    return await _get_ip_addresses(include_ipv6, publish_candidates_only=False)
+
+
+async def get_publish_ip_candidates(include_ipv6: bool = False) -> tuple[str, ...]:
+    """
+    Return the IP addresses a device on the local network may reach this host on.
+
+    Same as get_ip_addresses, minus the addresses of container, VM and VPN interfaces -
+    unless the host holds no other address at all.
+
+    :param include_ipv6: Whether to include IPv6 addresses in the result.
+    """
+    return await _get_ip_addresses(include_ipv6, publish_candidates_only=True)
+
+
+async def _get_ip_addresses(include_ipv6: bool, publish_candidates_only: bool) -> tuple[str, ...]:
+    """Return the host's IP addresses, enumerating the adapters at most once per TTL."""
+    cache_key = (include_ipv6, publish_candidates_only)
+    if cached := _ip_addresses_cache.get(cache_key):
         cached_at, addresses = cached
         if (time.monotonic() - cached_at) < IP_ADDRESSES_CACHE_TTL:
             return addresses
 
     async def _probe() -> tuple[str, ...]:
         try:
-            addresses = await asyncio.to_thread(_enumerate_ip_addresses, include_ipv6)
-            _ip_addresses_cache[include_ipv6] = (time.monotonic(), addresses)
+            addresses = await asyncio.to_thread(
+                _enumerate_ip_addresses, include_ipv6, publish_candidates_only
+            )
+            _ip_addresses_cache[cache_key] = (time.monotonic(), addresses)
             return addresses
         finally:
-            _ip_addresses_pending.pop(include_ipv6, None)
+            _ip_addresses_pending.pop(cache_key, None)
 
     # single-flight: no await between the pending-check and storing the task,
     # so concurrent callers always end up awaiting the same probe
-    if not (pending := _ip_addresses_pending.get(include_ipv6)):
+    if not (pending := _ip_addresses_pending.get(cache_key)):
         pending = asyncio.create_task(_probe())
         pending.add_done_callback(_log_ip_probe_failure)
-        _ip_addresses_pending[include_ipv6] = pending
+        _ip_addresses_pending[cache_key] = pending
     # wait for the shared probe instead of awaiting it directly: a caller awaiting a task
     # holds it as its fut_waiter, so cancelling that caller would otherwise cancel the probe
     # for all other callers. asyncio.shield achieves the same, but as of Python 3.14 a
@@ -980,9 +1026,11 @@ def _log_ip_probe_failure(probe: asyncio.Task[tuple[str, ...]]) -> None:
         LOGGER.debug("Enumerating IP addresses failed: %s", err)
 
 
-def _enumerate_ip_addresses(include_ipv6: bool) -> tuple[str, ...]:
+def _enumerate_ip_addresses(include_ipv6: bool, publish_candidates_only: bool) -> tuple[str, ...]:
     """Enumerate all IP addresses of all network interfaces (blocking)."""
     result: list[tuple[int, str]] = []
+    # the same addresses, without the ones no device on the local network can reach
+    lan_result: list[tuple[int, str]] = []
     # try to get the primary IP address
     # this is the IP address of the default route
     primary_ip = ""
@@ -1011,6 +1059,9 @@ def _enumerate_ip_addresses(include_ipv6: bool) -> tuple[str, ...]:
     # get all IP addresses of all network interfaces
     adapters = ifaddr.get_adapters()
     for adapter in adapters:
+        adapter_is_virtual = _is_virtual_interface(adapter.name) or _is_virtual_interface(
+            adapter.nice_name
+        )
         for ip in adapter.ips:
             if ip.is_IPv6 and not include_ipv6:
                 continue
@@ -1035,12 +1086,21 @@ def _enumerate_ip_addresses(include_ipv6: bool) -> tuple[str, ...]:
             else:
                 score = 0
             result.append((score, ip_str))
-    result.sort(key=lambda x: x[0], reverse=True)
-    if not result:
+            if not adapter_is_virtual:
+                lan_result.append((score, ip_str))
+    # a host that is only reachable over a tunnel or bridge still has to publish something
+    selected = (lan_result or result) if publish_candidates_only else result
+    selected.sort(key=lambda x: x[0], reverse=True)
+    if not selected:
         # no routable addresses found (e.g. offline host with only loopback/link-local):
         # fall back to loopback so callers that rely on at least one address keep working
         return ("127.0.0.1",)
-    return tuple(ip[1] for ip in result)
+    return tuple(ip[1] for ip in selected)
+
+
+def _is_virtual_interface(name: str) -> bool:
+    """Return whether the named interface belongs to a container, VM or VPN network."""
+    return name.lower().startswith(_VIRTUAL_INTERFACE_PREFIXES)
 
 
 def interface_name_for_ip(ip: str) -> str | None:
@@ -1194,19 +1254,6 @@ def format_ip_for_url(ip_address: str) -> str:
     if ":" in ip_address:
         return f"[{ip_address}]"
     return ip_address
-
-
-def select_announce_addresses(addresses: list[str]) -> list[str]:
-    """
-    Return the addresses to announce to devices on the local network.
-
-    :param addresses: Every address this host publishes, best candidate first.
-    """
-    # IPv6 privacy extensions add a fresh temporary address on every rotation, so a host
-    # can hold a whole prefix worth of them at once and there is no portable way to tell
-    # them apart from the stable one. Announcing them fills the record with addresses
-    # that expire, so stick to IPv4 unless this host has none at all.
-    return [address for address in addresses if ":" not in address] or list(addresses)
 
 
 async def get_folder_size(folderpath: str) -> float:

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -242,14 +242,7 @@ class AirPlayProvider(PlayerProvider):
         self._dacp_info = AsyncServiceInfo(
             DACP_DISCOVERY_TYPE,
             name=server_id,
-            # The DACP socket above listens on all interfaces, so advertise every address
-            # the players may reach us on. Advertising only the primary-route address
-            # leaves receivers on another interface of a multi-homed host unable to send
-            # their ActiveRemote callbacks: their transport/volume buttons and their
-            # device-prevent-playback notifications never arrive, while audio plays on.
-            addresses=[
-                await get_ip_pton(address) for address in self.mass.streams.publish_addresses
-            ],
+            addresses=[await get_ip_pton(self.mass.streams.publish_ip)],
             port=dacp_port,
             properties={
                 "txtvers": "1",

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -62,7 +62,7 @@ from music_assistant.constants import (
     SENDSPIN_SERVER_PORT,
     VERBOSE_LOG_LEVEL,
 )
-from music_assistant.helpers.util import format_ip_for_url, select_announce_addresses
+from music_assistant.helpers.util import format_ip_for_url
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.player import Player
 from music_assistant.models.player_provider import PlayerProvider
@@ -814,7 +814,7 @@ class SendspinProvider(PlayerProvider):
         await self.server_api.start_server(
             port=SENDSPIN_SERVER_PORT,
             host=self.mass.streams.bind_ip,
-            advertise_addresses=select_announce_addresses(self.mass.streams.publish_addresses),
+            advertise_addresses=[self.mass.streams.publish_ip],
         )
         for address in self._manual_ip_config:
             try:

--- a/music_assistant/providers/snapcast/provider.py
+++ b/music_assistant/providers/snapcast/provider.py
@@ -24,7 +24,7 @@ from music_assistant.constants import CONF_ENABLED, CONF_LOG_LEVEL, VERBOSE_LOG_
 from music_assistant.helpers.compare import create_safe_string
 from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.process import AsyncProcess, check_output
-from music_assistant.helpers.util import get_ip_pton, select_announce_addresses
+from music_assistant.helpers.util import get_ip_pton
 from music_assistant.models.player_provider import PlayerProvider
 from music_assistant.providers.snapcast.constants import (
     CONF_CATEGORY_BUILT_IN,
@@ -411,10 +411,7 @@ class SnapCastProvider(PlayerProvider):
             raise RuntimeError("Snapserver is already started!")
         logger = self.logger.getChild("snapserver")
         logger.info("Starting builtin Snapserver...")
-        # the snapserver listens on all interfaces, so announce the addresses a client
-        # could reach us on and let it pick one on its own network
-        announce_addresses = select_announce_addresses(self.mass.streams.publish_addresses)
-        addresses = [await get_ip_pton(address) for address in announce_addresses]
+        addresses = [await get_ip_pton(self.mass.streams.publish_ip)]
         # register the snapcast mdns services
         for name, port in (
             ("-http", 1780),

--- a/tests/common.py
+++ b/tests/common.py
@@ -133,6 +133,10 @@ def use_ephemeral_server_ports() -> Iterator[None]:
             "music_assistant.controllers.streams.controller.get_ip_addresses",
             AsyncMock(return_value=(LOOPBACK_IP,)),
         ),
+        patch(
+            "music_assistant.controllers.streams.controller.get_publish_ip_candidates",
+            AsyncMock(return_value=(LOOPBACK_IP,)),
+        ),
     ):
         yield
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -137,6 +137,14 @@ def use_ephemeral_server_ports() -> Iterator[None]:
             "music_assistant.controllers.streams.controller.get_publish_ip_candidates",
             AsyncMock(return_value=(LOOPBACK_IP,)),
         ),
+        patch(
+            "music_assistant.controllers.webserver.controller.get_ip_addresses",
+            AsyncMock(return_value=(LOOPBACK_IP,)),
+        ),
+        patch(
+            "music_assistant.controllers.webserver.controller.get_publish_ip_candidates",
+            AsyncMock(return_value=(LOOPBACK_IP,)),
+        ),
     ):
         yield
 

--- a/tests/controllers/streams/test_bind_fallback.py
+++ b/tests/controllers/streams/test_bind_fallback.py
@@ -49,7 +49,7 @@ async def _setup_with_bind_ip(
     config.update({CONF_BIND_IP: bind_ip, CONF_BIND_PORT: unused_port()})
     with (
         patch(
-            "music_assistant.controllers.streams.controller.get_ip_addresses",
+            "music_assistant.controllers.streams.controller.get_publish_ip_candidates",
             AsyncMock(return_value=ALL_ADDRESSES),
         ),
         patch(

--- a/tests/controllers/streams/test_publish_ip.py
+++ b/tests/controllers/streams/test_publish_ip.py
@@ -73,7 +73,7 @@ async def _setup_streams(
     )
     with (
         patch(
-            "music_assistant.controllers.streams.controller.get_ip_addresses",
+            "music_assistant.controllers.streams.controller.get_publish_ip_candidates",
             AsyncMock(return_value=all_ip_addresses),
         ),
         patch(

--- a/tests/controllers/webserver/test_bind_fallback.py
+++ b/tests/controllers/webserver/test_bind_fallback.py
@@ -131,7 +131,7 @@ async def test_setup_publishes_dialable_addresses_after_fallback(
     config.update({CONF_BIND_IP: UNBINDABLE_IP, CONF_BIND_PORT: port})
 
     with patch(
-        "music_assistant.controllers.webserver.controller.get_ip_addresses",
+        "music_assistant.controllers.webserver.controller.get_publish_ip_candidates",
         AsyncMock(return_value=ALL_ADDRESSES),
     ):
         await booted_controller.setup(config)

--- a/tests/controllers/webserver/test_ssl_base_url.py
+++ b/tests/controllers/webserver/test_ssl_base_url.py
@@ -236,7 +236,7 @@ async def _run_setup(
 
     with (
         patch(
-            "music_assistant.controllers.webserver.controller.get_ip_addresses",
+            "music_assistant.controllers.webserver.controller.get_publish_ip_candidates",
             AsyncMock(return_value=("192.168.1.5",)),
         ),
         patch(

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -1,6 +1,7 @@
 """Tests for music_assistant.helpers.util helpers."""
 
 import asyncio
+import contextlib
 import gc
 import socket
 import threading
@@ -8,6 +9,7 @@ import time
 from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
+import ifaddr
 import pytest
 from music_assistant_models.media_items import Album, ProviderMapping, Track
 
@@ -19,7 +21,6 @@ from music_assistant.helpers.util import (
     is_port_in_use,
     load_provider_module,
     sanitize_http_header_value,
-    select_announce_addresses,
     select_free_port,
 )
 from music_assistant.mass import MusicAssistant
@@ -280,7 +281,8 @@ class TestGetIpAddresses:
     def test_falls_back_to_loopback_without_routable_addresses(self) -> None:
         """With no routable addresses at all, loopback is returned instead of an empty tuple."""
         with patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=[]):
-            assert util._enumerate_ip_addresses(include_ipv6=True) == ("127.0.0.1",)
+            assert util._enumerate_ip_addresses(True, False) == ("127.0.0.1",)
+            assert util._enumerate_ip_addresses(True, True) == ("127.0.0.1",)
 
     @pytest.mark.asyncio
     async def test_concurrent_callers_share_a_single_probe(self, enumerate_mock: MagicMock) -> None:
@@ -311,8 +313,8 @@ class TestGetIpAddresses:
         """Once the TTL passed, the next call enumerates the adapters again."""
         await util.get_ip_addresses()
         # age the cached entry beyond the TTL
-        cached_at, addresses = util._ip_addresses_cache[False]
-        util._ip_addresses_cache[False] = (
+        cached_at, addresses = util._ip_addresses_cache[False, False]
+        util._ip_addresses_cache[False, False] = (
             cached_at - util.IP_ADDRESSES_CACHE_TTL - 1,
             addresses,
         )
@@ -323,7 +325,7 @@ class TestGetIpAddresses:
     async def test_cancelled_caller_does_not_break_concurrent_callers(self) -> None:
         """Cancelling one caller must not cancel the shared probe for the others."""
 
-        def slow_enumerate(_include_ipv6: bool) -> tuple[str, ...]:
+        def slow_enumerate(_include_ipv6: bool, _publish_candidates_only: bool) -> tuple[str, ...]:
             time.sleep(0.1)
             return ("192.168.1.10",)
 
@@ -346,7 +348,9 @@ class TestGetIpAddresses:
         """A probe failing after a caller gave up is not reported to the loop handler."""
         release = threading.Event()
 
-        def failing_enumerate(_include_ipv6: bool) -> tuple[str, ...]:
+        def failing_enumerate(
+            _include_ipv6: bool, _publish_candidates_only: bool
+        ) -> tuple[str, ...]:
             release.wait()
             raise OSError("probe failed")
 
@@ -378,7 +382,9 @@ class TestGetIpAddresses:
         """A probe failing with no caller left to receive it is not reported either."""
         release = threading.Event()
 
-        def failing_enumerate(_include_ipv6: bool) -> tuple[str, ...]:
+        def failing_enumerate(
+            _include_ipv6: bool, _publish_candidates_only: bool
+        ) -> tuple[str, ...]:
             release.wait()
             raise OSError("probe failed")
 
@@ -391,7 +397,7 @@ class TestGetIpAddresses:
         ):
             caller = asyncio.create_task(util.get_ip_addresses())
             await asyncio.sleep(0)
-            probe = util._ip_addresses_pending[False]
+            probe = util._ip_addresses_pending[False, False]
             caller.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await caller
@@ -405,29 +411,72 @@ class TestGetIpAddresses:
         assert reported == []
 
 
-class TestSelectAnnounceAddresses:
-    """select_announce_addresses picks the addresses that are safe to announce."""
+def _adapter(name: str, *ips: str) -> ifaddr.Adapter:
+    """Build an adapter of the given name holding the given IPv4 addresses."""
+    return ifaddr.Adapter(name, name, [ifaddr.IP(ip, 24, name) for ip in ips])
 
-    def test_ipv6_addresses_are_left_out(self) -> None:
-        """A dual-stack host announces its IPv4 addresses only, in their original order."""
-        assert select_announce_addresses(
-            ["192.168.1.10", "fd00::10", "10.0.0.5", "2001:db8::1"]
-        ) == ["192.168.1.10", "10.0.0.5"]
 
-    def test_ipv6_only_host_announces_ipv6(self) -> None:
-        """A host without any IPv4 address falls back to announcing its IPv6 addresses."""
-        assert select_announce_addresses(["fd00::10", "2001:db8::1"]) == [
-            "fd00::10",
-            "2001:db8::1",
-        ]
+@contextlib.contextmanager
+def _fake_adapters(*adapters: ifaddr.Adapter) -> Iterator[None]:
+    """Enumerate the given adapters, with the primary-route probe failing on this host."""
+    with (
+        patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=list(adapters)),
+        patch("music_assistant.helpers.util.socket.socket") as mock_socket,
+    ):
+        # without a primary route every address is ranked on its prefix alone, so the
+        # outcome does not depend on the network the test host happens to sit on
+        mock_socket.return_value.connect.side_effect = OSError
+        yield
 
-    def test_ipv4_only_host_is_unchanged(self) -> None:
-        """The common IPv4-only host announces exactly what it publishes."""
-        assert select_announce_addresses(["192.168.1.10"]) == ["192.168.1.10"]
 
-    def test_empty_input_yields_no_addresses(self) -> None:
-        """Nothing to publish means nothing to announce."""
-        assert select_announce_addresses([]) == []
+class TestGetPublishIpCandidates:
+    """get_publish_ip_candidates skips the addresses no local network device can reach."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_cache(self) -> Iterator[None]:
+        """Run every test against an empty module-level cache."""
+        util._ip_addresses_cache.clear()
+        util._ip_addresses_pending.clear()
+        yield
+        util._ip_addresses_cache.clear()
+        util._ip_addresses_pending.clear()
+
+    @pytest.mark.asyncio
+    async def test_container_and_tunnel_addresses_are_left_out(self) -> None:
+        """A HA OS host publishes its LAN address, not the docker bridges alongside it."""
+        with _fake_adapters(
+            _adapter("end0", "192.168.1.10"),
+            _adapter("hassio", "172.30.32.1"),
+            _adapter("docker0", "172.30.232.1"),
+            _adapter("tailscale0", "100.64.0.1"),
+        ):
+            assert await util.get_publish_ip_candidates() == ("192.168.1.10",)
+
+    @pytest.mark.asyncio
+    async def test_real_lan_bridge_is_kept(self) -> None:
+        """A host whose LAN lives on a bridge (Proxmox, Unraid) still publishes it."""
+        with _fake_adapters(
+            _adapter("vmbr0", "192.168.1.10"),
+            _adapter("br0", "10.0.0.5"),
+            _adapter("br-1a2b3c4d5e6f", "172.18.0.1"),
+        ):
+            assert await util.get_publish_ip_candidates() == ("192.168.1.10", "10.0.0.5")
+
+    @pytest.mark.asyncio
+    async def test_host_behind_a_tunnel_only_still_publishes(self) -> None:
+        """With nothing but a tunnel to offer, that tunnel beats publishing nothing."""
+        with _fake_adapters(_adapter("wg0", "10.6.0.2")):
+            assert await util.get_publish_ip_candidates() == ("10.6.0.2",)
+
+    @pytest.mark.asyncio
+    async def test_unfiltered_lookup_keeps_the_container_addresses(self) -> None:
+        """get_ip_addresses is unaffected: the HA ingress site binds one of those bridges."""
+        with _fake_adapters(
+            _adapter("end0", "192.168.1.10"),
+            _adapter("hassio", "172.30.32.1"),
+        ):
+            assert await util.get_ip_addresses() == ("192.168.1.10", "172.30.32.1")
+            assert await util.get_publish_ip_candidates() == ("192.168.1.10",)
 
 
 class TestSanitizeHttpHeaderValue:

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -454,10 +454,10 @@ class TestGetPublishIpCandidates:
 
     @pytest.mark.asyncio
     async def test_real_lan_bridge_is_kept(self) -> None:
-        """A host whose LAN lives on a bridge (Proxmox, Unraid) still publishes it."""
+        """A host whose LAN lives on a bridge (Proxmox, Unraid, OpenWrt) still publishes it."""
         with _fake_adapters(
             _adapter("vmbr0", "192.168.1.10"),
-            _adapter("br0", "10.0.0.5"),
+            _adapter("br-lan", "10.0.0.5"),
             _adapter("br-1a2b3c4d5e6f", "172.18.0.1"),
         ):
             assert await util.get_publish_ip_candidates() == ("192.168.1.10", "10.0.0.5")


### PR DESCRIPTION
# What does this implement/fix?

The Sendspin server announced every IP address of the host over mDNS, so on a Home Assistant OS install its record listed the internal docker bridge addresses (`172.30.32.1`, `172.30.232.1`) next to the real LAN address. mDNS does not preserve the order of those addresses, so a client picking one had a good chance of ending up on an address it can never reach. Music Assistant's own `_mass._tcp` record was unaffected because it only ever announced the publish IP.

All mDNS announcements now advertise that same single publish IP - which is exactly what the publish IP setting is for. On top of that, the auto-detected publish IP now skips container, VM and VPN interfaces, so it lands on the address devices on the local network can actually use.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

**Changes:**

- Sendspin, Snapcast and the AirPlay DACP record now announce only the publish IP
- New `get_publish_ip_candidates()` helper that leaves out docker/container bridges, VM host-only networks and VPN tunnels, and feeds the publish IP resolution of both the webserver and the streamserver
- `get_ip_addresses()` itself is unchanged, so the bind IP options, the Home Assistant ingress site and the AirPlay host check keep seeing every interface
- Removed the now unused `select_announce_addresses()` helper

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
