### PR TITLE
Remove unused extra_args parameter from ffmpeg helpers

### DIFF
--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -100,7 +100,6 @@ class FFMpeg(AsyncProcess):
         input_format: AudioFormat,
         output_format: AudioFormat,
         filter_params: Sequence[str | ComplexFilter] | None = None,
-        extra_args: list[str] | None = None,
         extra_input_args: list[str] | None = None,
         extra_output_args: list[str] | None = None,
         audio_output: str | int = "-",
@@ -112,7 +111,6 @@ class FFMpeg(AsyncProcess):
             input_format=input_format,
             output_format=output_format,
             filter_params=filter_params or [],
-            extra_args=extra_args or [],
             input_path=audio_input if isinstance(audio_input, str) else "-",
             output_path=audio_output if isinstance(audio_output, str) else "-",
             extra_input_args=extra_input_args or [],
@@ -390,7 +388,6 @@ async def get_ffmpeg_stream(
     input_format: AudioFormat,
     output_format: AudioFormat,
     filter_params: Sequence[str | ComplexFilter] | None = None,
-    extra_args: list[str] | None = None,
     chunk_size: int | None = None,
     extra_input_args: list[str] | None = None,
     extra_output_args: list[str] | None = None,
@@ -406,7 +403,6 @@ async def get_ffmpeg_stream(
         input_format=input_format,
         output_format=output_format,
         filter_params=filter_params,
-        extra_args=extra_args,
         extra_input_args=extra_input_args,
         extra_output_args=extra_output_args,
         collect_log_history=True,
@@ -507,7 +503,6 @@ def get_ffmpeg_args(
     input_format: AudioFormat,
     output_format: AudioFormat,
     filter_params: Sequence[str | ComplexFilter],
-    extra_args: list[str] | None = None,
     input_path: str = "-",
     output_path: str = "-",
     extra_input_args: list[str] | None = None,
@@ -516,8 +511,6 @@ def get_ffmpeg_args(
 ) -> list[str]:
     """Collect all args to send to the ffmpeg process."""
     filter_params = list(filter_params)
-    if extra_args is None:
-        extra_args = []
     if extra_input_args is None:
         extra_input_args = []
     if extra_output_args is None:
@@ -658,7 +651,7 @@ def get_ffmpeg_args(
         _build_filtergraph_args(filter_params) if filter_params else ([], [])
     )
 
-    return global_args + input_args + filter_input_args + filter_args + extra_args + output_args
+    return global_args + input_args + filter_input_args + filter_args + output_args
 
 
 def get_ffmpeg_channel_args(audio_format: AudioFormat) -> list[str]:


### PR DESCRIPTION
# What does this implement/fix?

The `extra_args` parameter on the ffmpeg helpers was never used. It was threaded through three signatures (`FFMpeg.__init__`, `get_ffmpeg_stream` and `get_ffmpeg_args`) and concatenated into the final ffmpeg command, but no caller anywhere passed it — so it was always an empty list. The last real user of it was removed years ago and the parameter was left behind.

Removing it keeps the helper signatures honest about what is actually configurable.

- Dropped `extra_args` from `FFMpeg.__init__`, `get_ffmpeg_stream` and `get_ffmpeg_args`
- Dropped it from the command assembly in `get_ffmpeg_args`

`extra_input_args` and `extra_output_args` are untouched — those have real callers. The generated ffmpeg commands are unchanged.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
