### PR TITLE
More accurate release years for Music Quiz songs

### DIFF
--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -476,19 +476,27 @@ class QuizType(ABC):
                     isrc_year = await self._isrc_release_year(provider, track)
                     # a remaster carries its own ISRC and the name search dates a release group
                     # by the oldest release it finds, so both run late on their own and on
-                    # different songs; the older of the two answers is right more often
+                    # different songs; the older of the two answers is right more often. the
+                    # search also stands in for an ISRC MusicBrainz has no recording for
                     if cross_check or isrc_year is None:
                         name_year = await self._name_release_year(provider, track)
                 except Exception as err:
                     LOGGER.debug("Could not date Music Quiz track %s: %s", track.uri, err)
         # the ISRC year is read before the search runs, so a search that stalls past the budget
         # or fails costs this track precision rather than the year the ISRC already supplied
-        release_year = min(
-            [year for year in (isrc_year, name_year) if year is not None], default=None
-        )
+        current_year = utc().year
         # a year outside this range is rejected by get_track_release_year anyway, and a year
-        # below 1 cannot be expressed as a datetime at all
-        if release_year is None or not MIN_RELEASE_YEAR <= release_year <= utc().year:
+        # below 1 cannot be expressed as a datetime at all. each answer is judged on its own,
+        # so an implausible one cannot pull the other one down with it
+        release_year = min(
+            [
+                year
+                for year in (isrc_year, name_year)
+                if year is not None and MIN_RELEASE_YEAR <= year <= current_year
+            ],
+            default=None,
+        )
+        if release_year is None:
             return track, None
         release_date = track.metadata.release_date
         if release_date is not None and release_date.year <= release_year:

--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -446,13 +446,18 @@ class QuizType(ABC):
             track, QUIZ_TRACK_RECENCY_SECONDS
         )
 
-    async def _musicbrainz_dated_track(self, track: Track) -> tuple[Track, int | None]:
+    async def _musicbrainz_dated_track(
+        self, track: Track, *, cross_check: bool = True
+    ) -> tuple[Track, int | None]:
         """
         Return the track dated with the first release year MusicBrainz knows for the song.
 
         The track itself is returned unchanged when MusicBrainz has nothing better to offer.
 
         :param track: Track to date.
+        :param cross_check: Whether to date the song by artist and title as well and keep the
+            older of the two answers. Costs a second MusicBrainz request, so callers that date
+            a batch of tracks against one shared budget leave it off.
         :return: The dated track and the usable release year MusicBrainz knows for the song.
             The year is reported even when the track already carries that year or an earlier one,
             and is None when MusicBrainz knows no year or only an implausible one.
@@ -460,17 +465,27 @@ class QuizType(ABC):
         musicbrainz = self.mass.get_provider("musicbrainz")
         if musicbrainz is None:
             return track, None
-        release_year: int | None = None
+        provider = cast("MusicbrainzProvider", musicbrainz)
+        isrc_year: int | None = None
+        name_year: int | None = None
         # callers wait for this and MusicBrainz throttles to 10 requests per 10 seconds, so a
         # lookup that does not resolve within the budget leaves the track on its library year
         with suppress(TimeoutError):
             async with asyncio.timeout(RELEASE_YEAR_LOOKUP_BUDGET_SECONDS):
                 try:
-                    release_year = await self._musicbrainz_release_year(
-                        cast("MusicbrainzProvider", musicbrainz), track
-                    )
+                    isrc_year = await self._isrc_release_year(provider, track)
+                    # a remaster carries its own ISRC and the name search dates a release group
+                    # by the oldest release it finds, so both run late on their own and on
+                    # different songs; the older of the two answers is right more often
+                    if cross_check or isrc_year is None:
+                        name_year = await self._name_release_year(provider, track)
                 except Exception as err:
                     LOGGER.debug("Could not date Music Quiz track %s: %s", track.uri, err)
+        # the ISRC year is read before the search runs, so a search that stalls past the budget
+        # or fails costs this track precision rather than the year the ISRC already supplied
+        release_year = min(
+            [year for year in (isrc_year, name_year) if year is not None], default=None
+        )
         # a year outside this range is rejected by get_track_release_year anyway, and a year
         # below 1 cannot be expressed as a datetime at all
         if release_year is None or not MIN_RELEASE_YEAR <= release_year <= utc().year:
@@ -487,33 +502,29 @@ class QuizType(ABC):
         return dated_track, release_year
 
     @staticmethod
-    async def _musicbrainz_release_year(
-        musicbrainz: MusicbrainzProvider, track: Track
-    ) -> int | None:
+    async def _isrc_release_year(musicbrainz: MusicbrainzProvider, track: Track) -> int | None:
         """
-        Return the first release year MusicBrainz knows for a track.
+        Return the year MusicBrainz first released the track's exact recording.
 
         :param musicbrainz: The loaded MusicBrainz provider.
         :param track: Track to date.
         """
-        isrc_year: int | None = None
-        if isrc := track.get_external_id(ExternalID.ISRC):
-            isrc_year = await musicbrainz.get_release_year_by_isrc(isrc)
-        # both lookups can date a song late on their own: a remaster gets a new ISRC, and the
-        # name search dates a release group by the oldest release it finds for it. Taking the
-        # oldest of the two answers cancels a good part of that, but an ISRC year that is not
-        # later than the year the library already carries shows no sign of a remaster and is
-        # not worth a second request
-        library_year = get_track_release_year(track)
-        if isrc_year is not None and library_year is not None and isrc_year <= library_year:
-            return isrc_year
+        if not (isrc := track.get_external_id(ExternalID.ISRC)):
+            return None
+        return await musicbrainz.get_release_year_by_isrc(isrc)
+
+    @staticmethod
+    async def _name_release_year(musicbrainz: MusicbrainzProvider, track: Track) -> int | None:
+        """
+        Return the year MusicBrainz first released the song, searched by artist and title.
+
+        :param musicbrainz: The loaded MusicBrainz provider.
+        :param track: Track to date.
+        """
         artist_name = track.artists[0].name if track.artists else None
         if not artist_name or not track.name:
-            return isrc_year
-        name_year = await musicbrainz.get_release_year_by_track_name(artist_name, track.name)
-        if name_year is None:
-            return isrc_year
-        return name_year if isrc_year is None else min(isrc_year, name_year)
+            return None
+        return await musicbrainz.get_release_year_by_track_name(artist_name, track.name)
 
 
 def get_track_release_year(track: Track) -> int | None:

--- a/music_assistant/providers/music_quiz/quiz_types/base.py
+++ b/music_assistant/providers/music_quiz/quiz_types/base.py
@@ -496,15 +496,24 @@ class QuizType(ABC):
         :param musicbrainz: The loaded MusicBrainz provider.
         :param track: Track to date.
         """
-        # an ISRC identifies the exact recording, so it is always the better evidence and
-        # the search below is only reached when it is absent or MusicBrainz does not know it
+        isrc_year: int | None = None
         if isrc := track.get_external_id(ExternalID.ISRC):
-            if (release_year := await musicbrainz.get_release_year_by_isrc(isrc)) is not None:
-                return release_year
+            isrc_year = await musicbrainz.get_release_year_by_isrc(isrc)
+        # both lookups can date a song late on their own: a remaster gets a new ISRC, and the
+        # name search dates a release group by the oldest release it finds for it. Taking the
+        # oldest of the two answers cancels a good part of that, but an ISRC year that is not
+        # later than the year the library already carries shows no sign of a remaster and is
+        # not worth a second request
+        library_year = get_track_release_year(track)
+        if isrc_year is not None and library_year is not None and isrc_year <= library_year:
+            return isrc_year
         artist_name = track.artists[0].name if track.artists else None
         if not artist_name or not track.name:
-            return None
-        return await musicbrainz.get_release_year_by_track_name(artist_name, track.name)
+            return isrc_year
+        name_year = await musicbrainz.get_release_year_by_track_name(artist_name, track.name)
+        if name_year is None:
+            return isrc_year
+        return name_year if isrc_year is None else min(isrc_year, name_year)
 
 
 def get_track_release_year(track: Track) -> int | None:

--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -295,7 +295,10 @@ class MusicTimelineQuizType(QuizType):
 
         async def _rescue_track(track: Track) -> None:
             async with semaphore:
-                dated_track, _ = await self._musicbrainz_dated_track(track)
+                # this batch shares one budget and one 10 requests per 10 seconds allowance, so
+                # every track gets the single lookup that decides whether it can be dated at
+                # all; the entry it may become is cross-checked on its own budget later
+                dated_track, _ = await self._musicbrainz_dated_track(track, cross_check=False)
             if dated_track.uri is not None and self._track_is_eligible(dated_track):
                 eligible_tracks[dated_track.uri] = dated_track
 

--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -296,8 +296,8 @@ class MusicTimelineQuizType(QuizType):
         async def _rescue_track(track: Track) -> None:
             async with semaphore:
                 # this batch shares one budget and one 10 requests per 10 seconds allowance, so
-                # every track gets the single lookup that decides whether it can be dated at
-                # all; the entry it may become is cross-checked on its own budget later
+                # every track gets the single lookup that answers what this pass is for: can
+                # the track be dated at all. entries are cross-checked one at a time instead
                 dated_track, _ = await self._musicbrainz_dated_track(track, cross_check=False)
             if dated_track.uri is not None and self._track_is_eligible(dated_track):
                 eligible_tracks[dated_track.uri] = dated_track

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import AlbumType, ExternalID, MediaType
-from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
+from music_assistant_models.errors import InvalidDataError, MediaNotFoundError, RateLimited
 from music_assistant_models.media_items import (
     Album,
     Artist,
@@ -811,27 +811,10 @@ async def test_musicbrainz_name_lookup_never_pushes_a_track_to_a_later_year() ->
 
 
 @pytest.mark.asyncio
-async def test_musicbrainz_does_not_look_up_by_name_when_the_isrc_year_is_not_late() -> None:
-    """Spend one MusicBrainz request while the ISRC dates a track before the library does."""
-    dated = _with_isrc(_track("dated", "Africa", "Toto", album_year=1998), "ISRC-DATED")
-    quiz, mass = _quiz([dated])
-    musicbrainz = _with_musicbrainz(
-        mass,
-        {"ISRC-DATED": 1982},
-        name_years={("Toto", "Africa"): 1955},
-    )
-
-    _, release_year = await quiz._musicbrainz_dated_track(dated)
-
-    assert release_year == 1982
-    musicbrainz.get_release_year_by_track_name.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_musicbrainz_looks_up_the_name_when_the_isrc_dates_a_track_late() -> None:
-    """Date a song by name when its ISRC points at a remaster released after the album."""
+async def test_musicbrainz_dates_a_remastered_recording_on_the_name_lookup() -> None:
+    """Date a song by name when its ISRC points at a remaster released after the song."""
     remastered = _with_isrc(
-        _track("remastered", "Africa", "Toto", album_year=1982), "ISRC-REMASTER"
+        _track("remastered", "Africa", "Toto", album_year=1998), "ISRC-REMASTER"
     )
     quiz, mass = _quiz([remastered])
     musicbrainz = _with_musicbrainz(
@@ -872,8 +855,65 @@ async def test_musicbrainz_keeps_the_isrc_year_when_the_name_lookup_finds_nothin
 
 
 @pytest.mark.asyncio
-async def test_musicbrainz_looks_up_the_name_without_a_library_year_to_check_against() -> None:
-    """Date a compilation track by both lookups, since its album year cannot vouch for either."""
+async def test_musicbrainz_keeps_the_isrc_year_when_the_name_lookup_fails() -> None:
+    """Never drop a year the ISRC supplied because the name search errored."""
+    late = _with_isrc(_track("late", "Africa", "Toto", album_year=1998), "ISRC-LATE")
+    quiz, mass = _quiz([late])
+    musicbrainz = _with_musicbrainz(mass, {"ISRC-LATE": 2005})
+    musicbrainz.get_release_year_by_track_name.side_effect = RateLimited("rate limited")
+
+    _, release_year = await quiz._musicbrainz_dated_track(late)
+
+    assert release_year == 2005
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_keeps_the_isrc_year_when_the_name_lookup_never_answers() -> None:
+    """Never drop a year the ISRC supplied because the name search outlasted the budget."""
+
+    async def _never_answer(*_args: object) -> int:
+        await asyncio.Event().wait()
+        return 0
+
+    late = _with_isrc(_track("late", "Africa", "Toto", album_year=1998), "ISRC-LATE")
+    quiz, mass = _quiz([late])
+    musicbrainz = _with_musicbrainz(mass, {"ISRC-LATE": 2005})
+    musicbrainz.get_release_year_by_track_name.side_effect = _never_answer
+
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types.base.RELEASE_YEAR_LOOKUP_BUDGET_SECONDS",
+        0.01,
+    ):
+        _, release_year = await quiz._musicbrainz_dated_track(late)
+
+    assert release_year == 2005
+
+
+@pytest.mark.asyncio
+async def test_rescuing_undated_tracks_spends_one_request_per_track() -> None:
+    """Keep the shared rescue budget within the MusicBrainz request allowance."""
+    candidates = [
+        _with_isrc(_track(f"undated-{index}", f"Song {index}", f"Artist {index}"), f"ISRC-{index}")
+        for index in range(5)
+    ]
+    quiz, mass = _quiz(candidates)
+    musicbrainz = _with_musicbrainz(
+        mass,
+        {f"ISRC-{index}": 1990 for index in range(5)},
+        name_years={(f"Artist {index}", f"Song {index}"): 1985 for index in range(5)},
+    )
+    eligible_tracks: dict[str, Track] = {}
+
+    await quiz._rescue_undated_tracks(eligible_tracks, candidates)
+
+    assert len(eligible_tracks) == 5
+    assert musicbrainz.get_release_year_by_isrc.await_count == 5
+    musicbrainz.get_release_year_by_track_name.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rescued_tracks_still_reach_the_name_lookup_as_timeline_entries() -> None:
+    """Cross-check a rescued track once it becomes an entry and has a budget of its own."""
     compilation = _with_isrc(_track("compilation", "Africa", "Toto"), "ISRC-COMPILATION")
     compilation.album = _full_album(
         "album-compilation",
@@ -882,16 +922,17 @@ async def test_musicbrainz_looks_up_the_name_without_a_library_year_to_check_aga
         year=1998,
     )
     quiz, mass = _quiz([compilation])
-    musicbrainz = _with_musicbrainz(
+    _with_musicbrainz(
         mass,
         {"ISRC-COMPILATION": 2005},
         name_years={("Toto", "Africa"): 1982},
     )
+    eligible_tracks: dict[str, Track] = {}
+    await quiz._rescue_undated_tracks(eligible_tracks, [compilation])
 
-    _, release_year = await quiz._musicbrainz_dated_track(compilation)
+    entry = await quiz._create_entry(next(iter(eligible_tracks.values())))
 
-    assert release_year == 1982
-    musicbrainz.get_release_year_by_track_name.assert_awaited_once_with("Toto", "Africa")
+    assert entry.release_year == 1982
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -811,8 +811,8 @@ async def test_musicbrainz_name_lookup_never_pushes_a_track_to_a_later_year() ->
 
 
 @pytest.mark.asyncio
-async def test_musicbrainz_does_not_look_up_by_name_when_the_isrc_dates_the_track() -> None:
-    """Spend one MusicBrainz request per track while the ISRC identifies the recording."""
+async def test_musicbrainz_does_not_look_up_by_name_when_the_isrc_year_is_not_late() -> None:
+    """Spend one MusicBrainz request while the ISRC dates a track before the library does."""
     dated = _with_isrc(_track("dated", "Africa", "Toto", album_year=1998), "ISRC-DATED")
     quiz, mass = _quiz([dated])
     musicbrainz = _with_musicbrainz(
@@ -825,6 +825,73 @@ async def test_musicbrainz_does_not_look_up_by_name_when_the_isrc_dates_the_trac
 
     assert release_year == 1982
     musicbrainz.get_release_year_by_track_name.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_looks_up_the_name_when_the_isrc_dates_a_track_late() -> None:
+    """Date a song by name when its ISRC points at a remaster released after the album."""
+    remastered = _with_isrc(
+        _track("remastered", "Africa", "Toto", album_year=1982), "ISRC-REMASTER"
+    )
+    quiz, mass = _quiz([remastered])
+    musicbrainz = _with_musicbrainz(
+        mass,
+        {"ISRC-REMASTER": 2005},
+        name_years={("Toto", "Africa"): 1982},
+    )
+
+    _, release_year = await quiz._musicbrainz_dated_track(remastered)
+
+    assert release_year == 1982
+    musicbrainz.get_release_year_by_track_name.assert_awaited_once_with("Toto", "Africa")
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_keeps_the_older_of_the_two_lookups() -> None:
+    """Keep the ISRC year when the name lookup dates the song later than the recording."""
+    late = _with_isrc(_track("late", "Africa", "Toto", album_year=1998), "ISRC-LATE")
+    quiz, mass = _quiz([late])
+    _with_musicbrainz(mass, {"ISRC-LATE": 1999}, name_years={("Toto", "Africa"): 2012})
+
+    _, release_year = await quiz._musicbrainz_dated_track(late)
+
+    assert release_year == 1999
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_keeps_the_isrc_year_when_the_name_lookup_finds_nothing() -> None:
+    """Never drop a year the ISRC supplied because the name search came back empty."""
+    late = _with_isrc(_track("late", "Africa", "Toto", album_year=1998), "ISRC-LATE")
+    quiz, mass = _quiz([late])
+    musicbrainz = _with_musicbrainz(mass, {"ISRC-LATE": 2005})
+
+    _, release_year = await quiz._musicbrainz_dated_track(late)
+
+    assert release_year == 2005
+    musicbrainz.get_release_year_by_track_name.assert_awaited_once_with("Toto", "Africa")
+
+
+@pytest.mark.asyncio
+async def test_musicbrainz_looks_up_the_name_without_a_library_year_to_check_against() -> None:
+    """Date a compilation track by both lookups, since its album year cannot vouch for either."""
+    compilation = _with_isrc(_track("compilation", "Africa", "Toto"), "ISRC-COMPILATION")
+    compilation.album = _full_album(
+        "album-compilation",
+        "Party Hits",
+        album_type=AlbumType.COMPILATION,
+        year=1998,
+    )
+    quiz, mass = _quiz([compilation])
+    musicbrainz = _with_musicbrainz(
+        mass,
+        {"ISRC-COMPILATION": 2005},
+        name_years={("Toto", "Africa"): 1982},
+    )
+
+    _, release_year = await quiz._musicbrainz_dated_track(compilation)
+
+    assert release_year == 1982
+    musicbrainz.get_release_year_by_track_name.assert_awaited_once_with("Toto", "Africa")
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -778,6 +778,8 @@ async def test_musicbrainz_lookups_do_not_scale_with_the_source_pool() -> None:
     assert isinstance(game_round.answer_state, TimelineRoundState)
     assert game_round.answer_state.candidate.entry.release_year == 1970
     assert musicbrainz.get_release_year_by_isrc.await_count <= quiz.config.round_count + 1
+    # the name search runs alongside the ISRC lookup, so it is bound to the same entries
+    assert musicbrainz.get_release_year_by_track_name.await_count <= quiz.config.round_count + 1
 
 
 @pytest.mark.asyncio
@@ -909,6 +911,46 @@ async def test_rescuing_undated_tracks_spends_one_request_per_track() -> None:
     assert len(eligible_tracks) == 5
     assert musicbrainz.get_release_year_by_isrc.await_count == 5
     musicbrainz.get_release_year_by_track_name.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rescuing_undated_tracks_still_dates_them_without_an_isrc() -> None:
+    """Rescue a track by name when it carries no ISRC, on the one lookup it is allowed."""
+    candidate = _track("undated", "Africa", "Toto")
+    quiz, mass = _quiz([candidate])
+    musicbrainz = _with_musicbrainz(mass, {}, name_years={("Toto", "Africa"): 1982})
+    eligible_tracks: dict[str, Track] = {}
+
+    await quiz._rescue_undated_tracks(eligible_tracks, [candidate])
+
+    assert MusicTimelineQuizType._release_year(eligible_tracks[str(candidate.uri)]) == 1982
+    musicbrainz.get_release_year_by_track_name.assert_awaited_once_with("Toto", "Africa")
+
+
+@pytest.mark.asyncio
+async def test_rescuing_undated_tracks_falls_back_to_the_name_for_an_unknown_isrc() -> None:
+    """Rescue a track by name when MusicBrainz has no recording for the ISRC it carries."""
+    candidate = _with_isrc(_track("undated", "Africa", "Toto"), "ISRC-UNKNOWN")
+    quiz, mass = _quiz([candidate])
+    musicbrainz = _with_musicbrainz(mass, {}, name_years={("Toto", "Africa"): 1982})
+    eligible_tracks: dict[str, Track] = {}
+
+    await quiz._rescue_undated_tracks(eligible_tracks, [candidate])
+
+    assert MusicTimelineQuizType._release_year(eligible_tracks[str(candidate.uri)]) == 1982
+    musicbrainz.get_release_year_by_track_name.assert_awaited_once_with("Toto", "Africa")
+
+
+@pytest.mark.asyncio
+async def test_an_implausible_year_does_not_discard_the_other_lookup() -> None:
+    """Judge each MusicBrainz answer on its own so one unusable year cannot annul the other."""
+    track = _with_isrc(_track("track", "Africa", "Toto", album_year=1998), "ISRC-TRACK")
+    quiz, mass = _quiz([track])
+    _with_musicbrainz(mass, {"ISRC-TRACK": 1982}, name_years={("Toto", "Africa"): 999})
+
+    _, release_year = await quiz._musicbrainz_dated_track(track)
+
+    assert release_year == 1982
 
 
 @pytest.mark.asyncio

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -1127,8 +1127,13 @@ async def test_compilation_year_round_is_scored_on_the_musicbrainz_year() -> Non
 @pytest.mark.asyncio
 async def test_compilation_year_round_prefers_the_older_of_both_lookups() -> None:
     """Score a compilation year round on the older year, since a remaster carries its own ISRC."""
+    # the track carries the compilation's own date, which is exactly the year Trivia may not
+    # fall back on, so it must not decide whether the song is dated by name as well
     tracks = [
-        _with_isrc(_track(f"track-{index}", f"Song {index}", f"Artist {index}"), f"ISRC-{index}")
+        _with_isrc(
+            _track(f"track-{index}", f"Song {index}", f"Artist {index}", release_year=2012),
+            f"ISRC-{index}",
+        )
         for index in range(3)
     ]
     for index, track in enumerate(tracks):

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -1125,6 +1125,46 @@ async def test_compilation_year_round_is_scored_on_the_musicbrainz_year() -> Non
 
 
 @pytest.mark.asyncio
+async def test_compilation_year_round_prefers_the_older_of_both_lookups() -> None:
+    """Score a compilation year round on the older year, since a remaster carries its own ISRC."""
+    tracks = [
+        _with_isrc(_track(f"track-{index}", f"Song {index}", f"Artist {index}"), f"ISRC-{index}")
+        for index in range(3)
+    ]
+    for index, track in enumerate(tracks):
+        track.album = _full_album(
+            f"album-{index}",
+            f"Compilation {index}",
+            album_type=AlbumType.COMPILATION,
+            year=2012,
+        )
+    provider = _ai_provider()
+    provider.ai_query.side_effect = [
+        _valid_response("Who performs the selected song?", ["Portishead", "Radiohead", "Air"]),
+        _valid_response("Which title is this?", ["Teardrop", "Genesis", "Midnight City"]),
+        _valid_response("In which year did this first appear?", ["1975", "1991", "2003"]),
+    ]
+    quiz, mass = _quiz(tracks, providers=[provider], round_count=3)
+    _with_musicbrainz(
+        mass,
+        {f"ISRC-{index}": 2005 for index in range(3)},
+        name_years={(f"Artist {index}", f"Song {index}"): 1982 for index in range(3)},
+    )
+
+    with patch(
+        "music_assistant.providers.music_quiz.quiz_types.trivia.SYSTEM_RANDOM.choice",
+        side_effect=lambda candidates: candidates[0],
+    ):
+        first_round = await quiz.prepare_round(0, [])
+        second_round = await quiz.prepare_round(1, [first_round])
+        year_round = await quiz.prepare_round(2, [first_round, second_round])
+
+    assert year_round.answer_label == "1982"
+    payload = _prompt_payload(provider.ai_query.await_args.args[0])
+    assert payload["correct_answer"] == "1982"
+
+
+@pytest.mark.asyncio
 async def test_undated_compilation_rounds_only_generate_artist_and_title_targets() -> None:
     """Generate valid rounds without album or year targets while MusicBrainz cannot date them."""
     first_track = _track("one", "First Song", "Artist One", release_year=2012)


### PR DESCRIPTION
# What does this implement/fix?

Music Timeline and Trivia ask MusicBrainz when a song was first released. That lookup runs on the
track's ISRC, and falls back to a search on artist and title when the ISRC gives nothing.

Both of those date a song years too late on their own, and they do it for different songs. A
remaster gets its own ISRC, so the ISRC lookup puts Imagine in 2018 and Beautiful People in 2014.
The name search dates a song by the oldest release it happens to find for it, so it puts We Will
Rock You in 2017, Purple Rain in 2020 and Lithium in 2021. Whichever one we asked first, songs
came out of the quiz with the wrong year.

Songs are now dated on the older of the two answers, which is right far more often because the two
are rarely wrong about the same song.

Measured on 175 songs from a real library, dated by hand from artist and title alone before any
lookup ran:

| | exact | more than 2 years off | average error |
|---|---|---|---|
| before | 82.0% | 10.5% | 2.16 years |
| after | 87.2% | 6.4% | 1.06 years |

The gain is biggest for songs on a compilation, where Trivia has no album year to fall back on and
a wrong year becomes the scored answer: 84.0% → 90.0% exact, average error 1.34 → 0.74 years.

The second lookup is spent per song, not per candidate. Picking the songs for a game dates a whole
batch at once against one shared time budget and one shared MusicBrainz request allowance, so that
step keeps the single lookup it always had — it only has to decide which songs can be dated at all.
The songs that actually appear in the game are then cross-checked one at a time, on their own
budget, by which point the first lookup is already cached.

## Changes

- Date a song on the older of the ISRC year and the artist/title year instead of the first one that
  answers.
- Keep dating a batch of candidate songs on one lookup each, so picking the songs for a game is as
  fast as before.
- Never let a song lose the year the ISRC already supplied because the artist/title search failed
  or ran out of time.

**Related issue (if applicable):**

- follow-up to #5386

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
