### PR TITLE
Stop stream options from piling up on repeated plays of the same item

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -443,7 +443,9 @@ class StreamsAudio:
         mass = self.mass
         logger = self.logger.getChild("media_stream")
         logger.log(VERBOSE_LOG_LEVEL, "Starting media stream for %s", streamdetails.uri)
-        extra_input_args = streamdetails.extra_input_args or []
+        # copy: the args below are appended per call, while the StreamDetails is cached on
+        # the queue item and reused across calls (retry, seek, background analysis)
+        extra_input_args = list(streamdetails.extra_input_args or [])
 
         # work out audio source for these streamdetails
         audio_source: str | AsyncGenerator[bytes]

--- a/tests/controllers/streams/test_get_media_stream.py
+++ b/tests/controllers/streams/test_get_media_stream.py
@@ -1,4 +1,4 @@
-"""Tests for StreamsAudio.get_media_stream's ffmpeg input_format handling."""
+"""Tests for the ffmpeg input arguments StreamsAudio.get_media_stream builds."""
 
 from __future__ import annotations
 
@@ -16,9 +16,13 @@ from music_assistant_models.streamdetails import StreamDetails
 import music_assistant.controllers.streams.audio as audio_mod
 from music_assistant.controllers.streams.audio import StreamsAudio
 
+# input args a provider may attach to its StreamDetails (podcastfeed does exactly this).
+# Kept as a tuple so the tests below can never assert against a mutated expectation.
+_PROVIDER_INPUT_ARGS = ("-user_agent", "Test/1.0")
+
 
 class _FakeFFMpeg:
-    """FFMpeg test double that records the input_format it was constructed with."""
+    """FFMpeg test double that records the arguments it was constructed with."""
 
     last_instance: _FakeFFMpeg | None = None
 
@@ -27,9 +31,11 @@ class _FakeFFMpeg:
         *,
         audio_input: object,
         input_format: AudioFormat,
+        extra_input_args: list[str] | None = None,
         **_kwargs: Any,
     ) -> None:
         self.audio_input = audio_input
+        self.extra_input_args = extra_input_args
         # Mirror the real FFMpeg, which mutates this object's codec_type after probe.
         # Tests inspect the original `input_format` AudioFormat passed in to confirm
         # which one the controller picked.
@@ -95,6 +101,22 @@ def _make_streamdetails(
         media_type=MediaType.AUDIO_SOURCE,
         stream_type=StreamType.NAMED_PIPE,
         path="/tmp/fake-fifo",  # noqa: S108
+    )
+
+
+def _seekable_streamdetails() -> StreamDetails:
+    """Build seekable StreamDetails carrying provider-supplied ffmpeg input args."""
+    return StreamDetails(
+        provider="test_provider",
+        item_id="episode-1",
+        audio_format=AudioFormat(content_type=ContentType.MP3),
+        media_type=MediaType.PODCAST_EPISODE,
+        stream_type=StreamType.HTTP,
+        path="http://test.invalid/episode-1.mp3",
+        duration=3600,
+        can_seek=True,
+        allow_seek=True,
+        extra_input_args=[*_PROVIDER_INPUT_ARGS],
     )
 
 
@@ -264,3 +286,26 @@ async def test_get_media_stream_writes_back_codec_when_no_decoded_format() -> No
     # decoded format that AudioFormat is the same object as streamdetails.audio_format,
     # so the controller's writeback path is exercised end-to-end.
     assert streamdetails.audio_format.codec_type is ContentType.FLAC
+
+
+@pytest.mark.asyncio
+async def test_get_media_stream_keeps_caller_extra_input_args_intact(
+    patch_ffmpeg: type[_FakeFFMpeg],
+) -> None:
+    """Per-call input args must not leak back onto the caller's StreamDetails."""
+    streamdetails = _seekable_streamdetails()
+    audio = _make_audio_controller()
+
+    await _drain(audio.get_media_stream(streamdetails, _make_pcm_format(), seek_position=30))
+
+    assert patch_ffmpeg.last_instance is not None
+    assert patch_ffmpeg.last_instance.extra_input_args == [*_PROVIDER_INPUT_ARGS, "-ss", "30"]
+    assert streamdetails.extra_input_args == [*_PROVIDER_INPUT_ARGS]
+
+    # StreamDetails are cached on the queue item and reach this method again on a
+    # retry, another seek or from the background analyzer: every call must build its
+    # args from the provider's list alone instead of stacking onto the previous call's.
+    await _drain(audio.get_media_stream(streamdetails, _make_pcm_format(), seek_position=600))
+
+    assert patch_ffmpeg.last_instance.extra_input_args == [*_PROVIDER_INPUT_ARGS, "-ss", "600"]
+    assert streamdetails.extra_input_args == [*_PROVIDER_INPUT_ARGS]


### PR DESCRIPTION
# What does this implement/fix?

When starting a stream, the streams controller took the list of extra ffmpeg input arguments straight off the StreamDetails and then appended its own per-stream options to it (`-ss` for seeking, `-re` for live sources, the decryption key for encrypted streams). Because that was a reference and not a copy, those options were written back onto the StreamDetails, which is cached on the queue item and reused. Playing or seeking the same item again therefore kept stacking options onto the provider's list.

Playback is unaffected today: the podcast provider is the only one that supplies its own arguments, and ffmpeg honours the last `-ss` it is given. So this is a cleanup of a latent issue rather than a fix for a reported problem. Spotted while reviewing #5407.

**Changes:**

- Copy the provider's input arguments before appending the per-stream ones, so the cached StreamDetails is left untouched.
- Added a regression test covering a repeated stream of the same item.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
