### PR TITLE
Fix cast dashboards freezing for players with reserved characters in their id

### DIFF
--- a/music_assistant/controllers/dashboard/controller.py
+++ b/music_assistant/controllers/dashboard/controller.py
@@ -36,6 +36,9 @@ APP_MA_HOST = "https://app.music-assistant.io"
 # every real dashboard type, i.e. what a registration supports when not given explicitly
 ALL_DASHBOARD_TYPES = frozenset(t for t in DashboardType if t != DashboardType.UNKNOWN)
 
+# the frontend's router leaves these literal in a query value; escaped, it never matches
+ROUTE_SAFE_CHARS = ":!'()*@,;$/"
+
 
 @dataclass
 class _RegisteredDashboard:
@@ -385,7 +388,7 @@ class DashboardController(CoreController):
             if not player_id:
                 msg = "player_id is required to show the now_playing dashboard"
                 raise InvalidCommand(msg)
-            return f"/now-playing?{urlencode({'player': player_id})}"
+            return f"/now-playing?{urlencode({'player': player_id}, safe=ROUTE_SAFE_CHARS)}"
         if dashboard == DashboardType.MUSIC_QUIZ:
             return "/music-quiz"
         msg = f"Unsupported dashboard type: {dashboard}"

--- a/tests/controllers/dashboard/test_controller.py
+++ b/tests/controllers/dashboard/test_controller.py
@@ -124,6 +124,31 @@ async def test_resolve_dashboard_url_encodes_player_id() -> None:
     assert query["path"] == "/now-playing?player=a%26b%3Dc+d"
 
 
+@pytest.mark.parametrize(
+    ("player_id", "expected"),
+    [
+        # dlna/wiim UDNs and MAC-based ids (bluesound, squeezelite, samsung_wam)
+        ("uuid:FF98F7F4-EEC9-70AF", "uuid:FF98F7F4-EEC9-70AF"),
+        ("20:F8:3B:09:6B:92", "20:F8:3B:09:6B:92"),
+        # alexa uses the device name the user typed, verbatim
+        ("Marvin's Echo (Kitchen)!", "Marvin's+Echo+(Kitchen)!"),
+    ],
+)
+async def test_resolve_dashboard_url_keeps_route_safe_chars_literal(
+    player_id: str, expected: str
+) -> None:
+    """The now_playing route leaves the characters the frontend's router keeps literal."""
+    controller = _make_controller()
+    controller.mass.webserver.base_url = "https://mass.example.com"  # type: ignore[misc]
+
+    with patch.object(
+        DashboardController, "_get_dashboard_code", AsyncMock(return_value="code456")
+    ):
+        url = await controller.resolve_dashboard_url(DashboardType.NOW_PLAYING, player_id)
+
+    assert _query(url)["path"] == f"/now-playing?player={expected}"
+
+
 async def test_resolve_dashboard_url_rejects_unknown_dashboard_type() -> None:
     """An UNKNOWN dashboard type is never a valid target to cast."""
     controller = _make_controller()

--- a/tests/controllers/dashboard/test_controller.py
+++ b/tests/controllers/dashboard/test_controller.py
@@ -132,6 +132,8 @@ async def test_resolve_dashboard_url_encodes_player_id() -> None:
         ("20:F8:3B:09:6B:92", "20:F8:3B:09:6B:92"),
         # alexa uses the device name the user typed, verbatim
         ("Marvin's Echo (Kitchen)!", "Marvin's+Echo+(Kitchen)!"),
+        # every remaining safe character, so the set cannot silently shrink
+        ("a*b@c,d;e$f/g", "a*b@c,d;e$f/g"),
     ],
 )
 async def test_resolve_dashboard_url_keeps_route_safe_chars_literal(


### PR DESCRIPTION
# What does this implement/fix?

Casting a **now playing** dashboard to a display froze it on "Authenticating…" until the device killed the app.

The now_playing route carries the `player_id` in its query string, built with `urlencode` defaults. That escapes characters the frontend's router leaves literal in a query value, so the pinned route (`…player=wiim_uuid%3AFF98…`) never equalled the route the frontend rebuilt from it (`…player=wiim_uuid:FF98…`). The dashboard viewer's navigation guard redirected on every navigation, the browser spun in an endless redirect loop at 100% CPU, and the display kept showing its last painted frame. Vue Router's own infinite-redirect detection is dev-only, so nothing caught it in a production build.

Affected today: every DLNA and WiiM player (`uuid:…` UDNs), MAC-based ids (Bluesound `mac:port`, Squeezelite, Samsung WAM, raw Sendspin clients), and Alexa, whose `player_id` is the device name the user typed and can contain `'`, `(`, `)` or `!`. On a test install that was 18 of 132 players.

Verified end to end on a Nest Hub with the unmodified frontend: the WiiM now playing dashboard that reproducibly froze now renders, and an Alexa-style id (`Marvin's Echo (Kitchen)!`) settles on a stable route instead of looping.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
