### PR TITLE
Keep a synced pair of speakers muted when the group volume changes

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -941,7 +941,11 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         # Set mute lock for players in a group
         # This prevents auto-unmute when group volume changes
         had_mute_lock = ATTR_MUTE_LOCK in player.extra_data
-        is_in_group = bool(player.state.synced_to or player.state.active_group)
+        # a sync leader has neither synced_to nor active_group set, but it does lead its
+        # own group_members, which stays empty for a player that is not grouped at all
+        is_in_group = bool(
+            player.state.synced_to or player.state.active_group or player.state.group_members
+        )
         if muted and is_in_group:
             player.extra_data[ATTR_MUTE_LOCK] = True
 

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1797,6 +1797,7 @@ class TestGroupMuteOnNonGroupPlayer:
                 PlayerFeature.VOLUME_SET,
                 PlayerFeature.VOLUME_MUTE,
             }
+            player._attr_volume_level = 50
             players[player_id] = player
         if members:
             # the leader is not listed as its own member here, so the tests also cover
@@ -1879,6 +1880,34 @@ class TestGroupMuteOnNonGroupPlayer:
         mutes["leader"].assert_awaited_once_with(False)
         mutes["member"].assert_awaited_once_with(False)
         assert ATTR_MUTE_LOCK not in players["member"].extra_data
+
+    async def test_group_mute_locks_the_sync_leader_too(self, mock_mass: MagicMock) -> None:
+        """A sync leader is as much part of the group as its members, so it is locked too."""
+        controller, players = self._setup(mock_mass, "member")
+        self._stub_mutes(players)
+
+        await controller.cmd_group_volume_mute("leader", True)
+
+        assert ATTR_MUTE_LOCK in players["leader"].extra_data
+        assert ATTR_MUTE_LOCK in players["member"].extra_data
+
+    async def test_group_volume_keeps_a_muted_sync_pair_muted(self, mock_mass: MagicMock) -> None:
+        """A group volume change may not half-unmute a muted pair of directly synced players."""
+        controller, players = self._setup(mock_mass, "member")
+        self._stub_mutes(players)
+        await controller.cmd_group_volume_mute("leader", True)
+        # the mock players do not act on the mute command, so reflect it in their state
+        for player in players.values():
+            player._attr_volume_muted = True
+            player.update_state(signal_event=False)
+            player.volume_set = AsyncMock()  # type: ignore[method-assign]
+        # re-stub so only the mute commands of the group volume change are counted
+        mutes = self._stub_mutes(players)
+
+        await controller.cmd_group_volume("leader", 30)
+
+        for mute in mutes.values():
+            mute.assert_not_awaited()
 
 
 class TestCurrentMediaTimeUpdates:


### PR DESCRIPTION
# What does this implement/fix?

Muting two speakers that are synced directly to each other (so without a group player) did not stay put: the next group volume change quietly unmuted the first speaker while the second stayed muted, leaving the pair half-muted.

Muting a player that is part of a group sets a lock so a following volume change does not undo it, but the leading speaker of a directly synced pair never got that lock — it is not a member of a group, it leads one. It now gets the lock as well.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Treat a sync leader as being in a group when handing out the mute lock
- Added regression tests for the leader's mute lock and for a group volume change on a muted pair

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
