### PR TITLE
Fix playback position being dropped from the player state

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -82,6 +82,29 @@ def _clamp_elapsed_time(elapsed_time: float | None) -> float | None:
     return max(0.0, elapsed_time) if elapsed_time is not None else None
 
 
+def _resolve_position(
+    primary: int | None,
+    primary_last_updated: float | None,
+    fallback: float | None,
+    fallback_last_updated: float | None,
+) -> tuple[int | None, float | None]:
+    """
+    Return the (elapsed_time, elapsed_time_last_updated) pair to report for a media item.
+
+    :param primary: Position reported by the media itself, preferred when set.
+    :param primary_last_updated: Timestamp belonging to the primary position.
+    :param fallback: Position to report when the media has none of its own.
+    :param fallback_last_updated: Timestamp belonging to the fallback position.
+    """
+    # a position is only meaningful together with the timestamp it was taken at,
+    # so both values always come from the same source - never a mix of the two
+    if primary is not None:
+        return primary, primary_last_updated
+    if fallback is not None:
+        return int(fallback), fallback_last_updated
+    return None, None
+
+
 # corrected-position jumps larger than this (in seconds) are treated as a discrete
 # position change (seek/buffer correction) instead of regular playback progression
 POSITION_JUMP_THRESHOLD = 1.0
@@ -2323,7 +2346,7 @@ class Player(ABC):
             or self.__final_synced_to
             or (self.type == PlayerType.PROTOCOL and self.__attr_protocol_parent_id)
         )
-        _, _, jumped = _reconcile_position_anchor(
+        position, timestamp, jumped = _reconcile_position_anchor(
             prev_media.elapsed_time,
             prev_media.elapsed_time_last_updated,
             new_media.elapsed_time,
@@ -2332,10 +2355,11 @@ class Player(ABC):
             new_playing,
             force_adopt=mirrors_parent,
         )
-        if not mirrors_parent and not jumped:
-            # steady playback: keep the previous anchor so nothing changed
-            new_media.elapsed_time = prev_media.elapsed_time
-            new_media.elapsed_time_last_updated = prev_media.elapsed_time_last_updated
+        if not mirrors_parent:
+            # steady playback resolves to the previous anchor, so nothing changed;
+            # a jump (or a previous anchor that was still incomplete) adopts the new one
+            new_media.elapsed_time = int(position) if position is not None else None
+            new_media.elapsed_time_last_updated = timestamp
         return jumped
 
     @cached_property
@@ -2566,6 +2590,12 @@ class Player(ABC):
             ):
                 # handle stream metadata in streamdetails (e.g. for radio stream)
                 image_url = stream_metadata.image_url or item_image_url
+                elapsed_time, elapsed_time_last_updated = _resolve_position(
+                    stream_metadata.elapsed_time,
+                    stream_metadata.elapsed_time_last_updated,
+                    active_queue.elapsed_time,
+                    active_queue.elapsed_time_last_updated,
+                )
                 return PlayerMedia(
                     uri=current_item.uri,
                     media_type=current_item.media_type,
@@ -2577,9 +2607,8 @@ class Player(ABC):
                     duration=stream_metadata.duration or current_item.duration,
                     source_id=active_queue.queue_id,
                     queue_item_id=current_item.queue_item_id,
-                    elapsed_time=stream_metadata.elapsed_time or int(active_queue.elapsed_time),
-                    elapsed_time_last_updated=stream_metadata.elapsed_time_last_updated
-                    or active_queue.elapsed_time_last_updated,
+                    elapsed_time=elapsed_time,
+                    elapsed_time_last_updated=elapsed_time_last_updated,
                 )
             if media_item := current_item.media_item:
                 # normal media item
@@ -2633,6 +2662,12 @@ class Player(ABC):
         # return native current media if no group/queue is active
         if self.current_media:
             image_url = self.current_media.image_url
+            elapsed_time, elapsed_time_last_updated = _resolve_position(
+                self.current_media.elapsed_time,
+                self.current_media.elapsed_time_last_updated,
+                self.elapsed_time,
+                self.elapsed_time_last_updated,
+            )
             return PlayerMedia(
                 uri=self.current_media.uri,
                 media_type=self.current_media.media_type,
@@ -2644,11 +2679,8 @@ class Player(ABC):
                 duration=self.current_media.duration,
                 source_id=self.current_media.source_id or active_source,
                 queue_item_id=self.current_media.queue_item_id,
-                elapsed_time=self.current_media.elapsed_time or int(self.elapsed_time)
-                if self.elapsed_time
-                else None,
-                elapsed_time_last_updated=self.current_media.elapsed_time_last_updated
-                or self.elapsed_time_last_updated,
+                elapsed_time=elapsed_time,
+                elapsed_time_last_updated=elapsed_time_last_updated,
             )
         return None
 

--- a/tests/models/test_player_state_updates.py
+++ b/tests/models/test_player_state_updates.py
@@ -8,7 +8,11 @@ from statistics import median
 from unittest.mock import MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import PlaybackState
+from music_assistant_models.enums import MediaType, PlaybackState
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.player_queue import PlayerQueue
+from music_assistant_models.queue_item import QueueItem
+from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
 
 import music_assistant.models.player as player_module
 from tests.common import MockPlayer, MockProvider
@@ -102,6 +106,247 @@ class TestUpdateStateChangeDetection:
             player.update_state(signal_event=False)
 
         state_cls.assert_called_once()
+
+
+class TestNativeCurrentMediaPosition:
+    """The published position of native current_media and the timestamp it is paired with."""
+
+    def _playing_player(
+        self,
+        mock_mass: MagicMock,
+        *,
+        media_elapsed_time: int | None,
+        media_last_updated: float | None,
+        player_elapsed_time: float | None,
+        player_last_updated: float | None,
+    ) -> MockPlayer:
+        """Build a playing player with the given media and player level position anchors."""
+        provider = MockProvider("test_provider", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+        player._attr_playback_state = PlaybackState.PLAYING
+        player._attr_elapsed_time = player_elapsed_time
+        player._attr_elapsed_time_last_updated = player_last_updated
+        player.set_current_media(uri="http://test/stream", title="Test")
+        assert player._attr_current_media is not None
+        player._attr_current_media.elapsed_time = media_elapsed_time
+        player._attr_current_media.elapsed_time_last_updated = media_last_updated
+        player.update_state(signal_event=False)
+        return player
+
+    def test_zero_position_is_reported(self, mock_mass: MagicMock) -> None:
+        """A position of zero (start of a track) is reported instead of being dropped."""
+        anchor = time.time()
+        player = self._playing_player(
+            mock_mass,
+            media_elapsed_time=0,
+            media_last_updated=anchor,
+            player_elapsed_time=0,
+            player_last_updated=anchor,
+        )
+
+        assert player.state.current_media is not None
+        assert player.state.current_media.elapsed_time == 0
+        assert player.state.current_media.elapsed_time_last_updated == anchor
+
+    def test_media_position_wins_without_player_position(self, mock_mass: MagicMock) -> None:
+        """A media position is reported even when the player reports none of its own."""
+        anchor = time.time()
+        player = self._playing_player(
+            mock_mass,
+            media_elapsed_time=42,
+            media_last_updated=anchor,
+            player_elapsed_time=None,
+            player_last_updated=None,
+        )
+
+        assert player.state.current_media is not None
+        assert player.state.current_media.elapsed_time == 42
+        assert player.state.current_media.elapsed_time_last_updated == anchor
+
+    def test_media_position_is_never_paired_with_the_player_timestamp(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A media position without its own timestamp does not borrow the player's."""
+        player = self._playing_player(
+            mock_mass,
+            media_elapsed_time=42,
+            media_last_updated=None,
+            player_elapsed_time=10.0,
+            player_last_updated=time.time(),
+        )
+
+        assert player.state.current_media is not None
+        assert player.state.current_media.elapsed_time == 42
+        assert player.state.current_media.elapsed_time_last_updated is None
+
+    def test_late_arriving_position_is_adopted(self, mock_mass: MagicMock) -> None:
+        """A position reported after the media was published still reaches the state."""
+        player = self._playing_player(
+            mock_mass,
+            media_elapsed_time=None,
+            media_last_updated=None,
+            player_elapsed_time=None,
+            player_last_updated=None,
+        )
+        published = player.state.current_media
+        assert published is not None
+        assert published.elapsed_time is None
+
+        anchor = time.time()
+        player._attr_elapsed_time = 5.0
+        player._attr_elapsed_time_last_updated = anchor
+        player.update_state(signal_event=False)
+
+        published = player.state.current_media
+        assert published is not None
+        assert published.elapsed_time == 5
+        assert published.elapsed_time_last_updated == anchor
+
+    def test_steady_playback_keeps_the_previous_anchor(self, mock_mass: MagicMock) -> None:
+        """A regular playback tick keeps the anchor it already published."""
+        anchor = time.time()
+        player = self._playing_player(
+            mock_mass,
+            media_elapsed_time=None,
+            media_last_updated=None,
+            player_elapsed_time=10.0,
+            player_last_updated=anchor,
+        )
+
+        player._attr_elapsed_time = 11.0
+        player._attr_elapsed_time_last_updated = anchor + 1
+        player.update_state(signal_event=False)
+
+        assert player.state.current_media is not None
+        assert player.state.current_media.elapsed_time == 10
+        assert player.state.current_media.elapsed_time_last_updated == anchor
+
+    def test_player_position_is_paired_with_its_own_timestamp(self, mock_mass: MagicMock) -> None:
+        """Falling back to the player position also takes the player level timestamp."""
+        player_anchor = time.time()
+        player = self._playing_player(
+            mock_mass,
+            media_elapsed_time=None,
+            media_last_updated=player_anchor - 30,
+            player_elapsed_time=42.7,
+            player_last_updated=player_anchor,
+        )
+
+        assert player.state.current_media is not None
+        assert player.state.current_media.elapsed_time == 42
+        assert player.state.current_media.elapsed_time_last_updated == player_anchor
+
+    def test_no_position_reports_no_timestamp(self, mock_mass: MagicMock) -> None:
+        """Without any position, the timestamp is dropped along with it."""
+        player = self._playing_player(
+            mock_mass,
+            media_elapsed_time=None,
+            media_last_updated=time.time(),
+            player_elapsed_time=None,
+            player_last_updated=time.time(),
+        )
+
+        assert player.state.current_media is not None
+        assert player.state.current_media.elapsed_time is None
+        assert player.state.current_media.elapsed_time_last_updated is None
+
+
+class TestStreamMetadataPosition:
+    """The published position of a queue item carrying live stream metadata."""
+
+    def _playing_player(
+        self,
+        mock_mass: MagicMock,
+        *,
+        metadata_elapsed_time: int | None,
+        metadata_last_updated: float | None,
+        queue_elapsed_time: float,
+        queue_last_updated: float,
+        media_type: MediaType = MediaType.RADIO,
+    ) -> MockPlayer:
+        """Build a playing player whose active queue item carries live stream metadata."""
+        queue = PlayerQueue(
+            queue_id="player_1",
+            active=True,
+            display_name="Player 1",
+            available=True,
+            items=1,
+            elapsed_time=queue_elapsed_time,
+            elapsed_time_last_updated=queue_last_updated,
+            current_item=QueueItem(
+                queue_id="player_1",
+                queue_item_id="item_1",
+                name="Live Radio",
+                duration=None,
+                streamdetails=StreamDetails(
+                    provider="test_provider",
+                    item_id="item_1",
+                    audio_format=AudioFormat(),
+                    media_type=media_type,
+                    stream_metadata=StreamMetadata(
+                        title="Live Track",
+                        elapsed_time=metadata_elapsed_time,
+                        elapsed_time_last_updated=metadata_last_updated,
+                    ),
+                ),
+            ),
+        )
+        mock_mass.player_queues.get = MagicMock(return_value=queue)
+        provider = MockProvider("test_provider", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+        player._attr_playback_state = PlaybackState.PLAYING
+        player.update_state(signal_event=False)
+        return player
+
+    def test_zero_metadata_position_is_reported(self, mock_mass: MagicMock) -> None:
+        """A live track that just started reports zero, not the elapsed stream time."""
+        metadata_anchor = time.time()
+        player = self._playing_player(
+            mock_mass,
+            metadata_elapsed_time=0,
+            metadata_last_updated=metadata_anchor,
+            queue_elapsed_time=300.0,
+            queue_last_updated=metadata_anchor - 30,
+        )
+
+        assert player.state.current_media is not None
+        assert player.state.current_media.title == "Live Track"
+        assert player.state.current_media.elapsed_time == 0
+        assert player.state.current_media.elapsed_time_last_updated == metadata_anchor
+
+    def test_queue_position_is_paired_with_its_own_timestamp(self, mock_mass: MagicMock) -> None:
+        """Without a metadata position, both values come from the queue."""
+        queue_anchor = time.time()
+        player = self._playing_player(
+            mock_mass,
+            metadata_elapsed_time=None,
+            metadata_last_updated=queue_anchor - 30,
+            queue_elapsed_time=300.5,
+            queue_last_updated=queue_anchor,
+        )
+
+        assert player.state.current_media is not None
+        assert player.state.current_media.title == "Live Track"
+        assert player.state.current_media.elapsed_time == 300
+        assert player.state.current_media.elapsed_time_last_updated == queue_anchor
+
+    def test_audio_source_position_matches_player_position(self, mock_mass: MagicMock) -> None:
+        """An upstream source position is reported identically on player and media level."""
+        metadata_anchor = time.time()
+        player = self._playing_player(
+            mock_mass,
+            metadata_elapsed_time=0,
+            metadata_last_updated=metadata_anchor,
+            queue_elapsed_time=300.0,
+            queue_last_updated=metadata_anchor - 30,
+            media_type=MediaType.AUDIO_SOURCE,
+        )
+
+        assert player.state.current_media is not None
+        assert player.state.elapsed_time == 0
+        assert player.state.current_media.elapsed_time == 0
+        assert player.state.elapsed_time_last_updated == metadata_anchor
+        assert player.state.current_media.elapsed_time_last_updated == metadata_anchor
 
 
 class TestMediaUpdatedCallback:


### PR DESCRIPTION
# What does this implement/fix?

A player's playback position could be dropped from the state the server publishes to clients, even though the player was reporting it. Two causes:

- In `__final_current_media`, an operator-precedence slip made the whole `elapsed_time` value collapse to `None` whenever the player's own position was falsy — including the perfectly valid position `0` at the start of a track, and including positions the provider had explicitly set on the media itself. The accompanying timestamp did not collapse, so clients received a timestamp for a position that was no longer there.
- Once a track was published without a position, `__reconcile_current_media_anchor` kept copying that empty position over every later one, so a position arriving a moment later (common for polling providers) never reached clients for the rest of that track — not even after a seek.

Position and timestamp are now always taken from the same source, so a client never extrapolates a position against a timestamp that belongs to a different one.

**Related issue (if applicable):**

- n/a — found while reviewing the frontend's elapsed-time handling in music-assistant/frontend#2279

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Not user-visible today: the frontend already falls back to the player-level position, so this is a server-side correctness fix.

### Changes

- Prefer the media's own position when it is set (distinguishing "no position" from position `0`), and fall back to the player/queue position otherwise
- Always report the timestamp belonging to whichever position is used
- Apply the same rule to live stream metadata (radio, Spotify Connect, AirPlay receiver), where a track reporting position `0` previously published the elapsed time of the whole stream
- Adopt a newly reported position when the previous one was still empty, instead of holding on to the empty one
- Test coverage for all of the above

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
