### PR TITLE
Make player test config mocks behave like the real config

### DIFF
--- a/tests/controllers/players/test_active_protocol_lifecycle.py
+++ b/tests/controllers/players/test_active_protocol_lifecycle.py
@@ -57,7 +57,7 @@ def mock_mass() -> MagicMock:
             return 0
         if key == "max_volume":
             return 100
-        return default if default is not None else "auto"
+        return default
 
     mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw_player_config_value)
     mass.config.get_raw_core_config_value = MagicMock(return_value="GLOBAL")

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -76,7 +76,7 @@ def _player_config_stub(
     def _conf(_player_id: str, key: str, default: object = None) -> object:
         if key in config:
             return config[key]
-        return default if default is not None else "auto"
+        return default
 
     return _conf
 
@@ -580,7 +580,7 @@ def _set_play_media_override(mock_mass: MagicMock, value: bool) -> None:
             return value
         if callable(original):
             return original(player_id, key, default)
-        return default if default is not None else "auto"
+        return default
 
     mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_side_effect)
 
@@ -1195,7 +1195,7 @@ class TestVolumeScalingOnRedirect:
             if key == "max_volume":
                 # user-facing player caps at 50, the protocol player has no limits of its own
                 return 50 if player_id == "user_player" else 100
-            return default if default is not None else "auto"
+            return default
 
         mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_conf)
 

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -36,7 +36,7 @@ def mock_mass() -> MagicMock:
             return 0
         if key == "max_volume":
             return 100
-        return default if default is not None else "auto"
+        return default
 
     mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw_player_config_value)
     # Return "GLOBAL" for log level config (standard default)

--- a/tests/controllers/players/test_player_protocol_state.py
+++ b/tests/controllers/players/test_player_protocol_state.py
@@ -25,7 +25,9 @@ def mock_mass() -> MagicMock:
     mass.loop = None
     mass.config = MagicMock()
     mass.config.get = MagicMock(return_value=[])
-    mass.config.get_raw_player_config_value = MagicMock(return_value="auto")
+    mass.config.get_raw_player_config_value = MagicMock(
+        side_effect=lambda _player_id, _key, default=None: default
+    )
     mass.config.get_raw_core_config_value = MagicMock(return_value="GLOBAL")
     mass.config.set = MagicMock()
     mass.signal_event = MagicMock()

--- a/tests/controllers/streams/test_audio_sources.py
+++ b/tests/controllers/streams/test_audio_sources.py
@@ -49,7 +49,9 @@ def mock_mass() -> MagicMock:
     mass.loop = None
     mass.config = MagicMock()
     mass.config.get = MagicMock(return_value=[])
-    mass.config.get_raw_player_config_value = MagicMock(return_value="auto")
+    mass.config.get_raw_player_config_value = MagicMock(
+        side_effect=lambda _player_id, _key, default=None: default
+    )
     mass.config.get_raw_core_config_value = MagicMock(return_value="GLOBAL")
     mass.signal_event = MagicMock()
     mass.get_providers = MagicMock(return_value=[])

--- a/tests/models/test_player_queue_source_capabilities.py
+++ b/tests/models/test_player_queue_source_capabilities.py
@@ -20,7 +20,9 @@ from tests.common import MockPlayer, MockProvider
 def mock_mass() -> MagicMock:
     """Create a mock MusicAssistant instance."""
     mass = MagicMock()
-    mass.config.get_raw_player_config_value = MagicMock(return_value="auto")
+    mass.config.get_raw_player_config_value = MagicMock(
+        side_effect=lambda _player_id, _key, default=None: default
+    )
     return mass
 
 

--- a/tests/models/test_player_state_select_source.py
+++ b/tests/models/test_player_state_select_source.py
@@ -15,7 +15,9 @@ from tests.common import MockPlayer, MockProvider
 def mock_mass() -> MagicMock:
     """Create a mock MusicAssistant instance."""
     mass = MagicMock()
-    mass.config.get_raw_player_config_value = MagicMock(return_value="auto")
+    mass.config.get_raw_player_config_value = MagicMock(
+        side_effect=lambda _player_id, _key, default=None: default
+    )
     return mass
 
 

--- a/tests/models/test_player_state_updates.py
+++ b/tests/models/test_player_state_updates.py
@@ -23,7 +23,9 @@ def mock_mass() -> MagicMock:
     """Create a mock MusicAssistant instance."""
     mass = MagicMock()
     mass.closing = False
-    mass.config.get_raw_player_config_value = MagicMock(return_value="auto")
+    mass.config.get_raw_player_config_value = MagicMock(
+        side_effect=lambda _player_id, _key, default=None: default
+    )
     # no queue registered: current_media resolves from the player's native media
     mass.player_queues.get = MagicMock(return_value=None)
     mass.players.scale_volume_from_device = MagicMock(side_effect=lambda _player_id, volume: volume)

--- a/tests/providers/universal_player/test_player.py
+++ b/tests/providers/universal_player/test_player.py
@@ -27,7 +27,7 @@ def _make_mock_mass() -> MagicMock:
             return 0
         if key == "max_volume":
             return 100
-        return default if default is not None else "auto"
+        return default
 
     mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw_player_config_value)
     mass.config.get_raw_core_config_value = MagicMock(return_value="GLOBAL")


### PR DESCRIPTION
# What does this implement/fix?

Several player test fixtures mocked `get_raw_player_config_value` so that it invented an `"auto"` value for any config key the test hadn't explicitly mocked. Real code reading a key without a default gets `None`, never `"auto"` — so the mocks did not match production and could hide bugs. This follows up #5384, which fixed the same pattern in `test_protocol_linking.py`.

Most of the fabricated reads were harmless in practice: the volume/power/mute control and preferred-protocol readers all treat `None` and `"auto"` the same way. One did not — the announcement chime URL is a plain truthiness check, so the mock made those tests announce with `"auto"` as the chime URL instead of the built-in default.

A second set of fixtures returned `"auto"` for *every* call, overriding even the defaults the caller explicitly passed. Those now hand back the caller's default, like the real config does.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
