### PR TITLE
Make the streamserver's internal address list private

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -203,7 +203,7 @@ class StreamsController(CoreController):
         self._configured_publish_ip: str | None = None
         # every address players may reach this host on, best candidate first; publish_ip is
         # the first of them and the network fingerprint watches the whole list for changes
-        self.publish_addresses: list[str] = []
+        self._publish_addresses: list[str] = []
         # the network as it was at the previous setup, to spot a runtime change
         self._network_fingerprint: tuple[str, str, int, tuple[str, ...]] | None = None
         self.audio = StreamsAudio(mass)
@@ -1653,7 +1653,7 @@ class StreamsController(CoreController):
             self._bind_ip,
             str(self.publish_ip),
             cast("int", self.publish_port),
-            tuple(self.publish_addresses),
+            tuple(self._publish_addresses),
         )
         if previous is None or previous == current:
             self._network_fingerprint = current
@@ -1702,11 +1702,11 @@ class StreamsController(CoreController):
         :param publish_candidates: Host addresses reachable from the local network, ranked.
         """
         self._bind_ip = bind_ip
-        self.publish_addresses = _get_publish_addresses(
+        self._publish_addresses = _get_publish_addresses(
             bind_ip, self._configured_publish_ip, publish_candidates
         )
-        # players that can only be handed one address get the highest ranked one
-        self.publish_ip = self.publish_addresses[0]
+        # the single address players are handed, taken from the top of the ranked list
+        self.publish_ip = self._publish_addresses[0]
         self._base_url = f"http://{format_ip_for_url(self.publish_ip)}:{self.publish_port}"
 
 

--- a/tests/controllers/streams/test_bind_fallback.py
+++ b/tests/controllers/streams/test_bind_fallback.py
@@ -67,7 +67,7 @@ async def test_unavailable_bind_ip_publishes_dialable_addresses(
     await _setup_with_bind_ip(controller, mass_minimal, UNBINDABLE_IP)
 
     assert controller.bind_ip == "0.0.0.0"
-    assert controller.publish_addresses == list(ALL_ADDRESSES)
+    assert controller._publish_addresses == list(ALL_ADDRESSES)
 
 
 async def test_available_bind_ip_publishes_only_that_address(
@@ -77,4 +77,4 @@ async def test_available_bind_ip_publishes_only_that_address(
     await _setup_with_bind_ip(controller, mass_minimal, "127.0.0.1")
 
     assert controller.bind_ip == "127.0.0.1"
-    assert controller.publish_addresses == ["127.0.0.1"]
+    assert controller._publish_addresses == ["127.0.0.1"]

--- a/tests/controllers/streams/test_network_change_reload.py
+++ b/tests/controllers/streams/test_network_change_reload.py
@@ -44,7 +44,7 @@ def _streams_controller(*providers: MagicMock) -> StreamsController:
     controller._bind_ip = BIND_IP
     controller.publish_ip = PUBLISH_IP
     controller.publish_port = PUBLISH_PORT
-    controller.publish_addresses = list(PUBLISH_ADDRESSES)
+    controller._publish_addresses = list(PUBLISH_ADDRESSES)
     return controller
 
 
@@ -83,7 +83,7 @@ async def test_reload_without_network_change_reloads_nothing() -> None:
         ("publish_ip", "10.45.0.20"),
         ("publish_port", 8098),
         # narrowing "auto" to one literal address leaves publish_ip itself untouched
-        ("publish_addresses", ["192.168.1.5"]),
+        ("_publish_addresses", ["192.168.1.5"]),
     ],
 )
 async def test_changed_network_reloads_only_dependent_providers(


### PR DESCRIPTION
# What does this implement/fix?

The streamserver keeps the list of addresses it could be reached on, so it can pick the best one as the publish IP and notice when the network underneath it changes. Now that every discovery announcement advertises the single publish IP, nothing outside the streams controller reads that list any more.

Leaving it public invites a provider to grab the whole list again — which is what led to announcements listing container addresses that devices cannot reach. Making it internal leaves the publish IP as the one way to ask the streamserver for its address.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- The streamserver's address list is now internal; `streams.publish_ip` stays the way to get its address.
- How that list is built is unchanged, and the webserver's own list (used for the `_mass._tcp` record) is untouched.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
