### PR TITLE
Stop tests crashing at random on a shared compile cache

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ from music_assistant.controllers.tasks import TasksController
 from music_assistant.mass import MusicAssistant
 from tests.common import suppress_auto_loaded_providers, use_ephemeral_server_ports, utf8_safe
 
-_NUMBA_CACHE_DIR = pytest.StashKey[tempfile.TemporaryDirectory[str]]()
+NUMBA_CACHE_DIR = pytest.StashKey[tempfile.TemporaryDirectory[str]]()
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -36,14 +36,14 @@ def pytest_configure(config: pytest.Config) -> None:
     See https://github.com/numba/numba/issues/10128.
     """
     cache_dir = tempfile.TemporaryDirectory(prefix="ma-numba-cache-")
-    config.stash[_NUMBA_CACHE_DIR] = cache_dir
+    config.stash[NUMBA_CACHE_DIR] = cache_dir
     # numba reads this once, when it is imported; nothing here imports it that early.
     os.environ["NUMBA_CACHE_DIR"] = cache_dir.name
 
 
 def pytest_unconfigure(config: pytest.Config) -> None:
     """Drop this test process's numba kernel cache."""
-    if (cache_dir := config.stash.get(_NUMBA_CACHE_DIR, None)) is not None:
+    if (cache_dir := config.stash.get(NUMBA_CACHE_DIR, None)) is not None:
         cache_dir.cleanup()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@
 
 import asyncio
 import logging
+import os
 import pathlib
+import tempfile
 import threading
 from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager
@@ -19,6 +21,30 @@ from music_assistant.controllers.music import MusicController
 from music_assistant.controllers.tasks import TasksController
 from music_assistant.mass import MusicAssistant
 from tests.common import suppress_auto_loaded_providers, use_ephemeral_server_ports, utf8_safe
+
+_NUMBA_CACHE_DIR = pytest.StashKey[tempfile.TemporaryDirectory[str]]()
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """
+    Give this test process its own numba kernel cache.
+
+    librosa compiles its numba kernels with ``cache=True`` into a directory shared by
+    every process on the machine. numba updates that cache's index non-atomically, so
+    xdist workers filling a cold cache can leave an entry pointing at another
+    signature's machine code — calling it then segfaults the worker.
+    See https://github.com/numba/numba/issues/10128.
+    """
+    cache_dir = tempfile.TemporaryDirectory(prefix="ma-numba-cache-")
+    config.stash[_NUMBA_CACHE_DIR] = cache_dir
+    # numba reads this once, when it is imported; nothing here imports it that early.
+    os.environ["NUMBA_CACHE_DIR"] = cache_dir.name
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Drop this test process's numba kernel cache."""
+    if (cache_dir := config.stash.get(_NUMBA_CACHE_DIR, None)) is not None:
+        cache_dir.cleanup()
 
 
 @pytest.hookimpl(wrapper=True)

--- a/tests/test_numba_cache_isolation.py
+++ b/tests/test_numba_cache_isolation.py
@@ -1,0 +1,17 @@
+"""Test that numba compiles its kernels into a cache private to this test process."""
+
+import os
+from pathlib import Path
+
+import librosa
+import numpy as np
+
+
+def test_numba_kernel_cache_is_process_private() -> None:
+    """Verify librosa's compiled kernels are cached in this process's own directory."""
+    cache_dir = Path(os.environ["NUMBA_CACHE_DIR"])
+    assert cache_dir.is_dir()
+
+    librosa.onset.onset_detect(onset_envelope=np.abs(np.sin(np.arange(256.0))), sr=22050)
+
+    assert list(cache_dir.rglob("*peak_pick*.nbi"))

--- a/tests/test_numba_cache_isolation.py
+++ b/tests/test_numba_cache_isolation.py
@@ -1,16 +1,27 @@
 """Test that numba compiles its kernels into a cache private to this test process."""
 
+from __future__ import annotations
+
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import librosa
 import numpy as np
 
+from tests.conftest import NUMBA_CACHE_DIR
 
-def test_numba_kernel_cache_is_process_private() -> None:
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_numba_kernel_cache_is_process_private(pytestconfig: pytest.Config) -> None:
     """Verify librosa's compiled kernels are cached in this process's own directory."""
+    # a TemporaryDirectory of this session's own, so no other process can be writing here
+    session_cache_dir = pytestconfig.stash[NUMBA_CACHE_DIR]
     cache_dir = Path(os.environ["NUMBA_CACHE_DIR"])
     assert cache_dir.is_dir()
+    assert str(cache_dir) == session_cache_dir.name
 
     librosa.onset.onset_detect(onset_envelope=np.abs(np.sin(np.arange(256.0))), sr=22050)
 

--- a/tests/test_numba_cache_isolation.py
+++ b/tests/test_numba_cache_isolation.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 from typing import TYPE_CHECKING
 
-import librosa
-import numpy as np
+from numba.core import config as numba_config
 
 from tests.conftest import NUMBA_CACHE_DIR
 
@@ -16,13 +14,8 @@ if TYPE_CHECKING:
 
 
 def test_numba_kernel_cache_is_process_private(pytestconfig: pytest.Config) -> None:
-    """Verify librosa's compiled kernels are cached in this process's own directory."""
-    # a TemporaryDirectory of this session's own, so no other process can be writing here
-    session_cache_dir = pytestconfig.stash[NUMBA_CACHE_DIR]
-    cache_dir = Path(os.environ["NUMBA_CACHE_DIR"])
-    assert cache_dir.is_dir()
-    assert str(cache_dir) == session_cache_dir.name
-
-    librosa.onset.onset_detect(onset_envelope=np.abs(np.sin(np.arange(256.0))), sr=22050)
-
-    assert list(cache_dir.rglob("*peak_pick*.nbi"))
+    """Verify numba caches its compiled kernels in a directory this process owns alone."""
+    # a TemporaryDirectory of this session's own, so no other process can be writing there
+    assert os.environ["NUMBA_CACHE_DIR"] == pytestconfig.stash[NUMBA_CACHE_DIR].name
+    # numba snapshots the variable as it is imported, so a mismatch means it got in first
+    assert os.environ["NUMBA_CACHE_DIR"] == numba_config.CACHE_DIR  # type: ignore[attr-defined]


### PR DESCRIPTION
# What does this implement/fix?

The `test` job sometimes died with a native crash instead of a test failure, naming a random
test each time and passing on a re-run of the exact same commit.

Cause: the audio analysis code uses librosa, which compiles its number-crunching kernels once
and stores the result in a cache directory shared by every process on the machine. Updating
that cache is not safe to do from several processes at the same time, so when our parallel
test workers all filled an empty cache at once, one of them could end up loading the wrong
compiled kernel and crash the moment it was called. This is a known, still-open bug in that
library (numba/numba#10128).

Each test process now gets its own cache directory, so there is nothing to collide over.
Only affects the test suite — the server runs analysis in a single process and was never hit
by this.

Reproduced locally with the same crash signature: 12 out of 12 processes crashed when sharing
a cold cache, and 0 out of 32 with the change applied.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
