### PR TITLE
Tidy up where the Music Quiz AI limits live

### DIFF
--- a/music_assistant/providers/music_quiz/ai_distractors.py
+++ b/music_assistant/providers/music_quiz/ai_distractors.py
@@ -11,6 +11,12 @@ from typing import TYPE_CHECKING
 
 from music_assistant.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads, strip_code_fence
 from music_assistant.helpers.plugin_engines import resolve_ai_engine
+from music_assistant.providers.music_quiz.constants import (
+    AI_QUERY_TIMEOUT_SECONDS,
+    MAX_AI_PROMPT_BYTES,
+    MAX_AI_RESPONSE_BYTES,
+    MAX_AI_RESPONSE_LINES,
+)
 from music_assistant.providers.music_quiz.suggestions import answer_labels_are_too_close
 
 if TYPE_CHECKING:
@@ -18,10 +24,6 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
-AI_QUERY_TIMEOUT_SECONDS = 30.0
-MAX_AI_PROMPT_BYTES = 8192
-MAX_AI_RESPONSE_BYTES = 4096
-MAX_AI_RESPONSE_LINES = 32
 MAX_AI_CONTEXT_VALUE_LENGTH = 500
 MAX_AI_LABEL_LENGTH = 200
 MAX_AI_SYNTHETIC_COUNT = 12

--- a/music_assistant/providers/music_quiz/constants.py
+++ b/music_assistant/providers/music_quiz/constants.py
@@ -1,0 +1,10 @@
+"""Constants for the Music Quiz provider."""
+
+from __future__ import annotations
+
+# guards applied to every AI request and response in this provider, so a wedged or
+# runaway engine fails the round instead of the whole quiz
+AI_QUERY_TIMEOUT_SECONDS = 30.0
+MAX_AI_PROMPT_BYTES = 8192
+MAX_AI_RESPONSE_BYTES = 4096
+MAX_AI_RESPONSE_LINES = 32

--- a/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
+++ b/music_assistant/providers/music_quiz/quiz_types/guess_the_song.py
@@ -15,12 +15,12 @@ from music_assistant_models.media_items import Track
 
 from music_assistant.helpers.json import json_dumps
 from music_assistant.providers.music_quiz.ai_distractors import (
-    AI_QUERY_TIMEOUT_SECONDS,
     AIDistractorResponse,
     bounded_ai_context,
     parse_ai_distractor_response,
     request_ai_distractors,
 )
+from music_assistant.providers.music_quiz.constants import AI_QUERY_TIMEOUT_SECONDS
 from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
 from music_assistant.providers.music_quiz.models import (
     DEFAULT_TRIVIA_LANGUAGE,

--- a/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
+++ b/music_assistant/providers/music_quiz/quiz_types/music_timeline.py
@@ -17,12 +17,12 @@ from music_assistant_models.media_items import Artist, ItemMapping, Track
 from music_assistant.helpers.compare import compare_artist
 from music_assistant.helpers.json import json_dumps
 from music_assistant.providers.music_quiz.ai_distractors import (
-    AI_QUERY_TIMEOUT_SECONDS,
     AIDistractorResponse,
     bounded_ai_context,
     parse_ai_distractor_response,
     request_ai_distractors,
 )
+from music_assistant.providers.music_quiz.constants import AI_QUERY_TIMEOUT_SECONDS
 from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
 from music_assistant.providers.music_quiz.models import (
     DEFAULT_TRIVIA_LANGUAGE,

--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -23,7 +23,7 @@ from music_assistant.helpers.json import (
     strip_code_fence,
 )
 from music_assistant.helpers.plugin_engines import get_ai_engines, resolve_ai_engine
-from music_assistant.providers.music_quiz.ai_distractors import (
+from music_assistant.providers.music_quiz.constants import (
     AI_QUERY_TIMEOUT_SECONDS,
     MAX_AI_PROMPT_BYTES,
     MAX_AI_RESPONSE_BYTES,

--- a/tests/providers/music_quiz/test_music_timeline.py
+++ b/tests/providers/music_quiz/test_music_timeline.py
@@ -25,7 +25,7 @@ from music_assistant_models.unique_list import UniqueList
 from music_assistant.constants import VARIOUS_ARTISTS_MBID, VARIOUS_ARTISTS_NAME
 from music_assistant.controllers.music.recency import RecencySnapshot
 from music_assistant.models.plugin import AIEngine, PluginProvider
-from music_assistant.providers.music_quiz.ai_distractors import AI_QUERY_TIMEOUT_SECONDS
+from music_assistant.providers.music_quiz.constants import AI_QUERY_TIMEOUT_SECONDS
 from music_assistant.providers.music_quiz.models import (
     MusicQuizConfig,
     MusicQuizDifficulty,

--- a/tests/providers/music_quiz/test_suggestions.py
+++ b/tests/providers/music_quiz/test_suggestions.py
@@ -11,11 +11,13 @@ import pytest
 from music_assistant.models.plugin import AIEngine, PluginProvider
 from music_assistant.providers.music_quiz.ai_distractors import (
     MAX_AI_LABEL_LENGTH,
+    parse_ai_distractor_response,
+    request_ai_distractors,
+)
+from music_assistant.providers.music_quiz.constants import (
     MAX_AI_PROMPT_BYTES,
     MAX_AI_RESPONSE_BYTES,
     MAX_AI_RESPONSE_LINES,
-    parse_ai_distractor_response,
-    request_ai_distractors,
 )
 from music_assistant.providers.music_quiz.suggestions import (
     SuggestionCandidate,

--- a/tests/providers/music_quiz/test_trivia.py
+++ b/tests/providers/music_quiz/test_trivia.py
@@ -26,7 +26,7 @@ from music_assistant.constants import VARIOUS_ARTISTS_MBID, VARIOUS_ARTISTS_NAME
 from music_assistant.controllers.music.recency import RecencySnapshot
 from music_assistant.helpers.json import json_dumps, json_loads
 from music_assistant.models.plugin import AIEngine, PluginProvider
-from music_assistant.providers.music_quiz.ai_distractors import (
+from music_assistant.providers.music_quiz.constants import (
     AI_QUERY_TIMEOUT_SECONDS,
     MAX_AI_PROMPT_BYTES,
     MAX_AI_RESPONSE_BYTES,


### PR DESCRIPTION
# What does this implement/fix?

The Music Quiz provider applies four limits to every AI request and response (timeout, max prompt size, max response size, max response lines). Those limits lived in `ai_distractors.py`, so all three quiz types had to import them from the distractor module — including Trivia, which switches distractors off entirely and uses none of that module's code.

Moved them to a plain `constants.py` in the provider, alongside how other providers (e.g. AI Radio) organise their constants. Trivia no longer imports the distractor module at all. No behaviour change: same values, same limits, same tests.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Added `music_assistant/providers/music_quiz/constants.py` holding the four shared AI request/response limits.
- Updated the three quiz types and `ai_distractors.py` to import them from there.
- Updated the matching test imports.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
