### PR TITLE
Document the native libraries needed to run the tests locally

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,6 +5,17 @@ Developer docs
 * ffmpeg (minimum version 6.1, version 7 recommended), must be available in the path so install at OS level
 * Python 3.14 is minimal required (the exact pinned runtime lives in `.python-version` at the repo root — that file is the single source of truth for all tools)
 * [Python venv](https://docs.python.org/3/library/venv.html)
+* libchromaprint and PortAudio, also at OS level. The `acoustid_lookup` and `local_audio` providers bind to these natively. Without libchromaprint the AcoustID tests abort the entire `pytest` run while collecting; without PortAudio the local audio tests that use it are skipped.
+
+      # macOS
+      brew install chromaprint portaudio
+
+      # Debian/Ubuntu
+      sudo apt-get install libchromaprint1 libportaudio2
+
+    On Apple Silicon, Homebrew installs into `/opt/homebrew`, which is not on the dynamic loader's default search path. `pyacoustid` opens libchromaprint by bare filename, so installing the package is not enough — add this to your shell profile as well:
+
+      export DYLD_FALLBACK_LIBRARY_PATH="$(brew --prefix)/lib:/usr/local/lib:/usr/lib"
 
 We recommend developing on a (recent) macOS or Linux machine.
 It is recommended to use Visual Studio Code as your IDE, since launch files to start Music Assistant are provided as part of the repository. Furthermore, the current code base is not verified to work on a native Windows machine. If you would like to develop on a Windows machine, install [WSL2](https://code.visualstudio.com/blogs/2019/09/03/wsl2) to increase your swag-level 🤘.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -46,5 +46,57 @@ else
   echo "⚠️  pre-commit not available. Install with: uv pip install pre-commit"
 fi
 
+missing_prereqs=0
+brew_lib_dir=""
+if [[ "$(uname -s)" == "Darwin" ]] && command -v brew &>/dev/null; then
+  brew_lib_dir="$(brew --prefix 2>/dev/null)/lib" || brew_lib_dir=""
+fi
+
+# Report a missing OS-level dependency with the install command for this platform.
+warn_missing() {
+  local reason=$1 brew_pkg=$2 apt_pkg=$3
+  echo "⚠️  $reason"
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "    Install it with: brew install $brew_pkg"
+  else
+    echo "    Install it with: sudo apt-get install $apt_pkg"
+  fi
+  missing_prereqs=1
+}
+
+# Report a Python binding that is installed but cannot load its native library.
+check_native_lib() {
+  local module=$1 brew_pkg=$2 apt_pkg=$3
+  # Only meaningful once requirements_all.txt has installed the binding itself.
+  if ! python -c "import importlib.util as u, sys; sys.exit(0 if u.find_spec('$module') else 1)" 2>/dev/null; then
+    return
+  fi
+  if python -c "import $module" 2>/dev/null; then
+    return
+  fi
+  # macOS strips DYLD_* before this script starts, so retry against the Homebrew prefix
+  # to tell "library absent" apart from "library present but off the loader path".
+  if [[ -n "$brew_lib_dir" ]] &&
+    DYLD_FALLBACK_LIBRARY_PATH="$brew_lib_dir:/usr/local/lib:/usr/lib" python -c "import $module" 2>/dev/null; then
+    echo "⚠️  '$module' only finds its native library through the Homebrew prefix."
+    echo "    Make sure your shell profile exports this (this script cannot see it):"
+    echo "      export DYLD_FALLBACK_LIBRARY_PATH=\"\$(brew --prefix)/lib:/usr/local/lib:/usr/lib\""
+    missing_prereqs=1
+    return
+  fi
+  warn_missing "'$module' is installed but cannot load its native library." "$brew_pkg" "$apt_pkg"
+}
+
+# These bindings are imported at module scope by their providers, so a missing native
+# library surfaces as a pytest collection error rather than a skipped test.
+echo "Checking OS-level dependencies..."
+command -v ffmpeg &>/dev/null || warn_missing "ffmpeg not found in PATH (6.1 minimum, 7.x recommended)." ffmpeg ffmpeg
+check_native_lib chromaprint chromaprint libchromaprint1
+check_native_lib sounddevice portaudio libportaudio2
+
+if [[ "$missing_prereqs" -eq 1 ]]; then
+  echo "⚠️  Tests may fail or be skipped until the above is resolved (see DEVELOPMENT.md)."
+fi
+
 echo "✅ Done. Interpreter: $(python -V). Package manager: $(uv --version)"
 echo "To activate the virtual environment, run: source $env_name/bin/activate"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -56,10 +56,12 @@ fi
 warn_missing() {
   local reason=$1 brew_pkg=$2 apt_pkg=$3
   echo "⚠️  $reason"
-  if [[ "$(uname -s)" == "Darwin" ]]; then
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "    Install it with: sudo apt-get install $apt_pkg"
+  elif command -v brew &>/dev/null; then
     echo "    Install it with: brew install $brew_pkg"
   else
-    echo "    Install it with: sudo apt-get install $apt_pkg"
+    echo "    Install Homebrew from https://brew.sh, then: brew install $brew_pkg"
   fi
   missing_prereqs=1
 }


### PR DESCRIPTION
# What does this implement/fix?

`DEVELOPMENT.md` listed only ffmpeg and Python as OS-level prerequisites, but the test suite also needs two native libraries that CI installs and the docs never mentioned. The `acoustid_lookup` and `local_audio` providers import their Python bindings at module scope, so someone who follows the docs and runs `pytest` gets a hard collection error that aborts the whole run rather than skipping a test:

    ImportError: couldn't find libchromaprint

On Apple Silicon, installing the Homebrew package is not enough on its own: `pyacoustid` opens the library by bare filename, and Homebrew's prefix is not on the dynamic loader's default search path.

- document libchromaprint and PortAudio in the prerequisites, with both brew and apt commands
- note the extra `DYLD_FALLBACK_LIBRARY_PATH` step Apple Silicon needs
- check ffmpeg and both libraries at the end of `scripts/setup.sh`, so a missing one is reported during setup instead of surfacing later as a confusing `pytest` error

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
