### PR TITLE
Share playlist track requests again on Yandex Music and KION Music

### DIFF
--- a/music_assistant/providers/kion_music/provider.py
+++ b/music_assistant/providers/kion_music/provider.py
@@ -1886,9 +1886,12 @@ class KionMusicProvider(MusicProvider):
             raise MediaNotFoundError(f"Playlist {prov_playlist_id} not found")
         return parse_playlist(self, playlist)
 
+    # single_flight=False: this advances the rotor cursor and sends a one-shot "radioStarted"
+    # feedback, which must happen once per call
+    @use_cache(3600 * 3, allow_expired_cache=True, single_flight=False)
     async def _get_my_wave_playlist_tracks(self, page: int) -> list[Track]:
         """
-        Get My Mix tracks for virtual playlist (uncached; uses cursor for page > 0).
+        Get My Mix tracks for virtual playlist (uses cursor for page > 0).
 
         Fetches MY_WAVE_BATCH_SIZE Rotor API batches per page call to reduce
         the number of round-trips when the player controller paginates through pages.
@@ -1963,6 +1966,7 @@ class KionMusicProvider(MusicProvider):
             self._my_wave_playlist_next_cursor = next_cursor
             return tracks
 
+    @use_cache(3600 * 3, allow_expired_cache=True)
     async def _get_liked_tracks_playlist_tracks(self, page: int) -> list[Track]:
         """
         Get liked tracks for virtual playlist (sorted in reverse chronological order).
@@ -2416,10 +2420,6 @@ class KionMusicProvider(MusicProvider):
             icon="mdi-weather-sunny",
         )
 
-    # single_flight=False: the My Mix branch advances the rotor cursor and sends a one-shot
-    # "radioStarted" feedback, which must happen once per call. The cache sits on this
-    # method, so the flag covers the other playlist kinds along with it
-    @use_cache(3600 * 3, allow_expired_cache=True, single_flight=False)
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
         """
         Get playlist tracks.
@@ -2443,6 +2443,17 @@ class KionMusicProvider(MusicProvider):
             self.logger.debug("Liked Tracks playlist returned %s tracks", len(result))
             return result
 
+        return await self._get_regular_playlist_tracks(prov_playlist_id, page)
+
+    @use_cache(3600 * 3, allow_expired_cache=True)
+    async def _get_regular_playlist_tracks(self, prov_playlist_id: str, page: int) -> list[Track]:
+        """
+        Get the tracks of a regular (non-virtual) playlist.
+
+        :param prov_playlist_id: The provider playlist ID (format: "owner_id:kind").
+        :param page: Page number for pagination.
+        :return: List of Track objects.
+        """
         # KION Music API returns all playlist tracks in one call (no server-side pagination).
         # Return empty list for page > 0 so the controller pagination loop terminates.
         if page > 0:

--- a/music_assistant/providers/kion_music/provider.py
+++ b/music_assistant/providers/kion_music/provider.py
@@ -1887,7 +1887,7 @@ class KionMusicProvider(MusicProvider):
         return parse_playlist(self, playlist)
 
     # single_flight=False: this advances the rotor cursor and sends a one-shot "radioStarted"
-    # feedback, which must happen once per call
+    # feedback, so concurrent callers must each get their own batch instead of sharing one
     @use_cache(3600 * 3, allow_expired_cache=True, single_flight=False)
     async def _get_my_wave_playlist_tracks(self, page: int) -> list[Track]:
         """

--- a/music_assistant/providers/yandex_music/provider.py
+++ b/music_assistant/providers/yandex_music/provider.py
@@ -2631,9 +2631,12 @@ class YandexMusicProvider(MusicProvider):
             raise MediaNotFoundError(f"Playlist {prov_playlist_id} not found")
         return parse_playlist(self, playlist)
 
+    # single_flight=False: this advances the rotor cursor and sends a one-shot "radioStarted"
+    # feedback, which must happen once per call
+    @use_cache(3600 * 3, allow_expired_cache=True, single_flight=False)
     async def _get_my_wave_playlist_tracks(self, page: int) -> list[Track]:
         """
-        Get My Wave tracks for virtual playlist (uncached; uses cursor for page > 0).
+        Get My Wave tracks for virtual playlist (uses cursor for page > 0).
 
         Fetches MY_WAVE_BATCH_SIZE Rotor API batches per page call to reduce
         the number of round-trips when the player controller paginates through pages.
@@ -2709,6 +2712,7 @@ class YandexMusicProvider(MusicProvider):
             wave.playlist_next_cursor = next_cursor
             return tracks
 
+    @use_cache(3600 * 3, allow_expired_cache=True)
     async def _get_liked_tracks_playlist_tracks(self, page: int) -> list[Track]:
         """
         Get liked tracks for virtual playlist (sorted in reverse chronological order).
@@ -3361,10 +3365,6 @@ class YandexMusicProvider(MusicProvider):
             icon="mdi-weather-sunny",
         )
 
-    # single_flight=False: the My Wave branch advances the rotor cursor and sends a one-shot
-    # "radioStarted" feedback, which must happen once per call. The cache sits on this
-    # method, so the flag covers the other playlist kinds along with it
-    @use_cache(3600 * 3, allow_expired_cache=True, single_flight=False)
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
         """
         Get playlist tracks.
@@ -3388,6 +3388,17 @@ class YandexMusicProvider(MusicProvider):
             self.logger.debug("Liked Tracks playlist returned %s tracks", len(result))
             return result
 
+        return await self._get_regular_playlist_tracks(prov_playlist_id, page)
+
+    @use_cache(3600 * 3, allow_expired_cache=True)
+    async def _get_regular_playlist_tracks(self, prov_playlist_id: str, page: int) -> list[Track]:
+        """
+        Get the tracks of a regular (non-virtual) playlist.
+
+        :param prov_playlist_id: The provider playlist ID (format: "owner_id:kind").
+        :param page: Page number for pagination.
+        :return: List of Track objects.
+        """
         # Yandex Music API returns all playlist tracks in one call (no server-side pagination).
         # Return empty list for page > 0 so the controller pagination loop terminates.
         if page > 0:

--- a/music_assistant/providers/yandex_music/provider.py
+++ b/music_assistant/providers/yandex_music/provider.py
@@ -2632,7 +2632,7 @@ class YandexMusicProvider(MusicProvider):
         return parse_playlist(self, playlist)
 
     # single_flight=False: this advances the rotor cursor and sends a one-shot "radioStarted"
-    # feedback, which must happen once per call
+    # feedback, so concurrent callers must each get their own batch instead of sharing one
     @use_cache(3600 * 3, allow_expired_cache=True, single_flight=False)
     async def _get_my_wave_playlist_tracks(self, page: int) -> list[Track]:
         """

--- a/tests/providers/kion_music/test_provider.py
+++ b/tests/providers/kion_music/test_provider.py
@@ -1,0 +1,113 @@
+"""
+Unit tests for KionMusicProvider (provider.py).
+
+These tests construct a partial provider instance via ``__new__`` (no
+``__init__``), attach the attributes the method-under-test reads, and
+exercise it directly. The pattern avoids the upstream Music Assistant
+provider-init machinery which would otherwise drag in a real
+``MusicAssistant`` instance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+from unittest import mock
+
+import pytest
+
+from music_assistant.providers.kion_music.constants import MY_WAVE_PLAYLIST_ID
+from music_assistant.providers.kion_music.provider import KionMusicProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from music_assistant.mass import MusicAssistant
+
+
+class _StubConfig:
+    """Minimal provider config for the @use_cache decorator."""
+
+    instance_id = "kion_music_test"
+
+    def get_value(self, key: str, default: Any = None) -> Any:
+        """Return the default for every config key."""
+        return default
+
+
+@pytest.fixture
+async def cached_provider(
+    mass_minimal: MusicAssistant,
+) -> tuple[KionMusicProvider, mock.AsyncMock]:
+    """Return a provider with a mocked API client, backed by a real (empty) cache."""
+    await mass_minimal.cache._setup_database()
+    provider = KionMusicProvider.__new__(KionMusicProvider)
+    mock_client = mock.AsyncMock()
+    mock_client.user_id = 12345
+    provider._client = mock_client
+    provider.logger = mock.MagicMock()
+    provider.mass = mass_minimal
+    provider.config = _StubConfig()  # type: ignore[assignment]
+    provider.manifest = mock.MagicMock(domain="kion_music")
+    provider._my_wave_lock = asyncio.Lock()
+    provider._my_wave_seen_track_ids = set()
+    provider._my_wave_radio_started_sent = False
+    provider._my_wave_playlist_next_cursor = None
+    return provider, mock_client
+
+
+async def _wait_for_gated_fetch(started: Callable[[], bool]) -> None:
+    """Wait until the gated fetch runs, then let the other callers catch up with it."""
+    for _ in range(200):
+        if started():
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("gated fetch never started")
+    # a caller arriving after the gate is released would start a second fetch,
+    # which the await-count assertions below catch
+    await asyncio.sleep(0.05)
+
+
+async def test_regular_playlist_fetch_is_shared_between_callers(
+    cached_provider: tuple[KionMusicProvider, mock.AsyncMock],
+) -> None:
+    """Concurrent callers for the same regular playlist share one provider fetch."""
+    provider, mock_client = cached_provider
+    gate = asyncio.Event()
+
+    async def _get_playlist(*_args: Any, **_kwargs: Any) -> Any:
+        await gate.wait()
+        return type("PL", (), {"tracks": [], "track_count": 0})()
+
+    mock_client.get_playlist = mock.AsyncMock(side_effect=_get_playlist)
+
+    tasks = [asyncio.create_task(provider.get_playlist_tracks("12345:67")) for _ in range(3)]
+    await _wait_for_gated_fetch(lambda: mock_client.get_playlist.await_count > 0)
+    gate.set()
+
+    assert await asyncio.gather(*tasks) == [[], [], []]
+    assert mock_client.get_playlist.await_count == 1
+
+
+async def test_my_mix_fetch_runs_for_every_caller(
+    cached_provider: tuple[KionMusicProvider, mock.AsyncMock],
+) -> None:
+    """Every My Mix caller runs its own fetch, so the rotor cursor keeps advancing."""
+    provider, mock_client = cached_provider
+    gate = asyncio.Event()
+
+    async def _get_my_wave_tracks(*_args: Any, **_kwargs: Any) -> tuple[list[Any], None]:
+        await gate.wait()
+        return [], None
+
+    mock_client.get_my_wave_tracks = mock.AsyncMock(side_effect=_get_my_wave_tracks)
+
+    tasks = [
+        asyncio.create_task(provider.get_playlist_tracks(MY_WAVE_PLAYLIST_ID)) for _ in range(3)
+    ]
+    await _wait_for_gated_fetch(lambda: mock_client.get_my_wave_tracks.await_count > 0)
+    gate.set()
+
+    assert await asyncio.gather(*tasks) == [[], [], []]
+    assert mock_client.get_my_wave_tracks.await_count == 3

--- a/tests/providers/kion_music/test_provider.py
+++ b/tests/providers/kion_music/test_provider.py
@@ -3,9 +3,9 @@ Unit tests for KionMusicProvider (provider.py).
 
 These tests construct a partial provider instance via ``__new__`` (no
 ``__init__``), attach the attributes the method-under-test reads, and
-exercise it directly. The pattern avoids the upstream Music Assistant
-provider-init machinery which would otherwise drag in a real
-``MusicAssistant`` instance.
+exercise it directly, so the upstream provider-init machinery does not run.
+The cache decorator does need a server, so those tests attach the minimal
+``MusicAssistant`` instance from the ``mass_minimal`` fixture.
 """
 
 from __future__ import annotations

--- a/tests/providers/yandex_music/test_provider.py
+++ b/tests/providers/yandex_music/test_provider.py
@@ -5,7 +5,8 @@ These tests construct a partial provider instance via ``__new__`` (no
 ``__init__``), attach the attributes the method-under-test reads, and
 exercise it directly. The pattern avoids the upstream Music Assistant
 provider-init machinery which would otherwise drag in a real
-``MusicAssistant`` instance.
+``MusicAssistant`` instance. Tests that exercise the cache decorator do
+need a server, and attach the minimal one from the ``mass_minimal`` fixture.
 """
 
 from __future__ import annotations

--- a/tests/providers/yandex_music/test_provider.py
+++ b/tests/providers/yandex_music/test_provider.py
@@ -10,15 +10,24 @@ provider-init machinery which would otherwise drag in a real
 
 from __future__ import annotations
 
-from typing import Any
+import asyncio
+from typing import TYPE_CHECKING, Any
 from unittest import mock
 
 import pytest
 from music_assistant_models.errors import ResourceTemporarilyUnavailable
 
 from music_assistant.models.music_provider import MusicProvider
-from music_assistant.providers.yandex_music.constants import TRACK_BATCH_SIZE
+from music_assistant.providers.yandex_music.constants import (
+    MY_WAVE_PLAYLIST_ID,
+    TRACK_BATCH_SIZE,
+)
 from music_assistant.providers.yandex_music.provider import YandexMusicProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from music_assistant.mass import MusicAssistant
 
 
 def _make_provider() -> tuple[YandexMusicProvider, mock.AsyncMock]:
@@ -79,8 +88,8 @@ async def test_get_playlist_tracks_continues_on_empty_batch() -> None:
         "music_assistant.providers.yandex_music.provider.parse_track",
         side_effect=lambda _self, t: t,
     ):
-        fn: Any = YandexMusicProvider.get_playlist_tracks.__wrapped__  # type: ignore[attr-defined]
-        result = await fn(provider, "12345:67")
+        cached: Any = YandexMusicProvider._get_regular_playlist_tracks
+        result = await cached.__wrapped__(provider, "12345:67", 0)
 
     # 50 from batch 1 + 50 from batch 3 = 100 tracks; the empty batch 2 must
     # not abort the load.
@@ -110,9 +119,94 @@ async def test_get_playlist_tracks_raises_only_when_every_batch_is_empty() -> No
     mock_client.get_playlist = mock.AsyncMock(return_value=playlist_obj)
     mock_client.get_tracks = mock.AsyncMock(side_effect=[[], []])
 
-    fn: Any = YandexMusicProvider.get_playlist_tracks.__wrapped__  # type: ignore[attr-defined]
+    cached: Any = YandexMusicProvider._get_regular_playlist_tracks
     with pytest.raises(ResourceTemporarilyUnavailable):
-        await fn(provider, "12345:67")
+        await cached.__wrapped__(provider, "12345:67", 0)
+
+
+# -- request coalescing is scoped to the branch that must run per call --------
+
+
+class _StubConfig:
+    """Minimal provider config for the @use_cache decorator."""
+
+    instance_id = "yandex_music_test"
+
+    def get_value(self, key: str, default: Any = None) -> Any:
+        """Return the default for every config key."""
+        return default
+
+
+@pytest.fixture
+async def cached_provider(
+    mass_minimal: MusicAssistant,
+) -> tuple[YandexMusicProvider, mock.AsyncMock]:
+    """Return a provider backed by a real (empty) cache controller."""
+    await mass_minimal.cache._setup_database()
+    provider, mock_client = _make_provider()
+    provider.mass = mass_minimal
+    provider.config = _StubConfig()  # type: ignore[assignment]
+    provider.manifest = mock.MagicMock(domain="yandex_music")
+    provider._wave_states = {}
+    return provider, mock_client
+
+
+async def _wait_for_gated_fetch(started: Callable[[], bool]) -> None:
+    """Wait until the gated fetch runs, then let the other callers catch up with it."""
+    for _ in range(200):
+        if started():
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("gated fetch never started")
+    # a caller arriving after the gate is released would start a second fetch,
+    # which the await-count assertions below catch
+    await asyncio.sleep(0.05)
+
+
+async def test_regular_playlist_fetch_is_shared_between_callers(
+    cached_provider: tuple[YandexMusicProvider, mock.AsyncMock],
+) -> None:
+    """Concurrent callers for the same regular playlist share one provider fetch."""
+    provider, mock_client = cached_provider
+    gate = asyncio.Event()
+
+    async def _get_playlist(*_args: Any, **_kwargs: Any) -> Any:
+        await gate.wait()
+        return type("PL", (), {"tracks": [], "track_count": 0})()
+
+    mock_client.get_playlist = mock.AsyncMock(side_effect=_get_playlist)
+
+    tasks = [asyncio.create_task(provider.get_playlist_tracks("12345:67")) for _ in range(3)]
+    await _wait_for_gated_fetch(lambda: mock_client.get_playlist.await_count > 0)
+    gate.set()
+
+    assert await asyncio.gather(*tasks) == [[], [], []]
+    assert mock_client.get_playlist.await_count == 1
+
+
+async def test_my_wave_fetch_runs_for_every_caller(
+    cached_provider: tuple[YandexMusicProvider, mock.AsyncMock],
+) -> None:
+    """Every My Wave caller runs its own fetch, so the rotor cursor keeps advancing."""
+    provider, _ = cached_provider
+    gate = asyncio.Event()
+
+    async def _fetch_batch(*_args: Any, **_kwargs: Any) -> tuple[list[Any], None]:
+        await gate.wait()
+        return [], None
+
+    fetch_batch = mock.AsyncMock(side_effect=_fetch_batch)
+    provider._fetch_rotor_session_batch = fetch_batch  # type: ignore[method-assign]
+
+    tasks = [
+        asyncio.create_task(provider.get_playlist_tracks(MY_WAVE_PLAYLIST_ID)) for _ in range(3)
+    ]
+    await _wait_for_gated_fetch(lambda: fetch_batch.await_count > 0)
+    gate.set()
+
+    assert await asyncio.gather(*tasks) == [[], [], []]
+    assert fetch_batch.await_count == 3
 
 
 # -- M11: unload() must clear every per-session cache -------------------------


### PR DESCRIPTION
# What does this implement/fix?

Fetching the same playlist twice at once now results in a single request to Yandex Music / KION Music again.

Both providers ask for one exception to that request sharing: the My Wave / My Mix branch has to run for every call, because it moves the station forward and sends a one-off "started listening" signal. That exception was set on the shared entry point, so it also switched off sharing for liked tracks and for ordinary playlists on those two providers. This scopes it to the branch that actually needs it.

**Related issue (if applicable):**

- follow-up on #5370

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- `get_playlist_tracks` is now a plain dispatcher on both providers; the caching moved onto the per-kind helpers.
- My Wave / My Mix keeps its opt-out, liked tracks and regular playlists share requests again.
- Added tests covering both sides of the split.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
