### PR TITLE
Report Sonos S1 grouping failures as proper player errors

### DIFF
--- a/music_assistant/providers/sonos_s1/helpers.py
+++ b/music_assistant/providers/sonos_s1/helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import inspect
 import logging
 from collections.abc import Callable
@@ -52,8 +53,9 @@ def soco_error(
         """Decorate functions."""
         if inspect.iscoroutinefunction(funct):
 
+            @functools.wraps(funct)
             async def async_wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> Any:
-                """Wrap for all soco UPnP exception."""
+                """Await the call so soco UPnP exceptions surface inside the try block."""
                 args_soco = next((arg for arg in args if isinstance(arg, SoCo)), None)
                 try:
                     return await funct(self, *args, **kwargs)
@@ -63,6 +65,7 @@ def soco_error(
 
             return cast("_ReturnFuncType[_T, _P, _R]", async_wrapper)
 
+        @functools.wraps(funct)
         def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R | None:
             """Wrap for all soco UPnP exception."""
             args_soco = next((arg for arg in args if isinstance(arg, SoCo)), None)

--- a/music_assistant/providers/sonos_s1/helpers.py
+++ b/music_assistant/providers/sonos_s1/helpers.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar, cast, overload
 
 from music_assistant_models.errors import PlayerCommandFailed
 from soco import SoCo
@@ -49,6 +50,18 @@ def soco_error(
 
     def decorator(funct: _FuncType[_T, _P, _R]) -> _ReturnFuncType[_T, _P, _R]:
         """Decorate functions."""
+        if inspect.iscoroutinefunction(funct):
+
+            async def async_wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> Any:
+                """Wrap for all soco UPnP exception."""
+                args_soco = next((arg for arg in args if isinstance(arg, SoCo)), None)
+                try:
+                    return await funct(self, *args, **kwargs)
+                except (OSError, SoCoException, SoCoUPnPException, TimeoutError) as err:
+                    _handle_soco_error(self, err, funct.__qualname__, errorcodes, args_soco)
+                    return None
+
+            return cast("_ReturnFuncType[_T, _P, _R]", async_wrapper)
 
         def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R | None:
             """Wrap for all soco UPnP exception."""
@@ -56,24 +69,35 @@ def soco_error(
             try:
                 result = funct(self, *args, **kwargs)
             except (OSError, SoCoException, SoCoUPnPException, TimeoutError) as err:
-                error_code = getattr(err, "error_code", None)
-                function = funct.__qualname__
-                if errorcodes and error_code in errorcodes:
-                    _LOGGER.debug("Error code %s ignored in call to %s", error_code, function)
-                    return None
-
-                if (target := _find_target_identifier(self, args_soco)) is None:
-                    msg = "Unexpected use of soco_error"
-                    raise RuntimeError(msg) from err
-
-                message = f"Error calling {function} on {target}: {err}"
-                raise SonosUpdateError(message) from err
+                _handle_soco_error(self, err, funct.__qualname__, errorcodes, args_soco)
+                return None
 
             return result
 
         return wrapper
 
     return decorator
+
+
+def _handle_soco_error(
+    instance: Any,
+    err: Exception,
+    function: str,
+    errorcodes: list[str] | None,
+    args_soco: SoCo | None,
+) -> None:
+    """Ignore a filtered UPnP error code or raise the error as a SonosUpdateError."""
+    error_code = getattr(err, "error_code", None)
+    if errorcodes and error_code in errorcodes:
+        _LOGGER.debug("Error code %s ignored in call to %s", error_code, function)
+        return
+
+    if (target := _find_target_identifier(instance, args_soco)) is None:
+        msg = "Unexpected use of soco_error"
+        raise RuntimeError(msg) from err
+
+    message = f"Error calling {function} on {target}: {err}"
+    raise SonosUpdateError(message) from err
 
 
 def _find_target_identifier(instance: Any, fallback_soco: SoCo | None) -> str | None:

--- a/music_assistant/providers/sonos_s1/helpers.py
+++ b/music_assistant/providers/sonos_s1/helpers.py
@@ -82,6 +82,25 @@ def soco_error(
     return decorator
 
 
+def hostname_to_uid(hostname: str) -> str:
+    """Convert a Sonos hostname to a uid."""
+    if hostname.startswith("Sonos-"):
+        baseuid = hostname.removeprefix("Sonos-").replace(".local.", "")
+    elif hostname.startswith("sonos"):
+        baseuid = hostname.removeprefix("sonos").replace(".local.", "")
+    else:
+        msg = f"{hostname} is not a sonos device."
+        raise ValueError(msg)
+    return f"{UID_PREFIX}{baseuid}{UID_POSTFIX}"
+
+
+def sync_get_visible_zones(soco: SoCo) -> set[SoCo]:
+    """Ensure I/O attributes are cached and return visible zones."""
+    _ = soco.household_id
+    _ = soco.uid
+    return soco.visible_zones or set()
+
+
 def _handle_soco_error(
     instance: Any,
     err: Exception,
@@ -113,22 +132,3 @@ def _find_target_identifier(instance: Any, fallback_soco: SoCo | None) -> str | 
         # Only use attributes with no I/O
         return str(soco._player_name or soco.ip_address)
     return None
-
-
-def hostname_to_uid(hostname: str) -> str:
-    """Convert a Sonos hostname to a uid."""
-    if hostname.startswith("Sonos-"):
-        baseuid = hostname.removeprefix("Sonos-").replace(".local.", "")
-    elif hostname.startswith("sonos"):
-        baseuid = hostname.removeprefix("sonos").replace(".local.", "")
-    else:
-        msg = f"{hostname} is not a sonos device."
-        raise ValueError(msg)
-    return f"{UID_PREFIX}{baseuid}{UID_POSTFIX}"
-
-
-def sync_get_visible_zones(soco: SoCo) -> set[SoCo]:
-    """Ensure I/O attributes are cached and return visible zones."""
-    _ = soco.household_id
-    _ = soco.uid
-    return soco.visible_zones or set()

--- a/tests/providers/sonos_s1/test_helpers.py
+++ b/tests/providers/sonos_s1/test_helpers.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import inspect
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
-from soco import SoCo
 from soco.exceptions import SoCoException, SoCoUPnPException
 
 from music_assistant.providers.sonos_s1.helpers import SonosUpdateError, soco_error
@@ -30,8 +30,9 @@ class _Speaker(SonosPlayer):
     """Minimal speaker exposing a decorated service call in a sync and an async flavour."""
 
     def __init__(self, error: Exception | None = None) -> None:
-        self.soco = SoCo("192.168.99.1")
-        self.soco._player_name = "Kitchen"
+        soco = MagicMock()
+        soco._player_name = "Kitchen"
+        self.soco = soco
         self._error = error
 
     @soco_error()

--- a/tests/providers/sonos_s1/test_helpers.py
+++ b/tests/providers/sonos_s1/test_helpers.py
@@ -1,0 +1,105 @@
+"""Unit tests for the Sonos S1 helpers."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+from soco import SoCo
+from soco.exceptions import SoCoException, SoCoUPnPException
+
+from music_assistant.providers.sonos_s1.helpers import SonosUpdateError, soco_error
+from music_assistant.providers.sonos_s1.player import SonosPlayer
+
+IGNORED_ERROR_CODE = "501"
+OTHER_ERROR_CODE = "701"
+
+SOCO_ERRORS = [
+    pytest.param(SoCoException("boom"), id="soco"),
+    pytest.param(SoCoUPnPException("boom", OTHER_ERROR_CODE, b""), id="upnp"),
+    pytest.param(OSError("boom"), id="oserror"),
+    pytest.param(TimeoutError("boom"), id="timeout"),
+]
+
+SYNC_AND_ASYNC = ["probe", "regroup"]
+SYNC_AND_ASYNC_FILTERED = ["probe_filtered", "regroup_filtered"]
+
+
+class _Speaker(SonosPlayer):
+    """Minimal speaker exposing a decorated service call in a sync and an async flavour."""
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self.soco = SoCo("192.168.99.1")
+        self.soco._player_name = "Kitchen"
+        self._error = error
+
+    @soco_error()
+    def probe(self) -> str:
+        """Sync service call."""
+        return self._service_call()
+
+    @soco_error()
+    async def regroup(self) -> str:
+        """Async service call."""
+        return self._service_call()
+
+    @soco_error([IGNORED_ERROR_CODE])
+    def probe_filtered(self) -> str:
+        """Sync service call that tolerates one error code."""
+        return self._service_call()
+
+    @soco_error([IGNORED_ERROR_CODE])
+    async def regroup_filtered(self) -> str:
+        """Async service call that tolerates one error code."""
+        return self._service_call()
+
+    def _service_call(self) -> str:
+        if self._error:
+            raise self._error
+        return "ok"
+
+
+async def _invoke(speaker: _Speaker, method: str) -> Any:
+    """Call the named decorated method, awaiting it for the async flavour."""
+    result = getattr(speaker, method)()
+    return await result if inspect.isawaitable(result) else result
+
+
+@pytest.mark.parametrize("method", SYNC_AND_ASYNC)
+async def test_result_is_returned_untouched(method: str) -> None:
+    """A call that succeeds returns its own result."""
+    assert await _invoke(_Speaker(), method) == "ok"
+
+
+@pytest.mark.parametrize("error", SOCO_ERRORS)
+@pytest.mark.parametrize("method", SYNC_AND_ASYNC)
+async def test_soco_errors_become_a_sonos_update_error(method: str, error: Exception) -> None:
+    """Every kind of soco failure is reported as a SonosUpdateError naming the speaker."""
+    with pytest.raises(SonosUpdateError, match="Kitchen") as exc_info:
+        await _invoke(_Speaker(error), method)
+
+    assert exc_info.value.__cause__ is error
+
+
+@pytest.mark.parametrize("method", SYNC_AND_ASYNC_FILTERED)
+async def test_ignored_error_code_is_swallowed(method: str) -> None:
+    """An error code the caller opted to ignore yields None instead of an exception."""
+    error = SoCoUPnPException("boom", IGNORED_ERROR_CODE, b"")
+
+    assert await _invoke(_Speaker(error), method) is None
+
+
+@pytest.mark.parametrize("method", SYNC_AND_ASYNC_FILTERED)
+async def test_other_error_codes_are_still_raised(method: str) -> None:
+    """Error codes outside the ignore list are reported as usual."""
+    error = SoCoUPnPException("boom", OTHER_ERROR_CODE, b"")
+
+    with pytest.raises(SonosUpdateError, match="Kitchen"):
+        await _invoke(_Speaker(error), method)
+
+
+def test_async_method_stays_a_coroutine_function() -> None:
+    """Decorated coroutine methods remain awaitable for their callers."""
+    assert inspect.iscoroutinefunction(_Speaker.regroup)
+    assert not inspect.iscoroutinefunction(_Speaker.probe)

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from music_assistant_models.enums import MediaType, PlaybackState
 from music_assistant_models.errors import PlayerCommandFailed
-from soco.exceptions import SoCoUPnPException
+from soco.exceptions import SoCoException
 
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.player import PlayerMedia
@@ -209,7 +209,7 @@ async def test_grouping_failure_is_reported_as_a_player_command_failure(
     kitchen = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
     study = _make_player(timer_mass, "RINCON_000E58BBBBBB01400", "Study")
     cast("MagicMock", timer_mass.players).get_player.side_effect = {study.player_id: study}.get
-    study.soco.join.side_effect = SoCoUPnPException("boom", "501", b"")
+    study.soco.join.side_effect = SoCoException("the speaker refused to join")
 
     with pytest.raises(PlayerCommandFailed, match="Kitchen"):
         await kitchen.set_members(player_ids_to_add=[study.player_id])

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -10,6 +10,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import MediaType, PlaybackState
+from music_assistant_models.errors import PlayerCommandFailed
+from soco.exceptions import SoCoUPnPException
 
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.player import PlayerMedia
@@ -33,6 +35,7 @@ def _make_soco(uid: str = "RINCON_000E58AAAAAA01400", name: str = "Test Sonos") 
     soco.uid = uid
     soco.household_id = "Sonos_household"
     soco.player_name = name
+    soco._player_name = name
     soco.ip_address = "127.0.0.1"
     soco.speaker_info = {"model_name": "Sonos Play:1"}
     return soco
@@ -197,6 +200,19 @@ async def test_set_members_polls_the_speakers_it_regrouped(timer_mass: MusicAssi
     await kitchen.set_members(player_ids_to_add=[study.player_id, hallway.player_id])
 
     assert _pending_polls(timer_mass) == sorted([_poll_id(study), _poll_id(hallway)])
+
+
+async def test_grouping_failure_is_reported_as_a_player_command_failure(
+    timer_mass: MusicAssistant,
+) -> None:
+    """A speaker that refuses to join surfaces as a typed player command failure."""
+    kitchen = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+    study = _make_player(timer_mass, "RINCON_000E58BBBBBB01400", "Study")
+    cast("MagicMock", timer_mass.players).get_player.side_effect = {study.player_id: study}.get
+    study.soco.join.side_effect = SoCoUPnPException("boom", "501", b"")
+
+    with pytest.raises(PlayerCommandFailed, match="Kitchen"):
+        await kitchen.set_members(player_ids_to_add=[study.player_id])
 
 
 async def test_unload_cancels_the_pending_poll(timer_mass: MusicAssistant) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The Sonos S1 provider has an error handler that turns speaker errors into a proper Music Assistant player error. It only ever worked on the regular (non-async) calls — on async calls it silently did nothing, so a failure to group speakers came back as a raw, unrecognisable error instead of a normal "player command failed".

Grouping still failed either way; only the reporting was wrong.

- Handle async calls in the Sonos S1 error handler, leaving the existing behaviour of the regular calls untouched
- Sonos S1 grouping failures now surface as a regular player error, with the speaker name in the log
- Added tests for both paths

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
