### PR TITLE
Fix Sonos S1 speakers no longer reacting instantly after a network hiccup

### DIFF
--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -94,7 +94,7 @@ class SonosPlayer(Player):
 
         # Subscriptions and events
         self._subscriptions: list[SubscriptionBase] = []
-        self._subscription_lock: asyncio.Lock | None = None
+        self._subscription_lock: asyncio.Lock = asyncio.Lock()
         self._last_activity: float = NEVER_TIME
         self._resub_cooldown_expires_at: float | None = None
         self._poll_task_id: str = f"sonos_poll_{self.player_id}"
@@ -118,18 +118,8 @@ class SonosPlayer(Player):
 
     async def offline(self) -> None:
         """Handle removal of speaker when unavailable."""
-        if not self._attr_available:
-            return
-
-        if self._resub_cooldown_expires_at is None and not self.mass.closing:
-            self._resub_cooldown_expires_at = time.monotonic() + RESUB_COOLDOWN_SECONDS
-            self.logger.debug("Starting resubscription cooldown for %s", self.display_name)
-
-        self._attr_available = False
-        self._share_link_plugin = None
-
-        self.update_state()
-        await self.unsubscribe()
+        async with self._subscription_lock:
+            await self._offline()
 
     async def on_unload(self) -> None:
         """Handle logic when the player is unloaded from the Player controller."""
@@ -402,9 +392,6 @@ class SonosPlayer(Player):
 
     async def subscribe(self) -> None:
         """Initiate event subscriptions under an async lock."""
-        if not self._subscription_lock:
-            self._subscription_lock = asyncio.Lock()
-
         async with self._subscription_lock:
             try:
                 # Create event subscriptions.
@@ -425,7 +412,7 @@ class SonosPlayer(Player):
             except SonosSubscriptionsFailed:
                 self.logger.warning("Creating subscriptions failed for %s", self.display_name)
                 # the subscription lock is already held here and is not reentrant
-                await self.offline()
+                await self._offline()
 
     async def unsubscribe(self) -> None:
         """Cancel all subscriptions."""
@@ -603,6 +590,21 @@ class SonosPlayer(Player):
         track_info[DURATION_SECONDS] = _timespan_secs(track_info.get("duration"))
         track_info[POSITION_SECONDS] = _timespan_secs(track_info.get("position"))
         return track_info
+
+    async def _offline(self) -> None:
+        """Handle removal of speaker when unavailable; caller must hold the subscription lock."""
+        if not self._attr_available:
+            return
+
+        if self._resub_cooldown_expires_at is None and not self.mass.closing:
+            self._resub_cooldown_expires_at = time.monotonic() + RESUB_COOLDOWN_SECONDS
+            self.logger.debug("Starting resubscription cooldown for %s", self.display_name)
+
+        self._attr_available = False
+        self._share_link_plugin = None
+
+        self.update_state()
+        await self.unsubscribe()
 
     async def _subscribe_target(
         self, target: SubscriptionBase, sub_callback: Callable[[SonosEvent], None]

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -302,7 +302,6 @@ async def test_failed_subscribe_marks_the_speaker_offline() -> None:
     await _subscribe_with_failing_speaker(player)
 
     assert player.available is False
-    assert player._subscription_lock is not None
     assert not player._subscription_lock.locked()
 
 
@@ -314,5 +313,66 @@ async def test_speaker_can_resubscribe_after_a_failed_subscribe() -> None:
     with patch.object(player, "_subscribe_target", AsyncMock()) as subscribe_target:
         async with asyncio.timeout(5):
             await player.subscribe()
+
+    assert subscribe_target.await_count == len(SUBSCRIPTION_SERVICES)
+
+
+async def test_speaker_taken_offline_mid_subscribe_keeps_no_subscriptions() -> None:
+    """A speaker that goes offline while subscribing must not keep the subscriptions it created."""
+    player = SonosPlayer(provider=MagicMock(), soco=_make_soco())
+    subscribing = asyncio.Event()
+    speaker_responds = asyncio.Event()
+
+    async def _slow_subscribe_target(_target: object, _callback: object) -> None:
+        subscribing.set()
+        await speaker_responds.wait()
+        player._subscriptions.append(MagicMock(unsubscribe=AsyncMock()))
+
+    with (
+        patch.object(player, "_subscribe_target", _slow_subscribe_target),
+        patch.object(player, "update_state"),
+    ):
+        subscribe_task = asyncio.create_task(player.subscribe())
+        await subscribing.wait()
+
+        offline_task = asyncio.create_task(player.offline())
+        await asyncio.sleep(0)
+        assert not offline_task.done()
+
+        speaker_responds.set()
+        async with asyncio.timeout(5):
+            await asyncio.gather(subscribe_task, offline_task)
+
+    assert player.available is False
+    assert player._subscriptions == []
+    assert player.missing_subscriptions == SUBSCRIPTION_SERVICES
+
+
+async def test_speaker_going_offline_is_not_resubscribed_halfway() -> None:
+    """No new subscriptions may be created while a speaker is still going offline."""
+    player = SonosPlayer(provider=MagicMock(), soco=_make_soco())
+    unsubscribing = asyncio.Event()
+    speaker_responds = asyncio.Event()
+
+    async def _slow_unsubscribe() -> None:
+        unsubscribing.set()
+        await speaker_responds.wait()
+
+    player._subscriptions = [MagicMock(unsubscribe=_slow_unsubscribe)]
+
+    with (
+        patch.object(player, "_subscribe_target", AsyncMock()) as subscribe_target,
+        patch.object(player, "update_state"),
+    ):
+        offline_task = asyncio.create_task(player.offline())
+        await unsubscribing.wait()
+
+        subscribe_task = asyncio.create_task(player.subscribe())
+        await asyncio.sleep(0)
+        subscribe_target.assert_not_called()
+
+        speaker_responds.set()
+        async with asyncio.timeout(5):
+            await asyncio.gather(offline_task, subscribe_task)
 
     assert subscribe_target.await_count == len(SUBSCRIPTION_SERVICES)


### PR DESCRIPTION
# What does this implement/fix?

A Sonos S1 speaker is checked every few seconds, and when it can't be reached it is marked unavailable and its event subscriptions are cancelled. That check could run right in the middle of setting those same subscriptions up — subscribing to a slow or flaky speaker takes longer than the time between two checks.

When that happened, the speaker was marked unavailable while the subscriptions it was still creating landed afterwards. Music Assistant then believed the speaker was already subscribed, so when it came back it never subscribed again. The speaker kept working, but stopped reacting instantly: volume, play/pause and track changes made on the speaker itself only showed up on the next poll, until the provider was reloaded.

Marking a speaker unavailable and subscribing it now wait for each other, so one always finishes before the other starts.

Changes:

- Take a speaker offline under the same lock that guards subscribing.
- Tests covering both orderings of the two.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
