### PR TITLE
Fix Sonos connections lingering after a provider reload

### DIFF
--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -195,6 +195,19 @@ class SonosPlayer(Player):
             CONF_ENTRY_HTTP_PROFILE_DEFAULT_2,
         ]
 
+    async def on_unload(self) -> None:
+        """Handle logic when the player is unloaded from the Player controller."""
+        await super().on_unload()
+        for task_id in (
+            f"sonos_reconnect_{self.player_id}",
+            f"restore_airplay_group_{self.player_id}",
+        ):
+            # a timer that already fired lives on as a task under the same id,
+            # so both are needed to cover the pending and the running case
+            self.mass.cancel_timer(task_id)
+            self.mass.cancel_task(task_id)
+        await self._disconnect()
+
     async def volume_set(self, volume_level: int) -> None:
         """
         Handle VOLUME_SET command on the player.

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -206,7 +206,12 @@ class SonosPlayer(Player):
             # so both are needed to cover the pending and the running case
             self.mass.cancel_timer(task_id)
             self.mass.cancel_task(task_id)
-        await self._disconnect()
+        # unregister does not guard this call, and it runs before the provider's
+        # remaining players are unregistered: a raise here would strand them
+        try:
+            await self._disconnect()
+        except Exception:
+            self.logger.exception("Error disconnecting from Sonos player %s", self.name)
 
     async def volume_set(self, volume_level: int) -> None:
         """

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -132,8 +132,10 @@ class SonosPlayer(Player):
         self.mass.cancel_timer(self._poll_task_id)
         self.mass.cancel_task(self._poll_task_id)
         # unsubscribe directly: offline() skips a speaker that is already marked
-        # unavailable, which would leave its subscriptions behind
-        await self.unsubscribe()
+        # unavailable, which would leave its subscriptions behind. The lock keeps a
+        # subscribe() that is still in flight from re-populating them afterwards.
+        async with self._subscription_lock:
+            await self.unsubscribe()
 
     async def stop(self) -> None:
         """Send STOP command to the player."""

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -131,6 +131,9 @@ class SonosPlayer(Player):
         # the poll runs as a task under the same id and cancel_task is what stops it
         self.mass.cancel_timer(self._poll_task_id)
         self.mass.cancel_task(self._poll_task_id)
+        # unsubscribe directly: offline() skips a speaker that is already marked
+        # unavailable, which would leave its subscriptions behind
+        await self.unsubscribe()
 
     async def stop(self) -> None:
         """Send STOP command to the player."""

--- a/music_assistant/providers/sonos_s1/provider.py
+++ b/music_assistant/providers/sonos_s1/provider.py
@@ -77,10 +77,6 @@ class SonosPlayerProvider(PlayerProvider):
         # await any in-progress discovery
         while self._discovery_running:
             await asyncio.sleep(0.5)
-        # Clean up subscriptions and connections
-        for sonos_player in self.mass.players.all_players(provider_filter=self.instance_id):
-            sonos_player = cast("SonosPlayer", sonos_player)
-            await sonos_player.offline()
         # Stop the async event listener
         if events_asyncio.event_listener:
             await events_asyncio.event_listener.async_stop()

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -209,6 +209,36 @@ async def test_on_unload_unsubscribes_before_disconnecting(timer_mass: MusicAssi
 
 
 @pytest.mark.asyncio
+async def test_a_listener_ending_during_the_unload_cannot_rearm_a_reconnect(
+    timer_mass: MusicAssistant,
+) -> None:
+    """Test a listener that ends while the player is unloading does not schedule a reconnect."""
+    player, client = _bind_player(timer_mass)
+    socket_drops = asyncio.Event()
+
+    async def _start_listening(init_ready: asyncio.Event) -> None:
+        init_ready.set()
+        await socket_drops.wait()
+        raise ConnectionResetError("socket dropped")
+
+    client.connect = AsyncMock()
+    client.start_listening = _start_listening
+    await player._connect()
+    listener = player._listen_task
+    assert listener is not None
+
+    # release the listener so it is queued to run its finally, then unload without
+    # yielding in between: the cancellations and connected=False must be indivisible
+    socket_drops.set()
+    await player.on_unload()
+
+    with pytest.raises(asyncio.CancelledError):
+        await listener
+    assert timer_mass._tracked_timers == {}
+    assert timer_mass._tracked_tasks == {}
+
+
+@pytest.mark.asyncio
 async def test_on_unload_survives_a_failing_disconnect(timer_mass: MusicAssistant) -> None:
     """Test a speaker that cannot be disconnected does not abort the unload."""
     player, client = _bind_player(timer_mass)

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -206,3 +206,16 @@ async def test_on_unload_unsubscribes_before_disconnecting(timer_mass: MusicAssi
     await player.on_unload()
 
     assert calls == ["unsubscribe", "disconnect"]
+
+
+@pytest.mark.asyncio
+async def test_on_unload_survives_a_failing_disconnect(timer_mass: MusicAssistant) -> None:
+    """Test a speaker that cannot be disconnected does not abort the unload."""
+    player, client = _bind_player(timer_mass)
+    client.disconnect = AsyncMock(side_effect=OSError("speaker unreachable"))
+    player.reconnect(0)
+
+    await player.on_unload()
+
+    assert player.connected is False
+    assert timer_mass._tracked_timers == {}

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -1,29 +1,71 @@
 """Tests for the Sonos player connection/reconnect handling."""
 
+import asyncio
 import logging
+import threading
+from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import ConnectionTimeoutError
 from aiosonos.exceptions import CannotConnect
+from music_assistant_models.enums import CoreState
 
+from music_assistant.mass import MusicAssistant
 from music_assistant.providers.sonos.player import SonosPlayer
 
 
-def _make_player() -> tuple[SonosPlayer, MagicMock]:
-    """Create a SonosPlayer with mocked connection dependencies."""
+@pytest.fixture
+async def timer_mass() -> AsyncGenerator[MusicAssistant]:
+    """Create a bare MusicAssistant exposing the real task/timer machinery."""
+    mass = object.__new__(MusicAssistant)
+    mass.loop = asyncio.get_running_loop()
+    mass.loop_thread_id = threading.get_ident()
+    mass._tracked_timers = {}
+    mass._tracked_tasks = {}
+    mass._state = CoreState.RUNNING
+    yield mass
+    for handle in mass._tracked_timers.values():
+        handle.cancel()
+    for task in mass._tracked_tasks.values():
+        task.cancel()
+
+
+def _bind_player(mass: MusicAssistant | MagicMock) -> tuple[SonosPlayer, MagicMock]:
+    """Create a SonosPlayer bound to the given MusicAssistant, with a mocked client."""
     player = SonosPlayer.__new__(SonosPlayer)
-    mass = MagicMock()
-    mass.closing = False
-    mass.players.get_player.return_value = MagicMock()
+    client = MagicMock()
+    client.disconnect = AsyncMock()
     player.mass = mass
     player.logger = logging.getLogger("test.sonos.player")
     player._player_id = "sonos_player"
     player._listen_task = None
     player.connected = False
-    player.client = MagicMock()
+    player.client = client
+    player._on_unload_callbacks = []
     player.update_state = MagicMock()  # type: ignore[misc, method-assign]
+    return player, client
+
+
+def _make_player() -> tuple[SonosPlayer, MagicMock]:
+    """Create a SonosPlayer with mocked connection dependencies."""
+    mass = MagicMock()
+    mass.closing = False
+    mass.players.get_player.return_value = MagicMock()
+    player, _ = _bind_player(mass)
     return player, mass
+
+
+async def _connect_player(player: SonosPlayer, client: MagicMock) -> None:
+    """Connect the player to a listener that stays alive until it is cancelled."""
+
+    async def _start_listening(init_ready: asyncio.Event) -> None:
+        init_ready.set()
+        await asyncio.sleep(3600)
+
+    client.connect = AsyncMock()
+    client.start_listening = _start_listening
+    await player._connect()
 
 
 @pytest.mark.asyncio
@@ -69,3 +111,98 @@ async def test_connect_websocket_handshake_failure_reschedules_reconnect() -> No
 
     assert player._attr_available is False
     mass.call_later.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_on_unload_disconnects_without_reconnecting(timer_mass: MusicAssistant) -> None:
+    """Test an unloaded player disconnects and its aborted listener does not reconnect."""
+    player, client = _bind_player(timer_mass)
+    await _connect_player(player, client)
+    listener = player._listen_task
+    assert listener is not None
+
+    await player.on_unload()
+
+    assert player.connected is False
+    client.disconnect.assert_awaited_once()
+    # let the aborted listener run its cleanup
+    with pytest.raises(asyncio.CancelledError):
+        await listener
+    assert timer_mass._tracked_timers == {}
+
+
+@pytest.mark.asyncio
+async def test_on_unload_cancels_a_pending_reconnect(timer_mass: MusicAssistant) -> None:
+    """Test a reconnect that is still waiting to fire does not connect after the unload."""
+    player, _ = _bind_player(timer_mass)
+    connect_attempts: list[int] = []
+
+    async def _connect(retry_on_fail: int = 0) -> None:
+        connect_attempts.append(retry_on_fail)
+
+    player._connect = _connect  # type: ignore[method-assign]
+    player.reconnect(0)
+    handle = timer_mass._tracked_timers[f"sonos_reconnect_{player.player_id}"]
+
+    await player.on_unload()
+    await asyncio.sleep(0.05)
+
+    assert handle.cancelled()
+    assert connect_attempts == []
+
+
+@pytest.mark.asyncio
+async def test_on_unload_cancels_a_scheduled_airplay_group_restore(
+    timer_mass: MusicAssistant,
+) -> None:
+    """Test the AirPlay group restore scheduled for a player does not run after the unload."""
+    player, client = _bind_player(timer_mass)
+    player._attr_name = "Sonos Player"
+    client.player.is_coordinator = True
+    client.player.group_members = [player.player_id, "sonos_player_2"]
+    output_protocol = MagicMock()
+    output_protocol.protocol_domain = "airplay"
+
+    await player.on_protocol_playback(output_protocol)
+    handle = timer_mass._tracked_timers[f"restore_airplay_group_{player.player_id}"]
+
+    await player.on_unload()
+
+    assert handle.cancelled()
+    assert timer_mass._tracked_timers == {}
+
+
+@pytest.mark.asyncio
+async def test_on_unload_cancels_an_airplay_group_restore_that_already_started(
+    timer_mass: MusicAssistant,
+) -> None:
+    """Test a group restore that already started is aborted when the player is unloaded."""
+    player, _ = _bind_player(timer_mass)
+    restoring = asyncio.Event()
+
+    async def _restore_airplay_group() -> None:
+        restoring.set()
+        await asyncio.sleep(5)
+
+    task_id = f"restore_airplay_group_{player.player_id}"
+    timer_mass.call_later(0, _restore_airplay_group, task_id=task_id)
+    await restoring.wait()
+    task = timer_mass._tracked_tasks[task_id]
+
+    await player.on_unload()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_on_unload_unsubscribes_before_disconnecting(timer_mass: MusicAssistant) -> None:
+    """Test the registered unload callbacks run before the client is disconnected."""
+    player, client = _bind_player(timer_mass)
+    calls: list[str] = []
+    player._on_unload_callbacks.append(lambda: calls.append("unsubscribe"))
+    client.disconnect = AsyncMock(side_effect=lambda: calls.append("disconnect"))
+
+    await player.on_unload()
+
+    assert calls == ["unsubscribe", "disconnect"]

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -312,6 +312,34 @@ async def test_on_unload_unsubscribes_even_when_already_unavailable(
     assert player._subscriptions == []
 
 
+async def test_unloading_mid_subscribe_keeps_no_subscriptions(
+    timer_mass: MusicAssistant,
+) -> None:
+    """A speaker unloaded while subscribing must not keep the subscriptions it created."""
+    player = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+    subscribing = asyncio.Event()
+    speaker_responds = asyncio.Event()
+
+    async def _slow_subscribe_target(_target: object, _callback: object) -> None:
+        subscribing.set()
+        await speaker_responds.wait()
+        player._subscriptions.append(MagicMock(unsubscribe=AsyncMock()))
+
+    with patch.object(player, "_subscribe_target", _slow_subscribe_target):
+        subscribe_task = asyncio.create_task(player.subscribe())
+        await subscribing.wait()
+
+        unload_task = asyncio.create_task(player.on_unload())
+        await asyncio.sleep(0)
+        assert not unload_task.done()
+
+        speaker_responds.set()
+        async with asyncio.timeout(5):
+            await asyncio.gather(subscribe_task, unload_task)
+
+    assert player._subscriptions == []
+
+
 async def test_unsubscribe_drops_subscriptions_even_when_cancelled() -> None:
     """A cancelled unsubscribe must not leave stale entries that block resubscribing."""
     provider = MagicMock()

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -283,6 +283,35 @@ async def test_unloaded_player_ignores_group_topology_updates(
     update_state.assert_not_called()
 
 
+async def test_on_unload_unsubscribes_from_soco_events(timer_mass: MusicAssistant) -> None:
+    """Unloading a speaker also tears down its soco event subscriptions."""
+    player = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+    subscription = MagicMock()
+    subscription.unsubscribe = AsyncMock()
+    player._subscriptions = [subscription]
+
+    await player.on_unload()
+
+    subscription.unsubscribe.assert_awaited_once()
+    assert player._subscriptions == []
+
+
+async def test_on_unload_unsubscribes_even_when_already_unavailable(
+    timer_mass: MusicAssistant,
+) -> None:
+    """Unlike offline(), on_unload() must still tear down an unavailable speaker's events."""
+    player = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+    subscription = MagicMock()
+    subscription.unsubscribe = AsyncMock()
+    player._subscriptions = [subscription]
+    player._attr_available = False
+
+    await player.on_unload()
+
+    subscription.unsubscribe.assert_awaited_once()
+    assert player._subscriptions == []
+
+
 async def test_unsubscribe_drops_subscriptions_even_when_cancelled() -> None:
     """A cancelled unsubscribe must not leave stale entries that block resubscribing."""
     provider = MagicMock()


### PR DESCRIPTION
# What does this implement/fix?

Reloading either Sonos provider left its connections to the speakers open. The provider's own cleanup ran over a player list that is already empty by the time it runs, so nothing was ever torn down.

For S1 that meant a speaker's event subscriptions kept firing for players that had already been removed. For S2 the connection was never closed at all, so the websocket and its listener task stayed alive, and any timer still pending for that speaker kept running — a reconnect that was already scheduled when the provider unloaded would fire afterwards and bring the removed player back to life on a fresh connection.

- S1: unsubscribe from the speaker's events when a player is unloaded, and drop the cleanup loop that could never run.
- S1: do that under the same lock #5432 introduced, so a subscribe that is still in flight can't put the subscriptions straight back.
- S2: close the connection when a player is unloaded, and cancel its pending reconnect and AirPlay group restore timers.
- Tests for both.

The S2 change touches connection lifecycle and couldn't be checked against real S2 hardware, so it's covered by tests only and kept deliberately small.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
