### PR TITLE
Load the AcoustID fingerprinting library only when it is needed

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,7 +5,7 @@ Developer docs
 * ffmpeg (minimum version 6.1, version 7 recommended), must be available in the path so install at OS level
 * Python 3.14 is minimal required (the exact pinned runtime lives in `.python-version` at the repo root — that file is the single source of truth for all tools)
 * [Python venv](https://docs.python.org/3/library/venv.html)
-* libchromaprint and PortAudio, also at OS level. The `acoustid_lookup` and `local_audio` providers bind to these natively and refuse to load without them, so install both if you want to run either provider. The test suite does not need them: the AcoustID tests drive a fake fingerprinter and the local audio tests that need PortAudio are skipped.
+* libchromaprint and PortAudio, also at OS level. Install both if you want to run the `acoustid_lookup` and `local_audio` providers: without libchromaprint AcoustID refuses to load, and without PortAudio local audio loads but finds no output devices. The test suite does not need either: the AcoustID tests drive a fake fingerprinter and the local audio tests that need PortAudio are skipped.
 
       # macOS
       brew install chromaprint portaudio

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,7 +5,7 @@ Developer docs
 * ffmpeg (minimum version 6.1, version 7 recommended), must be available in the path so install at OS level
 * Python 3.14 is minimal required (the exact pinned runtime lives in `.python-version` at the repo root — that file is the single source of truth for all tools)
 * [Python venv](https://docs.python.org/3/library/venv.html)
-* libchromaprint and PortAudio, also at OS level. The `acoustid_lookup` and `local_audio` providers bind to these natively. Without libchromaprint the AcoustID tests abort the entire `pytest` run while collecting; without PortAudio the local audio tests that use it are skipped.
+* libchromaprint and PortAudio, also at OS level. The `acoustid_lookup` and `local_audio` providers bind to these natively and refuse to load without them, so install both if you want to run either provider. The test suite does not need them: the AcoustID tests drive a fake fingerprinter and the local audio tests that need PortAudio are skipped.
 
       # macOS
       brew install chromaprint portaudio

--- a/music_assistant/providers/acoustid_lookup/provider.py
+++ b/music_assistant/providers/acoustid_lookup/provider.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
-import chromaprint
 import numpy as np
 from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import ConfigEntryType, ExternalID, MediaType, StreamType
@@ -26,7 +25,7 @@ from music_assistant.helpers.compare import create_safe_string
 from music_assistant.helpers.datetime import utc_timestamp
 from music_assistant.helpers.tags import write_identifier_tags
 from music_assistant.helpers.throttle_retry import ThrottlerManager, throttle_with_retries
-from music_assistant.helpers.util import parse_title_and_version
+from music_assistant.helpers.util import import_module_in_thread, parse_title_and_version
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import AudioAnalysisProvider
 from music_assistant.providers.musicbrainz import MusicbrainzProvider
@@ -95,6 +94,17 @@ class AcoustidLookupProvider(AudioAnalysisProvider):
         """Initialize the provider with an empty per-session state container."""
         super().__init__(mass, manifest, config, supported_features)
         self._data: dict[str, _AcoustidSessionData] = {}
+        # Populated once a real chromaprint fingerprinter is built; stays empty while no
+        # native fingerprinter exists, in which case its errors cannot be raised either.
+        self._fingerprint_errors: tuple[type[BaseException], ...] = ()
+
+    async def handle_async_init(self) -> None:
+        """Fail the provider load when the chromaprint native library is unavailable."""
+        # pyacoustid binds libchromaprint through ctypes at import time, so this import is
+        # what surfaces a missing native library. Route it through the shared import
+        # executor to keep the dlopen off the event loop; it also warms sys.modules so the
+        # per-session import in _create_fingerprinter is a plain lookup.
+        await import_module_in_thread("chromaprint")
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return config entries for this provider."""
@@ -154,9 +164,10 @@ class AcoustidLookupProvider(AudioAnalysisProvider):
                 data.error = f"pcm conversion failed: {err}"
                 return
 
+        feed_errors: tuple[type[BaseException], ...] = (*self._fingerprint_errors, TypeError)
         try:
             data.fingerprinter.feed(pcm_chunk)
-        except (chromaprint.FingerprintError, TypeError) as err:
+        except feed_errors as err:
             self.logger.debug("Chromaprint rejected PCM chunk for %s: %s", session_id, err)
             data.error = f"feed failed: {err}"
             return
@@ -377,6 +388,9 @@ class AcoustidLookupProvider(AudioAnalysisProvider):
         :param sample_rate: Audio sample rate in Hz.
         :param channels: Number of audio channels.
         """
+        import chromaprint  # noqa: PLC0415
+
+        self._fingerprint_errors = (chromaprint.FingerprintError,)
         try:
             fp = chromaprint.Fingerprinter()
             fp.start(int(sample_rate), int(channels))
@@ -399,7 +413,7 @@ class AcoustidLookupProvider(AudioAnalysisProvider):
 
         try:
             fingerprint_raw = data.fingerprinter.finish()
-        except chromaprint.FingerprintError as err:
+        except self._fingerprint_errors as err:
             self.logger.debug("Chromaprint failed to produce a fingerprint: %s", err)
             return None
 

--- a/music_assistant/providers/acoustid_lookup/provider.py
+++ b/music_assistant/providers/acoustid_lookup/provider.py
@@ -17,6 +17,7 @@ from music_assistant_models.errors import (
     RateLimited,
     ResourceTemporarilyUnavailable,
     RetriesExhausted,
+    UnsupportedSystemError,
 )
 
 from music_assistant.controllers.cache import use_cache
@@ -99,12 +100,23 @@ class AcoustidLookupProvider(AudioAnalysisProvider):
         self._fingerprint_errors: tuple[type[BaseException], ...] = ()
 
     async def handle_async_init(self) -> None:
-        """Fail the provider load when the chromaprint native library is unavailable."""
+        """
+        Handle async initialization of the provider.
+
+        :raises UnsupportedSystemError: When the chromaprint native library is missing.
+        """
         # pyacoustid binds libchromaprint through ctypes at import time, so this import is
         # what surfaces a missing native library. Route it through the shared import
         # executor to keep the dlopen off the event loop; it also warms sys.modules so the
         # per-session import in _create_fingerprinter is a plain lookup.
-        await import_module_in_thread("chromaprint")
+        try:
+            await import_module_in_thread("chromaprint")
+        except ImportError as err:
+            msg = (
+                "AcoustID needs the chromaprint library, which is not installed on this "
+                "system. See the Music Assistant documentation for how to install it."
+            )
+            raise UnsupportedSystemError(msg) from err
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return config entries for this provider."""

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -89,15 +89,15 @@ check_native_lib() {
   warn_missing "'$module' is installed but cannot load its native library." "$brew_pkg" "$apt_pkg"
 }
 
-# These bindings are imported at module scope by their providers, so a missing native
-# library surfaces as a pytest collection error rather than a skipped test.
+# Both providers import these bindings lazily, so a missing native library only stops the
+# provider that needs it. Check here so that shows up during setup instead of at runtime.
 echo "Checking OS-level dependencies..."
 command -v ffmpeg &>/dev/null || warn_missing "ffmpeg not found in PATH (6.1 minimum, 7.x recommended)." ffmpeg ffmpeg
 check_native_lib chromaprint chromaprint libchromaprint1
 check_native_lib sounddevice portaudio libportaudio2
 
 if [[ "$missing_prereqs" -eq 1 ]]; then
-  echo "⚠️  Tests may fail or be skipped until the above is resolved (see DEVELOPMENT.md)."
+  echo "⚠️  Some tests and providers may not work until the above is resolved (see DEVELOPMENT.md)."
 fi
 
 echo "✅ Done. Interpreter: $(python -V). Package manager: $(uv --version)"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -89,8 +89,9 @@ check_native_lib() {
   warn_missing "'$module' is installed but cannot load its native library." "$brew_pkg" "$apt_pkg"
 }
 
-# Both providers import these bindings lazily, so a missing native library only stops the
-# provider that needs it. Check here so that shows up during setup instead of at runtime.
+# Both providers import these bindings lazily, so a missing native library never breaks the
+# test run: acoustid_lookup refuses to load and local_audio finds no output devices. Check
+# here so that shows up during setup instead of at first use.
 echo "Checking OS-level dependencies..."
 command -v ffmpeg &>/dev/null || warn_missing "ffmpeg not found in PATH (6.1 minimum, 7.x recommended)." ffmpeg ffmpeg
 check_native_lib chromaprint chromaprint libchromaprint1

--- a/tests/providers/acoustid_lookup/test_provider.py
+++ b/tests/providers/acoustid_lookup/test_provider.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import aiohttp
 import pytest
 from music_assistant_models.enums import MediaType, StreamType
+from music_assistant_models.errors import UnsupportedSystemError
 
 from music_assistant.constants import CONF_LOG_LEVEL
 from music_assistant.helpers.datetime import utc_timestamp
@@ -591,7 +592,9 @@ async def test_async_init_imports_the_native_binding(monkeypatch: pytest.MonkeyP
         "music_assistant.providers.acoustid_lookup.provider.import_module_in_thread", fake_import
     )
 
-    with pytest.raises(ImportError):
+    # UnsupportedSystemError marks the failure as permanent, so the loader reports it
+    # to the user instead of retrying a library that will not appear on its own.
+    with pytest.raises(UnsupportedSystemError):
         await provider.handle_async_init()
     assert imported == ["chromaprint"]
 

--- a/tests/providers/acoustid_lookup/test_provider.py
+++ b/tests/providers/acoustid_lookup/test_provider.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+from types import ModuleType
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -21,6 +23,7 @@ from music_assistant.providers.acoustid_lookup.provider import (
     NO_MATCH_ANALYSIS_VERSION,
     NO_MATCH_RETRY_DAYS,
     AcoustidLookupProvider,
+    _AcoustidSessionData,
     _parse_response,
 )
 
@@ -126,7 +129,7 @@ class _FakeFingerprinter:
 
 
 def _install_fake_chromaprint(monkeypatch: pytest.MonkeyPatch, fp: _FakeFingerprinter) -> None:
-    """Patch the lazy chromaprint import so _create_fingerprinter returns our fake."""
+    """Patch _create_fingerprinter to return the given fake, started with the session's format."""
 
     def fake_create(
         _self: AcoustidLookupProvider, sample_rate: int, channels: int
@@ -135,6 +138,47 @@ def _install_fake_chromaprint(monkeypatch: pytest.MonkeyPatch, fp: _FakeFingerpr
         return fp
 
     monkeypatch.setattr(AcoustidLookupProvider, "_create_fingerprinter", fake_create)
+
+
+def _install_unidentified_track(provider: AcoustidLookupProvider) -> None:
+    """Make the provider's library lookup return a track with no MBID or ISRC."""
+    track = MagicMock(mbid=None)
+    track.get_external_id.return_value = None
+    cast("MagicMock", provider.mass.music.tracks).get_library_item_by_prov_id = AsyncMock(
+        return_value=track
+    )
+
+
+class _FakeFingerprintError(Exception):
+    """Stand-in for chromaprint.FingerprintError."""
+
+
+def _install_chromaprint_module(monkeypatch: pytest.MonkeyPatch, *, failing_call: str) -> None:
+    """
+    Inject a stand-in ``chromaprint`` module so the real _create_fingerprinter runs.
+
+    :param failing_call: Fingerprinter method ("start", "feed" or "finish") that
+        raises, letting a test drive one native error path.
+    """
+
+    class _Fingerprinter:
+        def start(self, sample_rate: int, channels: int) -> None:
+            if failing_call == "start":
+                raise _FakeFingerprintError("start failed")
+
+        def feed(self, data: bytes) -> None:
+            if failing_call == "feed":
+                raise _FakeFingerprintError("feed failed")
+
+        def finish(self) -> bytes:
+            if failing_call == "finish":
+                raise _FakeFingerprintError("finish failed")
+            return b"FAKEFINGERPRINT"
+
+    module = ModuleType("chromaprint")
+    module.FingerprintError = _FakeFingerprintError  # type: ignore[attr-defined]
+    module.Fingerprinter = _Fingerprinter  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "chromaprint", module)
 
 
 def _install_lookup_response(
@@ -526,6 +570,98 @@ async def test_finalize_rejects_low_score(monkeypatch: pytest.MonkeyPatch) -> No
     now = int(utc_timestamp())
     retry_after = kwargs["analysis"].extra_data["retry_after"]
     assert now < retry_after <= now + NO_MATCH_RETRY_DAYS * 86400 + 5
+
+
+# ---------------------------------------------------------------------------
+# Chromaprint binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_init_imports_the_native_binding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing libchromaprint surfaces as a provider load failure, not a per-track error."""
+    provider = _make_provider()
+    imported: list[str] = []
+
+    async def fake_import(name: str, _package: str | None = None) -> ModuleType:
+        imported.append(name)
+        raise ImportError("couldn't find libchromaprint")
+
+    monkeypatch.setattr(
+        "music_assistant.providers.acoustid_lookup.provider.import_module_in_thread", fake_import
+    )
+
+    with pytest.raises(ImportError):
+        await provider.handle_async_init()
+    assert imported == ["chromaprint"]
+
+
+@pytest.mark.asyncio
+async def test_fingerprinter_start_failure_declines_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A chromaprint error while starting the fingerprinter declines the session."""
+    _install_chromaprint_module(monkeypatch, failing_call="start")
+    provider = _make_provider()
+    _install_unidentified_track(provider)
+
+    accepted = await provider._start_analysis(
+        "session", _make_streamdetails(), _make_audio_format()
+    )
+
+    assert accepted is False
+
+
+@pytest.mark.asyncio
+async def test_chromaprint_error_while_feeding_is_caught(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A chromaprint error from feed() marks the session errored instead of propagating."""
+    _install_chromaprint_module(monkeypatch, failing_call="feed")
+    provider = _make_provider()
+    _install_unidentified_track(provider)
+    session_id = "session-feed"
+    assert await provider._start_analysis(session_id, _make_streamdetails(), _make_audio_format())
+
+    await provider.process_pcm_chunk(session_id, b"\x00\x01" * 100)
+
+    assert provider._data[session_id].error is not None
+
+
+@pytest.mark.asyncio
+async def test_chromaprint_error_while_finishing_is_caught(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A chromaprint error from finish() yields no result instead of propagating."""
+    _install_chromaprint_module(monkeypatch, failing_call="finish")
+    provider = _make_provider()
+    _install_unidentified_track(provider)
+    session_id = "session-finish"
+    assert await provider._start_analysis(session_id, _make_streamdetails(), _make_audio_format())
+    provider._data[session_id].pcm_seconds_fed = 30.0
+
+    assert await provider._finalize(session_id) is None
+
+
+@pytest.mark.asyncio
+async def test_feed_type_error_is_caught_without_a_native_fingerprinter() -> None:
+    """The feed() guard still catches TypeError when no chromaprint errors are registered."""
+    provider = _make_provider()
+    assert provider._fingerprint_errors == ()
+
+    class _RejectingFingerprinter:
+        def feed(self, data: bytes) -> None:
+            raise TypeError("unsupported buffer")
+
+    provider._data["session"] = _AcoustidSessionData(
+        fingerprinter=_RejectingFingerprinter(),
+        sample_rate=44100,
+        channels=2,
+        sample_width=2,
+        track_duration=180,
+    )
+
+    await provider.process_pcm_chunk("session", b"\x00\x01" * 100)
+
+    assert provider._data["session"].error is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

The `acoustid_lookup` provider imported `chromaprint` at module scope. Since that binding
loads libchromaprint through ctypes at import time, a developer without the native library
installed could not run the test suite at all — `pytest` aborted the entire run while
collecting, not just the AcoustID tests.

The import now happens when the provider initialises and when it actually builds a
fingerprinter, which is how the `local_audio` provider already handles PortAudio. A missing
native library still fails the provider load with a clear error, so nothing changes for users.

- Import `chromaprint` lazily instead of at module scope
- Verify the library up front in `handle_async_init`, so a missing one still fails the provider
  load rather than erroring on every analysed track
- Run that import through the shared import executor, keeping the `dlopen` off the event loop
- Add tests for the chromaprint error paths, which had no coverage
- Correct a test helper docstring that described an import patch it never did
- Update DEVELOPMENT.md and `scripts/setup.sh`, which documented the old behaviour

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
