### PR TITLE
Stop providers from reloading twice after a lost connection or settings change

### DIFF
--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -136,7 +136,9 @@ class Provider:
                 self.domain,
                 self.instance_id,
             )
-            task_id = f"provider_reload_{self.instance_id}"
+            # armed under the load path's task id so any (re)load starting before it fires
+            # cancels it
+            task_id = f"load_provider_{self.instance_id}"
             self.mass.call_later(1, self.mass.load_provider_config, config, task_id=task_id)
 
     async def get_diagnostics(self) -> dict[str, SerializableType] | None:

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -702,9 +702,16 @@ class HomeAssistantProvider(PluginProvider):
         if not self._startup_complete:
             return
         self.logger.info("Connection to HA lost. Connection will be automatically retried later.")
-        # schedule a reload of the provider
+        # schedule a reload of the provider, armed under the load path's task id so any
+        # (re)load starting before it fires cancels it
         self.available = False
-        self.mass.call_later(5, self.mass.load_provider, self.instance_id, allow_retry=True)
+        self.mass.call_later(
+            5,
+            self.mass.load_provider,
+            self.instance_id,
+            allow_retry=True,
+            task_id=f"load_provider_{self.instance_id}",
+        )
 
     def _on_entity_state_update(self, event: EntityStateEvent) -> None:
         """Handle Entity State event."""

--- a/music_assistant/providers/snapcast/provider.py
+++ b/music_assistant/providers/snapcast/provider.py
@@ -578,8 +578,15 @@ class SnapCastProvider(PlayerProvider):
             "Connection to SnapServer lost, reason: %s. Reloading provider in 5 seconds.",
             str(exc),
         )
-        # schedule a reload of the provider
-        self.mass.call_later(5, self.mass.load_provider, self.instance_id, allow_retry=True)
+        # schedule a reload of the provider, armed under the load path's task id so any
+        # (re)load starting before it fires cancels it
+        self.mass.call_later(
+            5,
+            self.mass.load_provider,
+            self.instance_id,
+            allow_retry=True,
+            task_id=f"load_provider_{self.instance_id}",
+        )
 
     async def remove_player(self, player_id: str) -> None:
         """Remove the client from the snapserver when it is deleted."""

--- a/tests/models/test_provider.py
+++ b/tests/models/test_provider.py
@@ -95,6 +95,18 @@ def test_unload_with_error_forwards_exception() -> None:
     )
 
 
+async def test_config_change_arms_the_reload_under_the_load_task_id() -> None:
+    """A config change arms the reload so a (re)load starting first cancels it."""
+    provider = _make_base_provider()
+    config = MagicMock()
+    config.instance_id = "test_instance"
+    await provider.update_config(config, {"values/some_setting"})
+    mass = cast("MagicMock", provider.mass)
+    mass.call_later.assert_called_once_with(
+        1, mass.load_provider_config, config, task_id="load_provider_test_instance"
+    )
+
+
 def test_verbose_log_level_stays_scoped_to_the_provider() -> None:
     """A provider on VERBOSE logs its own records without un-gating unrelated loggers."""
     logging.addLevelName(VERBOSE_LOG_LEVEL, "VERBOSE")

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -169,6 +169,8 @@ class _HomeAssistantClient:
         self._registry_result = (
             asyncio.get_running_loop().create_future() if block_registry else None
         )
+        # resolve this to make an already running listener return, as a lost connection does
+        self.connection_lost: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         self.send_command = AsyncMock(side_effect=self._send_command)
 
     async def connect(self) -> None:
@@ -179,13 +181,13 @@ class _HomeAssistantClient:
         self.connected = True
 
     async def start_listening(self) -> None:
-        """Listen until the provider stops the listener task."""
+        """Listen until the connection is lost or the provider stops the listener task."""
         self.calls.append("start_listening")
         self.listener_started.set()
         try:
             if self._listener_error:
                 raise self._listener_error
-            await asyncio.Event().wait()
+            await self.connection_lost
         except asyncio.CancelledError:
             self.listener_cancelled.set()
             raise
@@ -554,6 +556,23 @@ async def test_connection_failure_cleans_up_client() -> None:
 
     assert hass.disconnected
     assert provider._listen_task is None
+
+
+async def test_lost_connection_arms_the_reconnect_under_the_load_task_id() -> None:
+    """A lost connection arms the reconnect so a (re)load starting first cancels it."""
+    async with _start_provider([]) as (provider, hass):
+        mass = cast("MagicMock", provider.mass)
+        mass.call_later.reset_mock()
+        assert provider._listen_task is not None
+
+        hass.connection_lost.set_exception(BaseHassClientError("connection lost"))
+        async with asyncio.timeout(1):
+            await provider._listen_task
+
+        assert provider.available is False
+        retry = mass.call_later.call_args
+        assert retry.args == (5, mass.load_provider, "hass--test")
+        assert retry.kwargs == {"allow_retry": True, "task_id": "load_provider_hass--test"}
 
 
 async def test_engines_are_listed_for_every_feature_entity() -> None:

--- a/tests/providers/snapcast/test_provider.py
+++ b/tests/providers/snapcast/test_provider.py
@@ -52,3 +52,17 @@ async def test_log_level_config_update_realigns_snapcast_logger() -> None:
 
     update_config.assert_awaited_once_with(config, changed_keys)
     set_log_level.assert_called_once_with()
+
+
+def test_lost_connection_arms_the_reload_under_the_load_task_id() -> None:
+    """A lost SnapServer connection arms the reload so a (re)load starting first cancels it."""
+    provider = _provider_with_log_level(logging.INFO)
+    provider.config = MagicMock(instance_id="snapcast--test")
+    provider.mass = MagicMock(closing=False)
+    provider._stop_called = False
+
+    provider._handle_disconnect(ConnectionError("connection lost"))
+
+    retry = provider.mass.call_later.call_args
+    assert retry.args == (5, provider.mass.load_provider, "snapcast--test")
+    assert retry.kwargs == {"allow_retry": True, "task_id": "load_provider_snapcast--test"}


### PR DESCRIPTION
# What does this implement/fix?

Providers schedule a reload of themselves in a few situations: after losing their connection (Home Assistant, Snapcast), and a second after a config change. Those timers were registered under their own names, while the provider load path only cancels the timer named `load_provider_<instance_id>`. So if a load started before such a timer fired — someone hitting Reload, or saving the provider settings — the pending timer was left alone and reloaded the provider a second time for no reason.

All three now use the shared name, so a reload that is already underway cancels the pending one. The AI Radio provider already did this.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Home Assistant: arm the reconnect after a lost connection under the shared name.
- Snapcast: same for the SnapServer disconnect handler.
- Provider base class: same for the reload after a config change.
- Tests for all three.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
