### PR TITLE
Keep all members of a cached tuple value intact

### DIFF
--- a/music_assistant/helpers/api.py
+++ b/music_assistant/helpers/api.py
@@ -500,9 +500,17 @@ def parse_value(  # noqa: PLR0911
     if origin is tuple and (subtypes := get_args(value_type)) and subtypes[-1] is not Ellipsis:
         # a fixed-length tuple annotates every position separately, so each member is
         # parsed against its own type and kept, including the members that are None
+        if len(value) != len(subtypes):
+            msg = (
+                f"Value {value} of type {type(value)} is invalid for {name}, "
+                f"expected value of type {value_type}"
+            )
+            raise TypeError(msg)
         return tuple(
-            parse_value(name, subvalue, subtype, allow_value_convert=allow_value_convert)
-            for subvalue, subtype in zip(value, subtypes, strict=True)
+            parse_value(
+                f"{name}[{index}]", subvalue, subtype, allow_value_convert=allow_value_convert
+            )
+            for index, (subvalue, subtype) in enumerate(zip(value, subtypes, strict=True))
         )
     if origin in (tuple, list, set, frozenset, Sequence, Iterable):
         # For abstract types like Sequence and Iterable, use list as the concrete type

--- a/music_assistant/helpers/api.py
+++ b/music_assistant/helpers/api.py
@@ -497,6 +497,13 @@ def parse_value(  # noqa: PLR0911
     if value is None and value_type is NoneType:
         return None
     origin = get_origin(value_type)
+    if origin is tuple and (subtypes := get_args(value_type)) and subtypes[-1] is not Ellipsis:
+        # a fixed-length tuple annotates every position separately, so each member is
+        # parsed against its own type and kept, including the members that are None
+        return tuple(
+            parse_value(name, subvalue, subtype, allow_value_convert=allow_value_convert)
+            for subvalue, subtype in zip(value, subtypes, strict=True)
+        )
     if origin in (tuple, list, set, frozenset, Sequence, Iterable):
         # For abstract types like Sequence and Iterable, use list as the concrete type
         concrete_type = list if origin in (Sequence, Iterable) else origin

--- a/music_assistant/helpers/api.py
+++ b/music_assistant/helpers/api.py
@@ -463,7 +463,7 @@ def parse_utc_timestamp(datetime_string: str) -> datetime:
     return datetime.fromisoformat(datetime_string)
 
 
-def parse_value(  # noqa: PLR0911
+def parse_value(  # noqa: PLR0911, PLR0915
     name: str,
     value: Any,
     value_type: Any,

--- a/tests/controllers/cache/test_helpers.py
+++ b/tests/controllers/cache/test_helpers.py
@@ -368,6 +368,16 @@ async def test_result_shape_survives_being_copied(provider: _FakeProvider) -> No
     assert all(result == [("a", "name", None)] for result in results)
 
 
+async def test_tuple_result_shape_survives_a_cache_hit(
+    cache: CacheController, provider: _FakeProvider
+) -> None:
+    """Test that a cached tuple is rebuilt with all of its members, including the None ones."""
+    assert await provider.fetch_tuples("a") == [("a", "name", None)]
+    await _wait_for_stored(cache, "fetch_tuples.a")
+    assert await provider.fetch_tuples("a") == [("a", "name", None)]
+    assert provider.calls == 1
+
+
 async def test_uncopyable_result_is_still_returned(
     provider: _FakeProvider, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/helpers/test_parse_value_collections.py
+++ b/tests/helpers/test_parse_value_collections.py
@@ -47,7 +47,7 @@ def test_parse_value_frozenset_of_str() -> None:
 
 
 def test_parse_value_none_members_dropped_from_list() -> None:
-    """None members are dropped from a homogeneous list annotation."""
+    """None members are currently dropped from a homogeneous list annotation."""
     result = parse_value("values", ["a", None, "b"], list[str])
     assert result == ["a", "b"]
 
@@ -87,7 +87,7 @@ def test_parse_value_fixed_length_tuple_wrong_length() -> None:
 
 
 def test_parse_value_fixed_length_tuple_names_the_failing_member() -> None:
-    """An unparseable member is reported with its position in the tuple."""
+    """A member that does not fit its type is reported with its position in the tuple."""
     with pytest.raises(TypeError, match=r"invalid for values\[1\]"):
         parse_value("values", ["a", {}], tuple[str, str])
 

--- a/tests/helpers/test_parse_value_collections.py
+++ b/tests/helpers/test_parse_value_collections.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
 from music_assistant_models.enums import DashboardType
 
 from music_assistant.helpers.api import parse_value
@@ -43,3 +44,43 @@ def test_parse_value_frozenset_of_str() -> None:
     """A json list is parsed into a frozenset when the annotation is frozenset[str]."""
     result = parse_value("values", ["a", "b"], frozenset[str])
     assert result == frozenset({"a", "b"})
+
+
+def test_parse_value_none_members_dropped_from_list() -> None:
+    """None members are dropped from a homogeneous list annotation."""
+    result = parse_value("values", ["a", None, "b"], list[str])
+    assert result == ["a", "b"]
+
+
+def test_parse_value_fixed_length_tuple_per_position_types() -> None:
+    """Each member of a fixed-length tuple is parsed against the type of its own position."""
+    result = parse_value("values", ["a", 1, "party"], tuple[str, int, DashboardType])
+    assert result == ("a", 1, DashboardType.PARTY)
+
+
+def test_parse_value_fixed_length_tuple_keeps_none_members() -> None:
+    """A None member of a fixed-length tuple is kept, so the tuple keeps its length."""
+    result = parse_value("values", ["a", "name", None], tuple[str, str, str | None])
+    assert result == ("a", "name", None)
+
+
+def test_parse_value_list_of_fixed_length_tuples() -> None:
+    """A json list of lists is parsed into tuples that each keep their None members."""
+    result = parse_value(
+        "stations",
+        [["t1", "Name A", "http://img"], ["t2", "Name B", None]],
+        list[tuple[str, str, str | None]],
+    )
+    assert result == [("t1", "Name A", "http://img"), ("t2", "Name B", None)]
+
+
+def test_parse_value_variadic_tuple() -> None:
+    """A json list is parsed into a tuple of arbitrary length for a variadic annotation."""
+    result = parse_value("values", ["a", "b", "c"], tuple[str, ...])
+    assert result == ("a", "b", "c")
+
+
+def test_parse_value_fixed_length_tuple_wrong_length() -> None:
+    """A value with the wrong number of members is rejected for a fixed-length tuple."""
+    with pytest.raises(ValueError):  # noqa: PT011
+        parse_value("values", ["a"], tuple[str, str])

--- a/tests/helpers/test_parse_value_collections.py
+++ b/tests/helpers/test_parse_value_collections.py
@@ -82,5 +82,17 @@ def test_parse_value_variadic_tuple() -> None:
 
 def test_parse_value_fixed_length_tuple_wrong_length() -> None:
     """A value with the wrong number of members is rejected for a fixed-length tuple."""
-    with pytest.raises(ValueError):  # noqa: PT011
+    with pytest.raises(TypeError, match="is invalid for values"):
         parse_value("values", ["a"], tuple[str, str])
+
+
+def test_parse_value_fixed_length_tuple_names_the_failing_member() -> None:
+    """An unparseable member is reported with its position in the tuple."""
+    with pytest.raises(TypeError, match=r"invalid for values\[1\]"):
+        parse_value("values", ["a", {}], tuple[str, str])
+
+
+def test_parse_value_fixed_length_tuple_in_union() -> None:
+    """A union of fixed-length tuples falls through to the member that fits the value."""
+    result = parse_value("values", ["a", "b", "c"], tuple[str, str] | tuple[str, str, str])
+    assert result == ("a", "b", "c")


### PR DESCRIPTION
# What does this implement/fix?

When a cached value contains a tuple, reading it back from the cache rebuilt it incorrectly: every member was interpreted as the type of the *first* member, and any member that was empty was silently thrown away, so the tuple came back shorter than it went in.

That made browsing the personal radio stations of Yandex Music and KION fail on the second visit within the cache window, because any station without artwork ended up one member short.

**Related issue (if applicable):**

- n/a (spotted while reviewing #5370, not caused by it)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Fixed-length tuples now map each member to its own type instead of reusing the first one.
- Empty members of a fixed-length tuple are kept, so the tuple keeps its length.
- A tuple with the wrong number of members is now rejected instead of quietly truncated.
- Lists, sets and open-ended tuples are untouched.
- Added tests, including one covering the actual cache read that triggered this.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
