### PR TITLE
[Backport to stable] 2.9.12

### DIFF
--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -92,7 +92,7 @@ class SonosPlayer(Player):
 
         # Subscriptions and events
         self._subscriptions: list[SubscriptionBase] = []
-        self._subscription_lock: asyncio.Lock | None = None
+        self._subscription_lock: asyncio.Lock = asyncio.Lock()
         self._last_activity: float = NEVER_TIME
         self._resub_cooldown_expires_at: float | None = None
 
@@ -141,18 +141,8 @@ class SonosPlayer(Player):
 
     async def offline(self) -> None:
         """Handle removal of speaker when unavailable."""
-        if not self._attr_available:
-            return
-
-        if self._resub_cooldown_expires_at is None and not self.mass.closing:
-            self._resub_cooldown_expires_at = time.monotonic() + RESUB_COOLDOWN_SECONDS
-            self.logger.debug("Starting resubscription cooldown for %s", self.display_name)
-
-        self._attr_available = False
-        self._share_link_plugin = None
-
-        self.update_state()
-        await self.unsubscribe()
+        async with self._subscription_lock:
+            await self._offline()
 
     async def stop(self) -> None:
         """Send STOP command to the player."""
@@ -398,6 +388,21 @@ class SonosPlayer(Player):
             # will detect changes to the player object itself
             self.mass.loop.call_soon_threadsafe(self.update_state)
 
+    async def _offline(self) -> None:
+        """Handle removal of speaker when unavailable; caller must hold the subscription lock."""
+        if not self._attr_available:
+            return
+
+        if self._resub_cooldown_expires_at is None and not self.mass.closing:
+            self._resub_cooldown_expires_at = time.monotonic() + RESUB_COOLDOWN_SECONDS
+            self.logger.debug("Starting resubscription cooldown for %s", self.display_name)
+
+        self._attr_available = False
+        self._share_link_plugin = None
+
+        self.update_state()
+        await self.unsubscribe()
+
     async def _subscribe_target(
         self, target: SubscriptionBase, sub_callback: Callable[[SonosEvent], None]
     ) -> None:
@@ -449,9 +454,6 @@ class SonosPlayer(Player):
 
     async def subscribe(self) -> None:
         """Initiate event subscriptions under an async lock."""
-        if not self._subscription_lock:
-            self._subscription_lock = asyncio.Lock()
-
         async with self._subscription_lock:
             try:
                 # Create event subscriptions.
@@ -472,7 +474,7 @@ class SonosPlayer(Player):
             except SonosSubscriptionsFailed:
                 self.logger.warning("Creating subscriptions failed for %s", self.display_name)
                 # the subscription lock is already held here and is not reentrant
-                await self.offline()
+                await self._offline()
 
     async def unsubscribe(self) -> None:
         """Cancel all subscriptions."""

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -52,6 +52,7 @@ from music_assistant_models.streamdetails import StreamDetails
 from ytmusicapi.constants import SUPPORTED_LANGUAGES
 from ytmusicapi.exceptions import YTMusicServerError
 from ytmusicapi.helpers import get_authorization, sapisid_from_cookie
+from ytmusicapi.parsers.podcasts import Description
 
 from music_assistant.constants import (
     CONF_ENTRY_UNOFFICIAL_PROVIDER,
@@ -1113,7 +1114,10 @@ class YoutubeMusicProvider(MusicProvider):
             duration_sec = parse_str_duration(duration)
             episode.duration = int(duration_sec)
         if description := episode_obj.get("description"):
-            episode.metadata.description = description
+            # the single episode endpoint returns a Description object instead of a string
+            episode.metadata.description = (
+                description.text if isinstance(description, Description) else description
+            )
         if thumbnails := episode_obj.get("thumbnails"):
             episode.metadata.images = self._parse_thumbnails(thumbnails)
         if release_date := episode_obj.get("date"):

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -86,7 +86,6 @@ async def test_failed_subscribe_marks_the_speaker_offline() -> None:
     await _subscribe_with_failing_speaker(player)
 
     assert player.available is False
-    assert player._subscription_lock is not None
     assert not player._subscription_lock.locked()
 
 
@@ -98,5 +97,66 @@ async def test_speaker_can_resubscribe_after_a_failed_subscribe() -> None:
     with patch.object(player, "_subscribe_target", AsyncMock()) as subscribe_target:
         async with asyncio.timeout(5):
             await player.subscribe()
+
+    assert subscribe_target.await_count == len(SUBSCRIPTION_SERVICES)
+
+
+async def test_speaker_taken_offline_mid_subscribe_keeps_no_subscriptions() -> None:
+    """A speaker that goes offline while subscribing must not keep the subscriptions it created."""
+    player = SonosPlayer(provider=MagicMock(), soco=_make_soco())
+    subscribing = asyncio.Event()
+    speaker_responds = asyncio.Event()
+
+    async def _slow_subscribe_target(_target: object, _callback: object) -> None:
+        subscribing.set()
+        await speaker_responds.wait()
+        player._subscriptions.append(MagicMock(unsubscribe=AsyncMock()))
+
+    with (
+        patch.object(player, "_subscribe_target", _slow_subscribe_target),
+        patch.object(player, "update_state"),
+    ):
+        subscribe_task = asyncio.create_task(player.subscribe())
+        await subscribing.wait()
+
+        offline_task = asyncio.create_task(player.offline())
+        await asyncio.sleep(0)
+        assert not offline_task.done()
+
+        speaker_responds.set()
+        async with asyncio.timeout(5):
+            await asyncio.gather(subscribe_task, offline_task)
+
+    assert player.available is False
+    assert player._subscriptions == []
+    assert player.missing_subscriptions == SUBSCRIPTION_SERVICES
+
+
+async def test_speaker_going_offline_is_not_resubscribed_halfway() -> None:
+    """No new subscriptions may be created while a speaker is still going offline."""
+    player = SonosPlayer(provider=MagicMock(), soco=_make_soco())
+    unsubscribing = asyncio.Event()
+    speaker_responds = asyncio.Event()
+
+    async def _slow_unsubscribe() -> None:
+        unsubscribing.set()
+        await speaker_responds.wait()
+
+    player._subscriptions = [MagicMock(unsubscribe=_slow_unsubscribe)]
+
+    with (
+        patch.object(player, "_subscribe_target", AsyncMock()) as subscribe_target,
+        patch.object(player, "update_state"),
+    ):
+        offline_task = asyncio.create_task(player.offline())
+        await unsubscribing.wait()
+
+        subscribe_task = asyncio.create_task(player.subscribe())
+        await asyncio.sleep(0)
+        subscribe_target.assert_not_called()
+
+        speaker_responds.set()
+        async with asyncio.timeout(5):
+            await asyncio.gather(offline_task, subscribe_task)
 
     assert subscribe_target.await_count == len(SUBSCRIPTION_SERVICES)

--- a/tests/providers/test_ytmusic_podcast_parsing.py
+++ b/tests/providers/test_ytmusic_podcast_parsing.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 from music_assistant_models.media_items import Podcast
+from ytmusicapi.parsers.podcasts import Description
 
 from music_assistant.providers.ytmusic import YoutubeMusicProvider
 
@@ -15,6 +16,19 @@ def _make_provider() -> MagicMock:
     prov._parse_thumbnails = MagicMock(return_value=[])
     prov._parse_podcast = lambda obj: YoutubeMusicProvider._parse_podcast(prov, obj)
     return prov
+
+
+def _parse_episode(description: object) -> str | None:
+    """Parse an episode with the given raw description and return the parsed one."""
+    prov = _make_provider()
+    podcast = Podcast(
+        item_id="PLtest123", provider="ytmusic_test", name="Couple Of", provider_mappings=set()
+    )
+    episode_obj = {"videoId": "vid123", "title": "Episode 1", "description": description}
+
+    episode = YoutubeMusicProvider._parse_podcast_episode(prov, episode_obj, podcast)
+
+    return episode.metadata.description
 
 
 def test_browse_podcast_with_mpsp_browse_id_is_parsed() -> None:
@@ -63,3 +77,15 @@ def test_browse_item_without_browse_id_is_not_parsed_as_podcast() -> None:
     prov = _make_provider()
 
     assert YoutubeMusicProvider._parse_browse_podcast(prov, {"title": "X"}) is None
+
+
+def test_episode_description_object_is_stored_as_text() -> None:
+    """A Description object must be flattened, as the metadata expects a string."""
+    description = Description.from_runs([{"text": "Part one. "}, {"text": "Part two."}])
+
+    assert _parse_episode(description) == "Part one. Part two."
+
+
+def test_episode_description_string_is_stored_as_is() -> None:
+    """A description that already is a string must be left untouched."""
+    assert _parse_episode("Part one. Part two.") == "Part one. Part two."


### PR DESCRIPTION
Automated backport PR for stable release 2.9.12 with cherry-picked commits:

- [442f9dc](https://github.com/music-assistant/server/commit/442f9dcb933d81c9f07c1800e9bc288f5d7e178e) - Fix Sonos S1 speakers no longer reacting instantly after a network hiccup (#5432)

The automatic cherry-pick conflicted because `stable` orders the methods in `sonos_s1/player.py` differently, so this was applied by hand. The resulting change is the same as on `dev`.
- [71d80f7](https://github.com/music-assistant/server/commit/71d80f7caf09de779f8dc528b1217803b04bbd6f) - Fix YouTube Music episode description breaking player state (#5560)