### PR TITLE
Keep the PR label in sync when the description changes

### DIFF
--- a/.github/release-notes-config.yml
+++ b/.github/release-notes-config.yml
@@ -44,6 +44,7 @@ categories:
       - 'ci'
       - 'documentation'
       - 'maintenance'
+      - 'refactor'
       - 'dependencies'
 
 template: |

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -5,8 +5,8 @@ name: PR Labels
 # generator knows how to slot into a section. We derive that label
 # from the "Types of changes" checkbox in the PR template and apply
 # it automatically — most external contributors can't label their
-# own PRs. The job fails when zero or more than one checkbox is
-# ticked.
+# own PRs. The job fails when more than one box is ticked, or when
+# none is and the PR doesn't already carry a single known label.
 
 # yamllint disable-line rule:truthy
 on:
@@ -50,20 +50,6 @@ jobs:
             const current = (context.payload.pull_request.labels || [])
               .map(l => l.name);
 
-            // If the PR already carries exactly one known-set label
-            // (e.g. applied by auto-update-frontend or backport-to-stable
-            // tooling that doesn't use the PR template), trust it and
-            // exit. Zero or 2+ known labels still fall through to the
-            // checkbox-driven path so a stray manual label can't hide
-            // a missing template tick.
-            const alreadyLabelled = current.filter(n => known.includes(n));
-            if (alreadyLabelled.length === 1) {
-              core.info(
-                `Skipping: PR already labelled '${alreadyLabelled[0]}'.`
-              );
-              return;
-            }
-
             // Match a ticked checkbox bullet whose line ends with a
             // backticked label, e.g.  - [x] CI / workflow change — `ci`
             // The PR template puts the canonical label name in
@@ -72,24 +58,37 @@ jobs:
             const re = /^\s*-\s*\[x\][^`\n]*`([^`]+)`/gim;
             const ticked = [];
             for (const m of body.matchAll(re)) {
-              const name = m[1];
+              const name = m[1].trim();
               if (known.includes(name) && !ticked.includes(name)) {
                 ticked.push(name);
               }
             }
 
-            if (ticked.length === 0) {
-              core.setFailed(
-                'No "Types of changes" checkbox is ticked in the PR ' +
-                'description. Edit the description and tick exactly ' +
-                'one box so this PR can be release-noted.'
-              );
-              return;
-            }
             if (ticked.length > 1) {
               core.setFailed(
                 `Multiple "Types of changes" checkboxes are ticked ` +
                 `(${ticked.join(', ')}). Tick exactly one.`
+              );
+              return;
+            }
+
+            // The description is the source of truth, so a ticked box
+            // always wins — that keeps the label in step when someone
+            // reconsiders the type after opening. Only with nothing
+            // ticked do we fall back to a label already on the PR,
+            // covering PRs opened without the template. Two or more
+            // known labels are ambiguous, so those fail rather than
+            // guess.
+            if (ticked.length === 0) {
+              const existing = current.filter(n => known.includes(n));
+              if (existing.length === 1) {
+                core.info(`Skipping: PR already labelled '${existing[0]}'.`);
+                return;
+              }
+              core.setFailed(
+                'No "Types of changes" checkbox is ticked in the PR ' +
+                'description. Edit the description and tick exactly ' +
+                'one box so this PR can be release-noted.'
               );
               return;
             }

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -32,7 +32,7 @@ jobs:
     # GitHub-typed bots (Dependabot, musicassistant-bot[bot], etc.)
     # don't follow the PR template and apply their own labels, so
     # skip them outright. Trusted automation can also pre-apply a
-    # known-set label; those PRs are handled below.
+    # known-set label; that is honoured below when no box is ticked.
     if: github.event.pull_request.user.type != 'Bot'
     steps:
       - name: 🏷 Apply label from PR description checkbox


### PR DESCRIPTION
# What does this implement/fix?

Once the label workflow had applied a label it stopped there, before ever reading the PR description. Re-ticking a different "Types of changes" box was then a silent no-op and the label stayed frozen on whatever it was first, so a contributor correcting `bugfix` to `enhancement` after review still merged as a bugfix.

The description is now the source of truth. Separately, `refactor` is offered in the template but had no release-notes category, so those PRs ended up under "Other Changes" instead of Maintenance.

- Parse the ticked box first; a ticked box always wins and stale labels are stripped
- Only fall back to a label already on the PR when no box is ticked at all
- Still fail on two ticked boxes, or on none with zero or several known labels
- Ignore stray spaces inside the backticks so they no longer read as "no box ticked"
- Add `refactor` to the "Maintenance and dependency bumps" release-notes category

Mirrors https://github.com/music-assistant/models/pull/353.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
