### PR TITLE
Clean up unused leftovers in the Sonos S1 player

### DIFF
--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -71,7 +71,6 @@ class SonosPlayer(Player):
         super().__init__(provider, soco.uid)
         self.soco = soco
         self.household_id: str = soco.household_id
-        self.subscriptions: list[SubscriptionBase] = []
 
         # Set player attributes
         self._attr_supported_features = set(PLAYER_FEATURES)
@@ -606,7 +605,6 @@ class SonosPlayer(Player):
             self.logger.debug("Starting resubscription cooldown for %s", self.display_name)
 
         self._attr_available = False
-        self._share_link_plugin = None
 
         self.update_state()
         await self.unsubscribe()


### PR DESCRIPTION
# What does this implement/fix?

The Sonos S1 player carried two leftovers from the original Home Assistant Sonos port: a `subscriptions` list that was never filled or read (the real one is `_subscriptions`), and a `_share_link_plugin` reset for a plugin the provider does not use. Removing them so the player only holds state it actually uses.

No functional change.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
