### PR TITLE
Keep the fake AcoustID fingerprinter in sync with the real one

### DIFF
--- a/tests/providers/acoustid_lookup/test_provider.py
+++ b/tests/providers/acoustid_lookup/test_provider.py
@@ -129,12 +129,21 @@ class _FakeFingerprinter:
         return b"FAKEFINGERPRINT"
 
 
+class _FakeFingerprintError(Exception):
+    """Stand-in for chromaprint.FingerprintError."""
+
+
 def _install_fake_chromaprint(monkeypatch: pytest.MonkeyPatch, fp: _FakeFingerprinter) -> None:
-    """Patch _create_fingerprinter to return the given fake, started with the session's format."""
+    """
+    Patch _create_fingerprinter to return the given fake, started with the session's format.
+
+    Also registers a stand-in error tuple, mirroring the real fingerprinter setup.
+    """
 
     def fake_create(
-        _self: AcoustidLookupProvider, sample_rate: int, channels: int
+        provider: AcoustidLookupProvider, sample_rate: int, channels: int
     ) -> _FakeFingerprinter:
+        provider._fingerprint_errors = (_FakeFingerprintError,)
         fp.start(int(sample_rate), int(channels))
         return fp
 
@@ -148,10 +157,6 @@ def _install_unidentified_track(provider: AcoustidLookupProvider) -> None:
     cast("MagicMock", provider.mass.music.tracks).get_library_item_by_prov_id = AsyncMock(
         return_value=track
     )
-
-
-class _FakeFingerprintError(Exception):
-    """Stand-in for chromaprint.FingerprintError."""
 
 
 def _install_chromaprint_module(monkeypatch: pytest.MonkeyPatch, *, failing_call: str) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The AcoustID tests swap in a fake fingerprinter instead of the real one. Since #5434 the real setup
also records which fingerprinting errors should be caught, but the fake never did — so a handful of
tests ran with an empty error list and quietly skipped the error handling they look like they cover.

Test-only change, nothing about AcoustID itself changes.

- The fake fingerprinter now registers a stand-in error type, matching the real setup
- Moved the stand-in error class up so it sits above both helpers that use it

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
