### PR TITLE
Clean up unused code in the Sonos S1 error handling

### DIFF
--- a/music_assistant/providers/sonos_s1/helpers.py
+++ b/music_assistant/providers/sonos_s1/helpers.py
@@ -9,12 +9,13 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar, cast, overload
 
 from music_assistant_models.errors import PlayerCommandFailed
-from soco import SoCo
 from soco.exceptions import SoCoException, SoCoUPnPException
 
 from .constants import UID_POSTFIX, UID_PREFIX
 
 if TYPE_CHECKING:
+    from soco import SoCo
+
     from .player import SonosPlayer
 
 
@@ -56,11 +57,10 @@ def soco_error(
             @functools.wraps(funct)
             async def async_wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> Any:
                 """Await the call so soco UPnP exceptions surface inside the try block."""
-                args_soco = next((arg for arg in args if isinstance(arg, SoCo)), None)
                 try:
                     return await funct(self, *args, **kwargs)
                 except (OSError, SoCoException, SoCoUPnPException, TimeoutError) as err:
-                    _handle_soco_error(self, err, funct.__qualname__, errorcodes, args_soco)
+                    _handle_soco_error(self, err, funct.__qualname__, errorcodes)
                     return None
 
             return cast("_ReturnFuncType[_T, _P, _R]", async_wrapper)
@@ -68,11 +68,10 @@ def soco_error(
         @functools.wraps(funct)
         def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R | None:
             """Wrap for all soco UPnP exception."""
-            args_soco = next((arg for arg in args if isinstance(arg, SoCo)), None)
             try:
                 result = funct(self, *args, **kwargs)
             except (OSError, SoCoException, SoCoUPnPException, TimeoutError) as err:
-                _handle_soco_error(self, err, funct.__qualname__, errorcodes, args_soco)
+                _handle_soco_error(self, err, funct.__qualname__, errorcodes)
                 return None
 
             return result
@@ -106,7 +105,6 @@ def _handle_soco_error(
     err: Exception,
     function: str,
     errorcodes: list[str] | None,
-    args_soco: SoCo | None,
 ) -> None:
     """Ignore a filtered UPnP error code or raise the error as a SonosUpdateError."""
     error_code = getattr(err, "error_code", None)
@@ -114,7 +112,7 @@ def _handle_soco_error(
         _LOGGER.debug("Error code %s ignored in call to %s", error_code, function)
         return
 
-    if (target := _find_target_identifier(instance, args_soco)) is None:
+    if (target := _find_target_identifier(instance)) is None:
         msg = "Unexpected use of soco_error"
         raise RuntimeError(msg) from err
 
@@ -122,13 +120,9 @@ def _handle_soco_error(
     raise SonosUpdateError(message) from err
 
 
-def _find_target_identifier(instance: Any, fallback_soco: SoCo | None) -> str | None:
-    """Extract the best available target identifier from the provided instance object."""
-    if zone_name := getattr(instance, "zone_name", None):
-        # SonosPlayer instance
-        return str(zone_name)
-    if soco := getattr(instance, "soco", fallback_soco):
-        # Holds a SoCo instance attribute
+def _find_target_identifier(instance: Any) -> str | None:
+    """Return the name or IP address of the speaker, or None if the instance holds no SoCo."""
+    if soco := getattr(instance, "soco", None):
         # Only use attributes with no I/O
         return str(soco._player_name or soco.ip_address)
     return None

--- a/tests/providers/sonos_s1/test_helpers.py
+++ b/tests/providers/sonos_s1/test_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import re
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -14,6 +15,7 @@ from music_assistant.providers.sonos_s1.player import SonosPlayer
 
 IGNORED_ERROR_CODE = "501"
 OTHER_ERROR_CODE = "701"
+SPEAKER_IP = "192.168.1.20"
 
 SOCO_ERRORS = [
     pytest.param(SoCoException("boom"), id="soco"),
@@ -29,9 +31,10 @@ SYNC_AND_ASYNC_FILTERED = ["probe_filtered", "regroup_filtered"]
 class _Speaker(SonosPlayer):
     """Minimal speaker exposing a decorated service call in a sync and an async flavour."""
 
-    def __init__(self, error: Exception | None = None) -> None:
+    def __init__(self, error: Exception | None = None, player_name: str | None = "Kitchen") -> None:
         soco = MagicMock()
-        soco._player_name = "Kitchen"
+        soco._player_name = player_name
+        soco.ip_address = SPEAKER_IP
         self.soco = soco
         self._error = error
 
@@ -81,6 +84,12 @@ async def test_soco_errors_become_a_sonos_update_error(method: str, error: Excep
         await _invoke(_Speaker(error), method)
 
     assert exc_info.value.__cause__ is error
+
+
+def test_speaker_without_a_cached_name_is_reported_by_ip() -> None:
+    """A speaker whose name is not cached yet is named by its IP address."""
+    with pytest.raises(SonosUpdateError, match=re.escape(SPEAKER_IP)):
+        _Speaker(SoCoException("boom"), player_name=None).probe()
 
 
 @pytest.mark.parametrize("method", SYNC_AND_ASYNC_FILTERED)


### PR DESCRIPTION
# What does this implement/fix?

The helper that names the speaker in a Sonos S1 error message carried two paths that can never run: a lookup for a `zone_name` attribute that no player has, and a fallback speaker argument that no caller passes. The dead path also carried a comment claiming it handled the player object, which is misleading to read.

Every error already resolves the speaker the same way, so this keeps that one path and drops the rest. Errors name the same speaker as before.

- Drop the unreachable `zone_name` branch and its stale comment.
- Drop the `fallback_soco` argument that was threaded through the decorator but never used.
- Move the now type-only `SoCo` import into the `TYPE_CHECKING` block.
- Add test coverage for a speaker with no cached name, which is reported by its IP address.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
