### PR TITLE
Drop the entity dropdown from the Home Assistant settings

### DIFF
--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -22,7 +22,7 @@ from hass_client import HomeAssistantClient
 from hass_client.exceptions import BaseHassClientError
 from hass_client.utils import get_websocket_url
 from music_assistant_models.auth import Scope
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
+from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import (
     ConfigEntryType,
     ContentType,
@@ -51,7 +51,6 @@ from .constants import (
     CONF_MUTE_CONTROLS,
     CONF_POWER_CONTROLS,
     CONF_VOLUME_CONTROLS,
-    CONTROL_DOMAINS,
     OFF_STATES,
     MediaPlayerEntityFeature,
     parse_supported_features,
@@ -61,7 +60,7 @@ from .control_entities import (
     ControlEntitySearch,
     HassControlEntitySearchResult,
 )
-from .helpers import ControlCapabilities, get_control_capabilities, get_control_name
+from .helpers import ControlCapabilities, get_control_name
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Collection, Mapping
@@ -144,58 +143,19 @@ async def setup(
     return HomeAssistantProvider(mass, manifest, config, set())
 
 
-async def _get_config_entries(hass_prov: HomeAssistantProvider) -> tuple[ConfigEntry, ...]:
-    """Return the (entity based) config entries."""
-    all_power_entities: list[ConfigValueOption] = []
-    all_mute_entities: list[ConfigValueOption] = []
-    all_volume_entities: list[ConfigValueOption] = []
-    if not hass_prov.hass.connected:
-        return ()
-    states = await hass_prov.get_states(domains=CONTROL_DOMAINS)
-    for state in states:
-        capabilities = get_control_capabilities(state, hass_prov.logger)
-        option = ConfigValueOption(
-            state["entity_id"], title=get_control_name(state["entity_id"], state)
+def _control_config_entries() -> tuple[ConfigEntry, ...]:
+    """Return the config entries holding the entities selected as player controls."""
+    return tuple(
+        ConfigEntry(
+            key=conf_key,
+            type=ConfigEntryType.STRING,
+            multi_value=True,
+            required=True,
+            default_value=[],
+            category="player_controls",
         )
-        if capabilities.power:
-            all_power_entities.append(option)
-        if capabilities.volume:
-            all_volume_entities.append(option)
-        if capabilities.mute:
-            all_mute_entities.append(option)
-    all_power_entities.sort(key=lambda x: x.title or "")
-    all_mute_entities.sort(key=lambda x: x.title or "")
-    all_volume_entities.sort(key=lambda x: x.title or "")
-    entries: list[ConfigEntry] = [
-        ConfigEntry(
-            key=CONF_POWER_CONTROLS,
-            type=ConfigEntryType.STRING,
-            multi_value=True,
-            required=True,
-            options=all_power_entities,
-            default_value=[],
-            category="player_controls",
-        ),
-        ConfigEntry(
-            key=CONF_VOLUME_CONTROLS,
-            type=ConfigEntryType.STRING,
-            multi_value=True,
-            required=True,
-            options=all_volume_entities,
-            default_value=[],
-            category="player_controls",
-        ),
-        ConfigEntry(
-            key=CONF_MUTE_CONTROLS,
-            type=ConfigEntryType.STRING,
-            multi_value=True,
-            required=True,
-            options=all_mute_entities,
-            default_value=[],
-            category="player_controls",
-        ),
-    ]
-    return tuple(entries)
+        for conf_key in (CONF_POWER_CONTROLS, CONF_VOLUME_CONTROLS, CONF_MUTE_CONTROLS)
+    )
 
 
 class HomeAssistantProvider(PluginProvider):
@@ -275,46 +235,7 @@ class HomeAssistantProvider(PluginProvider):
             # url/token/verify_ssl are collected by the setup flow instead (see setup_flow.py)
             base_entries = ()
 
-        # append player controls entries (if we have an active instance)
-        if self.available:
-            try:
-                return (
-                    *base_entries,
-                    *(await _get_config_entries(self)),
-                )
-            except TimeoutError:
-                # listing the selectable entities needs a live sweep of Home Assistant, so a
-                # slow or busy instance must not fail config resolution for the whole server.
-                # The entries below carry no options but do keep any stored selection.
-                self.logger.warning(
-                    "Timeout fetching entities from Home Assistant, "
-                    "player control options are unavailable until the next refresh"
-                )
-
-        return (
-            *base_entries,
-            ConfigEntry(
-                key=CONF_POWER_CONTROLS,
-                type=ConfigEntryType.STRING,
-                multi_value=True,
-                label=CONF_POWER_CONTROLS,
-                default_value=[],
-            ),
-            ConfigEntry(
-                key=CONF_VOLUME_CONTROLS,
-                type=ConfigEntryType.STRING,
-                multi_value=True,
-                label=CONF_VOLUME_CONTROLS,
-                default_value=[],
-            ),
-            ConfigEntry(
-                key=CONF_MUTE_CONTROLS,
-                type=ConfigEntryType.STRING,
-                multi_value=True,
-                label=CONF_MUTE_CONTROLS,
-                default_value=[],
-            ),
-        )
+        return (*base_entries, *_control_config_entries())
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the plugin."""

--- a/tests/providers/hass/test_control_entity_search.py
+++ b/tests/providers/hass/test_control_entity_search.py
@@ -84,6 +84,8 @@ ENTITIES: dict[str, tuple[str | None, str | None, str, dict[str, Any]]] = {
         {"supported_features": FULL_MEDIA_PLAYER_FEATURES, "mass_player_type": "player"},
     ),
     "media_player.featureless": (None, None, "Featureless Player", {"supported_features": 0}),
+    # an uninterpretable supported_features value must not take the whole search down
+    "media_player.broken_features": (None, None, "Broken Receiver", {"supported_features": []}),
     "switch.kitchen_power": ("dev_kitchen", None, "Kitchen Power", {}),
     "number.kitchen_volume": ("dev_kitchen", "area_office", "Kitchen Volume", {}),
     "input_boolean.standalone": (None, "area_living", "Standalone Toggle", {}),
@@ -324,6 +326,16 @@ async def test_search_matches_every_word_separately(search: str, expected: list[
     assert sorted(_entity_ids(result["groups"])) == sorted(expected)
 
 
+async def test_search_survives_an_entity_with_invalid_features() -> None:
+    """Skip an entity reporting an uninterpretable supported_features value."""
+    async with _start_provider() as (provider, _):
+        result = await provider.search_control_entities(search="receiver")
+        usable = await provider.search_control_entities(search="amplifier")
+
+    assert _entity_ids(result["groups"]) == []
+    assert _entity_ids(usable["groups"]) == ["media_player.living_amp"]
+
+
 async def test_search_without_text_returns_all_eligible_entities() -> None:
     """Return every entity that can serve a control role when no search text is given."""
     async with _start_provider() as (provider, _):
@@ -375,6 +387,7 @@ async def test_control_type_filters_on_capability() -> None:
     # a volume search must not sweep the states of the on/off-only domains
     assert volume_requests == [
         "input_number.attic_volume",
+        "media_player.broken_features",
         "media_player.featureless",
         "media_player.living_amp",
         "media_player.mass_player",

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -29,7 +29,6 @@ from music_assistant.providers.hass.constants import (
     CONF_MUTE_CONTROLS,
     CONF_POWER_CONTROLS,
     CONF_VOLUME_CONTROLS,
-    MediaPlayerEntityFeature,
 )
 from tests.common import use_real_create_task
 
@@ -1211,58 +1210,32 @@ async def test_entity_registry_subscription_is_replaced() -> None:
         assert hass.active_event_subscriptions == 0
 
 
-async def test_config_entries_survive_a_state_fetch_timeout() -> None:
-    """A Home Assistant too slow to list its entities yields entries without options."""
+async def test_config_entries_do_not_read_home_assistant() -> None:
+    """Build the config entries without asking Home Assistant for anything."""
     async with _start_provider([_state("switch.example", "Example")]) as (provider, _):
-        # the entity sweep only runs for a provider the load machinery marked available
         provider.available = True
-        with patch.object(provider, "get_states", AsyncMock(side_effect=TimeoutError)):
+        with patch.object(provider, "get_states", AsyncMock()) as get_states:
             entries = await provider.get_config_entries()
 
-    keys = {entry.key for entry in entries}
-    assert CONF_POWER_CONTROLS in keys
-    assert all(not entry.options for entry in entries)
+    get_states.assert_not_awaited()
+    assert CONF_POWER_CONTROLS in {entry.key for entry in entries}
 
 
-async def test_config_entries_list_entities_as_options() -> None:
-    """A responsive Home Assistant offers its entities as player control options."""
+async def test_config_entries_offer_the_control_lists_without_options() -> None:
+    """Offer the control lists as plain entity id lists, filled in by the entity picker."""
     async with _start_provider([_state("switch.example", "Example")]) as (provider, _):
         provider.available = True
         entries = await provider.get_config_entries()
 
-    power_controls = next(entry for entry in entries if entry.key == CONF_POWER_CONTROLS)
-    assert [option.value for option in power_controls.options] == ["switch.example"]
-
-
-async def test_config_entries_survive_an_entity_with_invalid_features() -> None:
-    """An entity reporting an uninterpretable supported_features value is skipped."""
-    broken = {
-        "entity_id": "media_player.new_receiver",
-        "state": "idle",
-        "attributes": {"friendly_name": "New Receiver", "supported_features": []},
-    }
-    usable = {
-        "entity_id": "media_player.old_receiver",
-        "state": "idle",
-        "attributes": {
-            "friendly_name": "Old Receiver",
-            "supported_features": int(
-                MediaPlayerEntityFeature.TURN_ON
-                | MediaPlayerEntityFeature.TURN_OFF
-                | MediaPlayerEntityFeature.VOLUME_SET
-            ),
-        },
-    }
-
-    async with _start_provider([broken, usable]) as (provider, _):
-        provider.available = True
-        entries = await provider.get_config_entries()
-
-    options_by_key = {entry.key: entry.options for entry in entries}
-    for key in (CONF_POWER_CONTROLS, CONF_VOLUME_CONTROLS):
-        assert [option.value for option in options_by_key[key] or ()] == [
-            "media_player.old_receiver"
-        ]
+    control_entries = [
+        entry
+        for entry in entries
+        if entry.key in (CONF_POWER_CONTROLS, CONF_VOLUME_CONTROLS, CONF_MUTE_CONTROLS)
+    ]
+    assert len(control_entries) == 3
+    for entry in control_entries:
+        assert entry.options == []
+        assert entry.multi_value is True
 
 
 async def test_domain_states_use_a_single_subscription() -> None:


### PR DESCRIPTION
> Stacked on #5271. Pairs with music-assistant/frontend#2316, which adds the picker that replaces this dropdown.

# What does this implement/fix?

Each of the three player control settings in the Home Assistant plugin listed every eligible entity in the house as a dropdown option. That is unusable once a setup has more than a handful of entities, and building those lists swept the state of every entity in five domains every time the settings were opened.

The entity picker replaces the dropdown, so the lists no longer need to carry their options.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- offer the three control lists without options, leaving the picker to fill them in
- stop sweeping every entity in the control domains to build those options, so opening the settings no longer costs a full state fetch

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.