### PR TITLE
Show player settings in your own language again

### DIFF
--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -264,7 +264,7 @@ class PlayerConfigMixin:
             *[x for x in default_entries if x.key not in player_entries_keys],
             *player_entries,
         ]
-        return _with_translation_owner(all_entries, f"provider.{player.provider}")
+        return _with_translation_owner(all_entries, player.translation_owner)
 
     @api_command("config/players/invoke_action", required_scope=Scope.CONFIG_PLAYERS_WRITE)
     async def invoke_player_config_action(

--- a/tests/controllers/config/test_config_protocol_defaults.py
+++ b/tests/controllers/config/test_config_protocol_defaults.py
@@ -217,3 +217,14 @@ async def test_injected_protocol_entry_resolves_under_origin_provider(
     proto_entry = next(entry for entry in entries if entry.key == PREFIXED_KEY)
     assert proto_entry.translation_owner == "provider.dlna"
     assert proto_entry.translation_key == CONF_FLOW_MODE_SAMPLE_RATE
+
+
+async def test_player_entries_resolve_under_their_own_provider(mass: MusicAssistant) -> None:
+    """A player's own entries carry its provider's namespace, so its strings.json is consulted."""
+    await _setup_parent_with_protocol_child(mass)
+
+    entries = await mass.config.get_player_config_entries(PARENT_ID)
+    own_entries = [entry for entry in entries if CONF_PROTOCOL_KEY_SPLITTER not in entry.key]
+
+    assert own_entries
+    assert {entry.translation_owner for entry in own_entries} == {"provider.sonos"}


### PR DESCRIPTION
# What does this implement/fix?

Settings for a player were always shown in English, even with Music Assistant set to another language. Any label a player provider translates itself (buffer depth, sample rate handling, and so on) fell back to English in every locale.

The player's settings were being tagged with the wrong owner: the provider object was formatted into the name instead of the provider's domain, producing something like `provider.<PlayerProvider object at 0x...>`. Nothing matched that, so the provider's own translations were never found — silently, with no error anywhere.

**Related issue (if applicable):**

- found while working on #5402

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Tag a player's settings with its provider's namespace so provider-owned translations resolve
- Add a test that fails if the owner is malformed again

Note this also makes a player provider's own wording for a shared setting reachable, so some English text changes too. The clearest example is AirPlay, which has its own longer explanation for the audio synchronization delay and the device password but was always showing the generic one.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
