### PR TITLE
Share the Music Quiz AI limit checks between quiz types

### DIFF
--- a/music_assistant/providers/music_quiz/ai_distractors.py
+++ b/music_assistant/providers/music_quiz/ai_distractors.py
@@ -11,12 +11,11 @@ from typing import TYPE_CHECKING
 
 from music_assistant.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads, strip_code_fence
 from music_assistant.helpers.plugin_engines import resolve_ai_engine
-from music_assistant.providers.music_quiz.constants import (
-    AI_QUERY_TIMEOUT_SECONDS,
-    MAX_AI_PROMPT_BYTES,
-    MAX_AI_RESPONSE_BYTES,
-    MAX_AI_RESPONSE_LINES,
+from music_assistant.providers.music_quiz.ai_guards import (
+    ai_prompt_exceeds_limit,
+    validated_ai_response,
 )
+from music_assistant.providers.music_quiz.constants import AI_QUERY_TIMEOUT_SECONDS
 from music_assistant.providers.music_quiz.suggestions import answer_labels_are_too_close
 
 if TYPE_CHECKING:
@@ -61,7 +60,7 @@ async def request_ai_distractors(
     :param timeout: Maximum request duration in seconds.
     :return: The untrusted engine response, or ``None`` when unavailable.
     """
-    if len(prompt.encode("utf-8")) > MAX_AI_PROMPT_BYTES:
+    if ai_prompt_exceeds_limit(prompt):
         return None
     engine = await resolve_ai_engine(mass, engine_uid)
     if engine is None:
@@ -91,18 +90,13 @@ def parse_ai_distractor_response(
     :param expected_kinds: Exact ordered synthetic distractor kinds requested.
     :return: Strictly validated ranking and synthetic labels.
     """
-    if not isinstance(response, str):
-        raise TypeError("response must be a string")
-    if len(response.encode("utf-8")) > MAX_AI_RESPONSE_BYTES:
-        raise ValueError("response exceeds the size limit")
-    if len(response.splitlines()) > MAX_AI_RESPONSE_LINES:
-        raise ValueError("response exceeds the line limit")
+    response_text = validated_ai_response(response)
     if len(expected_kinds) > MAX_AI_SYNTHETIC_COUNT:
         raise ValueError("too many synthetic distractors were requested")
     if len(set(candidate_ids)) != len(candidate_ids):
         raise ValueError("candidate IDs must be unique")
     try:
-        payload = json_loads(strip_code_fence(response))
+        payload = json_loads(strip_code_fence(response_text))
     except JSON_DECODE_EXCEPTIONS as err:
         raise ValueError("response is not valid JSON") from err
     if not isinstance(payload, dict) or payload.keys() != {"ranked_ids", "synthetic"}:

--- a/music_assistant/providers/music_quiz/ai_distractors.py
+++ b/music_assistant/providers/music_quiz/ai_distractors.py
@@ -13,7 +13,7 @@ from music_assistant.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads, str
 from music_assistant.helpers.plugin_engines import resolve_ai_engine
 from music_assistant.providers.music_quiz.ai_guards import (
     ai_prompt_exceeds_limit,
-    validated_ai_response,
+    validate_ai_response,
 )
 from music_assistant.providers.music_quiz.constants import AI_QUERY_TIMEOUT_SECONDS
 from music_assistant.providers.music_quiz.suggestions import answer_labels_are_too_close
@@ -90,7 +90,7 @@ def parse_ai_distractor_response(
     :param expected_kinds: Exact ordered synthetic distractor kinds requested.
     :return: Strictly validated ranking and synthetic labels.
     """
-    response_text = validated_ai_response(response)
+    response_text = validate_ai_response(response)
     if len(expected_kinds) > MAX_AI_SYNTHETIC_COUNT:
         raise ValueError("too many synthetic distractors were requested")
     if len(set(candidate_ids)) != len(candidate_ids):

--- a/music_assistant/providers/music_quiz/ai_guards.py
+++ b/music_assistant/providers/music_quiz/ai_guards.py
@@ -1,4 +1,4 @@
-"""AI request and response limit guards for the Music Quiz provider."""
+"""Shared AI request and response limit guards for the Music Quiz provider."""
 
 from __future__ import annotations
 
@@ -18,7 +18,7 @@ def ai_prompt_exceeds_limit(prompt: str) -> bool:
     return len(prompt.encode("utf-8")) > MAX_AI_PROMPT_BYTES
 
 
-def validated_ai_response(response: object) -> str:
+def validate_ai_response(response: object) -> str:
     """
     Return the AI response text, if it is within the shared response limits.
 

--- a/music_assistant/providers/music_quiz/ai_guards.py
+++ b/music_assistant/providers/music_quiz/ai_guards.py
@@ -1,0 +1,35 @@
+"""AI request and response limit guards for the Music Quiz provider."""
+
+from __future__ import annotations
+
+from music_assistant.providers.music_quiz.constants import (
+    MAX_AI_PROMPT_BYTES,
+    MAX_AI_RESPONSE_BYTES,
+    MAX_AI_RESPONSE_LINES,
+)
+
+
+def ai_prompt_exceeds_limit(prompt: str) -> bool:
+    """
+    Return whether a prompt is too large to submit to an AI engine.
+
+    :param prompt: Prompt the caller intends to submit.
+    """
+    return len(prompt.encode("utf-8")) > MAX_AI_PROMPT_BYTES
+
+
+def validated_ai_response(response: object) -> str:
+    """
+    Return the AI response text, if it is within the shared response limits.
+
+    :param response: Untrusted response returned by an AI provider.
+    :raises TypeError: If the response is not a string.
+    :raises ValueError: If the response exceeds the size or line limit.
+    """
+    if not isinstance(response, str):
+        raise TypeError("response must be a string")
+    if len(response.encode("utf-8")) > MAX_AI_RESPONSE_BYTES:
+        raise ValueError("response exceeds the size limit")
+    if len(response.splitlines()) > MAX_AI_RESPONSE_LINES:
+        raise ValueError("response exceeds the line limit")
+    return response

--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -25,7 +25,7 @@ from music_assistant.helpers.json import (
 from music_assistant.helpers.plugin_engines import get_ai_engines, resolve_ai_engine
 from music_assistant.providers.music_quiz.ai_guards import (
     ai_prompt_exceeds_limit,
-    validated_ai_response,
+    validate_ai_response,
 )
 from music_assistant.providers.music_quiz.constants import AI_QUERY_TIMEOUT_SECONDS
 from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
@@ -398,7 +398,7 @@ class TriviaQuizType(QuizType):
         grounded_tracks: Collection[TriviaTrackFacts] = (),
     ) -> TriviaGeneration:
         """Parse and validate one strict AI Trivia response."""
-        response_text = validated_ai_response(response)
+        response_text = validate_ai_response(response)
         try:
             payload = json_loads(strip_code_fence(response_text))
         except JSON_DECODE_EXCEPTIONS as err:

--- a/music_assistant/providers/music_quiz/quiz_types/trivia.py
+++ b/music_assistant/providers/music_quiz/quiz_types/trivia.py
@@ -23,12 +23,11 @@ from music_assistant.helpers.json import (
     strip_code_fence,
 )
 from music_assistant.helpers.plugin_engines import get_ai_engines, resolve_ai_engine
-from music_assistant.providers.music_quiz.constants import (
-    AI_QUERY_TIMEOUT_SECONDS,
-    MAX_AI_PROMPT_BYTES,
-    MAX_AI_RESPONSE_BYTES,
-    MAX_AI_RESPONSE_LINES,
+from music_assistant.providers.music_quiz.ai_guards import (
+    ai_prompt_exceeds_limit,
+    validated_ai_response,
 )
+from music_assistant.providers.music_quiz.constants import AI_QUERY_TIMEOUT_SECONDS
 from music_assistant.providers.music_quiz.errors import TRANSLATION_OWNER
 from music_assistant.providers.music_quiz.models import (
     MultipleChoiceRoundState,
@@ -317,7 +316,7 @@ class TriviaQuizType(QuizType):
     async def _generate_question(self, fact: TriviaFact) -> TriviaGeneration:
         """Return validated AI wording and distractors for a server-selected fact."""
         prompt = self._build_prompt(fact)
-        if len(prompt.encode("utf-8")) > MAX_AI_PROMPT_BYTES:
+        if ai_prompt_exceeds_limit(prompt):
             raise self._generation_error()
         grounded_tracks = self._eligible_tracks.values() if self._eligible_tracks else ()
         engine = await self._require_ai_engine()
@@ -399,14 +398,9 @@ class TriviaQuizType(QuizType):
         grounded_tracks: Collection[TriviaTrackFacts] = (),
     ) -> TriviaGeneration:
         """Parse and validate one strict AI Trivia response."""
-        if not isinstance(response, str):
-            raise TypeError("response must be a string")
-        if len(response.encode("utf-8")) > MAX_AI_RESPONSE_BYTES:
-            raise ValueError("response exceeds the size limit")
-        if len(response.splitlines()) > MAX_AI_RESPONSE_LINES:
-            raise ValueError("response exceeds the line limit")
+        response_text = validated_ai_response(response)
         try:
-            payload = json_loads(strip_code_fence(response))
+            payload = json_loads(strip_code_fence(response_text))
         except JSON_DECODE_EXCEPTIONS as err:
             raise ValueError("response is not valid JSON") from err
         if not isinstance(payload, dict) or payload.keys() != {"question", "wrong_answers"}:

--- a/tests/providers/music_quiz/test_ai_guards.py
+++ b/tests/providers/music_quiz/test_ai_guards.py
@@ -1,0 +1,57 @@
+"""Tests for the shared Music Quiz AI limit guards."""
+
+from __future__ import annotations
+
+import pytest
+
+from music_assistant.providers.music_quiz.ai_guards import (
+    ai_prompt_exceeds_limit,
+    validate_ai_response,
+)
+from music_assistant.providers.music_quiz.constants import (
+    MAX_AI_PROMPT_BYTES,
+    MAX_AI_RESPONSE_BYTES,
+    MAX_AI_RESPONSE_LINES,
+)
+
+
+def test_ai_prompt_exceeds_limit_allows_a_prompt_at_the_limit() -> None:
+    """Accept a prompt that is exactly at the byte limit."""
+    assert ai_prompt_exceeds_limit("x" * MAX_AI_PROMPT_BYTES) is False
+    assert ai_prompt_exceeds_limit("x" * (MAX_AI_PROMPT_BYTES + 1)) is True
+
+
+def test_ai_prompt_exceeds_limit_counts_bytes_not_characters() -> None:
+    """Measure a prompt in UTF-8 bytes, so multi-byte metadata cannot slip past."""
+    at_limit = "é" * (MAX_AI_PROMPT_BYTES // 2)
+
+    assert len(at_limit) < MAX_AI_PROMPT_BYTES
+    assert ai_prompt_exceeds_limit(at_limit) is False
+    assert ai_prompt_exceeds_limit(f"{at_limit}é") is True
+
+
+def test_validate_ai_response_returns_a_response_at_the_limits() -> None:
+    """Return an unmodified response that is exactly at the size and line limits."""
+    at_size_limit = "x" * MAX_AI_RESPONSE_BYTES
+    at_line_limit = "\n".join("x" for _ in range(MAX_AI_RESPONSE_LINES))
+
+    assert validate_ai_response(at_size_limit) == at_size_limit
+    assert validate_ai_response(at_line_limit) == at_line_limit
+
+
+def test_validate_ai_response_rejects_a_non_string() -> None:
+    """Reject a response an AI provider did not return as text."""
+    with pytest.raises(TypeError, match="must be a string"):
+        validate_ai_response(42)
+
+
+def test_validate_ai_response_rejects_an_oversized_response() -> None:
+    """Reject a response one byte over the size limit."""
+    with pytest.raises(ValueError, match="size"):
+        validate_ai_response("x" * (MAX_AI_RESPONSE_BYTES + 1))
+
+
+def test_validate_ai_response_rejects_too_many_lines() -> None:
+    """Reject a response one line over the line limit."""
+    with pytest.raises(ValueError, match="line"):
+        validate_ai_response("\n".join("x" for _ in range(MAX_AI_RESPONSE_LINES + 1)))


### PR DESCRIPTION
# What does this implement/fix?

The Music Quiz provider shares the four limits it applies to every AI request and response, but the code enforcing three of them was written twice: once in the distractor module and once in Trivia. Both copies were identical down to the error messages, so any future change to how a limit is applied had to be made in two places to stay correct.

Moved the checks into a small `ai_guards.py` next to the limits themselves, and pointed both call sites at it. Trivia still does not import the distractor module. No behaviour change: same limits, same errors.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Added `music_assistant/providers/music_quiz/ai_guards.py` with the prompt-size check and the response size/line check.
- Updated `ai_distractors.py` and Trivia to use it, dropping their own copies.
- Added tests covering the guards at their exact limits.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
