### PR TITLE
Fix wrong playback position and track length for HEOS players

### DIFF
--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -238,6 +238,7 @@ class HeosPlayer(Player):
             else:
                 self._attr_active_source = str(now_playing.source_id)
 
+            # HEOS reports position and duration in milliseconds, PlayerMedia expects seconds
             self._attr_current_media = PlayerMedia(
                 uri=now_playing.media_id or media_uri_from_now_playing_media(now_playing),
                 media_type=HEOS_MEDIA_TYPE_TO_MEDIA_TYPE.get(
@@ -248,9 +249,13 @@ class HeosPlayer(Player):
                 artist=now_playing.artist,
                 album=now_playing.album,
                 image_url=now_playing.image_url,
-                duration=now_playing.duration,
+                duration=int(now_playing.duration / 1000) if now_playing.duration else None,
                 source_id=str(now_playing.source_id),
-                elapsed_time=now_playing.current_position,
+                elapsed_time=(
+                    int(now_playing.current_position / 1000)
+                    if now_playing.current_position is not None
+                    else None
+                ),
                 elapsed_time_last_updated=(
                     now_playing.current_position_updated.timestamp()
                     if now_playing.current_position_updated
@@ -264,7 +269,9 @@ class HeosPlayer(Player):
         now_playing = self._device.now_playing_media
 
         self._attr_elapsed_time = (
-            now_playing.current_position / 1000 if now_playing.current_position else None
+            now_playing.current_position / 1000
+            if now_playing.current_position is not None
+            else None
         )
         self._attr_elapsed_time_last_updated = (
             now_playing.current_position_updated.timestamp()

--- a/tests/providers/heos/test_player.py
+++ b/tests/providers/heos/test_player.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 from music_assistant_models.enums import MediaType
@@ -26,6 +27,17 @@ def _url_stream_now_playing() -> MagicMock:
     now_playing.current_position = None
     now_playing.current_position_updated = None
     now_playing.duration = None
+    return now_playing
+
+
+def _external_now_playing(current_position: int | None, duration: int | None = 245000) -> MagicMock:
+    """HEOS now-playing for an external source, with millisecond progress values."""
+    now_playing = _url_stream_now_playing()
+    now_playing.source_id = 9999
+    now_playing.song = "External Track"
+    now_playing.current_position = current_position
+    now_playing.current_position_updated = datetime(2026, 1, 1, tzinfo=UTC)
+    now_playing.duration = duration
     return now_playing
 
 
@@ -91,3 +103,51 @@ def test_external_source_now_playing_still_updates_media() -> None:
     player._update_player_current_media()
 
     assert player._attr_current_media.title == "External Track"
+
+
+def test_media_position_and_duration_reported_in_seconds() -> None:
+    """HEOS reports milliseconds; the media must carry seconds."""
+    player = _make_player(_external_now_playing(113000))
+    player._attr_active_source = "9999"
+
+    player._update_player_current_media()
+
+    assert player._attr_current_media is not None
+    assert player._attr_current_media.elapsed_time == 113
+    assert player._attr_current_media.duration == 245
+
+
+def test_media_and_player_position_agree() -> None:
+    """The media-level and player-level positions must use the same unit."""
+    player = _make_player(_external_now_playing(113000))
+    player._attr_active_source = "9999"
+
+    player.set_dynamic_attributes(update_media=True)
+
+    assert player._attr_current_media is not None
+    assert player._attr_current_media.elapsed_time == player._attr_elapsed_time == 113
+
+
+def test_position_zero_is_reported_not_dropped() -> None:
+    """Position 0 is a real position at the start of a track, not a missing one."""
+    player = _make_player(_external_now_playing(0))
+    player._attr_active_source = "9999"
+
+    player.set_dynamic_attributes(update_media=True)
+
+    assert player._attr_current_media is not None
+    assert player._attr_current_media.elapsed_time == 0
+    assert player._attr_elapsed_time == 0
+
+
+def test_missing_progress_stays_none() -> None:
+    """Without progress info, no position or duration is reported."""
+    player = _make_player(_external_now_playing(None, duration=None))
+    player._attr_active_source = "9999"
+
+    player.set_dynamic_attributes(update_media=True)
+
+    assert player._attr_current_media is not None
+    assert player._attr_current_media.elapsed_time is None
+    assert player._attr_current_media.duration is None
+    assert player._attr_elapsed_time is None


### PR DESCRIPTION
# What does this implement/fix?

HEOS reports the playback position and track length in milliseconds, but Music Assistant expects seconds. The provider already converted the position for the player itself, but passed the raw millisecond values straight through on the media object, so both ended up a thousand times too large there.

This only shows up when playback is started outside of Music Assistant (the HEOS app, Spotify Connect, an aux input); when MA's own queue is playing, the queue supplies the position instead. Found by inspection, not reported by a user.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Convert the position and track length on the media object from milliseconds to seconds
- Treat position `0` as a real position instead of a missing one, so the start of a track is reported
- Test coverage for both

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
