### PR TITLE
Tidy up duplicated fixtures in the controller tests

### DIFF
--- a/tests/controllers/cache/conftest.py
+++ b/tests/controllers/cache/conftest.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-async def cache(mass_minimal: MusicAssistant) -> CacheController:
+async def cache_controller(mass_minimal: MusicAssistant) -> CacheController:
     """Return an initialized cache controller."""
     await mass_minimal.cache._setup_database()
     return mass_minimal.cache

--- a/tests/controllers/cache/conftest.py
+++ b/tests/controllers/cache/conftest.py
@@ -1,0 +1,18 @@
+"""Shared fixtures for the cache controller tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from music_assistant.controllers.cache import CacheController
+    from music_assistant.mass import MusicAssistant
+
+
+@pytest.fixture
+async def cache(mass_minimal: MusicAssistant) -> CacheController:
+    """Return an initialized cache controller."""
+    await mass_minimal.cache._setup_database()
+    return mass_minimal.cache

--- a/tests/controllers/cache/test_cache_controller.py
+++ b/tests/controllers/cache/test_cache_controller.py
@@ -47,105 +47,105 @@ async def _create_db_files(cache_path: str) -> list[str]:
 # --- Core get/set behavior ---
 
 
-async def test_set_and_get_string(cache: CacheController) -> None:
+async def test_set_and_get_string(cache_controller: CacheController) -> None:
     """Test storing and retrieving a string value."""
-    await cache.set("test_key", "hello", provider="test")
-    result = await cache.get("test_key", provider="test")
+    await cache_controller.set("test_key", "hello", provider="test")
+    result = await cache_controller.get("test_key", provider="test")
     assert result == "hello"
 
 
-async def test_get_expiration(cache: CacheController) -> None:
+async def test_get_expiration(cache_controller: CacheController) -> None:
     """get_expiration returns the stored expiry epoch, also for expired rows."""
     before = int(time.time())
-    await cache.set("exp_key", {"a": 1}, provider="test", expiration=500)
-    expires = await cache.get_expiration("exp_key", provider="test")
+    await cache_controller.set("exp_key", {"a": 1}, provider="test", expiration=500)
+    expires = await cache_controller.get_expiration("exp_key", provider="test")
     assert expires is not None
     assert abs(expires - (before + 500)) <= 5
     # a missing key yields None
-    assert await cache.get_expiration("missing_key", provider="test") is None
+    assert await cache_controller.get_expiration("missing_key", provider="test") is None
     # an expired-but-present row still reports its (past) expiration
-    await cache.set("expired_key", "x", provider="test", expiration=-100)
-    expired = await cache.get_expiration("expired_key", provider="test")
+    await cache_controller.set("expired_key", "x", provider="test", expiration=-100)
+    expired = await cache_controller.get_expiration("expired_key", provider="test")
     assert expired is not None
     assert expired < int(time.time())
 
 
-async def test_set_and_get_int(cache: CacheController) -> None:
+async def test_set_and_get_int(cache_controller: CacheController) -> None:
     """Test storing and retrieving an integer value."""
-    await cache.set("num", 42, provider="test")
-    result = await cache.get("num", provider="test")
+    await cache_controller.set("num", 42, provider="test")
+    result = await cache_controller.get("num", provider="test")
     assert result == 42
 
 
-async def test_set_and_get_float(cache: CacheController) -> None:
+async def test_set_and_get_float(cache_controller: CacheController) -> None:
     """Test storing and retrieving a float value."""
-    await cache.set("pi", 3.14, provider="test")
-    result = await cache.get("pi", provider="test")
+    await cache_controller.set("pi", 3.14, provider="test")
+    result = await cache_controller.get("pi", provider="test")
     assert result == pytest.approx(3.14)
 
 
-async def test_set_and_get_bool(cache: CacheController) -> None:
+async def test_set_and_get_bool(cache_controller: CacheController) -> None:
     """Test storing and retrieving a boolean value."""
-    await cache.set("flag", True, provider="test")
-    result = await cache.get("flag", provider="test")
+    await cache_controller.set("flag", True, provider="test")
+    result = await cache_controller.get("flag", provider="test")
     assert result is True
 
 
-async def test_set_and_get_none(cache: CacheController) -> None:
+async def test_set_and_get_none(cache_controller: CacheController) -> None:
     """Test storing and retrieving None."""
-    await cache.set("empty", None, provider="test")
-    result = await cache.get("empty", provider="test", default="MISSING")
+    await cache_controller.set("empty", None, provider="test")
+    result = await cache_controller.get("empty", provider="test", default="MISSING")
     assert result is None
 
 
-async def test_set_and_get_dict(cache: CacheController) -> None:
+async def test_set_and_get_dict(cache_controller: CacheController) -> None:
     """Test storing and retrieving a dict value."""
     data = {"name": "test", "count": 5, "nested": {"a": 1}}
-    await cache.set("dict_key", data, provider="test")
-    result = await cache.get("dict_key", provider="test")
+    await cache_controller.set("dict_key", data, provider="test")
+    result = await cache_controller.get("dict_key", provider="test")
     assert result == data
 
 
-async def test_set_and_get_list(cache: CacheController) -> None:
+async def test_set_and_get_list(cache_controller: CacheController) -> None:
     """Test storing and retrieving a list value."""
     data = [1, "two", 3.0, None, True]
-    await cache.set("list_key", data, provider="test")
-    result = await cache.get("list_key", provider="test")
+    await cache_controller.set("list_key", data, provider="test")
+    result = await cache_controller.get("list_key", provider="test")
     assert result == data
 
 
-async def test_set_and_get_nested_structure(cache: CacheController) -> None:
+async def test_set_and_get_nested_structure(cache_controller: CacheController) -> None:
     """Test storing and retrieving a deeply nested structure."""
     data = {"items": [{"id": 1, "tags": ["a", "b"]}, {"id": 2, "tags": []}]}
-    await cache.set("nested", data, provider="test")
-    result = await cache.get("nested", provider="test")
+    await cache_controller.set("nested", data, provider="test")
+    result = await cache_controller.get("nested", provider="test")
     assert result == data
 
 
 # --- JSON serialization guarantees ---
 
 
-async def test_data_always_deserialized_from_json(cache: CacheController) -> None:
+async def test_data_always_deserialized_from_json(cache_controller: CacheController) -> None:
     """Test that data is always returned as JSON-deserialized (no Python objects)."""
-    await cache.set("list_data", [1, 2, 3], provider="test")
-    result = await cache.get("list_data", provider="test")
+    await cache_controller.set("list_data", [1, 2, 3], provider="test")
+    result = await cache_controller.get("list_data", provider="test")
     assert isinstance(result, list)
     assert result == [1, 2, 3]
 
 
-async def test_base_class_single_dict(cache: CacheController) -> None:
+async def test_base_class_single_dict(cache_controller: CacheController) -> None:
     """Test that base_class reconstructs a single dict into a model."""
-    await cache.set("model", {"name": "test", "value": 42}, provider="test")
-    result = await cache.get("model", provider="test", base_class=_FakeModel)
+    await cache_controller.set("model", {"name": "test", "value": 42}, provider="test")
+    result = await cache_controller.get("model", provider="test", base_class=_FakeModel)
     assert isinstance(result, _FakeModel)
     assert result.name == "test"
     assert result.value == 42
 
 
-async def test_base_class_list_of_dicts(cache: CacheController) -> None:
+async def test_base_class_list_of_dicts(cache_controller: CacheController) -> None:
     """Test that base_class reconstructs each item in a list of dicts."""
-    await cache.set("models", [{"name": "a"}, {"name": "b"}], provider="test")
-    result = await cache.get("models", provider="test", base_class=_FakeModel)
+    await cache_controller.set("models", [{"name": "a"}, {"name": "b"}], provider="test")
+    result = await cache_controller.get("models", provider="test", base_class=_FakeModel)
     assert isinstance(result, list)
     assert len(result) == 2
     assert all(isinstance(item, _FakeModel) for item in result)
@@ -153,145 +153,145 @@ async def test_base_class_list_of_dicts(cache: CacheController) -> None:
     assert result[1].name == "b"
 
 
-async def test_base_class_not_applied_to_none(cache: CacheController) -> None:
+async def test_base_class_not_applied_to_none(cache_controller: CacheController) -> None:
     """Test that base_class is not applied when cache returns default."""
-    result = await cache.get("nonexistent", provider="test", base_class=_FakeModel)
+    result = await cache_controller.get("nonexistent", provider="test", base_class=_FakeModel)
     assert result is None
 
 
-async def test_non_serializable_raises(cache: CacheController) -> None:
+async def test_non_serializable_raises(cache_controller: CacheController) -> None:
     """Test that non-serializable data raises on set."""
     with pytest.raises(TypeError):
-        await cache.set("bad", object(), provider="test")  # type: ignore[arg-type]
+        await cache_controller.set("bad", object(), provider="test")  # type: ignore[arg-type]
 
 
 # --- Expiration ---
 
 
-async def test_expired_cache_returns_default(cache: CacheController) -> None:
+async def test_expired_cache_returns_default(cache_controller: CacheController) -> None:
     """Test that expired cache entries return the default value."""
-    await cache.set("expiring", "data", provider="test", expiration=-1)
-    result = await cache.get("expiring", provider="test", default="gone")
+    await cache_controller.set("expiring", "data", provider="test", expiration=-1)
+    result = await cache_controller.get("expiring", provider="test", default="gone")
     assert result == "gone"
 
 
 # --- Checksum validation ---
 
 
-async def test_checksum_match(cache: CacheController) -> None:
+async def test_checksum_match(cache_controller: CacheController) -> None:
     """Test that data is returned when checksum matches."""
-    await cache.set("ck", "val", provider="test", checksum="abc")
-    result = await cache.get("ck", provider="test", checksum="abc")
+    await cache_controller.set("ck", "val", provider="test", checksum="abc")
+    result = await cache_controller.get("ck", provider="test", checksum="abc")
     assert result == "val"
 
 
-async def test_checksum_mismatch(cache: CacheController) -> None:
+async def test_checksum_mismatch(cache_controller: CacheController) -> None:
     """Test that default is returned when checksum doesn't match."""
-    await cache.set("ck2", "val", provider="test", checksum="abc")
-    result = await cache.get("ck2", provider="test", checksum="xyz", default="nope")
+    await cache_controller.set("ck2", "val", provider="test", checksum="abc")
+    result = await cache_controller.get("ck2", provider="test", checksum="xyz", default="nope")
     assert result == "nope"
 
 
-async def test_checksum_as_int(cache: CacheController) -> None:
+async def test_checksum_as_int(cache_controller: CacheController) -> None:
     """Test that integer checksums are converted to strings."""
-    await cache.set("ck3", "val", provider="test", checksum="123")
-    result = await cache.get("ck3", provider="test", checksum=123)
+    await cache_controller.set("ck3", "val", provider="test", checksum="123")
+    result = await cache_controller.get("ck3", provider="test", checksum=123)
     assert result == "val"
 
 
 # --- Category and provider isolation ---
 
 
-async def test_different_providers_isolated(cache: CacheController) -> None:
+async def test_different_providers_isolated(cache_controller: CacheController) -> None:
     """Test that the same key in different providers returns different data."""
-    await cache.set("key", "from_a", provider="prov_a")
-    await cache.set("key", "from_b", provider="prov_b")
-    assert await cache.get("key", provider="prov_a") == "from_a"
-    assert await cache.get("key", provider="prov_b") == "from_b"
+    await cache_controller.set("key", "from_a", provider="prov_a")
+    await cache_controller.set("key", "from_b", provider="prov_b")
+    assert await cache_controller.get("key", provider="prov_a") == "from_a"
+    assert await cache_controller.get("key", provider="prov_b") == "from_b"
 
 
-async def test_different_categories_isolated(cache: CacheController) -> None:
+async def test_different_categories_isolated(cache_controller: CacheController) -> None:
     """Test that the same key in different categories returns different data."""
-    await cache.set("key", "cat_1", provider="test", category=1)
-    await cache.set("key", "cat_2", provider="test", category=2)
-    assert await cache.get("key", provider="test", category=1) == "cat_1"
-    assert await cache.get("key", provider="test", category=2) == "cat_2"
+    await cache_controller.set("key", "cat_1", provider="test", category=1)
+    await cache_controller.set("key", "cat_2", provider="test", category=2)
+    assert await cache_controller.get("key", provider="test", category=1) == "cat_1"
+    assert await cache_controller.get("key", provider="test", category=2) == "cat_2"
 
 
 # --- Delete and clear ---
 
 
-async def test_delete_specific_key(cache: CacheController) -> None:
+async def test_delete_specific_key(cache_controller: CacheController) -> None:
     """Test deleting a specific cache entry."""
-    await cache.set("del_me", "data", provider="test")
-    await cache.delete("del_me", provider="test")
-    result = await cache.get("del_me", provider="test", default="gone")
+    await cache_controller.set("del_me", "data", provider="test")
+    await cache_controller.delete("del_me", provider="test")
+    result = await cache_controller.get("del_me", provider="test", default="gone")
     assert result == "gone"
 
 
-async def test_clear_removes_entries(cache: CacheController) -> None:
+async def test_clear_removes_entries(cache_controller: CacheController) -> None:
     """Test that clear removes all non-persistent entries."""
-    await cache.set("a", "1", provider="test")
-    await cache.set("b", "2", provider="test")
-    await cache.clear()
-    assert await cache.get("a", provider="test") is None
-    assert await cache.get("b", provider="test") is None
+    await cache_controller.set("a", "1", provider="test")
+    await cache_controller.set("b", "2", provider="test")
+    await cache_controller.clear()
+    assert await cache_controller.get("a", provider="test") is None
+    assert await cache_controller.get("b", provider="test") is None
 
 
-async def test_clear_preserves_persistent(cache: CacheController) -> None:
+async def test_clear_preserves_persistent(cache_controller: CacheController) -> None:
     """Test that clear preserves persistent entries."""
-    await cache.set("persist", "keep", provider="test", persistent=True)
-    await cache.set("temp", "drop", provider="test")
-    await cache.clear()
-    assert await cache.get("persist", provider="test") == "keep"
-    assert await cache.get("temp", provider="test") is None
+    await cache_controller.set("persist", "keep", provider="test", persistent=True)
+    await cache_controller.set("temp", "drop", provider="test")
+    await cache_controller.clear()
+    assert await cache_controller.get("persist", provider="test") == "keep"
+    assert await cache_controller.get("temp", provider="test") is None
 
 
-async def test_clear_with_provider_filter(cache: CacheController) -> None:
+async def test_clear_with_provider_filter(cache_controller: CacheController) -> None:
     """Test that clear with provider filter only removes matching entries."""
-    await cache.set("k", "v1", provider="spotify")
-    await cache.set("k", "v2", provider="tidal")
-    await cache.clear(provider_filter="spotify")
-    assert await cache.get("k", provider="spotify") is None
-    assert await cache.get("k", provider="tidal") == "v2"
+    await cache_controller.set("k", "v1", provider="spotify")
+    await cache_controller.set("k", "v2", provider="tidal")
+    await cache_controller.clear(provider_filter="spotify")
+    assert await cache_controller.get("k", provider="spotify") is None
+    assert await cache_controller.get("k", provider="tidal") == "v2"
 
 
 # --- Bypass ---
 
 
-async def test_bypass_cache(cache: CacheController) -> None:
+async def test_bypass_cache(cache_controller: CacheController) -> None:
     """Test that the bypass context manager skips cache reads."""
-    await cache.set("bypass_key", "data", provider="test")
-    async with cache.handle_refresh(bypass=True):
-        result = await cache.get("bypass_key", provider="test", default="bypassed")
+    await cache_controller.set("bypass_key", "data", provider="test")
+    async with cache_controller.handle_refresh(bypass=True):
+        result = await cache_controller.get("bypass_key", provider="test", default="bypassed")
     assert result == "bypassed"
     # outside bypass, cache should still work
-    result = await cache.get("bypass_key", provider="test")
+    result = await cache_controller.get("bypass_key", provider="test")
     assert result == "data"
 
 
 # --- Overwrite ---
 
 
-async def test_overwrite_existing_key(cache: CacheController) -> None:
+async def test_overwrite_existing_key(cache_controller: CacheController) -> None:
     """Test that setting the same key overwrites the previous value."""
-    await cache.set("ow", "old", provider="test")
-    await cache.set("ow", "new", provider="test")
-    assert await cache.get("ow", provider="test") == "new"
+    await cache_controller.set("ow", "old", provider="test")
+    await cache_controller.set("ow", "new", provider="test")
+    assert await cache_controller.get("ow", provider="test") == "new"
 
 
 # --- Empty key handling ---
 
 
-async def test_get_with_empty_key_raises(cache: CacheController) -> None:
+async def test_get_with_empty_key_raises(cache_controller: CacheController) -> None:
     """Test that getting with empty key raises."""
     with pytest.raises(AssertionError):
-        await cache.get("", provider="test")
+        await cache_controller.get("", provider="test")
 
 
-async def test_set_with_empty_key_is_noop(cache: CacheController) -> None:
+async def test_set_with_empty_key_is_noop(cache_controller: CacheController) -> None:
     """Test that setting with empty key is silently ignored."""
-    await cache.set("", "data", provider="test")
+    await cache_controller.set("", "data", provider="test")
     # should not raise, just be a no-op
 
 
@@ -371,53 +371,59 @@ async def test_all_three_db_files_included_in_size(
 
 
 async def test_get_with_allow_expired_cache_returns_expired_data(
-    cache: CacheController,
+    cache_controller: CacheController,
 ) -> None:
     """Test that get(allow_expired_cache=True) returns data past its expiration."""
-    await cache.set("stale", "old_data", provider="test", expiration=-1)
-    assert await cache.get("stale", provider="test", default="gone") == "gone"
+    await cache_controller.set("stale", "old_data", provider="test", expiration=-1)
+    assert await cache_controller.get("stale", provider="test", default="gone") == "gone"
     assert (
-        await cache.get("stale", provider="test", default="gone", allow_expired_cache=True)
+        await cache_controller.get(
+            "stale", provider="test", default="gone", allow_expired_cache=True
+        )
         == "old_data"
     )
 
 
 async def test_get_with_allow_expired_cache_still_returns_default_when_missing(
-    cache: CacheController,
+    cache_controller: CacheController,
 ) -> None:
     """Test that allow_expired_cache=True still returns default when nothing is cached."""
-    result = await cache.get(
+    result = await cache_controller.get(
         "nonexistent", provider="test", default="gone", allow_expired_cache=True
     )
     assert result == "gone"
 
 
-async def test_auto_cleanup_removes_expired_entries(cache: CacheController) -> None:
+async def test_auto_cleanup_removes_expired_entries(cache_controller: CacheController) -> None:
     """Test that auto_cleanup removes expired entries by default."""
-    await cache.set("evict", "data", provider="test", expiration=-1)
-    await cache.auto_cleanup()
-    result = await cache.get("evict", provider="test", default="gone", allow_expired_cache=True)
+    await cache_controller.set("evict", "data", provider="test", expiration=-1)
+    await cache_controller.auto_cleanup()
+    result = await cache_controller.get(
+        "evict", provider="test", default="gone", allow_expired_cache=True
+    )
     assert result == "gone"
 
 
 async def test_auto_cleanup_keeps_allow_expired_cache_entries(
-    cache: CacheController,
+    cache_controller: CacheController,
 ) -> None:
     """Test that auto_cleanup keeps expired entries with allow_expired_cache=True."""
-    await cache.set("keep", "data", provider="test", expiration=-1, allow_expired_cache=True)
-    await cache.auto_cleanup()
-    result = await cache.get("keep", provider="test", allow_expired_cache=True)
+    await cache_controller.set(
+        "keep", "data", provider="test", expiration=-1, allow_expired_cache=True
+    )
+    await cache_controller.auto_cleanup()
+    result = await cache_controller.get("keep", provider="test", allow_expired_cache=True)
     assert result == "data"
 
 
-async def test_auto_cleanup_keeps_fresh_entries(cache: CacheController) -> None:
+async def test_auto_cleanup_keeps_fresh_entries(cache_controller: CacheController) -> None:
     """Test that auto_cleanup keeps fresh entries regardless of the flag."""
-    await cache.set("alive", "data", provider="test", expiration=3600)
-    await cache.auto_cleanup()
-    assert await cache.get("alive", provider="test") == "data"
+    await cache_controller.set("alive", "data", provider="test", expiration=3600)
+    await cache_controller.auto_cleanup()
+    assert await cache_controller.get("alive", provider="test") == "data"
 
 
-async def test_auto_cleanup_scans_all_records(cache: CacheController) -> None:
+async def test_auto_cleanup_scans_all_records(cache_controller: CacheController) -> None:
     """
     Test that auto_cleanup removes expired entries beyond the row-fetch page size.
 
@@ -426,14 +432,14 @@ async def test_auto_cleanup_scans_all_records(cache: CacheController) -> None:
     """
     expired_count = 1200
     for i in range(expired_count):
-        await cache.set(f"expired_{i}", "data", provider="test", expiration=-1)
-    await cache.set("fresh", "data", provider="test", expiration=3600)
+        await cache_controller.set(f"expired_{i}", "data", provider="test", expiration=-1)
+    await cache_controller.set("fresh", "data", provider="test", expiration=3600)
 
-    await cache.auto_cleanup()
+    await cache_controller.auto_cleanup()
 
-    assert cache.database is not None
-    assert await cache.database.get_count(DB_TABLE_CACHE) == 1
-    assert await cache.get("fresh", provider="test") == "data"
+    assert cache_controller.database is not None
+    assert await cache_controller.database.get_count(DB_TABLE_CACHE) == 1
+    assert await cache_controller.get("fresh", provider="test") == "data"
 
 
 # --- Startup vacuum ---
@@ -476,21 +482,21 @@ async def test_setup_runs_vacuum_when_reclaimable(
 # --- upsert (in-place write) ---
 
 
-async def test_set_upserts_in_place(cache: CacheController) -> None:
+async def test_set_upserts_in_place(cache_controller: CacheController) -> None:
     """Test that overwriting a key updates the row in place instead of replacing it."""
-    assert cache.database is not None
-    await cache.set("k", "v1", provider="test")
-    row = await cache.database.get_row(
+    assert cache_controller.database is not None
+    await cache_controller.set("k", "v1", provider="test")
+    row = await cache_controller.database.get_row(
         DB_TABLE_CACHE, {"category": 0, "provider": "test", "key": "k"}
     )
     assert row is not None
     row_id = row["id"]
 
-    await cache.set("k", "v2", provider="test")
-    assert await cache.get("k", provider="test") == "v2"
+    await cache_controller.set("k", "v2", provider="test")
+    assert await cache_controller.get("k", provider="test") == "v2"
     # a single row that kept its id — an INSERT OR REPLACE would delete it and assign a new id
-    assert await cache.database.get_count(DB_TABLE_CACHE) == 1
-    row = await cache.database.get_row(
+    assert await cache_controller.database.get_count(DB_TABLE_CACHE) == 1
+    row = await cache_controller.database.get_row(
         DB_TABLE_CACHE, {"category": 0, "provider": "test", "key": "k"}
     )
     assert row is not None
@@ -500,19 +506,19 @@ async def test_set_upserts_in_place(cache: CacheController) -> None:
 # --- secondary indexes ---
 
 
-async def _index_names(cache: CacheController) -> set[str]:
+async def _index_names(cache_controller: CacheController) -> set[str]:
     """Return the names of all indexes on the cache table."""
-    assert cache.database is not None
-    rows = await cache.database.get_rows_from_query(
+    assert cache_controller.database is not None
+    rows = await cache_controller.database.get_rows_from_query(
         "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = :table",
         {"table": DB_TABLE_CACHE},
     )
     return {str(row["name"]) for row in rows}
 
 
-async def test_only_key_provider_index_is_created(cache: CacheController) -> None:
+async def test_only_key_provider_index_is_created(cache_controller: CacheController) -> None:
     """Test that only the (key, provider) secondary index is created besides the autoindex."""
-    names = await _index_names(cache)
+    names = await _index_names(cache_controller)
     assert f"{DB_TABLE_CACHE}_key_provider_idx" in names
     # the UNIQUE(category, key, provider) constraint provides an autoindex
     assert any(name.startswith("sqlite_autoindex") for name in names)
@@ -595,22 +601,26 @@ async def test_migration_drops_redundant_indexes(mass_minimal: MusicAssistant) -
 # --- stale-while-revalidate cleanup ---
 
 
-async def test_auto_cleanup_removes_stale_swr_rows(cache: CacheController) -> None:
+async def test_auto_cleanup_removes_stale_swr_rows(cache_controller: CacheController) -> None:
     """Test that auto_cleanup removes SWR fallback rows expired beyond the grace window."""
     # expired but within the grace window -> kept as fallback
-    await cache.set("recent", "data", provider="test", expiration=-1, allow_expired_cache=True)
+    await cache_controller.set(
+        "recent", "data", provider="test", expiration=-1, allow_expired_cache=True
+    )
     # expired well beyond the grace window -> removed
-    await cache.set(
+    await cache_controller.set(
         "ancient",
         "data",
         provider="test",
         expiration=-(SWR_FALLBACK_MAX_AGE + 86400),
         allow_expired_cache=True,
     )
-    await cache.auto_cleanup()
+    await cache_controller.auto_cleanup()
 
-    assert await cache.get("recent", provider="test", allow_expired_cache=True) == "data"
+    assert await cache_controller.get("recent", provider="test", allow_expired_cache=True) == "data"
     assert (
-        await cache.get("ancient", provider="test", default="gone", allow_expired_cache=True)
+        await cache_controller.get(
+            "ancient", provider="test", default="gone", allow_expired_cache=True
+        )
         == "gone"
     )

--- a/tests/controllers/cache/test_cache_controller.py
+++ b/tests/controllers/cache/test_cache_controller.py
@@ -30,13 +30,6 @@ class _FakeModel:
         return cls(name=data.get("name", ""), value=data.get("value", 0))
 
 
-@pytest.fixture
-async def cache(mass_minimal: MusicAssistant) -> CacheController:
-    """Return an initialized cache controller."""
-    await mass_minimal.cache._setup_database()
-    return mass_minimal.cache
-
-
 async def _create_db_files(cache_path: str) -> list[str]:
     """
     Create small cache.db, cache.db-wal, and cache.db-shm files.

--- a/tests/controllers/cache/test_helpers.py
+++ b/tests/controllers/cache/test_helpers.py
@@ -116,23 +116,23 @@ class _FakeProvider:
 
 
 @pytest.fixture
-def provider(cache: CacheController) -> _FakeProvider:
+def provider(cache_controller: CacheController) -> _FakeProvider:
     """Return a fake provider with @use_cache decorated methods."""
-    return _FakeProvider(cache.mass)
+    return _FakeProvider(cache_controller.mass)
 
 
-async def _get_row(cache: CacheController, key: str) -> Any:
+async def _get_row(cache_controller: CacheController, key: str) -> Any:
     """Return the raw cache db row for the given key."""
-    assert cache.database is not None
-    return await cache.database.get_row(
+    assert cache_controller.database is not None
+    return await cache_controller.database.get_row(
         DB_TABLE_CACHE, {"category": 0, "provider": _PROVIDER, "key": key}
     )
 
 
-async def _wait_for_stored(cache: CacheController, key: str) -> None:
+async def _wait_for_stored(cache_controller: CacheController, key: str) -> None:
     """Wait until the background store task has written the cache row."""
     for _ in range(200):
-        if await _get_row(cache, key):
+        if await _get_row(cache_controller, key):
             return
         await asyncio.sleep(0.01)
     pytest.fail(f"cache row for {key} was never written")
@@ -162,31 +162,33 @@ async def _wait_for_flight(provider: _FakeProvider) -> None:
 # --- result caching (including None results) ---
 
 
-async def test_result_served_from_cache(cache: CacheController, provider: _FakeProvider) -> None:
+async def test_result_served_from_cache(
+    cache_controller: CacheController, provider: _FakeProvider
+) -> None:
     """Test that a second call is served from cache without re-invoking the function."""
     provider.result = "value"
     assert await provider.fetch("a") == "value"
     assert provider.calls == 1
-    await _wait_for_stored(cache, "fetch.a")
+    await _wait_for_stored(cache_controller, "fetch.a")
     provider.result = "changed"
     assert await provider.fetch("a") == "value"
     assert provider.calls == 1
 
 
 async def test_none_result_cached_and_served(
-    cache: CacheController, provider: _FakeProvider
+    cache_controller: CacheController, provider: _FakeProvider
 ) -> None:
     """Test that a None result is cached and served without re-invoking the function."""
     provider.result = None
     assert await provider.fetch("a") is None
     assert provider.calls == 1
-    await _wait_for_stored(cache, "fetch.a")
+    await _wait_for_stored(cache_controller, "fetch.a")
     assert await provider.fetch("a") is None
     assert provider.calls == 1
 
 
 async def test_cache_none_false_retries_and_skips_store(
-    cache: CacheController, provider: _FakeProvider
+    cache_controller: CacheController, provider: _FakeProvider
 ) -> None:
     """Test that cache_none=False re-invokes on None and does not store the None result."""
     provider.result = None
@@ -194,23 +196,23 @@ async def test_cache_none_false_retries_and_skips_store(
     assert provider.calls == 1
     # give a (wrongly created) store task time to run, then verify nothing was written
     await asyncio.sleep(0.05)
-    assert await _get_row(cache, "fetch_no_none.a") is None
+    assert await _get_row(cache_controller, "fetch_no_none.a") is None
     assert await provider.fetch_no_none("a") is None
     assert provider.calls == 2
     # once the function returns a real value, it is cached again
     provider.result = "found"
     assert await provider.fetch_no_none("a") == "found"
     assert provider.calls == 3
-    await _wait_for_stored(cache, "fetch_no_none.a")
+    await _wait_for_stored(cache_controller, "fetch_no_none.a")
     assert await provider.fetch_no_none("a") == "found"
     assert provider.calls == 3
 
 
 async def test_cache_none_false_ignores_stored_none(
-    cache: CacheController, provider: _FakeProvider
+    cache_controller: CacheController, provider: _FakeProvider
 ) -> None:
     """Test that cache_none=False treats a previously stored None row as a cache miss."""
-    await cache.set("fetch_no_none.a", None, provider=_PROVIDER)
+    await cache_controller.set("fetch_no_none.a", None, provider=_PROVIDER)
     provider.result = "fresh"
     assert await provider.fetch_no_none("a") == "fresh"
     assert provider.calls == 1
@@ -220,17 +222,17 @@ async def test_cache_none_false_ignores_stored_none(
 
 
 async def test_swr_serves_stale_and_refreshes(
-    cache: CacheController, provider: _FakeProvider
+    cache_controller: CacheController, provider: _FakeProvider
 ) -> None:
     """Test that an expired entry is served immediately and refreshed in the background."""
-    await cache.set(
+    await cache_controller.set(
         "fetch_swr.a", "stale", provider=_PROVIDER, expiration=-1, allow_expired_cache=True
     )
     provider.result = "fresh"
     assert await provider.fetch_swr("a") == "stale"
 
     async def _refreshed() -> bool:
-        return bool(await cache.get("fetch_swr.a", provider=_PROVIDER) == "fresh")
+        return bool(await cache_controller.get("fetch_swr.a", provider=_PROVIDER) == "fresh")
 
     await _wait_for(_refreshed)
     assert provider.calls == 1
@@ -239,25 +241,31 @@ async def test_swr_serves_stale_and_refreshes(
 
 
 async def test_wrapper_performs_single_row_fetch(
-    cache: CacheController, provider: _FakeProvider
+    cache_controller: CacheController, provider: _FakeProvider
 ) -> None:
     """Test that one wrapper call does exactly one db row fetch (miss, fresh and stale)."""
-    assert cache.database is not None
+    assert cache_controller.database is not None
     # cache miss
     provider.result = "value"
-    with patch.object(cache.database, "get_row", wraps=cache.database.get_row) as spy:
+    with patch.object(
+        cache_controller.database, "get_row", wraps=cache_controller.database.get_row
+    ) as spy:
         assert await provider.fetch_swr("a") == "value"
     assert spy.await_count == 1
     # fresh hit
-    await _wait_for_stored(cache, "fetch_swr.a")
-    with patch.object(cache.database, "get_row", wraps=cache.database.get_row) as spy:
+    await _wait_for_stored(cache_controller, "fetch_swr.a")
+    with patch.object(
+        cache_controller.database, "get_row", wraps=cache_controller.database.get_row
+    ) as spy:
         assert await provider.fetch_swr("a") == "value"
     assert spy.await_count == 1
     # stale hit (previously fetched the same row twice)
-    await cache.set(
+    await cache_controller.set(
         "fetch_swr.b", "stale", provider=_PROVIDER, expiration=-1, allow_expired_cache=True
     )
-    with patch.object(cache.database, "get_row", wraps=cache.database.get_row) as spy:
+    with patch.object(
+        cache_controller.database, "get_row", wraps=cache_controller.database.get_row
+    ) as spy:
         assert await provider.fetch_swr("b") == "stale"
     assert spy.await_count == 1
 
@@ -266,18 +274,18 @@ async def test_wrapper_performs_single_row_fetch(
 
 
 async def test_concurrent_misses_share_one_fetch(
-    cache: CacheController, provider: _FakeProvider
+    cache_controller: CacheController, provider: _FakeProvider
 ) -> None:
     """Test that concurrent callers on the same key trigger one fetch and one store."""
     provider.result = "value"
     provider.gate.clear()
-    with patch.object(cache, "set", wraps=cache.set) as store:
+    with patch.object(cache_controller, "set", wraps=cache_controller.set) as store:
         tasks = [asyncio.create_task(provider.fetch("a")) for _ in range(3)]
         await _wait_for_flight(provider)
         provider.gate.set()
         assert await asyncio.gather(*tasks) == ["value", "value", "value"]
         assert provider.calls == 1
-        await _wait_for_stored(cache, "fetch.a")
+        await _wait_for_stored(cache_controller, "fetch.a")
     assert store.await_count == 1
 
 
@@ -315,7 +323,7 @@ async def test_model_results_are_copied_per_caller(provider: _FakeProvider) -> N
 
 
 async def test_caller_mutation_does_not_reach_the_other_callers(
-    cache: CacheController, provider: _FakeProvider
+    cache_controller: CacheController, provider: _FakeProvider
 ) -> None:
     """Test that a caller mutating its result right away cannot affect the others."""
 
@@ -338,8 +346,10 @@ async def test_caller_mutation_does_not_reach_the_other_callers(
     assert mutated[0]["played"] is True
     assert [result[0]["played"] for result in others] == [False, False]
     # the entry is written from the fetched objects, which no caller was handed
-    await _wait_for_stored(cache, "fetch_items.a")
-    assert await cache.get("fetch_items.a", provider=_PROVIDER) == [{"id": "a", "played": False}]
+    await _wait_for_stored(cache_controller, "fetch_items.a")
+    assert await cache_controller.get("fetch_items.a", provider=_PROVIDER) == [
+        {"id": "a", "played": False}
+    ]
 
 
 async def test_reentrant_call_on_the_same_key_completes(provider: _FakeProvider) -> None:
@@ -386,7 +396,7 @@ async def test_cancelled_fetch_cancels_every_caller(provider: _FakeProvider) -> 
 
 
 async def test_cancelled_caller_leaves_the_others_untouched(
-    cache: CacheController, provider: _FakeProvider
+    cache_controller: CacheController, provider: _FakeProvider
 ) -> None:
     """Test that one caller giving up neither cancels the fetch nor the other callers."""
     provider.result = "value"
@@ -398,11 +408,11 @@ async def test_cancelled_caller_leaves_the_others_untouched(
     assert await asyncio.gather(*tasks[1:]) == ["value", "value"]
     assert tasks[0].cancelled()
     assert provider.calls == 1
-    await _wait_for_stored(cache, "fetch.a")
+    await _wait_for_stored(cache_controller, "fetch.a")
 
 
 async def test_sole_cancelled_caller_still_completes_the_fetch(
-    cache: CacheController, provider: _FakeProvider
+    cache_controller: CacheController, provider: _FakeProvider
 ) -> None:
     """Test that a fetch runs to completion and stores after its only caller gave up."""
     provider.result = "value"
@@ -413,7 +423,7 @@ async def test_sole_cancelled_caller_still_completes_the_fetch(
     provider.gate.set()
     with pytest.raises(asyncio.CancelledError):
         await task
-    await _wait_for_stored(cache, "fetch.a")
+    await _wait_for_stored(cache_controller, "fetch.a")
     assert provider.calls == 1
 
 
@@ -439,12 +449,12 @@ async def test_failing_fetch_logs_no_task_warning(
 
 
 async def test_exception_is_shared_and_not_cached(
-    cache: CacheController, provider: _FakeProvider
+    cache_controller: CacheController, provider: _FakeProvider
 ) -> None:
     """Test that every caller gets the raised error and the next call fetches again."""
     provider.error = MediaNotFoundError("not found")
     provider.gate.clear()
-    with patch.object(cache, "set", AsyncMock()) as store:
+    with patch.object(cache_controller, "set", AsyncMock()) as store:
         tasks = [asyncio.create_task(provider.fetch("a")) for _ in range(3)]
         await _wait_for_flight(provider)
         provider.gate.set()
@@ -459,12 +469,12 @@ async def test_exception_is_shared_and_not_cached(
 
 
 async def test_cache_none_false_shares_one_attempt(
-    cache: CacheController, provider: _FakeProvider
+    cache_controller: CacheController, provider: _FakeProvider
 ) -> None:
     """Test that concurrent callers share one attempt and one None, then retry after."""
     provider.result = None
     provider.gate.clear()
-    with patch.object(cache, "set", AsyncMock()) as store:
+    with patch.object(cache_controller, "set", AsyncMock()) as store:
         tasks = [asyncio.create_task(provider.fetch_no_none("a")) for _ in range(3)]
         await _wait_for_flight(provider)
         provider.gate.set()
@@ -495,10 +505,10 @@ async def test_bypass_cache_does_not_join_a_fetch(provider: _FakeProvider) -> No
 
 
 async def test_swr_refreshes_once_for_concurrent_callers(
-    cache: CacheController, provider: _FakeProvider
+    cache_controller: CacheController, provider: _FakeProvider
 ) -> None:
     """Test that concurrent callers on a stale entry trigger one background refresh."""
-    await cache.set(
+    await cache_controller.set(
         "fetch_swr.a", "stale", provider=_PROVIDER, expiration=-1, allow_expired_cache=True
     )
     provider.result = "fresh"
@@ -509,14 +519,14 @@ async def test_swr_refreshes_once_for_concurrent_callers(
     provider.gate.set()
 
     async def _refreshed() -> bool:
-        return bool(await cache.get("fetch_swr.a", provider=_PROVIDER) == "fresh")
+        return bool(await cache_controller.get("fetch_swr.a", provider=_PROVIDER) == "fresh")
 
     await _wait_for(_refreshed)
     assert provider.calls == 1
 
 
 async def test_completed_fetch_is_not_reused(
-    cache: CacheController, provider: _FakeProvider
+    cache_controller: CacheController, provider: _FakeProvider
 ) -> None:
     """Test that a caller is not handed a fetch that already finished."""
 
@@ -526,7 +536,7 @@ async def test_completed_fetch_is_not_reused(
     # a finished flight left under the key must be replaced, not awaited for its outcome
     finished = asyncio.create_task(_noop())
     await finished
-    cache.mass._tracked_tasks[f"cache_flight.{_PROVIDER}.fetch.a"] = finished
+    cache_controller.mass._tracked_tasks[f"cache_flight.{_PROVIDER}.fetch.a"] = finished
     provider.result = "value"
     assert await provider.fetch("a") == "value"
     assert provider.calls == 1
@@ -546,19 +556,29 @@ async def test_single_flight_disabled_runs_every_caller(provider: _FakeProvider)
 # --- get_with_freshness ---
 
 
-async def test_get_with_freshness(cache: CacheController) -> None:
+async def test_get_with_freshness(cache_controller: CacheController) -> None:
     """Test that get_with_freshness reports the freshness and presence of entries."""
-    await cache.set("fresh", "data", provider=_PROVIDER, expiration=3600)
-    assert await cache.get_with_freshness("fresh", provider=_PROVIDER) == ("data", True, True)
-    await cache.set("expired", "old", provider=_PROVIDER, expiration=-1)
+    await cache_controller.set("fresh", "data", provider=_PROVIDER, expiration=3600)
+    assert await cache_controller.get_with_freshness("fresh", provider=_PROVIDER) == (
+        "data",
+        True,
+        True,
+    )
+    await cache_controller.set("expired", "old", provider=_PROVIDER, expiration=-1)
     # an expired entry is reported as not found unless include_expired is set
-    assert await cache.get_with_freshness("expired", provider=_PROVIDER) == (None, False, False)
-    assert await cache.get_with_freshness("expired", provider=_PROVIDER, include_expired=True) == (
+    assert await cache_controller.get_with_freshness("expired", provider=_PROVIDER) == (
+        None,
+        False,
+        False,
+    )
+    assert await cache_controller.get_with_freshness(
+        "expired", provider=_PROVIDER, include_expired=True
+    ) == (
         "old",
         False,
         True,
     )
-    data, is_fresh, found = await cache.get_with_freshness("missing", provider=_PROVIDER)
+    data, is_fresh, found = await cache_controller.get_with_freshness("missing", provider=_PROVIDER)
     assert found is False
     assert is_fresh is False
     assert data is None

--- a/tests/controllers/cache/test_helpers.py
+++ b/tests/controllers/cache/test_helpers.py
@@ -116,13 +116,6 @@ class _FakeProvider:
 
 
 @pytest.fixture
-async def cache(mass_minimal: MusicAssistant) -> CacheController:
-    """Return an initialized cache controller."""
-    await mass_minimal.cache._setup_database()
-    return mass_minimal.cache
-
-
-@pytest.fixture
 def provider(cache: CacheController) -> _FakeProvider:
     """Return a fake provider with @use_cache decorated methods."""
     return _FakeProvider(cache.mass)

--- a/tests/controllers/players/conftest.py
+++ b/tests/controllers/players/conftest.py
@@ -1,0 +1,18 @@
+"""Shared fixtures for the players controller tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.common import MockProvider
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+
+@pytest.fixture
+def provider(mock_mass: MagicMock) -> MockProvider:
+    """Create a mock provider."""
+    return MockProvider("test_provider", instance_id="test_prov", mass=mock_mass)

--- a/tests/controllers/players/conftest.py
+++ b/tests/controllers/players/conftest.py
@@ -15,4 +15,6 @@ if TYPE_CHECKING:
 @pytest.fixture
 def provider(mock_mass: MagicMock) -> MockProvider:
     """Create a mock provider."""
+    # mock_mass is defined per test module and differs between them, so a module
+    # requesting this fixture must bring its own
     return MockProvider("test_provider", instance_id="test_prov", mass=mock_mass)

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -104,12 +104,6 @@ def controller(mock_mass: MagicMock) -> PlayerController:
     return PlayerController(mock_mass)
 
 
-@pytest.fixture
-def provider(mock_mass: MagicMock) -> MockProvider:
-    """Create a mock provider."""
-    return MockProvider("test_provider", instance_id="test_prov", mass=mock_mass)
-
-
 class TestSetMembersValidation:
     """Test cmd_set_members validation logic."""
 

--- a/tests/controllers/players/test_player_protocol_state.py
+++ b/tests/controllers/players/test_player_protocol_state.py
@@ -45,12 +45,6 @@ def controller(mock_mass: MagicMock) -> PlayerController:
     return ctrl
 
 
-@pytest.fixture
-def provider(mock_mass: MagicMock) -> MockProvider:
-    """Create a mock provider."""
-    return MockProvider("test_provider", instance_id="test_prov", mass=mock_mass)
-
-
 class TestFinalPlaybackStateWithActiveProtocol:
     """When an active output protocol is set the protocol is the source of truth."""
 

--- a/tests/controllers/streams/conftest.py
+++ b/tests/controllers/streams/conftest.py
@@ -1,0 +1,34 @@
+"""Shared fixtures for the streams controller tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from music_assistant.controllers.streams.controller import StreamsController
+from music_assistant.controllers.tasks import TasksController
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from music_assistant.mass import MusicAssistant
+
+
+@pytest.fixture
+async def streams_controller(mass_minimal: MusicAssistant) -> AsyncGenerator[StreamsController]:
+    """
+    Yield a StreamsController attached to a minimal server, closed afterwards.
+
+    :param mass_minimal: Minimal MusicAssistant instance.
+    """
+    mass_minimal.tasks = TasksController(mass_minimal)
+    await mass_minimal.tasks.setup(await mass_minimal.config.get_core_config("tasks"))
+    streams = StreamsController(mass_minimal)
+    mass_minimal.streams = streams
+    try:
+        yield streams
+    finally:
+        # close unconditionally: a failed assertion must not leave the socket bound
+        await streams.close()
+        await mass_minimal.tasks.close()

--- a/tests/controllers/streams/test_bind_fallback.py
+++ b/tests/controllers/streams/test_bind_fallback.py
@@ -1,38 +1,16 @@
 """Tests for the streamserver adopting the address it actually bound to."""
 
-from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
-import pytest
 from aiohttp.test_utils import unused_port
 
 from music_assistant.constants import CONF_BIND_IP, CONF_BIND_PORT
 from music_assistant.controllers.streams.controller import StreamsController
-from music_assistant.controllers.tasks import TasksController
 from music_assistant.mass import MusicAssistant
 
 # TEST-NET-3 (RFC 5737) is never assigned to a host, so binding it always fails
 UNBINDABLE_IP = "203.0.113.7"
 ALL_ADDRESSES = ("192.168.1.10", "fd00::10")
-
-
-@pytest.fixture
-async def controller(mass_minimal: MusicAssistant) -> AsyncGenerator[StreamsController]:
-    """
-    Yield a StreamsController attached to a minimal server, closed afterwards.
-
-    :param mass_minimal: Minimal MusicAssistant instance.
-    """
-    mass_minimal.tasks = TasksController(mass_minimal)
-    await mass_minimal.tasks.setup(await mass_minimal.config.get_core_config("tasks"))
-    streams = StreamsController(mass_minimal)
-    mass_minimal.streams = streams
-    try:
-        yield streams
-    finally:
-        # close unconditionally: a failed assertion must not leave the socket bound
-        await streams.close()
-        await mass_minimal.tasks.close()
 
 
 async def _setup_with_bind_ip(
@@ -61,20 +39,20 @@ async def _setup_with_bind_ip(
 
 
 async def test_unavailable_bind_ip_publishes_dialable_addresses(
-    controller: StreamsController, mass_minimal: MusicAssistant
+    streams_controller: StreamsController, mass_minimal: MusicAssistant
 ) -> None:
     """An address that cannot be bound leaves the streamserver advertising reachable addresses."""
-    await _setup_with_bind_ip(controller, mass_minimal, UNBINDABLE_IP)
+    await _setup_with_bind_ip(streams_controller, mass_minimal, UNBINDABLE_IP)
 
-    assert controller.bind_ip == "0.0.0.0"
-    assert controller._publish_addresses == list(ALL_ADDRESSES)
+    assert streams_controller.bind_ip == "0.0.0.0"
+    assert streams_controller._publish_addresses == list(ALL_ADDRESSES)
 
 
 async def test_available_bind_ip_publishes_only_that_address(
-    controller: StreamsController, mass_minimal: MusicAssistant
+    streams_controller: StreamsController, mass_minimal: MusicAssistant
 ) -> None:
     """A bind that succeeded advertises exactly the interface the streamserver is pinned to."""
-    await _setup_with_bind_ip(controller, mass_minimal, "127.0.0.1")
+    await _setup_with_bind_ip(streams_controller, mass_minimal, "127.0.0.1")
 
-    assert controller.bind_ip == "127.0.0.1"
-    assert controller._publish_addresses == ["127.0.0.1"]
+    assert streams_controller.bind_ip == "127.0.0.1"
+    assert streams_controller._publish_addresses == ["127.0.0.1"]

--- a/tests/controllers/streams/test_publish_ip.py
+++ b/tests/controllers/streams/test_publish_ip.py
@@ -1,9 +1,7 @@
 """Tests for the streamserver publish IP resolution."""
 
-from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
-import pytest
 from aiohttp.test_utils import unused_port
 
 from music_assistant.constants import (
@@ -13,7 +11,6 @@ from music_assistant.constants import (
     CONF_VALUE_AUTO,
 )
 from music_assistant.controllers.streams.controller import StreamsController
-from music_assistant.controllers.tasks import TasksController
 from music_assistant.mass import MusicAssistant
 
 # TEST-NET-3 (RFC 5737) is never assigned to a host, so binding it always fails
@@ -24,25 +21,6 @@ LOOPBACK_IP = "127.0.0.1"
 # the address the tests bind is deliberately absent here, so a publish IP that follows
 # the bind address can never be mistaken for the one auto-detection would have picked
 ALL_ADDRESSES = ("192.168.1.10", "10.0.0.5", "fd00::10")
-
-
-@pytest.fixture
-async def controller(mass_minimal: MusicAssistant) -> AsyncGenerator[StreamsController]:
-    """
-    Yield a StreamsController attached to a minimal server, closed afterwards.
-
-    :param mass_minimal: Minimal MusicAssistant instance.
-    """
-    mass_minimal.tasks = TasksController(mass_minimal)
-    await mass_minimal.tasks.setup(await mass_minimal.config.get_core_config("tasks"))
-    streams = StreamsController(mass_minimal)
-    mass_minimal.streams = streams
-    try:
-        yield streams
-    finally:
-        # close unconditionally: a failed assertion must not leave the socket bound
-        await streams.close()
-        await mass_minimal.tasks.close()
 
 
 async def _setup_streams(
@@ -85,62 +63,73 @@ async def _setup_streams(
 
 
 async def test_specific_bind_ip_is_published(
-    controller: StreamsController, mass_minimal: MusicAssistant
+    streams_controller: StreamsController, mass_minimal: MusicAssistant
 ) -> None:
     """A streamserver pinned to one interface hands players that same address."""
-    await _setup_streams(controller, mass_minimal, bind_ip=LOOPBACK_IP)
+    await _setup_streams(streams_controller, mass_minimal, bind_ip=LOOPBACK_IP)
 
-    assert controller.publish_ip == LOOPBACK_IP
-    assert controller.base_url == f"http://{LOOPBACK_IP}:{controller.publish_port}"
+    assert streams_controller.publish_ip == LOOPBACK_IP
+    assert streams_controller.base_url == f"http://{LOOPBACK_IP}:{streams_controller.publish_port}"
 
 
 async def test_wildcard_bind_publishes_primary_address(
-    controller: StreamsController, mass_minimal: MusicAssistant
+    streams_controller: StreamsController, mass_minimal: MusicAssistant
 ) -> None:
     """A streamserver on all interfaces advertises the primary detected address."""
-    await _setup_streams(controller, mass_minimal, bind_ip="0.0.0.0")
+    await _setup_streams(streams_controller, mass_minimal, bind_ip="0.0.0.0")
 
-    assert controller.publish_ip == ALL_ADDRESSES[0]
-    assert controller.base_url == f"http://{ALL_ADDRESSES[0]}:{controller.publish_port}"
+    assert streams_controller.publish_ip == ALL_ADDRESSES[0]
+    assert (
+        streams_controller.base_url
+        == f"http://{ALL_ADDRESSES[0]}:{streams_controller.publish_port}"
+    )
 
 
 async def test_configured_publish_ip_outranks_bind_ip(
-    controller: StreamsController, mass_minimal: MusicAssistant
+    streams_controller: StreamsController, mass_minimal: MusicAssistant
 ) -> None:
     """An explicitly configured publish IP stays authoritative over the bind address."""
     await _setup_streams(
-        controller, mass_minimal, bind_ip=LOOPBACK_IP, publish_ip=EXTERNAL_PUBLISH_IP
+        streams_controller, mass_minimal, bind_ip=LOOPBACK_IP, publish_ip=EXTERNAL_PUBLISH_IP
     )
 
-    assert controller.publish_ip == EXTERNAL_PUBLISH_IP
-    assert controller.base_url == f"http://{EXTERNAL_PUBLISH_IP}:{controller.publish_port}"
+    assert streams_controller.publish_ip == EXTERNAL_PUBLISH_IP
+    assert (
+        streams_controller.base_url
+        == f"http://{EXTERNAL_PUBLISH_IP}:{streams_controller.publish_port}"
+    )
 
 
 async def test_unavailable_bind_ip_publishes_dialable_address(
-    controller: StreamsController, mass_minimal: MusicAssistant
+    streams_controller: StreamsController, mass_minimal: MusicAssistant
 ) -> None:
     """A bind that fell back to all interfaces advertises a reachable address, not the failed one."""
-    await _setup_streams(controller, mass_minimal, bind_ip=UNBINDABLE_IP)
+    await _setup_streams(streams_controller, mass_minimal, bind_ip=UNBINDABLE_IP)
 
-    assert controller.publish_ip == ALL_ADDRESSES[0]
-    assert controller.base_url == f"http://{ALL_ADDRESSES[0]}:{controller.publish_port}"
+    assert streams_controller.publish_ip == ALL_ADDRESSES[0]
+    assert (
+        streams_controller.base_url
+        == f"http://{ALL_ADDRESSES[0]}:{streams_controller.publish_port}"
+    )
 
 
 async def test_os_assigned_port_lands_in_base_url(
-    controller: StreamsController, mass_minimal: MusicAssistant
+    streams_controller: StreamsController, mass_minimal: MusicAssistant
 ) -> None:
     """A port the OS only assigns at bind time ends up in the URLs handed to players."""
-    await _setup_streams(controller, mass_minimal, bind_ip=LOOPBACK_IP, bind_port=0)
+    await _setup_streams(streams_controller, mass_minimal, bind_ip=LOOPBACK_IP, bind_port=0)
 
-    assert controller.publish_port != 0
-    assert controller.base_url == f"http://{LOOPBACK_IP}:{controller.publish_port}"
+    assert streams_controller.publish_port != 0
+    assert streams_controller.base_url == f"http://{LOOPBACK_IP}:{streams_controller.publish_port}"
 
 
 async def test_ipv6_publish_ip_is_bracketed_in_base_url(
-    controller: StreamsController, mass_minimal: MusicAssistant
+    streams_controller: StreamsController, mass_minimal: MusicAssistant
 ) -> None:
     """An IPv6 publish IP is bracketed in the stream URLs handed to players."""
-    await _setup_streams(controller, mass_minimal, bind_ip="::", all_ip_addresses=("fd00::10",))
+    await _setup_streams(
+        streams_controller, mass_minimal, bind_ip="::", all_ip_addresses=("fd00::10",)
+    )
 
-    assert controller.publish_ip == "fd00::10"
-    assert controller.base_url == f"http://[fd00::10]:{controller.publish_port}"
+    assert streams_controller.publish_ip == "fd00::10"
+    assert streams_controller.base_url == f"http://[fd00::10]:{streams_controller.publish_port}"

--- a/tests/controllers/webserver/conftest.py
+++ b/tests/controllers/webserver/conftest.py
@@ -1,0 +1,15 @@
+"""Shared fixtures for the webserver controller tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_mass() -> MagicMock:
+    """Create a mock Music Assistant instance."""
+    mass = MagicMock()
+    mass.config.get_raw_core_config_value.return_value = "GLOBAL"
+    return mass

--- a/tests/controllers/webserver/test_internal_base_url.py
+++ b/tests/controllers/webserver/test_internal_base_url.py
@@ -12,14 +12,6 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def mock_mass() -> MagicMock:
-    """Create a mock Music Assistant instance."""
-    mass = MagicMock()
-    mass.config.get_raw_core_config_value.return_value = "GLOBAL"
-    return mass
-
-
-@pytest.fixture
 def webserver(mock_mass: MagicMock) -> WebserverController:
     """Create a WebserverController carrying the state that setup() resolves."""
     webserver = WebserverController(mock_mass)

--- a/tests/controllers/webserver/test_internal_sendspin_url.py
+++ b/tests/controllers/webserver/test_internal_sendspin_url.py
@@ -8,14 +8,6 @@ from music_assistant.controllers.webserver.controller import WebserverController
 
 
 @pytest.fixture
-def mock_mass() -> MagicMock:
-    """Create a mock Music Assistant instance."""
-    mass = MagicMock()
-    mass.config.get_raw_core_config_value.return_value = "GLOBAL"
-    return mass
-
-
-@pytest.fixture
 def webserver(mock_mass: MagicMock) -> WebserverController:
     """Create a WebserverController backed by a mocked Music Assistant instance."""
     return WebserverController(mock_mass)

--- a/tests/controllers/webserver/test_ssl_base_url.py
+++ b/tests/controllers/webserver/test_ssl_base_url.py
@@ -57,6 +57,8 @@ def self_signed_cert() -> tuple[str, str]:
 @pytest.fixture
 def mock_mass() -> MagicMock:
     """Create a mock Music Assistant instance."""
+    # deliberate override of the package fixture: the base URL these tests exercise
+    # is also derived from the addon and provider state
     mass = MagicMock()
     mass.config.get_raw_core_config_value.return_value = "GLOBAL"
     mass.running_as_hass_addon = False


### PR DESCRIPTION
# What does this implement/fix?

Several controller test directories had the exact same fixture copy-pasted into two or three files. Each copy is free to drift from the others, and a fix to one silently leaves the rest behind. This moves those copies into a package-level `conftest.py` per directory, following what was already done for the metadata controller tests.

A fixture was only moved when its copies were byte-identical **and** no other file in the same directory defines its own version under that name — so the shared fixtures stay easy to follow rather than being buried under overrides. That is why, for example, `mock_mass` in the players tests stays where it is.

- new `conftest.py` for the cache, players, streams and webserver controller tests
- `cache`, `provider` and `mock_mass` fixtures now live in one place instead of two
- the cache fixture is renamed to `cache_controller`, since `cache` is also the name of a built-in pytest fixture
- the streams fixture is renamed to `streams_controller`, since it was one of three unrelated fixtures in that directory called `controller`
- `test_ssl_base_url.py` keeps its own `mock_mass`, which genuinely differs; a comment now says so

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
