### PR TITLE
Tidy up duplicated fixtures in the provider tests

### DIFF
--- a/tests/providers/bandcamp/conftest.py
+++ b/tests/providers/bandcamp/conftest.py
@@ -1,0 +1,15 @@
+"""Shared fixtures for the Bandcamp provider tests."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.fixture
+def manifest_mock() -> Mock:
+    """Return a mock provider manifest."""
+    manifest = Mock()
+    manifest.domain = "bandcamp"
+    return manifest

--- a/tests/providers/bandcamp/test_provider.py
+++ b/tests/providers/bandcamp/test_provider.py
@@ -77,14 +77,6 @@ def mass_mock() -> Mock:
 
 
 @pytest.fixture
-def manifest_mock() -> Mock:
-    """Return a mock provider manifest."""
-    manifest = Mock()
-    manifest.domain = "bandcamp"
-    return manifest
-
-
-@pytest.fixture
 def config_mock() -> Mock:
     """Return a mock provider config."""
     config = Mock()

--- a/tests/providers/bandcamp/test_recommendations.py
+++ b/tests/providers/bandcamp/test_recommendations.py
@@ -27,14 +27,6 @@ def mass_mock() -> Mock:
 
 
 @pytest.fixture
-def manifest_mock() -> Mock:
-    """Return a mock provider manifest."""
-    manifest = Mock()
-    manifest.domain = "bandcamp"
-    return manifest
-
-
-@pytest.fixture
 def config_mock() -> Mock:
     """Return a mock provider config."""
     config = Mock()

--- a/tests/providers/fastmcp_server/conftest.py
+++ b/tests/providers/fastmcp_server/conftest.py
@@ -298,6 +298,18 @@ def fake_event_emitter(mock_mass: MagicMock) -> Any:
 
 
 @pytest.fixture
+def library_server(mock_mass: Any) -> Any:
+    """Build a root FastMCP with only the library sub-server mounted."""
+    from fastmcp import FastMCP
+
+    from music_assistant.providers.fastmcp_server.tools.library import build_library_server
+
+    mcp = FastMCP(name="t")
+    mcp.mount(build_library_server(mock_mass), namespace="library")
+    return mcp
+
+
+@pytest.fixture
 def mounted_queue(mock_mass: Any) -> Any:
     """Build a root FastMCP with the queue sub-server mounted, no confirmation gate."""
     from fastmcp import FastMCP

--- a/tests/providers/fastmcp_server/test_add_to_queue.py
+++ b/tests/providers/fastmcp_server/test_add_to_queue.py
@@ -25,7 +25,10 @@ from music_assistant.providers.fastmcp_server.tools.queue import build_queue_ser
 def mounted_queue_no_delete(mock_mass: Any) -> FastMCP:
     """Queue server with delete:queue permission disabled."""
     mcp: FastMCP = FastMCP(name="test")
-    mcp.mount(build_queue_server(mock_mass, delete_queue_enabled=False), namespace="queue")
+    mcp.mount(
+        build_queue_server(mock_mass, delete_queue_enabled=False, require_confirmation=False),
+        namespace="queue",
+    )
     return mcp
 
 

--- a/tests/providers/fastmcp_server/test_add_to_queue.py
+++ b/tests/providers/fastmcp_server/test_add_to_queue.py
@@ -22,14 +22,6 @@ from music_assistant.providers.fastmcp_server.tools.queue import build_queue_ser
 
 
 @pytest.fixture
-def mounted_queue(mock_mass: Any) -> FastMCP:
-    """Build a root FastMCP with the queue sub-server mounted."""
-    mcp: FastMCP = FastMCP(name="test")
-    mcp.mount(build_queue_server(mock_mass), namespace="queue")
-    return mcp
-
-
-@pytest.fixture
 def mounted_queue_no_delete(mock_mass: Any) -> FastMCP:
     """Queue server with delete:queue permission disabled."""
     mcp: FastMCP = FastMCP(name="test")

--- a/tests/providers/fastmcp_server/test_library_album_tracks.py
+++ b/tests/providers/fastmcp_server/test_library_album_tracks.py
@@ -15,7 +15,6 @@ from music_assistant.providers.fastmcp_server.tools._common import (
     album_tracks_from_uri,
     artist_albums_from_uri,
 )
-from music_assistant.providers.fastmcp_server.tools.library import build_library_server
 
 from .media_fakes import (
     fake_album,
@@ -23,14 +22,6 @@ from .media_fakes import (
     fake_media_item,
     fake_track,
 )
-
-
-@pytest.fixture
-def library_server(mock_mass: Any) -> FastMCP:
-    """Mount only the library sub-server."""
-    mcp: FastMCP = FastMCP(name="t")
-    mcp.mount(build_library_server(mock_mass), namespace="library")
-    return mcp
 
 
 class TestAlbumTracksFromUri:

--- a/tests/providers/fastmcp_server/test_library_list_tools.py
+++ b/tests/providers/fastmcp_server/test_library_list_tools.py
@@ -8,16 +8,6 @@ from typing import Any
 import pytest
 from fastmcp import Client, FastMCP
 
-from music_assistant.providers.fastmcp_server.tools.library import build_library_server
-
-
-@pytest.fixture
-def library_server(mock_mass: Any) -> FastMCP:
-    """Mount only the library sub-server."""
-    mcp: FastMCP = FastMCP(name="t")
-    mcp.mount(build_library_server(mock_mass), namespace="library")
-    return mcp
-
 
 class TestListToolsRequestFullItems:
     """

--- a/tests/providers/fastmcp_server/test_media_resolve.py
+++ b/tests/providers/fastmcp_server/test_media_resolve.py
@@ -38,18 +38,9 @@ from music_assistant.providers.fastmcp_server.tools._common import (
     resolve_uri,
     to_brief_track,
 )
-from music_assistant.providers.fastmcp_server.tools.library import build_library_server
 from music_assistant.providers.fastmcp_server.tools.metadata import build_metadata_server
 
 from .media_fakes import fake_media_item
-
-
-@pytest.fixture
-def library_server(mock_mass: Any) -> FastMCP:
-    """Mount only the library sub-server."""
-    mcp: FastMCP = FastMCP(name="t")
-    mcp.mount(build_library_server(mock_mass), namespace="library")
-    return mcp
 
 
 @pytest.fixture

--- a/tests/providers/fastmcp_server/test_set_repeat.py
+++ b/tests/providers/fastmcp_server/test_set_repeat.py
@@ -8,23 +8,12 @@ Validates that:
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 from fastmcp import Client, FastMCP
 from fastmcp.exceptions import ToolError
 from music_assistant_models.enums import RepeatMode
-
-from music_assistant.providers.fastmcp_server.tools.queue import build_queue_server
-
-
-@pytest.fixture
-def mounted_queue(mock_mass: Any) -> FastMCP:
-    """Build a root FastMCP with the queue sub-server mounted."""
-    mcp: FastMCP = FastMCP(name="test")
-    mcp.mount(build_queue_server(mock_mass), namespace="queue")
-    return mcp
 
 
 async def test_set_repeat_accepts_valid_modes(mounted_queue: FastMCP, mock_mass: MagicMock) -> None:

--- a/tests/providers/tidal/conftest.py
+++ b/tests/providers/tidal/conftest.py
@@ -11,6 +11,8 @@ from music_assistant.providers.tidal.media import TidalMediaManager
 @pytest.fixture
 def media_manager(provider_mock: Mock) -> TidalMediaManager:
     """Return a TidalMediaManager instance."""
+    # provider_mock is defined per test module and differs between them, so a module
+    # requesting this fixture must bring its own
     return TidalMediaManager(provider_mock)
 
 

--- a/tests/providers/tidal/conftest.py
+++ b/tests/providers/tidal/conftest.py
@@ -1,9 +1,17 @@
 """Fixtures for Tidal provider tests."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+
+from music_assistant.providers.tidal.media import TidalMediaManager
+
+
+@pytest.fixture
+def media_manager(provider_mock: Mock) -> TidalMediaManager:
+    """Return a TidalMediaManager instance."""
+    return TidalMediaManager(provider_mock)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/providers/tidal/test_media.py
+++ b/tests/providers/tidal/test_media.py
@@ -45,12 +45,6 @@ def provider_mock() -> Mock:
     return provider
 
 
-@pytest.fixture
-def media_manager(provider_mock: Mock) -> TidalMediaManager:
-    """Return a TidalMediaManager instance."""
-    return TidalMediaManager(provider_mock)
-
-
 @patch("music_assistant.providers.tidal.media.parse_artist")
 @patch("music_assistant.providers.tidal.media.parse_album")
 @patch("music_assistant.providers.tidal.media.parse_track")

--- a/tests/providers/tidal/test_media_extended.py
+++ b/tests/providers/tidal/test_media_extended.py
@@ -35,12 +35,6 @@ def provider_mock() -> Mock:
     return provider
 
 
-@pytest.fixture
-def media_manager(provider_mock: Mock) -> TidalMediaManager:
-    """Return a TidalMediaManager instance."""
-    return TidalMediaManager(provider_mock)
-
-
 @patch("music_assistant.providers.tidal.media.parse_playlist")
 async def test_get_playlist_mix(
     mock_parse_playlist: Mock, media_manager: TidalMediaManager, provider_mock: Mock


### PR DESCRIPTION
# What does this implement/fix?

Same clean-up as the controller tests, now for the provider tests: a handful of fixtures were copy-pasted byte-identically across files in the same directory, so a fix to one copy silently left the others behind. The duplicates move into the directory's `conftest.py`.

The FastMCP queue tests also carried their own `mounted_queue` fixture that shadowed the shared one purely to keep the confirmation gate on — but neither file exercises a confirmation-gated tool, so those copies are simply dropped in favour of the shared fixture.

- new `conftest.py` for the Bandcamp provider tests
- `media_manager` (Tidal) and `library_server` (FastMCP) move into the existing `conftest.py`
- two redundant `mounted_queue` copies removed from the FastMCP queue tests
- fixtures that merely share a name but differ in body were left alone

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
