### PR TITLE
Remove the last spurious error log entries for shared work

### DIFF
--- a/music_assistant/helpers/shared_playback.py
+++ b/music_assistant/helpers/shared_playback.py
@@ -33,6 +33,8 @@ from music_assistant_models.errors import (
     UnsupportedFeaturedException,
 )
 
+from music_assistant.helpers.util import join_task
+
 if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
     from music_assistant.models.player import Player
@@ -144,7 +146,9 @@ class SharedPlaybackSession:
             cls._cancel_and_observe_creation(mass, sendspin, creation_task)
             raise
         try:
-            player_id = await asyncio.shield(creation_task)
+            # join: cancelling the caller must not abort the creation halfway, or the
+            # cleanup task can no longer remove the player it left behind
+            player_id = await join_task(creation_task)
         except asyncio.CancelledError:
             cleanup_required.set_result(True)
             raise

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -2043,6 +2043,33 @@ class TimedAsyncGenerator:
         return self._factory()
 
 
+async def join_task[T](task: asyncio.Future[T], timeout: float | None = None) -> T:
+    """
+    Wait for a task started elsewhere and return its result.
+
+    Cancelling the waiter leaves the task running, so work that is shared between callers -
+    or that must outlive a caller's deadline - keeps going and still reaches every other
+    waiter. A task that can lose all its waiters needs a done callback that retrieves its
+    exception (as mass.create_task installs) to keep asyncio quiet about it.
+
+    :param task: The task (or future) to wait for.
+    :param timeout: Optional number of seconds to wait before giving up.
+    :raises TimeoutError: If the task did not complete within the timeout.
+    :raises asyncio.CancelledError: If the task itself was cancelled.
+    :return: The task's result.
+    """
+    if not task.done():
+        # awaiting the task directly would hold it as this coroutine's fut_waiter, so
+        # cancelling the waiter would cancel the task itself. asyncio.shield achieves the
+        # same isolation, but as of Python 3.14 a cancelled waiter makes it report the task's
+        # exception through loop.call_exception_handler, even when another waiter already
+        # handled it.
+        await asyncio.wait((task,), timeout=timeout)
+    if not task.done():
+        raise TimeoutError
+    return task.result()
+
+
 # Bound for guard_single_request: it only needs ``.mass``, so a structural protocol
 # lets it decorate providers, core controllers and media controllers alike without
 # coupling to their concrete base classes.

--- a/music_assistant/models/audio_analysis_provider.py
+++ b/music_assistant/models/audio_analysis_provider.py
@@ -11,6 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeVar
 
+from music_assistant.helpers.util import join_task
 from music_assistant.models.audio_analysis import AudioAnalysisError
 
 from .provider import Provider
@@ -418,8 +419,8 @@ class AudioAnalysisProvider(Provider):
             semaphore.release()
             raise
         future.add_done_callback(_release)
-        # shield: a cancelled awaiter leaves the thread and its slot held until the work finishes.
-        return await asyncio.shield(future)
+        # join: a cancelled awaiter leaves the thread and its slot held until the work finishes.
+        return await join_task(future)
 
     async def _run_offloaded_timed(
         self, func: Callable[..., _T], /, *args: Any, **kwargs: Any

--- a/music_assistant/models/setup_flow.py
+++ b/music_assistant/models/setup_flow.py
@@ -293,7 +293,7 @@ class SetupSession:
         step's countdown and the engine deadline cannot drift. On the deadline
         StepExpiredError is raised here and the awaitable is cancelled - this also
         cancels a pre-existing Task (cancellation propagates through the await);
-        wrap work in ``asyncio.shield`` if it must survive the deadline.
+        pass ``join_task(task)`` (helpers.util) if a task must survive the deadline.
 
         :param awaitable: The work/wait to perform while the progress step shows.
         :param step_id: Stable slug identifying this step (also the i18n key segment).

--- a/music_assistant/providers/local_audio/sendspin_bridge.py
+++ b/music_assistant/providers/local_audio/sendspin_bridge.py
@@ -17,6 +17,7 @@ from aiosendspin.models.types import AudioCodec, PlayerCommand
 from music_assistant_models.enums import IdentifierType
 from music_assistant_models.player import DeviceInfo
 
+from music_assistant.helpers.util import join_task
 from music_assistant.models.player import Player
 from music_assistant.providers.sendspin.bridge_manager import SendspinBridgeManagerBase
 from music_assistant.providers.sendspin.bridge_role import (
@@ -859,7 +860,7 @@ class SendspinLocalAudioBridge:
         :raises TimeoutError: The device did not open in time.
         """
         try:
-            return await asyncio.wait_for(asyncio.shield(open_future), _DEVICE_OPEN_TIMEOUT_SECONDS)
+            return await join_task(open_future, _DEVICE_OPEN_TIMEOUT_SECONDS)
         except asyncio.CancelledError:
             self._release_orphaned_stream(open_future, close_stream)
             raise

--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -25,6 +25,7 @@ from music_assistant.constants import SENDSPIN_SERVER_PORT
 from music_assistant.controllers.streams.audio_processing import get_media_session_id
 from music_assistant.controllers.webserver.helpers.auth_middleware import ImpersonatedUser
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
+from music_assistant.helpers.util import join_task
 
 from .constants import (
     CONF_SHOW_STOP_NOTIFICATION,
@@ -2390,11 +2391,9 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         cache_key = (image_url, party.qr_version)
         if (cached := self._qr_cover_cache.get(cache_key)) is None:
             try:
-                # shield: a TV dropping its request must not cancel the shared
+                # join: a TV dropping its request must not cancel the shared
                 # render — late joiners and the cache still get the result
-                cached = await asyncio.shield(
-                    self._qr_cover_task(cache_key, image_url, party.join_url)
-                )
+                cached = await join_task(self._qr_cover_task(cache_key, image_url, party.join_url))
             except Exception as err:
                 logger.debug("QR cover composite failed for %s: %s", image_url, err)
                 raise web.HTTPFound(location=image_url) from None

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -72,7 +72,7 @@ from PIL import Image
 
 from music_assistant.constants import HIDDEN_ANNOUNCE_VOLUME_CONFIG_ENTRIES
 from music_assistant.controllers.streams.audio_analysis import SMART_FADES_ANALYSIS_DOMAIN
-from music_assistant.helpers.util import is_valid_mac_address
+from music_assistant.helpers.util import is_valid_mac_address, join_task
 from music_assistant.models.player import Player, PlayerMedia
 from music_assistant.models.setup_flow import AbortFlow, StepExpiredError
 
@@ -880,10 +880,10 @@ class SendspinBasePlayer(Player):
                     continue
                 task = pin_session.task
                 if task is not None and not task.done():
-                    # Shield the pairing task: the step deadline must not cancel it.
+                    # Join the pairing task: the step deadline must not cancel it.
                     with suppress(StepExpiredError):
                         await session.progress_until(
-                            asyncio.shield(task),
+                            join_task(task),
                             step_id="confirming",
                             text="confirming",
                             expires_in=PAIR_CONFIRM_TIMEOUT,

--- a/tests/helpers/test_shared_playback.py
+++ b/tests/helpers/test_shared_playback.py
@@ -12,6 +12,7 @@ from music_assistant_models.enums import PlayerFeature
 from music_assistant_models.errors import SetupFailedError, UnsupportedFeaturedException
 
 from music_assistant.helpers.shared_playback import SharedPlaybackMode, SharedPlaybackSession
+from tests.common import collect_loop_errors
 
 if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
@@ -434,6 +435,50 @@ async def test_cancelled_remote_creation_failure_is_observed() -> None:
     logger.debug.assert_called_once()
     sendspin.remove_virtual_player.assert_not_awaited()
     assert all(task.done() for task in tasks)
+
+
+async def test_cancelled_remote_creation_failure_logs_no_loop_error() -> None:
+    """A creation failure observed after the caller was cancelled is not reported to the loop."""
+    sendspin = MagicMock()
+    mass, tasks = _create_mock_remote_mass(sendspin)
+    creation_started = asyncio.Event()
+    allow_creation = asyncio.Event()
+
+    async def _create_virtual_player(**_kwargs: object) -> str:
+        creation_started.set()
+        await allow_creation.wait()
+        raise RuntimeError("creation failed")
+
+    sendspin.create_virtual_player = AsyncMock(side_effect=_create_virtual_player)
+    sendspin.remove_virtual_player = AsyncMock()
+
+    with (
+        collect_loop_errors() as reported,
+        patch("music_assistant.helpers.shared_playback.LOGGER") as logger,
+    ):
+        session_task = asyncio.create_task(
+            SharedPlaybackSession.create_remote(
+                mass,
+                owner_instance_id="plugin--test",
+                display_name="Test Party",
+            )
+        )
+        await creation_started.wait()
+        session_task.cancel()
+        # the cancellation must be fully processed before the gate is released, so the
+        # creation failure reliably lands after the caller has already given up -- releasing
+        # the gate first would let the failure race the cancellation and pass even on the
+        # buggy shield-based code
+        with pytest.raises(asyncio.CancelledError):
+            await session_task
+
+        allow_creation.set()
+        await tasks[1]
+
+    logger.debug.assert_called_once()  # the cleanup task still observes and logs the failure
+    sendspin.remove_virtual_player.assert_not_awaited()
+    assert all(task.done() for task in tasks)
+    assert reported == []
 
 
 async def test_cancelled_remote_creation_timeout_cancels_task() -> None:

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -19,6 +19,7 @@ from music_assistant.helpers.util import (
     guard_single_request,
     import_module_in_thread,
     is_port_in_use,
+    join_task,
     load_provider_module,
     sanitize_http_header_value,
     select_free_port,
@@ -479,6 +480,66 @@ class TestGetPublishIpCandidates:
             assert await util.get_publish_ip_candidates() == ("192.168.1.10",)
 
 
+class TestJoinTask:
+    """join_task waits for a task without adopting it, so a waiter never cancels the work."""
+
+    @pytest.mark.asyncio
+    async def test_returns_the_task_result(self) -> None:
+        """A completed task hands its result to the waiter."""
+        release = asyncio.Event()
+        release.set()
+        task = asyncio.create_task(_gated_task(release, "done"))
+        assert await join_task(task) == "done"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_waiter_leaves_the_task_running(self) -> None:
+        """Cancelling one waiter must not disturb the task or the waiters that remain."""
+        release = asyncio.Event()
+        task = asyncio.create_task(_gated_task(release, "done"))
+        waiter_a = asyncio.create_task(join_task(task))
+        waiter_b = asyncio.create_task(join_task(task))
+        await asyncio.sleep(0)
+        waiter_a.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter_a
+
+        release.set()
+        assert await waiter_b == "done"
+        assert not task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_waiter_of_a_failing_task_logs_no_loop_error(self) -> None:
+        """A task failing after a waiter gave up is not reported to the loop handler."""
+        release = asyncio.Event()
+        with collect_loop_errors() as reported:
+            task = asyncio.create_task(_gated_task(release, "done", fail=True))
+            waiter_a = asyncio.create_task(join_task(task))
+            waiter_b = asyncio.create_task(join_task(task))
+            await asyncio.sleep(0)
+            waiter_a.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await waiter_a
+            # release the task only once the cancellation is fully processed, so the failure
+            # reliably lands after the giving-up waiter is gone
+            release.set()
+            with pytest.raises(RuntimeError, match="task failed"):
+                await waiter_b
+
+        assert reported == []
+
+    @pytest.mark.asyncio
+    async def test_timeout_leaves_the_task_running(self) -> None:
+        """Giving up on the timeout raises TimeoutError but keeps the task alive."""
+        release = asyncio.Event()
+        task = asyncio.create_task(_gated_task(release, "done"))
+        with pytest.raises(TimeoutError):
+            await join_task(task, timeout=0.01)
+        assert not task.done()
+
+        release.set()
+        assert await task == "done"
+
+
 class TestSanitizeHttpHeaderValue:
     """sanitize_http_header_value strips characters aiohttp forbids in response headers."""
 
@@ -639,6 +700,20 @@ class _GatedMusicProvider(MusicProvider):
             name="Track",
             provider_mappings={_provider_mapping(prov_track_id)},
         )
+
+
+async def _gated_task(release: asyncio.Event, result: str, fail: bool = False) -> str:
+    """
+    Return (or raise) once the given event is set.
+
+    :param release: Event that lets the task complete.
+    :param result: Value to return.
+    :param fail: Raise instead of returning the result.
+    """
+    await release.wait()
+    if fail:
+        raise RuntimeError("task failed")
+    return result
 
 
 def _provider_mapping(item_id: str) -> ProviderMapping:

--- a/tests/models/test_audio_analysis_provider.py
+++ b/tests/models/test_audio_analysis_provider.py
@@ -18,6 +18,7 @@ from music_assistant.models.audio_analysis_provider import (
     AudioAnalysisProvider,
     InstrumentedSemaphore,
 )
+from tests.common import collect_loop_errors
 
 if TYPE_CHECKING:
     from music_assistant_models.media_items import AudioFormat
@@ -244,6 +245,45 @@ async def test_run_offloaded_holds_permit_until_thread_finishes_on_cancel() -> N
             break
         await asyncio.sleep(0.02)
     assert not semaphore.locked()
+
+
+@pytest.mark.asyncio
+async def test_run_offloaded_worker_failure_after_cancel_logs_no_loop_error() -> None:
+    """A worker failing after the awaiter was cancelled must not be reported to the loop."""
+    provider = _make_provider()
+    semaphore = InstrumentedSemaphore(1)
+    provider.mass.streams.audio_analysis.analysis_semaphore = semaphore
+
+    started = threading.Event()
+    may_finish = threading.Event()
+
+    def _failing() -> str:
+        started.set()
+        may_finish.wait(timeout=5)
+        raise RuntimeError("boom")
+
+    with collect_loop_errors() as reported:
+        task = asyncio.create_task(provider._run_offloaded(_failing))
+        assert await asyncio.to_thread(started.wait, 5)  # thread is running, permit acquired
+        assert semaphore.locked()
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # release the worker only once the cancellation is fully processed, so the failure
+        # reliably lands after the awaiter has already given up -- releasing earlier would
+        # let the failure race the cancellation and pass even on the buggy shield-based code
+        may_finish.set()
+
+        # the done-callback releases the permit once the worker (and its failure) is
+        # observed, so waiting for that also gives any (buggy) loop report time to land
+        for _ in range(100):
+            if not semaphore.locked():
+                break
+            await asyncio.sleep(0.02)
+        assert not semaphore.locked()  # permit still released despite the failure
+
+    assert reported == []
 
 
 @pytest.mark.asyncio

--- a/tests/providers/local_audio/test_sendspin_bridge.py
+++ b/tests/providers/local_audio/test_sendspin_bridge.py
@@ -48,6 +48,7 @@ from music_assistant.providers.sendspin.bridge_role import (
     BRIDGE_CHANNELS,
     BRIDGE_SAMPLE_RATE,
 )
+from tests.common import collect_loop_errors
 
 _MODULE = "music_assistant.providers.local_audio.sendspin_bridge"
 
@@ -541,6 +542,27 @@ async def test_a_device_that_never_finishes_opening_leaves_the_session(backend: 
 
     assert bridge._is_streaming is False
     leave.assert_called_once_with()
+
+
+async def test_a_device_failing_after_the_open_timeout_logs_no_loop_error() -> None:
+    """A device open that fails once the writer gave up on it is not reported to the loop."""
+    bridge = _make_bridge()
+    opening: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+    cast("MagicMock", bridge.mass).loop.run_in_executor = MagicMock(return_value=opening)
+    _queue_chunks(bridge, _pcm_chunk(1))
+
+    with (
+        collect_loop_errors() as reported,
+        patch(f"{_MODULE}._DEVICE_OPEN_TIMEOUT_SECONDS", 0.01),
+        patch.object(bridge, "_leave_sendspin_session", MagicMock()),
+    ):
+        await _run_writer(bridge)
+        # fail the open only once the writer has given up waiting for it, so the failure
+        # reliably lands after the caller is gone
+        opening.set_exception(OSError("device is already in use"))
+        await _settle()
+
+    assert reported == []
 
 
 async def test_abandoning_a_stream_defers_the_leave_off_the_writer() -> None:

--- a/tests/providers/msx_bridge/test_party_qr_cover.py
+++ b/tests/providers/msx_bridge/test_party_qr_cover.py
@@ -7,15 +7,18 @@ import io
 import json
 import threading
 import time
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock
-from urllib.parse import parse_qs, urlsplit
+from urllib.parse import parse_qs, urlencode, urlsplit
 
+import pytest
 import segno
+from aiohttp import web
 from aiohttp.test_utils import TestClient as AiohttpTestClient
-from aiohttp.test_utils import TestServer
+from aiohttp.test_utils import TestServer, make_mocked_request
 from PIL import Image
 
+from music_assistant.helpers.util import join_task
 from music_assistant.providers.msx_bridge import http_server as http_server_module
 from music_assistant.providers.msx_bridge.http_server import (
     MSXHTTPServer,
@@ -23,13 +26,8 @@ from music_assistant.providers.msx_bridge.http_server import (
     _stamp_qr_on_cover,
 )
 from music_assistant.providers.msx_bridge.mappers import map_tracks_to_msx_playlist
-
-if TYPE_CHECKING:
-    import pytest
 from music_assistant.providers.msx_bridge.provider import MSXBridgeProvider
-
-if TYPE_CHECKING:
-    import pytest
+from tests.common import collect_loop_errors
 
 JOIN_URL = "http://ma.local:8095/?join=ABC123"
 COVER_URL = "http://ma.local:8095/imageproxy?path=cover.jpg"
@@ -65,6 +63,24 @@ def _http_session_mock(body: bytes, status: int = 200) -> Mock:
     resp = AsyncMock()
     resp.status = status
     resp.read = AsyncMock(return_value=body)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=resp)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    session = Mock()
+    session.get = Mock(return_value=cm)
+    return session
+
+
+def _failing_http_session_mock(release: asyncio.Event) -> Mock:
+    """Return a mock session whose get() fails once released."""
+
+    async def _gated_read() -> bytes:
+        await release.wait()
+        raise ConnectionResetError("connection reset while fetching the cover")
+
+    resp = AsyncMock()
+    resp.status = 200
+    resp.read = _gated_read
     cm = MagicMock()
     cm.__aenter__ = AsyncMock(return_value=resp)
     cm.__aexit__ = AsyncMock(return_value=False)
@@ -211,7 +227,7 @@ async def test_qr_cover_render_survives_requester_cancellation(
 
     task = server._qr_cover_task(cache_key, COVER_URL, JOIN_URL)
     assert server._qr_cover_task(cache_key, COVER_URL, JOIN_URL) is task
-    waiter = asyncio.ensure_future(asyncio.shield(task))
+    waiter = asyncio.ensure_future(join_task(task))
     await asyncio.sleep(0)
     waiter.cancel()
     release.set()
@@ -219,6 +235,41 @@ async def test_qr_cover_render_survives_requester_cancellation(
 
     assert server._qr_cover_cache[cache_key] == rendered
     assert cache_key not in server._qr_cover_inflight
+
+
+async def test_qr_cover_render_failure_after_cancellation_logs_no_loop_error(
+    provider: MSXBridgeProvider, mass_mock: Mock
+) -> None:
+    """A render failing after one TV gave up reaches the waiting TV only, not the log."""
+    release = asyncio.Event()
+    mass_mock.get_provider = Mock(return_value=_party_mock())
+    mass_mock.webserver.base_url = "http://ma.local:8095"
+    mass_mock.http_session = _failing_http_session_mock(release)
+    server = MSXHTTPServer(provider, 0)
+    path = f"/api/party/qr-cover.png?{urlencode({'image': COVER_URL})}"
+
+    with collect_loop_errors() as reported:
+        gave_up = asyncio.create_task(
+            server._handle_party_qr_cover(make_mocked_request("GET", path))
+        )
+        waiting = asyncio.create_task(
+            server._handle_party_qr_cover(make_mocked_request("GET", path))
+        )
+        while not server._qr_cover_inflight and not gave_up.done():
+            await asyncio.sleep(0)
+        await asyncio.sleep(0)  # let the second TV join the same render
+        gave_up.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await gave_up
+        # release the fetch only once the cancellation is fully processed, so the failure
+        # reliably lands after the TV that gave up is gone
+        release.set()
+        with pytest.raises(web.HTTPFound) as redirect:
+            await waiting
+
+    assert str(redirect.value.location) == COVER_URL
+    assert mass_mock.http_session.get.call_count == 1
+    assert reported == []
 
 
 async def test_qr_cover_no_party_redirects_to_original(

--- a/tests/providers/sendspin/test_setup_flow.py
+++ b/tests/providers/sendspin/test_setup_flow.py
@@ -22,6 +22,7 @@ from music_assistant.models.setup_flow import (
     SetupSession,
     StepExpiredError,
 )
+from music_assistant.providers.sendspin import player as player_module
 from music_assistant.providers.sendspin.constants import (
     CONF_PAIRING_METHOD,
     CONF_PAIRING_PIN,
@@ -32,6 +33,7 @@ from music_assistant.providers.sendspin.constants import (
 )
 from music_assistant.providers.sendspin.helpers import SecurityActionError
 from music_assistant.providers.sendspin.player import SendspinBasePlayer
+from tests.common import collect_loop_errors
 
 if TYPE_CHECKING:
     from aiosendspin.server.client import SendspinClient
@@ -278,6 +280,41 @@ async def test_select_method_pin_gesture_submit_success() -> None:
     steps = _published_steps(mass)
     assert [s.step_id for s in steps if s.type == FlowStepType.PROGRESS] == ["awaiting_gesture"]
     assert steps[-1].type == FlowStepType.FINISH
+
+
+async def test_confirming_wait_failure_after_deadline_logs_no_loop_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pairing attempt failing after the confirming step expired is not reported to the loop."""
+    release = asyncio.Event()
+
+    async def _failing_attempt() -> None:
+        await release.wait()
+        raise RuntimeError("refreshing the player failed")
+
+    monkeypatch.setattr(player_module, "PAIR_CONFIRM_TIMEOUT", 0.01)
+    api = _FakeApi([_desc(PairMethod.DYNAMIC_PIN)])
+    provider = _FakeProvider(api)
+    session, _mass = _make_session(_ok_finish)
+    player = _make_player(api, provider)
+
+    with collect_loop_errors() as reported:
+        flow = asyncio.create_task(player.run_setup_flow(session))
+        await _wait_step(session, step_type=FlowStepType.FORM, step_id="enter_pin")
+        assert provider.session is not None
+        attempt = asyncio.create_task(_failing_attempt())
+        provider.session.task = attempt
+        session.handle_submit({CONF_PAIRING_PIN: "123456"})
+
+        # let the attempt fail only once the confirming step has expired and the flow has
+        # moved on, so the failure reliably lands after the flow stopped waiting for it
+        await _wait_for(lambda: session.finished)
+        await flow
+        release.set()
+        with pytest.raises(RuntimeError, match="refreshing the player failed"):
+            await attempt
+
+    assert reported == []
 
 
 async def test_single_pin_method_skips_select() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Some work in the server keeps running after the caller that started it walks away: a cover
being rendered for several TVs at once, an audio analysis running in a worker thread, a
party/quiz session being created, a speaker pairing attempt waiting for confirmation. If
that work then fails, Python 3.14 reports the failure a second time on its own, which
showed up in the log as a scary `Error doing task: ... exception in shielded future` entry
with a full traceback — even though the failure was already handled and reported properly
elsewhere.

This is the last batch of the cleanup started in #5288 and #5295. The waiting pattern those
PRs used by hand is now a small shared helper, so new code has something correct to copy.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- New `join_task()` helper: wait for work someone else started, without cancelling it if you
  give up on it.
- Applied to the MSX Bridge party cover, audio analysis offloading, shared playback
  (party/quiz) session creation, Sendspin PIN pairing confirmation and opening a local
  sound card.
- The setup flow docs now point contributors at it, instead of at the pattern that causes
  the stray error.
- Checked two more candidates as well: the provider search and the shared playback cleanup
  wait cannot produce this error, so they are left alone.
- No behaviour change for callers: the work still survives a caller giving up, and its
  result or error still reaches everyone else unchanged.
- Added tests covering each spot.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
