### PR TITLE
Fix failing cache controller test on dev

### DIFF
--- a/tests/controllers/cache/test_helpers.py
+++ b/tests/controllers/cache/test_helpers.py
@@ -372,11 +372,11 @@ async def test_result_shape_survives_being_copied(provider: _FakeProvider) -> No
 
 
 async def test_tuple_result_shape_survives_a_cache_hit(
-    cache: CacheController, provider: _FakeProvider
+    cache_controller: CacheController, provider: _FakeProvider
 ) -> None:
     """Test that a cached tuple is rebuilt with all of its members, including the None ones."""
     assert await provider.fetch_tuples("a") == [("a", "name", None)]
-    await _wait_for_stored(cache, "fetch_tuples.a")
+    await _wait_for_stored(cache_controller, "fetch_tuples.a")
     assert await provider.fetch_tuples("a") == [("a", "name", None)]
     assert provider.calls == 1
 


### PR DESCRIPTION
# What does this implement/fix?

The test suite on `dev` is currently failing. #5451 replaced the local `cache` fixture in the cache controller tests with a shared `cache_controller` one, while #5437 added a new test that used the old name. Both were fine on their own branches, so nothing conflicted on merge and the clash only appeared once both were on `dev`.

The stale name silently picks up an unrelated `cache` fixture, so the test errors with `AttributeError: 'Cache' object has no attribute 'database'`.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Point the tuple cache-hit test at the shared `cache_controller` fixture.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
