### PR TITLE
Limit the length of AI-written smart playlist descriptions

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -1438,7 +1438,9 @@ class SmartPlaylistProvider(PluginProvider):
             for playlist_id, entry in data.items():
                 self._rules_store[playlist_id] = SmartPlaylistRules.from_dict(entry["rules"])
                 self._names_store[playlist_id] = entry.get("name", playlist_id)
-                if description := entry.get("ai_description"):
+                # a description persisted before the size cap existed is dropped here too
+                description = str(entry.get("ai_description") or "")
+                if description and len(description.encode("utf-8")) <= MAX_AI_DESCRIPTION_BYTES:
                     self._descriptions_store[playlist_id] = description
         except Exception as exc:
             self.logger.warning("Failed to load smart playlist rules: %s", exc)

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -1439,8 +1439,12 @@ class SmartPlaylistProvider(PluginProvider):
                 self._rules_store[playlist_id] = SmartPlaylistRules.from_dict(entry["rules"])
                 self._names_store[playlist_id] = entry.get("name", playlist_id)
                 # a description persisted before the size cap existed is dropped here too
-                description = str(entry.get("ai_description") or "")
-                if description and len(description.encode("utf-8")) <= MAX_AI_DESCRIPTION_BYTES:
+                description = entry.get("ai_description")
+                if (
+                    isinstance(description, str)
+                    and description
+                    and len(description.encode("utf-8")) <= MAX_AI_DESCRIPTION_BYTES
+                ):
                     self._descriptions_store[playlist_id] = description
         except Exception as exc:
             self.logger.warning("Failed to load smart playlist rules: %s", exc)

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -84,6 +84,9 @@ CONF_AI_ENGINE = "ai_engine"
 DESCRIPTION_PREFIX = "[Smart Playlist] "
 # descriptions are a sentence or two, so this only has to cover a slow local model
 AI_QUERY_TIMEOUT_SECONDS = 60
+# a reply is persisted and served in every playlist listing, so a runaway one is discarded
+# in favour of the rules summary; the cap sits well above the sentence or two we ask for
+MAX_AI_DESCRIPTION_BYTES = 2048
 
 SUPPORTED_FEATURES: set[ProviderFeature] = {
     ProviderFeature.BROWSE,
@@ -1380,7 +1383,8 @@ class SmartPlaylistProvider(PluginProvider):
 
         :param name: The playlist name, included in the prompt for context.
         :param rules: The rules whose summary the description should reflect.
-        :return: The AI-generated description, or None when disabled, unavailable, or on error.
+        :return: The AI-generated description, or None when disabled, unavailable, too large,
+            or on error.
         """
         if not self.config.get_value(CONF_AI_DESCRIPTIONS):
             return None
@@ -1404,7 +1408,15 @@ class SmartPlaylistProvider(PluginProvider):
             )
             self.logger.debug("AI description generation failed for '%s': %s", name, details)
             return None
-        return response.strip() or None
+        description = response.strip()
+        if len(description.encode("utf-8")) > MAX_AI_DESCRIPTION_BYTES:
+            self.logger.debug(
+                "AI description for '%s' exceeds %d bytes, keeping the rules summary",
+                name,
+                MAX_AI_DESCRIPTION_BYTES,
+            )
+            return None
+        return description or None
 
     def _build_ai_prompt(self, name: str, rules: SmartPlaylistRules, locale: str) -> str:
         """Build the prompt asking an AI provider to describe the smart playlist."""

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -2085,7 +2085,7 @@ async def test_generate_ai_description_blank_response_returns_none(tmp_path: Any
 
 @pytest.mark.asyncio
 async def test_generate_ai_description_oversized_response_returns_none(tmp_path: Any) -> None:
-    """A reply beyond the size cap is discarded so the rules summary stays in place."""
+    """A reply beyond the size cap is discarded."""
     oversized = "x" * (MAX_AI_DESCRIPTION_BYTES + 1)
     plugin = _make_ai_plugin(tmp_path, ai_enabled=True, ai_provider=_make_ai_provider(oversized))
 
@@ -2403,6 +2403,58 @@ async def test_refresh_ai_description_no_provider_uses_fallback(tmp_path: Any) -
     assert "abc" not in plugin._descriptions_store
     written = cast("Any", plugin)._update_playlist_description.await_args.args[1]
     assert written == f"[Smart Playlist] {rules.human_readable()}"
+
+
+@pytest.mark.asyncio
+async def test_refresh_ai_description_oversized_reply_uses_fallback(tmp_path: Any) -> None:
+    """An oversized reply drops the stored text and writes the fallback."""
+    oversized = "x" * (MAX_AI_DESCRIPTION_BYTES + 1)
+    plugin = _make_ai_plugin(tmp_path, ai_provider=_make_ai_provider(oversized))
+    await plugin.handle_async_init()
+    rules = SmartPlaylistRules(favorites_only=True)
+    plugin._rules_store["abc"] = rules
+    plugin._names_store["abc"] = "Name"
+    plugin._descriptions_store["abc"] = "Good text."
+    cast("Any", plugin.mass).music.playlists.get_library_item_by_prov_id = AsyncMock(
+        return_value=_make_library_item(plugin, "abc")
+    )
+    cast("Any", plugin)._update_playlist_description = AsyncMock()
+
+    await plugin._refresh_ai_description("abc")
+
+    assert "abc" not in plugin._descriptions_store
+    written = cast("Any", plugin)._update_playlist_description.await_args.args[1]
+    assert written == f"[Smart Playlist] {rules.human_readable()}"
+
+
+@pytest.mark.asyncio
+async def test_load_rules_from_disk_drops_an_oversized_description(tmp_path: Any) -> None:
+    """A description persisted before the size cap existed is not adopted on load."""
+    plugin = _make_ai_plugin(tmp_path)
+    await plugin.handle_async_init()
+    await write_json(
+        str(tmp_path / "smart_playlists" / RULES_FILENAME),
+        {
+            "abc": {
+                "name": "Name",
+                "rules": SmartPlaylistRules(favorites_only=True).to_dict(),
+                "ai_description": "x" * (MAX_AI_DESCRIPTION_BYTES + 1),
+            },
+            "def": {
+                "name": "Other",
+                "rules": SmartPlaylistRules(favorites_only=True).to_dict(),
+                "ai_description": "Short and fine.",
+            },
+        },
+    )
+    plugin._rules_store.clear()
+    plugin._descriptions_store.clear()
+
+    await plugin._load_rules_from_disk()
+
+    assert "abc" in plugin._rules_store
+    assert "abc" not in plugin._descriptions_store
+    assert plugin._descriptions_store["def"] == "Short and fine."
 
 
 @pytest.mark.asyncio

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -28,6 +28,7 @@ from music_assistant.models.plugin import AIEngine, PluginProvider
 from music_assistant.providers.smart_playlist import (
     CONF_AI_DESCRIPTIONS,
     CONF_AI_ENGINE,
+    MAX_AI_DESCRIPTION_BYTES,
     SmartPlaylistProvider,
 )
 from music_assistant.providers.smart_playlist.helpers import (
@@ -2076,6 +2077,40 @@ async def test_disabled_toggle_does_not_schedule_refresh(tmp_path: Any) -> None:
 async def test_generate_ai_description_blank_response_returns_none(tmp_path: Any) -> None:
     """A blank/whitespace AI response is treated as no description."""
     plugin = _make_ai_plugin(tmp_path, ai_enabled=True, ai_provider=_make_ai_provider("   "))
+
+    result = await plugin._generate_ai_description("X", SmartPlaylistRules(favorites_only=True))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_description_oversized_response_returns_none(tmp_path: Any) -> None:
+    """A reply beyond the size cap is discarded so the rules summary stays in place."""
+    oversized = "x" * (MAX_AI_DESCRIPTION_BYTES + 1)
+    plugin = _make_ai_plugin(tmp_path, ai_enabled=True, ai_provider=_make_ai_provider(oversized))
+
+    result = await plugin._generate_ai_description("X", SmartPlaylistRules(favorites_only=True))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_description_accepts_a_response_at_the_size_cap(tmp_path: Any) -> None:
+    """A reply exactly at the size cap is still accepted."""
+    at_cap = "x" * MAX_AI_DESCRIPTION_BYTES
+    plugin = _make_ai_plugin(tmp_path, ai_enabled=True, ai_provider=_make_ai_provider(at_cap))
+
+    result = await plugin._generate_ai_description("X", SmartPlaylistRules(favorites_only=True))
+
+    assert result == at_cap
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_description_measures_the_cap_in_bytes(tmp_path: Any) -> None:
+    """The cap counts utf-8 bytes, so multibyte replies are not measured as characters."""
+    # under the cap as characters, over it as utf-8 bytes
+    multibyte = "あ" * (MAX_AI_DESCRIPTION_BYTES // 2)
+    plugin = _make_ai_plugin(tmp_path, ai_enabled=True, ai_provider=_make_ai_provider(multibyte))
 
     result = await plugin._generate_ai_description("X", SmartPlaylistRules(favorites_only=True))
 

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -2428,19 +2428,26 @@ async def test_refresh_ai_description_oversized_reply_uses_fallback(tmp_path: An
 
 
 @pytest.mark.asyncio
-async def test_load_rules_from_disk_drops_an_oversized_description(tmp_path: Any) -> None:
-    """A description persisted before the size cap existed is not adopted on load."""
+async def test_load_rules_from_disk_drops_an_unusable_description(tmp_path: Any) -> None:
+    """Only a short, textual persisted description is adopted on load."""
     plugin = _make_ai_plugin(tmp_path)
     await plugin.handle_async_init()
     await write_json(
         str(tmp_path / "smart_playlists" / RULES_FILENAME),
         {
+            # both unusable entries come first, so an entry that raises instead of being
+            # skipped would abort the load and cost the good entry below it
             "abc": {
                 "name": "Name",
                 "rules": SmartPlaylistRules(favorites_only=True).to_dict(),
                 "ai_description": "x" * (MAX_AI_DESCRIPTION_BYTES + 1),
             },
             "def": {
+                "name": "Corrupt",
+                "rules": SmartPlaylistRules(favorites_only=True).to_dict(),
+                "ai_description": {"not": "a string"},
+            },
+            "ghi": {
                 "name": "Other",
                 "rules": SmartPlaylistRules(favorites_only=True).to_dict(),
                 "ai_description": "Short and fine.",
@@ -2452,9 +2459,10 @@ async def test_load_rules_from_disk_drops_an_oversized_description(tmp_path: Any
 
     await plugin._load_rules_from_disk()
 
-    assert "abc" in plugin._rules_store
+    assert set(plugin._rules_store) == {"abc", "def", "ghi"}
     assert "abc" not in plugin._descriptions_store
-    assert plugin._descriptions_store["def"] == "Short and fine."
+    assert "def" not in plugin._descriptions_store
+    assert plugin._descriptions_store["ghi"] == "Short and fine."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Smart Playlist can let an AI engine write the playlist description. That reply was used as-is, with no limit on how long it could be. A description is stored in the library database and on disk, and is sent to the apps with every playlist listing, so an AI engine that runs away and produces pages of text would leave that text sitting in the library instead of a short description.

The reply is now discarded when it is unreasonably long, and the normal rules summary is shown instead.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Added a size limit for the AI-generated smart playlist description.
- An oversized reply is dropped and the playlist keeps its rules summary as description.
- Added tests covering the limit, including a reply that is only oversized once encoded.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
