### PR TITLE
Tidy up the duplicated Tidal test fixtures

### DIFF
--- a/tests/providers/tidal/conftest.py
+++ b/tests/providers/tidal/conftest.py
@@ -1,18 +1,75 @@
 """Fixtures for Tidal provider tests."""
 
-from collections.abc import Generator
-from unittest.mock import AsyncMock, Mock, patch
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Generator
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from music_assistant_models.media_items import ItemMapping
 
 from music_assistant.providers.tidal.media import TidalMediaManager
+
+if TYPE_CHECKING:
+    from music_assistant_models.enums import MediaType
+
+
+@pytest.fixture
+def provider_mock() -> Mock:
+    """Return a mock Tidal provider with an authenticated session and wired collaborators."""
+    provider = Mock()
+    provider.domain = "tidal"
+    provider.instance_id = "tidal_instance"
+
+    provider.auth.user_id = "12345"
+    provider.auth.country_code = "US"
+    provider.auth.access_token = "token"
+    provider.auth.session_id = "session"
+    provider.auth.user.profile_name = "Test User"
+    provider.auth.user.user_name = "Test User"
+    provider.auth.ensure_valid_token = AsyncMock(return_value=True)
+    provider.auth.refresh_token = AsyncMock()
+
+    provider.api = AsyncMock()
+    provider.api.get.return_value = {}
+    # paginate is an async generator, so it cannot be an AsyncMock child: it yields the
+    # items a test assigns to paginate.return_value
+    provider.api.paginate = MagicMock()
+
+    async def paginate(*_args: Any, **_kwargs: Any) -> AsyncGenerator[Any]:
+        for item in provider.api.paginate.return_value:
+            yield item
+
+    provider.api.paginate.side_effect = paginate
+    provider.api.paginate.return_value = []
+
+    provider.get_track = AsyncMock()
+
+    def get_item_mapping(media_type: MediaType, key: str, name: str) -> ItemMapping:
+        return ItemMapping(
+            media_type=media_type,
+            item_id=key,
+            provider=provider.instance_id,
+            name=name,
+        )
+
+    provider.get_item_mapping.side_effect = get_item_mapping
+
+    provider.mass.http_session = AsyncMock()
+    provider.mass.metadata.locale = "en_US"
+    provider.mass.config.get_provider_configs = AsyncMock(return_value=[])
+    provider.mass.cache.get = AsyncMock(return_value=None)
+    provider.mass.cache.set = AsyncMock()
+    provider.mass.cache.delete = AsyncMock()
+    provider.mass.music.tracks.get_library_item_by_prov_id = AsyncMock(return_value=None)
+
+    return provider
 
 
 @pytest.fixture
 def media_manager(provider_mock: Mock) -> TidalMediaManager:
     """Return a TidalMediaManager instance."""
-    # provider_mock is defined per test module and differs between them, so a module
-    # requesting this fixture must bring its own
     return TidalMediaManager(provider_mock)
 
 

--- a/tests/providers/tidal/test_api_client.py
+++ b/tests/providers/tidal/test_api_client.py
@@ -15,22 +15,6 @@ from music_assistant.providers.tidal.api_client import TidalAPIClient
 
 
 @pytest.fixture
-def provider_mock() -> Mock:
-    """Return a mock provider."""
-    provider = Mock()
-    provider.auth = AsyncMock()
-    provider.auth.ensure_valid_token.return_value = True
-    provider.auth.access_token = "token"
-    provider.auth.session_id = "session"
-    provider.auth.country_code = "US"
-    provider.mass = Mock()
-    provider.mass.http_session = AsyncMock()
-    provider.mass.metadata.locale = "en_US"
-    provider.logger = Mock()
-    return provider
-
-
-@pytest.fixture
 def api_client(provider_mock: Mock) -> TidalAPIClient:
     """Return a TidalAPIClient instance."""
     return TidalAPIClient(provider_mock)

--- a/tests/providers/tidal/test_library.py
+++ b/tests/providers/tidal/test_library.py
@@ -2,47 +2,12 @@
 
 from collections.abc import AsyncGenerator
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 from music_assistant_models.enums import MediaType
-from music_assistant_models.media_items import ItemMapping
 
 from music_assistant.providers.tidal.library import TidalLibraryManager
-
-
-@pytest.fixture
-def provider_mock() -> Mock:
-    """Return a mock provider."""
-    provider = Mock()
-    provider.domain = "tidal"
-    provider.instance_id = "tidal_instance"
-    provider.auth.user_id = "12345"
-    provider.api = AsyncMock()
-    provider.api.get.return_value = {"items": []}
-    provider.api.paginate = MagicMock()
-
-    # Configure async iterator for paginate
-    async def async_iter(*_args: Any, **_kwargs: Any) -> AsyncGenerator[Any]:
-        for item in provider.api.paginate.return_value:
-            yield item
-
-    provider.api.paginate.side_effect = async_iter
-    provider.api.paginate.return_value = []
-
-    provider.logger = Mock()
-
-    def get_item_mapping(media_type: MediaType, key: str, name: str) -> ItemMapping:
-        return ItemMapping(
-            media_type=media_type,
-            item_id=key,
-            provider=provider.instance_id,
-            name=name,
-        )
-
-    provider.get_item_mapping.side_effect = get_item_mapping
-
-    return provider
 
 
 @pytest.fixture

--- a/tests/providers/tidal/test_media.py
+++ b/tests/providers/tidal/test_media.py
@@ -1,48 +1,11 @@
 """Test Tidal Media Manager."""
 
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
-import pytest
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import RetriesExhausted
-from music_assistant_models.media_items import ItemMapping
 
 from music_assistant.providers.tidal.media import TidalMediaManager
-
-
-@pytest.fixture
-def provider_mock() -> Mock:
-    """Return a mock provider."""
-    provider = Mock()
-    provider.domain = "tidal"
-    provider.instance_id = "tidal_instance"
-    provider.auth.user_id = "12345"
-    provider.auth.country_code = "US"
-    provider.api = AsyncMock()
-    provider.api.get.return_value = {}
-    provider.api.paginate = MagicMock()
-
-    async def async_iter(*_args: Any, **_kwargs: Any) -> Any:
-        for item in provider.api.paginate.return_value:
-            yield item
-
-    provider.api.paginate.side_effect = async_iter
-    provider.api.paginate.return_value = []
-
-    provider.logger = Mock()
-
-    def get_item_mapping(media_type: MediaType, key: str, name: str) -> ItemMapping:
-        return ItemMapping(
-            media_type=media_type,
-            item_id=key,
-            provider=provider.instance_id,
-            name=name,
-        )
-
-    provider.get_item_mapping.side_effect = get_item_mapping
-
-    return provider
 
 
 @patch("music_assistant.providers.tidal.media.parse_artist")

--- a/tests/providers/tidal/test_media_extended.py
+++ b/tests/providers/tidal/test_media_extended.py
@@ -1,38 +1,12 @@
 """Additional tests for Tidal Media Manager - Mix operations and similar tracks."""
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import MediaNotFoundError
-from music_assistant_models.media_items import ItemMapping
 
 from music_assistant.providers.tidal.media import TidalMediaManager
-
-
-@pytest.fixture
-def provider_mock() -> Mock:
-    """Return a mock provider."""
-    provider = Mock()
-    provider.domain = "tidal"
-    provider.instance_id = "tidal_instance"
-    provider.auth.user_id = "12345"
-    provider.auth.country_code = "US"
-    provider.api = AsyncMock()
-    provider.api.get.return_value = {}
-    provider.logger = Mock()
-
-    def get_item_mapping(media_type: MediaType, key: str, name: str) -> ItemMapping:
-        return ItemMapping(
-            media_type=media_type,
-            item_id=key,
-            provider=provider.instance_id,
-            name=name,
-        )
-
-    provider.get_item_mapping.side_effect = get_item_mapping
-
-    return provider
 
 
 @patch("music_assistant.providers.tidal.media.parse_playlist")

--- a/tests/providers/tidal/test_page_parser.py
+++ b/tests/providers/tidal/test_page_parser.py
@@ -13,17 +13,6 @@ FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 PAGE_FIXTURES = list(FIXTURES_DIR.glob("pages/*.json"))
 
 
-@pytest.fixture
-def provider_mock() -> Mock:
-    """Return a mock provider."""
-    provider = Mock()
-    provider.domain = "tidal"
-    provider.instance_id = "tidal_instance"
-    provider.auth.user_id = "12345"
-    provider.logger = Mock()
-    return provider
-
-
 @pytest.mark.parametrize("example", PAGE_FIXTURES, ids=lambda val: str(val.stem))
 def test_page_parser(example: pathlib.Path, provider_mock: Mock) -> None:
     """Test page parser with fixtures."""

--- a/tests/providers/tidal/test_page_parser_extended.py
+++ b/tests/providers/tidal/test_page_parser_extended.py
@@ -1,37 +1,11 @@
 """Extended tests for Tidal Page Parser."""
 
 from typing import Any
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock, patch
 
-import pytest
 from music_assistant_models.enums import MediaType
-from music_assistant_models.media_items import ItemMapping
 
 from music_assistant.providers.tidal.tidal_page_parser import TidalPageParser
-
-
-@pytest.fixture
-def provider_mock() -> Mock:
-    """Return a mock provider."""
-    provider = Mock()
-    provider.domain = "tidal"
-    provider.instance_id = "tidal_instance"
-    provider.auth.user_id = "12345"
-    provider.logger = Mock()
-    provider.mass = Mock()
-    provider.mass.cache.get = AsyncMock(return_value=None)
-    provider.mass.cache.set = AsyncMock()
-
-    def get_item_mapping(media_type: MediaType, key: str, name: str) -> ItemMapping:
-        return ItemMapping(
-            media_type=media_type,
-            item_id=key,
-            provider=provider.instance_id,
-            name=name,
-        )
-
-    provider.get_item_mapping.side_effect = get_item_mapping
-    return provider
 
 
 def test_parser_initialization(provider_mock: Mock) -> None:

--- a/tests/providers/tidal/test_parsers.py
+++ b/tests/providers/tidal/test_parsers.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
-from music_assistant_models.media_items import ItemMapping
 
 from music_assistant.providers.tidal.parsers import (
     parse_album,
@@ -16,7 +15,6 @@ from music_assistant.providers.tidal.parsers import (
 )
 
 if TYPE_CHECKING:
-    from music_assistant_models.enums import MediaType
     from syrupy.assertion import SnapshotAssertion
 
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
@@ -24,29 +22,6 @@ ARTIST_FIXTURES = list(FIXTURES_DIR.glob("artists/*.json"))
 ALBUM_FIXTURES = list(FIXTURES_DIR.glob("albums/*.json"))
 TRACK_FIXTURES = list(FIXTURES_DIR.glob("tracks/*.json"))
 PLAYLIST_FIXTURES = list(FIXTURES_DIR.glob("playlists/*.json"))
-
-
-@pytest.fixture
-def provider_mock() -> Mock:
-    """Return a mock provider."""
-    provider = Mock()
-    provider.domain = "tidal"
-    provider.instance_id = "tidal_instance"
-    provider.auth.user_id = "12345"
-    provider.auth.user.profile_name = "Test User"
-    provider.auth.user.user_name = "Test User"
-
-    def get_item_mapping(media_type: MediaType, key: str, name: str) -> ItemMapping:
-        return ItemMapping(
-            media_type=media_type,
-            item_id=key,
-            provider=provider.instance_id,
-            name=name,
-        )
-
-    provider.get_item_mapping.side_effect = get_item_mapping
-
-    return provider
 
 
 @pytest.mark.parametrize("example", ARTIST_FIXTURES, ids=lambda val: str(val.stem))

--- a/tests/providers/tidal/test_playlist.py
+++ b/tests/providers/tidal/test_playlist.py
@@ -1,20 +1,10 @@
 """Test Tidal Playlist Manager."""
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 from music_assistant.providers.tidal.playlist import TidalPlaylistManager
-
-
-@pytest.fixture
-def provider_mock() -> Mock:
-    """Return a mock provider."""
-    provider = Mock()
-    provider.auth.user_id = "12345"
-    provider.api = AsyncMock()
-    provider.logger = Mock()
-    return provider
 
 
 @pytest.fixture

--- a/tests/providers/tidal/test_recommendations.py
+++ b/tests/providers/tidal/test_recommendations.py
@@ -22,26 +22,6 @@ INSTANCE_ID = "tidal_test"
 
 
 @pytest.fixture
-def provider_mock() -> Mock:
-    """Return a mock provider for manager-level tests."""
-    provider = Mock()
-    provider.domain = "tidal"
-    provider.instance_id = "tidal_instance"
-    provider.auth.user_id = "12345"
-    provider.auth.country_code = "US"
-    provider.api = AsyncMock()
-    provider.logger = Mock()
-
-    # Mock mass
-    provider.mass = Mock()
-    provider.mass.config.get_provider_configs = AsyncMock(return_value=[])
-    provider.mass.metadata.locale = "en_US"
-    provider.mass.cache.set = AsyncMock()
-
-    return provider
-
-
-@pytest.fixture
 def recommendation_manager(provider_mock: Mock) -> TidalRecommendationManager:
     """Return a TidalRecommendationManager instance."""
     return TidalRecommendationManager(provider_mock)

--- a/tests/providers/tidal/test_streaming.py
+++ b/tests/providers/tidal/test_streaming.py
@@ -14,32 +14,16 @@ from music_assistant.providers.tidal.streaming import TidalStreamingManager
 
 
 @pytest.fixture
-def provider_mock() -> Mock:
-    """Return a mock provider."""
-    provider = Mock()
-    provider.domain = "tidal"
-    provider.instance_id = "tidal_instance"
-    provider.config.get_value.return_value = "HIGH"
-    provider.api = AsyncMock()
-    provider.api.OPEN_API_URL = "https://openapi.tidal.com/v2"
+def provider_mock(provider_mock: Mock) -> Mock:
+    """Return the shared provider mock with the streaming quality and throttler bypass wired."""
+    provider_mock.config.get_value.return_value = "HIGH"
+    provider_mock.api.OPEN_API_URL = "https://openapi.tidal.com/v2"
 
-    # Mock throttler bypass as async context manager using MagicMock
-    bypass_ctx = MagicMock()
-    bypass_ctx.__aenter__ = AsyncMock(return_value=None)
-    bypass_ctx.__aexit__ = AsyncMock(return_value=None)
-    provider.api.throttler = Mock()
-    provider.api.throttler.bypass = Mock(return_value=bypass_ctx)
+    # the streaming manager enters api.throttler.bypass() as an async context manager,
+    # which a MagicMock supports out of the box
+    provider_mock.api.throttler.bypass = Mock(return_value=MagicMock())
 
-    provider.get_track = AsyncMock()
-
-    # Mock mass
-    provider.mass = Mock()
-    provider.mass.cache.get = AsyncMock(return_value=None)
-    provider.mass.cache.set = AsyncMock()
-    provider.mass.cache.delete = AsyncMock()
-    provider.mass.music.tracks.get_library_item_by_prov_id = AsyncMock(return_value=None)
-
-    return provider
+    return provider_mock
 
 
 @pytest.fixture


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5452, which left alone the fixtures that "merely share a name but differ in body". The Tidal tests were the worst case: ten test files each defined their own `provider_mock`, all variations on the same thing, and some missing bits the others had.

That became a trap once #5452 hoisted `media_manager` into the directory's `conftest.py`, because that fixture depends on `provider_mock` and the conftest doesn't define one. It resolves from whichever module asks for it, so adding a `media_manager` test to `test_playlist.py` would silently get a mock with no `get_item_mapping` and fail on an unreadable `<Mock name='mock.get_item_mapping().item_id'>` comparison instead of a clear error.

The ten copies now merge into one shared `provider_mock` in the directory's `conftest.py`, so `media_manager` is self-contained and every module starts from the same fully-wired provider.

- one `provider_mock` in `tests/providers/tidal/conftest.py`, merged from the ten module copies
- `test_streaming.py` keeps a small same-name override for the parts only it needs (streaming quality and the throttler bypass)
- the note on `media_manager` explaining the cross-module resolution is no longer needed

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
