### PR TITLE
Tidy up the API value parser

### DIFF
--- a/music_assistant/helpers/api.py
+++ b/music_assistant/helpers/api.py
@@ -630,7 +630,7 @@ def _parse_union(
     allow_value_convert: bool,
 ) -> Any:
     """
-    Parse a value against a union annotation, trying every member until one fits.
+    Parse a value against a union annotation.
 
     :param name: Name of the value, used in error messages.
     :param value: The raw (json) value to parse.

--- a/music_assistant/helpers/api.py
+++ b/music_assistant/helpers/api.py
@@ -585,14 +585,19 @@ def _parse_sequence(
     :param origin: The unsubscripted origin of the annotation.
     :param allow_value_convert: Whether conversion of common type mistakes is allowed.
     """
+    subtypes = get_args(value_type)
+    # a None member is only kept when the element type admits it, so a plain annotation
+    # like list[str] still shrugs off the nulls a client may have sent along
+    keep_none = bool(subtypes) and (
+        subtypes[0] is NoneType
+        or (get_origin(subtypes[0]) in (Union, UnionType) and NoneType in get_args(subtypes[0]))
+    )
     # For abstract types like Sequence and Iterable, use list as the concrete type
     concrete_type = list if origin in (Sequence, Iterable) else origin
     return concrete_type(
-        parse_value(
-            name, subvalue, get_args(value_type)[0], allow_value_convert=allow_value_convert
-        )
+        parse_value(name, subvalue, subtypes[0], allow_value_convert=allow_value_convert)
         for subvalue in value
-        if subvalue is not None
+        if subvalue is not None or keep_none
     )
 
 

--- a/music_assistant/helpers/api.py
+++ b/music_assistant/helpers/api.py
@@ -463,7 +463,7 @@ def parse_utc_timestamp(datetime_string: str) -> datetime:
     return datetime.fromisoformat(datetime_string)
 
 
-def parse_value(  # noqa: PLR0911, PLR0915
+def parse_value(
     name: str,
     value: Any,
     value_type: Any,
@@ -498,65 +498,13 @@ def parse_value(  # noqa: PLR0911, PLR0915
         return None
     origin = get_origin(value_type)
     if origin is tuple and (subtypes := get_args(value_type)) and subtypes[-1] is not Ellipsis:
-        # a fixed-length tuple annotates every position separately, so each member is
-        # parsed against its own type and kept, including the members that are None
-        if len(value) != len(subtypes):
-            msg = (
-                f"Value {value} of type {type(value)} is invalid for {name}, "
-                f"expected value of type {value_type}"
-            )
-            raise TypeError(msg)
-        return tuple(
-            parse_value(
-                f"{name}[{index}]", subvalue, subtype, allow_value_convert=allow_value_convert
-            )
-            for index, (subvalue, subtype) in enumerate(zip(value, subtypes, strict=True))
-        )
+        return _parse_fixed_length_tuple(name, value, value_type, subtypes, allow_value_convert)
     if origin in (tuple, list, set, frozenset, Sequence, Iterable):
-        # For abstract types like Sequence and Iterable, use list as the concrete type
-        concrete_type = list if origin in (Sequence, Iterable) else origin
-        return concrete_type(
-            parse_value(
-                name, subvalue, get_args(value_type)[0], allow_value_convert=allow_value_convert
-            )
-            for subvalue in value
-            if subvalue is not None
-        )
+        return _parse_sequence(name, value, value_type, origin, allow_value_convert)
     if origin is dict:
-        subkey_type = get_args(value_type)[0]
-        subvalue_type = get_args(value_type)[1]
-        return {
-            parse_value(subkey, subkey, subkey_type): parse_value(
-                f"{subkey}.value", subvalue, subvalue_type, allow_value_convert=allow_value_convert
-            )
-            for subkey, subvalue in value.items()
-        }
+        return _parse_dict(value, value_type, allow_value_convert)
     if origin is Union or origin is UnionType:
-        # try all possible types
-        sub_value_types = get_args(value_type)
-        if value is None and NoneType in sub_value_types:
-            # an optional annotation with no value needs no further parsing
-            return None
-        for sub_arg_type in sub_value_types:
-            # try them all until one succeeds
-            try:
-                return parse_value(
-                    name, value, sub_arg_type, allow_value_convert=allow_value_convert
-                )
-            except KeyError, TypeError, ValueError, MissingField:
-                pass
-        # if we get to this point, all possibilities failed
-        # find out if we should raise or log this
-        err = (
-            f"Value {value} of type {type(value)} is invalid for {name}, "
-            f"expected value of type {value_type}"
-        )
-        if NoneType not in sub_value_types:
-            # raise exception, we have no idea how to handle this value
-            raise TypeError(err)
-        # failed to parse the (sub) value but None allowed, log only
-        logging.getLogger(__name__).warning(err)
-        return None
+        return _parse_union(name, value, value_type, allow_value_convert)
     if origin is type:
         # type[X] parameters are skipped in parse_arguments so this branch
         # should not be reachable from API input. Reject as a safeguard.
@@ -579,17 +527,7 @@ def parse_value(  # noqa: PLR0911, PLR0915
         pass
 
     if allow_value_convert:
-        # allow conversion of common types/mistakes
-        if value_type is float and isinstance(value, int):
-            return float(value)
-        if value_type is int and isinstance(value, float):
-            return int(value)
-        if value_type is int and isinstance(value, str) and value.isnumeric():
-            return int(value)
-        if value_type is float and isinstance(value, str) and value.isnumeric():
-            return float(value)
-        if value_type is bool and isinstance(value, str | int):
-            return try_parse_bool(value)
+        value = _convert_common_value(value, value_type)
 
     if not isinstance(value, value_type):
         # all options failed, raise exception
@@ -598,4 +536,141 @@ def parse_value(  # noqa: PLR0911, PLR0915
             f"expected value of type {value_type}"
         )
         raise TypeError(msg)
+    return value
+
+
+def _parse_fixed_length_tuple(
+    name: str,
+    value: Any,
+    value_type: Any,
+    subtypes: tuple[Any, ...],
+    allow_value_convert: bool,
+) -> tuple[Any, ...]:
+    """
+    Parse a value against a fixed-length tuple annotation.
+
+    :param name: Name of the value, used in error messages.
+    :param value: The raw (json) value to parse.
+    :param value_type: The tuple annotation to parse against.
+    :param subtypes: The type arguments of the tuple annotation, one per position.
+    :param allow_value_convert: Whether conversion of common type mistakes is allowed.
+    """
+    # a fixed-length tuple annotates every position separately, so each member is
+    # parsed against its own type and kept, including the members that are None
+    if len(value) != len(subtypes):
+        msg = (
+            f"Value {value} of type {type(value)} is invalid for {name}, "
+            f"expected value of type {value_type}"
+        )
+        raise TypeError(msg)
+    return tuple(
+        parse_value(f"{name}[{index}]", subvalue, subtype, allow_value_convert=allow_value_convert)
+        for index, (subvalue, subtype) in enumerate(zip(value, subtypes, strict=True))
+    )
+
+
+def _parse_sequence(
+    name: str,
+    value: Any,
+    value_type: Any,
+    origin: Any,
+    allow_value_convert: bool,
+) -> Any:
+    """
+    Parse a value against a homogeneous sequence annotation.
+
+    :param name: Name of the value, used in error messages.
+    :param value: The raw (json) value to parse.
+    :param value_type: The sequence annotation to parse against.
+    :param origin: The unsubscripted origin of the annotation.
+    :param allow_value_convert: Whether conversion of common type mistakes is allowed.
+    """
+    # For abstract types like Sequence and Iterable, use list as the concrete type
+    concrete_type = list if origin in (Sequence, Iterable) else origin
+    return concrete_type(
+        parse_value(
+            name, subvalue, get_args(value_type)[0], allow_value_convert=allow_value_convert
+        )
+        for subvalue in value
+        if subvalue is not None
+    )
+
+
+def _parse_dict(
+    value: Any,
+    value_type: Any,
+    allow_value_convert: bool,
+) -> dict[Any, Any]:
+    """
+    Parse a value against a dict annotation.
+
+    :param value: The raw (json) value to parse.
+    :param value_type: The dict annotation to parse against.
+    :param allow_value_convert: Whether conversion of common type mistakes is allowed.
+    """
+    subkey_type = get_args(value_type)[0]
+    subvalue_type = get_args(value_type)[1]
+    return {
+        parse_value(subkey, subkey, subkey_type): parse_value(
+            f"{subkey}.value", subvalue, subvalue_type, allow_value_convert=allow_value_convert
+        )
+        for subkey, subvalue in value.items()
+    }
+
+
+def _parse_union(
+    name: str,
+    value: Any,
+    value_type: Any,
+    allow_value_convert: bool,
+) -> Any:
+    """
+    Parse a value against a union annotation, trying every member until one fits.
+
+    :param name: Name of the value, used in error messages.
+    :param value: The raw (json) value to parse.
+    :param value_type: The union annotation to parse against.
+    :param allow_value_convert: Whether conversion of common type mistakes is allowed.
+    """
+    sub_value_types = get_args(value_type)
+    if value is None and NoneType in sub_value_types:
+        # an optional annotation with no value needs no further parsing
+        return None
+    for sub_arg_type in sub_value_types:
+        # try them all until one succeeds
+        try:
+            return parse_value(name, value, sub_arg_type, allow_value_convert=allow_value_convert)
+        except KeyError, TypeError, ValueError, MissingField:
+            pass
+    # if we get to this point, all possibilities failed
+    # find out if we should raise or log this
+    err = (
+        f"Value {value} of type {type(value)} is invalid for {name}, "
+        f"expected value of type {value_type}"
+    )
+    if NoneType not in sub_value_types:
+        # raise exception, we have no idea how to handle this value
+        raise TypeError(err)
+    # failed to parse the (sub) value but None allowed, log only
+    logging.getLogger(__name__).warning(err)
+    return None
+
+
+def _convert_common_value(value: Any, value_type: Any) -> Any:
+    """
+    Convert common type mistakes in raw (json) data, or return the value untouched.
+
+    :param value: The raw (json) value to convert.
+    :param value_type: The type to convert the value to.
+    """
+    if value_type is float and isinstance(value, int):
+        return float(value)
+    if value_type is int and isinstance(value, float):
+        return int(value)
+    if value_type is int and isinstance(value, str) and value.isnumeric():
+        return int(value)
+    if value_type is float and isinstance(value, str) and value.isnumeric():
+        return float(value)
+    if value_type is bool and isinstance(value, str | int):
+        return try_parse_bool(value)
     return value

--- a/tests/helpers/test_parse_value_collections.py
+++ b/tests/helpers/test_parse_value_collections.py
@@ -47,9 +47,27 @@ def test_parse_value_frozenset_of_str() -> None:
 
 
 def test_parse_value_none_members_dropped_from_list() -> None:
-    """None members are currently dropped from a homogeneous list annotation."""
+    """None members are dropped when the element type of a list does not admit None."""
     result = parse_value("values", ["a", None, "b"], list[str])
     assert result == ["a", "b"]
+
+
+def test_parse_value_none_members_kept_for_optional_element_type() -> None:
+    """None members are kept when the element type of a list admits None."""
+    result = parse_value("values", ["a", None, "b"], list[str | None])
+    assert result == ["a", None, "b"]
+
+
+def test_parse_value_none_member_kept_in_set_of_optional() -> None:
+    """A None member is kept for a set with an element type that admits None."""
+    result = parse_value("values", ["a", None], set[str | None])
+    assert result == {"a", None}
+
+
+def test_parse_value_none_member_kept_in_variadic_tuple_of_optional() -> None:
+    """A None member is kept for a variadic tuple with an element type that admits None."""
+    result = parse_value("values", ["a", None, "b"], tuple[str | None, ...])
+    assert result == ("a", None, "b")
 
 
 def test_parse_value_fixed_length_tuple_per_position_types() -> None:

--- a/tests/helpers/test_parse_value_conversion.py
+++ b/tests/helpers/test_parse_value_conversion.py
@@ -1,0 +1,82 @@
+"""Tests for value conversion and union fallthrough in API argument parsing."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import get_type_hints
+
+import pytest
+
+from music_assistant.helpers.api import parse_arguments, parse_value
+
+
+def test_numeric_string_converted_to_int() -> None:
+    """A numeric string is accepted for an int annotation when conversion is allowed."""
+    assert parse_value("volume", "5", int, allow_value_convert=True) == 5
+
+
+def test_int_converted_to_float() -> None:
+    """An int is accepted for a float annotation when conversion is allowed."""
+    result = parse_value("gain", 1, float, allow_value_convert=True)
+    assert isinstance(result, float)
+    assert result == 1.0
+
+
+def test_numeric_string_converted_to_float() -> None:
+    """A numeric string is accepted for a float annotation when conversion is allowed."""
+    assert parse_value("gain", "5", float, allow_value_convert=True) == 5.0
+
+
+def test_float_converted_to_int() -> None:
+    """A float is truncated for an int annotation when conversion is allowed."""
+    assert parse_value("volume", 1.9, int, allow_value_convert=True) == 1
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("true", True), ("1", True), (1, True), ("false", False), ("nope", False), (0, False)],
+)
+def test_string_and_int_converted_to_bool(value: str | int, expected: bool) -> None:
+    """A string or int is accepted for a bool annotation when conversion is allowed."""
+    assert parse_value("enabled", value, bool, allow_value_convert=True) is expected
+
+
+def test_no_conversion_without_allow_value_convert() -> None:
+    """A value of the wrong type is rejected while conversion is not allowed."""
+    with pytest.raises(TypeError, match="is invalid for volume"):
+        parse_value("volume", "5", int)
+
+
+def test_value_without_a_conversion_is_still_rejected() -> None:
+    """A value that no conversion applies to is rejected even when conversion is allowed."""
+    with pytest.raises(TypeError, match="is invalid for name"):
+        parse_value("name", 5, str, allow_value_convert=True)
+
+
+def test_parse_arguments_retries_with_conversion() -> None:
+    """Arguments that only fit after conversion are accepted by the retry."""
+
+    def _handler(volume: int, gain: float) -> None: ...
+
+    result = parse_arguments(
+        inspect.signature(_handler),
+        get_type_hints(_handler),
+        {"volume": "5", "gain": 1},
+    )
+    assert result == {"volume": 5, "gain": 1.0}
+
+
+def test_union_that_fits_no_member_raises() -> None:
+    """A value that fits no member of a union without None is rejected."""
+    with pytest.raises(TypeError, match="is invalid for values"):
+        parse_value("values", {}, int | str)
+
+
+def test_optional_union_that_fits_no_member_warns_and_returns_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A value that fits no member of an optional union is logged and dropped."""
+    with caplog.at_level(logging.WARNING):
+        assert parse_value("values", {}, int | str | None) is None
+    assert "is invalid for values" in caplog.text


### PR DESCRIPTION
# What does this implement/fix?

`parse_value` in `helpers/api.py` had grown into one long function that handled every kind of
annotation inline, and had tripped three of our complexity limits at once (two of them were
silenced with a `noqa` in #5437 to keep that fix small). It is now a short dispatch that hands each
kind of annotation to its own small helper, so both suppressions could go.

While that helper was isolated, one rough edge in it was worth fixing too: a list, set or variadic
tuple threw away the `None` entries it was given even when the annotation explicitly allowed them
(`list[str | None]` came back as `['a']` instead of `['a', None]`), while a fixed-length tuple kept
them since #5437. `None` entries are now kept when the element type allows them, and still dropped
when it does not, so a plain `list[str]` keeps shrugging off nulls from a buggy client. Nothing in
the API or the cache uses such an annotation today, so no behaviour anyone can reach changes.

Beyond that the refactor is behaviour-preserving: `parse_value` is used for every incoming API
argument and for rebuilding cached values, so the old and new versions were run side by side over
232 cases (every tuple spelling, lists/sets/frozensets/sequences/iterables, dicts, unions, enums,
datetimes, models, and the value-conversion fallbacks) and matched on all of them, results and
error messages alike, apart from the optional-element cases above.

**Related issue (if applicable):**

- follow-up on #5437

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Split the fixed-length tuple, sequence, dict and union handling out of `parse_value` into one
  helper each.
- Moved the value-conversion fallbacks (int/float/bool) into their own helper.
- Dropped the `PLR0911` and `PLR0915` suppressions; the function now also fits within the branch
  limit that is globally ignored.
- Keep the `None` entries of a list, set or variadic tuple when its element type allows them.
- Added tests for the value conversion and union fallthrough paths, which had no coverage at all.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
