### PR TITLE
Keep a playback position of zero instead of treating it as unknown

### DIFF
--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -699,12 +699,13 @@ class AriaCastReceiver(PluginProvider):
         if "album" in data:
             m.album = data["album"]
 
-        # Accept both camelCase (Android) and snake_case (spec broadcast) per interop rule.
-        # The fallback is on the key and not on the value, so a reported 0 survives.
-        duration = data.get("durationMs", data.get("duration_ms"))
+        # Accept both camelCase (Android) and snake_case (spec broadcast) per interop rule
+        duration = data.get("durationMs") or data.get("duration_ms")
         if duration is not None:
             m.duration = int(duration) // 1000
 
+        # the fallback is on the key rather than on the value, so a reported position
+        # of 0 (the start of a track) is applied instead of read as 'not reported'
         position = data.get("positionMs", data.get("position_ms"))
         if position is not None:
             m.elapsed_time = int(position) // 1000

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -684,7 +684,7 @@ class AriaCastReceiver(PluginProvider):
             "album": m.album,
             "artwork_url": m.image_url,
             "duration_ms": int(m.duration * 1000) if m.duration else None,
-            "position_ms": int(m.elapsed_time * 1000) if m.elapsed_time else None,
+            "position_ms": int(m.elapsed_time * 1000) if m.elapsed_time is not None else None,
             "is_playing": self._is_playing,
         }
 

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -699,12 +699,13 @@ class AriaCastReceiver(PluginProvider):
         if "album" in data:
             m.album = data["album"]
 
-        # Accept both camelCase (Android) and snake_case (spec broadcast) per interop rule
-        duration = data.get("durationMs") or data.get("duration_ms")
+        # Accept both camelCase (Android) and snake_case (spec broadcast) per interop rule.
+        # The fallback is on the key and not on the value, so a reported 0 survives.
+        duration = data.get("durationMs", data.get("duration_ms"))
         if duration is not None:
             m.duration = int(duration) // 1000
 
-        position = data.get("positionMs") or data.get("position_ms")
+        position = data.get("positionMs", data.get("position_ms"))
         if position is not None:
             m.elapsed_time = int(position) // 1000
             m.elapsed_time_last_updated = time.time()

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -505,7 +505,14 @@ class UniversalGroupPlayer(Player):
         # use state properties (not raw attributes) to account for protocol player propagation
         for child_player in self.mass.players.iter_group_members(self, active_only=True):
             self._attr_playback_state = child_player.state.playback_state
-            if child_player.state.elapsed_time:
+            # a position is only meaningful together with the timestamp it was taken at,
+            # so the pair is adopted as a whole or not at all. Position 0 is a valid
+            # position: members that serve the group stream from a buffer report a fixed
+            # 0 and let the timestamp carry the correction for their buffer delay.
+            if (
+                child_player.state.elapsed_time is not None
+                and child_player.state.elapsed_time_last_updated is not None
+            ):
                 self._attr_elapsed_time = child_player.state.elapsed_time
                 self._attr_elapsed_time_last_updated = child_player.state.elapsed_time_last_updated
             break

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -507,8 +507,8 @@ class UniversalGroupPlayer(Player):
             self._attr_playback_state = child_player.state.playback_state
             # a position is only meaningful together with the timestamp it was taken at,
             # so the pair is adopted as a whole or not at all. Position 0 is a valid
-            # position: members that serve the group stream from a buffer report a fixed
-            # 0 and let the timestamp carry the correction for their buffer delay.
+            # position: members that anchor the group stream once report a fixed 0 and
+            # let the timestamp carry both the progression and their own buffer delay.
             if (
                 child_player.state.elapsed_time is not None
                 and child_player.state.elapsed_time_last_updated is not None

--- a/tests/providers/ariacast_receiver/__init__.py
+++ b/tests/providers/ariacast_receiver/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the AriaCast receiver provider."""

--- a/tests/providers/ariacast_receiver/test_metadata.py
+++ b/tests/providers/ariacast_receiver/test_metadata.py
@@ -52,11 +52,6 @@ async def test_zero_position_from_sender_is_applied() -> None:
     assert (await _apply_meta({"positionMs": 0})).elapsed_time == 0
 
 
-async def test_zero_duration_from_sender_is_applied() -> None:
-    """A sender switching to a stream of unknown length clears the previous duration."""
-    assert (await _apply_meta({"durationMs": 0})).duration == 0
-
-
 @pytest.mark.parametrize("key", ["positionMs", "position_ms"])
 async def test_position_from_sender_is_applied(key: str) -> None:
     """Senders may use either casing for the position."""

--- a/tests/providers/ariacast_receiver/test_metadata.py
+++ b/tests/providers/ariacast_receiver/test_metadata.py
@@ -1,22 +1,35 @@
-"""Tests for the metadata payload the AriaCast receiver sends to its senders."""
+"""Tests for the metadata the AriaCast receiver exchanges with its senders."""
 
 from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
+import pytest
 from music_assistant_models.streamdetails import StreamMetadata
 
 from music_assistant.providers.ariacast_receiver import AriaCastReceiver
 
 
 def _meta_dict(elapsed_time: int | None) -> dict[str, Any]:
-    """Serialise the wire payload for a stream reporting the given position."""
+    """Serialise the outgoing wire payload for a stream at the given position."""
     receiver = SimpleNamespace(
         _stream_meta=StreamMetadata(title="Test Track", elapsed_time=elapsed_time),
         _is_playing=True,
     )
     return AriaCastReceiver._meta_dict(cast("AriaCastReceiver", receiver))
+
+
+async def _apply_meta(data: dict[str, Any]) -> StreamMetadata:
+    """Merge an incoming sender update into a stream that already has a position."""
+    receiver = SimpleNamespace(
+        _stream_meta=StreamMetadata(title="Test Track", elapsed_time=120, duration=240),
+        _last_artwork_url=None,
+        _broadcast_meta=AsyncMock(),
+    )
+    await AriaCastReceiver._apply_meta(cast("AriaCastReceiver", receiver), data)
+    return cast("StreamMetadata", receiver._stream_meta)
 
 
 def test_zero_position_is_reported() -> None:
@@ -32,3 +45,24 @@ def test_position_is_reported_in_milliseconds() -> None:
 def test_missing_position_stays_none() -> None:
     """A stream without a position reports none."""
     assert _meta_dict(None)["position_ms"] is None
+
+
+async def test_zero_position_from_sender_is_applied() -> None:
+    """A sender rewinding to the start of a track replaces the previous position."""
+    assert (await _apply_meta({"positionMs": 0})).elapsed_time == 0
+
+
+async def test_zero_duration_from_sender_is_applied() -> None:
+    """A sender switching to a stream of unknown length clears the previous duration."""
+    assert (await _apply_meta({"durationMs": 0})).duration == 0
+
+
+@pytest.mark.parametrize("key", ["positionMs", "position_ms"])
+async def test_position_from_sender_is_applied(key: str) -> None:
+    """Senders may use either casing for the position."""
+    assert (await _apply_meta({key: 42000})).elapsed_time == 42
+
+
+async def test_update_without_position_keeps_the_previous_one() -> None:
+    """An update that carries no position leaves the known position alone."""
+    assert (await _apply_meta({"title": "Other Track"})).elapsed_time == 120

--- a/tests/providers/ariacast_receiver/test_metadata.py
+++ b/tests/providers/ariacast_receiver/test_metadata.py
@@ -1,0 +1,34 @@
+"""Tests for the metadata payload the AriaCast receiver sends to its senders."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from music_assistant_models.streamdetails import StreamMetadata
+
+from music_assistant.providers.ariacast_receiver import AriaCastReceiver
+
+
+def _meta_dict(elapsed_time: int | None) -> dict[str, Any]:
+    """Serialise the wire payload for a stream reporting the given position."""
+    receiver = SimpleNamespace(
+        _stream_meta=StreamMetadata(title="Test Track", elapsed_time=elapsed_time),
+        _is_playing=True,
+    )
+    return AriaCastReceiver._meta_dict(cast("AriaCastReceiver", receiver))
+
+
+def test_zero_position_is_reported() -> None:
+    """The start of a track is sent as position 0, not as 'unknown'."""
+    assert _meta_dict(0)["position_ms"] == 0
+
+
+def test_position_is_reported_in_milliseconds() -> None:
+    """A known position is converted from seconds to milliseconds."""
+    assert _meta_dict(42)["position_ms"] == 42000
+
+
+def test_missing_position_stays_none() -> None:
+    """A stream without a position reports none."""
+    assert _meta_dict(None)["position_ms"] is None

--- a/tests/providers/universal_group/test_universal_group.py
+++ b/tests/providers/universal_group/test_universal_group.py
@@ -304,6 +304,73 @@ class TestIdleGraceTimer:
         assert ugp._idle_grace_task is None
 
 
+class TestMemberPositionPropagation:
+    """The group mirrors the playback position reported by its active member."""
+
+    def test_position_is_adopted(self) -> None:
+        """A member's position anchor becomes the group's position anchor."""
+        ugp = self._ugp_with_member(self._member(42.0, 2000.0))
+
+        with patch.object(ugp, "update_state"):
+            ugp._set_attributes()
+
+        assert ugp._attr_elapsed_time == 42.0
+        assert ugp._attr_elapsed_time_last_updated == 2000.0
+
+    def test_zero_position_is_adopted(self) -> None:
+        """Position 0 is a real position and replaces the group's own anchor."""
+        ugp = self._ugp_with_member(self._member(0.0, 2000.0))
+
+        with patch.object(ugp, "update_state"):
+            ugp._set_attributes()
+
+        assert ugp._attr_elapsed_time == 0.0
+        assert ugp._attr_elapsed_time_last_updated == 2000.0
+
+    def test_position_without_timestamp_is_ignored(self) -> None:
+        """A position without its timestamp is unusable, so the group keeps its anchor."""
+        ugp = self._ugp_with_member(self._member(0.0, None))
+
+        with patch.object(ugp, "update_state"):
+            ugp._set_attributes()
+
+        assert ugp._attr_elapsed_time == 12.0
+        assert ugp._attr_elapsed_time_last_updated == 1000.0
+
+    def test_unknown_position_is_ignored(self) -> None:
+        """A member that reports no position leaves the group's own anchor in place."""
+        ugp = self._ugp_with_member(self._member(None, 2000.0))
+
+        with patch.object(ugp, "update_state"):
+            ugp._set_attributes()
+
+        assert ugp._attr_elapsed_time == 12.0
+        assert ugp._attr_elapsed_time_last_updated == 1000.0
+
+    @staticmethod
+    def _member(elapsed_time: float | None, last_updated: float | None) -> MagicMock:
+        """Create an active member reporting the given position anchor."""
+        member = _make_mock_player(
+            "m1", playback_state=PlaybackState.PLAYING, active_group="ugp_test"
+        )
+        member.state.elapsed_time = elapsed_time
+        member.state.elapsed_time_last_updated = last_updated
+        return member
+
+    @staticmethod
+    def _ugp_with_member(member: MagicMock) -> UniversalGroupPlayer:
+        """Create a playing UGP holding a stale anchor and deriving state from the member."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        ugp.stream = MagicMock()
+        ugp.stream.done = False
+        ugp._attr_playback_state = PlaybackState.PLAYING
+        ugp._attr_elapsed_time = 12.0
+        ugp._attr_elapsed_time_last_updated = 1000.0
+        mass.players.iter_group_members.side_effect = lambda *_args, **_kwargs: iter([member])
+        return ugp
+
+
 class TestFakePowerLifecycle:
     """When the user assigns Fake power control, power(True/False) drives form/dissolve."""
 

--- a/tests/providers/universal_group/test_universal_group.py
+++ b/tests/providers/universal_group/test_universal_group.py
@@ -329,7 +329,7 @@ class TestMemberPositionPropagation:
 
     def test_position_without_timestamp_is_ignored(self) -> None:
         """A position without its timestamp is unusable, so the group keeps its anchor."""
-        ugp = self._ugp_with_member(self._member(0.0, None))
+        ugp = self._ugp_with_member(self._member(42.0, None))
 
         with patch.object(ugp, "update_state"):
             ugp._set_attributes()


### PR DESCRIPTION
# What does this implement/fix?

A playback position of exactly `0` was read as "no position reported" instead of as the valid position it is (the very start of a track).

For a universal group this meant the group never adopted the position its member reported when that position was `0`, and kept the optimistic anchor it set itself when playback started. Members that serve the group stream from a buffer (Snapcast, for example) always report position `0` and let the timestamp carry the correction for their buffer delay — so those groups showed a position that ran a couple of seconds ahead of the actual audio for the whole session. The AriaCast receiver had the same issue and told its senders the position was unknown at the start of every track.

## Changes

- Universal group: adopt a member's position of `0` instead of discarding it, and take the position and its timestamp as a pair so an incomplete anchor is skipped.
- AriaCast receiver: report position `0` to senders instead of "unknown", and stop dropping a position of `0` coming *from* a sender (the camelCase/snake_case fallback ran on the value instead of on the key, so a `0` fell through and the stale position was kept).
- Tests for all three.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
