### PR TITLE
Stop the dependency check from blaming a PR for a vulnerability it did not introduce

### DIFF
--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -142,6 +142,7 @@ jobs:
           git show origin/$BASE_BRANCH:requirements_all.txt > base_requirements.txt
           echo "pip-audit" >> base_requirements.txt
 
+          # Step 1 leaves the PR's own requirements_all.txt in place, in sync or not
           cp requirements_all.txt head_requirements.txt
           echo "pip-audit" >> head_requirements.txt
 
@@ -172,7 +173,7 @@ jobs:
               echo "⚠️  **Vulnerabilities detected in the dependencies this PR introduces!**" >> audit_report.md
               ;;
             preexisting)
-              echo "ℹ️  The findings above are already present on the target branch, so this PR does not introduce them." >> audit_report.md
+              echo "ℹ️  The findings above are not ones this PR introduces." >> audit_report.md
               ;;
             scan_failed)
               echo "❌ The vulnerability scan could not be completed." >> audit_report.md

--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -129,20 +129,26 @@ jobs:
 
           cat deps_report.md
 
-      # Step 3: Resolve what the target branch installs, so findings can be split into
-      # ones this PR introduces and ones that already exist there. Resolving is enough,
-      # no second environment has to be installed. pip-audit is included because it is
-      # part of the audited environment. On failure no file is written and the audit
-      # falls back to comparing the changed requirements.
-      - name: Resolve target branch dependencies
+      # Step 3: Resolve what both branches install, so findings can be split into ones
+      # this PR introduces and ones that already exist on the target branch. Resolving is
+      # enough, no second environment has to be installed. pip-audit is included because
+      # it is part of the audited environment. Both are resolved back to back so that a
+      # release published mid-run cannot make them disagree. On failure no file is written
+      # and the audit falls back to comparing the changed requirements.
+      - name: Resolve branch dependencies
         continue-on-error: true
         run: |
           BASE_BRANCH="${{ github.base_ref }}"
           git show origin/$BASE_BRANCH:requirements_all.txt > base_requirements.txt
           echo "pip-audit" >> base_requirements.txt
 
+          cp requirements_all.txt head_requirements.txt
+          echo "pip-audit" >> head_requirements.txt
+
           uv pip compile --index-strategy unsafe-best-match --python .venv/bin/python \
             --no-annotate --no-header base_requirements.txt -o base_closure.txt
+          uv pip compile --index-strategy unsafe-best-match --python .venv/bin/python \
+            --no-annotate --no-header head_requirements.txt -o head_closure.txt
 
       # Step 4: Run pip-audit for known vulnerabilities. The audit covers the whole
       # installed environment, so only findings this PR introduces gate it; the ones
@@ -157,7 +163,7 @@ jobs:
           .venv/bin/pip-audit --format=json --output=audit.json || true
 
           # Gate when the scan itself could not be completed, rather than pass silently
-          STATUS=$(python3 scripts/audit_changed_packages.py audit.json new_deps.txt base_closure.txt) || STATUS=scan_failed
+          STATUS=$(python3 scripts/audit_changed_packages.py audit.json new_deps.txt base_closure.txt head_closure.txt) || STATUS=scan_failed
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
           echo "" >> audit_report.md

--- a/scripts/audit_changed_packages.py
+++ b/scripts/audit_changed_packages.py
@@ -14,7 +14,7 @@ published in between must not read as a finding the pull request brings in.
 
 Prints the status the reporting workflow gates on:
     pass         no known vulnerabilities at all
-    preexisting  vulnerabilities exist, but the target branch has all of them too
+    preexisting  vulnerabilities exist, but none of them are this pull request's doing
     fail         vulnerabilities this pull request introduces
 
 Usage:

--- a/scripts/audit_changed_packages.py
+++ b/scripts/audit_changed_packages.py
@@ -8,7 +8,9 @@ author cannot act on them, and the resulting status is not overridable by a main
 Findings are compared against the resolved dependency set of the target branch, so one
 that reaches the environment through a transitive dependency gates as well. Without that
 set the comparison falls back to the requirement lines the pull request changes, which
-covers direct dependencies only.
+covers direct dependencies only. The pull request's own resolved set is taken into account
+as well: the environment is installed before either branch is resolved, so a release
+published in between must not read as a finding the pull request brings in.
 
 Prints the status the reporting workflow gates on:
     pass         no known vulnerabilities at all
@@ -16,7 +18,8 @@ Prints the status the reporting workflow gates on:
     fail         vulnerabilities this pull request introduces
 
 Usage:
-    python3 scripts/audit_changed_packages.py audit.json new_deps.txt [base_closure.txt]
+    python3 scripts/audit_changed_packages.py audit.json new_deps.txt \
+        [base_closure.txt] [head_closure.txt]
 """
 
 from __future__ import annotations
@@ -115,7 +118,27 @@ def introduced_packages(
     return introduced
 
 
-def audit_status(audit: str, requirements: str, base_closure: str = "") -> str:
+def resolved_findings(
+    findings: set[tuple[str, str]], resolved: dict[str, set[str]]
+) -> set[tuple[str, str]]:
+    """
+    Return the findings the given resolved dependency set installs.
+
+    :param findings: Vulnerable packages as (name, version) pairs.
+    :param resolved: Versions the dependency set resolves to, keyed on package name.
+    """
+    return {
+        (name, version)
+        for name, version in findings
+        # A URL requirement carries no version to compare against, so its presence is
+        # all that can be matched on
+        if (pinned := resolved.get(name)) is not None and (not pinned or version in pinned)
+    }
+
+
+def audit_status(
+    audit: str, requirements: str, base_closure: str = "", head_closure: str = ""
+) -> str:
     """
     Return `pass`, `preexisting` or `fail` for the given audit report.
 
@@ -123,18 +146,22 @@ def audit_status(audit: str, requirements: str, base_closure: str = "") -> str:
     :param requirements: Requirement lines the pull request adds or changes, one per line.
     :param base_closure: The target branch's resolved dependency set as pinned requirement
         lines. When empty, only the changed requirement lines are compared.
+    :param head_closure: The pull request's own resolved dependency set as pinned requirement
+        lines. When empty, every introduced finding gates.
     """
     findings = vulnerable_packages(audit)
     if not findings:
         return "pass"
 
     if base_closure.strip():
-        resolved = requirement_versions(base_closure)
-        # A resolution that cannot be read would mark every finding as introduced
-        if not resolved:
-            raise ValueError("No packages found in the resolved dependency set")
         changed = changed_packages(requirements)
-        return "fail" if introduced_packages(findings, resolved, changed) else "preexisting"
+        introduced = introduced_packages(findings, _resolution(base_closure), changed)
+        # The environment is installed before either branch is resolved, so a release
+        # published in between reads as introduced. Gate only on the findings the pull
+        # request's own resolution carries as well.
+        if head_closure.strip():
+            introduced = resolved_findings(introduced, _resolution(head_closure))
+        return "fail" if introduced else "preexisting"
 
     changed = changed_packages(requirements)
     return "fail" if {name for name, _ in findings} & changed else "preexisting"
@@ -153,16 +180,39 @@ def main(argv: list[str] | None = None) -> int:
         nargs="?",
         help="Resolved dependency set of the branch the pull request targets.",
     )
+    parser.add_argument(
+        "head_closure",
+        type=Path,
+        nargs="?",
+        help="Resolved dependency set of the pull request itself.",
+    )
     args = parser.parse_args(argv)
 
     # The requirements file is only written when the pull request changes dependencies,
-    # the resolved set only when resolving the target branch succeeded
-    requirements = args.requirements.read_text() if args.requirements.is_file() else ""
-    base_closure = (
-        args.base_closure.read_text() if args.base_closure and args.base_closure.is_file() else ""
+    # the resolved sets only when resolving them succeeded
+    print(
+        audit_status(
+            args.audit.read_text(),
+            _read_optional(args.requirements),
+            _read_optional(args.base_closure),
+            _read_optional(args.head_closure),
+        )
     )
-    print(audit_status(args.audit.read_text(), requirements, base_closure))
     return 0
+
+
+def _read_optional(path: Path | None) -> str:
+    """Return the contents of a file the workflow writes conditionally."""
+    return path.read_text() if path and path.is_file() else ""
+
+
+def _resolution(closure: str) -> dict[str, set[str]]:
+    """Return the versions the given resolved dependency set pins."""
+    resolved = requirement_versions(closure)
+    # A resolution that cannot be read would silently reclassify every finding
+    if not resolved:
+        raise ValueError("No packages found in the resolved dependency set")
+    return resolved
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_audit_changed_packages.py
+++ b/tests/scripts/test_audit_changed_packages.py
@@ -14,6 +14,7 @@ from scripts.audit_changed_packages import (
     main,
     normalize,
     requirement_versions,
+    resolved_findings,
     vulnerable_packages,
 )
 
@@ -138,6 +139,21 @@ def test_introduced_packages_reads_a_url_pin_from_the_changed_requirements() -> 
     assert introduced_packages(findings, resolved, {"aiolibdatachannel"}) == findings
 
 
+def test_resolved_findings_keeps_what_the_set_installs() -> None:
+    """Only findings the resolved set carries count; a URL requirement matches on name alone."""
+    resolved = {"aiohttp": {"3.14.1"}, "aiolibdatachannel": set()}
+    findings = {
+        ("aiohttp", "3.14.1"),
+        ("aiohttp", "3.14.3"),
+        ("transformers", "5.14.1"),
+        ("aiolibdatachannel", "0.1.0"),
+    }
+    assert resolved_findings(findings, resolved) == {
+        ("aiohttp", "3.14.1"),
+        ("aiolibdatachannel", "0.1.0"),
+    }
+
+
 def test_no_findings_passes() -> None:
     """A clean audit passes even when the pull request changes dependencies."""
     assert audit_status(audit_report(), "aiohttp==3.14.1", BASE_CLOSURE) == "pass"
@@ -162,6 +178,25 @@ def test_findings_in_a_new_transitive_package_fail() -> None:
     )
 
 
+def test_a_release_published_during_the_run_is_not_gated() -> None:
+    """The environment is installed before either branch is resolved; that skew must not gate."""
+    # Both branches resolve to the release that landed after the environment was installed
+    closure = "aiohttp==3.14.3\nclean-package==1.0.0\n"
+    report = audit_report("aiohttp==3.14.1")
+    changed = "music-assistant-models==1.1.183"
+
+    assert audit_status(report, changed, closure) == "fail"
+    assert audit_status(report, changed, closure, closure) == "preexisting"
+
+
+def test_findings_the_pull_request_resolves_to_still_fail() -> None:
+    """A bumped version the pull request's own resolution carries is genuinely introduced."""
+    head_closure = "aiohttp==3.14.3\nclean-package==1.0.0\n"
+    report = audit_report("aiohttp==3.14.3")
+
+    assert audit_status(report, "aiohttp==3.14.3", BASE_CLOSURE, head_closure) == "fail"
+
+
 def test_swapping_a_url_pin_for_a_vulnerable_release_fails() -> None:
     """Replacing a URL requirement with a published version brings that version in."""
     base_closure = "aiolibdatachannel @ git+https://github.com/example/aiolibdatachannel@v1"
@@ -175,6 +210,17 @@ def test_an_unreadable_target_branch_set_raises() -> None:
     """A resolved set no package can be read from must fail loudly rather than gate everything."""
     with pytest.raises(ValueError, match="No packages"):
         audit_status(audit_report("aiohttp"), "", '{"packages": [{"name": "aiohttp"}]}')
+
+
+def test_an_unreadable_pull_request_set_raises() -> None:
+    """The same holds the other way around: it would clear every finding instead."""
+    with pytest.raises(ValueError, match="No packages"):
+        audit_status(
+            audit_report("aiohttp==3.14.3"),
+            "aiohttp==3.14.3",
+            BASE_CLOSURE,
+            '{"packages": [{"name": "aiohttp"}]}',
+        )
 
 
 def test_findings_without_a_target_branch_set_compare_changed_requirements() -> None:
@@ -204,6 +250,21 @@ def test_main_prints_status(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
 
     assert main([str(audit), str(requirements), str(base_closure)]) == 0
     assert capsys.readouterr().out.strip() == "fail"
+
+
+def test_main_reads_the_head_resolution(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The pull request's own resolved set narrows the findings that gate."""
+    audit = tmp_path / "audit.json"
+    audit.write_text(audit_report("aiohttp==3.14.1"))
+    requirements = tmp_path / "new_deps.txt"
+    requirements.write_text("music-assistant-models==1.1.183\n")
+    base_closure = tmp_path / "base_closure.txt"
+    base_closure.write_text("aiohttp==3.14.3\n")
+    head_closure = tmp_path / "head_closure.txt"
+    head_closure.write_text("aiohttp==3.14.3\n")
+
+    assert main([str(audit), str(requirements), str(base_closure), str(head_closure)]) == 0
+    assert capsys.readouterr().out.strip() == "preexisting"
 
 
 def test_main_without_a_base_closure_file(

--- a/tests/scripts/test_audit_changed_packages.py
+++ b/tests/scripts/test_audit_changed_packages.py
@@ -161,9 +161,10 @@ def test_no_findings_passes() -> None:
 
 def test_findings_the_target_branch_has_too_are_preexisting() -> None:
     """Vulnerabilities the target branch already installs describe it, not the pull request."""
-    assert audit_status(audit_report("aiohttp==3.14.1"), "aiohttp==3.14.1", BASE_CLOSURE) == (
-        "preexisting"
-    )
+    report = audit_report("aiohttp==3.14.1")
+
+    assert audit_status(report, "aiohttp==3.14.1", BASE_CLOSURE) == "preexisting"
+    assert audit_status(report, "aiohttp==3.14.1", BASE_CLOSURE, BASE_CLOSURE) == "preexisting"
 
 
 def test_findings_in_a_bumped_package_fail() -> None:
@@ -204,6 +205,15 @@ def test_swapping_a_url_pin_for_a_vulnerable_release_fails() -> None:
 
     assert audit_status(report, "aiolibdatachannel==0.1.0", base_closure) == "fail"
     assert audit_status(report, "", base_closure) == "preexisting"
+
+
+def test_a_changed_url_pin_fails_against_both_resolutions() -> None:
+    """A URL requirement pins no version, so the pull request's resolution matches on name."""
+    base_closure = "aiolibdatachannel @ git+https://github.com/example/aiolibdatachannel@v1"
+    head_closure = "aiolibdatachannel @ git+https://github.com/example/aiolibdatachannel@v2"
+    report = audit_report("aiolibdatachannel==0.1.0")
+
+    assert audit_status(report, head_closure, base_closure, head_closure) == "fail"
 
 
 def test_an_unreadable_target_branch_set_raises() -> None:
@@ -252,18 +262,23 @@ def test_main_prints_status(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
     assert capsys.readouterr().out.strip() == "fail"
 
 
-def test_main_reads_the_head_resolution(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    """The pull request's own resolved set narrows the findings that gate."""
+def test_main_reads_the_resolutions_in_order(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The target branch is the third argument, the pull request's own set the fourth."""
     audit = tmp_path / "audit.json"
     audit.write_text(audit_report("aiohttp==3.14.1"))
     requirements = tmp_path / "new_deps.txt"
     requirements.write_text("music-assistant-models==1.1.183\n")
-    base_closure = tmp_path / "base_closure.txt"
-    base_closure.write_text("aiohttp==3.14.3\n")
-    head_closure = tmp_path / "head_closure.txt"
-    head_closure.write_text("aiohttp==3.14.3\n")
+    without = tmp_path / "without.txt"
+    without.write_text("aiohttp==3.14.3\n")
+    carrying = tmp_path / "carrying.txt"
+    carrying.write_text("aiohttp==3.14.1\n")
 
-    assert main([str(audit), str(requirements), str(base_closure), str(head_closure)]) == 0
+    assert main([str(audit), str(requirements), str(without), str(carrying)]) == 0
+    assert capsys.readouterr().out.strip() == "fail"
+
+    assert main([str(audit), str(requirements), str(carrying), str(without)]) == 0
     assert capsys.readouterr().out.strip() == "preexisting"
 
 


### PR DESCRIPTION
# What does this implement/fix?

The dependency security check installs the environment first and only resolves the target branch about a minute later. Most of the ~300 packages are not pinned to an exact version, so a release published in that window makes the two disagree: the check then sees a version the target branch "does not have" and blames the PR for a vulnerability it never touched. That produces a hard, non-overridable failure on an innocent PR, only clearable by re-running the job.

The PR's own dependency set is now resolved right next to the target branch's, and a finding only gates when that resolution carries it too. The window shrinks from about a minute to a second, and anything left over errs towards reporting a finding instead of blocking on it.

**Related issue (if applicable):**

- follow-up to #5424

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Resolve both branches back to back in the audit workflow instead of the target branch alone (~2s extra, no second install)
- Gate a finding only when the PR's own resolution contains that exact package and version
- Keep the previous behaviour when that resolution is unavailable
- Fail loudly rather than silently clearing findings when a resolution cannot be read
- Reword the report line for findings a PR does not introduce, which no longer always means the target branch has them

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
