### PR TITLE
Remove duplicated code around waiting for shared work

### DIFF
--- a/music_assistant/helpers/colors.py
+++ b/music_assistant/helpers/colors.py
@@ -26,6 +26,7 @@ from music_assistant.helpers.images import (
     create_thumb_hash,
     get_image_data,
 )
+from music_assistant.helpers.util import join_task
 
 if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
@@ -270,14 +271,7 @@ async def get_palette(
         task_id=f"palette.{key}",
         abort_existing=False,
     )
-    # wait for the shared extraction instead of awaiting it directly: a caller awaiting a
-    # task holds it as its fut_waiter, so cancelling that caller would cancel the
-    # extraction for every other caller too. asyncio.shield achieves the same, but as of
-    # Python 3.14 a cancelled caller makes it report the extraction's exception through
-    # loop.call_exception_handler, even when another caller already handled it.
-    if not task.done():
-        await asyncio.wait((task,))
-    return task.result()
+    return await join_task(task)
 
 
 async def invalidate_cached_palette(mass: MusicAssistant, provider: str, path_or_url: str) -> None:

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -30,6 +30,7 @@ from PIL import Image, UnidentifiedImageError
 from music_assistant.constants import APPLICATION_NAME
 from music_assistant.helpers.security import is_safe_path
 from music_assistant.helpers.tags import get_embedded_image
+from music_assistant.helpers.util import join_task
 from music_assistant.models.metadata_provider import MetadataProvider
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.models.player_provider import PlayerProvider
@@ -325,14 +326,7 @@ async def get_image_data(
         task_id=f"imgsrc.{cache_key}",
         abort_existing=False,
     )
-    # wait for the shared fetch instead of awaiting it directly: a caller awaiting a task
-    # holds it as its fut_waiter, so cancelling that caller would cancel the fetch for
-    # every other caller too. asyncio.shield achieves the same, but as of Python 3.14 a
-    # cancelled caller makes it report the fetch's exception through
-    # loop.call_exception_handler, even when another caller already handled it.
-    if not task.done():
-        await asyncio.wait((task,))
-    return task.result()
+    return await join_task(task)
 
 
 async def _resolve_own_imageproxy_url(mass: MusicAssistant, url: str) -> tuple[str, str] | None:
@@ -639,10 +633,7 @@ async def _get_image_thumb(
         task_id=f"thumb.{cache_filename}",
         abort_existing=False,
     )
-    # wait for the shared generation rather than awaiting it: see get_image_data
-    if not task.done():
-        await asyncio.wait((task,))
-    thumb_data = task.result()
+    thumb_data = await join_task(task)
     _put_in_memory_cache(cache_filename, thumb_data)
     return thumb_data, cache_filepath
 

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -1010,14 +1010,7 @@ async def _get_ip_addresses(include_ipv6: bool, publish_candidates_only: bool) -
         pending = asyncio.create_task(_probe())
         pending.add_done_callback(_log_ip_probe_failure)
         _ip_addresses_pending[cache_key] = pending
-    # wait for the shared probe instead of awaiting it directly: a caller awaiting a task
-    # holds it as its fut_waiter, so cancelling that caller would otherwise cancel the probe
-    # for all other callers. asyncio.shield achieves the same, but as of Python 3.14 a
-    # cancelled caller makes it report the probe's exception through
-    # loop.call_exception_handler, even when another caller already handled it.
-    if not pending.done():
-        await asyncio.wait((pending,))
-    return pending.result()
+    return await join_task(pending)
 
 
 def _log_ip_probe_failure(probe: asyncio.Task[tuple[str, ...]]) -> None:
@@ -2116,13 +2109,6 @@ def guard_single_request[SelfT: _SupportsMass, **P, R](
             eager_start=True,
             **kwargs,
         )
-        # wait for the shared task instead of awaiting it directly: a caller awaiting a
-        # task holds it as its fut_waiter, so cancelling that caller would cancel the
-        # request for every other caller too. asyncio.shield achieves the same, but as of
-        # Python 3.14 a cancelled caller makes it report the request's exception through
-        # loop.call_exception_handler, even when another caller already handled it.
-        if not task.done():
-            await asyncio.wait((task,))
-        return task.result()
+        return await join_task(task)
 
     return wrapper

--- a/music_assistant/models/recommendation_payload.py
+++ b/music_assistant/models/recommendation_payload.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, TypeVar, cast
 from music_assistant_models.media_items import RecommendationFolder
 from music_assistant_models.unique_list import UniqueList
 
+from music_assistant.helpers.util import join_task
+
 if TYPE_CHECKING:
     from collections.abc import Coroutine
     from typing import Any
@@ -136,14 +138,9 @@ class RecommendationPayloadMixin(_MixinBase):
                 task_id=f"recommendation_payload_fetch.{self.instance_id}",
             )
             self._recommendation_payload_task = task
-        # wait for the shared load instead of awaiting it directly: a timed-out caller must
-        # not cancel it out from under the other waiters (and the load must still complete
-        # to warm memory + cache). asyncio.shield achieves the same, but as of Python 3.14 a
-        # cancelled caller makes it report the load's exception through
-        # loop.call_exception_handler, even when another caller already handled it.
-        if not task.done():
-            await asyncio.wait((task,))
-        return task.result()
+        # a timed-out caller must not cancel the load: it still has to complete to warm
+        # memory + cache for the other waiters
+        return await join_task(task)
 
     async def _refresh_recommendation_payload(self) -> list[RecommendationFolder]:
         """
@@ -153,11 +150,8 @@ class RecommendationPayloadMixin(_MixinBase):
         cached payload is known to be outdated (e.g. after detecting rotated backend ids).
         Subsequent _recommendation_payload calls serve the refreshed payload.
         """
-        # wait for the shared refresh rather than awaiting it: see _recommendation_payload
         task = self._schedule_recommendation_refresh()
-        if not task.done():
-            await asyncio.wait((task,))
-        return task.result()
+        return await join_task(task)
 
     def _schedule_recommendation_refresh(self) -> asyncio.Task[list[RecommendationFolder]]:
         """Return the in-flight refresh task, starting one if none is running."""


### PR DESCRIPTION
# What does this implement/fix?

PR #5453 added a `join_task()` helper for waiting on work that is shared between callers. Seven older call sites still had their own copy of exactly the same code, each with the same five-line explanation attached, so the codebase had two ways of doing one thing.

These now all use the helper. No behaviour change — the helper does exactly what the inlined code did, and the existing tests pass untouched.

- Converted the remaining hand-rolled waits in `helpers/util.py`, `helpers/colors.py`, `helpers/images.py` and `models/recommendation_payload.py` to `join_task()`
- Dropped the duplicated explanation comments (that reasoning now lives in the helper itself), keeping the one site-specific note

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
