### PR TITLE
Keep a muted speaker working normally after it leaves a group

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -941,12 +941,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         # Set mute lock for players in a group
         # This prevents auto-unmute when group volume changes
         had_mute_lock = ATTR_MUTE_LOCK in player.extra_data
-        # a sync leader has neither synced_to nor active_group set, but it does lead its
-        # own group_members, which stays empty for a player that is not grouped at all
-        is_in_group = bool(
-            player.state.synced_to or player.state.active_group or player.state.group_members
-        )
-        if muted and is_in_group:
+        if muted and self._is_in_group(player.state):
             player.extra_data[ATTR_MUTE_LOCK] = True
 
         try:
@@ -3450,13 +3445,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
 
         # Check if player has mute lock (set when individually muted in a group)
         # If locked, don't auto-unmute when volume changes
-        # Also check the protocol parent player, because cmd_volume_mute stores
-        # the lock on the parent player while this method may be called with
-        # the protocol player ID (e.g. during group volume changes).
-        has_mute_lock = player.extra_data.get(ATTR_MUTE_LOCK, False)
-        if not has_mute_lock and player.protocol_parent_id:
-            if parent := self.get_player(player.protocol_parent_id):
-                has_mute_lock = parent.extra_data.get(ATTR_MUTE_LOCK, False)
+        has_mute_lock = self._has_active_mute_lock(player)
         if (
             not has_mute_lock
             # the live value is what cmd_volume_mute checks, so a control change that
@@ -3538,6 +3527,28 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             )
             await self._handle_cmd_volume_set(protocol_player.player_id, device_volume)
             return
+
+    @staticmethod
+    def _is_in_group(state: PlayerState) -> bool:
+        """Check if the given player is currently grouped with other players."""
+        # a sync leader has neither synced_to nor active_group set, but it does lead its
+        # own group_members, which stays empty for a player that is not grouped at all
+        return bool(state.synced_to or state.active_group or state.group_members)
+
+    def _has_active_mute_lock(self, player: Player) -> bool:
+        """
+        Check if the given player holds a mute lock that still applies to it.
+
+        A lock is only earned inside a group and only holds for as long as the player
+        is still grouped, so it can not outlive the group it was earned in.
+        """
+        if player.extra_data.get(ATTR_MUTE_LOCK) and self._is_in_group(player.state):
+            return True
+        # cmd_volume_mute stores the lock on the parent player, while the volume command
+        # may arrive with the protocol player ID (e.g. during group volume changes)
+        if player.protocol_parent_id and (parent := self.get_player(player.protocol_parent_id)):
+            return bool(parent.extra_data.get(ATTR_MUTE_LOCK)) and self._is_in_group(parent.state)
+        return False
 
     async def _mute_group_members(self, group_player: Player, muted: bool) -> None:
         """

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3530,7 +3530,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
 
     @staticmethod
     def _is_in_group(state: PlayerState) -> bool:
-        """Check if the given player is currently grouped with other players."""
+        """Check if the player with the given state is currently grouped with other players."""
         # a sync leader has neither synced_to nor active_group set, but it does lead its
         # own group_members, which stays empty for a player that is not grouped at all
         return bool(state.synced_to or state.active_group or state.group_members)
@@ -3541,6 +3541,8 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
 
         A lock is only earned inside a group and only holds for as long as the player
         is still grouped, so it can not outlive the group it was earned in.
+
+        :param player: The player to check, which may be a protocol player.
         """
         if player.extra_data.get(ATTR_MUTE_LOCK) and self._is_in_group(player.state):
             return True

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -2107,6 +2107,54 @@ class TestMuteLockAfterUngroup:
         assert players["member"].state.volume_level == 0
         assert players["member"].state.volume_muted is True
 
+    async def test_protocol_player_follows_the_lock_of_its_parent(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A protocol player inherits the lock of the parent it renders for, group and all."""
+        controller, players = self._make_synced_pair(mock_mass, PLAYER_CONTROL_NATIVE)
+        member = players["member"]
+        protocol_player = MockPlayer(
+            MockProvider("sendspin", instance_id="sendspin", mass=mock_mass),
+            "proto_member",
+            "Member Protocol",
+            player_type=PlayerType.PROTOCOL,
+        )
+        protocol_player._attr_supported_features = {
+            PlayerFeature.VOLUME_SET,
+            PlayerFeature.VOLUME_MUTE,
+        }
+        protocol_player._attr_volume_muted = True
+        protocol_player.set_protocol_parent_id("member")
+        # an unmute on a protocol player is redirected to the parent it renders for
+        mute = AsyncMock()
+        member.volume_mute = mute  # type: ignore[method-assign]
+        protocol_player.volume_mute = AsyncMock()  # type: ignore[method-assign]
+        protocol_player.volume_set = AsyncMock()  # type: ignore[method-assign]
+        controller._players["proto_member"] = protocol_player
+        member.set_linked_output_protocols(
+            [
+                OutputProtocol(
+                    output_protocol_id="proto_member",
+                    name="Sendspin",
+                    protocol_domain="sendspin",
+                    priority=40,
+                )
+            ]
+        )
+        protocol_player.set_initialized()
+        protocol_player.update_state(signal_event=False)
+        member.refresh_state(signal_event=False)
+        member.extra_data[ATTR_MUTE_LOCK] = True
+
+        # a group volume change reaches the protocol player through the internal handler
+        await controller._handle_cmd_volume_set("proto_member", 70)
+        mute.assert_not_awaited()
+
+        self._dissolve_group(players)
+        await controller._handle_cmd_volume_set("proto_member", 70)
+
+        mute.assert_awaited_once_with(False)
+
 
 class TestCurrentMediaTimeUpdates:
     """Playback-position anchor semantics of timing-only state updates."""

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -2021,6 +2021,93 @@ class TestGroupMuteOnNonGroupPlayer:
             mute.assert_not_awaited()
 
 
+class TestMuteLockAfterUngroup:
+    """A mute lock is only honored while the player it belongs to is still grouped."""
+
+    def _make_synced_pair(
+        self, mock_mass: MagicMock, member_mute_control: str
+    ) -> tuple[PlayerController, dict[str, MockPlayer]]:
+        """
+        Build a leader with one synced member.
+
+        :param member_mute_control: Mute control to configure on both players.
+        """
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_player_config_stub({CONF_MUTE_CONTROL: member_mute_control})
+        )
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        players: dict[str, MockPlayer] = {}
+        for player_id in ("leader", "member"):
+            player = MockPlayer(provider, player_id, player_id.title())
+            player._attr_supported_features = {
+                PlayerFeature.VOLUME_SET,
+                PlayerFeature.VOLUME_MUTE,
+            }
+            player._attr_volume_level = 50
+            player.volume_set = AsyncMock(  # type: ignore[method-assign]
+                side_effect=lambda volume, _player=player: setattr(
+                    _player, "_attr_volume_level", volume
+                )
+            )
+            players[player_id] = player
+        players["leader"]._attr_group_members = ["member"]
+        controller._players = dict(players)
+        mock_mass.players = controller
+        mock_mass.player_queues.get = MagicMock(return_value=None)
+        for player in players.values():
+            player.set_initialized()
+            player._cache.clear()
+            player.update_state(signal_event=False)
+        return controller, players
+
+    def _dissolve_group(self, players: dict[str, MockPlayer]) -> None:
+        """Drop the sync group, the way a provider side topology change does."""
+        players["leader"]._attr_group_members = []
+        for player in players.values():
+            player.refresh_state(signal_event=False)
+
+    async def test_fake_muted_player_follows_volume_again(self, mock_mass: MagicMock) -> None:
+        """A fake muted player is no longer forced silent once its group is gone."""
+        controller, players = self._make_synced_pair(mock_mass, PLAYER_CONTROL_FAKE)
+        await controller.cmd_volume_mute("member", True)
+        self._dissolve_group(players)
+
+        await controller.cmd_volume_set("member", 70)
+
+        players["member"].update_state()
+        assert players["member"].state.volume_level == 70
+        assert players["member"].state.volume_muted is False
+
+    async def test_natively_muted_player_is_unmuted_again(self, mock_mass: MagicMock) -> None:
+        """A natively muted player is auto-unmuted by a volume change once its group is gone."""
+        controller, players = self._make_synced_pair(mock_mass, PLAYER_CONTROL_NATIVE)
+        mute = AsyncMock(
+            side_effect=lambda muted: setattr(players["member"], "_attr_volume_muted", muted)
+        )
+        players["member"].volume_mute = mute  # type: ignore[method-assign]
+        await controller.cmd_volume_mute("member", True)
+        self._dissolve_group(players)
+
+        await controller.cmd_volume_set("member", 70)
+
+        assert mute.await_args_list == [call(True), call(False)]
+        players["member"].update_state()
+        assert players["member"].state.volume_level == 70
+        assert players["member"].state.volume_muted is False
+
+    async def test_still_grouped_player_keeps_its_lock(self, mock_mass: MagicMock) -> None:
+        """A muted player that is still grouped stays silent on a volume change."""
+        controller, players = self._make_synced_pair(mock_mass, PLAYER_CONTROL_FAKE)
+        await controller.cmd_volume_mute("member", True)
+
+        await controller.cmd_volume_set("member", 70)
+
+        players["member"].update_state()
+        assert players["member"].state.volume_level == 0
+        assert players["member"].state.volume_muted is True
+
+
 class TestCurrentMediaTimeUpdates:
     """Playback-position anchor semantics of timing-only state updates."""
 


### PR DESCRIPTION
# What does this implement/fix?

When a player is muted while it is part of a group, we remember that with a "mute lock" so a
group volume change does not bring it back to life. That lock was never cleared once the player
left the group, so an ungrouped speaker could keep behaving as if it were still a muted group
member: it was no longer auto-unmuted by a volume change, and a speaker using fake mute even had
its volume forced back to 0 on every volume command.

The lock is now only honoured for as long as the player is actually grouped — the same condition
under which it is set. That also covers groups that fall apart outside Music Assistant (Home
Assistant and WiiM report their group members straight from the device), which no cleanup on our
own ungroup commands would have caught.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

One side effect worth calling out: an announcement aimed at a single muted speaker that was in
a group releases that speaker from the group first, so it is now turned up for the announcement
instead of announcing into a muted speaker. That matches what already happens for a muted
speaker that was not in a group.

## Changes

- A mute lock is only applied while the player is still synced, in a group, or leading one.
- Moved the group check and the mute lock lookup into small shared helpers.
- Added regression tests for a muted player whose group disappears, for both native and fake
  mute, and for a player that plays through a separate streaming protocol.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
