### PR TITLE
Make the Tidal ISRC lookup test check the real API URL

### DIFF
--- a/tests/providers/tidal/test_streaming.py
+++ b/tests/providers/tidal/test_streaming.py
@@ -10,6 +10,7 @@ from music_assistant_models.enums import ContentType, ExternalID, StreamType
 from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import AudioFormat, Track
 
+from music_assistant.providers.tidal.constants import OPEN_API_URL
 from music_assistant.providers.tidal.streaming import TidalStreamingManager
 
 
@@ -17,7 +18,6 @@ from music_assistant.providers.tidal.streaming import TidalStreamingManager
 def provider_mock(provider_mock: Mock) -> Mock:
     """Return the shared provider mock with the streaming quality and throttler bypass wired."""
     provider_mock.config.get_value.return_value = "HIGH"
-    provider_mock.api.OPEN_API_URL = "https://openapi.tidal.com/v2"
 
     # the streaming manager enters api.throttler.bypass() as an async context manager,
     # which a MagicMock supports out of the box
@@ -315,7 +315,7 @@ async def test_get_track_by_isrc_cache_miss_lookup_success(
     provider_mock.api.get.assert_called_with(
         "tracks",
         params={"filter[isrc]": "US1234567890"},
-        base_url=provider_mock.api.OPEN_API_URL,
+        base_url=OPEN_API_URL,
     )
 
     # Verify cache set


### PR DESCRIPTION
# What does this implement/fix?

A Tidal test checked that the ISRC lookup is sent to the Tidal open API, but it compared the URL against a value the test fixture had made up itself rather than the URL the provider actually uses. The check passed only because the two strings happened to be identical, so it would not have noticed if the lookup stopped targeting the open API.

The test now compares against the provider's real `OPEN_API_URL` constant.

- Import `OPEN_API_URL` from the Tidal provider constants in `tests/providers/tidal/test_streaming.py` and assert against it
- Drop the unused `provider_mock.api.OPEN_API_URL` line from the fixture (production code never reads that attribute)

Verified by removing `base_url` from the lookup call in the provider: the test now fails, where before it passed.

Follow-up to #5459, which left this alone to keep that PR behaviour-neutral.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
