### PR TITLE
Show which vulnerability findings the dependency check set aside

### DIFF
--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -163,9 +163,12 @@ jobs:
           .venv/bin/pip-audit --desc --format=markdown >> audit_report.md 2>&1 || true
           .venv/bin/pip-audit --format=json --output=audit.json || true
 
-          # Gate when the scan itself could not be completed, rather than pass silently
-          STATUS=$(python3 scripts/audit_changed_packages.py audit.json new_deps.txt base_closure.txt head_closure.txt) || STATUS=scan_failed
+          # Gate when the scan itself could not be completed, rather than pass silently.
+          # Only the status goes to stdout; stderr carries the findings that were not
+          # gated on, and is echoed back so it stays in the job log as well.
+          STATUS=$(python3 scripts/audit_changed_packages.py audit.json new_deps.txt base_closure.txt head_closure.txt 2>audit_notes.txt) || STATUS=scan_failed
           echo "status=$STATUS" >> $GITHUB_OUTPUT
+          cat audit_notes.txt >&2
 
           echo "" >> audit_report.md
           case "$STATUS" in
@@ -182,6 +185,12 @@ jobs:
               echo "✅ No known vulnerabilities found" >> audit_report.md
               ;;
           esac
+
+          # On a failed scan stderr holds the traceback, which belongs in the log only
+          if [ "$STATUS" != "scan_failed" ] && [ -s audit_notes.txt ]; then
+            echo "" >> audit_report.md
+            echo "ℹ️  $(cat audit_notes.txt)" >> audit_report.md
+          fi
 
           if [ "$STATUS" != "pass" ] && [ ! -s base_closure.txt ]; then
             echo "" >> audit_report.md

--- a/scripts/audit_changed_packages.py
+++ b/scripts/audit_changed_packages.py
@@ -146,6 +146,8 @@ def audit_status(
     """
     Return `pass`, `preexisting` or `fail` for the given audit report.
 
+    Findings the pull request's own resolution does not carry are named on stderr.
+
     :param audit: A pip-audit report in JSON format.
     :param requirements: Requirement lines the pull request adds or changes, one per line.
     :param base_closure: The target branch's resolved dependency set as pinned requirement
@@ -208,9 +210,11 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-def _carried(pinned: set[str] | None) -> str:
+def _describe_resolution(pinned: set[str] | None) -> str:
     """Describe what a resolved dependency set holds for a package."""
-    if not pinned:
+    # A package the set carries without an exact version is never set aside, so the only
+    # findings described here are the ones it resolves to another version or not at all
+    if pinned is None:
         return "not in the resolved set"
     return "resolved to " + ", ".join(sorted(pinned))
 
@@ -225,7 +229,7 @@ def _report_set_aside(set_aside: set[tuple[str, str]], resolved: dict[str, set[s
     if not set_aside:
         return
     described = ", ".join(
-        f"`{name} {version}` ({_carried(resolved.get(name))})"
+        f"`{name} {version}` ({_describe_resolution(resolved.get(name))})"
         for name, version in sorted(set_aside)
     )
     print(

--- a/scripts/audit_changed_packages.py
+++ b/scripts/audit_changed_packages.py
@@ -17,6 +17,9 @@ Prints the status the reporting workflow gates on:
     preexisting  vulnerabilities exist, but none of them are this pull request's doing
     fail         vulnerabilities this pull request introduces
 
+Findings set aside because the pull request's own resolved set does not carry them are
+named on stderr, so a maintainer can tell a timing artifact from a wrongly cleared finding.
+
 Usage:
     python3 scripts/audit_changed_packages.py audit.json new_deps.txt \
         [base_closure.txt] [head_closure.txt]
@@ -27,6 +30,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 from pathlib import Path
 
 # ruff: noqa: T201
@@ -160,7 +164,10 @@ def audit_status(
         # published in between reads as introduced. Gate only on the findings the pull
         # request's own resolution carries as well.
         if head_closure.strip():
-            introduced = resolved_findings(introduced, _resolution(head_closure))
+            head_resolution = _resolution(head_closure)
+            carried = resolved_findings(introduced, head_resolution)
+            _report_set_aside(introduced - carried, head_resolution)
+            introduced = carried
         return "fail" if introduced else "preexisting"
 
     changed = changed_packages(requirements)
@@ -201,9 +208,31 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def _carried(pinned: set[str] | None) -> str:
+    """Describe what a resolved dependency set holds for a package."""
+    if not pinned:
+        return "not in the resolved set"
+    return "resolved to " + ", ".join(sorted(pinned))
+
+
 def _read_optional(path: Path | None) -> str:
     """Return the contents of a file the workflow writes conditionally."""
     return path.read_text() if path and path.is_file() else ""
+
+
+def _report_set_aside(set_aside: set[tuple[str, str]], resolved: dict[str, set[str]]) -> None:
+    """Name the findings that were not gated on, and what the resolution carries instead."""
+    if not set_aside:
+        return
+    described = ", ".join(
+        f"`{name} {version}` ({_carried(resolved.get(name))})"
+        for name, version in sorted(set_aside)
+    )
+    print(
+        "Not counted against this PR, because its own resolved dependencies do not"
+        f" carry them: {described}.",
+        file=sys.stderr,
+    )
 
 
 def _resolution(closure: str) -> dict[str, set[str]]:

--- a/tests/scripts/test_audit_changed_packages.py
+++ b/tests/scripts/test_audit_changed_packages.py
@@ -204,6 +204,17 @@ def test_findings_not_gated_on_are_named(capsys: pytest.CaptureFixture[str]) -> 
     assert "`transformers 5.14.1` (not in the resolved set)" in captured.err
 
 
+def test_findings_are_named_alongside_a_gating_one(capsys: pytest.CaptureFixture[str]) -> None:
+    """A pull request that introduces one finding can have another set aside at the same time."""
+    head_closure = "aiohttp==3.14.3\nclean-package==1.0.0\n"
+    report = audit_report("aiohttp==3.14.3", "transformers==5.14.1")
+
+    assert audit_status(report, "aiohttp==3.14.3", BASE_CLOSURE, head_closure) == "fail"
+    captured = capsys.readouterr()
+    assert "`transformers 5.14.1` (not in the resolved set)" in captured.err
+    assert "aiohttp" not in captured.err
+
+
 def test_gated_findings_are_not_named(capsys: pytest.CaptureFixture[str]) -> None:
     """Nothing is set aside when the pull request's own resolution carries every finding."""
     head_closure = "aiohttp==3.14.3\nclean-package==1.0.0\n"

--- a/tests/scripts/test_audit_changed_packages.py
+++ b/tests/scripts/test_audit_changed_packages.py
@@ -190,6 +190,28 @@ def test_a_release_published_during_the_run_is_not_gated() -> None:
     assert audit_status(report, changed, closure, closure) == "preexisting"
 
 
+def test_findings_not_gated_on_are_named(capsys: pytest.CaptureFixture[str]) -> None:
+    """What the pull request's resolution carries instead tells an artifact from a mistake."""
+    closure = "aiohttp==3.14.3\nclean-package==1.0.0\n"
+    report = audit_report("aiohttp==3.14.1", "transformers==5.14.1")
+
+    assert audit_status(report, "music-assistant-models==1.1.183", closure, closure) == (
+        "preexisting"
+    )
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "`aiohttp 3.14.1` (resolved to 3.14.3)" in captured.err
+    assert "`transformers 5.14.1` (not in the resolved set)" in captured.err
+
+
+def test_gated_findings_are_not_named(capsys: pytest.CaptureFixture[str]) -> None:
+    """Nothing is set aside when the pull request's own resolution carries every finding."""
+    head_closure = "aiohttp==3.14.3\nclean-package==1.0.0\n"
+
+    assert audit_status(audit_report("aiohttp==3.14.3"), "", BASE_CLOSURE, head_closure) == "fail"
+    assert capsys.readouterr().err == ""
+
+
 def test_findings_the_pull_request_resolves_to_still_fail() -> None:
     """A bumped version the pull request's own resolution carries is genuinely introduced."""
     head_closure = "aiohttp==3.14.3\nclean-package==1.0.0\n"
@@ -280,6 +302,23 @@ def test_main_reads_the_resolutions_in_order(
 
     assert main([str(audit), str(requirements), str(carrying), str(without)]) == 0
     assert capsys.readouterr().out.strip() == "preexisting"
+
+
+def test_main_keeps_the_status_alone_on_stdout(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The workflow captures stdout into its status variable, so the note goes to stderr."""
+    audit = tmp_path / "audit.json"
+    audit.write_text(audit_report("aiohttp==3.14.1"))
+    requirements = tmp_path / "new_deps.txt"
+    requirements.write_text("music-assistant-models==1.1.183\n")
+    closure = tmp_path / "closure.txt"
+    closure.write_text("aiohttp==3.14.3\nclean-package==1.0.0\n")
+
+    assert main([str(audit), str(requirements), str(closure), str(closure)]) == 0
+    captured = capsys.readouterr()
+    assert captured.out == "preexisting\n"
+    assert "`aiohttp 3.14.1` (resolved to 3.14.3)" in captured.err
 
 
 def test_main_without_a_base_closure_file(


### PR DESCRIPTION
# What does this implement/fix?

The dependency security check ignores vulnerability findings that the PR's own resolved dependencies don't contain. That filter exists because the test environment is installed before either branch is resolved, so a release published in between would otherwise be blamed on the PR.

Until now nothing said *which* findings were skipped, so the report just read "the findings above are not ones this PR introduces". That makes a genuine timing artifact indistinguishable from a finding that was wrongly cleared, and a maintainer has no way to tell them apart.

The check now names those findings and says what the PR resolves to instead, for example:

> ℹ️ Not counted against this PR, because its own resolved dependencies do not carry them: `aiohttp 3.14.1` (resolved to 3.14.3), `transformers 5.14.1` (not in the resolved set).

**Related issue (if applicable):**

- follow-up to #5462

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- `audit_changed_packages.py` names the set-aside findings on stderr, along with the version the PR's resolution carries (or that it carries none)
- The workflow appends that note to the scan report and keeps it in the job log; stdout still carries only the status it gates on
- A failed scan puts its traceback in the log only, not in the PR comment
- Tests cover the note, the case where nothing is set aside, and stdout staying clean

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
