### PR TITLE
Tidy up the helper order in the API helpers module

### DIFF
--- a/music_assistant/helpers/api.py
+++ b/music_assistant/helpers/api.py
@@ -32,6 +32,258 @@ _MODEL_TYPE_CACHE: dict[str, Any] = {}
 _MAX_TYPE_HINT_RESOLVE_ATTEMPTS = 32
 
 
+@dataclass
+class APICommandHandler:
+    """Model for an API command handler."""
+
+    command: str
+    signature: inspect.Signature
+    type_hints: dict[str, Any]
+    target: Callable[..., Coroutine[Any, Any, Any] | AsyncGenerator[Any, Any]]
+    authenticated: bool = True
+    required_scope: Scope | None = None  # None means any authenticated user
+    allow_impersonation: bool = False  # If True, the command accepts a 'user' argument
+    alias: bool = False  # If True, this is an alias for backward compatibility
+
+    @classmethod
+    def parse(
+        cls,
+        command: str,
+        func: Callable[..., Coroutine[Any, Any, Any] | AsyncGenerator[Any, Any]],
+        authenticated: bool = True,
+        required_scope: Scope | None = None,
+        allow_impersonation: bool = False,
+        alias: bool = False,
+    ) -> APICommandHandler:
+        """
+        Parse APICommandHandler by providing a function.
+
+        :param command: The command name/path.
+        :param func: The function to handle the command.
+        :param authenticated: Whether authentication is required (default: True).
+        :param required_scope: Scope required to execute the command,
+            None for any authenticated user.
+        :param allow_impersonation: Whether the command accepts a 'user' argument
+            to execute the command on behalf of another user (default: False).
+        :param alias: Whether this is an alias for backward compatibility (default: False).
+        """
+        type_hints = _get_type_hints_for_api_command(func)
+        # workaround for generic typevar ItemCls that needs to be resolved
+        # to the real media item type. TODO: find a better way to do this
+        # without this hack
+        # Import type aliases to compare against
+        from music_assistant_models.config_entries import (  # noqa: PLC0415
+            ConfigValueType as config_value_type,  # noqa: N813
+        )
+        from music_assistant_models.media_items import (  # noqa: PLC0415
+            MediaItemType as media_item_type,  # noqa: N813
+        )
+
+        for key, value in type_hints.items():
+            # Handle generic types (list, tuple, dict, etc.) that may contain TypeVars
+            # For example: list[ItemCls] should become list[Artist]
+            # For example: dict[str, ConfigValueType] should preserve ConfigValueType
+            origin = get_origin(value)
+            if origin in (list, tuple, set, frozenset, dict):
+                args = get_args(value)
+                if args:
+                    new_args, changed = _resolve_generic_type_args(
+                        args, func, config_value_type, media_item_type
+                    )
+                    if changed:
+                        # Reconstruct the generic type with resolved TypeVars
+                        type_hints[key] = origin[tuple(new_args)]
+                continue
+
+            # Handle Union types that may contain TypeVars
+            # For example: _ConfigValueT | ConfigValueType should become just "ConfigValueType"
+            # when _ConfigValueT is bound to ConfigValueType
+            if origin is Union or origin is UnionType:
+                args = get_args(value)
+                # Check if union contains a TypeVar
+                # If the TypeVar's bound is a union that was flattened into the current union,
+                # we can just use the bound type for documentation purposes
+                typevar_found = False
+                for i, arg in enumerate(args):
+                    if isinstance(arg, TypeVar) and arg.__bound__ is not None:
+                        typevar_found = True
+                        type_hints[key] = _resolve_typevar_in_union(arg, func, args, i)
+                        break
+                if typevar_found:
+                    continue
+            if not hasattr(value, "__name__"):
+                continue
+            if value.__name__ == "ItemCls":
+                type_hints[key] = func.__self__.item_cls  # type: ignore[attr-defined]
+            # Resolve TypeVars to their bound type for API documentation
+            # This handles cases like _ConfigValueT which should show as ConfigValueType
+            elif isinstance(value, TypeVar):
+                if value.__bound__ is not None:
+                    type_hints[key] = value.__bound__
+        signature = inspect.signature(func)
+        # the 'user' argument of impersonation-enabled commands is injected by the
+        # command dispatch, so it may not clash with the handler's own arguments
+        if allow_impersonation and not signature.parameters.keys().isdisjoint(("user", "username")):
+            msg = f"Command {command} allows impersonation but accepts a user(name) argument"
+            raise RuntimeError(msg)
+        return APICommandHandler(
+            command=command,
+            signature=signature,
+            type_hints=type_hints,
+            target=func,
+            authenticated=authenticated,
+            required_scope=required_scope,
+            allow_impersonation=allow_impersonation,
+            alias=alias,
+        )
+
+
+def api_command(
+    command: str,
+    authenticated: bool = True,
+    required_scope: Scope | None = None,
+    allow_impersonation: bool = False,
+    alias: bool = False,
+) -> Callable[[_F], _F]:
+    """
+    Decorate a function as API route/command.
+
+    :param command: The command name/path.
+    :param authenticated: Whether authentication is required (default: True).
+    :param required_scope: Scope required to execute the command,
+        None means any authenticated user.
+    :param allow_impersonation: Whether the command accepts a 'user' argument
+        to execute the command on behalf of another user (default: False).
+    :param alias: Whether this is a backward-compatible alias (default: False).
+        Aliases remain functional but are hidden from the API documentation.
+    """
+
+    def decorate(func: _F) -> _F:
+        func.api_cmd = command  # type: ignore[attr-defined]
+        func.api_authenticated = authenticated  # type: ignore[attr-defined]
+        func.api_required_scope = required_scope  # type: ignore[attr-defined]
+        func.api_allow_impersonation = allow_impersonation  # type: ignore[attr-defined]
+        func.api_alias = alias  # type: ignore[attr-defined]
+        return func
+
+    return decorate
+
+
+def parse_arguments(
+    func_sig: inspect.Signature,
+    func_types: dict[str, Any],
+    args: dict[str, Any] | None,
+    strict: bool = False,
+) -> dict[str, Any]:
+    """Parse (and convert) incoming arguments to correct types."""
+    if args is None:
+        args = {}
+    final_args = {}
+    # ignore extra args if not strict
+    if strict:
+        for key, value in args.items():
+            if key not in func_sig.parameters:
+                raise KeyError(f"Invalid parameter: '{key}'")
+    # parse arguments to correct type
+    for name, param in func_sig.parameters.items():
+        value_type = func_types[name]
+        # Skip type[X] parameters — these are for static type checking only
+        # and must not be resolved from API input.
+        if _is_type_hint(value_type):
+            continue
+        value = args.get(name)
+        default = MISSING if param.default is inspect.Parameter.empty else param.default
+        try:
+            final_args[name] = parse_value(name, value, value_type, default)
+        except TypeError:
+            # retry one more time with allow_value_convert=True
+            final_args[name] = parse_value(
+                name, value, value_type, default, allow_value_convert=True
+            )
+    return final_args
+
+
+def parse_utc_timestamp(datetime_string: str) -> datetime:
+    """Parse datetime from string."""
+    return datetime.fromisoformat(datetime_string)
+
+
+def parse_value(
+    name: str,
+    value: Any,
+    value_type: Any,
+    default: Any = MISSING,
+    allow_value_convert: bool = False,
+) -> Any:
+    """Try to parse a value from raw (json) data and type annotations."""
+    # Resolve string type hints early for proper handling
+    if isinstance(value_type, str):
+        value_type = _resolve_string_type(value_type)
+        # If still a string after resolution, return value as-is
+        if isinstance(value_type, str):
+            LOGGER.debug("Unknown string type hint: %s, returning value as-is", value_type)
+            return value
+
+    if isinstance(value, dict) and hasattr(value_type, "from_dict"):
+        # Only validate media_type for actual MediaItem subclasses, not for other classes
+        # like StreamDetails that have a media_type field for a different purpose
+        if (
+            "media_type" in value
+            and value_type.__name__ != "ItemMapping"
+            and issubclass(value_type, MediaItem)
+            and value["media_type"] != value_type.media_type
+        ):
+            msg = "Invalid MediaType"
+            raise ValueError(msg)
+        return value_type.from_dict(value)
+
+    if value is None and not isinstance(default, type(MISSING)):
+        return default
+    if value is None and value_type is NoneType:
+        return None
+    origin = get_origin(value_type)
+    if origin is tuple and (subtypes := get_args(value_type)) and subtypes[-1] is not Ellipsis:
+        return _parse_fixed_length_tuple(name, value, value_type, subtypes, allow_value_convert)
+    if origin in (tuple, list, set, frozenset, Sequence, Iterable):
+        return _parse_sequence(name, value, value_type, origin, allow_value_convert)
+    if origin is dict:
+        return _parse_dict(value, value_type, allow_value_convert)
+    if origin is Union or origin is UnionType:
+        return _parse_union(name, value, value_type, allow_value_convert)
+    if origin is type:
+        # type[X] parameters are skipped in parse_arguments so this branch
+        # should not be reachable from API input. Reject as a safeguard.
+        msg = f"Cannot resolve type from string: {value!r}"
+        raise ValueError(msg)
+    if value_type is Any:
+        return value
+    if value is None and value_type is not NoneType:
+        msg = f"`{name}` of type `{value_type}` is required."
+        raise KeyError(msg)
+
+    try:
+        if issubclass(value_type, Enum):
+            return value_type(value)
+        if issubclass(value_type, datetime):
+            assert isinstance(value, str)  # for type checking
+            return parse_utc_timestamp(value)
+    except TypeError:
+        # happens if value_type is not a class
+        pass
+
+    if allow_value_convert:
+        value = _convert_common_value(value, value_type)
+
+    if not isinstance(value, value_type):
+        # all options failed, raise exception
+        msg = (
+            f"Value {value} of type {type(value)} is invalid for {name}, "
+            f"expected value of type {value_type}"
+        )
+        raise TypeError(msg)
+    return value
+
+
 def _resolve_string_type(type_str: str) -> Any:
     """
     Resolve a string type reference back to the actual type.
@@ -273,143 +525,6 @@ def _resolve_typevar_in_union(
     return bound_type
 
 
-@dataclass
-class APICommandHandler:
-    """Model for an API command handler."""
-
-    command: str
-    signature: inspect.Signature
-    type_hints: dict[str, Any]
-    target: Callable[..., Coroutine[Any, Any, Any] | AsyncGenerator[Any, Any]]
-    authenticated: bool = True
-    required_scope: Scope | None = None  # None means any authenticated user
-    allow_impersonation: bool = False  # If True, the command accepts a 'user' argument
-    alias: bool = False  # If True, this is an alias for backward compatibility
-
-    @classmethod
-    def parse(
-        cls,
-        command: str,
-        func: Callable[..., Coroutine[Any, Any, Any] | AsyncGenerator[Any, Any]],
-        authenticated: bool = True,
-        required_scope: Scope | None = None,
-        allow_impersonation: bool = False,
-        alias: bool = False,
-    ) -> APICommandHandler:
-        """
-        Parse APICommandHandler by providing a function.
-
-        :param command: The command name/path.
-        :param func: The function to handle the command.
-        :param authenticated: Whether authentication is required (default: True).
-        :param required_scope: Scope required to execute the command,
-            None for any authenticated user.
-        :param allow_impersonation: Whether the command accepts a 'user' argument
-            to execute the command on behalf of another user (default: False).
-        :param alias: Whether this is an alias for backward compatibility (default: False).
-        """
-        type_hints = _get_type_hints_for_api_command(func)
-        # workaround for generic typevar ItemCls that needs to be resolved
-        # to the real media item type. TODO: find a better way to do this
-        # without this hack
-        # Import type aliases to compare against
-        from music_assistant_models.config_entries import (  # noqa: PLC0415
-            ConfigValueType as config_value_type,  # noqa: N813
-        )
-        from music_assistant_models.media_items import (  # noqa: PLC0415
-            MediaItemType as media_item_type,  # noqa: N813
-        )
-
-        for key, value in type_hints.items():
-            # Handle generic types (list, tuple, dict, etc.) that may contain TypeVars
-            # For example: list[ItemCls] should become list[Artist]
-            # For example: dict[str, ConfigValueType] should preserve ConfigValueType
-            origin = get_origin(value)
-            if origin in (list, tuple, set, frozenset, dict):
-                args = get_args(value)
-                if args:
-                    new_args, changed = _resolve_generic_type_args(
-                        args, func, config_value_type, media_item_type
-                    )
-                    if changed:
-                        # Reconstruct the generic type with resolved TypeVars
-                        type_hints[key] = origin[tuple(new_args)]
-                continue
-
-            # Handle Union types that may contain TypeVars
-            # For example: _ConfigValueT | ConfigValueType should become just "ConfigValueType"
-            # when _ConfigValueT is bound to ConfigValueType
-            if origin is Union or origin is UnionType:
-                args = get_args(value)
-                # Check if union contains a TypeVar
-                # If the TypeVar's bound is a union that was flattened into the current union,
-                # we can just use the bound type for documentation purposes
-                typevar_found = False
-                for i, arg in enumerate(args):
-                    if isinstance(arg, TypeVar) and arg.__bound__ is not None:
-                        typevar_found = True
-                        type_hints[key] = _resolve_typevar_in_union(arg, func, args, i)
-                        break
-                if typevar_found:
-                    continue
-            if not hasattr(value, "__name__"):
-                continue
-            if value.__name__ == "ItemCls":
-                type_hints[key] = func.__self__.item_cls  # type: ignore[attr-defined]
-            # Resolve TypeVars to their bound type for API documentation
-            # This handles cases like _ConfigValueT which should show as ConfigValueType
-            elif isinstance(value, TypeVar):
-                if value.__bound__ is not None:
-                    type_hints[key] = value.__bound__
-        signature = inspect.signature(func)
-        # the 'user' argument of impersonation-enabled commands is injected by the
-        # command dispatch, so it may not clash with the handler's own arguments
-        if allow_impersonation and not signature.parameters.keys().isdisjoint(("user", "username")):
-            msg = f"Command {command} allows impersonation but accepts a user(name) argument"
-            raise RuntimeError(msg)
-        return APICommandHandler(
-            command=command,
-            signature=signature,
-            type_hints=type_hints,
-            target=func,
-            authenticated=authenticated,
-            required_scope=required_scope,
-            allow_impersonation=allow_impersonation,
-            alias=alias,
-        )
-
-
-def api_command(
-    command: str,
-    authenticated: bool = True,
-    required_scope: Scope | None = None,
-    allow_impersonation: bool = False,
-    alias: bool = False,
-) -> Callable[[_F], _F]:
-    """
-    Decorate a function as API route/command.
-
-    :param command: The command name/path.
-    :param authenticated: Whether authentication is required (default: True).
-    :param required_scope: Scope required to execute the command,
-        None means any authenticated user.
-    :param allow_impersonation: Whether the command accepts a 'user' argument
-        to execute the command on behalf of another user (default: False).
-    :param alias: Whether this is a backward-compatible alias (default: False).
-        Aliases remain functional but are hidden from the API documentation.
-    """
-
-    def decorate(func: _F) -> _F:
-        func.api_cmd = command  # type: ignore[attr-defined]
-        func.api_authenticated = authenticated  # type: ignore[attr-defined]
-        func.api_required_scope = required_scope  # type: ignore[attr-defined]
-        func.api_allow_impersonation = allow_impersonation  # type: ignore[attr-defined]
-        func.api_alias = alias  # type: ignore[attr-defined]
-        return func
-
-    return decorate
-
-
 def _is_type_hint(value_type: Any) -> bool:
     """
     Check if a type annotation is or contains type[X].
@@ -422,121 +537,6 @@ def _is_type_hint(value_type: Any) -> bool:
     if origin is Union or origin is UnionType:
         return any(get_origin(arg) is type for arg in get_args(value_type))
     return False
-
-
-def parse_arguments(
-    func_sig: inspect.Signature,
-    func_types: dict[str, Any],
-    args: dict[str, Any] | None,
-    strict: bool = False,
-) -> dict[str, Any]:
-    """Parse (and convert) incoming arguments to correct types."""
-    if args is None:
-        args = {}
-    final_args = {}
-    # ignore extra args if not strict
-    if strict:
-        for key, value in args.items():
-            if key not in func_sig.parameters:
-                raise KeyError(f"Invalid parameter: '{key}'")
-    # parse arguments to correct type
-    for name, param in func_sig.parameters.items():
-        value_type = func_types[name]
-        # Skip type[X] parameters — these are for static type checking only
-        # and must not be resolved from API input.
-        if _is_type_hint(value_type):
-            continue
-        value = args.get(name)
-        default = MISSING if param.default is inspect.Parameter.empty else param.default
-        try:
-            final_args[name] = parse_value(name, value, value_type, default)
-        except TypeError:
-            # retry one more time with allow_value_convert=True
-            final_args[name] = parse_value(
-                name, value, value_type, default, allow_value_convert=True
-            )
-    return final_args
-
-
-def parse_utc_timestamp(datetime_string: str) -> datetime:
-    """Parse datetime from string."""
-    return datetime.fromisoformat(datetime_string)
-
-
-def parse_value(
-    name: str,
-    value: Any,
-    value_type: Any,
-    default: Any = MISSING,
-    allow_value_convert: bool = False,
-) -> Any:
-    """Try to parse a value from raw (json) data and type annotations."""
-    # Resolve string type hints early for proper handling
-    if isinstance(value_type, str):
-        value_type = _resolve_string_type(value_type)
-        # If still a string after resolution, return value as-is
-        if isinstance(value_type, str):
-            LOGGER.debug("Unknown string type hint: %s, returning value as-is", value_type)
-            return value
-
-    if isinstance(value, dict) and hasattr(value_type, "from_dict"):
-        # Only validate media_type for actual MediaItem subclasses, not for other classes
-        # like StreamDetails that have a media_type field for a different purpose
-        if (
-            "media_type" in value
-            and value_type.__name__ != "ItemMapping"
-            and issubclass(value_type, MediaItem)
-            and value["media_type"] != value_type.media_type
-        ):
-            msg = "Invalid MediaType"
-            raise ValueError(msg)
-        return value_type.from_dict(value)
-
-    if value is None and not isinstance(default, type(MISSING)):
-        return default
-    if value is None and value_type is NoneType:
-        return None
-    origin = get_origin(value_type)
-    if origin is tuple and (subtypes := get_args(value_type)) and subtypes[-1] is not Ellipsis:
-        return _parse_fixed_length_tuple(name, value, value_type, subtypes, allow_value_convert)
-    if origin in (tuple, list, set, frozenset, Sequence, Iterable):
-        return _parse_sequence(name, value, value_type, origin, allow_value_convert)
-    if origin is dict:
-        return _parse_dict(value, value_type, allow_value_convert)
-    if origin is Union or origin is UnionType:
-        return _parse_union(name, value, value_type, allow_value_convert)
-    if origin is type:
-        # type[X] parameters are skipped in parse_arguments so this branch
-        # should not be reachable from API input. Reject as a safeguard.
-        msg = f"Cannot resolve type from string: {value!r}"
-        raise ValueError(msg)
-    if value_type is Any:
-        return value
-    if value is None and value_type is not NoneType:
-        msg = f"`{name}` of type `{value_type}` is required."
-        raise KeyError(msg)
-
-    try:
-        if issubclass(value_type, Enum):
-            return value_type(value)
-        if issubclass(value_type, datetime):
-            assert isinstance(value, str)  # for type checking
-            return parse_utc_timestamp(value)
-    except TypeError:
-        # happens if value_type is not a class
-        pass
-
-    if allow_value_convert:
-        value = _convert_common_value(value, value_type)
-
-    if not isinstance(value, value_type):
-        # all options failed, raise exception
-        msg = (
-            f"Value {value} of type {type(value)} is invalid for {name}, "
-            f"expected value of type {value_type}"
-        )
-        raise TypeError(msg)
-    return value
 
 
 def _parse_fixed_length_tuple(


### PR DESCRIPTION
# What does this implement/fix?

Our code style says private helpers live at the bottom of a file and the public API at the top. In `helpers/api.py` a group of private helpers still sat above the public API, so the file had privates at both ends and you had to scroll past internals before reaching the actual API.

This is a pure move — no logic, signature or docstring changes (the diff is the same lines in a different order).

Note: the `check_method_order` pre-commit hook only inspects classes, not module-level functions, which is why this slipped through. Widening that hook to module level is a sensible follow-up.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
