### PR TITLE
Stop confusing an unknown DLNA position or volume with zero

### DIFF
--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -139,8 +139,11 @@ class DLNAPlayer(Player):
             return
         assert self.device is not None  # for type checking
         self._attr_name = self.device.name
-        self._attr_volume_level = int((self.device.volume_level or 0) * 100)
-        self._attr_volume_muted = self.device.is_volume_muted or False
+        # a device reports an unknown volume as None (RenderingControl Volume/Mute unset
+        # or not reported yet), which must stay unknown instead of collapsing to 0/unmuted
+        volume_level = self.device.volume_level
+        self._attr_volume_level = int(volume_level * 100) if volume_level is not None else None
+        self._attr_volume_muted = self.device.is_volume_muted
         _playback_state = self._get_playback_state()
         assert _playback_state is not None  # for type checking
         self._attr_playback_state = _playback_state
@@ -184,9 +187,11 @@ class DLNAPlayer(Player):
             # No URI - idle or unknown
             self._attr_active_source = None
         # TODO: extend this list with other possible sources
-        if self.device.media_position:
-            # only update elapsed_time if the device actually reports it
-            self._attr_elapsed_time = float(self.device.media_position)
+        # a device reports 'no position' as None (RelativeTimePosition unset, sent as
+        # NOT_IMPLEMENTED or unparsable), so a reported 0 is a position like any other
+        # and is adopted instead of being discarded as 'not reported'.
+        if (media_position := self.device.media_position) is not None:
+            self._attr_elapsed_time = float(media_position)
             if self.device.media_position_updated_at is not None:
                 self._attr_elapsed_time_last_updated = (
                     self.device.media_position_updated_at.timestamp()

--- a/tests/providers/dlna/test_device_state.py
+++ b/tests/providers/dlna/test_device_state.py
@@ -1,0 +1,110 @@
+"""Tests for the state the DLNA player reads from its device."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from async_upnp_client.profiles.dlna import TransportState
+
+from music_assistant.providers.dlna.player import DLNAPlayer
+from tests.common import MockProvider
+
+REPORTED_AT = datetime(2026, 8, 7, 12, 0, 0, tzinfo=UTC)
+STALE_POSITION = 120.0
+STALE_REPORTED_AT = 1000.0
+
+
+async def _updated_player(**device_state: Any) -> DLNAPlayer:
+    """
+    Run a state update on a player that already knows a position, and return it.
+
+    :param device_state: Attributes to override on the fully reporting mocked device.
+    """
+    provider = MockProvider("dlna", instance_id="dlna_test")
+    provider.mass.streams.base_url = "http://192.168.1.2:8097"
+
+    device = MagicMock()
+    device.profile_device.available = True
+    device.name = "Living Room Renderer"
+    device.volume_level = 0.5
+    device.is_volume_muted = False
+    device.transport_state = TransportState.PLAYING
+    device.current_track_uri = "http://192.168.1.10/stream.mp3"
+    device.media_title = "Test Title"
+    device.media_artist = "Test Artist"
+    device.media_album_name = "Test Album"
+    device.media_image_url = "http://192.168.1.10/cover.jpg"
+    device.media_duration = 240
+    device.media_position = 42
+    device.media_position_updated_at = REPORTED_AT
+    for name, value in device_state.items():
+        setattr(device, name, value)
+
+    player = DLNAPlayer(
+        provider,  # type: ignore[arg-type]
+        "uuid:dlna-player",
+        "http://192.168.1.10/description.xml",
+        device=device,
+    )
+    player._attr_elapsed_time = STALE_POSITION
+    player._attr_elapsed_time_last_updated = STALE_REPORTED_AT
+
+    await player.set_dynamic_attributes()
+    return player
+
+
+async def test_zero_position_replaces_the_previous_one() -> None:
+    """A device restarting a track reports 0, which must not be read as 'unknown'."""
+    player = await _updated_player(media_position=0)
+
+    assert player.elapsed_time == 0.0
+    assert player.elapsed_time_last_updated == REPORTED_AT.timestamp()
+
+
+async def test_known_position_is_applied() -> None:
+    """A position reported by the device is adopted together with its timestamp."""
+    player = await _updated_player(media_position=42)
+
+    assert player.elapsed_time == 42.0
+    assert player.elapsed_time_last_updated == REPORTED_AT.timestamp()
+
+
+async def test_missing_position_keeps_the_previous_one() -> None:
+    """A device that reports no position at all leaves the known position alone."""
+    player = await _updated_player(media_position=None)
+
+    assert player.elapsed_time == STALE_POSITION
+    assert player.elapsed_time_last_updated == STALE_REPORTED_AT
+
+
+@pytest.mark.parametrize(("reported", "expected"), [(0.5, 50), (0.0, 0), (1.0, 100)])
+async def test_volume_level_is_scaled_to_percent(reported: float, expected: int) -> None:
+    """The device reports volume as a 0..1 fraction, the player as a percentage."""
+    player = await _updated_player(volume_level=reported)
+
+    assert player.volume_level == expected
+
+
+async def test_unknown_volume_level_stays_unknown() -> None:
+    """A device that does not report its volume must not read as volume 0."""
+    player = await _updated_player(volume_level=None)
+
+    assert player.volume_level is None
+
+
+@pytest.mark.parametrize("reported", [True, False])
+async def test_mute_state_is_applied(reported: bool) -> None:
+    """A mute state reported by the device is adopted as-is."""
+    player = await _updated_player(is_volume_muted=reported)
+
+    assert player.volume_muted is reported
+
+
+async def test_unknown_mute_state_stays_unknown() -> None:
+    """A device that does not report its mute state must not read as unmuted."""
+    player = await _updated_player(is_volume_muted=None)
+
+    assert player.volume_muted is None


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5461 for the DLNA provider, which mixed up "zero" and "unknown" in both directions.

**Playback position.** A position of exactly `0` was read as "no position reported", so the previous, now stale, position was kept instead. The inline comment framed the check as "did the device actually report anything?", but `async_upnp_client` already answers that with `None` — it returns `None` when `RelativeTimePosition` is unset, when the device sends `NOT_IMPLEMENTED`, and when the reported time cannot be parsed. A `0` only ever comes from a device that genuinely reported `00:00:00`. Since #5461 a DLNA player's position also feeds the position anchor of any universal group it plays in, so a stale position there propagates to the group.

**Volume and mute.** The other way around: an *unknown* volume or mute state was reported as `0` / unmuted. Both are documented as nullable on the player model, and a protocol player reporting volume `0` for "unknown" is the exact confusion that #5139 had to work around twice for AirPlay — so this removes the cause rather than adding a third workaround.

**Related issue (if applicable):**

- follow-up to #5461

## Changes

- Adopt a reported position of `0` instead of keeping the previous one.
- Keep an unknown volume or mute state unknown instead of reporting `0` / unmuted.
- Replaced the misleading comment with what the library actually guarantees.
- Tests for the position and volume/mute contracts, which had no coverage before.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
