### PR TITLE
Fix a stray error in the log when a Cast speaker fails to join a group

### DIFF
--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -200,6 +200,8 @@ _MANAGEMENT_ACTIONS = {
 PAIR_GESTURE_TIMEOUT = 120.0
 # Seconds the setup flow waits for pairing to complete after the PIN is submitted.
 PAIR_CONFIRM_TIMEOUT = 30.0
+# Seconds a Cast-bridged member gets to report its Sendspin app ready.
+CAST_APP_READY_TIMEOUT = 30.0
 
 # Terminal pairing-error slugs that map to a dedicated setup_flow.abort reason;
 # anything else falls back to the generic "pairing_failed" abort.
@@ -1332,7 +1334,7 @@ class SendspinPlayer(SendspinBasePlayer):
         if cast_app_ready is None:
             return
         try:
-            await asyncio.wait_for(asyncio.shield(cast_app_ready), timeout=30.0)
+            await asyncio.wait_for(asyncio.shield(cast_app_ready), timeout=CAST_APP_READY_TIMEOUT)
         except BaseException as exc:
             if not cast_app_ready.done():
                 cast_app_ready.cancel()
@@ -1450,19 +1452,25 @@ class SendspinPlayer(SendspinBasePlayer):
                 await self.api.group.add_client(member_player.api)
 
             if pending_cast:
-                try:
-                    await asyncio.wait_for(
-                        asyncio.gather(*(asyncio.shield(f) for _, f in pending_cast)),
-                        timeout=30.0,
-                    )
-                except TimeoutError:
-                    stuck = [m.display_name for m, f in pending_cast if not f.done()]
+                # asyncio.wait leaves the futures untouched: the stuck list below needs
+                # them intact, and a waiter that adopts them makes asyncio report a member
+                # failing afterwards to the loop exception handler as well
+                await asyncio.wait(
+                    [f for _, f in pending_cast],
+                    timeout=CAST_APP_READY_TIMEOUT,
+                    return_when=asyncio.FIRST_EXCEPTION,
+                )
+                for _, ready in pending_cast:
+                    if ready.done():
+                        # a member's own failure outranks the readiness timeout
+                        ready.result()
+                if stuck := [m.display_name for m, f in pending_cast if not f.done()]:
                     raise PlayerCommandFailed(
                         f"Cast app on {', '.join(stuck)} did not report ready within 30s",
                         translation_key="cast_app_members_not_ready",
                         translation_owner=self.translation_owner,
                         translation_args=[", ".join(stuck)],
-                    ) from None
+                    )
         except BaseException:
             # Roll back Cast members we just added so a failed group operation
             # doesn't leave dead members in the Sendspin group.

--- a/tests/providers/sendspin/test_set_members_cast_ready.py
+++ b/tests/providers/sendspin/test_set_members_cast_ready.py
@@ -1,9 +1,9 @@
 """
 Tests for Cast-member readiness handling in SendspinPlayer.set_members.
 
-Adding a Cast-bridged member waits for its Sendspin app to report ready. A member
-that fails after that wait gave up is already turned into a PlayerCommandFailed for
-the caller, so it must not also reach the loop exception handler.
+Adding a Cast-bridged member waits for its Sendspin app to report ready. The caller
+always learns why a member did not join, so a member failing after that wait gave up
+must not also surface through the loop exception handler.
 """
 
 from __future__ import annotations

--- a/tests/providers/sendspin/test_set_members_cast_ready.py
+++ b/tests/providers/sendspin/test_set_members_cast_ready.py
@@ -1,0 +1,102 @@
+"""
+Tests for Cast-member readiness handling in SendspinPlayer.set_members.
+
+Adding a Cast-bridged member waits for its Sendspin app to report ready. A member
+that fails after that wait gave up is already turned into a PlayerCommandFailed for
+the caller, so it must not also reach the loop exception handler.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from music_assistant_models.errors import PlayerCommandFailed
+
+from music_assistant.providers.sendspin import player as player_module
+from music_assistant.providers.sendspin.player import SendspinPlayer
+from tests.common import collect_loop_errors
+
+MEMBER_ID = "cast-member"
+MEMBER_NAME = "Living Room TV"
+
+
+def _make_player_mock(ready: asyncio.Future[None]) -> MagicMock:
+    """Create a mock leader whose single member to add is Cast-bridged."""
+    mock = MagicMock()
+    mock.translation_owner = "sendspin"
+    mock.api.group.has_active_stream = True
+    mock.api.group.add_client = AsyncMock()
+    mock.api.group.remove_client = AsyncMock()
+    member = MagicMock()
+    member.display_name = MEMBER_NAME
+    mock.mass.players.get_player.return_value = member
+    bridge = MagicMock()
+    bridge.reset_cast_app_ready.return_value = ready
+    mock._get_cast_bridge_manager.return_value.get_bridge_by_client_id.return_value = bridge
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_member_failing_after_the_timeout_logs_no_loop_error() -> None:
+    """A member reporting its failure once the wait gave up stays out of the loop handler."""
+    ready: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    mock = _make_player_mock(ready)
+    rollback_started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _park_rollback(_api: object) -> None:
+        rollback_started.set()
+        await release.wait()
+
+    mock.api.group.remove_client = AsyncMock(side_effect=_park_rollback)
+
+    with (
+        collect_loop_errors() as reported,
+        patch.object(player_module, "CAST_APP_READY_TIMEOUT", 0.01),
+    ):
+        call = asyncio.create_task(SendspinPlayer.set_members(mock, player_ids_to_add=[MEMBER_ID]))
+        await rollback_started.wait()
+        # fail the member only once the readiness wait has demonstrably given up, so the
+        # failure reliably lands after the waiter is gone
+        ready.set_exception(PlayerCommandFailed("Cast app stopped before reporting ready."))
+        ready.exception()
+        release.set()
+        with pytest.raises(PlayerCommandFailed, match="did not report ready"):
+            await call
+        await asyncio.sleep(0)
+
+    assert reported == []
+
+
+@pytest.mark.asyncio
+async def test_member_failure_is_surfaced_over_the_timeout() -> None:
+    """A member's own failure reaches the caller instead of the readiness timeout."""
+    ready: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    mock = _make_player_mock(ready)
+    ready.set_exception(PlayerCommandFailed(f"Sendspin isn't supported on {MEMBER_NAME}."))
+    ready.exception()
+
+    with (
+        patch.object(player_module, "CAST_APP_READY_TIMEOUT", 5.0),
+        pytest.raises(PlayerCommandFailed, match="isn't supported"),
+    ):
+        await SendspinPlayer.set_members(mock, player_ids_to_add=[MEMBER_ID])
+
+    mock.api.group.remove_client.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_timeout_names_the_members_that_never_reported_ready() -> None:
+    """Members still pending when the wait expires are named and then cleaned up."""
+    ready: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    mock = _make_player_mock(ready)
+
+    with (
+        patch.object(player_module, "CAST_APP_READY_TIMEOUT", 0.01),
+        pytest.raises(PlayerCommandFailed, match=MEMBER_NAME),
+    ):
+        await SendspinPlayer.set_members(mock, player_ids_to_add=[MEMBER_ID])
+
+    assert ready.cancelled()


### PR DESCRIPTION
# What does this implement/fix?

Adding a Chromecast-bridged speaker to a Sendspin group waits up to 30 seconds for the Cast app to report ready. When that wait timed out and the Cast app then reported a failure while the group was being rolled back, the failure also showed up in the log as a stray `ERROR ... exception in shielded future` with a traceback — on top of the clear error the user already gets.

The readiness wait no longer takes ownership of those futures, so only the real error is reported.

Follow-up to #5288, #5295 and #5453. The other remaining `asyncio.shield` uses were checked and left alone: their shielded work either can't fail or can't be waited on by a cancelled caller, so they never produce this log entry.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Wait for Cast member readiness with `asyncio.wait` instead of a shielded `gather`, so a member failing after the timeout no longer reaches the loop error handler.
- A member's own failure (e.g. audio unsupported) still wins over the generic readiness timeout.
- Named the duplicated 30s readiness timeout `CAST_APP_READY_TIMEOUT`.
- Added tests covering the late failure, the member failure and the timeout message.

One knock-on: if a member's readiness is superseded while the group is still waiting, the failure now surfaces when the wait ends instead of straight away. Same outcome, just not as quick, and it takes a rare bit of timing to hit.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
