### PR TITLE
Name the argument in dictionary parse errors

### DIFF
--- a/music_assistant/helpers/api.py
+++ b/music_assistant/helpers/api.py
@@ -247,7 +247,7 @@ def parse_value(
     if origin in (tuple, list, set, frozenset, Sequence, Iterable):
         return _parse_sequence(name, value, value_type, origin, allow_value_convert)
     if origin is dict:
-        return _parse_dict(value, value_type, allow_value_convert)
+        return _parse_dict(name, value, value_type, allow_value_convert)
     if origin is Union or origin is UnionType:
         return _parse_union(name, value, value_type, allow_value_convert)
     if origin is type:
@@ -602,6 +602,7 @@ def _parse_sequence(
 
 
 def _parse_dict(
+    name: str,
     value: Any,
     value_type: Any,
     allow_value_convert: bool,
@@ -609,6 +610,7 @@ def _parse_dict(
     """
     Parse a value against a dict annotation.
 
+    :param name: Name of the value, used in error messages.
     :param value: The raw (json) value to parse.
     :param value_type: The dict annotation to parse against.
     :param allow_value_convert: Whether conversion of common type mistakes is allowed.
@@ -616,8 +618,8 @@ def _parse_dict(
     subkey_type = get_args(value_type)[0]
     subvalue_type = get_args(value_type)[1]
     return {
-        parse_value(subkey, subkey, subkey_type): parse_value(
-            f"{subkey}.value", subvalue, subvalue_type, allow_value_convert=allow_value_convert
+        parse_value(f"{name} key", subkey, subkey_type): parse_value(
+            f"{name}[{subkey}]", subvalue, subvalue_type, allow_value_convert=allow_value_convert
         )
         for subkey, subvalue in value.items()
     }

--- a/tests/helpers/test_parse_value_collections.py
+++ b/tests/helpers/test_parse_value_collections.py
@@ -110,6 +110,12 @@ def test_parse_value_fixed_length_tuple_names_the_failing_member() -> None:
         parse_value("values", ["a", {}], tuple[str, str])
 
 
+def test_parse_value_fixed_length_tuple_in_union() -> None:
+    """A union of fixed-length tuples falls through to the member that fits the value."""
+    result = parse_value("values", ["a", "b", "c"], tuple[str, str] | tuple[str, str, str])
+    assert result == ("a", "b", "c")
+
+
 def test_parse_value_dict_names_the_failing_value() -> None:
     """A dict value that does not fit its type is reported with its argument and key."""
     with pytest.raises(TypeError, match=r"invalid for supported_types\[a\]"):
@@ -120,9 +126,3 @@ def test_parse_value_dict_names_the_failing_key() -> None:
     """A dict key that does not fit its type is reported with the argument it belongs to."""
     with pytest.raises(TypeError, match="invalid for supported_types key"):
         parse_value("supported_types", {1: "a"}, dict[str, str])
-
-
-def test_parse_value_fixed_length_tuple_in_union() -> None:
-    """A union of fixed-length tuples falls through to the member that fits the value."""
-    result = parse_value("values", ["a", "b", "c"], tuple[str, str] | tuple[str, str, str])
-    assert result == ("a", "b", "c")

--- a/tests/helpers/test_parse_value_collections.py
+++ b/tests/helpers/test_parse_value_collections.py
@@ -110,6 +110,18 @@ def test_parse_value_fixed_length_tuple_names_the_failing_member() -> None:
         parse_value("values", ["a", {}], tuple[str, str])
 
 
+def test_parse_value_dict_names_the_failing_value() -> None:
+    """A dict value that does not fit its type is reported with its argument and key."""
+    with pytest.raises(TypeError, match=r"invalid for supported_types\[a\]"):
+        parse_value("supported_types", {"a": {}}, dict[str, int])
+
+
+def test_parse_value_dict_names_the_failing_key() -> None:
+    """A dict key that does not fit its type is reported with the argument it belongs to."""
+    with pytest.raises(TypeError, match="invalid for supported_types key"):
+        parse_value("supported_types", {1: "a"}, dict[str, str])
+
+
 def test_parse_value_fixed_length_tuple_in_union() -> None:
     """A union of fixed-length tuples falls through to the member that fits the value."""
     result = parse_value("values", ["a", "b", "c"], tuple[str, str] | tuple[str, str, str])


### PR DESCRIPTION
# What does this implement/fix?

When a value inside a dictionary argument fails to parse, the error we send back only mentioned the
dictionary key, not the argument the dictionary came from. For a handler taking
`supported_types: dict[str, int]`, a bad entry reported `... is invalid for a.value`, which is hard
to place if you don't already know which argument holds a key called `a`. Keys were reported using
the key itself as the name.

Dictionary members are now named after the argument they belong to, the same way the other
collection types already do it: `... is invalid for supported_types[a]` for a value, and
`... is invalid for supported_types key` for a key.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Pass the argument name into the dictionary parser and use it to label both keys and values.
- Added tests covering both error messages.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
