### PR TITLE
Fix volume changes when unmuting a speaker

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3634,10 +3634,19 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                 player.extra_data[ATTR_FAKE_MUTE] = True
                 player.update_state()
             else:
-                prev_volume = player.extra_data.get(ATTR_PREVIOUS_VOLUME, 1)
+                was_muted = bool(player.extra_data.get(ATTR_FAKE_MUTE))
                 player.extra_data[ATTR_FAKE_MUTE] = False
                 player.update_state()
-                await self._handle_cmd_volume_set(player.player_id, prev_volume)
+                if not was_muted:
+                    # the volume is the one the user is listening at, restoring
+                    # anything here would turn a no-op unmute into a volume change
+                    return
+                stored_volume: int | None = player.extra_data.pop(ATTR_PREVIOUS_VOLUME, None)
+                # the volume was still unknown at mute time, so pick a low volume
+                # rather than blasting the speaker at some assumed level
+                await self._handle_cmd_volume_set(
+                    player.player_id, 1 if stored_volume is None else stored_volume
+                )
             return
 
         # handle external player control

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1657,8 +1657,15 @@ class TestEnforceVolumeLimits:
 class TestFakeMuteControl:
     """Fake mute must report the muted state and restore the volume on unmute."""
 
-    def _make_player(self, mock_mass: MagicMock) -> tuple[PlayerController, MockPlayer, AsyncMock]:
-        """Build a controller with a single player using fake mute control."""
+    def _make_player(
+        self, mock_mass: MagicMock, volume_level: int | None = 40
+    ) -> tuple[PlayerController, MockPlayer, AsyncMock]:
+        """
+        Build a controller with a single player using fake mute control.
+
+        :param mock_mass: the mocked MusicAssistant instance.
+        :param volume_level: initial volume level of the player, None if unknown.
+        """
         mock_mass.config.get_raw_player_config_value = MagicMock(
             side_effect=_player_config_stub({CONF_MUTE_CONTROL: PLAYER_CONTROL_FAKE})
         )
@@ -1669,7 +1676,7 @@ class TestFakeMuteControl:
         mock_mass.players = controller
         mock_mass.player_queues.get = MagicMock(return_value=None)
         player.set_initialized()
-        player._attr_volume_level = 40
+        player._attr_volume_level = volume_level
         # let the mocked native volume control behave like a real device
         volume_set = AsyncMock(
             side_effect=lambda volume: setattr(player, "_attr_volume_level", volume)
@@ -1707,6 +1714,34 @@ class TestFakeMuteControl:
 
         await controller.cmd_volume_mute("player_1", False)
         volume_set.assert_awaited_with(40)
+
+    async def test_unmute_with_unknown_previous_volume(self, mock_mass: MagicMock) -> None:
+        """Unmuting a player whose volume was unknown at mute time restores a low volume."""
+        controller, player, volume_set = self._make_player(mock_mass, volume_level=None)
+
+        await controller.cmd_volume_mute("player_1", True)
+        assert player.extra_data[ATTR_PREVIOUS_VOLUME] is None
+
+        await controller.cmd_volume_mute("player_1", False)
+        volume_set.assert_awaited_with(1)
+        player.update_state()
+        assert player.state.volume_muted is False
+
+    async def test_unmute_of_unmuted_player_keeps_volume(self, mock_mass: MagicMock) -> None:
+        """An unmute command for a player that is not muted may not touch the volume."""
+        controller, player, volume_set = self._make_player(mock_mass, volume_level=50)
+
+        await controller.cmd_volume_mute("player_1", False)
+        volume_set.assert_not_awaited()
+        assert player.state.volume_level == 50
+
+    async def test_unmute_restores_a_stored_zero_volume(self, mock_mass: MagicMock) -> None:
+        """A player that was already silent stays silent after mute and unmute."""
+        controller, _player, volume_set = self._make_player(mock_mass, volume_level=0)
+
+        await controller.cmd_volume_mute("player_1", True)
+        await controller.cmd_volume_mute("player_1", False)
+        volume_set.assert_awaited_with(0)
 
     async def test_volume_set_clears_fake_mute(self, mock_mass: MagicMock) -> None:
         """A regular volume change while fake muted implies an unmute."""


### PR DESCRIPTION
# What does this implement/fix?

When a player uses the "fake" mute control, muting is simulated by turning the volume down to zero and remembering the volume so it can be put back on unmute. Two things went wrong there:

- An unmute for a player that was not muted at all still forced its volume down to 1. This is easy to hit: unmuting a group sends an unmute to every member, muted or not, and Home Assistant scripts and voice assistants happily send an unmute unconditionally.
- If the player's volume was still unknown at mute time, nothing usable was remembered and the unmute failed with an error instead of restoring the sound. Players can legitimately report an unknown volume (MusicCast, Sendspin and DLNA all do so while the device has not reported its volume yet).

Neither was reported by a user, hence the maintenance label.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- An unmute now only restores a volume if the player was actually muted through the fake mute control.
- Fall back to a low volume when the player's volume was unknown at mute time.
- Added regression tests for both cases, plus one covering a player that was already silent.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
