### PR TITLE
Play announcements on muted speakers

### DIFF
--- a/music_assistant/controllers/players/announcements.py
+++ b/music_assistant/controllers/players/announcements.py
@@ -112,6 +112,10 @@ class AnnouncementsMixin:
 
         async def _handle_cmd_volume_set(self, player_id: str, volume_level: int) -> None: ...
 
+        async def _handle_cmd_volume_mute(
+            self, player: Player, mute_control: str, muted: bool
+        ) -> None: ...
+
         async def _handle_cmd_power(
             self, player_id: str, powered: bool, skip_auto_play: bool = False
         ) -> None: ...
@@ -362,8 +366,9 @@ class AnnouncementsMixin:
             player.current_media is not None
             and player.current_media.media_type == MediaType.ANNOUNCEMENT
         )
-        # filled while the temporary announcement volume is applied below
+        # filled while the players are unmuted and the temporary volume is applied below
         prev_volumes: dict[str, int] = {}
+        prev_muted: set[str] = set()
         # everything from here on alters the player state, so the restore in the finally
         # block must run even when the announcement itself fails halfway through
         try:
@@ -375,6 +380,7 @@ class AnnouncementsMixin:
                 prev_group=prev_group,
                 prev_media_name=prev_media_name,
                 prev_volumes=prev_volumes,
+                prev_muted=prev_muted,
             )
             # play the announcement
             self.logger.debug(
@@ -427,6 +433,7 @@ class AnnouncementsMixin:
                 player,
                 prev_power=prev_power,
                 prev_volumes=prev_volumes,
+                prev_muted=prev_muted,
                 prev_synced_to=prev_synced_to,
                 prev_group=prev_group,
                 prev_source=prev_source,
@@ -444,6 +451,7 @@ class AnnouncementsMixin:
         prev_group: Player | None,
         prev_media_name: str | None,
         prev_volumes: dict[str, int],
+        prev_muted: set[str],
     ) -> None:
         """
         Free up the player for an announcement and apply the temporary announcement volume.
@@ -456,6 +464,8 @@ class AnnouncementsMixin:
         :param prev_media_name: Name of the media the player was playing (for logging).
         :param prev_volumes: Mapping that is filled in-place with the previous volume level
             per player id, so the caller can restore the volumes even if this call fails.
+        :param prev_muted: Set that is filled in-place with the ids of the players that were
+            muted, so the caller can restore the mute state even if this call fails.
         """
         if prev_synced_to:
             # ungroup player if its currently synced
@@ -493,7 +503,7 @@ class AnnouncementsMixin:
             await self._handle_cmd_stop(player.player_id)
             # wait for the player to stop
             await self._wait_for_playback_state(player, PlaybackState.IDLE, 10, 0.4)
-        # adjust volume if needed
+        # unmute and adjust volume if needed
         # in case of a (sync) group, we need to do this for all child players
         async with TaskManager(self.mass) as tg:
             for volume_player_id in player.state.group_members or (player.player_id,):
@@ -516,26 +526,11 @@ class AnnouncementsMixin:
                         volume_player.state.name,
                     )
                     tg.create_task(self._handle_cmd_stop(volume_player.player_id))
-                if volume_player.state.volume_control == PLAYER_CONTROL_NONE:
-                    continue
-                if (prev_volume := volume_player.state.volume_level) is None:
-                    continue
-                announcement_volume = self.get_announcement_volume(volume_player_id, volume_level)
-                # get_announcement_volume already returns None when the volume must be left
-                # alone, so any number it does return is the volume to announce at - including
-                # 0, which must not be mistaken for 'no volume configured'
-                if announcement_volume is None:
-                    continue
-                if announcement_volume != prev_volume:
-                    prev_volumes[volume_player_id] = prev_volume
-                    self.logger.debug(
-                        "Announcement to player %s - setting temporary volume (%s)...",
-                        volume_player.state.name,
-                        announcement_volume,
+                tg.create_task(
+                    self._unmute_and_set_announcement_volume(
+                        volume_player, volume_level, prev_volumes, prev_muted
                     )
-                    tg.create_task(
-                        self._handle_cmd_volume_set(volume_player.player_id, announcement_volume)
-                    )
+                )
 
     async def _restore_after_announcement(
         self,
@@ -543,6 +538,7 @@ class AnnouncementsMixin:
         *,
         prev_power: bool,
         prev_volumes: dict[str, int],
+        prev_muted: set[str],
         prev_synced_to: str | None,
         prev_group: Player | None,
         prev_source: str | None,
@@ -558,6 +554,7 @@ class AnnouncementsMixin:
         :param player: The player the announcement was played on.
         :param prev_power: Whether the player was powered before the announcement.
         :param prev_volumes: The previous volume level per player id.
+        :param prev_muted: The ids of the players that were muted before the announcement.
         :param prev_synced_to: Player ID of the sync leader the player was synced to (if any).
         :param prev_group: The group player the player was a member of (if any).
         :param prev_source: The source that was active before the announcement.
@@ -571,6 +568,12 @@ class AnnouncementsMixin:
         async with TaskManager(self.mass) as tg:
             for volume_player_id, prev_volume in prev_volumes.items():
                 tg.create_task(self._handle_cmd_volume_set(volume_player_id, prev_volume))
+        # restore mute after the volume, because setting a volume unmutes the player again
+        async with TaskManager(self.mass) as tg:
+            for muted_player_id in prev_muted:
+                if not (muted_player := self.get_player(muted_player_id)):
+                    continue
+                tg.create_task(self._set_announcement_mute(muted_player, True))
         await asyncio.sleep(0.2)
         try:
             # either power off the player or resume playing
@@ -618,3 +621,59 @@ class AnnouncementsMixin:
                 player.state.name,
                 err,
             )
+
+    async def _unmute_and_set_announcement_volume(
+        self,
+        volume_player: Player,
+        volume_level: int | None,
+        prev_volumes: dict[str, int],
+        prev_muted: set[str],
+    ) -> None:
+        """
+        Make a single player ready to be heard: unmute it and set the announcement volume.
+
+        :param volume_player: The player to prepare.
+        :param volume_level: Optional volume level override for the announcement.
+        :param prev_volumes: Mapping that is filled in-place with the previous volume level
+            per player id.
+        :param prev_muted: Set that is filled in-place with the ids of the players that
+            were muted.
+        """
+        if volume_player.state.volume_muted:
+            # an announcement is always meant to be heard, so a deliberate mute is lifted
+            # for its duration. this happens before the volume is read below, since a
+            # fake mute control parks the player at volume 0 to mute it.
+            prev_muted.add(volume_player.player_id)
+            await self._set_announcement_mute(volume_player, False)
+        if volume_player.state.volume_control == PLAYER_CONTROL_NONE:
+            return
+        if (prev_volume := volume_player.state.volume_level) is None:
+            return
+        announcement_volume = self.get_announcement_volume(volume_player.player_id, volume_level)
+        # get_announcement_volume already returns None when the volume must be left
+        # alone, so any number it does return is the volume to announce at - including
+        # 0, which must not be mistaken for 'no volume configured'
+        if announcement_volume is None or announcement_volume == prev_volume:
+            return
+        prev_volumes[volume_player.player_id] = prev_volume
+        self.logger.debug(
+            "Announcement to player %s - setting temporary volume (%s)...",
+            volume_player.state.name,
+            announcement_volume,
+        )
+        await self._handle_cmd_volume_set(volume_player.player_id, announcement_volume)
+
+    async def _set_announcement_mute(self, player: Player, muted: bool) -> None:
+        """
+        Mute or unmute a player for the duration of an announcement.
+
+        :param player: The player to mute or unmute.
+        :param muted: bool if the player should be muted.
+        """
+        # the internal handler is used instead of cmd_volume_mute so the player keeps the
+        # mute lock it earned as a group member: the public command clears that lock on
+        # unmute and the player may well be ungrouped by the time it is muted back.
+        mute_control = player.mute_control
+        if mute_control == PLAYER_CONTROL_NONE:
+            return
+        await self._handle_cmd_volume_mute(player, mute_control, muted)

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -2512,6 +2512,20 @@ class TestPlayAnnouncementRestore:
             duration=3,
         )
 
+    @staticmethod
+    def _mute_natively(player: MockPlayer) -> AsyncMock:
+        """Give the player a native mute control, mute it and return its mute handler."""
+        player._attr_supported_features.add(PlayerFeature.VOLUME_MUTE)
+        player._attr_volume_muted = True
+        mute_mock = AsyncMock(
+            side_effect=lambda muted: setattr(player, "_attr_volume_muted", muted)
+        )
+        player.volume_mute = mute_mock  # type: ignore[method-assign]
+        player._cache.clear()
+        player.update_state(force_update=True, signal_event=False)
+        assert player.state.volume_muted is True
+        return mute_mock
+
     async def test_previous_playback_is_restored(self, mock_mass: MagicMock) -> None:
         """Content that was playing before the announcement is resumed afterwards."""
         controller, player, resume_mock = self._make_player(
@@ -2665,6 +2679,106 @@ class TestPlayAnnouncementRestore:
             call(player_ids_to_remove=["player_1"]),
             call(player_ids_to_add=["player_1"]),
         ]
+
+    async def test_muted_player_is_unmuted_and_muted_back(self, mock_mass: MagicMock) -> None:
+        """A muted player hears the announcement and is muted again afterwards."""
+        controller, player, _ = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+        mute_mock = self._mute_natively(player)
+
+        await controller._play_announcement(player, self._announcement())
+
+        assert mute_mock.await_args_list == [call(False), call(True)]
+
+    async def test_unmuted_player_is_left_alone(self, mock_mass: MagicMock) -> None:
+        """A player that was not muted is never sent a mute command."""
+        controller, player, _ = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+        mute_mock = self._mute_natively(player)
+        player._attr_volume_muted = False
+        player._cache.clear()
+        player.update_state(force_update=True, signal_event=False)
+        mute_mock.reset_mock()
+
+        await controller._play_announcement(player, self._announcement())
+
+        mute_mock.assert_not_awaited()
+
+    async def test_mute_is_restored_when_playback_fails(self, mock_mass: MagicMock) -> None:
+        """A failing announcement never leaves the player unmuted."""
+        controller, player, _ = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+        mute_mock = self._mute_natively(player)
+        controller._handle_play_media = AsyncMock(  # type: ignore[method-assign]
+            side_effect=PlayerCommandFailed("player went away")
+        )
+
+        with pytest.raises(PlayerCommandFailed):
+            await controller._play_announcement(player, self._announcement())
+
+        assert mute_mock.await_args_list == [call(False), call(True)]
+
+    async def test_muted_sync_group_members_all_hear_the_announcement(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Every member of a muted sync group is unmuted, keeping its mute lock."""
+        controller, leader, _ = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+        member = MockPlayer(cast("MockProvider", leader.provider), "player_2", "Player 2")
+        controller._players["player_2"] = member
+        member.set_initialized()
+        leader._attr_group_members = ["player_1", "player_2"]
+        mute_mocks = {player.player_id: self._mute_natively(player) for player in (leader, member)}
+        # both members were muted while grouped, so both hold a mute lock
+        for player in (leader, member):
+            player.extra_data[ATTR_MUTE_LOCK] = True
+
+        await controller._play_announcement(leader, self._announcement())
+
+        for player_id, mute_mock in mute_mocks.items():
+            assert mute_mock.await_args_list == [call(False), call(True)], player_id
+            assert controller._players[player_id].extra_data[ATTR_MUTE_LOCK] is True
+
+    async def test_fake_muted_player_announces_at_its_real_volume(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A fake muted player announces at its real volume, not at the zero it is parked on."""
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_player_config_stub({CONF_MUTE_CONTROL: PLAYER_CONTROL_FAKE})
+        )
+        controller, player, _ = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+
+        def _apply_volume(volume: int) -> None:
+            player._attr_volume_level = volume
+            player.update_state(signal_event=False)
+
+        player._attr_volume_level = 40
+        volume_set = AsyncMock(side_effect=_apply_volume)
+        player.volume_set = volume_set  # type: ignore[method-assign]
+        player._cache.clear()
+        player.update_state(force_update=True, signal_event=False)
+        await controller.cmd_volume_mute("player_1", True)
+        assert player.state.volume_muted is True
+        controller.get_announcement_volume = MagicMock(return_value=80)  # type: ignore[method-assign]
+
+        await controller._play_announcement(player, self._announcement())
+
+        # unmute to 40, announce at 80, restore 40 and park back on 0 for the fake mute
+        assert volume_set.await_args_list == [
+            call(0),
+            call(40),
+            call(80),
+            call(40),
+            call(0),
+        ]
+        assert player.state.volume_muted is True
+        assert player.extra_data[ATTR_PREVIOUS_VOLUME] == 40
 
 
 class TestScheduleActiveOutputProtocolClear:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -2691,6 +2691,60 @@ class TestPlayAnnouncementRestore:
 
         assert mute_mock.await_args_list == [call(False), call(True)]
 
+    async def test_player_without_volume_control_is_still_unmuted(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A player that can only be muted is unmuted for the announcement all the same."""
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_player_config_stub({CONF_VOLUME_CONTROL: PLAYER_CONTROL_NONE})
+        )
+        controller, player, _ = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+        mute_mock = self._mute_natively(player)
+        assert player.state.volume_control == PLAYER_CONTROL_NONE
+
+        await controller._play_announcement(player, self._announcement())
+
+        assert mute_mock.await_args_list == [call(False), call(True)]
+
+    async def test_mute_is_restored_before_the_player_is_regrouped(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A player is handed back to its group already muted, holding on to its mute lock."""
+        controller, player, _ = self._make_player(
+            mock_mass, PlayerMedia(uri="http://test/track.mp3", media_type=MediaType.TRACK)
+        )
+        group = self._add_group(controller, player, supports_set_members=True)
+        real_set_members = group.set_members
+
+        async def _set_members(**kwargs: list[str]) -> None:
+            # let the membership really change, so the player is ungrouped while the
+            # announcement plays - just like it is in production. neither player picks
+            # the new membership up on its own here, so publish it on both.
+            await real_set_members(**kwargs)
+            group.update_state(force_update=True, signal_event=False)
+            player._cache.clear()
+            player.update_state(force_update=True, signal_event=False)
+
+        set_members = AsyncMock(side_effect=_set_members)
+        group.set_members = set_members  # type: ignore[method-assign]
+        player.extra_data[ATTR_MUTE_LOCK] = True
+        recorder = MagicMock()
+        recorder.attach_mock(self._mute_natively(player), "mute")
+        recorder.attach_mock(set_members, "set_members")
+
+        await controller._play_announcement(player, self._announcement())
+
+        assert recorder.mock_calls == [
+            call.set_members(player_ids_to_remove=["player_1"]),
+            call.mute(False),
+            call.mute(True),
+            call.set_members(player_ids_to_add=["player_1"]),
+        ]
+        # the lock survives the announcement, so the regroup does not unmute the player
+        assert player.extra_data[ATTR_MUTE_LOCK] is True
+
     async def test_unmuted_player_is_left_alone(self, mock_mass: MagicMock) -> None:
         """A player that was not muted is never sent a mute command."""
         controller, player, _ = self._make_player(


### PR DESCRIPTION
# What does this implement/fix?

Announcements (TTS, doorbell, alerts) behaved differently on muted speakers depending on how they were grouped:

- An announcement to a muted group or a muted synced pair was completely silent — every member stays grouped, so nothing was ever turned up and you heard nothing at all.
- A muted single speaker did play the announcement, but was left unmuted afterwards.

An announcement is meant to be heard, so it now always overrides the mute — and the speaker is muted again once the announcement is done.

Follows on from #5465, which fixed a single muted speaker being released from its group but did not restore its mute afterwards.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

## Changes

- Muted speakers are explicitly unmuted for an announcement instead of relying on a side effect of the volume change, so a muted group is no longer silent.
- The mute state is restored afterwards, for every speaker involved.
- Speakers that use volume-based (fake) mute announce at their real volume instead of at the muted zero.
- Added test coverage for announcements on muted speakers, groups and fake-muted speakers.
