### PR TITLE
Make shared-request deduplication reliable for media item arguments

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -6,6 +6,7 @@ import asyncio
 import functools
 import html
 import importlib
+import inspect
 import logging
 import os
 import platform
@@ -25,6 +26,7 @@ from contextlib import suppress
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from ipaddress import IPv4Address, IPv6Address, ip_address
+from itertools import islice
 from pathlib import Path
 from types import ModuleType, TracebackType
 from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, Protocol, Self, TypeVar, cast
@@ -2080,11 +2082,15 @@ def guard_single_request[SelfT: _SupportsMass, **P, R](
 
     Callers arriving while an identical call is already in flight await that same call and
     receive its result. Cancelling one caller leaves both the request and the other callers
-    unaffected. Calls count as identical when they are made on the same object with equally
-    represented arguments.
+    unaffected. Calls count as identical when they are made on the same object with equal
+    arguments, no matter whether those were passed positionally or by keyword.
+
+    Every argument must be either a scalar or a media item, so that equal arguments are
+    guaranteed to produce an equal key.
 
     :param func: The coroutine method to guard.
     """
+    signature = inspect.signature(func)
 
     @functools.wraps(func)
     async def wrapper(self: SelfT, *args: P.args, **kwargs: P.kwargs) -> R:
@@ -2096,10 +2102,23 @@ def guard_single_request[SelfT: _SupportsMass, **P, R](
         # (e.g. a provider set up twice), which must never join each other's flight.
         # id(self) is stable while a flight is live because the task references self;
         # the class name only serves to keep the task_id readable while debugging.
-        cache_key_parts = [type(self).__name__, id(self), func.__qualname__, *args]
-        for key in sorted(kwargs.keys()):
-            cache_key_parts.append(f"{key}{kwargs[key]}")
-        task_id = ".".join(map(str, cache_key_parts))
+        # binding the arguments to their parameter names and filling in the defaults keys a
+        # call the same however it was spelled; repr of the resulting tuple quotes every
+        # part, so an id that itself contains punctuation stays unambiguous.
+        bound = signature.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        task_id = repr(
+            (
+                type(self).__name__,
+                id(self),
+                func.__qualname__,
+                # skip the instance: it is the first parameter and is keyed by id() above
+                *(
+                    (name, _canonical_key_part(value))
+                    for name, value in islice(bound.arguments.items(), 1, None)
+                ),
+            )
+        )
         task: asyncio.Task[R] = mass.create_task(
             func,
             self,
@@ -2112,3 +2131,13 @@ def guard_single_request[SelfT: _SupportsMass, **P, R](
         return await join_task(task)
 
     return wrapper
+
+
+def _canonical_key_part(value: Any) -> Any:
+    """Return a stable stand-in for a single argument of a guarded request."""
+    if (uri := getattr(value, "uri", None)) is not None:
+        # a media item renders as a multi-kilobyte dataclass repr in which the set-typed
+        # fields (provider_mappings, external_ids) can iterate in different orders for two
+        # equal items. the uri identifies the item, which is all a request key needs.
+        return uri
+    return value

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -2083,10 +2083,11 @@ def guard_single_request[SelfT: _SupportsMass, **P, R](
     Callers arriving while an identical call is already in flight await that same call and
     receive its result. Cancelling one caller leaves both the request and the other callers
     unaffected. Calls count as identical when they are made on the same object with equal
-    arguments, no matter whether those were passed positionally or by keyword.
+    arguments, no matter whether those were passed positionally or by keyword; the request
+    runs with the arguments of the caller that started it.
 
-    Every argument must be either a scalar or a media item, so that equal arguments are
-    guaranteed to produce an equal key.
+    Every argument must be a scalar or an object identified by its ``uri``, so that equal
+    arguments are guaranteed to produce an equal key.
 
     :param func: The coroutine method to guard.
     """
@@ -2103,8 +2104,8 @@ def guard_single_request[SelfT: _SupportsMass, **P, R](
         # id(self) is stable while a flight is live because the task references self;
         # the class name only serves to keep the task_id readable while debugging.
         # binding the arguments to their parameter names and filling in the defaults keys a
-        # call the same however it was spelled; repr of the resulting tuple quotes every
-        # part, so an id that itself contains punctuation stays unambiguous.
+        # call the same however it was spelled; repr of the resulting tuple keeps the parts
+        # apart, so an id that itself contains punctuation cannot run into the next one.
         bound = signature.bind(self, *args, **kwargs)
         bound.apply_defaults()
         task_id = repr(
@@ -2138,6 +2139,7 @@ def _canonical_key_part(value: Any) -> Any:
     if (uri := getattr(value, "uri", None)) is not None:
         # a media item renders as a multi-kilobyte dataclass repr in which the set-typed
         # fields (provider_mappings, external_ids) can iterate in different orders for two
-        # equal items. the uri identifies the item, which is all a request key needs.
-        return uri
+        # equal items. the uri identifies the item, and the type travels with it because a
+        # full item and an ItemMapping for that same item are not handled the same.
+        return (type(value).__name__, uri)
     return value

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -643,6 +643,55 @@ class TestGuardSingleRequest:
         assert provider.album_calls == 1
         assert provider.track_calls == 1
 
+    @pytest.mark.asyncio
+    async def test_media_item_argument_keys_on_its_uri(self, mass_minimal: MusicAssistant) -> None:
+        """Media item arguments pointing at the same provider item share a request."""
+        caller = _GuardedCaller(mass_minimal)
+        calls = [
+            asyncio.create_task(
+                caller.fetch_item("123", fallback=_guarded_album("First", ("a", "b")))
+            ),
+            asyncio.create_task(
+                caller.fetch_item("123", fallback=_guarded_album("Second", ("b", "a", "c")))
+            ),
+        ]
+        # both fallbacks describe item 123, only their contents differ
+        await asyncio.sleep(0)
+        caller.release.set()
+
+        assert await asyncio.gather(*calls) == ["result-123-False", "result-123-False"]
+        assert caller.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_positional_and_keyword_arguments_share_a_request(
+        self, mass_minimal: MusicAssistant
+    ) -> None:
+        """The same call spelled positionally and by keyword shares a request."""
+        caller = _GuardedCaller(mass_minimal)
+        calls = [
+            asyncio.create_task(caller.fetch_item("123", True)),
+            asyncio.create_task(caller.fetch_item("123", force_refresh=True)),
+        ]
+        await asyncio.sleep(0)
+        caller.release.set()
+
+        assert await asyncio.gather(*calls) == ["result-123-True", "result-123-True"]
+        assert caller.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_force_refresh_gets_its_own_request(self, mass_minimal: MusicAssistant) -> None:
+        """A force refresh must issue its own request instead of joining a normal one."""
+        caller = _GuardedCaller(mass_minimal)
+        calls = [
+            asyncio.create_task(caller.fetch_item("123")),
+            asyncio.create_task(caller.fetch_item("123", force_refresh=True)),
+        ]
+        await asyncio.sleep(0)
+        caller.release.set()
+
+        assert await asyncio.gather(*calls) == ["result-123-False", "result-123-True"]
+        assert caller.calls == 2
+
 
 class _GuardedCaller:
     """Minimal stand-in for a controller exposing a guarded request."""
@@ -663,6 +712,15 @@ class _GuardedCaller:
         self.calls += 1
         await self.release.wait()
         return f"result-{item_id}"
+
+    @guard_single_request
+    async def fetch_item(
+        self, item_id: str, force_refresh: bool = False, fallback: Album | None = None
+    ) -> str:
+        """Return the result for the given item id, once released."""
+        self.calls += 1
+        await self.release.wait()
+        return f"result-{item_id}-{force_refresh}"
 
 
 class _GatedMusicProvider(MusicProvider):
@@ -714,6 +772,21 @@ async def _gated_task(release: asyncio.Event, result: str, fail: bool = False) -
     if fail:
         raise RuntimeError("task failed")
     return result
+
+
+def _guarded_album(name: str, mapping_ids: tuple[str, ...]) -> Album:
+    """
+    Build an album on the gated test provider to pass as a fallback argument.
+
+    :param name: The album name.
+    :param mapping_ids: The provider item ids to add as provider mappings.
+    """
+    return Album(
+        item_id="123",
+        provider=GUARDED_PROVIDER_ID,
+        name=name,
+        provider_mappings={_provider_mapping(item_id) for item_id in mapping_ids},
+    )
 
 
 def _provider_mapping(item_id: str) -> ProviderMapping:

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -11,7 +11,8 @@ from unittest.mock import MagicMock, patch
 
 import ifaddr
 import pytest
-from music_assistant_models.media_items import Album, ProviderMapping, Track
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import Album, ItemMapping, ProviderMapping, Track
 
 from music_assistant.helpers import util
 from music_assistant.helpers.util import (
@@ -644,8 +645,31 @@ class TestGuardSingleRequest:
         assert provider.track_calls == 1
 
     @pytest.mark.asyncio
-    async def test_media_item_argument_keys_on_its_uri(self, mass_minimal: MusicAssistant) -> None:
-        """Media item arguments pointing at the same provider item share a request."""
+    async def test_equal_media_item_arguments_share_a_request(
+        self, mass_minimal: MusicAssistant
+    ) -> None:
+        """Equal media items key the same however their set fields happen to iterate."""
+        caller = _GuardedCaller(mass_minimal)
+        mapping_ids = ("a", "b", "c", "d")
+        calls = [
+            asyncio.create_task(
+                caller.fetch_item("123", fallback=_guarded_album("Album", mapping_ids))
+            ),
+            asyncio.create_task(
+                caller.fetch_item("123", fallback=_guarded_album("Album", mapping_ids[::-1]))
+            ),
+        ]
+        await asyncio.sleep(0)
+        caller.release.set()
+
+        assert await asyncio.gather(*calls) == [f"123-{GUARDED_PROVIDER_ID}-False-Album"] * 2
+        assert caller.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_media_item_arguments_key_on_their_uri(
+        self, mass_minimal: MusicAssistant
+    ) -> None:
+        """Media items for the same provider item share a request, contents aside."""
         caller = _GuardedCaller(mass_minimal)
         calls = [
             asyncio.create_task(
@@ -655,28 +679,67 @@ class TestGuardSingleRequest:
                 caller.fetch_item("123", fallback=_guarded_album("Second", ("b", "a", "c")))
             ),
         ]
-        # both fallbacks describe item 123, only their contents differ
         await asyncio.sleep(0)
         caller.release.set()
 
-        assert await asyncio.gather(*calls) == ["result-123-False", "result-123-False"]
+        # both fallbacks describe item 123, so the second caller joins and is answered
+        # with the fallback of the caller that started the request
+        assert await asyncio.gather(*calls) == [f"123-{GUARDED_PROVIDER_ID}-False-First"] * 2
         assert caller.calls == 1
 
     @pytest.mark.asyncio
-    async def test_positional_and_keyword_arguments_share_a_request(
+    async def test_item_mapping_and_full_item_get_their_own_request(
         self, mass_minimal: MusicAssistant
     ) -> None:
-        """The same call spelled positionally and by keyword shares a request."""
+        """A mapping and a full item for one item resolve differently, so they never share."""
         caller = _GuardedCaller(mass_minimal)
         calls = [
-            asyncio.create_task(caller.fetch_item("123", True)),
-            asyncio.create_task(caller.fetch_item("123", force_refresh=True)),
+            asyncio.create_task(caller.fetch_item("123", fallback=_guarded_album("Album", ("a",)))),
+            asyncio.create_task(caller.fetch_item("123", fallback=_guarded_mapping("Mapping"))),
         ]
         await asyncio.sleep(0)
         caller.release.set()
 
-        assert await asyncio.gather(*calls) == ["result-123-True", "result-123-True"]
+        assert await asyncio.gather(*calls) == [
+            f"123-{GUARDED_PROVIDER_ID}-False-Album",
+            f"123-{GUARDED_PROVIDER_ID}-False-Mapping",
+        ]
+        assert caller.calls == 2
+
+    @pytest.mark.asyncio
+    async def test_calls_spelled_differently_share_a_request(
+        self, mass_minimal: MusicAssistant
+    ) -> None:
+        """The same call shares a request however its arguments are spelled."""
+        caller = _GuardedCaller(mass_minimal)
+        calls = [
+            asyncio.create_task(caller.fetch_item("123")),
+            asyncio.create_task(caller.fetch_item("123", GUARDED_PROVIDER_ID)),
+            asyncio.create_task(
+                caller.fetch_item("123", provider=GUARDED_PROVIDER_ID, force_refresh=False)
+            ),
+        ]
+        await asyncio.sleep(0)
+        caller.release.set()
+
+        assert await asyncio.gather(*calls) == [f"123-{GUARDED_PROVIDER_ID}-False-None"] * 3
         assert caller.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_arguments_containing_punctuation_do_not_collide(
+        self, mass_minimal: MusicAssistant
+    ) -> None:
+        """Ids carrying punctuation must not run into the argument that follows them."""
+        caller = _GuardedCaller(mass_minimal)
+        calls = [
+            asyncio.create_task(caller.fetch_item("a.b", "c")),
+            asyncio.create_task(caller.fetch_item("a", "b.c")),
+        ]
+        await asyncio.sleep(0)
+        caller.release.set()
+
+        assert await asyncio.gather(*calls) == ["a.b-c-False-None", "a-b.c-False-None"]
+        assert caller.calls == 2
 
     @pytest.mark.asyncio
     async def test_force_refresh_gets_its_own_request(self, mass_minimal: MusicAssistant) -> None:
@@ -689,7 +752,10 @@ class TestGuardSingleRequest:
         await asyncio.sleep(0)
         caller.release.set()
 
-        assert await asyncio.gather(*calls) == ["result-123-False", "result-123-True"]
+        assert await asyncio.gather(*calls) == [
+            f"123-{GUARDED_PROVIDER_ID}-False-None",
+            f"123-{GUARDED_PROVIDER_ID}-True-None",
+        ]
         assert caller.calls == 2
 
 
@@ -715,12 +781,17 @@ class _GuardedCaller:
 
     @guard_single_request
     async def fetch_item(
-        self, item_id: str, force_refresh: bool = False, fallback: Album | None = None
+        self,
+        item_id: str,
+        provider: str = GUARDED_PROVIDER_ID,
+        force_refresh: bool = False,
+        fallback: Album | ItemMapping | None = None,
     ) -> str:
         """Return the result for the given item id, once released."""
         self.calls += 1
         await self.release.wait()
-        return f"result-{item_id}-{force_refresh}"
+        # the fallback is echoed so a caller receiving another caller's argument is visible
+        return f"{item_id}-{provider}-{force_refresh}-{fallback.name if fallback else None}"
 
 
 class _GatedMusicProvider(MusicProvider):
@@ -786,6 +857,20 @@ def _guarded_album(name: str, mapping_ids: tuple[str, ...]) -> Album:
         provider=GUARDED_PROVIDER_ID,
         name=name,
         provider_mappings={_provider_mapping(item_id) for item_id in mapping_ids},
+    )
+
+
+def _guarded_mapping(name: str) -> ItemMapping:
+    """
+    Build an item mapping on the gated test provider to pass as a fallback argument.
+
+    :param name: The item name.
+    """
+    return ItemMapping(
+        media_type=MediaType.ALBUM,
+        item_id="123",
+        provider=GUARDED_PROVIDER_ID,
+        name=name,
     )
 
 


### PR DESCRIPTION
# What does this implement/fix?

When several parts of the server ask for the same item at the same time, we collapse those
into a single request. Which requests count as "the same" is decided by a key built from the
call arguments, and that key was built by stringifying every argument.

For the seven places that pass a whole media item as a `fallback`, that meant the key
contained the item's full representation — around 2000 characters — and because some of its
fields are sets, two equal items could produce two different keys. Identical requests then
missed each other and ran twice. The key was also built by joining the parts with a dot,
while item ids can contain dots themselves, so different calls could in theory produce the
same key.

No user-visible bug here — the worst case was a duplicate request — so this is maintenance.

- Key each call on its parameter names, so the same call keys the same whether arguments are
  passed positionally or by keyword
- Key a media item argument on its uri instead of its full representation (~2000 -> ~190
  characters, and stable for equal items)
- Encode the key so parts containing punctuation can no longer run together
- Keep a full item and a short reference to that same item apart, as they resolve differently
- Tests for the above, including that a forced refresh still never joins a normal request

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
