### PR TITLE
Fix DLNA players reporting a position that runs ahead of the audio

### DIFF
--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -94,6 +94,9 @@ class DLNAPlayer(Player):
 
         self.force_poll = False  # used, if connection is lost
 
+        self._observed_playback_state: PlaybackState | None = None
+        self._playing_since: float | None = None
+
         # ssdp_connect_failed: bool = False
         #
         # Track BOOTID in SSDP advertisements for device changes
@@ -146,6 +149,12 @@ class DLNAPlayer(Player):
         self._attr_volume_muted = self.device.is_volume_muted
         _playback_state = self._get_playback_state()
         assert _playback_state is not None  # for type checking
+        prev_playback_state = self._observed_playback_state
+        self._observed_playback_state = _playback_state
+        if _playback_state != PlaybackState.PLAYING:
+            self._playing_since = None
+        elif prev_playback_state not in (None, PlaybackState.PLAYING):
+            self._playing_since = time.time()
         self._attr_playback_state = _playback_state
 
         _device_uri = self.device.current_track_uri or ""
@@ -192,10 +201,14 @@ class DLNAPlayer(Player):
         # and is adopted instead of being discarded as 'not reported'.
         if (media_position := self.device.media_position) is not None:
             self._attr_elapsed_time = float(media_position)
-            if self.device.media_position_updated_at is not None:
-                self._attr_elapsed_time_last_updated = (
-                    self.device.media_position_updated_at.timestamp()
-                )
+            if (position_updated_at := self.device.media_position_updated_at) is not None:
+                anchor = position_updated_at.timestamp()
+                if self._playing_since is not None:
+                    # a device only re-stamps a position that actually changed, so shortly
+                    # after a resume the timestamp still dates from before the pause. The
+                    # position may not be extrapolated across the time it was not playing.
+                    anchor = max(anchor, self._playing_since)
+                self._attr_elapsed_time_last_updated = anchor
 
     async def get_config_entries(self) -> list[ConfigEntry]:
         """Return all (provider/player specific) Config Entries for the given player (if any)."""
@@ -413,6 +426,7 @@ class DLNAPlayer(Player):
             # Indicates a failure to resubscribe, check if device is still available
             self.force_poll = True
             return
+        poll_first = False
         if service.service_id == "urn:upnp-org:serviceId:AVTransport":
             for state_variable in state_variables:
                 # Force a state refresh when player begins or pauses playback
@@ -422,7 +436,7 @@ class DLNAPlayer(Player):
                     TransportState.PAUSED_PLAYBACK,
                 ):
                     self.force_poll = True
-                    self.mass.create_task(self.poll())
+                    poll_first = True
                     self.logger.log(
                         VERBOSE_LOG_LEVEL,
                         "Received new state from event for Player %s: %s",
@@ -430,10 +444,19 @@ class DLNAPlayer(Player):
                         state_variable.value,
                     )
         self.last_seen = time.time()
-        self.mass.create_task(self._update_player())
+        self.mass.create_task(self._update_player(poll_first=poll_first))
 
-    async def _update_player(self) -> None:
-        """Update DLNA Player."""
+    async def _update_player(self, poll_first: bool = False) -> None:
+        """
+        Update DLNA Player.
+
+        :param poll_first: Refresh the device state before reading it, so that the
+            position info belongs to the state that is about to be reported.
+        """
+        if poll_first:
+            # an unavailable device is reported as such by the state update below
+            with suppress(PlayerUnavailableError):
+                await self.poll()
         prev_url = self._attr_current_media.uri if self._attr_current_media is not None else ""
         prev_state = self.state
         await self.set_dynamic_attributes()

--- a/tests/providers/dlna/test_device_state.py
+++ b/tests/providers/dlna/test_device_state.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from async_upnp_client.profiles.dlna import TransportState
+from music_assistant_models.enums import PlaybackState
 
 from music_assistant.providers.dlna.player import DLNAPlayer
 from tests.common import MockProvider
@@ -125,6 +126,38 @@ async def test_position_from_before_a_resume_is_not_extrapolated() -> None:
     assert player.elapsed_time_last_updated >= resumed_at
 
 
+async def test_position_of_a_player_found_while_playing_keeps_its_own_anchor() -> None:
+    """Without having seen playback start, the timestamp the device reports is all there is."""
+    player = await _updated_player(media_position=200, media_position_updated_at=REPORTED_AT)
+
+    assert player.elapsed_time == 200.0
+    assert player.elapsed_time_last_updated == REPORTED_AT.timestamp()
+
+
+async def test_optimistic_playing_state_does_not_hide_the_start_of_playback() -> None:
+    """
+    Playback starting is tracked from what the device reports, not from what MA assumes.
+
+    A play command marks the player as playing before the device confirms it, which must
+    not be mistaken for the player having been playing all along.
+    """
+    device = _mock_device(
+        transport_state=TransportState.STOPPED,
+        media_position=200,
+        media_position_updated_at=datetime.now(UTC) - timedelta(minutes=10),
+    )
+    player = _player(device)
+    await player.set_dynamic_attributes()
+
+    player._attr_playback_state = PlaybackState.PLAYING
+    device.transport_state = TransportState.PLAYING
+    started_at = time.time()
+    await player.set_dynamic_attributes()
+
+    assert player.elapsed_time_last_updated is not None
+    assert player.elapsed_time_last_updated >= started_at
+
+
 async def test_transport_state_event_polls_before_reading_the_position() -> None:
     """A player that starts playing reports the position of the track it just started."""
     device = _mock_device(
@@ -146,7 +179,11 @@ async def test_transport_state_event_polls_before_reading_the_position() -> None
     tasks: list[asyncio.Task[Any]] = []
 
     def _create_task(target: Coroutine[Any, Any, Any], **_kwargs: Any) -> asyncio.Task[Any]:
-        task: asyncio.Task[Any] = asyncio.ensure_future(target)
+        # eager, like the real helper: the stale read happened because the update task
+        # ran up to its first suspension before the poll task got its answer
+        task: asyncio.Task[Any] = asyncio.Task(
+            target, loop=asyncio.get_running_loop(), eager_start=True
+        )
         tasks.append(task)
         return task
 
@@ -158,10 +195,13 @@ async def test_transport_state_event_polls_before_reading_the_position() -> None
     state_variable.name = "TransportState"
     state_variable.value = TransportState.PLAYING
 
+    started_at = time.time()
     player._handle_event(service, [state_variable])
     await asyncio.gather(*tasks)
 
     assert player.elapsed_time == 0.0
+    assert player.elapsed_time_last_updated is not None
+    assert player.elapsed_time_last_updated >= started_at
 
 
 @pytest.mark.parametrize(("reported", "expected"), [(0.5, 50), (0.0, 0), (1.0, 100)])

--- a/tests/providers/dlna/test_device_state.py
+++ b/tests/providers/dlna/test_device_state.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+import asyncio
+import time
+from collections.abc import Coroutine
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -17,15 +20,12 @@ STALE_POSITION = 120.0
 STALE_REPORTED_AT = 1000.0
 
 
-async def _updated_player(**device_state: Any) -> DLNAPlayer:
+def _mock_device(**device_state: Any) -> MagicMock:
     """
-    Run a state update on a player that already knows a position, and return it.
+    Return a mocked device that fully reports its state.
 
-    :param device_state: Attributes to override on the fully reporting mocked device.
+    :param device_state: Attributes to override on the device.
     """
-    provider = MockProvider("dlna", instance_id="dlna_test")
-    provider.mass.streams.base_url = "http://192.168.1.2:8097"
-
     device = MagicMock()
     device.profile_device.available = True
     device.name = "Living Room Renderer"
@@ -42,6 +42,17 @@ async def _updated_player(**device_state: Any) -> DLNAPlayer:
     device.media_position_updated_at = REPORTED_AT
     for name, value in device_state.items():
         setattr(device, name, value)
+    return device
+
+
+def _player(device: MagicMock) -> DLNAPlayer:
+    """
+    Return a player for the given device that already knows a position.
+
+    :param device: The mocked device to attach to the player.
+    """
+    provider = MockProvider("dlna", instance_id="dlna_test")
+    provider.mass.streams.base_url = "http://192.168.1.2:8097"
 
     player = DLNAPlayer(
         provider,  # type: ignore[arg-type]
@@ -51,7 +62,16 @@ async def _updated_player(**device_state: Any) -> DLNAPlayer:
     )
     player._attr_elapsed_time = STALE_POSITION
     player._attr_elapsed_time_last_updated = STALE_REPORTED_AT
+    return player
 
+
+async def _updated_player(**device_state: Any) -> DLNAPlayer:
+    """
+    Run a state update on a player that already knows a position, and return it.
+
+    :param device_state: Attributes to override on the fully reporting mocked device.
+    """
+    player = _player(_mock_device(**device_state))
     await player.set_dynamic_attributes()
     return player
 
@@ -78,6 +98,70 @@ async def test_missing_position_keeps_the_previous_one() -> None:
 
     assert player.elapsed_time == STALE_POSITION
     assert player.elapsed_time_last_updated == STALE_REPORTED_AT
+
+
+async def test_position_from_before_a_resume_is_not_extrapolated() -> None:
+    """
+    A position reported from before a resume is anchored at the resume.
+
+    A device does not re-stamp a position that did not change, so the timestamp it
+    reports right after a resume still dates from before the pause.
+    """
+    paused_at = datetime.now(UTC) - timedelta(minutes=10)
+    device = _mock_device(
+        transport_state=TransportState.PAUSED_PLAYBACK,
+        media_position=200,
+        media_position_updated_at=paused_at,
+    )
+    player = _player(device)
+    await player.set_dynamic_attributes()
+
+    device.transport_state = TransportState.PLAYING
+    resumed_at = time.time()
+    await player.set_dynamic_attributes()
+
+    assert player.elapsed_time == 200.0
+    assert player.elapsed_time_last_updated is not None
+    assert player.elapsed_time_last_updated >= resumed_at
+
+
+async def test_transport_state_event_polls_before_reading_the_position() -> None:
+    """A player that starts playing reports the position of the track it just started."""
+    device = _mock_device(
+        transport_state=TransportState.STOPPED,
+        media_position=200,
+        media_position_updated_at=datetime.now(UTC) - timedelta(minutes=10),
+    )
+
+    async def _async_update(**_kwargs: Any) -> None:
+        """Answer the poll a round trip later with the position of the new track."""
+        await asyncio.sleep(0)
+        device.transport_state = TransportState.PLAYING
+        device.media_position = 0
+        device.media_position_updated_at = datetime.now(UTC)
+
+    device.async_update = _async_update
+
+    player = _player(device)
+    tasks: list[asyncio.Task[Any]] = []
+
+    def _create_task(target: Coroutine[Any, Any, Any], **_kwargs: Any) -> asyncio.Task[Any]:
+        task: asyncio.Task[Any] = asyncio.ensure_future(target)
+        tasks.append(task)
+        return task
+
+    player.mass.create_task = _create_task  # type: ignore[assignment]
+
+    service = MagicMock()
+    service.service_id = "urn:upnp-org:serviceId:AVTransport"
+    state_variable = MagicMock()
+    state_variable.name = "TransportState"
+    state_variable.value = TransportState.PLAYING
+
+    player._handle_event(service, [state_variable])
+    await asyncio.gather(*tasks)
+
+    assert player.elapsed_time == 0.0
 
 
 @pytest.mark.parametrize(("reported", "expected"), [(0.5, 50), (0.0, 0), (1.0, 100)])


### PR DESCRIPTION
# What does this implement/fix?

A DLNA player could report a playback position that ran ahead of the audio, which since #5461 also propagates to any universal group it plays in.

A DLNA device never sends its position as an event, and the underlying library only re-stamps a position that actually changed. Two things went wrong with that:

- When a device reported that it started or resumed playing, the position refresh and the state update were kicked off at the same time, so the state update read the position from before the refresh had landed — the position of whatever played last, timestamped minutes or hours earlier.
- Right after a resume the device still reports the same position it had when it was paused, so the timestamp that comes with it still dates from the start of the pause. The whole paused period was then counted as playback time.

Resuming after a longer pause could therefore report a position far past the real one, which can make the queue skip the rest of the track.

**Related issue (if applicable):**

- follow-up to #5469

## Changes

- Refresh the device state before reporting a start or resume, instead of alongside it.
- Never anchor a position earlier than the moment playback started.
- Tests for both cases.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
