### PR TITLE
Stop Sonos S1 discovery from freezing the server

### DIFF
--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -177,11 +177,18 @@ class SonosPlayer(Player):
                 self.player_id,
             )
             return
-        if "Pause" not in self.soco.available_actions:
+
+        def _pause() -> bool:
+            """Pause the speaker, reporting whether it accepts the command."""
+            if "Pause" not in self.soco.available_actions:
+                return False
+            self.soco.pause()
+            return True
+
+        if not await asyncio.to_thread(_pause):
             # pause not possible
             await self.stop()
             return
-        await asyncio.to_thread(self.soco.pause)
         self.schedule_poll()
 
     async def volume_set(self, volume_level: int) -> None:

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -351,7 +351,7 @@ class SonosPlayer(Player):
 
         :param soco: The SoCo instance discovered at the new address.
         """
-        if self._attr_available:
+        if self._unloaded or self._attr_available:
             return
         self.logger.debug(
             "Player IP-address changed from %s to %s", self.soco.ip_address, soco.ip_address

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -357,6 +357,8 @@ class SonosPlayer(Player):
         except SonosUpdateError:
             # the regular poll retries the new address until the speaker answers again
             return
+        # mark the speaker alive before reading it back, so its state survives the update
+        self._speaker_activity("IP change")
         await self.setup()
         self._attr_device_info = DeviceInfo(
             model=self._attr_device_info.model,

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -107,11 +107,16 @@ class SonosPlayer(Player):
 
     async def setup(self) -> None:
         """Set up the player."""
-        self._attr_volume_level = self.soco.volume
-        self._attr_volume_muted = self.soco.mute
-        self.update_groups()
-        if not self.synced_to:
-            self.poll_media()
+
+        def _read_speaker_state() -> None:
+            """Read the initial state from the speaker (NOT async friendly)."""
+            self._attr_volume_level = self.soco.volume
+            self._attr_volume_muted = self.soco.mute
+            self.update_groups()
+            if not self.synced_to:
+                self.poll_media()
+
+        await asyncio.to_thread(_read_speaker_state)
         await self.subscribe()
         await self.mass.players.register_or_update(self)
 
@@ -333,25 +338,32 @@ class SonosPlayer(Player):
         self._set_basic_track_info(update_position=update_position)
         self.update_player()
 
-    def update_ip(self, ip_address: str) -> None:
-        """Handle updated IP of a Sonos player (NOT async friendly)."""
+    async def update_ip(self, soco: SoCo) -> None:
+        """
+        Handle a Sonos player that was rediscovered at another IP-address.
+
+        :param soco: The SoCo instance discovered at the new address.
+        """
         if self._attr_available:
             return
         self.logger.debug(
-            "Player IP-address changed from %s to %s", self.soco.ip_address, ip_address
+            "Player IP-address changed from %s to %s", self.soco.ip_address, soco.ip_address
         )
+        # the UPnP endpoints of a SoCo instance are resolved once, when it is constructed,
+        # so reaching the speaker at its new address takes the rediscovered instance
+        self.soco = soco
         try:
-            self.ping()
+            await asyncio.to_thread(self.ping)
         except SonosUpdateError:
+            # the regular poll retries the new address until the speaker answers again
             return
-        self.soco.ip_address = ip_address
-        asyncio.run_coroutine_threadsafe(self.setup(), self.mass.loop)
+        await self.setup()
         self._attr_device_info = DeviceInfo(
             model=self._attr_device_info.model,
             manufacturer=self._attr_device_info.manufacturer,
         )
-        self._attr_device_info.add_identifier(IdentifierType.IP_ADDRESS, ip_address)
-        self._attr_device_info.add_identifier(IdentifierType.UUID, self.soco.uid)
+        self._attr_device_info.add_identifier(IdentifierType.IP_ADDRESS, soco.ip_address)
+        self._attr_device_info.add_identifier(IdentifierType.UUID, self.player_id)
         mac_address = self._extract_mac_from_player_id()
         if mac_address:
             self._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, mac_address)

--- a/music_assistant/providers/sonos_s1/provider.py
+++ b/music_assistant/providers/sonos_s1/provider.py
@@ -161,24 +161,38 @@ class SonosPlayerProvider(PlayerProvider):
 
     async def _setup_player(self, soco: SoCo) -> None:
         """Set up a discovered Sonos player."""
-        player_id = soco.uid
+
+        def _read_uid() -> str:
+            """Read the unique id of the speaker (NOT async friendly)."""
+            return cast("str", soco.uid)
+
+        def _interrogate() -> tuple[bool, bool]:
+            """Read whether the speaker is visible and has a fixed volume (NOT async friendly)."""
+            # Ensure speaker info is available during setup
+            if not soco.speaker_info:
+                soco.get_speaker_info(True, timeout=7)
+            # SonosPlayer reads these off the SoCo instance while it is constructed,
+            # resolving them here keeps their lookups off the event loop
+            _ = soco.household_id
+            _ = soco.player_name
+            return soco.is_visible, soco.fixed_volume
+
+        player_id = await asyncio.to_thread(_read_uid)
 
         if existing := cast("SonosPlayer", self.mass.players.get_player(player_id=player_id)):
             if existing.soco.ip_address != soco.ip_address:
-                existing.update_ip(soco.ip_address)
-            return
-        if not soco.is_visible:
+                await existing.update_ip(soco)
             return
         enabled = self.mass.config.get_raw_player_config_value(player_id, "enabled", True)
         if not enabled:
             self.logger.debug("Ignoring disabled player: %s", player_id)
             return
+        is_visible, fixed_volume = await asyncio.to_thread(_interrogate)
+        if not is_visible:
+            return
         try:
-            # Ensure speaker info is available during setup
-            if not soco.speaker_info:
-                soco.get_speaker_info(True, timeout=7)
             sonos_player = SonosPlayer(self, soco)
-            if not soco.fixed_volume:
+            if not fixed_volume:
                 sonos_player._attr_supported_features = {
                     *sonos_player._attr_supported_features,
                     PlayerFeature.VOLUME_SET,

--- a/music_assistant/providers/sonos_s1/provider.py
+++ b/music_assistant/providers/sonos_s1/provider.py
@@ -168,14 +168,18 @@ class SonosPlayerProvider(PlayerProvider):
 
         def _interrogate() -> tuple[bool, bool]:
             """Read whether the speaker is visible and has a fixed volume (NOT async friendly)."""
+            if not soco.is_visible:
+                # a bridge or the follower of a stereo pair is never registered
+                return False, False
             # Ensure speaker info is available during setup
             if not soco.speaker_info:
                 soco.get_speaker_info(True, timeout=7)
-            # SonosPlayer reads these off the SoCo instance while it is constructed,
-            # resolving them here keeps their lookups off the event loop
+            fixed_volume: bool = soco.fixed_volume
+            # SonosPlayer reads these while it is constructed; the zone group lookup
+            # behind player_name is only cached briefly, so resolve them last
             _ = soco.household_id
             _ = soco.player_name
-            return soco.is_visible, soco.fixed_volume
+            return True, fixed_volume
 
         player_id = await asyncio.to_thread(_read_uid)
 

--- a/scripts/check_blocking_io.py
+++ b/scripts/check_blocking_io.py
@@ -4,9 +4,10 @@ Fail when async code makes a known-blocking, module-qualified call that ruff's A
 Music Assistant is fully async: blocking IO inside a coroutine stalls the event loop and every other
 task on it. Ruff's flake8-async already flags the obvious offenders (``open()``, ``time.sleep()``,
 ``subprocess`` …); this check complements it with high-confidence library calls it does not cover
-(``requests``, ``urllib.request``, ``shutil``, blocking ``os`` filesystem calls, ``socket`` …) made
-directly inside an ``async def``. Wrap such work in ``asyncio.to_thread`` / ``run_in_executor`` (pass
-the function reference rather than calling it inline) or use an async client.
+(``requests``, ``urllib.request``, ``shutil``, blocking ``os`` filesystem calls, ``socket``,
+``soco`` …) made directly inside an ``async def``. Wrap such work in ``asyncio.to_thread`` /
+``run_in_executor`` (pass the function reference rather than calling it inline) or use an async
+client. Only calls are matched, so a blocking attribute read (``soco.volume``) slips through.
 
 The call sites that predate this check are grandfathered through
 ``scripts/lint_baselines/blocking_io_in_async.txt``.
@@ -52,6 +53,8 @@ BLOCKING_CALLS: dict[str, frozenset[str]] = {
         }
     ),
     "socket": frozenset({"create_connection"}),
+    # every method on a SoCo device speaks UPnP over synchronous HTTP
+    "soco": frozenset(),
 }
 
 # urllib.request.urlopen(...) / .urlretrieve(...): matched anywhere a ``urllib`` chain ends in these.

--- a/scripts/check_blocking_io.py
+++ b/scripts/check_blocking_io.py
@@ -32,6 +32,25 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_ROOT = REPO_ROOT / "music_assistant"
 BASELINE_PATH = REPO_ROOT / "scripts" / "lint_baselines" / "blocking_io_in_async.txt"
 
+# A SoCo device and the UPnP service proxies it exposes: every method on these is a SOAP
+# request over synchronous HTTP. ``zone_group_state`` is deliberately absent, its calls only
+# touch an in-memory cache.
+SOCO_OBJECTS = frozenset(
+    {
+        "soco",
+        "alarmClock",
+        "audioIn",
+        "avTransport",
+        "contentDirectory",
+        "deviceProperties",
+        "groupRenderingControl",
+        "musicServices",
+        "renderingControl",
+        "systemProperties",
+        "zoneGroupTopology",
+    }
+)
+
 # Blocking, module-qualified calls ruff's ASYNC rules don't catch, keyed by the immediate module
 # name in the attribute chain (``module.method(...)``). An empty value set means "any attribute".
 BLOCKING_CALLS: dict[str, frozenset[str]] = {
@@ -53,8 +72,7 @@ BLOCKING_CALLS: dict[str, frozenset[str]] = {
         }
     ),
     "socket": frozenset({"create_connection"}),
-    # every method on a SoCo device speaks UPnP over synchronous HTTP
-    "soco": frozenset(),
+    **dict.fromkeys(SOCO_OBJECTS, frozenset()),
 }
 
 # urllib.request.urlopen(...) / .urlretrieve(...): matched anywhere a ``urllib`` chain ends in these.

--- a/scripts/check_blocking_io.py
+++ b/scripts/check_blocking_io.py
@@ -44,6 +44,7 @@ SOCO_OBJECTS = frozenset(
         "contentDirectory",
         "deviceProperties",
         "groupRenderingControl",
+        "music_library",
         "musicServices",
         "renderingControl",
         "systemProperties",

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -407,12 +407,25 @@ async def test_update_ip_probes_the_speaker_off_the_event_loop(sonos_player: Son
     new_soco.renderingControl.GetVolume.side_effect = _blocking_probe
 
     # a probe held on the event loop would starve this block until it hits the timeout
-    with patch.object(sonos_player, "setup", AsyncMock()):
+    with patch.object(sonos_player, "setup", AsyncMock()) as setup:
         async with asyncio.timeout(2):
             update = asyncio.create_task(sonos_player.update_ip(new_soco))
             await asyncio.to_thread(probing.wait, 5)
             probe_may_finish.set()
             await update
+
+    setup.assert_awaited_once()
+
+
+async def test_update_ip_marks_the_recovered_speaker_available(sonos_player: SonosPlayer) -> None:
+    """A speaker that answers at its new address counts as reachable again."""
+    sonos_player._attr_available = False
+    new_soco = _make_rediscovered_soco()
+
+    with patch.object(sonos_player, "setup", AsyncMock()):
+        await sonos_player.update_ip(new_soco)
+
+    assert sonos_player.available
 
 
 async def test_update_ip_skips_setup_when_the_new_address_stays_silent(

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -120,6 +120,51 @@ async def test_play_media_builds_didl_from_stream_url(sonos_player: SonosPlayer)
     assert "library://track/123" not in call_args.kwargs["meta"]
 
 
+class _RecordingSoco:
+    """Minimal soco stand-in that records the thread its speaker query ran on."""
+
+    def __init__(self, actions: list[str]) -> None:
+        self._actions = actions
+        self.query_threads: list[int] = []
+        self.paused = False
+
+    @property
+    def available_actions(self) -> list[str]:
+        """Return the transport actions the speaker currently offers."""
+        self.query_threads.append(threading.get_ident())
+        return self._actions
+
+    def pause(self) -> None:
+        """Pause playback on the speaker."""
+        self.paused = True
+
+
+async def test_pause_queries_the_speaker_off_the_event_loop(sonos_player: SonosPlayer) -> None:
+    """Asking a speaker whether it can pause must not stall the event loop."""
+    soco = _RecordingSoco(["Play", "Stop", "Pause"])
+    sonos_player.soco = soco
+
+    await sonos_player.pause()
+
+    assert len(soco.query_threads) == 1
+    assert soco.query_threads[0] != threading.get_ident()
+    assert soco.paused
+
+
+async def test_pause_falls_back_to_stop_when_the_speaker_cannot_pause(
+    sonos_player: SonosPlayer,
+) -> None:
+    """A speaker that offers no pause action is stopped instead."""
+    soco = _RecordingSoco(["Play", "Stop"])
+    sonos_player.soco = soco
+
+    with patch.object(sonos_player, "stop", AsyncMock()) as stop:
+        await sonos_player.pause()
+
+    stop.assert_awaited_once()
+    assert not soco.paused
+
+
 def _set_transport_state(sonos_player: SonosPlayer, state: str) -> None:
     """Make the mocked speaker report the given transport state."""
     sonos_player.soco.get_current_transport_info.return_value = {"current_transport_state": state}

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import MediaType, PlaybackState
+from music_assistant_models.enums import IdentifierType, MediaType, PlaybackState
 from music_assistant_models.errors import PlayerCommandFailed
 from soco.exceptions import SoCoException
 
@@ -371,6 +371,94 @@ async def test_unloading_mid_subscribe_keeps_no_subscriptions(
             await asyncio.gather(subscribe_task, unload_task)
 
     assert player._subscriptions == []
+
+
+def _make_rediscovered_soco(ip_address: str = "127.0.0.2") -> MagicMock:
+    """Create the mocked soco device that discovery hands over for a speaker that moved."""
+    soco = _make_soco()
+    soco.ip_address = ip_address
+    return soco
+
+
+async def test_update_ip_talks_to_the_rediscovered_speaker(sonos_player: SonosPlayer) -> None:
+    """A speaker found at another address is reached through the newly discovered device."""
+    sonos_player._attr_available = False
+    new_soco = _make_rediscovered_soco()
+
+    with patch.object(sonos_player, "setup", AsyncMock()) as setup:
+        await sonos_player.update_ip(new_soco)
+
+    assert sonos_player.soco is new_soco
+    setup.assert_awaited_once()
+    assert sonos_player.device_info.identifiers[IdentifierType.IP_ADDRESS] == "127.0.0.2"
+
+
+async def test_update_ip_probes_the_speaker_off_the_event_loop(sonos_player: SonosPlayer) -> None:
+    """Probing the rediscovered speaker must not stall the event loop."""
+    sonos_player._attr_available = False
+    new_soco = _make_rediscovered_soco()
+    probing = threading.Event()
+    probe_may_finish = threading.Event()
+
+    def _blocking_probe(*_args: object, **_kwargs: object) -> None:
+        probing.set()
+        probe_may_finish.wait(5)
+
+    new_soco.renderingControl.GetVolume.side_effect = _blocking_probe
+
+    # a probe held on the event loop would starve this block until it hits the timeout
+    with patch.object(sonos_player, "setup", AsyncMock()):
+        async with asyncio.timeout(2):
+            update = asyncio.create_task(sonos_player.update_ip(new_soco))
+            await asyncio.to_thread(probing.wait, 5)
+            probe_may_finish.set()
+            await update
+
+
+async def test_update_ip_skips_setup_when_the_new_address_stays_silent(
+    sonos_player: SonosPlayer,
+) -> None:
+    """An unanswered probe leaves the speaker for the regular poll to pick up."""
+    sonos_player._attr_available = False
+    new_soco = _make_rediscovered_soco()
+    new_soco.renderingControl.GetVolume.side_effect = SoCoException("no answer")
+
+    with patch.object(sonos_player, "setup", AsyncMock()) as setup:
+        await sonos_player.update_ip(new_soco)
+
+    setup.assert_not_awaited()
+    assert sonos_player.soco is new_soco
+
+
+async def test_update_ip_leaves_a_responding_speaker_alone(sonos_player: SonosPlayer) -> None:
+    """A speaker that is still reachable keeps the device it is already talking to."""
+    original_soco = sonos_player.soco
+
+    with patch.object(sonos_player, "setup", AsyncMock()) as setup:
+        await sonos_player.update_ip(_make_rediscovered_soco())
+
+    assert sonos_player.soco is original_soco
+    setup.assert_not_awaited()
+
+
+async def test_setup_reads_the_speaker_off_the_event_loop(sonos_player: SonosPlayer) -> None:
+    """Reading the initial state of a speaker must not stall the event loop."""
+    cast("MagicMock", sonos_player.mass.players).register_or_update = AsyncMock()
+    reading_threads: list[int] = []
+
+    with (
+        patch.object(
+            sonos_player,
+            "update_groups",
+            lambda: reading_threads.append(threading.get_ident()),
+        ),
+        patch.object(sonos_player, "poll_media"),
+        patch.object(sonos_player, "subscribe", AsyncMock()),
+    ):
+        await sonos_player.setup()
+
+    assert len(reading_threads) == 1
+    assert reading_threads[0] != threading.get_ident()
 
 
 async def test_unsubscribe_drops_subscriptions_even_when_cancelled() -> None:

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -488,6 +488,19 @@ async def test_update_ip_skips_setup_when_the_new_address_stays_silent(
     assert sonos_player.soco is new_soco
 
 
+async def test_update_ip_leaves_an_unloaded_speaker_alone(sonos_player: SonosPlayer) -> None:
+    """An unloaded speaker must not be reconnected, its subscriptions would leak."""
+    sonos_player._attr_available = False
+    sonos_player._unloaded = True
+    original_soco = sonos_player.soco
+
+    with patch.object(sonos_player, "setup", AsyncMock()) as setup:
+        await sonos_player.update_ip(_make_rediscovered_soco())
+
+    assert sonos_player.soco is original_soco
+    setup.assert_not_awaited()
+
+
 async def test_update_ip_leaves_a_responding_speaker_alone(sonos_player: SonosPlayer) -> None:
     """A speaker that is still reachable keeps the device it is already talking to."""
     original_soco = sonos_player.soco

--- a/tests/providers/sonos_s1/test_provider.py
+++ b/tests/providers/sonos_s1/test_provider.py
@@ -1,12 +1,13 @@
-"""Unit tests for the Sonos S1 provider discovery scheduling."""
+"""Unit tests for the Sonos S1 player provider."""
 
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import CoreState
@@ -178,3 +179,93 @@ async def test_unload_stops_an_untracked_discovery_from_rescheduling(
             await post_load
 
     assert harness.armed_reschedules == []
+
+
+def _make_provider() -> tuple[SonosPlayerProvider, MagicMock]:
+    """Create a provider bound to a mocked server, and return both."""
+    mass = MagicMock()
+    mass.players.get_player.return_value = None
+    mass.config.get_raw_player_config_value.return_value = True
+    provider = object.__new__(SonosPlayerProvider)
+    provider.mass = mass
+    provider.logger = logging.getLogger("test.sonos_s1.provider")
+    return provider, mass
+
+
+def _make_soco(ip_address: str = "127.0.0.1") -> MagicMock:
+    """Create a mocked soco device as discovery hands it over."""
+    soco = MagicMock()
+    soco.uid = "RINCON_000E58AAAAAA01400"
+    soco.ip_address = ip_address
+    soco.is_visible = True
+    soco.fixed_volume = False
+    # a freshly discovered device has not been asked for its details yet
+    soco.speaker_info = {}
+    return soco
+
+
+async def test_disabled_speaker_is_not_interrogated() -> None:
+    """A speaker the user disabled must not be queried over the network at all."""
+    provider, mass = _make_provider()
+    mass.config.get_raw_player_config_value.return_value = False
+    soco = _make_soco()
+
+    with patch("music_assistant.providers.sonos_s1.provider.SonosPlayer") as player_cls:
+        await provider._setup_player(soco)
+
+    soco.get_speaker_info.assert_not_called()
+    player_cls.assert_not_called()
+
+
+async def test_invisible_speaker_is_not_interrogated() -> None:
+    """A bridge or stereo-pair follower is skipped before it is queried any further."""
+    provider, _ = _make_provider()
+    soco = _make_soco()
+    soco.is_visible = False
+
+    with patch("music_assistant.providers.sonos_s1.provider.SonosPlayer") as player_cls:
+        await provider._setup_player(soco)
+
+    soco.get_speaker_info.assert_not_called()
+    player_cls.assert_not_called()
+
+
+async def test_new_speaker_is_registered() -> None:
+    """A newly discovered speaker is built and set up."""
+    provider, _ = _make_provider()
+    soco = _make_soco()
+
+    with patch("music_assistant.providers.sonos_s1.provider.SonosPlayer") as player_cls:
+        player_cls.return_value.setup = AsyncMock()
+        await provider._setup_player(soco)
+
+    soco.get_speaker_info.assert_called_once()
+    player_cls.assert_called_once_with(provider, soco)
+    player_cls.return_value.setup.assert_awaited_once()
+
+
+async def test_speaker_found_at_a_new_address_is_handed_the_rediscovered_device() -> None:
+    """A known speaker seen at another address adopts the device discovery just built."""
+    provider, mass = _make_provider()
+    existing = MagicMock()
+    existing.soco.ip_address = "127.0.0.1"
+    existing.update_ip = AsyncMock()
+    mass.players.get_player.return_value = existing
+    soco = _make_soco("127.0.0.2")
+
+    await provider._setup_player(soco)
+
+    existing.update_ip.assert_awaited_once_with(soco)
+
+
+async def test_known_speaker_at_the_same_address_is_left_alone() -> None:
+    """Rediscovering a speaker at the address it already uses changes nothing."""
+    provider, mass = _make_provider()
+    existing = MagicMock()
+    existing.soco.ip_address = "127.0.0.1"
+    existing.update_ip = AsyncMock()
+    mass.players.get_player.return_value = existing
+
+    await provider._setup_player(_make_soco("127.0.0.1"))
+
+    existing.update_ip.assert_not_awaited()


### PR DESCRIPTION
# What does this implement/fix?

Sonos S1 asked speakers for their details on the main thread, so the whole server paused for a few seconds per speaker every time discovery ran — at startup and again every 30 minutes. With a handful of speakers that is a noticeable freeze of the UI and of playback commands. Pausing a speaker did the same thing on a smaller scale: it asked the speaker whether it supports pause before doing anything else, which stalls everything if that speaker has dropped off the network.

While working on that path it turned out a speaker that gets a new IP address never recovers either. The new address was written onto a device object whose connection details are fixed the moment it is created, so every command kept going to the old address. The reachability check also ran against the old address before the switch, so it always failed and the new address was dropped. The speaker now reconnects through the device that discovery just found at the new address.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Speaker lookups during discovery and player setup now run in a background thread instead of on the main thread.
- Pausing no longer asks the speaker about its capabilities on the main thread.
- A speaker found at another address is reconnected using the device discovery returned for it, is checked at that new address rather than the old one, and counts as reachable again right away.
- `check_blocking_io` now knows about `soco` and its UPnP service proxies, so a call like this cannot creep back in unnoticed.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
