### PR TITLE
Prevent Sonos S1 speakers from reconnecting after a provider reload

### DIFF
--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -802,6 +802,8 @@ class SonosPlayer(Player):
 
     def _speaker_activity(self, source: str) -> None:
         """Track the last activity on this speaker, set availability and resubscribe."""
+        if self._unloaded:
+            return
         if self._resub_cooldown_expires_at:
             if time.monotonic() < self._resub_cooldown_expires_at:
                 self.logger.debug(

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -312,6 +312,39 @@ async def test_on_unload_unsubscribes_even_when_already_unavailable(
     assert player._subscriptions == []
 
 
+async def test_unloaded_player_is_not_resubscribed_by_a_late_poll(
+    timer_mass: MusicAssistant,
+) -> None:
+    """A poll that reaches an unloaded speaker must not subscribe it to events again."""
+    player = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+    # the speaker was marked unavailable earlier, so it carries no subscriptions and
+    # unloading it leaves that unavailable state behind for a late poll to act on
+    player._attr_available = False
+    await player.on_unload()
+
+    with patch.object(player, "subscribe", AsyncMock()) as subscribe:
+        await player.poll()
+
+    subscribe.assert_not_called()
+    assert player._attr_available is False
+
+
+async def test_speaker_answering_a_poll_again_is_resubscribed(
+    timer_mass: MusicAssistant,
+) -> None:
+    """A speaker that answers a poll after being unavailable is subscribed to events again."""
+    player = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+    player.soco.group.coordinator.uid = player.player_id
+    player.soco.group.members = [player.soco.group.coordinator]
+    player._attr_available = False
+
+    with patch.object(player, "subscribe", AsyncMock()) as subscribe:
+        await player.poll()
+
+    subscribe.assert_called_once()
+    assert player._attr_available is True
+
+
 async def test_unloading_mid_subscribe_keeps_no_subscriptions(
     timer_mass: MusicAssistant,
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

A Sonos S1 speaker that was already offline could reconnect itself after its provider was reloaded, leaving a connection behind that nothing ever cleans up. This is the leak #5433 closed, reachable through a route that fix did not cover.

The player controller can still be inside `await player.poll()` for a speaker while that speaker is being unloaded — the availability ping alone suspends for up to a second per speaker. When that poll finished, a speaker that had been marked unavailable read as "it is back" and was subscribed to all Sonos events again, with auto-renew, on a player the controller no longer owns. It needs the speaker to have been offline for longer than the resubscribe cooldown, so the window is narrow, but once it happens there is nothing left to ever clean those subscriptions up.

- ignore speaker activity once the player has been unloaded, matching the guards already on the other event entry points
- add tests for a poll that reaches an unloaded speaker, and for one that reaches a speaker that recovered

**Related issue (if applicable):**

- follow-up to #5433

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
