### PR TITLE
Clean up pending Sonos speaker setups when the provider is removed

### DIFF
--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -40,6 +40,8 @@ class SonosPlayerProvider(PlayerProvider):
     """Sonos Player provider."""
 
     _ignored_disabled_players: set[str]
+    _pending_setup_tasks: set[str]
+    _unloaded: bool
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to setup this provider."""
@@ -48,6 +50,8 @@ class SonosPlayerProvider(PlayerProvider):
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
         self._ignored_disabled_players = set()
+        self._pending_setup_tasks = set()
+        self._unloaded = False
         self._set_aiosonos_log_level()
         self.mass.streams.register_dynamic_route(
             "/sonos_queue/*", self._handle_sonos_cloud_queue_request
@@ -76,7 +80,14 @@ class SonosPlayerProvider(PlayerProvider):
 
     async def unload(self, is_removed: bool = False) -> None:
         """Handle close/cleanup of the provider."""
+        self._unloaded = True
         self.mass.streams.unregister_dynamic_route("/sonos_queue/*")
+        for task_id in self._pending_setup_tasks:
+            # a timer that already fired lives on as a task under the same id,
+            # so both are needed to cover the pending and the running case
+            self.mass.cancel_timer(task_id)
+            self.mass.cancel_task(task_id)
+        self._pending_setup_tasks.clear()
 
     async def update_config(self, config: ProviderConfig, changed_keys: set[str]) -> None:
         """Handle logic when the config is updated."""
@@ -109,6 +120,10 @@ class SonosPlayerProvider(PlayerProvider):
         self, name: str, state_change: ServiceStateChange, info: AsyncServiceInfo | None
     ) -> None:
         """Handle MDNS service state callback."""
+        if self._unloaded:
+            # discovery resolves an announcement before it dispatches it, so a callback
+            # picked up before the unload can still arrive after it
+            return
         if state_change == ServiceStateChange.Removed:
             # we don't listen for removed players here.
             # instead we just wait for the player connection to fail
@@ -146,6 +161,7 @@ class SonosPlayerProvider(PlayerProvider):
         # handle new player setup in a delayed task because mdns announcements
         # can arrive in (duplicated) bursts
         task_id = f"setup_sonos_{player_id}"
+        self._pending_setup_tasks.add(task_id)
         self.mass.call_later(5, self._setup_player, player_id, name, info, task_id=task_id)
 
     def _set_aiosonos_log_level(self) -> None:

--- a/tests/providers/sonos/conftest.py
+++ b/tests/providers/sonos/conftest.py
@@ -1,0 +1,26 @@
+"""Fixtures for the Sonos provider tests."""
+
+import asyncio
+import threading
+from collections.abc import AsyncGenerator
+
+import pytest
+from music_assistant_models.enums import CoreState
+
+from music_assistant.mass import MusicAssistant
+
+
+@pytest.fixture
+async def timer_mass() -> AsyncGenerator[MusicAssistant]:
+    """Create a bare MusicAssistant exposing the real task/timer machinery."""
+    mass = object.__new__(MusicAssistant)
+    mass.loop = asyncio.get_running_loop()
+    mass.loop_thread_id = threading.get_ident()
+    mass._tracked_timers = {}
+    mass._tracked_tasks = {}
+    mass._state = CoreState.RUNNING
+    yield mass
+    for handle in mass._tracked_timers.values():
+        handle.cancel()
+    for task in mass._tracked_tasks.values():
+        task.cancel()

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -2,33 +2,14 @@
 
 import asyncio
 import logging
-import threading
-from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import ConnectionTimeoutError
 from aiosonos.exceptions import CannotConnect
-from music_assistant_models.enums import CoreState
 
 from music_assistant.mass import MusicAssistant
 from music_assistant.providers.sonos.player import SonosPlayer
-
-
-@pytest.fixture
-async def timer_mass() -> AsyncGenerator[MusicAssistant]:
-    """Create a bare MusicAssistant exposing the real task/timer machinery."""
-    mass = object.__new__(MusicAssistant)
-    mass.loop = asyncio.get_running_loop()
-    mass.loop_thread_id = threading.get_ident()
-    mass._tracked_timers = {}
-    mass._tracked_tasks = {}
-    mass._state = CoreState.RUNNING
-    yield mass
-    for handle in mass._tracked_timers.values():
-        handle.cancel()
-    for task in mass._tracked_tasks.values():
-        task.cancel()
 
 
 def _bind_player(mass: MusicAssistant | MagicMock) -> tuple[SonosPlayer, MagicMock]:

--- a/tests/providers/sonos/test_provider.py
+++ b/tests/providers/sonos/test_provider.py
@@ -1,27 +1,49 @@
 """Tests for Sonos provider discovery."""
 
+import asyncio
 import logging
 from unittest.mock import MagicMock
 
 import pytest
 from zeroconf import ServiceStateChange
 
+from music_assistant.mass import MusicAssistant
 from music_assistant.providers.sonos.provider import SonosPlayerProvider
+
+PLAYER_ID = "sonos_player"
+SERVICE_NAME = "Toilet._sonos._tcp.local."
+
+
+def _bind_provider(mass: MusicAssistant | MagicMock) -> SonosPlayerProvider:
+    """Create a Sonos provider bound to the given MusicAssistant."""
+    provider = SonosPlayerProvider.__new__(SonosPlayerProvider)
+    provider.mass = mass
+    provider.logger = logging.getLogger("test.sonos.discovery")
+    provider._ignored_disabled_players = set()
+    provider._pending_setup_tasks = set()
+    provider._unloaded = False
+    return provider
 
 
 def _make_provider(enabled: bool = False) -> tuple[SonosPlayerProvider, MagicMock]:
     """Create a Sonos provider with mocked discovery dependencies."""
-    provider = SonosPlayerProvider.__new__(SonosPlayerProvider)
     mass = MagicMock()
-    provider.mass = mass
-    provider.logger = logging.getLogger("test.sonos.discovery")
-    provider._ignored_disabled_players = set()
     mass.config.get_raw_player_config_value.return_value = enabled
     mass.players.get_player.return_value = None
-    return provider, mass
+    return _bind_provider(mass), mass
 
 
-def _make_discovery_info(player_id: str = "sonos_player") -> MagicMock:
+def _bind_discovering_provider(mass: MusicAssistant) -> SonosPlayerProvider:
+    """Create a Sonos provider that discovers players on the real timer machinery."""
+    mass.config = MagicMock()
+    mass.config.get_raw_player_config_value.return_value = True
+    mass.players = MagicMock()
+    mass.players.get_player.return_value = None
+    mass.streams = MagicMock()
+    return _bind_provider(mass)
+
+
+def _make_discovery_info(player_id: str = PLAYER_ID) -> MagicMock:
     """Create minimal Sonos mDNS discovery information."""
     info = MagicMock()
     info.decoded_properties = {"uuid": player_id}
@@ -37,12 +59,8 @@ async def test_disabled_discovery_is_not_scheduled_repeatedly(
     info = _make_discovery_info()
 
     with caplog.at_level(logging.DEBUG, logger=provider.logger.name):
-        await provider.on_mdns_service_state_change(
-            "Toilet._sonos._tcp.local.", ServiceStateChange.Added, info
-        )
-        await provider.on_mdns_service_state_change(
-            "Toilet._sonos._tcp.local.", ServiceStateChange.Updated, info
-        )
+        await provider.on_mdns_service_state_change(SERVICE_NAME, ServiceStateChange.Added, info)
+        await provider.on_mdns_service_state_change(SERVICE_NAME, ServiceStateChange.Updated, info)
 
     mass.call_later.assert_not_called()
     ignored_records = [
@@ -60,20 +78,93 @@ async def test_disabled_discovery_logs_again_after_reenable(
     info = _make_discovery_info()
 
     with caplog.at_level(logging.DEBUG, logger=provider.logger.name):
-        await provider.on_mdns_service_state_change(
-            "Toilet._sonos._tcp.local.", ServiceStateChange.Added, info
-        )
+        await provider.on_mdns_service_state_change(SERVICE_NAME, ServiceStateChange.Added, info)
         mass.config.get_raw_player_config_value.return_value = True
-        await provider.on_mdns_service_state_change(
-            "Toilet._sonos._tcp.local.", ServiceStateChange.Updated, info
-        )
+        await provider.on_mdns_service_state_change(SERVICE_NAME, ServiceStateChange.Updated, info)
         mass.config.get_raw_player_config_value.return_value = False
-        await provider.on_mdns_service_state_change(
-            "Toilet._sonos._tcp.local.", ServiceStateChange.Updated, info
-        )
+        await provider.on_mdns_service_state_change(SERVICE_NAME, ServiceStateChange.Updated, info)
 
     mass.call_later.assert_called_once()
     ignored_records = [
         record for record in caplog.records if "in discovery as it is disabled" in record.message
     ]
     assert len(ignored_records) == 2
+
+
+@pytest.mark.asyncio
+async def test_unload_cancels_a_pending_player_setup(timer_mass: MusicAssistant) -> None:
+    """Test a discovered player that is still waiting to be set up is dropped on unload."""
+    provider = _bind_discovering_provider(timer_mass)
+
+    await provider.on_mdns_service_state_change(
+        SERVICE_NAME, ServiceStateChange.Added, _make_discovery_info()
+    )
+    handle = timer_mass._tracked_timers[f"setup_sonos_{PLAYER_ID}"]
+
+    await provider.unload(is_removed=True)
+
+    assert handle.cancelled()
+    assert provider._pending_setup_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_unload_cancels_a_player_setup_that_already_started(
+    timer_mass: MusicAssistant,
+) -> None:
+    """Test a player setup that is already running is aborted when the provider unloads."""
+    provider = _bind_discovering_provider(timer_mass)
+    setup_started = asyncio.Event()
+
+    async def _setup_player(*_args: object) -> None:
+        setup_started.set()
+        await asyncio.sleep(5)
+
+    provider._setup_player = _setup_player  # type: ignore[assignment]
+    await provider.on_mdns_service_state_change(
+        SERVICE_NAME, ServiceStateChange.Added, _make_discovery_info()
+    )
+    task_id = f"setup_sonos_{PLAYER_ID}"
+    # let the armed timer fire now instead of waiting out the discovery debounce
+    timer_mass.call_later(0, provider._setup_player, task_id=task_id)
+    await setup_started.wait()
+    task = timer_mass._tracked_tasks[task_id]
+
+    await provider.unload(is_removed=True)
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_an_announcement_arriving_after_the_unload_is_ignored(
+    timer_mass: MusicAssistant,
+) -> None:
+    """Test a discovery callback that lands after the unload does not arm a new setup."""
+    provider = _bind_discovering_provider(timer_mass)
+
+    await provider.unload(is_removed=True)
+    await provider.on_mdns_service_state_change(
+        SERVICE_NAME, ServiceStateChange.Added, _make_discovery_info()
+    )
+
+    assert timer_mass._tracked_timers == {}
+    assert provider._pending_setup_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_unload_sweeps_every_discovered_player(timer_mass: MusicAssistant) -> None:
+    """Test a burst of discovered players leaves no setup behind after unload."""
+    provider = _bind_discovering_provider(timer_mass)
+
+    for index in range(3):
+        await provider.on_mdns_service_state_change(
+            f"Speaker{index}._sonos._tcp.local.",
+            ServiceStateChange.Added,
+            _make_discovery_info(f"sonos_player_{index}"),
+        )
+    assert len(timer_mass._tracked_timers) == 3
+
+    await provider.unload(is_removed=True)
+
+    assert timer_mass._tracked_timers == {}
+    assert provider._pending_setup_tasks == set()


### PR DESCRIPTION
# What does this implement/fix?

When a Sonos speaker announces itself, the provider waits a few seconds before setting it up, because those announcements arrive in bursts. Unloading the provider did not cancel that pending setup, so a speaker that announced itself just before the Sonos provider was removed still got set up afterwards — connecting to the speaker and registering a player for a provider that is no longer there.

Follow-up on #5433, which fixed the same class of leak per player but left the provider level out of scope.

- Keep track of the player setups that are still waiting to run.
- Cancel them when the provider is unloaded, both while still pending and once already started.
- Ignore speaker announcements that arrive once the provider is gone, so a late one cannot start a new setup.
- Tests for each case.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
