### PR TITLE
Stop Sonos S1 from scanning for speakers after it is turned off

### DIFF
--- a/music_assistant/providers/sonos_s1/constants.py
+++ b/music_assistant/providers/sonos_s1/constants.py
@@ -116,6 +116,7 @@ SUBSCRIPTION_SERVICES = {
 }
 
 # Timing Constants
+DISCOVERY_INTERVAL = 1800
 NEVER_TIME = 0
 RESUB_COOLDOWN_SECONDS = 10.0
 # S1 speakers apply a command a moment after acknowledging it, so the resulting state is

--- a/music_assistant/providers/sonos_s1/provider.py
+++ b/music_assistant/providers/sonos_s1/provider.py
@@ -17,7 +17,12 @@ from music_assistant.constants import CONF_ENTRY_MANUAL_DISCOVERY_IPS, VERBOSE_L
 from music_assistant.helpers.util import format_ip_for_url
 from music_assistant.models.player_provider import PlayerProvider
 
-from .constants import CONF_HOUSEHOLD_ID, CONF_NETWORK_SCAN, SUBSCRIPTION_TIMEOUT
+from .constants import (
+    CONF_HOUSEHOLD_ID,
+    CONF_NETWORK_SCAN,
+    DISCOVERY_INTERVAL,
+    SUBSCRIPTION_TIMEOUT,
+)
 from .player import SonosPlayer
 
 
@@ -25,11 +30,12 @@ class SonosPlayerProvider(PlayerProvider):
     """Sonos S1 Player Provider for legacy Sonos speakers."""
 
     _discovery_running: bool = False
-    _discovery_reschedule_timer: asyncio.TimerHandle | None = None
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the provider."""
         super().__init__(*args, **kwargs)
+        self._discovery_task_id: str = f"sonos_s1_discovery_{self.instance_id}"
+        self._unloaded: bool = False
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to setup this provider."""
@@ -71,9 +77,13 @@ class SonosPlayerProvider(PlayerProvider):
 
     async def unload(self, is_removed: bool = False) -> None:
         """Handle unload/close of the provider."""
-        if self._discovery_reschedule_timer:
-            self._discovery_reschedule_timer.cancel()
-            self._discovery_reschedule_timer = None
+        # a discovery already running in its worker thread cannot be interrupted, so the
+        # flag is what stops it from arming a new reschedule once it resumes
+        self._unloaded = True
+        # a reschedule that already fired lives on as a task under the same id,
+        # so both are needed to cover the pending and the running case
+        self.mass.cancel_timer(self._discovery_task_id)
+        self.mass.cancel_task(self._discovery_task_id)
         # await any in-progress discovery
         while self._discovery_running:
             await asyncio.sleep(0.5)
@@ -142,12 +152,12 @@ class SonosPlayerProvider(PlayerProvider):
 
         await asyncio.to_thread(do_discover)
 
-        def reschedule() -> None:
-            self._discovery_reschedule_timer = None
-            self.mass.create_task(self.discover_players())
-
-        # reschedule self once finished
-        self._discovery_reschedule_timer = self.mass.loop.call_later(1800, reschedule)
+        if self._unloaded:
+            return
+        # reschedule self once finished, replacing any reschedule already armed
+        self.mass.call_later(
+            DISCOVERY_INTERVAL, self.discover_players, task_id=self._discovery_task_id
+        )
 
     async def _setup_player(self, soco: SoCo) -> None:
         """Set up a discovered Sonos player."""

--- a/tests/providers/sonos_s1/test_provider.py
+++ b/tests/providers/sonos_s1/test_provider.py
@@ -1,0 +1,180 @@
+"""Unit tests for the Sonos S1 provider discovery scheduling."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from music_assistant_models.enums import CoreState
+
+from music_assistant.mass import MusicAssistant
+from music_assistant.providers.sonos_s1.constants import DISCOVERY_INTERVAL
+from music_assistant.providers.sonos_s1.provider import SonosPlayerProvider
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Callable
+
+
+@dataclass
+class DiscoveryHarness:
+    """A bare MusicAssistant together with the timers armed on its event loop."""
+
+    mass: MusicAssistant
+    scheduled: list[asyncio.TimerHandle]
+
+    @property
+    def armed_reschedules(self) -> list[asyncio.TimerHandle]:
+        """
+        Return the discovery reschedules still armed, however they were scheduled.
+
+        The reschedule is the only timer these tests arm for the long haul, so the
+        delay tells it apart from the short-lived handles asyncio arms internally.
+        """
+        now = self.mass.loop.time()
+        return [
+            handle
+            for handle in self.scheduled
+            if not handle.cancelled() and handle.when() - now > DISCOVERY_INTERVAL / 2
+        ]
+
+    def make_provider(self) -> SonosPlayerProvider:
+        """Create a SonosPlayerProvider bound to this MusicAssistant."""
+        provider = object.__new__(SonosPlayerProvider)
+        provider.mass = self.mass
+        provider.logger = MagicMock()
+        provider.config = MagicMock()
+        provider.config.instance_id = "sonos_s1--abc"
+        provider.config.get_value.side_effect = lambda key, *_args, **_kwargs: (
+            [] if "ip" in key else False
+        )
+        provider._discovery_task_id = "sonos_s1_discovery_test"
+        provider._unloaded = False
+        return provider
+
+
+@pytest.fixture
+async def harness() -> AsyncGenerator[DiscoveryHarness]:
+    """Create a bare MusicAssistant exposing the real task/timer machinery."""
+    mass = object.__new__(MusicAssistant)
+    loop = asyncio.get_running_loop()
+    mass.loop = loop
+    mass.loop_thread_id = threading.get_ident()
+    mass._tracked_timers = {}
+    mass._tracked_tasks = {}
+    mass._state = CoreState.RUNNING
+    scheduled: list[asyncio.TimerHandle] = []
+    original_call_later = loop.call_later
+
+    # record every handle armed on the loop, so a reschedule that bypasses the
+    # tracked timers is still visible to the assertions
+    def _recording_call_later(
+        delay: float, callback: Callable[..., object], *args: Any, **kwargs: Any
+    ) -> asyncio.TimerHandle:
+        handle = original_call_later(delay, callback, *args, **kwargs)
+        scheduled.append(handle)
+        return handle
+
+    loop.call_later = _recording_call_later  # type: ignore[assignment,method-assign]
+    harness = DiscoveryHarness(mass, scheduled)
+    yield harness
+    loop.call_later = original_call_later  # type: ignore[method-assign]
+    # only the reschedules are ours to disarm: the rest of the recorded handles
+    # belong to asyncio itself
+    for handle in harness.armed_reschedules:
+        handle.cancel()
+    for task in mass._tracked_tasks.values():
+        task.cancel()
+
+
+async def test_repeated_discovery_arms_a_single_reschedule(harness: DiscoveryHarness) -> None:
+    """Every load runs discovery twice, which must not leave a second reschedule armed."""
+    provider = harness.make_provider()
+
+    with patch("music_assistant.providers.sonos_s1.provider.discover", return_value=set()):
+        await provider.discover_players()
+        await provider.discover_players()
+
+    assert len(harness.armed_reschedules) == 1
+
+
+async def test_unload_disarms_the_reschedule(harness: DiscoveryHarness) -> None:
+    """An unloaded provider must not keep a discovery reschedule armed."""
+    provider = harness.make_provider()
+
+    with patch("music_assistant.providers.sonos_s1.provider.discover", return_value=set()):
+        await provider.discover_players()
+        await provider.discover_players()
+        with patch("music_assistant.providers.sonos_s1.provider.events_asyncio") as events:
+            events.event_listener = None
+            await provider.unload()
+
+    assert harness.armed_reschedules == []
+
+
+async def test_unload_aborts_a_reschedule_that_already_fired(harness: DiscoveryHarness) -> None:
+    """A rescheduled discovery that already started must be cancelled by the unload."""
+    provider = harness.make_provider()
+    loop = asyncio.get_running_loop()
+    scanning = asyncio.Event()
+    unload_reached = threading.Event()
+
+    def _blocking_discover(*_args: object, **_kwargs: object) -> set[object]:
+        loop.call_soon_threadsafe(scanning.set)
+        # hold the worker thread so the scan is unmistakably in flight during the unload
+        assert unload_reached.wait(timeout=5)
+        return set()
+
+    with patch("music_assistant.providers.sonos_s1.provider.discover", _blocking_discover):
+        harness.mass.call_later(0, provider.discover_players, task_id=provider._discovery_task_id)
+        await scanning.wait()
+        task = harness.mass._tracked_tasks[provider._discovery_task_id]
+
+        with patch("music_assistant.providers.sonos_s1.provider.events_asyncio") as events:
+            events.event_listener = None
+            unload_task = asyncio.create_task(provider.unload())
+            # the unload waits out the scan already running in its worker thread
+            await asyncio.sleep(0)
+            assert not unload_task.done()
+            unload_reached.set()
+            async with asyncio.timeout(5):
+                await unload_task
+
+    assert task.cancelled()
+    assert harness.armed_reschedules == []
+
+
+async def test_unload_stops_an_untracked_discovery_from_rescheduling(
+    harness: DiscoveryHarness,
+) -> None:
+    """A discovery the provider does not own must not reschedule itself after the unload."""
+    provider = harness.make_provider()
+    loop = asyncio.get_running_loop()
+    scanning = asyncio.Event()
+    unload_reached = threading.Event()
+
+    def _blocking_discover(*_args: object, **_kwargs: object) -> set[object]:
+        loop.call_soon_threadsafe(scanning.set)
+        assert unload_reached.wait(timeout=5)
+        return set()
+
+    with patch("music_assistant.providers.sonos_s1.provider.discover", _blocking_discover):
+        # the discovery run after a provider load is awaited directly, so it is not
+        # tracked under the provider's task id and the unload cannot cancel it
+        post_load = asyncio.create_task(provider.discover_players())
+        await scanning.wait()
+
+        with patch("music_assistant.providers.sonos_s1.provider.events_asyncio") as events:
+            events.event_listener = None
+            unload_task = asyncio.create_task(provider.unload())
+            await asyncio.sleep(0)
+            unload_reached.set()
+            async with asyncio.timeout(5):
+                await unload_task
+        async with asyncio.timeout(5):
+            await post_load
+
+    assert harness.armed_reschedules == []


### PR DESCRIPTION
# What does this implement/fix?

A Sonos S1 provider that was unloaded kept scanning the network for speakers every 30 minutes, forever.

Each provider load runs discovery twice (once while starting up, once right after loading). Every run armed a new "scan again in 30 minutes" timer on top of the previous one without cancelling it, and unloading the provider could only cancel the one timer it still knew about. The leftover timer stayed alive, and every time it fired it started another scan and armed itself again — so an unloaded provider never stopped. If the provider had been disabled or removed, those scans also re-connected to the speakers, which is the leak that #5433 fixed coming back through another route. Each reload left another one of these behind.

Discovery is now scheduled through the server's own timer helper under a fixed id, so a new run replaces the previous one instead of stacking. Unloading cancels a pending scan as well as one that already started, and a scan that is already talking to the network can no longer schedule itself again on the way out.

**Related issue (if applicable):**

- n/a — found while reviewing the discovery/unload path after #5433

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
