### PR TITLE
Keep speaker grouping correct for every user

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -294,6 +294,38 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         """Return all loaded/running MusicProviders."""
         return cast("list[PlayerProvider]", self.mass.get_providers(ProviderType.PLAYER))
 
+    def iter_players(
+        self,
+        return_unavailable: bool = True,
+        return_disabled: bool = False,
+        provider_filter: str | None = None,
+        return_protocol_players: bool = False,
+    ) -> Iterator[Player]:
+        """
+        Iterate over all registered players, regardless of who is asking.
+
+        Use this for internal logic - state derivation, bookkeeping and topology
+        lookups - which must stay correct no matter which user's command happened
+        to trigger it. Use :meth:`all_players` for anything presented to a user.
+
+        :param return_unavailable [bool]: Include unavailable players.
+        :param return_disabled [bool]: Include disabled players.
+        :param provider_filter [str]: Optional filter by provider lookup key.
+        :param return_protocol_players [bool]: Include protocol players (hidden by default).
+        """
+        for player in list(self._players.values()):
+            if not (player.state.available or return_unavailable):
+                continue
+            if not (player.state.enabled or return_disabled):
+                continue
+            if not player.initialized.is_set():
+                continue
+            if provider_filter is not None and player.provider.instance_id != provider_filter:
+                continue
+            if not return_protocol_players and player.state.type == PlayerType.PROTOCOL:
+                continue
+            yield player
+
     def all_players(
         self,
         return_unavailable: bool = True,
@@ -302,9 +334,10 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         return_protocol_players: bool = False,
     ) -> list[Player]:
         """
-        Return all registered players.
+        Return the registered players the current user is allowed to see.
 
-        Note that this applies user filters for players (for non admin users).
+        Note that this applies user filters for players (for non admin users),
+        which makes it unsuitable for internal logic - use :meth:`iter_players` there.
 
         :param return_unavailable [bool]: Include unavailable players.
         :param return_disabled [bool]: Include disabled players.
@@ -322,17 +355,15 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         current_sendspin_player = get_sendspin_player_id()
         return [
             player
-            for player in list(self._players.values())
-            if (player.state.available or return_unavailable)
-            and (player.state.enabled or return_disabled)
-            and player.initialized.is_set()
-            and (provider_filter is None or player.provider.instance_id == provider_filter)
-            and (
-                not user_filter
-                or player.player_id in user_filter
-                or player.player_id == current_sendspin_player
+            for player in self.iter_players(
+                return_unavailable=return_unavailable,
+                return_disabled=return_disabled,
+                provider_filter=provider_filter,
+                return_protocol_players=return_protocol_players,
             )
-            and (return_protocol_players or player.state.type != PlayerType.PROTOCOL)
+            if not user_filter
+            or player.player_id in user_filter
+            or player.player_id == current_sendspin_player
         ]
 
     @api_command("players/all", required_scope=Scope.PLAYERS_READ)
@@ -1254,7 +1285,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         # unjoin from any dynamic sync groups if we're currently in one (edge case)
         # this is in particular used for the Home Assistant integration which does
         # not have a set_members command and only supports a single unjoin command
-        for player in self.all_players(False):
+        for player in self.iter_players(False):
             if not player.state.group_members or player.state.synced_to:
                 continue
             if PlayerFeature.SET_MEMBERS not in player.state.supported_features:
@@ -2590,19 +2621,13 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
 
         :param player: The player to look up the group memberships for.
         """
-        # Deliberately walks the registry instead of all_players(): this is internal
-        # topology used to keep derived state consistent, so it must not be narrowed by
-        # the user context of whichever command happens to trigger the lookup. A group
-        # player mirrors its members, so it is also included while unavailable -
-        # skipping it there is exactly how its state goes stale. Disabled players take
-        # no part at all and players still registering are not fully set up yet.
+        # A group player mirrors its members, so it is also included while unavailable -
+        # skipping it there is exactly how its state goes stale.
         player_id = player.player_id
-        for _player in list(self._players.values()):
+        for _player in self.iter_players():
             if _player.player_id == player_id:
                 continue
             if _player.state.type != PlayerType.GROUP:
-                continue
-            if not _player.state.enabled or not _player.initialized.is_set():
                 continue
             if player_id in _player.state.group_members:
                 yield _player

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -671,7 +671,7 @@ class Player(ABC):
         # provider has a more efficient way to determine this
         if self.type == PlayerType.GROUP:
             return None
-        for player in self.mass.players.all_players(
+        for player in self.mass.players.iter_players(
             return_unavailable=False,
             provider_filter=self.provider.instance_id,
             return_protocol_players=True,
@@ -2538,7 +2538,7 @@ class Player(ABC):
             # protocol players should not have an active group,
             # they follow the group state of their parent player
             return None
-        for group_player in self.mass.players.all_players(
+        for group_player in self.mass.players.iter_players(
             return_unavailable=False, return_disabled=False
         ):
             if group_player.type != PlayerType.GROUP:
@@ -3034,7 +3034,7 @@ class Player(ABC):
                 continue  # already a player ID
             # Check if member_id is a provider instance ID
             if provider := self.mass.get_provider(member_id):
-                for player in self.mass.players.all_players(
+                for player in self.mass.players.iter_players(
                     return_unavailable=False,  # Only include available players
                     provider_filter=provider.instance_id,
                     return_protocol_players=True,

--- a/music_assistant/models/player_provider.py
+++ b/music_assistant/models/player_provider.py
@@ -80,6 +80,13 @@ class PlayerProvider(Provider):
     @property
     def players(self) -> list[Player]:
         """Return all players belonging to this provider."""
-        return self.mass.players.all_players(
-            provider_filter=self.instance_id, return_protocol_players=True
+        # a provider owns these players, so it always sees all of them - narrowing this
+        # to what some user happens to see corrupts the provider's own bookkeeping, such
+        # as the grouping options it derives from this list. Note this still hides
+        # disabled and still-initializing players; teardown needs those too and therefore
+        # walks the registry itself (see mass.unload_provider).
+        return list(
+            self.mass.players.iter_players(
+                provider_filter=self.instance_id, return_protocol_players=True
+            )
         )

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -246,7 +246,7 @@ class SyncGroupPlayer(Player):
         # all members offline), offer any compatible player.
         # Actual compatibility is validated when adding members
         can_group_with = set()
-        for player in self.mass.players.all_players(return_unavailable=False):
+        for player in self.mass.players.iter_players(return_unavailable=False):
             if not player.available or player.type == PlayerType.GROUP:
                 # let's avoid showing group players as options to group with
                 continue

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Callable, Iterator
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -334,6 +334,29 @@ def _group_with_member(
     return controller, group_player, member
 
 
+@contextlib.contextmanager
+def _restricted_user(visible_player_ids: list[str]) -> Iterator[None]:
+    """
+    Run the wrapped block as a non-admin user that may only see the given players.
+
+    :param visible_player_ids: The player ids the user is allowed to see.
+    """
+    # the contextvar is copied into the task an API command runs in, so it stays
+    # live for everything that command reaches, internal bookkeeping included
+    token = current_user.set(
+        User(
+            user_id="user_1",
+            username="restricted",
+            role=UserRole.USER,
+            player_filter=visible_player_ids,
+        )
+    )
+    try:
+        yield
+    finally:
+        current_user.reset(token)
+
+
 class TestStateForwarding:
     """Test forwarding of player state changes to related players."""
 
@@ -427,22 +450,11 @@ class TestStateForwarding:
         """The fan-out must not be narrowed by the user that triggered the update."""
         controller, group_player, member = _group_with_member(mock_mass)
 
-        # a non-admin user that may only see the member; the contextvar is copied into
-        # the task an API command runs in, so it is live during the state fan-out
-        restricted_user = User(
-            user_id="user_1",
-            username="restricted",
-            role=UserRole.USER,
-            player_filter=["member"],
-        )
-        token = current_user.set(restricted_user)
-        try:
+        with _restricted_user(["member"]):
             assert group_player not in controller.all_players()
             with patch.object(group_player, "on_group_member_updated") as on_group_member_updated:
                 changed_values = {"playback_state": (PlaybackState.IDLE, PlaybackState.PLAYING)}
                 controller._forward_state_update(member, changed_values)
-        finally:
-            current_user.reset(token)
 
         on_group_member_updated.assert_called_once_with(member, changed_values)
 
@@ -483,6 +495,69 @@ class TestStateForwarding:
             )
 
         on_group_member_updated.assert_not_called()
+
+
+class TestUnscopedPlayerLookups:
+    """Derived player state must not depend on who triggered the recalculation."""
+
+    def test_iter_players_ignores_the_user_filter(self, mock_mass: MagicMock) -> None:
+        """iter_players is the internal view: every registered player, no user filter."""
+        controller, group_player, member = _group_with_member(mock_mass)
+
+        with _restricted_user(["member"]):
+            assert controller.all_players() == [member]
+            assert set(controller.iter_players()) == {group_player, member}
+
+    def test_active_group_survives_a_restricted_user_context(self, mock_mass: MagicMock) -> None:
+        """A member must still know its group when the triggering user cannot see it."""
+        _controller, group_player, member = _group_with_member(mock_mass)
+        group_player._attr_group_members = ["member"]
+        group_player._attr_powered = True
+        group_player.update_state(signal_event=False)
+
+        with _restricted_user(["member"]):
+            member.update_state(signal_event=False, force_update=True)
+            assert member.state.active_group == "group"
+
+    def test_synced_to_survives_a_restricted_user_context(self, mock_mass: MagicMock) -> None:
+        """A follower must still resolve its sync leader across a user filter."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        leader = MockPlayer(provider, "leader", "Leader")
+        follower = MockPlayer(provider, "follower", "Follower")
+        controller._players = {"leader": leader, "follower": follower}
+        mock_mass.players = controller
+
+        leader._attr_group_members = ["leader", "follower"]
+        for player in (leader, follower):
+            player.initialized.set()
+            player.update_state(signal_event=False)
+
+        with _restricted_user(["follower"]):
+            follower.update_state(signal_event=False, force_update=True)
+            assert follower.state.synced_to == "leader"
+
+    def test_can_group_with_survives_a_restricted_user_context(self, mock_mass: MagicMock) -> None:
+        """Expanding a provider id into players must not drop players the user cannot see."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        mock_mass.get_provider.return_value = provider
+
+        player_a = MockPlayer(provider, "player_a", "Player A")
+        player_b = MockPlayer(provider, "player_b", "Player B")
+        controller._players = {"player_a": player_a, "player_b": player_b}
+        mock_mass.players = controller
+
+        # a provider instance id stands for "every player of that provider"
+        player_a._attr_can_group_with = {"test"}
+        for player in (player_a, player_b):
+            player.initialized.set()
+            player.update_state(signal_event=False)
+
+        with _restricted_user(["player_a"]):
+            player_a.update_state(signal_event=False, force_update=True)
+            assert "player_b" in player_a.state.can_group_with
 
 
 class TestSleepTimer:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -53,6 +53,7 @@ from music_assistant.constants import (
 )
 from music_assistant.controllers.players import PlayerController
 from music_assistant.controllers.webserver.helpers.auth_middleware import current_user
+from music_assistant.models.player_provider import PlayerProvider
 from tests.common import MockPlayer, MockProvider
 
 
@@ -507,6 +508,35 @@ class TestUnscopedPlayerLookups:
         with _restricted_user(["member"]):
             assert controller.all_players() == [member]
             assert set(controller.iter_players()) == {group_player, member}
+
+    def test_provider_filter_still_ignores_the_user_filter(self, mock_mass: MagicMock) -> None:
+        """A lookup scoped to one provider must still ignore the user filter."""
+        controller, group_player, member = _group_with_member(mock_mass)
+
+        with _restricted_user(["member"]):
+            found = set(controller.iter_players(provider_filter="test"))
+
+        assert found == {group_player, member}
+
+    def test_provider_sees_all_of_its_own_players(self, mock_mass: MagicMock) -> None:
+        """A provider owns its players, so a user filter must never hide them from it."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        plain = MockPlayer(provider, "plain", "Plain")
+        # a protocol player id is picked from a list that hides protocol players, so it
+        # is never in a user's filter - the whole set used to disappear for any non-admin
+        protocol = MockPlayer(provider, "protocol", "Protocol", player_type=PlayerType.PROTOCOL)
+        controller._players = {"plain": plain, "protocol": protocol}
+        mock_mass.players = controller
+        for player in (plain, protocol):
+            player.initialized.set()
+            player.update_state(signal_event=False)
+
+        with _restricted_user(["plain"]):
+            owned = set(PlayerProvider.players.fget(provider))  # type: ignore[attr-defined]
+
+        assert owned == {plain, protocol}
 
     def test_active_group_survives_a_restricted_user_context(self, mock_mass: MagicMock) -> None:
         """A member must still know its group when the triggering user cannot see it."""

--- a/tests/providers/airplay/dacp/conftest.py
+++ b/tests/providers/airplay/dacp/conftest.py
@@ -32,7 +32,7 @@ def mock_mass() -> MagicMock:
     mass.players.get_active_queue = MagicMock(
         return_value=MagicMock(queue_id="q1", shuffle_enabled=False)
     )
-    mass.players.all_players = MagicMock(return_value=[])
+    mass.players.iter_players = MagicMock(return_value=[])
     mass.player_queues = MagicMock()
     mass.player_queues.set_shuffle = AsyncMock()
     mass.call_later = MagicMock()
@@ -132,5 +132,5 @@ def make_player(  # noqa: PLR0913
         player.stream = stream
     else:
         player.stream = None
-    mass.players.all_players.return_value = [player]
+    mass.players.iter_players.return_value = [player]
     return player

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -884,7 +884,7 @@ async def test_grouped_play_resumes_active_native_queue(airplay_player: AirPlayP
 async def test_single_player_pause_sends_action_pause(airplay_player: AirPlayPlayer) -> None:
     """An unsynced player pauses the stream in place with ACTION=PAUSE."""
     airplay_player._attr_group_members = []
-    airplay_player.mass.players.all_players.return_value = []  # type: ignore[attr-defined]
+    airplay_player.mass.players.iter_players.return_value = []  # type: ignore[attr-defined]
     send_cmd = _setup_running_stream(airplay_player)
 
     with patch.object(AirPlayPlayer, "stop", new=AsyncMock()) as mock_stop:
@@ -963,7 +963,7 @@ def _make_idle_player(player_id: str = "test_player") -> AirPlayPlayer:
         airplay_discovery_info=None,
     )
     # the synced_to property scans all players of the provider
-    _players_mock(player).all_players.return_value = []
+    _players_mock(player).iter_players.return_value = []
     player._attr_group_members = []
     player._attr_playback_state = PlaybackState.IDLE
     player.stream = None
@@ -1123,7 +1123,7 @@ async def test_rejoin_aborts_when_synced_into_foreign_group() -> None:
     foreign_leader.player_id = "other"
     foreign_leader.group_members = ["other", player.player_id]
     # the player reports it is now synced to a leader outside the original group
-    _players_mock(player).all_players.return_value = [foreign_leader]
+    _players_mock(player).iter_players.return_value = [foreign_leader]
     players_mock = _players_mock(player)
     players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
     players_mock.cmd_group = AsyncMock()
@@ -1153,7 +1153,7 @@ def test_resolve_rejoin_target_skips_candidate_in_foreign_group() -> None:
     foreign_leader._attr_group_members = ["foreign", "old_leader"]
     old_leader = _make_playing_leader("old_leader")
     # the old leader reports it is now synced to the foreign leader
-    _players_mock(old_leader).all_players.return_value = [foreign_leader]
+    _players_mock(old_leader).iter_players.return_value = [foreign_leader]
     _players_mock(player).get_player.side_effect = lambda player_id: {
         "old_leader": old_leader,
         "foreign": foreign_leader,
@@ -1198,7 +1198,7 @@ async def test_rejoin_heals_session_when_membership_survived() -> None:
     # the sync membership survived the stream loss: the player is still listed
     # as a member of (and synced to) the leader
     leader._attr_group_members = ["leader", player.player_id]
-    _players_mock(player).all_players.return_value = [leader]
+    _players_mock(player).iter_players.return_value = [leader]
     players_mock = _players_mock(player)
     players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
     players_mock.cmd_group = AsyncMock()
@@ -1225,7 +1225,7 @@ async def test_rejoin_session_heal_failure_keeps_membership() -> None:
     player = _make_idle_player()
     leader = _make_playing_leader()
     leader._attr_group_members = ["leader", player.player_id]
-    _players_mock(player).all_players.return_value = [leader]
+    _players_mock(player).iter_players.return_value = [leader]
     players_mock = _players_mock(player)
     players_mock.get_player.side_effect = lambda player_id: {"leader": leader}.get(player_id)
     players_mock.cmd_group = AsyncMock()

--- a/tests/providers/msx_bridge/conftest.py
+++ b/tests/providers/msx_bridge/conftest.py
@@ -85,6 +85,7 @@ def mass_mock(player_config_mock: Mock) -> Mock:
     mass.players.unregister = AsyncMock()
     mass.players.all = Mock(return_value=[])
     mass.players.all_players = Mock(return_value=[])
+    mass.players.iter_players = Mock(return_value=[])
 
     # Image URLs
     mass.metadata.get_image_url = Mock(return_value=None)

--- a/tests/providers/msx_bridge/test_provider.py
+++ b/tests/providers/msx_bridge/test_provider.py
@@ -154,7 +154,7 @@ async def test_unload_stops_server_first(provider: MSXBridgeProvider) -> None:
     mock_player.display_name = "Test TV"
     mock_player.player_id = "msx_test"
     provider.mass.players.all.return_value = [mock_player]  # type: ignore[attr-defined]
-    provider.mass.players.all_players.return_value = [mock_player]  # type: ignore[attr-defined]
+    provider.mass.players.iter_players.return_value = [mock_player]  # type: ignore[attr-defined]
 
     await provider.unload()
 
@@ -166,7 +166,7 @@ async def test_unload_no_server(provider: MSXBridgeProvider) -> None:
     """Unload should not crash when http_server is None."""
     provider.http_server = None
     provider.mass.players.all.return_value = []  # type: ignore[attr-defined]
-    provider.mass.players.all_players.return_value = []  # type: ignore[attr-defined]
+    provider.mass.players.iter_players.return_value = []  # type: ignore[attr-defined]
 
     await provider.unload()  # should not raise
 

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -884,7 +884,7 @@ class TestPresetMembersInDynamicGroup:
         mass.players.get_player = _player_lookup(
             {"offline_member": offline_member, "candidate": candidate}
         )
-        mass.players.all_players = MagicMock(return_value=[candidate])
+        mass.players.iter_players = MagicMock(return_value=[candidate])
 
         assert "candidate" in sgp.can_group_with
 
@@ -905,7 +905,7 @@ class TestPresetMembersInDynamicGroup:
         result = sgp.can_group_with
 
         assert {"online_member", "friend"} <= result
-        mass.players.all_players.assert_not_called()
+        mass.players.iter_players.assert_not_called()
 
 
 class TestGetConfigEntriesMemberPicker:


### PR DESCRIPTION
# What does this implement/fix?

A player works out its active group, its sync leader and which players it can be grouped with by scanning the other players. That scan went through the regular "list players" helper, which only returns the players the current user is allowed to see.

Since the user context of an API command carries into everything that command touches, a state recalculation triggered by a non-admin user (or by an automation impersonating one) could not see the other players involved. The wrong answer was then stored as the player's state and sent to everyone, so a speaker could show up as not grouped, or refuse to be grouped, until something else recalculated it.

Follow-up to #5393, which fixed the same problem for the group state fan-out.

**Related issue (if applicable):**

- n/a (found while reviewing #5385)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Added `iter_players()`, which returns every registered player regardless of who is asking, and turned `all_players()` into a thin wrapper that applies the user filter on top of it — so the filter now lives in one place instead of being something each caller has to remember to avoid.
- Use it when working out a player's sync leader, active group and groupable players, and when ungrouping a player.
- A provider's own player list now uses it too. That list feeds the grouping options a provider offers (AirPlay derives them straight from it), and also drives the group-related refresh of every player of a provider. For protocol players it emptied out completely, because their ids never appear in a user's filter.
- Same for the sync group's fallback list of groupable players, used when a group has no available members.
- Simplified the group lookup added in #5393 to reuse the same iterator.
- Updated the test doubles that stand in for the players controller.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
