### PR TITLE
Keep unloading a provider when one of its players fails to shut down

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1598,7 +1598,12 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             handle.cancel()
         self._clear_sleep_timer(player)
         self.mass.player_queues.on_player_remove(player_id, permanent=permanent)
-        await player.on_unload()
+        # teardown is best-effort: a provider that fails to release its player must not
+        # strand the other players of that provider, nor the provider unload itself
+        try:
+            await player.on_unload()
+        except Exception:
+            self.logger.exception("Error unloading player %s", player.name)
         if permanent:
             # player permanent removal: cleanup protocol links, delete config
             # and signal PLAYER_REMOVED event

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -1026,16 +1026,16 @@ class MusicAssistant:
             for dep_prov in self.providers:
                 if dep_prov.manifest.depends_on == provider.domain:
                     await self.unload_provider(dep_prov.instance_id)
-            if is_player_provider(provider):
-                # unregister all players of this provider, straight from the registry: the
-                # provider's own players listing hides disabled and still-initializing
-                # players, which must be unregistered here too so their on_unload runs
-                # and no stale entry is left behind
-                for player in list(self.players):
-                    if player.provider.instance_id != instance_id:
-                        continue
-                    await self.players.unregister(player.player_id, permanent=is_removed)
             try:
+                if is_player_provider(provider):
+                    # unregister all players of this provider, straight from the registry: the
+                    # provider's own players listing hides disabled and still-initializing
+                    # players, which must be unregistered here too so their on_unload runs
+                    # and no stale entry is left behind
+                    for player in list(self.players):
+                        if player.provider.instance_id != instance_id:
+                            continue
+                        await self.players.unregister(player.player_id, permanent=is_removed)
                 await provider.unload(is_removed)
             except Exception as err:
                 LOGGER.warning(

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -206,8 +206,6 @@ class SonosPlayer(Player):
             # so both are needed to cover the pending and the running case
             self.mass.cancel_timer(task_id)
             self.mass.cancel_task(task_id)
-        # unregister does not guard this call, and it runs before the provider's
-        # remaining players are unregistered: a raise here would strand them
         try:
             await self._disconnect()
         except Exception:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -3085,5 +3085,36 @@ class TestRemovePlayerControl:
         mock_mass.loop.call_soon.assert_not_called()
 
 
+class _FailingTeardownPlayer(MockPlayer):
+    """Player whose provider fails to release it."""
+
+    unloaded = False
+
+    async def on_unload(self) -> None:
+        """Handle logic when the player is unloaded from the Player controller."""
+        self.unloaded = True
+        msg = "device is gone"
+        raise RuntimeError(msg)
+
+
+class TestUnregisterTeardown:
+    """Test that a failing player teardown stays contained."""
+
+    async def test_failing_on_unload_still_unregisters_the_player(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Test that a provider raising while releasing its player does not break unregister."""
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+        provider = MockProvider("test_provider", instance_id="test_prov", mass=mock_mass)
+        player = _FailingTeardownPlayer(provider, "boom", "Boom")
+        controller._players = {"boom": player}
+
+        await controller.unregister("boom")
+
+        assert "boom" not in controller._players
+        assert player.unloaded
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/core/test_provider_unload.py
+++ b/tests/core/test_provider_unload.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.config_entries import ProviderConfig
-from music_assistant_models.enums import MediaType, ProviderType
+from music_assistant_models.enums import EventType, MediaType, ProviderType
 from music_assistant_models.errors import LoginFailed
 from music_assistant_models.provider import ProviderManifest
 
@@ -246,3 +246,124 @@ async def test_unload_provider_unregisters_hidden_players(
         (mock_call.args[0], mock_call.kwargs["permanent"])
         for mock_call in mass_minimal.player_queues.on_player_remove.call_args_list
     } == {(player_id, is_removed) for player_id in provider_player_ids}
+
+
+class _TeardownProvider(PlayerProvider):
+    """Player provider that records whether its own unload ran."""
+
+    unloaded = False
+
+    async def unload(self, is_removed: bool = False) -> None:
+        """Handle unload of the provider."""
+        self.unloaded = True
+
+
+class _TeardownPlayer(Player):
+    """Player that records its teardown and optionally fails it."""
+
+    def __init__(self, provider: PlayerProvider, player_id: str, fails: bool = False) -> None:
+        """
+        Initialize the player.
+
+        :param provider: Player provider this player belongs to.
+        :param player_id: ID of the player.
+        :param fails: Raise from on_unload to simulate a provider that fails to release it.
+        """
+        super().__init__(provider, player_id)
+        self._attr_name = player_id
+        self._attr_available = True
+        self._fails = fails
+        self.unloaded = False
+
+    async def on_unload(self) -> None:
+        """Handle logic when the player is unloaded from the Player controller."""
+        self.unloaded = True
+        if self._fails:
+            msg = "device is gone"
+            raise RuntimeError(msg)
+
+
+def _setup_player_provider(
+    mass: MusicAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    failing_player_id: str,
+) -> tuple[_TeardownProvider, list[_TeardownPlayer], list[EventType]]:
+    """
+    Wire a minimal mass with one player provider owning three registered players.
+
+    :param mass: Minimal MusicAssistant instance to wire up.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param failing_player_id: ID of the player whose on_unload must raise.
+    :return: The provider, its players (in registration order) and the recorded event types.
+    """
+    monkeypatch.setattr(
+        mass, "music", MagicMock(unschedule_provider_sync=AsyncMock()), raising=False
+    )
+    monkeypatch.setattr(mass, "player_queues", MagicMock(), raising=False)
+    monkeypatch.setattr(mass, "_update_available_providers_cache", AsyncMock())
+    monkeypatch.setattr(mass.discovery, "on_provider_unload", MagicMock())
+    signalled: list[EventType] = []
+    monkeypatch.setattr(
+        mass, "signal_event", lambda event, *_args, **_kwargs: signalled.append(event)
+    )
+    monkeypatch.setattr(mass, "players", PlayerController(mass), raising=False)
+
+    provider = _TeardownProvider(
+        mass,
+        manifest=ProviderManifest(
+            type=ProviderType.PLAYER,
+            domain="test_player_provider",
+            name="Test player provider",
+            description="Test player provider",
+            codeowners=["@music-assistant"],
+        ),
+        config=ProviderConfig(
+            values={},
+            type=ProviderType.PLAYER,
+            domain="test_player_provider",
+            instance_id="test_player_provider--instance",
+            name="Test player provider",
+        ),
+    )
+    mass._providers[provider.instance_id] = provider
+
+    players = [
+        _TeardownPlayer(provider, player_id, fails=player_id == failing_player_id)
+        for player_id in ("player_a", "player_b", "player_c")
+    ]
+    for player in players:
+        mass.players._players[player.player_id] = player
+        player.set_initialized()
+    return provider, players, signalled
+
+
+async def test_failing_player_teardown_does_not_strand_the_others(
+    mass_minimal: MusicAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A player that fails to release must not block the rest of the provider unload."""
+    provider, players, signalled = _setup_player_provider(mass_minimal, monkeypatch, "player_a")
+
+    await mass_minimal.unload_provider(provider.instance_id)
+
+    assert all(player.unloaded for player in players)
+    assert mass_minimal.players._players == {}
+    assert provider.unloaded
+    assert provider.instance_id not in mass_minimal._providers
+    assert EventType.PROVIDERS_UPDATED in signalled
+
+
+async def test_failing_unregister_still_deregisters_the_provider(
+    mass_minimal: MusicAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unregister that raises must still leave the provider deregistered and signalled."""
+    provider, _players, signalled = _setup_player_provider(mass_minimal, monkeypatch, "player_a")
+    monkeypatch.setattr(
+        mass_minimal.players, "unregister", AsyncMock(side_effect=RuntimeError("teardown blew up"))
+    )
+
+    await mass_minimal.unload_provider(provider.instance_id)
+
+    assert provider.instance_id not in mass_minimal._providers
+    assert EventType.PROVIDERS_UPDATED in signalled


### PR DESCRIPTION
# What does this implement/fix?

When a provider is unloaded (reload, disable, remove), Music Assistant unregisters each of its players first. If one player failed to shut down cleanly, everything after it was skipped: the provider's other players were never unregistered and kept their connections and listeners running, the provider itself was never unloaded, and it stayed listed as loaded because the cleanup step never ran.

Player shutdown is now best-effort, so one misbehaving player no longer takes the rest of the unload down with it.

Changes:

- a player that fails to shut down is logged and skipped instead of aborting the unload
- the remaining players of the provider are still unregistered
- the provider is always cleaned up and stops being listed as loaded

**Related issue (if applicable):**

- follow-up on review feedback from #5433

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
