### PR TITLE
Add test coverage for removing a player provider

### DIFF
--- a/tests/core/test_provider_unload.py
+++ b/tests/core/test_provider_unload.py
@@ -219,6 +219,7 @@ async def test_unload_provider_unregisters_hidden_players(
     add_player(provider, "initializing_player", initialized=False)
     other_player = add_player(other_provider, "other_provider_player")
     provider_player_ids = {"enabled_player", "disabled_player", "initializing_player"}
+    all_player_ids = provider_player_ids | {other_player.player_id}
 
     try:
         await mass_minimal.unload_provider(provider.instance_id, is_removed=is_removed)
@@ -234,10 +235,14 @@ async def test_unload_provider_unregisters_hidden_players(
     # the players come back with their settings
     stored_configs = {
         player_id
-        for player_id in provider_player_ids | {other_player.player_id}
+        for player_id in all_player_ids
         if mass_minimal.config.get(f"{CONF_PLAYERS}/{player_id}")
     }
-    expected_configs = (
-        {other_player.player_id} if is_removed else provider_player_ids | {other_player.player_id}
-    )
-    assert stored_configs == expected_configs
+    assert stored_configs == ({other_player.player_id} if is_removed else all_player_ids)
+
+    # the queue controller is the other consumer of the removal flag: it drops the
+    # persisted queue of a player only when that player is gone for good
+    assert {
+        (mock_call.args[0], mock_call.kwargs["permanent"])
+        for mock_call in mass_minimal.player_queues.on_player_remove.call_args_list
+    } == {(player_id, is_removed) for player_id in provider_player_ids}

--- a/tests/core/test_provider_unload.py
+++ b/tests/core/test_provider_unload.py
@@ -6,12 +6,14 @@ import asyncio
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.config_entries import ProviderConfig
 from music_assistant_models.enums import MediaType, ProviderType
 from music_assistant_models.errors import LoginFailed
 from music_assistant_models.provider import ProviderManifest
 
+from music_assistant.constants import CONF_PLAYERS
 from music_assistant.controllers.music import MusicController
 from music_assistant.controllers.players import PlayerController
 from music_assistant.controllers.tasks import TasksController
@@ -22,7 +24,6 @@ from music_assistant.models.player import Player
 from music_assistant.models.player_provider import PlayerProvider
 
 if TYPE_CHECKING:
-    import pytest
     from music_assistant_models.config_entries import ProviderError
 
 
@@ -141,11 +142,17 @@ async def test_unload_provider_waits_for_running_sync(
     assert sync_finished_on_unload is True
 
 
+@pytest.mark.parametrize("is_removed", [False, True])
 async def test_unload_provider_unregisters_hidden_players(
     mass_minimal: MusicAssistant,
     monkeypatch: pytest.MonkeyPatch,
+    is_removed: bool,
 ) -> None:
-    """Unloading a player provider also unregisters its disabled and initializing players."""
+    """
+    Unloading a player provider also unregisters its disabled and initializing players.
+
+    Removing the provider deletes their configs as well, a plain reload keeps them.
+    """
     mass_minimal.players = PlayerController(mass_minimal)
     mass_minimal.music = MagicMock(unschedule_provider_sync=AsyncMock())
     mass_minimal.player_queues = MagicMock()
@@ -211,12 +218,26 @@ async def test_unload_provider_unregisters_hidden_players(
     # a player that is still being set up when its provider goes away
     add_player(provider, "initializing_player", initialized=False)
     other_player = add_player(other_provider, "other_provider_player")
+    provider_player_ids = {"enabled_player", "disabled_player", "initializing_player"}
 
     try:
-        await mass_minimal.unload_provider(provider.instance_id)
+        await mass_minimal.unload_provider(provider.instance_id, is_removed=is_removed)
     finally:
         # unregistering schedules a debounced state update for the players that remain
         mass_minimal.cancel_timer(f"player_update_state_{other_player.player_id}")
 
-    assert set(unloaded_players) == {"enabled_player", "disabled_player", "initializing_player"}
+    assert set(unloaded_players) == provider_player_ids
     assert set(mass_minimal.players._players) == {other_player.player_id}
+
+    # a removed provider takes the configs of all its players with it, including the ones
+    # its own players listing hides; a plain reload must leave every config untouched so
+    # the players come back with their settings
+    stored_configs = {
+        player_id
+        for player_id in provider_player_ids | {other_player.player_id}
+        if mass_minimal.config.get(f"{CONF_PLAYERS}/{player_id}")
+    }
+    expected_configs = (
+        {other_player.player_id} if is_removed else provider_player_ids | {other_player.player_id}
+    )
+    assert stored_configs == expected_configs

--- a/tests/core/test_provider_unload.py
+++ b/tests/core/test_provider_unload.py
@@ -236,7 +236,7 @@ async def test_unload_provider_unregisters_hidden_players(
     stored_configs = {
         player_id
         for player_id in all_player_ids
-        if mass_minimal.config.get(f"{CONF_PLAYERS}/{player_id}")
+        if mass_minimal.config.get(f"{CONF_PLAYERS}/{player_id}") is not None
     }
     assert stored_configs == ({other_player.player_id} if is_removed else all_player_ids)
 


### PR DESCRIPTION
# What does this implement/fix?

When a player provider is removed from the configuration, its players should be gone for good — including the ones the provider deliberately keeps hidden (disabled players, and players still being set up). A plain provider reload must do the opposite: leave every player config alone so the players come back with their settings intact.

That difference was untested. This adds coverage for it by parametrizing the existing unload test over both cases, so a future change can't silently start wiping configs on reload — or start leaving stale ones behind after a removal.

Test-only change, no behaviour change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
