### PR TITLE
Show the real reason when AirPlay pairing fails

### DIFF
--- a/music_assistant/providers/airplay/pairing.py
+++ b/music_assistant/providers/airplay/pairing.py
@@ -273,13 +273,12 @@ class AirPlayPairing:
         :param summary: Short summary prefixed to the error detail.
         """
         detail = f"{summary}: {self._pair_setup_error()}"
-        if translation_key := self._pair_setup_translation_key():
-            return PlayerCommandFailed(detail, translation_key=translation_key)
-        return PlayerCommandFailed(detail)
+        translation_key = self._pair_setup_translation_key() or "pairing_failed"
+        return PlayerCommandFailed(detail, translation_key=translation_key)
 
     def _pair_setup_translation_key(self) -> str | None:
         """Map the HAP error tag from the pair-setup stderr (if any) to an error translation."""
-        for line in self._pair_proc_stderr:
+        for line in reversed(self._pair_proc_stderr):
             if match := HAP_ERROR_TAG_RE.search(line):
                 tag = int(match.group(1))
                 if tag == 2:
@@ -294,8 +293,11 @@ class AirPlayPairing:
         # the binary reports failures as plain lines on stderr; the last specific
         # line wins, its generic "Pairing failed." trailer only as a last resort
         fallback = "no error details reported"
-        for line in reversed(self._pair_proc_stderr):
-            if not line or "Enter the PIN" in line:
+        for raw_line in reversed(self._pair_proc_stderr):
+            # the PIN prompt is written without a newline, so it arrives glued
+            # to the front of the next line - strip it rather than skip the line
+            line = raw_line.split("Enter the PIN shown on the device:")[-1].strip()
+            if not line:
                 continue
             if line == "Pairing failed.":
                 fallback = line

--- a/music_assistant/providers/airplay/pairing.py
+++ b/music_assistant/providers/airplay/pairing.py
@@ -17,6 +17,7 @@ import hashlib
 import logging
 import os
 import plistlib
+import re
 
 import aiohttp
 from cryptography.hazmat.primitives import serialization
@@ -32,6 +33,9 @@ from .helpers import get_cli_binary
 
 # Timeout for the binary to complete the SRP exchange after the PIN is entered
 PAIR_SETUP_TIMEOUT = 60
+
+# HAP error tag in the binary's pair-setup stderr lines ("... error tag: 3 (backoff ...)")
+HAP_ERROR_TAG_RE = re.compile(r"error tag: (\d+)")
 
 # ============================================================================
 # RAOP Pairing constants (for AirPlay 1 legacy)
@@ -241,11 +245,9 @@ class AirPlayPairing:
             )
             returncode = await proc.wait_with_timeout(10)
         except (TimeoutError, BrokenPipeError, ConnectionResetError) as err:
-            raise PlayerCommandFailed(f"Pairing failed: {self._pair_setup_error()}") from err
+            raise self._pair_setup_failure("Pairing failed") from err
         if not credentials or returncode != 0:
-            raise PlayerCommandFailed(
-                f"Pairing failed (exit code {returncode}): {self._pair_setup_error()}"
-            )
+            raise self._pair_setup_failure(f"Pairing failed (exit code {returncode})")
         if len(credentials) != 192:
             raise PlayerCommandFailed(
                 f"Pairing produced invalid credentials (length {len(credentials)})"
@@ -264,14 +266,43 @@ class AirPlayPairing:
                     return line.split(":", 1)[1].strip()
         return None
 
+    def _pair_setup_failure(self, summary: str) -> PlayerCommandFailed:
+        """
+        Build the pairing failure carrying the most specific error detail available.
+
+        :param summary: Short summary prefixed to the error detail.
+        """
+        detail = f"{summary}: {self._pair_setup_error()}"
+        if translation_key := self._pair_setup_translation_key():
+            return PlayerCommandFailed(detail, translation_key=translation_key)
+        return PlayerCommandFailed(detail)
+
+    def _pair_setup_translation_key(self) -> str | None:
+        """Map the HAP error tag from the pair-setup stderr (if any) to an error translation."""
+        for line in self._pair_proc_stderr:
+            if match := HAP_ERROR_TAG_RE.search(line):
+                tag = int(match.group(1))
+                if tag == 2:
+                    return "pairing_wrong_pin"
+                if tag in (3, 5):
+                    # backoff/max tries: the device rate-limits pairing attempts
+                    return "pairing_backoff"
+        return None
+
     def _pair_setup_error(self) -> str:
         """Return a short error description from the pair-setup stderr output."""
-        # the binary reports failures as plain lines on stderr; the last
-        # (non-prompt) line is the most specific one
+        # the binary reports failures as plain lines on stderr; the last specific
+        # line wins, its generic "Pairing failed." trailer only as a last resort
+        fallback = "no error details reported"
         for line in reversed(self._pair_proc_stderr):
-            if line and "Enter the PIN" not in line:
-                return line
-        return "no error details reported"
+            if not line or "Enter the PIN" in line:
+                continue
+            if line == "Pairing failed.":
+                fallback = line
+                continue
+            # strip the binary's log prefix ("[time] func:line [HAP] message")
+            return line.rsplit("] ", 1)[-1]
+        return fallback
 
     # ========================================================================
     # RAOP (AirPlay 1 legacy) pairing implementation

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -1007,6 +1007,9 @@ class AirPlayPlayer(Player):
                 entered_value = str(values[field_key])
                 credentials = await pairing.finish_pairing(pin=entered_value)
             except PlayerCommandFailed as err:
+                # leave a default-level trace: the flow swallows the error into
+                # the re-served form, which support logs otherwise never show
+                self.logger.warning("Pairing with %s failed: %s", self.display_name, err)
                 errors = {"base": err.translation_key or str(err)}
                 continue
             finally:

--- a/music_assistant/providers/airplay/strings.json
+++ b/music_assistant/providers/airplay/strings.json
@@ -88,7 +88,9 @@
   "errors": {
     "invalid_pin": "Enter the numeric PIN shown on the screen of your device.",
     "authentication_failed": "The device rejected the saved password. Run the setup for this player to enter it again.",
-    "show_dashboard_failed": "Failed to show the dashboard on {0}."
+    "show_dashboard_failed": "Failed to show the dashboard on {0}.",
+    "pairing_backoff": "The device is refusing new pairing attempts after too many tries. Restart the device, then start pairing once and wait for the PIN.",
+    "pairing_wrong_pin": "The device rejected the PIN. Start pairing again and enter the new code shown on its screen."
   },
   "manifest": {
     "description": "Stream to AirPlay-enabled devices on your local network."

--- a/music_assistant/providers/airplay/strings.json
+++ b/music_assistant/providers/airplay/strings.json
@@ -90,6 +90,7 @@
     "authentication_failed": "The device rejected the saved password. Run the setup for this player to enter it again.",
     "show_dashboard_failed": "Failed to show the dashboard on {0}.",
     "pairing_backoff": "The device is refusing new pairing attempts after too many tries. Restart the device, then start pairing once and wait for the PIN.",
+    "pairing_failed": "The device refused the pairing attempt. Make sure it is awake and reachable, then try again.",
     "pairing_wrong_pin": "The device rejected the PIN. Start pairing again and enter the new code shown on its screen."
   },
   "manifest": {

--- a/music_assistant/providers/airplay/strings.json
+++ b/music_assistant/providers/airplay/strings.json
@@ -90,7 +90,7 @@
     "authentication_failed": "The device rejected the saved password. Run the setup for this player to enter it again.",
     "show_dashboard_failed": "Failed to show the dashboard on {0}.",
     "pairing_backoff": "The device is refusing new pairing attempts after too many tries. Restart the device, then start pairing once and wait for the PIN.",
-    "pairing_failed": "The device refused the pairing attempt. Make sure it is awake and reachable, then try again.",
+    "pairing_failed": "Pairing did not complete. Make sure the device is awake and reachable, then try again.",
     "pairing_wrong_pin": "The device rejected the PIN. Start pairing again and enter the new code shown on its screen."
   },
   "manifest": {

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -863,6 +863,7 @@
   "provider.airplay.errors.authentication_failed": "The device rejected the saved password. Run the setup for this player to enter it again.",
   "provider.airplay.errors.invalid_pin": "Enter the numeric PIN shown on the screen of your device.",
   "provider.airplay.errors.pairing_backoff": "The device is refusing new pairing attempts after too many tries. Restart the device, then start pairing once and wait for the PIN.",
+  "provider.airplay.errors.pairing_failed": "The device refused the pairing attempt. Make sure it is awake and reachable, then try again.",
   "provider.airplay.errors.pairing_wrong_pin": "The device rejected the PIN. Start pairing again and enter the new code shown on its screen.",
   "provider.airplay.errors.show_dashboard_failed": "Failed to show the dashboard on {0}.",
   "provider.airplay.manifest.description": "Stream to AirPlay-enabled devices on your local network.",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -863,7 +863,7 @@
   "provider.airplay.errors.authentication_failed": "The device rejected the saved password. Run the setup for this player to enter it again.",
   "provider.airplay.errors.invalid_pin": "Enter the numeric PIN shown on the screen of your device.",
   "provider.airplay.errors.pairing_backoff": "The device is refusing new pairing attempts after too many tries. Restart the device, then start pairing once and wait for the PIN.",
-  "provider.airplay.errors.pairing_failed": "The device refused the pairing attempt. Make sure it is awake and reachable, then try again.",
+  "provider.airplay.errors.pairing_failed": "Pairing did not complete. Make sure the device is awake and reachable, then try again.",
   "provider.airplay.errors.pairing_wrong_pin": "The device rejected the PIN. Start pairing again and enter the new code shown on its screen.",
   "provider.airplay.errors.show_dashboard_failed": "Failed to show the dashboard on {0}.",
   "provider.airplay.manifest.description": "Stream to AirPlay-enabled devices on your local network.",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -862,6 +862,8 @@
   "provider.airplay.config_entries.verbose_ptp_logging.label": "Verbose PTP daemon logging",
   "provider.airplay.errors.authentication_failed": "The device rejected the saved password. Run the setup for this player to enter it again.",
   "provider.airplay.errors.invalid_pin": "Enter the numeric PIN shown on the screen of your device.",
+  "provider.airplay.errors.pairing_backoff": "The device is refusing new pairing attempts after too many tries. Restart the device, then start pairing once and wait for the PIN.",
+  "provider.airplay.errors.pairing_wrong_pin": "The device rejected the PIN. Start pairing again and enter the new code shown on its screen.",
   "provider.airplay.errors.show_dashboard_failed": "Failed to show the dashboard on {0}.",
   "provider.airplay.manifest.description": "Stream to AirPlay-enabled devices on your local network.",
   "provider.airplay.setup_flow.abort.pairing_failed": "Could not start pairing with the device. Make sure the device is reachable on the network and try again.",

--- a/tests/providers/airplay/test_pairing.py
+++ b/tests/providers/airplay/test_pairing.py
@@ -74,12 +74,39 @@ async def test_backoff_failure_carries_specific_translation() -> None:
     assert "error tag: 3" in str(excinfo.value)
 
 
-async def test_wrong_pin_failure_carries_specific_translation() -> None:
-    """A rejected PIN (error tag 2 at M4) surfaces as the pairing_wrong_pin error."""
+@pytest.mark.parametrize(
+    ("tag", "translation_key"),
+    [(2, "pairing_wrong_pin"), (3, "pairing_backoff"), (5, "pairing_backoff")],
+)
+async def test_hap_error_tags_map_to_specific_translations(tag: int, translation_key: str) -> None:
+    """Actionable HAP error tags surface as their specific error translation."""
     pairing = _make_pairing()
     _attach_proc(pairing)
     pairing._pair_proc_stderr = [
-        "[10:00:01.000] ap2_hap_pair_setup_pin:1310 [HAP] Pair-setup M4 error tag: 2",
+        f"[10:00:01.000] ap2_hap_pair_setup_pin:1310 [HAP] Pair-setup M4 error tag: {tag}",
+        "Pairing failed.",
+    ]
+
+    with pytest.raises(PlayerCommandFailed) as excinfo:
+        await pairing.finish_pairing(pin="0000")
+
+    assert excinfo.value.translation_key == translation_key
+
+
+async def test_error_line_glued_to_pin_prompt_still_surfaces() -> None:
+    """
+    Surface the error even when it arrives glued to the PIN prompt.
+
+    The binary writes its PIN prompt without a newline, so the line-based stderr
+    reader glues the prompt to the front of the next line - which on a post-PIN
+    failure is the error line itself.
+    """
+    pairing = _make_pairing()
+    _attach_proc(pairing)
+    pairing._pair_proc_stderr = [
+        "[10:00:00.000] ap2_hap_pair_setup_pin:1272 [HAP] Pair-setup M2 OK - waiting for the PIN entry",
+        "Enter the PIN shown on the device: [10:00:05.000] ap2_hap_pair_setup_pin:1313 "
+        "[HAP] Pair-setup M4 error tag: 2 (authentication failed - wrong PIN or key mismatch)",
         "Pairing failed.",
     ]
 
@@ -87,10 +114,12 @@ async def test_wrong_pin_failure_carries_specific_translation() -> None:
         await pairing.finish_pairing(pin="0000")
 
     assert excinfo.value.translation_key == "pairing_wrong_pin"
+    assert "error tag: 2" in str(excinfo.value)
+    assert "M2 OK" not in str(excinfo.value)
 
 
-async def test_unclassified_failure_keeps_default_translation() -> None:
-    """Failures without a HAP error tag keep the generic player command error."""
+async def test_unclassified_failure_uses_generic_pairing_translation() -> None:
+    """Failures without a HAP error tag surface as the generic pairing error."""
     pairing = _make_pairing()
     _attach_proc(pairing)
     pairing._pair_proc_stderr = ["Cannot connect to 192.168.68.60:7000"]
@@ -98,5 +127,5 @@ async def test_unclassified_failure_keeps_default_translation() -> None:
     with pytest.raises(PlayerCommandFailed) as excinfo:
         await pairing.finish_pairing(pin="1234")
 
-    assert excinfo.value.translation_key == PlayerCommandFailed.translation_key
+    assert excinfo.value.translation_key == "pairing_failed"
     assert "Cannot connect" in str(excinfo.value)

--- a/tests/providers/airplay/test_pairing.py
+++ b/tests/providers/airplay/test_pairing.py
@@ -1,0 +1,102 @@
+"""Tests for the AirPlay pairing session (cliairplay pair-setup handling)."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.errors import PlayerCommandFailed
+
+from music_assistant.providers.airplay.constants import StreamingProtocol
+from music_assistant.providers.airplay.pairing import AirPlayPairing
+
+# stderr of a pair-setup run that hit the ATV's pairing rate limit (HAP backoff)
+BACKOFF_STDERR = [
+    "[01:08:00.786] ap2_hap_create:608 [HAP] Created context without credentials",
+    "[01:08:00.786] ap2_hap_pair_setup_pin:1197 [HAP] Starting HomeKit pair-setup (PIN)...",
+    "[01:08:00.796] ap2_hap_pair_setup_pin:1215 [HAP] /pair-pin-start -> 200",
+    "[01:08:00.927] ap2_hap_pair_setup_pin:1236 [HAP] Pair-setup M2 error tag: 3",
+    "Pairing failed.",
+]
+
+
+def _make_pairing() -> AirPlayPairing:
+    """Build an AirPlay 2 pairing session without starting anything."""
+    return AirPlayPairing(
+        address="192.168.68.60",
+        name="Apple TV",
+        protocol=StreamingProtocol.AIRPLAY2,
+        logger=logging.getLogger("test.airplay.pairing"),
+        port=7000,
+        device_id="ABCDEF0123456789",
+    )
+
+
+def _attach_proc(pairing: AirPlayPairing, **overrides: object) -> MagicMock:
+    """Attach a fake live pair-setup process to the pairing session."""
+    proc = MagicMock()
+    proc.closed = False
+    proc.write = AsyncMock()
+    proc.read = AsyncMock(return_value=b"")
+    proc.wait_with_timeout = AsyncMock(return_value=1)
+    proc.kill = AsyncMock()
+    for name, value in overrides.items():
+        setattr(proc, name, value)
+    pairing._pair_proc = proc
+    return proc
+
+
+def test_pair_setup_error_prefers_specific_line_over_trailer() -> None:
+    """The generic "Pairing failed." trailer must not hide the specific error line."""
+    pairing = _make_pairing()
+    pairing._pair_proc_stderr = list(BACKOFF_STDERR)
+    assert pairing._pair_setup_error() == "Pair-setup M2 error tag: 3"
+
+
+def test_pair_setup_error_falls_back_to_trailer() -> None:
+    """With no specific line, the generic trailer is still better than nothing."""
+    pairing = _make_pairing()
+    pairing._pair_proc_stderr = ["Enter the PIN shown on the device: ", "Pairing failed."]
+    assert pairing._pair_setup_error() == "Pairing failed."
+
+
+async def test_backoff_failure_carries_specific_translation() -> None:
+    """A device in HAP backoff (error tag 3) surfaces as the pairing_backoff error."""
+    pairing = _make_pairing()
+    _attach_proc(pairing, write=AsyncMock(side_effect=BrokenPipeError))
+    pairing._pair_proc_stderr = list(BACKOFF_STDERR)
+
+    with pytest.raises(PlayerCommandFailed) as excinfo:
+        await pairing.finish_pairing(pin="1234")
+
+    assert excinfo.value.translation_key == "pairing_backoff"
+    assert "error tag: 3" in str(excinfo.value)
+
+
+async def test_wrong_pin_failure_carries_specific_translation() -> None:
+    """A rejected PIN (error tag 2 at M4) surfaces as the pairing_wrong_pin error."""
+    pairing = _make_pairing()
+    _attach_proc(pairing)
+    pairing._pair_proc_stderr = [
+        "[10:00:01.000] ap2_hap_pair_setup_pin:1310 [HAP] Pair-setup M4 error tag: 2",
+        "Pairing failed.",
+    ]
+
+    with pytest.raises(PlayerCommandFailed) as excinfo:
+        await pairing.finish_pairing(pin="0000")
+
+    assert excinfo.value.translation_key == "pairing_wrong_pin"
+
+
+async def test_unclassified_failure_keeps_default_translation() -> None:
+    """Failures without a HAP error tag keep the generic player command error."""
+    pairing = _make_pairing()
+    _attach_proc(pairing)
+    pairing._pair_proc_stderr = ["Cannot connect to 192.168.68.60:7000"]
+
+    with pytest.raises(PlayerCommandFailed) as excinfo:
+        await pairing.finish_pairing(pin="1234")
+
+    assert excinfo.value.translation_key == PlayerCommandFailed.translation_key
+    assert "Cannot connect" in str(excinfo.value)


### PR DESCRIPTION
# What does this implement/fix?

When AirPlay pairing fails, the setup flow only showed a generic "player command failed" message while the actual reason stayed buried in the debug logs. Users then keep retrying, which can make things worse: an Apple TV rate-limits pairing after several aborted attempts (HAP backoff), and every extra retry extends that lockout (seen in the linked support issue).

- Show a specific message in the pairing form for the two actionable failures: the device is rate-limiting pairing attempts (restart it and pair once), or it rejected the entered PIN
- Surface the pairing binary's specific error line instead of its generic "Pairing failed." trailer
- Log a warning when a pairing attempt fails, so support logs show it at the default log level
- Companion change in cliairplay that annotates the raw HAP error tags: music-assistant/airplay-cli#57

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5312

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.