### PR TITLE
Fix the OpenAI Compatible provider failing to load

### DIFF
--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -69,11 +69,12 @@ class Provider:
         """
         Return the (options) config entries to configure this provider instance.
 
-        Called only for an existing (loaded) instance: read the current values via
-        ``self.config``/``self.get_config_value`` and the capabilities via
-        ``self.supported_features``. One-time setup input is collected by the setup flow
-        (see ``setup_flow.py``), not here. Include ``ConfigEntryType.ACTION`` entries for
-        one-shot buttons and handle their presses in ``handle_config_action``.
+        Resolved on every load - before ``handle_async_init`` - as well as whenever the
+        options page is opened, so this may not read state that async init assigns. Read
+        the current values via ``self.config``/``self.get_config_value`` and the
+        capabilities via ``self.supported_features``. One-time setup input is collected by
+        the setup flow (see ``setup_flow.py``), not here. Include ``ConfigEntryType.ACTION``
+        entries for one-shot buttons and handle their presses in ``handle_config_action``.
         """
         return ()
 
@@ -94,7 +95,12 @@ class Provider:
         raise ActionUnavailable(f"Unknown action: {action}")
 
     async def handle_async_init(self) -> None:
-        """Handle async initialization of the provider."""
+        """
+        Handle async initialization of the provider.
+
+        Runs after ``get_config_entries`` was already resolved, so state assigned here
+        is not available to it.
+        """
 
     async def loaded_in_mass(self) -> None:
         """Call after the provider has been loaded."""

--- a/music_assistant/providers/openai_compatible/__init__.py
+++ b/music_assistant/providers/openai_compatible/__init__.py
@@ -44,18 +44,11 @@ async def setup(
 class OpenAICompatibleProvider(PluginProvider):
     """Exposes the models of an OpenAI-compatible API as selectable AI engines."""
 
-    _base_url: str
-    _api_key: str
-
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        base_url = str(self.get_setup_value(CONF_BASE_URL) or "").strip().rstrip("/")
-        if not base_url:
+        if not self._base_url:
             msg = "No API base URL is configured"
             raise SetupFailedError(msg)
-        self._base_url = base_url
-        api_key = self.get_setup_value(CONF_API_KEY)
-        self._api_key = api_key.strip() if isinstance(api_key, str) else ""
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return the (options) config entries to configure this provider instance."""
@@ -98,6 +91,19 @@ class OpenAICompatibleProvider(PluginProvider):
             prompt=query,
             timeout=CHAT_REQUEST_TIMEOUT,
         )
+
+    @property
+    def _base_url(self) -> str:
+        """Return the configured API endpoint, without trailing slash."""
+        # read on demand: the config entries are resolved before async init runs,
+        # so nothing this provider needs may live on an attribute set there
+        return str(self.get_setup_value(CONF_BASE_URL) or "").strip().rstrip("/")
+
+    @property
+    def _api_key(self) -> str:
+        """Return the configured API key, empty for an endpoint without auth."""
+        api_key = self.get_setup_value(CONF_API_KEY)
+        return api_key.strip() if isinstance(api_key, str) else ""
 
     def _configured_models(self) -> list[str]:
         """Return the models the user selected, in a stable order."""

--- a/music_assistant/providers/openai_compatible/__init__.py
+++ b/music_assistant/providers/openai_compatible/__init__.py
@@ -96,7 +96,7 @@ class OpenAICompatibleProvider(PluginProvider):
     def _base_url(self) -> str:
         """Return the configured API endpoint, without trailing slash."""
         # read on demand: the config entries are resolved before async init runs,
-        # so nothing this provider needs may live on an attribute set there
+        # so this has to be readable without it
         return str(self.get_setup_value(CONF_BASE_URL) or "").strip().rstrip("/")
 
     @property

--- a/tests/providers/openai_compatible/test_provider.py
+++ b/tests/providers/openai_compatible/test_provider.py
@@ -50,7 +50,7 @@ def mass() -> AsyncMock:
 @pytest.fixture
 def provider(mass: AsyncMock) -> OpenAICompatibleProvider:
     """Return an OpenAICompatibleProvider with mocked dependencies and no models selected."""
-    return _provider_on(mass, {"base_url": BASE_URL})
+    return _build_provider(mass, {"base_url": BASE_URL})
 
 
 async def test_list_models_returns_sorted_ids(mass: AsyncMock) -> None:
@@ -278,6 +278,13 @@ def test_base_url_strips_whitespace() -> None:
     assert provider._base_url == "https://api.example.com/v1"
 
 
+async def test_handle_async_init_accepts_a_configured_base_url() -> None:
+    """A usable endpoint must pass the init check, whatever shape the address has."""
+    provider = _provider_for_setup({"base_url": "http://localhost:11434/v1"})
+
+    await provider.handle_async_init()
+
+
 async def test_handle_async_init_raises_when_base_url_missing() -> None:
     """A never-configured base URL cannot be initialized into a working provider."""
     provider = _provider_for_setup({})
@@ -301,8 +308,8 @@ def test_api_key_defaults_to_empty_string_when_not_stored() -> None:
     assert provider._api_key == ""
 
 
-def test_api_key_is_decrypted_and_stripped() -> None:
-    """A stored key is used once decrypted, with surrounding whitespace removed."""
+def test_api_key_comes_from_setup_data_and_is_stripped() -> None:
+    """The key is only stored in setup_data, and surrounding whitespace is removed."""
     provider = _provider_for_setup({"base_url": BASE_URL, "api_key": "  sk-secret  "})
 
     assert provider._api_key == "sk-secret"
@@ -624,10 +631,10 @@ def _provider_for_setup(setup_data: dict[str, Any]) -> OpenAICompatibleProvider:
     mass = AsyncMock()
     mass.http_session = MagicMock()
     mass.config = MagicMock()
-    return _provider_on(mass, setup_data)
+    return _build_provider(mass, setup_data)
 
 
-def _provider_on(mass: AsyncMock, setup_data: dict[str, Any]) -> OpenAICompatibleProvider:
+def _build_provider(mass: AsyncMock, setup_data: dict[str, Any]) -> OpenAICompatibleProvider:
     """Build a provider on the given mass, backed by the given setup_data."""
     mass.config.get = MagicMock(return_value=dict(setup_data))
     mass.config.decrypt_string = MagicMock(side_effect=lambda value: value)

--- a/tests/providers/openai_compatible/test_provider.py
+++ b/tests/providers/openai_compatible/test_provider.py
@@ -43,22 +43,14 @@ def mass() -> AsyncMock:
     """Return a mocked MusicAssistant instance with a mockable HTTP session."""
     ma = AsyncMock()
     ma.http_session = MagicMock()
+    ma.config = MagicMock()
     return ma
 
 
 @pytest.fixture
 def provider(mass: AsyncMock) -> OpenAICompatibleProvider:
     """Return an OpenAICompatibleProvider with mocked dependencies and no models selected."""
-    manifest = MagicMock()
-    manifest.domain = "openai_compatible"
-    config = MagicMock()
-    config.values = {}
-    config.instance_id = INSTANCE_ID
-    config.get_value = MagicMock(return_value="GLOBAL")
-    prov = OpenAICompatibleProvider(mass, manifest, config, SUPPORTED_FEATURES)
-    prov._base_url = BASE_URL
-    prov._api_key = ""
-    return prov
+    return _provider_on(mass, {"base_url": BASE_URL})
 
 
 async def test_list_models_returns_sorted_ids(mass: AsyncMock) -> None:
@@ -272,20 +264,16 @@ def test_error_detail_truncates_overlong_messages() -> None:
     assert result == long_message[: helpers.MAX_ERROR_DETAIL_CHARS]
 
 
-async def test_handle_async_init_strips_trailing_slash_from_base_url() -> None:
+def test_base_url_strips_trailing_slash() -> None:
     """Every request path is built by appending to the stored base URL."""
     provider = _provider_for_setup({"base_url": "https://api.example.com/v1/"})
-
-    await provider.handle_async_init()
 
     assert provider._base_url == "https://api.example.com/v1"
 
 
-async def test_handle_async_init_strips_whitespace_from_base_url() -> None:
+def test_base_url_strips_whitespace() -> None:
     """Whitespace around a stored base URL is stripped."""
     provider = _provider_for_setup({"base_url": "  https://api.example.com/v1  "})
-
-    await provider.handle_async_init()
 
     assert provider._base_url == "https://api.example.com/v1"
 
@@ -306,20 +294,16 @@ async def test_handle_async_init_raises_when_base_url_blank() -> None:
         await provider.handle_async_init()
 
 
-async def test_handle_async_init_defaults_missing_api_key_to_empty_string() -> None:
+def test_api_key_defaults_to_empty_string_when_not_stored() -> None:
     """No stored key means the no-auth local-server case, not None or the text "None"."""
     provider = _provider_for_setup({"base_url": BASE_URL})
-
-    await provider.handle_async_init()
 
     assert provider._api_key == ""
 
 
-async def test_handle_async_init_keeps_the_stored_api_key() -> None:
+def test_api_key_is_decrypted_and_stripped() -> None:
     """A stored key is used once decrypted, with surrounding whitespace removed."""
     provider = _provider_for_setup({"base_url": BASE_URL, "api_key": "  sk-secret  "})
-
-    await provider.handle_async_init()
 
     assert provider._api_key == "sk-secret"
 
@@ -594,6 +578,23 @@ async def test_get_config_entries_survives_an_endpoint_without_a_listing(
     assert [option.value for option in models_entry.options] == ["typed-by-hand"]
 
 
+async def test_get_config_entries_reaches_the_endpoint_without_async_init(
+    provider: OpenAICompatibleProvider, mass: AsyncMock
+) -> None:
+    """Loading resolves the config entries before async init, so they must not depend on it."""
+    _configure_models(provider, [])
+    mass.http_session.request = MagicMock(
+        return_value=_response_cm(response=_json_response(200, {"data": [{"id": "fresh-model"}]}))
+    )
+
+    # deliberately no handle_async_init(): mass._load_provider only runs it afterwards
+    entries = await provider.get_config_entries()
+
+    assert mass.http_session.request.call_args.args[1] == f"{BASE_URL}/models"
+    models_entry = next(entry for entry in entries if entry.key == CONF_MODELS)
+    assert [option.value for option in models_entry.options] == ["fresh-model"]
+
+
 def _response_cm(*, response: MagicMock | None = None, exc: Exception | None = None) -> MagicMock:
     """Build a fake async context manager mimicking aiohttp's session.request()."""
     cm = MagicMock()
@@ -623,6 +624,11 @@ def _provider_for_setup(setup_data: dict[str, Any]) -> OpenAICompatibleProvider:
     mass = AsyncMock()
     mass.http_session = MagicMock()
     mass.config = MagicMock()
+    return _provider_on(mass, setup_data)
+
+
+def _provider_on(mass: AsyncMock, setup_data: dict[str, Any]) -> OpenAICompatibleProvider:
+    """Build a provider on the given mass, backed by the given setup_data."""
     mass.config.get = MagicMock(return_value=dict(setup_data))
     mass.config.decrypt_string = MagicMock(side_effect=lambda value: value)
     manifest = MagicMock()


### PR DESCRIPTION
# What does this implement/fix?

Adding an OpenAI Compatible endpoint failed with an internal error, and the provider could not be loaded at all — not while adding it, and not on a restart afterwards.

The provider looked up its API address and key from values that only get filled in halfway through starting it, while the server already needs them a step earlier. Both are now read from the saved settings whenever they are needed.

- Read the API address and key on demand instead of storing them while starting up
- Corrected the provider developer docs, which claimed the opposite and made this easy to get wrong
- Added a test that loads the provider the way the server actually does

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
