### PR TITLE
Fix playlists not loading in Home Assistant

### DIFF
--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -9,7 +9,7 @@ DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
 
-DB_SCHEMA_VERSION: Final[int] = 55
+DB_SCHEMA_VERSION: Final[int] = 56
 
 # tracks longer that this will not be included in radio mode
 RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60

--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -969,9 +969,9 @@ async def migrate_database(  # noqa: PLR0915
         # know it yet refuse to parse a playlist that advertises it. Rewriting the rows
         # here makes upgrading enough, instead of having to wait for the next library sync.
         await database.execute(
-            f"UPDATE {DB_TABLE_PLAYLISTS} SET supported_mediatypes = ("
+            f"UPDATE {DB_TABLE_PLAYLISTS} SET supported_mediatypes = json(("
             "SELECT json_group_array(value) FROM json_each"
-            f"({DB_TABLE_PLAYLISTS}.supported_mediatypes) WHERE value != 'sound_effect')"
+            f"({DB_TABLE_PLAYLISTS}.supported_mediatypes) WHERE value != 'sound_effect'))"
             " WHERE json_valid(supported_mediatypes)"
             " AND supported_mediatypes LIKE '%sound_effect%'"
         )

--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -964,6 +964,18 @@ async def migrate_database(  # noqa: PLR0915
                 migrated_artwork_rows,
             )
 
+    if prev_version <= 55:
+        # drop the sound effect media type from the stored playlists: clients that do not
+        # know it yet refuse to parse a playlist that advertises it. Rewriting the rows
+        # here makes upgrading enough, instead of having to wait for the next library sync.
+        await database.execute(
+            f"UPDATE {DB_TABLE_PLAYLISTS} SET supported_mediatypes = ("
+            "SELECT json_group_array(value) FROM json_each"
+            f"({DB_TABLE_PLAYLISTS}.supported_mediatypes) WHERE value != 'sound_effect')"
+            " WHERE json_valid(supported_mediatypes)"
+            " AND supported_mediatypes LIKE '%sound_effect%'"
+        )
+
     # NOTE: this genre restore runs after the <= 50 step on purpose: it inserts genres
     # with the current code/schema, so the external_ids column must be gone first.
     if prev_version <= 47:

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -277,11 +277,14 @@ class BuiltinProvider(MusicProvider):
                 )
             },
             owner="Music Assistant",
+            # MediaType.SOUND_EFFECT is deliberately left out here: clients that do not
+            # know this media type yet reject the entire playlist listing when they
+            # receive it. Sound effects can still be added to these playlists, as the
+            # builtin provider accepts any uri regardless of this (advisory) set.
             supported_mediatypes={
                 MediaType.AUDIOBOOK,
                 MediaType.PODCAST_EPISODE,
                 MediaType.RADIO,
-                MediaType.SOUND_EFFECT,
                 MediaType.TRACK,
             },
             is_editable=True,

--- a/tests/controllers/music/test_music_migrations.py
+++ b/tests/controllers/music/test_music_migrations.py
@@ -451,7 +451,8 @@ async def test_migration_strips_sound_effect_from_playlists(
         "INSERT INTO playlists (item_id, supported_mediatypes) VALUES "
         '(1, \'["track","sound_effect","radio"]\'), '
         "(2, '[\"track\"]'), "
-        "(3, 'corrupt value naming sound_effect')"
+        "(3, 'corrupt value naming sound_effect'), "
+        "(4, '[\"sound_effect\"]')"
     )
     await database.commit()
 
@@ -472,3 +473,5 @@ async def test_migration_strips_sound_effect_from_playlists(
     # playlists without the media type, and rows we cannot parse, are left alone
     assert json.loads(rows[1]["supported_mediatypes"]) == ["track"]
     assert rows[2]["supported_mediatypes"] == "corrupt value naming sound_effect"
+    # a playlist left with nothing yields an empty list, not NULL (the column is NOT NULL)
+    assert json.loads(rows[3]["supported_mediatypes"]) == []

--- a/tests/controllers/music/test_music_migrations.py
+++ b/tests/controllers/music/test_music_migrations.py
@@ -49,7 +49,14 @@ async def database(tmp_path: Path) -> AsyncGenerator[DatabaseConnection]:
     for table in MEDIA_TABLES:
         await db.execute(
             f"CREATE TABLE {table}([item_id] INTEGER PRIMARY KEY, "
-            "[external_ids] json NOT NULL DEFAULT '[]')"
+            "[external_ids] json NOT NULL DEFAULT '[]'"
+            # every playlists table at the schema versions under test carries this column
+            + (
+                ", [supported_mediatypes] json NOT NULL DEFAULT '[\"track\"]'"
+                if table == "playlists"
+                else ""
+            )
+            + ")"
         )
     await db.execute(
         f"CREATE TABLE {DB_TABLE_EXTERNAL_ID_LOOKUP}([media_type] TEXT NOT NULL, "
@@ -434,3 +441,34 @@ async def test_migration_rewrites_apple_music_artwork_to_tokens(
     assert json.loads(rows[1]["metadata"])["images"] == [
         {"path": "https://x/y.jpg", "provider": "spotify"}
     ]
+
+
+async def test_migration_strips_sound_effect_from_playlists(
+    database: DatabaseConnection,
+) -> None:
+    """The sound effect media type is removed from the stored playlists."""
+    await database.execute(
+        "INSERT INTO playlists (item_id, supported_mediatypes) VALUES "
+        '(1, \'["track","sound_effect","radio"]\'), '
+        "(2, '[\"track\"]'), "
+        "(3, 'corrupt value naming sound_effect')"
+    )
+    await database.commit()
+
+    mass = MagicMock()
+    mass.cache.clear = AsyncMock()
+    await migrate_database(
+        mass,
+        database,
+        MagicMock(),
+        prev_version=55,
+        create_tables=AsyncMock(),
+    )
+
+    rows = await database.get_rows_from_query(
+        "SELECT item_id, supported_mediatypes FROM playlists ORDER BY item_id"
+    )
+    assert json.loads(rows[0]["supported_mediatypes"]) == ["track", "radio"]
+    # playlists without the media type, and rows we cannot parse, are left alone
+    assert json.loads(rows[1]["supported_mediatypes"]) == ["track"]
+    assert rows[2]["supported_mediatypes"] == "corrupt value naming sound_effect"

--- a/tests/providers/builtin/test_playlist_media_types.py
+++ b/tests/providers/builtin/test_playlist_media_types.py
@@ -1,0 +1,45 @@
+"""Tests for the media types a builtin playlist advertises to clients."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import MediaType
+
+from music_assistant.providers.builtin import BuiltinProvider
+
+
+def _make_provider(playlists_dir: Path) -> BuiltinProvider:
+    """Create a minimal BuiltinProvider that reads playlists from the given directory."""
+    prov = object.__new__(BuiltinProvider)
+    prov.mass = MagicMock()
+    prov.logger = MagicMock()
+    prov.manifest = MagicMock(domain="builtin")
+    prov.config = MagicMock(instance_id="builtin_1")
+    prov._playlists_dir = str(playlists_dir)
+    prov._playlist_lock = asyncio.Lock()
+    return prov
+
+
+@pytest.mark.asyncio
+async def test_user_playlist_does_not_advertise_sound_effect(tmp_path: Path) -> None:
+    """
+    A user created playlist must not offer SOUND_EFFECT in its supported media types.
+
+    Clients that do not know this media type yet reject the entire playlist listing
+    when they receive it.
+    """
+    (tmp_path / "my-playlist.m3u").write_text("#EXTM3U\n#PLAYLIST:My Playlist\n", encoding="utf-8")
+    prov = _make_provider(tmp_path)
+
+    playlist = await prov.get_playlist("my-playlist")
+
+    assert playlist.supported_mediatypes == {
+        MediaType.AUDIOBOOK,
+        MediaType.PODCAST_EPISODE,
+        MediaType.RADIO,
+        MediaType.TRACK,
+    }


### PR DESCRIPTION
# What does this implement/fix?

Playing or browsing a Music Assistant playlist from Home Assistant fails with `Playlists are only supported for {...}`, and because one bad playlist aborts the whole listing, *all* playlists become unusable from Home Assistant.

The builtin provider recently started advertising the "sound effect" media type on user created playlists. Home Assistant ships an older client that does not know this media type yet and refuses to parse a playlist that uses it.

Sound effects can still be added to these playlists — the builtin provider accepts any item regardless of this (advisory) list. We can advertise it again once Home Assistant ships a client that understands it.

- builtin provider no longer advertises the sound effect media type on user created playlists
- a migration corrects playlists that are already in the library, so upgrading is enough
- added tests so it cannot be re-introduced unnoticed

**Related issue (if applicable):**

- models companion (durable fix, so a future media type cannot do this again): https://github.com/music-assistant/models/pull/355

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
